### PR TITLE
Fix pkill process completions

### DIFF
--- a/crates/warp_completer/src/completer/engine/argument/legacy.rs
+++ b/crates/warp_completer/src/completer/engine/argument/legacy.rs
@@ -38,7 +38,7 @@ use crate::parsers::{
     ArgumentError::{MissingMandatoryPositional, MissingValueForName, UnexpectedArgument},
 };
 
-use super::add_extra_positional;
+use super::{add_extra_positional, should_use_file_path_fallback};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn complete(
@@ -102,6 +102,7 @@ pub async fn complete(
     // a completion spec we attempted, fallback to the fallback type (if any).
     if suggestions.is_empty()
         && !arg_has_spec
+        && should_use_file_path_fallback(tokens_from_command)
         && matches!(
             options.fallback_strategy,
             CompletionsFallbackStrategy::FilePaths

--- a/crates/warp_completer/src/completer/engine/argument/mod.rs
+++ b/crates/warp_completer/src/completer/engine/argument/mod.rs
@@ -31,3 +31,9 @@ fn add_extra_positional(shell_command: &mut ShellCommand, cursor: &Span) {
         None => shell_command.args.positionals = Some(positional),
     };
 }
+
+fn should_use_file_path_fallback(tokens_from_command: &[&str]) -> bool {
+    !tokens_from_command
+        .first()
+        .is_some_and(|command| command.eq_ignore_ascii_case("pkill"))
+}

--- a/crates/warp_completer/src/completer/engine/argument/v2.rs
+++ b/crates/warp_completer/src/completer/engine/argument/v2.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use smol_str::SmolStr;
 
-use super::add_extra_positional;
+use super::{add_extra_positional, should_use_file_path_fallback};
 use crate::completer::GeneratorContext;
 use crate::{
     completer::{
@@ -95,6 +95,7 @@ pub async fn complete(
     // a completion spec we attempted, fallback to the fallback type (if any).
     if suggestions.is_empty()
         && !arg_has_spec
+        && should_use_file_path_fallback(tokens_without_last_editing)
         && matches!(
             options.fallback_strategy,
             CompletionsFallbackStrategy::FilePaths

--- a/crates/warp_completer/src/completer/suggest/test.rs
+++ b/crates/warp_completer/src/completer/suggest/test.rs
@@ -23,8 +23,16 @@ cfg_if::cfg_if! {
     if #[cfg(not(feature = "v2"))] {
         use std::collections::HashSet;
         use crate::signatures::testing::add_content_signature;
+        use warp_command_signatures::{
+            Argument, ArgumentType, CommandBuilder, CommandSignatureGenerators, Generator,
+            GeneratorName, GeneratorResults, IsArgumentOptional, Signature,
+            Suggestion as MetadataSuggestion,
+        };
     }
 }
+
+#[cfg(not(feature = "v2"))]
+const PKILL_TEST_COMMAND: &str = "ps names";
 
 #[cfg(windows)]
 mod windows_constants {
@@ -269,6 +277,80 @@ pub fn test_files_includes_directories() {
         complete_at_end_of_line("cat ", &ctx),
         vec!["foo/", "foobar"],
     );
+}
+
+#[cfg(not(feature = "v2"))]
+#[test]
+pub fn test_pkill_completes_process_names_not_paths() {
+    let path_ctx = MockPathCompletionContext::default().with_entries_in_pwd([
+        EngineDirEntry::test_dir("Desktop"),
+        EngineDirEntry::test_file("warp.md"),
+    ]);
+    let generator_ctx =
+        MockGeneratorContext::new().with_expected_command(PKILL_TEST_COMMAND, "Finder\nlogin\n");
+    let ctx = FakeCompletionContext::new(pkill_test_registry())
+        .with_path_completion_context(path_ctx)
+        .with_generator_context(generator_ctx);
+
+    assert_eq!(
+        complete_at_end_of_line("pkill ", &ctx),
+        vec!["Finder", "login"],
+    );
+}
+
+#[cfg(not(feature = "v2"))]
+#[test]
+pub fn test_pkill_does_not_fallback_to_paths_without_generator_context() {
+    let path_ctx = MockPathCompletionContext::default().with_entries_in_pwd([
+        EngineDirEntry::test_dir("Desktop"),
+        EngineDirEntry::test_file("warp.md"),
+    ]);
+    let ctx =
+        FakeCompletionContext::new(pkill_test_registry()).with_path_completion_context(path_ctx);
+
+    assert!(complete_at_end_of_line("pkill ", &ctx).is_empty());
+}
+
+#[cfg(not(feature = "v2"))]
+fn pkill_test_registry() -> CommandRegistry {
+    let generators = HashMap::from([CommandSignatureGenerators::new("pkill")
+        .add_generator(
+            "process_name",
+            Generator::script(
+                CommandBuilder::single_command(PKILL_TEST_COMMAND),
+                |output| GeneratorResults {
+                    suggestions: output.lines().map(MetadataSuggestion::new).collect(),
+                    is_ordered: false,
+                },
+            ),
+        )
+        .into()]);
+
+    CommandRegistry::new_for_test([pkill_test_signature()], generators)
+}
+
+#[cfg(not(feature = "v2"))]
+fn pkill_test_signature() -> Signature {
+    Signature {
+        name: "pkill".to_string(),
+        alias_generator: None,
+        description: None,
+        arguments: Some(vec![Argument {
+            display_name: Some("process_name".to_string()),
+            description: None,
+            is_variadic: false,
+            is_command: false,
+            argument_types: vec![ArgumentType::Generator(GeneratorName(
+                "process_name".to_string(),
+            ))],
+            optional: IsArgumentOptional::Required,
+            skip_generator_validation: false,
+        }]),
+        subcommands: None,
+        options: None,
+        priority: Default::default(),
+        parser_directives: Default::default(),
+    }
 }
 
 #[test]

--- a/crates/warp_completer/src/signatures/legacy/mod.rs
+++ b/crates/warp_completer/src/signatures/legacy/mod.rs
@@ -1,12 +1,14 @@
 use std::sync::{Arc, OnceLock};
 
+use warp_command_signatures::{
+    Argument, ArgumentType, CommandBuilder, CommandSignatureGenerators, Generator, GeneratorName,
+    GeneratorResults, IsArgumentOptional, Signature, Suggestion as MetadataSuggestion,
+};
 use warp_core::channel::Channel;
 
 pub mod registry;
 
 pub use registry::CommandRegistry;
-#[cfg(feature = "test-util")]
-use warp_command_signatures::Signature;
 
 static GLOBAL_REGISTRY: OnceLock<Arc<CommandRegistry>> = OnceLock::new();
 
@@ -30,6 +32,13 @@ impl CommandRegistry {
     /// Returns a new [`CommandRegistry`] that looks up commands in the embedded
     /// set of command signatures.
     fn new_with_embedded_signatures() -> Self {
+        let mut dynamic_completion_data = warp_command_signatures::dynamic_command_signature_data();
+        let (pkill_command_name, pkill_completion_data): (
+            String,
+            warp_command_signatures::DynamicCompletionData,
+        ) = pkill_dynamic_completion_data().into();
+        dynamic_completion_data.insert(pkill_command_name, pkill_completion_data);
+
         let registry = CommandRegistry::new(
             |command| {
                 let start = instant::Instant::now();
@@ -40,10 +49,11 @@ impl CommandRegistry {
                 );
                 signature
             },
-            warp_command_signatures::dynamic_command_signature_data(),
+            dynamic_completion_data,
         );
 
         Self::register_warp_signatures(&registry);
+        registry.register_signature(pkill_signature());
 
         registry
     }
@@ -90,6 +100,85 @@ impl CommandRegistry {
             .into_iter()
             .for_each(|signature| registry.register_signature(signature));
         registry
+    }
+}
+
+fn pkill_signature() -> Signature {
+    Signature {
+        name: "pkill".to_string(),
+        alias_generator: None,
+        description: Some("signal processes by name".to_string()),
+        arguments: Some(vec![Argument {
+            display_name: Some("process_name".to_string()),
+            description: Some("Process name or pattern".to_string()),
+            is_variadic: false,
+            is_command: false,
+            argument_types: vec![ArgumentType::Generator(GeneratorName(
+                "process_name".to_string(),
+            ))],
+            optional: IsArgumentOptional::Required,
+            skip_generator_validation: false,
+        }]),
+        subcommands: None,
+        options: None,
+        priority: Default::default(),
+        parser_directives: Default::default(),
+    }
+}
+
+fn pkill_dynamic_completion_data() -> CommandSignatureGenerators {
+    CommandSignatureGenerators::new("pkill").add_generator(
+        "process_name",
+        Generator::script(
+            CommandBuilder::pipe(
+                CommandBuilder::single_command("ps -A -o comm"),
+                CommandBuilder::single_command("sort -u"),
+            ),
+            |output| GeneratorResults {
+                suggestions: output
+                    .trim()
+                    .lines()
+                    .filter_map(pkill_process_suggestion)
+                    .collect(),
+                is_ordered: false,
+            },
+        ),
+    )
+}
+
+fn pkill_process_suggestion(path: &str) -> Option<MetadataSuggestion> {
+    let name = path.rsplit_once('/').map_or(path, |(_, name)| name);
+
+    if name.is_empty() || name == "COMM" {
+        return None;
+    }
+
+    Some(MetadataSuggestion::with_description(name, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pkill_process_suggestion;
+
+    #[test]
+    fn pkill_process_suggestion_uses_basename() {
+        let suggestion = pkill_process_suggestion("/usr/bin/login").unwrap();
+
+        assert_eq!(suggestion.exact_string, "login");
+        assert_eq!(suggestion.description.as_deref(), Some("/usr/bin/login"));
+    }
+
+    #[test]
+    fn pkill_process_suggestion_allows_bare_process_names() {
+        let suggestion = pkill_process_suggestion("zsh").unwrap();
+
+        assert_eq!(suggestion.exact_string, "zsh");
+        assert_eq!(suggestion.description.as_deref(), Some("zsh"));
+    }
+
+    #[test]
+    fn pkill_process_suggestion_skips_ps_header() {
+        assert!(pkill_process_suggestion("COMM").is_none());
     }
 }
 


### PR DESCRIPTION
Fixes #10924

## Summary
- Add a pkill command signature backed by process-name completions.
- Prevent pkill from falling back to filesystem paths when process completions are unavailable.
- Apply the fallback guard to both legacy and v2 argument completion paths.

## Tests
- cargo fmt --check
- PATH="/tmp/codex-fake-xcrun:$PATH" cargo test -p warp_completer pkill --features test-util
- PATH="/tmp/codex-fake-xcrun:$PATH" cargo test -p warp_completer pkill --features 'test-util v2'