### PR TITLE
Actually fix errant task status reporting for cloud mode conversations.

### DIFF
--- a/app/src/ai/active_agent_views_model.rs
+++ b/app/src/ai/active_agent_views_model.rs
@@ -5,9 +5,7 @@ use chrono::{DateTime, Utc};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent_conversations_model::AgentConversationEntryId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::blocklist::agent_view::{
-    AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin,
-};
+use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
 use crate::ai::blocklist::orchestration_event_streamer::{
     register_agent_event_consumer, unregister_agent_event_consumer,
 };
@@ -489,20 +487,6 @@ impl ActiveAgentViewsModel {
         }
 
         None
-    }
-
-    /// Returns the active agent-view entry origin for a terminal view.
-    pub fn agent_view_origin_for_terminal_view(
-        &self,
-        terminal_view_id: EntityId,
-        ctx: &AppContext,
-    ) -> Option<AgentViewEntryOrigin> {
-        let controller = self
-            .agent_view_handles
-            .get(&terminal_view_id)?
-            .controller
-            .upgrade(ctx)?;
-        controller.as_ref(ctx).agent_view_state().origin()
     }
 
     /// Get all currently active conversation IDs.

--- a/app/src/ai/ambient_agents/mod.rs
+++ b/app/src/ai/ambient_agents/mod.rs
@@ -78,6 +78,18 @@ pub fn conversation_output_status_from_conversation(
             blocked_action: blocked_action.clone(),
         });
     }
+    if let ConversationStatus::Error = conversation.status() {
+        if let Some(error_message) = conversation.status_error_message() {
+            return Some(AmbientConversationStatus::Error {
+                error: RenderableAIError::Other {
+                    error_message: error_message.to_string(),
+                    will_attempt_resume: false,
+                    waiting_for_network: false,
+                },
+            });
+        }
+    }
+
     if let Some(last_exchange) = conversation.root_task_exchanges().last() {
         if let AIAgentOutputStatus::Finished { finished_output } = &last_exchange.output_status {
             let status = match finished_output {
@@ -92,17 +104,6 @@ pub fn conversation_output_status_from_conversation(
                 FinishedAIAgentOutput::Success { output: _ } => AmbientConversationStatus::Success,
             };
             return Some(status);
-        }
-    }
-    if let ConversationStatus::Error = conversation.status() {
-        if let Some(error_message) = conversation.status_error_message() {
-            return Some(AmbientConversationStatus::Error {
-                error: RenderableAIError::Other {
-                    error_message: error_message.to_string(),
-                    will_attempt_resume: false,
-                    waiting_for_network: false,
-                },
-            });
         }
     }
 

--- a/app/src/ai/blocklist/task_status_sync_model.rs
+++ b/app/src/ai/blocklist/task_status_sync_model.rs
@@ -1,11 +1,9 @@
 use super::history_model::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate,
 };
-use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::agent::{AIAgentOutputStatus, FinishedAIAgentOutput, RenderableAIError};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::server::server_api::ai::{AIClient, TaskStatusUpdate};
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::cli_agent_sessions::{
@@ -89,12 +87,11 @@ impl TaskStatusSyncModel {
         match event {
             BlocklistAIHistoryEvent::UpdatedConversationStatus {
                 conversation_id,
-                terminal_view_id,
                 update,
                 ..
             } => {
                 if matches!(update, ConversationStatusUpdate::Changed { .. }) {
-                    self.on_conversation_status_updated(*conversation_id, *terminal_view_id, ctx);
+                    self.on_conversation_status_updated(*conversation_id, ctx);
                 }
             }
             // When the server token (and thus task_id) is first assigned to a
@@ -102,10 +99,9 @@ impl TaskStatusSyncModel {
             // where ConversationStatus::InProgress fires before task_id is
             // available — we catch up here once the task_id arrives.
             BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
-                conversation_id,
-                terminal_view_id,
+                conversation_id, ..
             } => {
-                self.on_conversation_status_updated(*conversation_id, *terminal_view_id, ctx);
+                self.on_conversation_status_updated(*conversation_id, ctx);
             }
             _ => {}
         }
@@ -136,16 +132,9 @@ impl TaskStatusSyncModel {
     fn on_conversation_status_updated(
         &self,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         let (task_id, task_state, status_message) = {
-            if !should_sync_task_status_to_server(
-                ActiveAgentViewsModel::as_ref(ctx)
-                    .agent_view_origin_for_terminal_view(terminal_view_id, ctx),
-            ) {
-                return;
-            }
             let Some(conversation) =
                 BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
             else {
@@ -212,13 +201,6 @@ impl TaskStatusSyncModel {
             |_, _, _| {},
         );
     }
-}
-
-pub(crate) fn should_sync_task_status_to_server(origin: Option<AgentViewEntryOrigin>) -> bool {
-    !matches!(
-        origin,
-        Some(AgentViewEntryOrigin::CloudAgent | AgentViewEntryOrigin::ThirdPartyCloudAgent)
-    )
 }
 
 impl Entity for TaskStatusSyncModel {

--- a/app/src/ai/blocklist/task_status_sync_model_tests.rs
+++ b/app/src/ai/blocklist/task_status_sync_model_tests.rs
@@ -1,6 +1,5 @@
-use super::{classify_renderable_error, map_cli_session_status, should_sync_task_status_to_server};
+use super::{classify_renderable_error, map_cli_session_status};
 use crate::ai::agent::RenderableAIError;
-use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::server::server_api::ai::TaskStatusUpdate;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionStatus;
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
@@ -142,22 +141,4 @@ fn cli_blocked_without_message() {
     let (state, update) = map_cli_session_status(&CLIAgentSessionStatus::Blocked { message: None });
     assert_eq!(state, AgentTaskState::Blocked);
     assert!(update.is_none());
-}
-
-#[test]
-fn cloud_agent_view_origin_does_not_sync_task_status() {
-    assert!(!should_sync_task_status_to_server(Some(
-        AgentViewEntryOrigin::CloudAgent
-    )));
-    assert!(!should_sync_task_status_to_server(Some(
-        AgentViewEntryOrigin::ThirdPartyCloudAgent
-    )));
-}
-
-#[test]
-fn driver_and_unknown_view_origins_sync_task_status() {
-    assert!(should_sync_task_status_to_server(Some(
-        AgentViewEntryOrigin::Cli
-    )));
-    assert!(should_sync_task_status_to_server(None));
 }

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4028,7 +4028,10 @@ impl PaneGroup {
         }
 
         match cloud_conversation {
-            CloudConversationData::Oz(conversation) => {
+            CloudConversationData::Oz(mut conversation) => {
+                if ambient_agent_task_id.is_some() {
+                    conversation.set_is_viewing_shared_session(true);
+                }
                 terminal_view.update(ctx, |view, ctx| {
                     view.restore_conversation_after_view_creation(
                         RestoredAIConversation::new(*conversation),
@@ -5460,8 +5463,9 @@ impl PaneGroup {
                 .set_is_executing_oz_environment_startup_commands(false);
 
             match cloud_conversation {
-                CloudConversationData::Oz(conversation) => {
+                CloudConversationData::Oz(mut conversation) => {
                     let id = conversation.id();
+                    conversation.set_is_viewing_shared_session(true);
                     view.restore_conversation_after_view_creation(
                         RestoredAIConversation::new(*conversation),
                         true,

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -228,6 +228,7 @@ pub struct AmbientAgentViewModel {
     /// Used as the previous session ID when submitting a follow-up so polling can wait for a
     /// different fresh session after the prior execution has ended.
     last_ended_execution_session_id: Option<SessionId>,
+
     /// Prompt text for a follow-up that has been submitted but not yet attached to a new session.
     pending_followup_prompt: Option<String>,
 


### PR DESCRIPTION
## Description

Instead of relying on `AgentViewOrigin` to determine if the conversation is being viewed in cloud mode, use existing shared_session_viewer check and ensure that cloud agent conversations restored into cloud mode are treated as such.