### PR TITLE
Add RPC for fetching branches

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -94,7 +94,7 @@ use crate::terminal::cli_agent::{
 };
 #[cfg(feature = "local_fs")]
 use crate::util::file::external_editor::EditorSettings;
-use crate::util::git::get_all_branches;
+use crate::util::git::{get_all_branches, BranchEntry};
 #[cfg(feature = "local_fs")]
 use crate::util::openable_file_type::resolve_file_target_with_editor_choice;
 #[cfg(feature = "local_fs")]
@@ -587,7 +587,7 @@ struct PendingPreciseScroll {
 struct RepositoryState {
     repo_path: PathBuf,
     state: CodeReviewViewState,
-    available_branches: Vec<(String, bool)>, // (branch_name, is_main_branch)
+    available_branches: Vec<BranchEntry>,
 
     /// Whether a file has been explicitly expanded (true) or collapsed (false).
     file_expanded: HashMap<PathBuf, bool>,
@@ -1556,7 +1556,7 @@ impl CodeReviewView {
             let already_present = repo
                 .available_branches
                 .iter()
-                .any(|(name, _)| name == branch_name);
+                .any(|entry| entry.name == *branch_name);
             if !already_present {
                 targets.push(DiffTarget::new(
                     branch_name.clone(),
@@ -1567,10 +1567,10 @@ impl CodeReviewView {
         }
 
         // 3. Main branch, if known.
-        let main_branch = repo.available_branches.iter().find(|(_, is_main)| *is_main);
-        if let Some((main_branch_name, _)) = main_branch {
+        let main_branch = repo.available_branches.iter().find(|entry| entry.is_main);
+        if let Some(main_entry) = main_branch {
             targets.push(DiffTarget::new(
-                main_branch_name.clone(),
+                main_entry.name.clone(),
                 DiffMode::MainBranch,
                 matches!(current_mode, DiffMode::MainBranch),
             ));
@@ -1579,22 +1579,22 @@ impl CodeReviewView {
         // 4. Other branches, filtered to exclude main and the currently
         // checked-out branch (the latter is functionally the same as
         // "Uncommitted changes").
-        for (branch_name, is_main) in repo.available_branches.iter() {
-            if *is_main {
+        for entry in repo.available_branches.iter() {
+            if entry.is_main {
                 continue;
             }
             if let Some(current_name) = &current_branch_name {
-                if branch_name == current_name {
+                if entry.name == *current_name {
                     continue;
                 }
             }
             let is_selected = match &current_mode {
-                DiffMode::OtherBranch(name) => name == branch_name,
+                DiffMode::OtherBranch(name) => name == &entry.name,
                 DiffMode::Head | DiffMode::MainBranch => false,
             };
             targets.push(DiffTarget::new(
-                branch_name.clone(),
-                DiffMode::OtherBranch(branch_name.clone()),
+                entry.name.clone(),
+                DiffMode::OtherBranch(entry.name.clone()),
                 is_selected,
             ));
         }

--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -790,9 +790,18 @@ fn test_setup_dropdown_with_branches_includes_all_items() {
         let target_count = ctx.code_review_view.update(&mut app, |view, view_ctx| {
             if let Some(repo) = view.active_repo.as_mut() {
                 repo.available_branches = vec![
-                    ("main".to_string(), true),
-                    ("feature-1".to_string(), false),
-                    ("feature-2".to_string(), false),
+                    BranchEntry {
+                        name: "main".to_string(),
+                        is_main: true,
+                    },
+                    BranchEntry {
+                        name: "feature-1".to_string(),
+                        is_main: false,
+                    },
+                    BranchEntry {
+                        name: "feature-2".to_string(),
+                        is_main: false,
+                    },
                 ];
             }
             view.build_diff_targets(view_ctx).len()
@@ -847,8 +856,16 @@ fn test_on_close_then_on_open_reinitializes_repo_state() {
         // Populate branches to simulate a working state
         let target_count_before = ctx.code_review_view.update(&mut app, |view, view_ctx| {
             if let Some(repo) = view.active_repo.as_mut() {
-                repo.available_branches =
-                    vec![("main".to_string(), true), ("feature-1".to_string(), false)];
+                repo.available_branches = vec![
+                    BranchEntry {
+                        name: "main".to_string(),
+                        is_main: true,
+                    },
+                    BranchEntry {
+                        name: "feature-1".to_string(),
+                        is_main: false,
+                    },
+                ];
             }
             view.build_diff_targets(view_ctx).len()
         });

--- a/app/src/code_review/diff_state/local_tests.rs
+++ b/app/src/code_review/diff_state/local_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::util::git::{parse_range, parse_unified_diff_header, sort_branches_main_first};
+use crate::util::git::{
+    parse_range, parse_unified_diff_header, sort_branches_main_first, BranchEntry,
+};
 
 #[test]
 fn test_parse_range_with_comma() {
@@ -52,7 +54,7 @@ fn test_parse_unified_diff_header_single_line() {
 
 #[test]
 fn test_sort_branches_main_first_empty() {
-    let branches: Vec<(String, bool)> = vec![];
+    let branches: Vec<BranchEntry> = vec![];
     let result: Vec<_> = sort_branches_main_first(&branches).collect();
     assert!(result.is_empty());
 }
@@ -60,9 +62,18 @@ fn test_sort_branches_main_first_empty() {
 #[test]
 fn test_sort_branches_main_first_no_main() {
     let branches = vec![
-        ("feature-a".to_string(), false),
-        ("feature-b".to_string(), false),
-        ("feature-c".to_string(), false),
+        BranchEntry {
+            name: "feature-a".to_string(),
+            is_main: false,
+        },
+        BranchEntry {
+            name: "feature-b".to_string(),
+            is_main: false,
+        },
+        BranchEntry {
+            name: "feature-c".to_string(),
+            is_main: false,
+        },
     ];
     let result: Vec<_> = sort_branches_main_first(&branches).collect();
     // No main branches — order should be unchanged.
@@ -72,12 +83,21 @@ fn test_sort_branches_main_first_no_main() {
 #[test]
 fn test_sort_branches_main_first_promotes_main() {
     let branches = vec![
-        ("feature-a".to_string(), false),
-        ("main".to_string(), true),
-        ("feature-b".to_string(), false),
+        BranchEntry {
+            name: "feature-a".to_string(),
+            is_main: false,
+        },
+        BranchEntry {
+            name: "main".to_string(),
+            is_main: true,
+        },
+        BranchEntry {
+            name: "feature-b".to_string(),
+            is_main: false,
+        },
     ];
     let result: Vec<_> = sort_branches_main_first(&branches)
-        .map(|(name, _)| name.as_str())
+        .map(|entry| entry.name.as_str())
         .collect();
     assert_eq!(result, vec!["main", "feature-a", "feature-b"]);
 }
@@ -85,12 +105,21 @@ fn test_sort_branches_main_first_promotes_main() {
 #[test]
 fn test_sort_branches_main_first_main_already_first() {
     let branches = vec![
-        ("main".to_string(), true),
-        ("feature-a".to_string(), false),
-        ("feature-b".to_string(), false),
+        BranchEntry {
+            name: "main".to_string(),
+            is_main: true,
+        },
+        BranchEntry {
+            name: "feature-a".to_string(),
+            is_main: false,
+        },
+        BranchEntry {
+            name: "feature-b".to_string(),
+            is_main: false,
+        },
     ];
     let result: Vec<_> = sort_branches_main_first(&branches)
-        .map(|(name, _)| name.as_str())
+        .map(|entry| entry.name.as_str())
         .collect();
     assert_eq!(result, vec!["main", "feature-a", "feature-b"]);
 }
@@ -99,13 +128,25 @@ fn test_sort_branches_main_first_main_already_first() {
 fn test_sort_branches_main_first_preserves_recency_order_for_non_main() {
     // Non-main branches should remain in their original (recency) order.
     let branches = vec![
-        ("recent-feature".to_string(), false),
-        ("main".to_string(), true),
-        ("older-feature".to_string(), false),
-        ("oldest-feature".to_string(), false),
+        BranchEntry {
+            name: "recent-feature".to_string(),
+            is_main: false,
+        },
+        BranchEntry {
+            name: "main".to_string(),
+            is_main: true,
+        },
+        BranchEntry {
+            name: "older-feature".to_string(),
+            is_main: false,
+        },
+        BranchEntry {
+            name: "oldest-feature".to_string(),
+            is_main: false,
+        },
     ];
     let result: Vec<_> = sort_branches_main_first(&branches)
-        .map(|(name, _)| name.as_str())
+        .map(|entry| entry.name.as_str())
         .collect();
     assert_eq!(
         result,
@@ -118,12 +159,21 @@ fn test_sort_branches_main_first_multiple_main_flags() {
     // Defensive: both flagged as main (shouldn't happen in practice, but
     // sort_branches_main_first should handle it gracefully).
     let branches = vec![
-        ("feature".to_string(), false),
-        ("main".to_string(), true),
-        ("master".to_string(), true),
+        BranchEntry {
+            name: "feature".to_string(),
+            is_main: false,
+        },
+        BranchEntry {
+            name: "main".to_string(),
+            is_main: true,
+        },
+        BranchEntry {
+            name: "master".to_string(),
+            is_main: true,
+        },
     ];
     let result: Vec<_> = sort_branches_main_first(&branches)
-        .map(|(name, _)| name.as_str())
+        .map(|entry| entry.name.as_str())
         .collect();
     // Both main-flagged entries appear first, non-main last.
     assert_eq!(result, vec!["main", "master", "feature"]);

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -176,6 +176,7 @@ impl RemoteCodebaseIndexModel {
             | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
             | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
             | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. }
+            | RemoteServerManagerEvent::GetBranchesResponse { .. }
             | RemoteServerManagerEvent::SetupStateChanged { .. }
             | RemoteServerManagerEvent::BinaryCheckComplete { .. }
             | RemoteServerManagerEvent::BinaryInstallComplete { .. }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -60,6 +60,11 @@ use crate::code_review::diff_state::{DiffMode, FileStatusInfo};
 /// How long the daemon waits with no connections before exiting.
 pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 * 60);
 
+/// Server-side cap on the number of branches returned by `GetBranches`.
+/// Prevents a client from forcing the daemon to enumerate an arbitrarily
+/// large ref list.
+const MAX_BRANCH_COUNT_CAP: usize = 500;
+
 /// Unique identifier for a connected proxy session in daemon mode.
 pub type ConnectionId = uuid::Uuid;
 use super::protocol::RequestId;
@@ -2294,7 +2299,9 @@ impl ServerModel {
             }
         };
 
-        let max_branch_count = msg.max_branch_count.map(|c| c as usize);
+        let max_branch_count = msg
+            .max_branch_count
+            .map(|c| (c as usize).min(MAX_BRANCH_COUNT_CAP));
         let include_remotes = msg.include_remotes;
 
         log::info!(

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -37,21 +37,21 @@ use super::diff_state_tracker::{
 use super::proto::{
     client_message, delete_file_response, discard_files_response, get_diff_state_response,
     get_fragment_metadata_from_hash_response, resolve_conflict_response, run_command_response,
-    save_buffer_response, server_message, write_file_response, Abort, Authenticate, BufferEdit,
-    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexStatusState,
+    save_buffer_response, server_message, write_file_response, Abort, Authenticate, BranchInfo,
+    BufferEdit, BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexStatusState,
     CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, DeleteFile, DeleteFileResponse,
     DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse, DiscardFilesSuccess,
     DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead, FileContextProto,
     FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
-    FragmentMetadataLookupErrorCode, GetDiffStateResponse, GetFragmentMetadataFromHash,
-    GetFragmentMetadataFromHashResponse, GetFragmentMetadataFromHashSuccess, IndexCodebase,
-    Initialize, InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
-    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
-    ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, RunCommandError,
-    RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer,
-    SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, WriteFile,
-    WriteFileResponse, WriteFileSuccess,
+    FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
+    GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
+    GetFragmentMetadataFromHashSuccess, IndexCodebase, Initialize, InitializeResponse,
+    MissingFragmentMetadata, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
+    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
+    ResolveConflictSuccess, RunCommandError, RunCommandErrorCode, RunCommandRequest,
+    RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess,
+    ServerMessage, SessionBootstrapped, TextEdit, WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 
@@ -704,6 +704,9 @@ impl ServerModel {
             Some(client_message::Message::UnsubscribeDiffState(msg)) => {
                 self.handle_unsubscribe_diff_state(msg, conn_id, ctx);
                 return; // fire-and-forget notification
+            }
+            Some(client_message::Message::GetBranches(msg)) => {
+                self.handle_get_branches(msg, &request_id, conn_id, ctx)
             }
             Some(client_message::Message::DiscardFiles(msg)) => {
                 self.handle_discard_files(msg, &request_id, ctx)
@@ -2262,6 +2265,80 @@ impl ServerModel {
                 }
             }
         }
+    }
+
+    /// Handles `GetBranches` — request/response.
+    ///
+    /// Runs `get_all_branches` on the remote filesystem and responds with
+    /// the branch list.
+    fn handle_get_branches(
+        &mut self,
+        msg: super::proto::GetBranches,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let repo_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path))
+        {
+            Ok(p) => p.to_local_path_lossy(),
+            Err(e) => {
+                return HandlerOutcome::Sync(server_message::Message::GetBranchesResponse(
+                    GetBranchesResponse {
+                        result: Some(super::proto::get_branches_response::Result::Error(
+                            GetBranchesError {
+                                message: format!("Invalid repo_path: {e}"),
+                            },
+                        )),
+                    },
+                ));
+            }
+        };
+
+        let max_branch_count = msg.max_branch_count.map(|c| c as usize);
+        let include_remotes = msg.include_remotes;
+
+        log::info!(
+            "Handling GetBranches repo={} (request_id={request_id})",
+            msg.repo_path,
+        );
+
+        let request_id_for_response = request_id.clone();
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move {
+                crate::util::git::get_all_branches(&repo_path, max_branch_count, include_remotes)
+                    .await
+            },
+            move |me, branches_result, _ctx| {
+                let message = match branches_result {
+                    Ok(branches) => {
+                        server_message::Message::GetBranchesResponse(GetBranchesResponse {
+                            result: Some(super::proto::get_branches_response::Result::Success(
+                                GetBranchesSuccess {
+                                    branches: branches
+                                        .into_iter()
+                                        .map(|entry| BranchInfo {
+                                            name: entry.name,
+                                            is_main: entry.is_main,
+                                        })
+                                        .collect(),
+                                },
+                            )),
+                        })
+                    }
+                    Err(e) => server_message::Message::GetBranchesResponse(GetBranchesResponse {
+                        result: Some(super::proto::get_branches_response::Result::Error(
+                            GetBranchesError {
+                                message: format!("{e:#}"),
+                            },
+                        )),
+                    }),
+                };
+                me.send_server_message(Some(conn_id), Some(&request_id_for_response), message);
+            },
+            ctx,
+        );
+        HandlerOutcome::Async(Some(handle))
     }
 
     /// Handles `DiscardFilesRequest` — request/response.

--- a/app/src/tab_configs/branch_picker.rs
+++ b/app/src/tab_configs/branch_picker.rs
@@ -9,7 +9,7 @@ use crate::{
     tab_configs::PickerStyle,
     util::git::{
         detect_current_branch, get_all_branches, get_all_branches_with_known_main,
-        sort_branches_main_first,
+        sort_branches_main_first, BranchEntry,
     },
     view_components::{DropdownItem, FilterableDropdown},
 };
@@ -154,7 +154,10 @@ impl BranchPicker {
                         if let Ok(current) = detect_current_branch(&cwd).await {
                             let trimmed = current.trim().to_string();
                             if !trimmed.is_empty() {
-                                return Ok(vec![(trimmed, true)]);
+                                return Ok(vec![BranchEntry {
+                                    name: trimmed,
+                                    is_main: true,
+                                }]);
                             }
                         }
                         branches
@@ -186,19 +189,19 @@ impl BranchPicker {
                 if me.cached_main_branch.is_none() {
                     me.cached_main_branch = branches
                         .iter()
-                        .find(|(_, is_main)| *is_main)
-                        .map(|(name, _)| name.clone());
+                        .find(|entry| entry.is_main)
+                        .map(|entry| entry.name.clone());
                 }
 
                 // Main branches first, then the rest in recency order.
                 let mut items: Vec<DropdownItem<String>> = sort_branches_main_first(&branches)
-                    .map(|(name, _)| DropdownItem::new(name.clone(), name.clone()))
+                    .map(|entry| DropdownItem::new(entry.name.clone(), entry.name.clone()))
                     .collect();
 
                 // Add the default as the first item if it isn't already in the list
                 // (e.g. the user typed a branch name that doesn't exist locally yet).
                 if let Some(ref default) = me.default_value {
-                    if !branches.iter().any(|(name, _)| name == default) {
+                    if !branches.iter().any(|entry| entry.name == *default) {
                         items.insert(0, DropdownItem::new(default.clone(), default.clone()));
                     }
                 }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -186,7 +186,8 @@ impl Sessions {
                 | RemoteServerManagerEvent::ServerMessageDecodingError { .. }
                 | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
                 | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
-                | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => {}
+                | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. }
+                | RemoteServerManagerEvent::GetBranchesResponse { .. } => {}
                 RemoteServerManagerEvent::SessionReconnected {
                     session_id: sid,
                     client,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4641,7 +4641,8 @@ impl TerminalView {
                     | RemoteServerManagerEvent::BufferConflictDetected { .. }
                     | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
                     | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
-                    | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => {}
+                    | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. }
+                    | RemoteServerManagerEvent::GetBranchesResponse { .. } => {}
                 }
             });
         }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -153,7 +153,8 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::BufferConflictDetected { .. }
             | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
             | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
-            | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => {}
+            | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. }
+            | RemoteServerManagerEvent::GetBranchesResponse { .. } => {}
         });
 
         Self {

--- a/app/src/util/git.rs
+++ b/app/src/util/git.rs
@@ -872,14 +872,20 @@ pub async fn create_pr(
     Err(anyhow!("Not supported on wasm"))
 }
 
+/// A single branch entry returned by [`get_all_branches`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct BranchEntry {
+    pub name: String,
+    pub is_main: bool,
+}
+
 /// Gets git branches, sorted by commit date (most recent first).
-/// Returns a list of `(branch_name, is_main_branch)` tuples.
 /// Defaults to the most recent 100 branches for performance.
 pub async fn get_all_branches(
     repo_path: &Path,
     max_branch_count: Option<usize>,
     include_remotes: bool,
-) -> Result<Vec<(String, bool)>> {
+) -> Result<Vec<BranchEntry>> {
     let main_branch = match detect_main_branch(repo_path).await {
         Ok(branch) => branch,
         Err(err) => {
@@ -900,7 +906,7 @@ pub async fn get_all_branches_with_known_main(
     main_branch: &str,
     max_branch_count: Option<usize>,
     include_remotes: bool,
-) -> Result<Vec<(String, bool)>> {
+) -> Result<Vec<BranchEntry>> {
     fetch_branch_list_with_main(repo_path, main_branch, max_branch_count, include_remotes).await
 }
 
@@ -912,7 +918,7 @@ async fn fetch_branch_list_with_main(
     main_branch: &str,
     max_branch_count: Option<usize>,
     include_remotes: bool,
-) -> Result<Vec<(String, bool)>> {
+) -> Result<Vec<BranchEntry>> {
     let count_arg = format!("--count={}", max_branch_count.unwrap_or(100));
 
     let mut args = vec![
@@ -946,12 +952,15 @@ async fn fetch_branch_list_with_main(
         }
 
         let is_main = branch == main_branch || branch == main_branch.trim_start_matches("origin/");
-        branches.push((branch.to_string(), is_main));
+        branches.push(BranchEntry {
+            name: branch.to_string(),
+            is_main,
+        });
     }
 
     // Remove duplicates while preserving order (most recent first)
     let mut seen = std::collections::HashSet::new();
-    branches.retain(|(name, _)| seen.insert(name.clone()));
+    branches.retain(|entry| seen.insert(entry.name.clone()));
 
     if branches.is_empty() {
         safe_warn!(
@@ -963,15 +972,13 @@ async fn fetch_branch_list_with_main(
     Ok(branches)
 }
 
-/// Returns an iterator over `branches` with main branches (`is_main == true`) first,
+/// Returns an iterator over `branches` with main branches first,
 /// then the rest in their existing order.
-pub fn sort_branches_main_first(
-    branches: &[(String, bool)],
-) -> impl Iterator<Item = &(String, bool)> {
+pub fn sort_branches_main_first(branches: &[BranchEntry]) -> impl Iterator<Item = &BranchEntry> {
     branches
         .iter()
-        .filter(|(_, is_main)| *is_main)
-        .chain(branches.iter().filter(|(_, is_main)| !is_main))
+        .filter(|entry| entry.is_main)
+        .chain(branches.iter().filter(|entry| !entry.is_main))
 }
 
 /// Represents a parsed unified diff header.

--- a/crates/remote_server/proto/diff_state.proto
+++ b/crates/remote_server/proto/diff_state.proto
@@ -263,3 +263,36 @@ message DiscardFilesSuccess {}
 message DiscardFilesError {
   string message = 1;
 }
+
+// ── Branch listing ────────────────────────────────────────────────
+
+// Client → server: list branches for a repository.
+message GetBranches {
+  string repo_path = 1;
+  // Maximum number of branches to return. Absent = server default (100).
+  optional uint32 max_branch_count = 2;
+  // Whether to include remote-tracking branches (refs/remotes).
+  bool include_remotes = 3;
+}
+
+// A single branch entry.
+message BranchInfo {
+  string name = 1;
+  bool is_main = 2;
+}
+
+// Server → client: result of a GetBranches request.
+message GetBranchesResponse {
+  oneof result {
+    GetBranchesSuccess success = 1;
+    GetBranchesError error = 2;
+  }
+}
+
+message GetBranchesSuccess {
+  repeated BranchInfo branches = 1;
+}
+
+message GetBranchesError {
+  string message = 1;
+}

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -37,6 +37,7 @@ message ClientMessage {
     IndexCodebase index_codebase = 21;
     DropCodebaseIndex drop_codebase_index = 22;
     GetFragmentMetadataFromHash get_fragment_metadata_from_hash = 23;
+    GetBranches get_branches = 24;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -68,6 +69,7 @@ message ServerMessage {
     DiscardFilesResponse discard_files_response = 22;
     BufferConflictDetected buffer_conflict_detected = 23;
     GetFragmentMetadataFromHashResponse get_fragment_metadata_from_hash_response = 24;
+    GetBranchesResponse get_branches_response = 25;
   }
 }
 

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -14,10 +14,11 @@ use futures::io::{AsyncRead, AsyncWrite};
 use warpui::r#async::{executor, FutureExt as _};
 
 use crate::proto::{
-    client_message, get_fragment_metadata_from_hash_response, server_message, Abort, Authenticate,
-    BufferEdit, ClientMessage, CloseBuffer, DeleteFile, DiffMode, DiffStateFileDelta,
-    DiffStateMetadataUpdate, DiffStateSnapshot, DiscardFilesRequest, DropCodebaseIndex, ErrorCode,
-    FileStatusInfo, FragmentMetadataLookupErrorCode, GetDiffState, GetDiffStateResponse,
+    client_message, get_branches_response, get_fragment_metadata_from_hash_response,
+    server_message, Abort, Authenticate, BranchInfo, BufferEdit, ClientMessage, CloseBuffer,
+    DeleteFile, DiffMode, DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot,
+    DiscardFilesRequest, DropCodebaseIndex, ErrorCode, FileStatusInfo,
+    FragmentMetadataLookupErrorCode, GetBranches, GetDiffState, GetDiffStateResponse,
     GetFragmentMetadataFromHash, GetFragmentMetadataFromHashSuccess, IndexCodebase, Initialize,
     InitializeResponse, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse,
     OpenBuffer, OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse,
@@ -931,6 +932,56 @@ impl RemoteServerClient {
             )),
         };
         self.send_notification(msg);
+    }
+
+    /// Sends a `GetBranches` request and awaits the response.
+    pub async fn get_branches(
+        &self,
+        repo_path: &StandardizedPath,
+        max_branch_count: Option<u32>,
+        include_remotes: bool,
+    ) -> Result<Vec<BranchInfo>, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::GetBranches(GetBranches {
+                repo_path: repo_path.to_string(),
+                max_branch_count,
+                include_remotes,
+            })),
+        };
+
+        let response = self
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::GetBranches,
+            )
+            .await?;
+
+        match response.message {
+            Some(server_message::Message::GetBranchesResponse(resp)) => match resp.result {
+                Some(get_branches_response::Result::Success(success)) => Ok(success.branches),
+                Some(get_branches_response::Result::Error(e)) => Err(ClientError::ServerError {
+                    code: ErrorCode::Internal,
+                    message: e.message,
+                }),
+                None => {
+                    safe_error!(
+                        safe: ("Remote server empty result for GetBranches"),
+                        full: ("Remote server empty result for GetBranches")
+                    );
+                    Err(ClientError::UnexpectedResponse)
+                }
+            },
+            other => {
+                safe_error!(
+                    safe: ("Remote server unexpected response for GetBranches"),
+                    full: ("Remote server unexpected response for GetBranches: response={other:?}")
+                );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
     }
 
     /// Sends a `DiscardFiles` request and awaits the response.

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -123,6 +123,7 @@ pub enum RemoteServerOperation {
     GetFragmentMetadataFromHash,
     GetDiffState,
     DiscardFiles,
+    GetBranches,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -476,6 +477,15 @@ pub enum RemoteServerManagerEvent {
         delta: DiffStateFileDelta,
     },
 
+    // --- Branch listing ---
+    /// Response to a `GetBranches` request.
+    GetBranchesResponse {
+        session_id: SessionId,
+        repo_path: StandardizedPath,
+        /// Branch list on success, error message on failure.
+        result: Result<Vec<crate::proto::BranchInfo>, String>,
+    },
+
     // --- Setup events ---
     /// Intermediate state change during the binary check/install flow.
     SetupStateChanged {
@@ -546,9 +556,8 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::BinaryCheckComplete { session_id, .. }
             | RemoteServerManagerEvent::BinaryInstallComplete { session_id, .. }
             | RemoteServerManagerEvent::ClientRequestFailed { session_id, .. }
-            | RemoteServerManagerEvent::ServerMessageDecodingError { session_id } => {
-                Some(*session_id)
-            }
+            | RemoteServerManagerEvent::ServerMessageDecodingError { session_id }
+            | RemoteServerManagerEvent::GetBranchesResponse { session_id, .. } => Some(*session_id),
             RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::HostDisconnected { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
@@ -1745,6 +1754,43 @@ impl RemoteServerManager {
                             .await;
                     }
                 }
+            })
+            .detach();
+    }
+
+    /// Sends a `GetBranches` request to the remote server for the given
+    /// session and emits the result as a manager event.
+    pub fn get_branches(
+        &mut self,
+        session_id: SessionId,
+        remote_path: RemotePath,
+        max_branch_count: Option<u32>,
+        include_remotes: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(client) = self.client_for_session(session_id).cloned() else {
+            log::warn!("Remote server get_branches: no connected client session={session_id:?}");
+            return;
+        };
+
+        let repo_path = remote_path.path;
+        let repo_path_for_event = repo_path.clone();
+        let spawner = self.spawner.clone();
+        ctx.background_executor()
+            .spawn(async move {
+                let result = client
+                    .get_branches(&repo_path, max_branch_count, include_remotes)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = spawner
+                    .spawn(move |_me, ctx| {
+                        ctx.emit(RemoteServerManagerEvent::GetBranchesResponse {
+                            session_id,
+                            repo_path: repo_path_for_event,
+                            result,
+                        });
+                    })
+                    .await;
             })
             .detach();
     }


### PR DESCRIPTION
## Description

Add a `GetBranches` request/response to the remote client-server protocol so code review can fetch branches from a remote server instead of only running local git commands.

**What:** Adds a new `GetBranches` RPC across all protocol layers:
- Proto definitions (`GetBranches`, `BranchInfo`, `GetBranchesResponse`) in `diff_state.proto`
- Client method (`RemoteServerClient::get_branches`)
- Manager method + event (`RemoteServerManager::get_branches` → `GetBranchesResponse`)
- Daemon handler (`ServerModel::handle_get_branches`) — spawns `get_all_branches` on the background executor

**Why:** Code review's `fetch_branches_and_setup_dropdown` currently calls `get_all_branches()` which runs local git subprocesses. This doesn't work when the repo is on a remote server. This PR adds the protocol plumbing so a future PR can wire up the callsite.

**How:** Follows the existing `GetDiffState` pattern across all layers (proto → client → manager → daemon handler). Also introduces a `BranchEntry` struct to replace the `(String, bool)` tuple used throughout the codebase for branch data, improving readability.

**Not included:** Hooking up the actual code review callsite to use the remote path — that will be done in a follow-up PR.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- No user-visible changes; this is protocol plumbing only (not yet wired to callsites)
- Verified compilation with `cargo check`, `cargo check --tests`, and `cargo fmt`
- Exhaustive match arms added for the new `GetBranchesResponse` event variant in all 4 subscriber sites

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

CHANGELOG-NONE
-->

Co-Authored-By: Warp <agent@warp.dev>