### PR TITLE
[SPEC] i18n / zh-CN locale support — product and technical spec

### DIFF
--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -35,12 +35,13 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
     - Any locale starting with `"zh"` (e.g., `zh-CN`, `zh-TW`, `zh-HK`, `zh`) resolves to `zh-CN` (Simplified Chinese). This is an intentional simplification: zh-CN is the only Chinese locale shipped, so all Chinese-language systems receive Simplified Chinese.
     - All other locales — including explicit non-Chinese values of `WARP_LANG` — resolve to `en` (English).
     - The explicit `WARP_LANG` override is NOT passed through as a raw locale string. Setting `WARP_LANG=fr` results in `en`, not `fr`.
+    - The `WARP_LANG` variable takes precedence over system locale only when its value starts with `"zh"`. On a Chinese-system machine (where the OS locale is `zh-CN`), setting `WARP_LANG=fr` still yields `en`; unsetting `WARP_LANG` restores `zh-CN`.
 
 1.3. The application ships with exactly two locale files: `en.yml` and `zh-CN.yml`.
 
 ### 2. Translation rendering
 
-2.1. Every user-facing text string in the Warp UI is wrapped in a translation call (`t!()` macro in Rust source). English strings serve as both the translation key and the fallback value — the lookup key is a dot-separated path into a YAML locale file.
+2.1. Every user-facing text string in the Warp UI is translated via the `t!("dot.path")` macro. The argument to `t!()` is a dot-separated path into a YAML locale file — this path is the lookup key. The English value at that path in `en.yml` serves as the fallback text when no translation exists for the active locale. The Chinese value at the same path in `zh-CN.yml` is shown when zh-CN is active.
 
 2.2. When a translation is requested for a given key:
     1. The active locale file is checked first.

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -33,7 +33,8 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 1.2. The resolved locale is matched as follows:
     - Any locale starting with `"zh"` (e.g., `zh-CN`, `zh-TW`, `zh-HK`, `zh`) resolves to `zh-CN`.
-    - All other locales resolve to `en` (English).
+    - All other locales — including explicit non-Chinese values of `WARP_LANG` — resolve to `en` (English).
+    - The explicit `WARP_LANG` override is NOT passed through as a raw locale string. Setting `WARP_LANG=fr` results in `en`, not `fr`.
 
 1.3. The application ships with exactly two locale files: `en.yml` and `zh-CN.yml`.
 

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -64,7 +64,7 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 ### 2. Translation rendering
 
-2.1. Every user-facing text string in the Warp UI is translated via the `t!("dot.path")` macro. The argument to `t!()` is a dot-separated path into a YAML locale file — this path is the lookup key. The English value at that path in `en.yml` serves as the fallback text when no translation exists for the active locale. The Chinese value at the same path in `zh-CN.yml` is shown when zh-CN is active.
+2.1. Every user-facing text string in the Warp UI is translated via the `t!("dot.path")` macro or the security-sensitive `t_required!("dot.path", "English fallback")` macro. The key argument is a dot-separated path into a YAML locale file. The English value at that path in `en.yml` serves as the fallback text when no translation exists for the active locale. The Chinese value at the same path in `zh-CN.yml` is shown when zh-CN is active.
 
 2.2. When a translation is requested for a given key:
     1. The active locale file is checked first.

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -1,0 +1,108 @@
+# PRODUCT: i18n / Multiple Language Support
+
+## Summary
+
+Add internationalization (i18n) support to Warp, enabling the application UI to render in languages other than English. Simplified Chinese (zh-CN) is shipped as the first non-English locale. English remains the default and fallback language. Locale selection is automatic based on system settings, with an environment variable override for power users.
+
+## Problem
+
+Warp's UI is entirely hardcoded in English. Non-English-speaking developers must navigate menus, settings, agent UI, and onboarding in a language they may not be fluent in, creating friction and limiting adoption. Internationalization is consistently one of the most-requested features from the Warp community.
+
+## Goals / Non-goals
+
+**Goals:**
+- Provide a complete zh-CN translation of the Warp UI
+- Establish an i18n framework that supports adding more locales in the future
+- Automatic locale detection that requires zero configuration
+- Graceful fallback to English for any untranslated strings
+
+**Non-goals:**
+- A language picker in Settings UI (this is env-var-only for the initial release)
+- Pluralization or locale-aware number/date formatting
+- Right-to-left (RTL) language support
+- Runtime locale switching without application restart
+
+## Behavior
+
+### 1. Locale detection
+
+1.1. On application startup, Warp determines the active locale from the following sources, in order:
+    1. The `WARP_LANG` environment variable (highest priority).
+    2. The system locale, read from the platform's native locale API (e.g., `LANG` / `LC_ALL` / `LC_MESSAGES` on Linux, `GetUserDefaultLocaleName` on Windows, `NSLocale` on macOS).
+    3. If no locale can be determined, the application defaults to English (`en`).
+
+1.2. The resolved locale is matched as follows:
+    - Any locale starting with `"zh"` (e.g., `zh-CN`, `zh-TW`, `zh-HK`, `zh`) resolves to `zh-CN`.
+    - All other locales resolve to `en` (English).
+
+1.3. The application ships with exactly two locale files: `en.yml` and `zh-CN.yml`.
+
+### 2. Translation rendering
+
+2.1. Every user-facing text string in the Warp UI is wrapped in a translation call (`t!()` macro in Rust source). English strings serve as both the translation key and the fallback value — the lookup key is a dot-separated path into a YAML locale file.
+
+2.2. When a translation is requested for a given key:
+    1. The active locale file is checked first.
+    2. If the key is missing from the active locale, the English (`en`) locale file is checked.
+    3. If the key is missing from both, the raw key string is displayed (e.g., `"menu.file"`).
+
+2.3. The entire UI surface is covered: macOS menu bar, tab context menus, workspace toolbar, settings panels (AI, appearance, keybindings, billing, features), agent UI, onboarding, auth dialogs, resource center, code review, terminal prompts, tooltips, notifications, and all modal dialogs. In total, approximately 2,700 distinct UI strings are translated.
+
+### 3. String interpolation
+
+3.1. Some translated strings contain dynamic values (e.g., `"Hand off to {environment}"`). These placeholders use `{name}` syntax within the YAML locale strings.
+
+3.2. At render time, the translation macro accepts named arguments: `t!("key", name = value)`. The value is converted to a string and substituted for `{name}` in the translated template.
+
+3.3. If a key with interpolation arguments is missing from both locale files, the raw key is displayed (interpolation is not applied to the fallback key).
+
+### 4. Locale file format
+
+4.1. Locale files use YAML and are stored at `resources/bundled/locales/<locale>.yml`.
+
+4.2. The top-level key in each file is the locale name (e.g., `en:`, `zh-CN:`). Nested YAML structure maps to dot-separated translation keys. For example:
+    ```yaml
+    en:
+      menu:
+        file: "File"
+        edit: "Edit"
+    ```
+    produces keys `menu.file` and `menu.edit`.
+
+4.3. English (`en.yml`) is the canonical source of truth for key names. Every key present in `en.yml` must have a corresponding entry in `zh-CN.yml`.
+
+### 5. Locale switching
+
+5.1. There is no in-app language switcher in the initial release.
+
+5.2. To change locale, the user sets `WARP_LANG=zh-CN` (or `WARP_LANG=zh`) before launching Warp, and the change takes effect on next launch.
+
+5.3. Setting `WARP_LANG` to a non-Chinese value (or unsetting it) restores the system-locale-based default (English for non-Chinese systems).
+
+### 6. Fallback and missing translations
+
+6.1. If a translation key is present in `en.yml` but missing from `zh-CN.yml`, the English string is shown. No warning or error is surfaced to the user.
+
+6.2. If a translation key is missing from both `en.yml` and `zh-CN.yml` (e.g., a newly-added UI string that has not been localized yet), the raw key string is shown. This ensures the application never panics or renders empty text due to a missing translation.
+
+6.3. The English locale file (`en.yml`) is always loaded regardless of the active locale, to serve as the fallback.
+
+### 7. Platform consistency
+
+7.1. macOS menu bar items are fully localized. Chinese users see localized menu labels (e.g., "文件" for "File", "编辑" for "Edit").
+
+7.2. Onboarding slides shown to new users on first launch are localized.
+
+7.3. Keyboard shortcut labels and modifier key names are NOT translated (e.g., `⌘S` remains `⌘S` regardless of locale).
+
+7.4. Terminal output (PTY content) is NOT affected by i18n. Only the Warp UI chrome is translated.
+
+## Figma
+
+Figma: none provided
+
+## Open questions
+
+- **Language picker in Settings:** Should a future iteration add a UI language selector in the Appearance or General settings? This would require runtime locale switching without restart.
+- **Contributor workflow:** How should translators contribute locale files for additional languages? A CONTRIBUTING guide for new locale YAML files may be needed.
+- **String extraction:** Should locale keys be auto-generated from source code, or manually authored in YAML? The current approach is manual YAML authorship.

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -26,16 +26,26 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 ### 1. Locale detection
 
-1.1. On application startup, Warp determines the active locale from the following sources, in order:
-    1. The `WARP_LANG` environment variable (highest priority).
-    2. The system locale, read from the platform's native locale API (e.g., `LANG` / `LC_ALL` / `LC_MESSAGES` on Linux, `GetUserDefaultLocaleName` on Windows, `NSLocale` on macOS).
-    3. If no locale can be determined, the application defaults to English (`en`).
+1.1. On application startup, Warp determines the active locale in two steps:
 
-1.2. The resolved locale is matched as follows:
-    - Any locale starting with `"zh"` (e.g., `zh-CN`, `zh-TW`, `zh-HK`, `zh`) resolves to `zh-CN` (Simplified Chinese). This is an intentional simplification: zh-CN is the only Chinese locale shipped, so all Chinese-language systems receive Simplified Chinese.
-    - All other locales — including explicit non-Chinese values of `WARP_LANG` — resolve to `en` (English).
-    - The explicit `WARP_LANG` override is NOT passed through as a raw locale string. Setting `WARP_LANG=fr` results in `en`, not `fr`.
-    - The `WARP_LANG` variable takes precedence over system locale only when its value starts with `"zh"`. On a Chinese-system machine (where the OS locale is `zh-CN`), setting `WARP_LANG=fr` still yields `en`; unsetting `WARP_LANG` restores `zh-CN`.
+    **Step 1 — Resolve the raw locale string.** The first non-empty value from these sources is used:
+    1. `WARP_LANG` environment variable (highest priority)
+    2. `LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES` (POSIX) or platform-native locale API
+    3. Default: `"en"`
+
+    **Step 2 — Classify into a supported locale.** The raw locale string is mapped:
+    - `zh*` → `"zh-CN"`
+    - Everything else → `"en"`
+
+    Step 1 resolves *which* source to use (env var beats system beats default). Step 2 maps the resulting string to one of the two supported locales. The key invariant: Step 2 always produces either `"zh-CN"` or `"en"` — the raw locale string is never used directly.
+
+1.2. Examples:
+    - `WARP_LANG=zh-CN` → zh-CN (env var, zh match)
+    - `WARP_LANG=zh-TW` → zh-CN (env var, zh match)
+    - `WARP_LANG=fr` → en (env var, non-zh match)
+    - Chinese OS, no `WARP_LANG` → zh-CN (system, zh match)
+    - English OS, no `WARP_LANG` → en (system, non-zh match)
+    - No `WARP_LANG`, no system locale → en (default)
 
 1.3. The application ships with exactly two locale files: `en.yml` and `zh-CN.yml`.
 

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -32,7 +32,7 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
     3. If no locale can be determined, the application defaults to English (`en`).
 
 1.2. The resolved locale is matched as follows:
-    - Any locale starting with `"zh"` (e.g., `zh-CN`, `zh-TW`, `zh-HK`, `zh`) resolves to `zh-CN`.
+    - Any locale starting with `"zh"` (e.g., `zh-CN`, `zh-TW`, `zh-HK`, `zh`) resolves to `zh-CN` (Simplified Chinese). This is an intentional simplification: zh-CN is the only Chinese locale shipped, so all Chinese-language systems receive Simplified Chinese.
     - All other locales — including explicit non-Chinese values of `WARP_LANG` — resolve to `en` (English).
     - The explicit `WARP_LANG` override is NOT passed through as a raw locale string. Setting `WARP_LANG=fr` results in `en`, not `fr`.
 

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -28,21 +28,31 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 1.1. The active locale is always exactly `"zh-CN"` or `"en"`. These are the only two supported locales. The determination is:
 
-    A candidate locale string is selected from the first available source:
+    Candidate locale strings are selected from the first available source:
     1. `WARP_LANG` environment variable
-    2. `LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES` environment variables
+    2. `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, `LANG` environment variables
     3. Platform-native system locale API
     4. Default: `"en"`
 
-    The candidate is then classified:
+    Each candidate is normalized before classification:
+    - Trim whitespace.
+    - For `LANGUAGE`, split colon-separated preference lists and evaluate each entry in order.
+    - Strip encoding and modifier suffixes after `.` or `@` (for example, `.UTF-8`, `.utf8`, `@pinyin`).
+    - Treat `_` and `-` as equivalent separators, and compare language/script/region subtags case-insensitively.
+
+    The first supported normalized candidate is then classified:
     - `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, or `zh_Hans*` → `"zh-CN"`
     - Everything else, including `zh-TW`, `zh-HK`, `zh-Hant*`, and other non-Simplified Chinese locales → `"en"`
+    - `WARP_LANG` is an explicit override: if it is set but does not resolve to zh-CN, the active locale is `"en"` and no lower-priority source is consulted.
 
     Examples:
     - `WARP_LANG=zh-CN` → "zh-CN" candidate → zh-CN
+    - `WARP_LANG=zh_CN.UTF-8` → "zh-CN" candidate → zh-CN
     - `WARP_LANG=zh-Hans` → "zh-Hans" candidate → zh-CN
     - `WARP_LANG=zh-TW` → "zh-TW" candidate → en (Traditional Chinese is not shipped yet)
     - `WARP_LANG=fr` → "fr" candidate → en (non-zh candidate, no fallthrough to system)
+    - `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset → first supported candidate is "zh-CN" → zh-CN
+    - `LANG=zh_CN.UTF-8@pinyin` → "zh-CN" candidate → zh-CN
     - No env vars, Simplified Chinese OS → system "zh-CN" → zh-CN
     - No env vars, Traditional Chinese OS → system "zh-TW" → en (Traditional Chinese is not shipped yet)
     - No env vars, English OS → system "en_US" → en
@@ -100,7 +110,9 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 6.3. Security-sensitive UI must not degrade to raw dot-path keys. Auth, billing, sharing/permission, and agent-consent surfaces must either render meaningful embedded English fallback text or fail closed by disabling the affected action and showing a readable English error.
 
-6.4. The English locale file (`en.yml`) is always loaded regardless of the active locale, to serve as the fallback.
+6.4. Security-sensitive call sites must use the required-translation API defined in the technical spec. That API accepts an embedded English fallback string and records the key as security-sensitive for automated checks. Raw-key fallback is allowed only for ordinary UI that has no auth, billing, permission, privacy, sharing, or agent-consent meaning.
+
+6.5. The English locale file (`en.yml`) is always loaded regardless of the active locale, to serve as the fallback.
 
 ### 7. Platform consistency
 

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -28,10 +28,10 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 1.1. The active locale is always exactly `"zh-CN"` or `"en"`. These are the only two supported locales. The determination is:
 
-    Candidate locale strings are selected from the first available source:
+    Candidate locale strings are selected from:
     1. `WARP_LANG` environment variable
-    2. `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, `LANG` environment variables
-    3. Platform-native system locale API
+    2. Platform-native system locale API
+    3. `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, `LANG` environment variables, only when the platform-native locale API is unavailable or returns no locale
     4. Default: `"en"`
 
     Each candidate is normalized before classification:
@@ -42,8 +42,9 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
     The first non-empty source is authoritative:
     - `WARP_LANG` is an explicit override. If it is set, `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, or `zh_Hans*` resolve to `"zh-CN"`; every other value resolves to `"en"` and no lower-priority source is consulted.
-    - For `LANGUAGE`, entries are evaluated in order as a preference list. The first Simplified Chinese entry resolves to `"zh-CN"`. Unsupported entries, including `fr`, `zh-TW`, `zh-HK`, and `zh-Hant*`, are skipped within that list; if no entry resolves to zh-CN, the result is `"en"` and no lower-priority source is consulted.
-    - For `LC_ALL`, `LC_MESSAGES`, `LANG`, and the platform system locale API, Simplified Chinese values resolve to `"zh-CN"`; every other value resolves to `"en"` and no lower-priority source is consulted.
+    - The platform-native system locale API is the zero-configuration desktop default. If it returns a locale, Simplified Chinese values resolve to `"zh-CN"`; every other value resolves to `"en"` and POSIX locale environment variables are not consulted.
+    - POSIX locale environment variables are a fallback for headless, test, or platform API unavailable cases. For `LANGUAGE`, entries are evaluated in order as a preference list. The first Simplified Chinese entry resolves to `"zh-CN"`. Unsupported entries, including `fr`, `zh-TW`, `zh-HK`, and `zh-Hant*`, are skipped within that list; if no entry resolves to zh-CN, the result is `"en"` and no lower-priority source is consulted.
+    - For fallback `LC_ALL`, `LC_MESSAGES`, and `LANG`, Simplified Chinese values resolve to `"zh-CN"`; every other value resolves to `"en"` and no lower-priority source is consulted.
 
     Examples:
     - `WARP_LANG=zh-CN` → "zh-CN" candidate → zh-CN
@@ -51,10 +52,12 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
     - `WARP_LANG=zh-Hans` → "zh-Hans" candidate → zh-CN
     - `WARP_LANG=zh-TW` → "zh-TW" candidate → en (Traditional Chinese is not shipped yet)
     - `WARP_LANG=fr` → "fr" candidate → en (non-zh candidate, no fallthrough to system)
-    - `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset → first supported candidate is "zh-CN" → zh-CN
-    - `LANGUAGE=fr:zh_TW:en` with `WARP_LANG` unset → no Simplified Chinese candidate → en, no fallthrough to `LANG` or system locale
-    - `LC_ALL=fr_FR.UTF-8` and `LANG=zh_CN.UTF-8` with `WARP_LANG`/`LANGUAGE` unset → en because `LC_ALL` is the first non-empty source
-    - `LANG=zh_CN.UTF-8@pinyin` → "zh-CN" candidate → zh-CN
+    - No `WARP_LANG`, Simplified Chinese OS, `LANG=en_US.UTF-8` → system "zh-CN" → zh-CN
+    - No `WARP_LANG`, English OS, `LANG=zh_CN.UTF-8` → system "en-US" → en
+    - `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset and no system locale → first supported fallback candidate is "zh-CN" → zh-CN
+    - `LANGUAGE=fr:zh_TW:en` with `WARP_LANG` unset and no system locale → no Simplified Chinese fallback candidate → en, no fallthrough to `LANG`
+    - `LC_ALL=fr_FR.UTF-8` and `LANG=zh_CN.UTF-8` with `WARP_LANG` unset and no system locale → en because `LC_ALL` is the first non-empty fallback source
+    - `LANG=zh_CN.UTF-8@pinyin` with `WARP_LANG` unset and no system locale → "zh-CN" candidate → zh-CN
     - No env vars, Simplified Chinese OS → system "zh-CN" → zh-CN
     - No env vars, Traditional Chinese OS → system "zh-TW" → en (Traditional Chinese is not shipped yet)
     - No env vars, English OS → system "en_US" → en

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -35,17 +35,20 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
     4. Default: `"en"`
 
     The candidate is then classified:
-    - Starts with `"zh"` → `"zh-CN"`
-    - Otherwise → `"en"`
+    - `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, or `zh_Hans*` → `"zh-CN"`
+    - Everything else, including `zh-TW`, `zh-HK`, `zh-Hant*`, and other non-Simplified Chinese locales → `"en"`
 
     Examples:
     - `WARP_LANG=zh-CN` → "zh-CN" candidate → zh-CN
+    - `WARP_LANG=zh-Hans` → "zh-Hans" candidate → zh-CN
+    - `WARP_LANG=zh-TW` → "zh-TW" candidate → en (Traditional Chinese is not shipped yet)
     - `WARP_LANG=fr` → "fr" candidate → en (non-zh candidate, no fallthrough to system)
-    - No env vars, Chinese OS → system "zh-CN" → zh-CN
+    - No env vars, Simplified Chinese OS → system "zh-CN" → zh-CN
+    - No env vars, Traditional Chinese OS → system "zh-TW" → en (Traditional Chinese is not shipped yet)
     - No env vars, English OS → system "en_US" → en
     - No env vars, no system locale → default "en" → en
 
-1.3. The application ships with exactly two locale files: `en.yml` and `zh-CN.yml`.
+1.2. The application ships with exactly two locale files: `en.yml` and `zh-CN.yml`.
 
 ### 2. Translation rendering
 
@@ -54,7 +57,7 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 2.2. When a translation is requested for a given key:
     1. The active locale file is checked first.
     2. If the key is missing from the active locale, the English (`en`) locale file is checked.
-    3. If the key is missing from both, the raw key string is displayed (e.g., `"menu.file"`).
+    3. For ordinary, non-sensitive UI, if the key is missing from both, the raw key string is displayed (e.g., `"menu.file"`). Security-sensitive exceptions are defined in section 6.
 
 2.3. The entire UI surface is covered: macOS menu bar, tab context menus, workspace toolbar, settings panels (AI, appearance, keybindings, billing, features), agent UI, onboarding, auth dialogs, resource center, code review, terminal prompts, tooltips, notifications, and all modal dialogs. In total, approximately 2,700 distinct UI strings are translated.
 
@@ -64,7 +67,7 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 3.2. At render time, the translation macro accepts named arguments: `t!("key", name = value)`. The value is converted to a string and substituted for `{name}` in the translated template.
 
-3.3. If a key with interpolation arguments is missing from both locale files, the raw key is displayed (interpolation is not applied to the fallback key).
+3.3. If a key with interpolation arguments is missing from both locale files, ordinary non-sensitive UI displays the raw key (interpolation is not applied to the fallback key). Security-sensitive exceptions are defined in section 6.
 
 ### 4. Locale file format
 
@@ -87,19 +90,21 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 5.2. To change locale, the user sets `WARP_LANG=zh-CN` (or `WARP_LANG=zh`) before launching Warp, and the change takes effect on next launch.
 
-5.3. Setting `WARP_LANG` to a non-Chinese value (or unsetting it) restores the system-locale-based default (English for non-Chinese systems).
+5.3. Setting `WARP_LANG` to a non-Simplified-Chinese value explicitly forces English, even on a Chinese-system machine. Only unsetting `WARP_LANG` restores system-locale detection.
 
 ### 6. Fallback and missing translations
 
 6.1. If a translation key is present in `en.yml` but missing from `zh-CN.yml`, the English string is shown. No warning or error is surfaced to the user.
 
-6.2. If a translation key is missing from both `en.yml` and `zh-CN.yml` (e.g., a newly-added UI string that has not been localized yet), the raw key string is shown. This ensures the application never panics or renders empty text due to a missing translation.
+6.2. For ordinary, non-sensitive UI, if a translation key is missing from both `en.yml` and `zh-CN.yml` (e.g., a newly-added UI string that has not been localized yet), the raw key string is shown. This ensures the application never panics or renders empty text due to a missing translation.
 
-6.3. The English locale file (`en.yml`) is always loaded regardless of the active locale, to serve as the fallback.
+6.3. Security-sensitive UI must not degrade to raw dot-path keys. Auth, billing, sharing/permission, and agent-consent surfaces must either render meaningful embedded English fallback text or fail closed by disabling the affected action and showing a readable English error.
+
+6.4. The English locale file (`en.yml`) is always loaded regardless of the active locale, to serve as the fallback.
 
 ### 7. Platform consistency
 
-7.1. macOS menu bar items are fully localized. Chinese users see localized menu labels (e.g., "文件" for "File", "编辑" for "Edit").
+7.1. macOS menu bar items are fully localized. zh-CN users see localized menu labels (e.g., "文件" for "File", "编辑" for "Edit").
 
 7.2. Onboarding slides shown to new users on first launch are localized.
 

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -26,26 +26,24 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
 
 ### 1. Locale detection
 
-1.1. On application startup, Warp determines the active locale in two steps:
+1.1. The active locale is always exactly `"zh-CN"` or `"en"`. These are the only two supported locales. The determination is:
 
-    **Step 1 — Resolve the raw locale string.** The first non-empty value from these sources is used:
-    1. `WARP_LANG` environment variable (highest priority)
-    2. `LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES` (POSIX) or platform-native locale API
-    3. Default: `"en"`
+    A candidate locale string is selected from the first available source:
+    1. `WARP_LANG` environment variable
+    2. `LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES` environment variables
+    3. Platform-native system locale API
+    4. Default: `"en"`
 
-    **Step 2 — Classify into a supported locale.** The raw locale string is mapped:
-    - `zh*` → `"zh-CN"`
-    - Everything else → `"en"`
+    The candidate is then classified:
+    - Starts with `"zh"` → `"zh-CN"`
+    - Otherwise → `"en"`
 
-    Step 1 resolves *which* source to use (env var beats system beats default). Step 2 maps the resulting string to one of the two supported locales. The key invariant: Step 2 always produces either `"zh-CN"` or `"en"` — the raw locale string is never used directly.
-
-1.2. Examples:
-    - `WARP_LANG=zh-CN` → zh-CN (env var, zh match)
-    - `WARP_LANG=zh-TW` → zh-CN (env var, zh match)
-    - `WARP_LANG=fr` → en (env var, non-zh match)
-    - Chinese OS, no `WARP_LANG` → zh-CN (system, zh match)
-    - English OS, no `WARP_LANG` → en (system, non-zh match)
-    - No `WARP_LANG`, no system locale → en (default)
+    Examples:
+    - `WARP_LANG=zh-CN` → "zh-CN" candidate → zh-CN
+    - `WARP_LANG=fr` → "fr" candidate → en (non-zh candidate, no fallthrough to system)
+    - No env vars, Chinese OS → system "zh-CN" → zh-CN
+    - No env vars, English OS → system "en_US" → en
+    - No env vars, no system locale → default "en" → en
 
 1.3. The application ships with exactly two locale files: `en.yml` and `zh-CN.yml`.
 

--- a/specs/gh-1194/PRODUCT.md
+++ b/specs/gh-1194/PRODUCT.md
@@ -40,10 +40,10 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
     - Strip encoding and modifier suffixes after `.` or `@` (for example, `.UTF-8`, `.utf8`, `@pinyin`).
     - Treat `_` and `-` as equivalent separators, and compare language/script/region subtags case-insensitively.
 
-    The first supported normalized candidate is then classified:
-    - `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, or `zh_Hans*` → `"zh-CN"`
-    - Everything else, including `zh-TW`, `zh-HK`, `zh-Hant*`, and other non-Simplified Chinese locales → `"en"`
-    - `WARP_LANG` is an explicit override: if it is set but does not resolve to zh-CN, the active locale is `"en"` and no lower-priority source is consulted.
+    The first non-empty source is authoritative:
+    - `WARP_LANG` is an explicit override. If it is set, `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, or `zh_Hans*` resolve to `"zh-CN"`; every other value resolves to `"en"` and no lower-priority source is consulted.
+    - For `LANGUAGE`, entries are evaluated in order as a preference list. The first Simplified Chinese entry resolves to `"zh-CN"`. Unsupported entries, including `fr`, `zh-TW`, `zh-HK`, and `zh-Hant*`, are skipped within that list; if no entry resolves to zh-CN, the result is `"en"` and no lower-priority source is consulted.
+    - For `LC_ALL`, `LC_MESSAGES`, `LANG`, and the platform system locale API, Simplified Chinese values resolve to `"zh-CN"`; every other value resolves to `"en"` and no lower-priority source is consulted.
 
     Examples:
     - `WARP_LANG=zh-CN` → "zh-CN" candidate → zh-CN
@@ -52,6 +52,8 @@ Warp's UI is entirely hardcoded in English. Non-English-speaking developers must
     - `WARP_LANG=zh-TW` → "zh-TW" candidate → en (Traditional Chinese is not shipped yet)
     - `WARP_LANG=fr` → "fr" candidate → en (non-zh candidate, no fallthrough to system)
     - `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset → first supported candidate is "zh-CN" → zh-CN
+    - `LANGUAGE=fr:zh_TW:en` with `WARP_LANG` unset → no Simplified Chinese candidate → en, no fallthrough to `LANG` or system locale
+    - `LC_ALL=fr_FR.UTF-8` and `LANG=zh_CN.UTF-8` with `WARP_LANG`/`LANGUAGE` unset → en because `LC_ALL` is the first non-empty source
     - `LANG=zh_CN.UTF-8@pinyin` → "zh-CN" candidate → zh-CN
     - No env vars, Simplified Chinese OS → system "zh-CN" → zh-CN
     - No env vars, Traditional Chinese OS → system "zh-TW" → en (Traditional Chinese is not shipped yet)

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -63,7 +63,7 @@ fn load_translations() -> Translations {
 `load_dir` reads all `.yml`/`.yaml` files in a directory, parses them with `serde_yaml`, identifies the locale from the top-level key, and recursively flattens nested YAML into dot-separated keys via `flatten_value`.
 
 **File discovery order** (non-WASM):
-1. `$WARP_LOCALES_DIR` env var (if set). **Trust boundary:** this path is intended for development and testing only. It is not used in production builds — the bundled resources path (priority 2) is the sole source of locale files in shipped binaries. No integrity validation is performed on locale files loaded from this path. If a file is malformed (e.g., invalid YAML, wrong locale key), it is silently skipped and the next discovery path is tried.
+1. `$WARP_LOCALES_DIR` env var (if set). **Trust boundary:** this path is an override for development and testing only. The implementation must gate this path behind `#[cfg(debug_assertions)]` or an equivalent compile-time check so it is never compiled into release/production binaries. In shipped builds, the bundled resources path (priority 2) is the sole source of locale files. No integrity validation is performed on locale files loaded from this path; if a file is malformed (e.g., invalid YAML, wrong locale key), it is silently skipped and the next discovery path is tried.
 2. Platform bundled resources: `<exe_dir>/resources/bundled/locales`
 3. `$CARGO_MANIFEST_DIR/../resources/bundled/locales` (and up to 4 ancestor levels)
 4. `$PWD/resources/bundled/locales`
@@ -113,7 +113,7 @@ Two YAML files at `resources/bundled/locales/`:
 
 Both files share identical structure — 94 top-level YAML sections corresponding to UI areas: `menu`, `tab`, `workspace`, `auth`, `billing`, `settings`, `ai_settings_page`, `terminal`, `shared_session`, `common`, etc.
 
-Each string value in `en.yml` serves as the canonical key identifier. The `zh-CN.yml` file has the same keys with Chinese translations.
+The dot-separated YAML path (e.g., `menu.file`) is the lookup key used in `t!()` calls. The English string value at that path is the runtime fallback rendered when the active locale has no entry. The zh-CN string value is the Chinese rendering shown when zh-CN is active. Both values are independently authored — the key is the path, not the English text.
 
 ### 4. Usage patterns in the codebase
 
@@ -141,6 +141,7 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
 
 ### Locale file integrity (automated)
 - Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` should cause a CI failure.
+- **Interpolation placeholder parity:** for every key whose English value contains `{name}` placeholders, the zh-CN value must contain the exact same set of placeholder names (same count, same names). Mismatched placeholder names (e.g., en has `{count}` but zh-CN has `{number}`) produce runtime rendering bugs and must be rejected at CI time.
 - Both YAML files must parse successfully as valid YAML and produce the expected top-level locale key (`en:` / `zh-CN:`).
 - No orphaned keys: every key referenced by a `t!()` call in the codebase must exist in `en.yml`. A static analysis script (e.g., `rg 't!\("([^"]+)"' --only-matching | sort -u` diffed against keys extracted from `en.yml`) should be runnable locally and in CI to catch callsite-locale drift.
 - The number of keys in `en.yml` and `zh-CN.yml` must be equal (after accounting for any intentionally untranslatable keys).

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -88,7 +88,7 @@ The approved helper functions live in `warp_i18n` so the lint can recognize them
 ```rust
 fn load_translations() -> Translations {
     for dir in locale_dirs() {          // Try multiple filesystem paths
-        if let Some(t) = load_dir(dir) { // First successful directory wins
+        if let Some(t) = load_complete_dir(dir) { // First complete directory wins
             return t;
         }
     }
@@ -96,7 +96,17 @@ fn load_translations() -> Translations {
 }
 ```
 
-`load_dir` reads all `.yml`/`.yaml` files in a directory, parses them with `serde_yaml`, identifies the locale from the top-level key, and recursively flattens nested YAML into dot-separated keys via `flatten_value`.
+`load_complete_dir` reads locale files from one directory, parses them with `serde_yaml`, identifies each locale from the top-level key, and recursively flattens nested YAML into dot-separated keys via `flatten_value`.
+
+A directory is accepted only if it is complete:
+- It contains parseable `en.yml`.
+- It contains parseable `zh-CN.yml`.
+- Both files have the expected top-level locale key (`en:` / `zh-CN:`).
+- Both flattened maps have the same key set after applying the checked-in intentional-exception allowlists.
+- Placeholder parity holds for every shared key.
+- Required security-sensitive keys are present in `en.yml`.
+
+If any completeness check fails, the whole directory is skipped and the next discovery path is tried. A partial `$WARP_LOCALES_DIR`, damaged source-tree checkout, or damaged bundle must not shadow a later complete directory.
 
 **File discovery order** (non-WASM):
 
@@ -118,7 +128,7 @@ The release resource path is platform-specific and must be shared by runtime dis
 | Linux app packages/AppImage | `/opt/warpdotdev/<package>/resources/bundled/locales` inside the package/AppDir |
 | Linux CLI artifact | `<bundle-output>/resources/bundled/locales` adjacent to the CLI binary bundle |
 
-**Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. In debug builds, locale files loaded from dev-only paths are subject to a size cap (8 MB per file) to prevent intentionally large or malformed YAML from causing excessive startup parsing in poisoned local environments. If a file loaded from a dev-only path exceeds the cap or is malformed, it is silently skipped and the next discovery path is tried — the application does not crash.
+**Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. Every runtime-loaded locale file, including release-bundled files, is subject to parser bounds before `serde_yaml` parsing: maximum 8 MB per file, maximum YAML nesting depth 16, maximum 10,000 flattened keys per locale, and scalar string values only after flattening. If a locale file exceeds the bounds, has unsupported YAML shape, is malformed, or fails directory completeness checks, the directory is skipped and the next discovery path is tried. The application does not crash.
 
 **No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. For ordinary non-sensitive UI, the translation map remains empty and `t!()` returns the raw key string as the rendered text. Security-sensitive UI is different: auth, billing, privacy, sharing/permission, and agent-consent surfaces must not render raw dot-path keys. Those call sites must use `t_required!()` with an embedded English fallback, or fail closed by disabling the affected action and showing a readable English error that also uses `t_required!()`.
 
@@ -239,7 +249,7 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` for direct function access 
 - Every `zh-CN.yml` value must be non-empty after trimming whitespace, unless the key is listed in a checked-in empty-value allowlist with a reason.
 - **Interpolation placeholder parity:** for every key whose English value contains `{name}` placeholders, the zh-CN value must contain the exact same set of placeholder names (same count, same names). Mismatched placeholder names (e.g., en has `{count}` but zh-CN has `{number}`) produce runtime rendering bugs and must be rejected at CI time.
 - Both YAML files must parse successfully as valid YAML and produce the expected top-level locale key (`en:` / `zh-CN:`).
-- No orphaned keys: every key referenced by a `t!()` or `t_required!()` call in the codebase must exist in `en.yml`. A static analysis script (e.g., `rg 't(_required)?!\("([^"]+)"' --only-matching | sort -u` diffed against keys extracted from `en.yml`) must run locally and in CI to catch callsite-locale drift.
+- No orphaned keys: every key referenced by a `t!()` or `t_required!()` call in the codebase must exist in `en.yml`. This check must use a Rust-aware parser (`syn` over Rust source files or tree-sitter-rust) to extract macro invocations, not regex-only matching. It must handle multiline macro calls, interpolation arguments, raw string literals, module-qualified macro imports, and both `t!` and `t_required!` forms. Regex may be used only as a fast prefilter before AST parsing.
 - The number of keys in `en.yml` and `zh-CN.yml` must be equal (after accounting for any intentionally untranslatable keys).
 - Copied-English detection: a CI check rejects `zh-CN.yml` values that are byte-identical to their English value, except keys in a checked-in allowlist for brand names, product names, protocol identifiers, keyboard shortcuts, commands, file extensions, URLs, and intentionally untranslated technical terms.
 - zh-CN script coverage: for non-allowlisted values longer than two visible characters, the translation must contain at least one CJK Unified Ideograph or full-width CJK punctuation character. This catches accidental English-only translations without blocking short symbols or brand terms.
@@ -249,6 +259,7 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` for direct function access 
 - Rich/parsed text interpolation audit: a lint scans call sites that pass translated strings into Markdown, rich text, URL/link-capable text, or formatted-fragment APIs. Interpolated values from file paths, branch names, agent labels, server metadata, repository names, or URLs must either be escaped for that renderer or supplied as structured plain-text fragments. The lint rejects direct string concatenation or direct `t!()`/`t_required!()` interpolation into parsed markup.
 - Release bundle check: every packaged app artifact must contain both `en.yml` and `zh-CN.yml` at the exact runtime path for that artifact: macOS `<Warp*.app>/Contents/Resources/bundled/locales`, Windows `{app}\resources\bundled\locales`, Linux app packages/AppImage `/opt/warpdotdev/<package>/resources/bundled/locales`, and Linux CLI `<bundle-output>/resources/bundled/locales`. CI fails if either file is missing from any packaging output or if the validation path differs from runtime discovery.
 - Dev-only locale loading check: release binaries must not reference `$WARP_LOCALES_DIR`, `$PWD/resources/bundled/locales`, or source-tree fallback paths. A binary/string or build-time assertion verifies those discovery paths are compiled out outside `debug_assertions`.
+- Runtime locale bounds check: unit tests cover oversized files, excessive YAML nesting, non-string scalar values after flattening, too many flattened keys, missing `en.yml`, missing `zh-CN.yml`, mismatched key sets, and placeholder mismatch. Every one of these cases must skip the directory rather than partially loading it.
 
 ### Unit tests
 
@@ -266,8 +277,12 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` for direct function access 
   - `LANGUAGE=fr:zh_TW:en` resolves to `en` without falling through to `LANG` or system locale
   - `LC_ALL=fr_FR.UTF-8` with `LANG=zh_CN.UTF-8` resolves to `en` because `LC_ALL` is the first non-empty source
   - `zh-TW`, `zh-HK`, and `zh-Hant*` resolve to `en`
-  - `load_dir()` correctly parses YAML and produces flattened keys
+  - `load_complete_dir()` correctly parses YAML and produces flattened keys
+  - partial locale directories are skipped and do not shadow later complete directories
   - malformed or over-size dev locale files are skipped without panicking
+  - malformed or over-size release-bundled locale files are skipped without panicking
+  - YAML shape bounds reject excessive nesting, too many flattened keys, and non-string flattened values
+  - AST-based key extraction finds single-line and multiline `t!()` / `t_required!()` calls, including security-sensitive required fallback calls
   - Markdown/rich-text lint rejects unescaped interpolation into parsed renderers and accepts approved escaping or structured-fragment APIs
   - locale quality checks reject empty zh-CN values, copied-English values, and non-allowlisted English-only zh-CN values
 

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -33,10 +33,10 @@ pub fn t(key: &'static str) -> Cow<'static, str>        // Primary translation l
 pub fn interpolate(template: &str, args: &[(&str, String)]) -> Cow<'static, str>
 ```
 
-**Locale resolution pipeline** (`init_locale`):
-1. Check `WARP_LANG` env var → if set and starts with `"zh"`, use `zh-CN`.
-2. Check system locale (`LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES` on POSIX; native API on Windows/macOS) → if starts with `"zh"`, use `zh-CN`.
-3. Default to `en`.
+**Locale resolution** (`init_locale`):
+1. Select a candidate locale: first non-empty value from `WARP_LANG` > `LANG` > `LANGUAGE` > `LC_ALL` > `LC_MESSAGES` > system locale API > `"en"` (default).
+2. Classify: if candidate starts with `"zh"` → `"zh-CN"`, otherwise → `"en"`.
+3. The candidate is NOT used as a raw locale string; it is always mapped to one of the two supported values.
 
 **Translation lookup** (`t`):
 1. Look up key in `TRANSLATIONS[current_locale]`.

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -63,10 +63,17 @@ fn load_translations() -> Translations {
 `load_dir` reads all `.yml`/`.yaml` files in a directory, parses them with `serde_yaml`, identifies the locale from the top-level key, and recursively flattens nested YAML into dot-separated keys via `flatten_value`.
 
 **File discovery order** (non-WASM):
-1. `$WARP_LOCALES_DIR` env var (if set). **Trust boundary:** this path is an override for development and testing only. The implementation must gate this path behind `#[cfg(debug_assertions)]` or an equivalent compile-time check so it is never compiled into release/production binaries. In shipped builds, the bundled resources path (priority 2) is the sole source of locale files. No integrity validation is performed on locale files loaded from this path; if a file is malformed (e.g., invalid YAML, wrong locale key), it is silently skipped and the next discovery path is tried.
-2. Platform bundled resources: `<exe_dir>/resources/bundled/locales`
-3. `$CARGO_MANIFEST_DIR/../resources/bundled/locales` (and up to 4 ancestor levels)
-4. `$PWD/resources/bundled/locales`
+
+Release builds (`#[cfg(not(debug_assertions))]`) only search the platform bundled resources path. Dev builds add the following higher-priority paths for rapid iteration:
+
+| Priority | Path | Gate |
+|----------|------|------|
+| 1 | `$WARP_LOCALES_DIR` env var | `#[cfg(debug_assertions)]` |
+| 2 | Platform bundled resources: `<exe_dir>/resources/bundled/locales` | Always enabled |
+| 3 | `$CARGO_MANIFEST_DIR/../resources/bundled/locales` (and up to 4 ancestor levels) | `#[cfg(debug_assertions)]` |
+| 4 | `$PWD/resources/bundled/locales` | `#[cfg(debug_assertions)]` |
+
+**Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. If a file loaded from a dev-only path is malformed (e.g., invalid YAML, wrong locale key), it is silently skipped and the next discovery path is tried — the application does not crash.
 
 ### 2. `t!()` macro (defined in `app/src/lib.rs`)
 
@@ -100,7 +107,7 @@ match i18n::t("some.key") {
 
 The match guard `value if value == key` detects when `t()` returned the key itself (translation missing). In that case, the key string is returned as `Cow::Owned` — interpolation is skipped because there is no template to interpolate into.
 
-A duplicate `t!()` macro exists in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate.
+A duplicate `t!()` macro exists in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate. The two macros are structurally identical — same three match arms, same fallback logic, same interpolation semantics. The only difference is the function reference: `$crate::i18n::t` in the app crate vs `warp_i18n::t` in onboarding. When changes to the macro are needed, both copies must be updated in the same commit. A code comment at each macro location references the other copy's file path to prevent drift.
 
 ### 3. Locale files
 

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -23,13 +23,15 @@ A new workspace crate at `crates/i18n/` with dependencies `serde_yaml` (for pars
 
 **Core types:**
 - `Translations`: `HashMap<Locale, HashMap<Key, String>>` — double-map structure where the outer key is locale (`"en"`, `"zh-CN"`) and the inner key is a dot-separated path (e.g., `"menu.file"`).
+- `TranslationLookup`: enum with `Found(Cow<'static, str>)` and `Missing` variants. Missing state is explicit and is never inferred by comparing rendered text to the lookup key.
 - Global state: `TRANSLATIONS` (lazy-initialized via `OnceLock`) and `CURRENT_LOCALE` (backed by `RwLock<&'static str>`).
 
 **Public API:**
 ```rust
 pub fn init_locale()                                    // Resolve & set current locale
 pub fn set_locale(locale: &str)                         // Force a specific locale
-pub fn t(key: &'static str) -> Cow<'static, str>        // Primary translation lookup
+pub fn lookup(key: &'static str) -> TranslationLookup   // Primary translation lookup
+pub fn t(key: &'static str) -> Cow<'static, str>        // Ordinary UI convenience wrapper
 pub fn t_required(key: &'static str, fallback: &'static str) -> Cow<'static, str>
 pub fn interpolate(template: &str, args: &[(&str, String)]) -> String
 #[macro_export]
@@ -39,7 +41,7 @@ macro_rules! t_required { ... }
 ```
 
 **Locale resolution** (`init_locale`):
-1. Select candidates from the first non-empty source in priority order: `WARP_LANG` > `LANGUAGE` > `LC_ALL` > `LC_MESSAGES` > `LANG` > system locale API > `"en"` (default). `WARP_LANG` is Warp-specific and has highest priority. `LANGUAGE` is treated as the message-translation preference list on Linux-like environments.
+1. Select candidates from the first available source in priority order: `WARP_LANG` > platform-native system locale API > POSIX locale env fallback (`LANGUAGE` > `LC_ALL` > `LC_MESSAGES` > `LANG`) > `"en"` (default). `WARP_LANG` is Warp-specific and has highest priority. The platform-native API is the zero-configuration desktop default. POSIX environment variables are consulted only when the platform API is unavailable or returns no locale, so ordinary shell locale variables do not override desktop language on normal app launches. `LANGUAGE` is treated as the message-translation preference list on Linux-like fallback paths.
 2. Normalize each candidate before classification:
    - Trim whitespace.
    - For `LANGUAGE`, split colon-separated preference lists and evaluate entries in order.
@@ -47,20 +49,23 @@ macro_rules! t_required { ... }
    - Convert `_` to `-`, compare language/script/region subtags case-insensitively, and normalize script/region casing for tests (`zh-hans-cn` → `zh-Hans-CN`).
 3. Resolve the first non-empty source authoritatively:
    - `WARP_LANG`: if the normalized value is Simplified Chinese (`zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, or `zh_Hans*`), return `"zh-CN"`; otherwise return `"en"` without consulting lower-priority sources.
-   - `LANGUAGE`: evaluate colon-separated entries in order. Return `"zh-CN"` for the first Simplified Chinese entry. Skip unsupported entries within the list (`fr`, `zh-TW`, `zh-HK`, `zh-Hant*`, etc.); if no entry is Simplified Chinese, return `"en"` without consulting lower-priority sources.
-   - `LC_ALL`, `LC_MESSAGES`, `LANG`, and system locale API: return `"zh-CN"` for Simplified Chinese values; otherwise return `"en"` without consulting lower-priority sources.
+   - Platform-native system locale API: return `"zh-CN"` for Simplified Chinese values; otherwise return `"en"` without consulting POSIX locale environment variables.
+   - Fallback `LANGUAGE`: evaluate colon-separated entries in order. Return `"zh-CN"` for the first Simplified Chinese entry. Skip unsupported entries within the list (`fr`, `zh-TW`, `zh-HK`, `zh-Hant*`, etc.); if no entry is Simplified Chinese, return `"en"` without consulting lower-priority fallback sources.
+   - Fallback `LC_ALL`, `LC_MESSAGES`, and `LANG`: return `"zh-CN"` for Simplified Chinese values; otherwise return `"en"` without consulting lower-priority fallback sources.
 4. No raw candidate is ever used as a locale key; runtime locale is always one of the two supported values.
 
-**Translation lookup** (`t`):
+**Translation lookup** (`lookup` / `t`):
 1. Look up key in `TRANSLATIONS[current_locale]`.
 2. If missing, fall back to `TRANSLATIONS["en"]`.
-3. If still missing, ordinary non-sensitive UI returns the key string itself as a borrowed `Cow` (never panic, never render empty text). Security-sensitive UI must follow the no-locale fallback rule below instead of rendering raw dot-path keys.
+3. If a value is found, return `TranslationLookup::Found(value)`.
+4. If still missing, return `TranslationLookup::Missing`. The ordinary `t(key)` wrapper converts `Missing` to `Cow::Borrowed(key)` for non-sensitive UI. Security-sensitive UI must use `t_required` / `t_required!()` instead of the ordinary wrapper.
 
 **Required translation lookup** (`t_required`):
 1. Look up key in `TRANSLATIONS[current_locale]`.
 2. If missing, fall back to `TRANSLATIONS["en"]`.
 3. If still missing, return the embedded English fallback passed by the call site.
 4. `t_required` never returns the raw key. Auth, billing, privacy, sharing/permission, and agent-consent surfaces must use this API, either directly or through the `t_required!()` macro.
+5. The fallback literal is not an independent source of English copy. CI verifies that each `t_required!("key", "fallback")` literal is byte-identical to the canonical `en.yml` value for that key, after normalizing line endings. Any exception must be listed in a checked-in allowlist with a reason and owner approval.
 
 **Interpolation** (`interpolate`):
 - Simple `str::replace` of `{name}` placeholders with provided values.
@@ -130,6 +135,8 @@ The release resource path is platform-specific and must be shared by runtime dis
 
 **Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. Every runtime-loaded locale file, including release-bundled files, is subject to parser bounds before `serde_yaml` parsing: maximum 8 MB per file, maximum YAML nesting depth 16, maximum 10,000 flattened keys per locale, and scalar string values only after flattening. If a locale file exceeds the bounds, has unsupported YAML shape, is malformed, or fails directory completeness checks, the directory is skipped and the next discovery path is tried. The application does not crash.
 
+**Parser dependency posture:** `serde_yaml` is treated as a security-sensitive startup parser dependency. The implementation must pin it through `Cargo.lock`, include it in the repository's dependency review / audit workflow, and avoid enabling optional features beyond YAML parsing. Locale files use a deliberately restricted YAML subset: one top-level locale mapping, nested mappings, and string scalar leaves only. Anchors, aliases, merge keys, custom tags, non-string leaves, and multi-document YAML are rejected by shape validation before the flattened map is accepted. Dependency updates to `serde_yaml` or its parser stack must run the malformed/oversized locale tests before merge.
+
 **No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. For ordinary non-sensitive UI, the translation map remains empty and `t!()` returns the raw key string as the rendered text. Security-sensitive UI is different: auth, billing, privacy, sharing/permission, and agent-consent surfaces must not render raw dot-path keys. Those call sites must use `t_required!()` with an embedded English fallback, or fail closed by disabling the affected action and showing a readable English error that also uses `t_required!()`.
 
 ### 2. `t!()` and `t_required!()` macros (defined once in `crates/i18n`)
@@ -142,29 +149,33 @@ The macro has three match arms. The actual expansion uses `match` (not combinato
 // Arm 1: Simple lookup
 t!("menu.file")
 // Expands to:
-match $crate::t("menu.file") {
-    value if value == "menu.file" => Cow::Owned("menu.file".to_string()),
-    value => value,
+match $crate::lookup("menu.file") {
+    $crate::TranslationLookup::Found(value) => value,
+    $crate::TranslationLookup::Missing => Cow::Borrowed("menu.file"),
 }
 
 // Arm 2: Explicit interpolation
 t!("terminal.hand_off", environment = name)
 // Expands to:
-match $crate::t("terminal.hand_off") {
-    value if value == "terminal.hand_off" => Cow::Owned("terminal.hand_off".to_string()),
-    value => Cow::Owned($crate::interpolate(value.as_ref(), &[("environment", format!("{}", name))])),
+match $crate::lookup("terminal.hand_off") {
+    $crate::TranslationLookup::Found(value) => {
+        Cow::Owned($crate::interpolate(value.as_ref(), &[("environment", format!("{}", name))]))
+    }
+    $crate::TranslationLookup::Missing => Cow::Borrowed("terminal.hand_off"),
 }
 
 // Arm 3: Implicit interpolation (variable name = key name)
 t!("some.key", count)
 // Expands to:
-match $crate::t("some.key") {
-    value if value == "some.key" => Cow::Owned("some.key".to_string()),
-    value => Cow::Owned($crate::interpolate(value.as_ref(), &[("count", format!("{}", count))])),
+match $crate::lookup("some.key") {
+    $crate::TranslationLookup::Found(value) => {
+        Cow::Owned($crate::interpolate(value.as_ref(), &[("count", format!("{}", count))]))
+    }
+    $crate::TranslationLookup::Missing => Cow::Borrowed("some.key"),
 }
 ```
 
-The match guard `value if value == key` detects when `t()` returned the key itself (translation missing). In that case, the key string is returned as `Cow::Owned` — interpolation is skipped because there is no template to interpolate into.
+The macros branch on `TranslationLookup::Found` versus `TranslationLookup::Missing`. They must not infer missing state by comparing the rendered string to the key, because a valid translation may intentionally equal its key text. When lookup is missing, interpolation is skipped because there is no template to interpolate into.
 
 `t_required!()` is the security-sensitive variant. It mirrors the same simple and interpolated call shapes, but requires an embedded English fallback literal:
 
@@ -243,6 +254,7 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` for direct function access 
 - The reviewer verifies that Chinese translations preserve the legal and behavioral intent of the original English text — warnings are not weakened, consent semantics are not altered, and permission descriptions remain accurate.
 - A checklist of security-sensitive keys is maintained alongside the locale files for targeted review. It must include exact YAML sections and prefixes for auth, billing, sharing, agent consent, and data-handling surfaces: `auth.*`, `billing.*`, `billing_ext.*`, `teams.*`, `privacy.*`, `shared_session.*`, `agent_management.*`, `hoa_onboarding.*`, `ai_ext.grant_access_files`, `ai_ext.grant_access_repository`, `ai_ext.missing_github_auth`, `ai_ext.authenticate_github`, `ai_ext.hand_off_to_cloud`, `ai_ext.handoff_to_cloud`, `ai_ext.hand_off_to_environment`, `ai_output.manage_ai_autonomy_permissions`, `ai_output.read_mcp_resource_permission`, `ai_output.upload_artifact_permission`, `ai_output.manage_agent_permissions`, and `ai_output.use_computer_permission`. When new permission, handoff, data-retention, or account/billing warning keys are added, the checklist must be updated in the same PR.
 - Every key in that checklist must be reached through `t_required!()` or an explicit fail-closed path. A CI lint rejects security-sensitive keys rendered through plain `t!()` and rejects `t_required!()` calls whose fallback is not a string literal.
+- Every `t_required!()` fallback literal must match the canonical English value in `en.yml` for the same key, after normalizing line endings. A fallback that intentionally differs must be listed in a checked-in allowlist with the key, call site, reason, and product/legal owner approval. This prevents security-sensitive embedded fallback copy from drifting away from reviewed English locale text.
 
 ### Locale file integrity (automated)
 - Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` cause a CI failure.
@@ -254,12 +266,14 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` for direct function access 
 - Copied-English detection: a CI check rejects `zh-CN.yml` values that are byte-identical to their English value, except keys in a checked-in allowlist for brand names, product names, protocol identifiers, keyboard shortcuts, commands, file extensions, URLs, and intentionally untranslated technical terms.
 - zh-CN script coverage: for non-allowlisted values longer than two visible characters, the translation must contain at least one CJK Unified Ideograph or full-width CJK punctuation character. This catches accidental English-only translations without blocking short symbols or brand terms.
 - Security-sensitive translation quality: keys in the security-sensitive checklist must pass the copied-English and CJK checks with no broad section-level allowlist. Any exception requires an inline reason naming the legal/product owner who approved preserving the English text.
+- Required fallback drift check: AST extraction of `t_required!()` calls compares each fallback literal to the corresponding `en.yml` value and fails CI on mismatch unless the exact call site is allowlisted with owner approval.
 - No stale locale keys: every key in `en.yml` is either referenced by `t!()` / `t_required!()` or listed in a checked-in allowlist for platform/resource-only strings.
 - No unlocalized required-scope strings: the static extractor scans the migration-scope directories for UI literals passed to common label/button/menu/tooltip/modal APIs without `t!()` or `t_required!()`. Remaining literals must be intentionally allowed with a reason.
 - Rich/parsed text interpolation audit: a lint scans call sites that pass translated strings into Markdown, rich text, URL/link-capable text, or formatted-fragment APIs. Interpolated values from file paths, branch names, agent labels, server metadata, repository names, or URLs must either be escaped for that renderer or supplied as structured plain-text fragments. The lint rejects direct string concatenation or direct `t!()`/`t_required!()` interpolation into parsed markup.
 - Release bundle check: every packaged app artifact must contain both `en.yml` and `zh-CN.yml` at the exact runtime path for that artifact: macOS `<Warp*.app>/Contents/Resources/bundled/locales`, Windows `{app}\resources\bundled\locales`, Linux app packages/AppImage `/opt/warpdotdev/<package>/resources/bundled/locales`, and Linux CLI `<bundle-output>/resources/bundled/locales`. CI fails if either file is missing from any packaging output or if the validation path differs from runtime discovery.
 - Dev-only locale loading check: release binaries must not reference `$WARP_LOCALES_DIR`, `$PWD/resources/bundled/locales`, or source-tree fallback paths. A binary/string or build-time assertion verifies those discovery paths are compiled out outside `debug_assertions`.
 - Runtime locale bounds check: unit tests cover oversized files, excessive YAML nesting, non-string scalar values after flattening, too many flattened keys, missing `en.yml`, missing `zh-CN.yml`, mismatched key sets, and placeholder mismatch. Every one of these cases must skip the directory rather than partially loading it.
+- YAML parser supply-chain check: dependency review and audit tooling must cover `serde_yaml` and its parser dependencies, and parser updates must run malformed, oversized, multi-document, alias/tag, and unsupported-shape locale tests.
 
 ### Unit tests
 
@@ -268,20 +282,24 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` for direct function access 
   - `t()` with a key present only in English falls back to English
   - `t()` with a missing key returns the key string itself
   - `t_required()` with a missing key returns the embedded English fallback, never the raw key
+  - `t_required!()` fallback literals match `en.yml` canonical English values or fail the drift lint
   - `interpolate()` correctly substitutes one and multiple placeholders
   - exported `t!()` and `t_required!()` macros compile from both `app` and `crates/onboarding` without local macro copies
   - `set_locale("zh-CN")` correctly switches the active locale
   - `set_locale("fr")` falls back to `en`
   - locale normalization handles `zh_CN.UTF-8`, `zh_CN.utf8`, `zh_CN.UTF-8@pinyin`, mixed-case `zh-hans-cn`, and colon-separated `LANGUAGE` lists
   - `WARP_LANG=fr` forces `en` even when lower-priority locale sources are Simplified Chinese
-  - `LANGUAGE=fr:zh_TW:en` resolves to `en` without falling through to `LANG` or system locale
-  - `LC_ALL=fr_FR.UTF-8` with `LANG=zh_CN.UTF-8` resolves to `en` because `LC_ALL` is the first non-empty source
+  - platform-native Simplified Chinese locale resolves to `zh-CN` even when `LANG=en_US.UTF-8`
+  - platform-native English locale resolves to `en` even when `LANG=zh_CN.UTF-8`
+  - `LANGUAGE=fr:zh_TW:en` resolves to `en` without falling through to `LANG` when the platform-native locale API is unavailable
+  - `LC_ALL=fr_FR.UTF-8` with `LANG=zh_CN.UTF-8` resolves to `en` when the platform-native locale API is unavailable because `LC_ALL` is the first non-empty fallback source
   - `zh-TW`, `zh-HK`, and `zh-Hant*` resolve to `en`
   - `load_complete_dir()` correctly parses YAML and produces flattened keys
   - partial locale directories are skipped and do not shadow later complete directories
   - malformed or over-size dev locale files are skipped without panicking
   - malformed or over-size release-bundled locale files are skipped without panicking
   - YAML shape bounds reject excessive nesting, too many flattened keys, and non-string flattened values
+  - YAML shape validation rejects anchors, aliases, merge keys, custom tags, and multi-document YAML
   - AST-based key extraction finds single-line and multiline `t!()` / `t_required!()` calls, including security-sensitive required fallback calls
   - Markdown/rich-text lint rejects unescaped interpolation into parsed renderers and accepts approved escaping or structured-fragment APIs
   - locale quality checks reject empty zh-CN values, copied-English values, and non-allowlisted English-only zh-CN values
@@ -297,10 +315,12 @@ Manual verification must cover platform resource loading and locale detection, n
 | macOS release artifact | `WARP_LANG=zh-TW` | English UI |
 | Windows MSVC release artifact | Simplified Chinese system locale with no `WARP_LANG` | zh-CN UI after bundled resource load |
 | Windows MSVC release artifact | `WARP_LANG=fr` on Simplified Chinese system locale | English UI, proving explicit override behavior |
-| Linux release artifact | `LANG=zh_CN.UTF-8` | zh-CN UI |
-| Linux release artifact | `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset | zh-CN UI |
-| Linux release artifact | `LANGUAGE=fr:zh_TW:en` and `LANG=zh_CN.UTF-8` with `WARP_LANG` unset | English UI, proving unsupported `LANGUAGE` preferences do not fall through to `LANG` |
-| Linux release artifact | `LC_ALL=fr_FR.UTF-8` and `LANG=zh_CN.UTF-8` with `WARP_LANG`/`LANGUAGE` unset | English UI, proving first-source-wins fallback semantics |
+| Linux desktop release artifact | Simplified Chinese system locale, `LANG=en_US.UTF-8`, no `WARP_LANG` | zh-CN UI, proving native desktop locale beats ordinary POSIX env |
+| Linux desktop release artifact | English system locale, `LANG=zh_CN.UTF-8`, no `WARP_LANG` | English UI, proving ordinary POSIX env does not override native desktop locale |
+| Linux fallback/headless test build | no platform-native locale, `LANG=zh_CN.UTF-8` | zh-CN UI |
+| Linux fallback/headless test build | no platform-native locale, `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset | zh-CN UI |
+| Linux fallback/headless test build | no platform-native locale, `LANGUAGE=fr:zh_TW:en` and `LANG=zh_CN.UTF-8` with `WARP_LANG` unset | English UI, proving unsupported `LANGUAGE` preferences do not fall through to `LANG` |
+| Linux fallback/headless test build | no platform-native locale, `LC_ALL=fr_FR.UTF-8` and `LANG=zh_CN.UTF-8` with `WARP_LANG`/`LANGUAGE` unset | English UI, proving first-source-wins fallback semantics |
 | All platforms | bundled locale directory missing or unreadable | app launches; ordinary UI may show raw keys; security-sensitive surfaces show embedded English fallback or disabled fail-closed action |
 | All platforms | terminal PTY output under zh-CN UI | shell output is unchanged |
 | All platforms | deliberate ordinary missing key in a test-only build | raw key renders without panic |
@@ -310,7 +330,7 @@ Manual verification must cover platform resource loading and locale detection, n
 - The `cargo check` / `cargo build` pipeline for the `warp-oss` binary must pass on macOS, Windows MSVC, and Linux
 - All existing tests must pass after the migration — no test assertions may be broken by i18n
 - Behavior invariants from `PRODUCT.md` map to verification steps above
-- CI must run the locale integrity script, translation quality checks, security-sensitive key lint, rich/parsed interpolation lint, macro drift lint, release bundle check, and locale normalization tests before the implementation PR can merge
+- CI must run the locale integrity script, translation quality checks, required-fallback drift lint, security-sensitive key lint, rich/parsed interpolation lint, macro drift lint, release bundle check, parser dependency audit, and locale normalization tests before the implementation PR can merge
 
 ## Parallelization
 

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -63,32 +63,42 @@ fn load_translations() -> Translations {
 `load_dir` reads all `.yml`/`.yaml` files in a directory, parses them with `serde_yaml`, identifies the locale from the top-level key, and recursively flattens nested YAML into dot-separated keys via `flatten_value`.
 
 **File discovery order** (non-WASM):
-1. `$WARP_LOCALES_DIR` env var (if set)
+1. `$WARP_LOCALES_DIR` env var (if set). **Trust boundary:** this path is intended for development and testing only. It is not used in production builds — the bundled resources path (priority 2) is the sole source of locale files in shipped binaries. No integrity validation is performed on locale files loaded from this path. If a file is malformed (e.g., invalid YAML, wrong locale key), it is silently skipped and the next discovery path is tried.
 2. Platform bundled resources: `<exe_dir>/resources/bundled/locales`
 3. `$CARGO_MANIFEST_DIR/../resources/bundled/locales` (and up to 4 ancestor levels)
 4. `$PWD/resources/bundled/locales`
 
 ### 2. `t!()` macro (defined in `app/src/lib.rs`)
 
-A `macro_rules!` macro with three match arms:
+A `macro_rules!` macro with three match arms. The actual expansion uses `match` (not combinator chains) to preserve `Cow<'static, str>` type flow:
 
 ```rust
 // Arm 1: Simple lookup
 t!("menu.file")
-// Expands to: i18n::t("menu.file")
+// Expands to:
+match i18n::t("menu.file") {
+    value if value == "menu.file" => Cow::Owned("menu.file".to_string()),
+    value => value,
+}
 
 // Arm 2: Explicit interpolation
 t!("terminal.hand_off", environment = name)
-// Expands to: i18n::t("terminal.hand_off")
-//               .map(|v| i18n::interpolate(&v, &[("environment", format!("{}", name))]))
+// Expands to:
+match i18n::t("terminal.hand_off") {
+    value if value == "terminal.hand_off" => Cow::Owned("terminal.hand_off".to_string()),
+    value => i18n::interpolate(value.as_ref(), &[("environment", format!("{}", name))]),
+}
 
 // Arm 3: Implicit interpolation (variable name = key name)
 t!("some.key", count)
-// Expands to: i18n::t("some.key")
-//               .map(|v| i18n::interpolate(&v, &[("count", format!("{}", count))]))
+// Expands to:
+match i18n::t("some.key") {
+    value if value == "some.key" => Cow::Owned("some.key".to_string()),
+    value => i18n::interpolate(value.as_ref(), &[("count", format!("{}", count))]),
+}
 ```
 
-All arms include the English fallback check: if `t()` returns the key itself (meaning no translation was found), no interpolation is performed — the raw key is returned.
+The match guard `value if value == key` detects when `t()` returned the key itself (translation missing). In that case, the key string is returned as `Cow::Owned` — interpolation is skipped because there is no template to interpolate into.
 
 A duplicate `t!()` macro exists in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate.
 
@@ -128,6 +138,12 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
 `windows-rs` crate macros generate code referencing `i18n::t()` on the `app` crate. Windows resource compilation works correctly because no i18n call appears in a const-evaluation context.
 
 ## Testing and validation
+
+### Locale file integrity (automated)
+- Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` should cause a CI failure.
+- Both YAML files must parse successfully as valid YAML and produce the expected top-level locale key (`en:` / `zh-CN:`).
+- No orphaned keys: every key referenced by a `t!()` call in the codebase must exist in `en.yml`. A static analysis script (e.g., `rg 't!\("([^"]+)"' --only-matching | sort -u` diffed against keys extracted from `en.yml`) should be runnable locally and in CI to catch callsite-locale drift.
+- The number of keys in `en.yml` and `zh-CN.yml` must be equal (after accounting for any intentionally untranslatable keys).
 
 ### Unit tests
 

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -35,18 +35,19 @@ pub fn interpolate(template: &str, args: &[(&str, String)]) -> Cow<'static, str>
 
 **Locale resolution** (`init_locale`):
 1. Select a candidate locale: first non-empty value from `WARP_LANG` > `LANG` > `LANGUAGE` > `LC_ALL` > `LC_MESSAGES` > system locale API > `"en"` (default).
-2. Classify: if candidate starts with `"zh"` → `"zh-CN"`, otherwise → `"en"`.
+2. Classify: `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, and `zh_Hans*` map to `"zh-CN"`; all other candidates, including `zh-TW`, `zh-HK`, and `zh-Hant*`, map to `"en"` until a Traditional Chinese locale ships.
 3. The candidate is NOT used as a raw locale string; it is always mapped to one of the two supported values.
 
 **Translation lookup** (`t`):
 1. Look up key in `TRANSLATIONS[current_locale]`.
 2. If missing, fall back to `TRANSLATIONS["en"]`.
-3. If still missing, return the key string itself as a borrowed `Cow` (never panic, never render empty text).
+3. If still missing, ordinary non-sensitive UI returns the key string itself as a borrowed `Cow` (never panic, never render empty text). Security-sensitive UI must follow the no-locale fallback rule below instead of rendering raw dot-path keys.
 
 **Interpolation** (`interpolate`):
 - Simple `str::replace` of `{name}` placeholders with provided values.
 - Not a template engine — no escaping, no positional arguments, no format specifiers.
 - Values are pre-formatted to `String` by the `t!()` macro before reaching `interpolate`.
+- Interpolated values are treated as plain text. Call sites that render into rich, Markdown, link-capable, or otherwise parsed UI must pass interpolated values through the appropriate escaping layer or build the rich UI from structured fragments rather than by concatenating formatted strings. File paths, branch names, agent-provided labels, and server-provided metadata must never be allowed to inject markup, links, or formatting through translation interpolation.
 
 **YAML loading:**
 ```rust
@@ -75,7 +76,7 @@ Release builds (`#[cfg(not(debug_assertions))]`) only search the platform bundle
 
 **Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. In debug builds, locale files loaded from dev-only paths are subject to a size cap (8 MB per file) to prevent intentionally large or malformed YAML from causing excessive startup parsing in poisoned local environments. If a file loaded from a dev-only path exceeds the cap or is malformed, it is silently skipped and the next discovery path is tried — the application does not crash.
 
-**No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. The translation map remains empty, and every `t!()` call returns its raw key string as the rendered text. The application starts and functions normally — menu items, buttons, and labels display their dot-path keys (e.g., `"menu.file"`, `"common.save"`) instead of English text. This degraded mode ensures the application never fails to launch due to missing locale data.
+**No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. For ordinary non-sensitive UI, the translation map remains empty and `t!()` returns the raw key string as the rendered text. Security-sensitive UI is different: auth, billing, sharing/permission, and agent-consent surfaces must not render raw dot-path keys. Those call sites must either use embedded English fallback strings that do not depend on locale files, or fail closed by disabling the affected action and showing a readable English error.
 
 ### 2. `t!()` macro (defined in `app/src/lib.rs`)
 
@@ -150,8 +151,8 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
 
 ### Security-sensitive translation review (manual)
 - Strings in security-relevant UI surfaces must be manually reviewed by a maintainer before merge. These surfaces include: auth dialogs (sign-in, sign-up, permission prompts), billing pages (pricing, plan descriptions, credit consumption warnings), sharing/permission controls (access grant text, visibility labels), and agent-mode consent prompts (data-handling disclosures, handoff confirmations).
-- The reviewer verifies that Chinesetranslations preserve the legal and behavioral intent of the original English text — warnings are not weakened, consent semantics are not altered, and permission descriptions remain accurate.
-- A checklist of security-sensitive keys (identified by YAML section prefix: `auth.*`, `billing.*`, `teams.*`, `shared_session.*`, `hoa_onboarding.*`) is maintained alongside the locale files for targeted review.
+- The reviewer verifies that Chinese translations preserve the legal and behavioral intent of the original English text — warnings are not weakened, consent semantics are not altered, and permission descriptions remain accurate.
+- A checklist of security-sensitive keys is maintained alongside the locale files for targeted review. It must include exact YAML sections and prefixes for auth, billing, sharing, agent consent, and data-handling surfaces: `auth.*`, `billing.*`, `billing_ext.*`, `teams.*`, `privacy.*`, `shared_session.*`, `agent_management.*`, `hoa_onboarding.*`, `ai_ext.grant_access_files`, `ai_ext.grant_access_repository`, `ai_ext.missing_github_auth`, `ai_ext.authenticate_github`, `ai_ext.hand_off_to_cloud`, `ai_ext.handoff_to_cloud`, `ai_ext.hand_off_to_environment`, `ai_output.manage_ai_autonomy_permissions`, `ai_output.read_mcp_resource_permission`, `ai_output.upload_artifact_permission`, `ai_output.manage_agent_permissions`, and `ai_output.use_computer_permission`. When new permission, handoff, data-retention, or account/billing warning keys are added, the checklist must be updated in the same PR.
 
 ### Locale file integrity (automated)
 - Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` should cause a CI failure.

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -73,7 +73,9 @@ Release builds (`#[cfg(not(debug_assertions))]`) only search the platform bundle
 | 3 | `$CARGO_MANIFEST_DIR/../resources/bundled/locales` (and up to 4 ancestor levels) | `#[cfg(debug_assertions)]` |
 | 4 | `$PWD/resources/bundled/locales` | `#[cfg(debug_assertions)]` |
 
-**Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. If a file loaded from a dev-only path is malformed (e.g., invalid YAML, wrong locale key), it is silently skipped and the next discovery path is tried — the application does not crash.
+**Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. In debug builds, locale files loaded from dev-only paths are subject to a size cap (8 MB per file) to prevent intentionally large or malformed YAML from causing excessive startup parsing in poisoned local environments. If a file loaded from a dev-only path exceeds the cap or is malformed, it is silently skipped and the next discovery path is tried — the application does not crash.
+
+**No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. The translation map remains empty, and every `t!()` call returns its raw key string as the rendered text. The application starts and functions normally — menu items, buttons, and labels display their dot-path keys (e.g., `"menu.file"`, `"common.save"`) instead of English text. This degraded mode ensures the application never fails to launch due to missing locale data.
 
 ### 2. `t!()` macro (defined in `app/src/lib.rs`)
 
@@ -145,6 +147,11 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
 `windows-rs` crate macros generate code referencing `i18n::t()` on the `app` crate. Windows resource compilation works correctly because no i18n call appears in a const-evaluation context.
 
 ## Testing and validation
+
+### Security-sensitive translation review (manual)
+- Strings in security-relevant UI surfaces must be manually reviewed by a maintainer before merge. These surfaces include: auth dialogs (sign-in, sign-up, permission prompts), billing pages (pricing, plan descriptions, credit consumption warnings), sharing/permission controls (access grant text, visibility labels), and agent-mode consent prompts (data-handling disclosures, handoff confirmations).
+- The reviewer verifies that Chinesetranslations preserve the legal and behavioral intent of the original English text — warnings are not weakened, consent semantics are not altered, and permission descriptions remain accurate.
+- A checklist of security-sensitive keys (identified by YAML section prefix: `auth.*`, `billing.*`, `teams.*`, `shared_session.*`, `hoa_onboarding.*`) is maintained alongside the locale files for targeted review.
 
 ### Locale file integrity (automated)
 - Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` should cause a CI failure.

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -5,12 +5,12 @@
 Warp has no existing i18n infrastructure. Every user-facing string in the codebase is a hardcoded English literal — `"Save"`, `"File"`, `"Close tab"`, etc. This spec proposes a custom, lightweight i18n framework built directly into the Warp Rust codebase, with zh-CN as the first non-English locale.
 
 **Relevant files:**
-- `crates/i18n/src/lib.rs` — core i18n engine (new crate)
-- `app/src/lib.rs:4-30` — `t!()` macro definition
+- `crates/i18n/src/lib.rs` — core i18n engine plus single exported `t!()` and `t_required!()` macro definitions
 - `app/src/lib.rs:610` — `init_locale()` call in application startup
 - `resources/bundled/locales/en.yml` — English locale file (2,944 lines)
 - `resources/bundled/locales/zh-CN.yml` — Chinese locale file (2,944 lines)
-- `crates/onboarding/src/lib.rs:3-29` — duplicate `t!()` macro for onboarding binary
+- `app/src/i18n.rs` — re-export of `warp_i18n::*` for app call sites
+- `crates/onboarding/src/lib.rs` — import/re-export of `warp_i18n::{t, t_required}` for onboarding call sites
 - `crates/onboarding/src/bin/main.rs:43` — `init_locale()` for onboarding
 
 **Why not a third-party crate?** Existing Rust i18n crates (Fluent, gettext, ICU4X) add significant complexity and dependencies for a feature that currently only needs two locales with simple key-value lookups. A custom solution keeps the surface area small and the build fast.
@@ -32,6 +32,10 @@ pub fn set_locale(locale: &str)                         // Force a specific loca
 pub fn t(key: &'static str) -> Cow<'static, str>        // Primary translation lookup
 pub fn t_required(key: &'static str, fallback: &'static str) -> Cow<'static, str>
 pub fn interpolate(template: &str, args: &[(&str, String)]) -> String
+#[macro_export]
+macro_rules! t { ... }
+#[macro_export]
+macro_rules! t_required { ... }
 ```
 
 **Locale resolution** (`init_locale`):
@@ -64,6 +68,21 @@ pub fn interpolate(template: &str, args: &[(&str, String)]) -> String
 - Values are pre-formatted to `String` by the `t!()` macro before reaching `interpolate`.
 - `interpolate()` returns an owned `String`; the macros wrap it in `Cow::Owned(...)`. This avoids returning a borrowed value tied to a temporary `Cow` from `t()` or `t_required()`.
 - Interpolated values are treated as plain text. Call sites that render into rich, Markdown, link-capable, or otherwise parsed UI must pass interpolated values through the appropriate escaping layer or build the rich UI from structured fragments rather than by concatenating formatted strings. File paths, branch names, agent-provided labels, and server-provided metadata must never be allowed to inject markup, links, or formatting through translation interpolation.
+
+**Rich/parsed rendering contract:**
+
+Interpolated translations are allowed to enter only these renderer categories:
+
+| Renderer category | Approved strategy |
+|-------------------|-------------------|
+| Plain UI text, labels, buttons, menus, tooltips, toasts without links | Use `t!()` / `t_required!()` directly; interpolation values are plain text. |
+| Formatted text fragments | Build structured fragments and pass dynamic values only through plain-text fragment constructors such as `FormattedTextFragment::plain_text(...)`; do not concatenate dynamic values into markup-bearing fragments. |
+| Markdown body text | Escape dynamic values with `warp_i18n::escape_markdown_text(...)` before interpolation, or avoid interpolation and insert the dynamic value as a plain-text fragment after Markdown parsing. |
+| Markdown link text | Escape dynamic values with `warp_i18n::escape_markdown_link_text(...)`; URLs must not be interpolated into Markdown source. |
+| Link destinations / hrefs | Do not translate or interpolate raw hrefs. Build links with typed link APIs such as `ToastLink::with_href(...)`, `ctx.open_url(...)`, or the relevant URL type after validating the URL with existing URL parsing/allowlist logic. |
+| HTML, webview, or other markup-capable renderers | Do not pass interpolated translated strings directly. Use renderer-specific escaping or structured nodes, with a local allowlist entry naming the API used. |
+
+The approved helper functions live in `warp_i18n` so the lint can recognize them. New renderer APIs that parse markup must be added to the lint configuration in the same PR that introduces their first translated call site.
 
 **YAML loading:**
 ```rust
@@ -103,15 +122,17 @@ The release resource path is platform-specific and must be shared by runtime dis
 
 **No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. For ordinary non-sensitive UI, the translation map remains empty and `t!()` returns the raw key string as the rendered text. Security-sensitive UI is different: auth, billing, privacy, sharing/permission, and agent-consent surfaces must not render raw dot-path keys. Those call sites must use `t_required!()` with an embedded English fallback, or fail closed by disabling the affected action and showing a readable English error that also uses `t_required!()`.
 
-### 2. `t!()` and `t_required!()` macros (defined in `app/src/lib.rs`)
+### 2. `t!()` and `t_required!()` macros (defined once in `crates/i18n`)
 
-`t!()` is a `macro_rules!` macro with three match arms. The actual expansion uses `match` (not combinator chains) to preserve `Cow<'static, str>` type flow:
+`t!()` is a `#[macro_export] macro_rules!` macro owned by `crates/i18n`. The app and onboarding binaries import the same macro from `warp_i18n`; they must not maintain local duplicate macro definitions. This keeps fallback and security-sensitive behavior single-sourced.
+
+The macro has three match arms. The actual expansion uses `match` (not combinator chains) to preserve `Cow<'static, str>` type flow:
 
 ```rust
 // Arm 1: Simple lookup
 t!("menu.file")
 // Expands to:
-match i18n::t("menu.file") {
+match $crate::t("menu.file") {
     value if value == "menu.file" => Cow::Owned("menu.file".to_string()),
     value => value,
 }
@@ -119,17 +140,17 @@ match i18n::t("menu.file") {
 // Arm 2: Explicit interpolation
 t!("terminal.hand_off", environment = name)
 // Expands to:
-match i18n::t("terminal.hand_off") {
+match $crate::t("terminal.hand_off") {
     value if value == "terminal.hand_off" => Cow::Owned("terminal.hand_off".to_string()),
-    value => Cow::Owned(i18n::interpolate(value.as_ref(), &[("environment", format!("{}", name))])),
+    value => Cow::Owned($crate::interpolate(value.as_ref(), &[("environment", format!("{}", name))])),
 }
 
 // Arm 3: Implicit interpolation (variable name = key name)
 t!("some.key", count)
 // Expands to:
-match i18n::t("some.key") {
+match $crate::t("some.key") {
     value if value == "some.key" => Cow::Owned("some.key".to_string()),
-    value => Cow::Owned(i18n::interpolate(value.as_ref(), &[("count", format!("{}", count))])),
+    value => Cow::Owned($crate::interpolate(value.as_ref(), &[("count", format!("{}", count))])),
 }
 ```
 
@@ -146,9 +167,9 @@ t_required!(
 )
 ```
 
-The required macro expands through `i18n::t_required(key, fallback)`, then applies interpolation to the translated value or embedded fallback and wraps interpolated output with `Cow::Owned(...)`. It must never branch back to the raw key. The fallback argument must be a string literal so static analysis can verify that every security-sensitive call site has readable English text even when locale files are missing.
+The required macro expands through `$crate::t_required(key, fallback)`, then applies interpolation to the translated value or embedded fallback and wraps interpolated output with `Cow::Owned(...)`. It must never branch back to the raw key. The fallback argument must be a string literal so static analysis can verify that every security-sensitive call site has readable English text even when locale files are missing.
 
-Duplicate `t!()` and `t_required!()` macros exist in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate. The macro copies are structurally identical — same call shapes, same fallback logic, same interpolation semantics. The only difference is the function reference: `$crate::i18n::*` in the app crate vs `warp_i18n::*` in onboarding. When changes to either macro are needed, both copies must be updated in the same commit. A code comment at each macro location references the other copy's file path to prevent drift.
+Both `app` and `crates/onboarding` import these exported macros from `warp_i18n`. A CI lint rejects any local `macro_rules! t` or `macro_rules! t_required` definitions outside `crates/i18n`, preventing macro drift across binaries.
 
 ### 3. Locale files
 
@@ -165,7 +186,7 @@ The dot-separated YAML path (e.g., `menu.file`) is the lookup key used in `t!()`
 
 ### 4. Usage patterns in the codebase
 
-All user-facing string literals are replaced with `t!()` or `t_required!()` calls. ~4,700+ callsites across `app/src/`. Key patterns:
+All user-facing string literals in the required source tree are replaced with `t!()` or `t_required!()` calls. The initial app migration is expected to touch ~4,700+ call sites, plus onboarding, shared UI crates, and platform resource copy discovered by the extractor. Key patterns:
 
 | Pattern | Example | When |
 |---------|---------|------|
@@ -182,23 +203,24 @@ The migration scope must match the product requirement for the whole Warp UI sur
 
 | Area | Required coverage |
 |------|-------------------|
-| macOS app/menu chrome | app menu, tab/window menus, context menus, command palette labels |
-| Core app UI in `app/src/` | workspace, panes, tabs, toolbars, settings, modals, notifications, toasts, tooltips, empty states |
+| `app/src/**` | workspace, panes, tabs, toolbars, settings, modals, notifications, toasts, tooltips, empty states, command palette labels, terminal-adjacent UI chrome |
+| `crates/onboarding/src/**` | first-run onboarding screens, onboarding prompts, onboarding buttons, onboarding error text |
+| UI support crates used by the app (`crates/ui_components/**`, `crates/warpui*/**`, `crates/editor/**` where user-visible labels are authored) | reusable controls, formatted text components, editor labels, shared prompts, and component-owned empty/error states |
+| Platform/app resources (`app/channels/**`, macOS menu/plist resources, Windows installer-visible app metadata when rendered in Warp UI, Linux desktop metadata shown by the app) | app/menu chrome, platform-visible labels owned by Warp, resource strings that surface inside the running application |
 | Account and monetization | auth, onboarding login, teams, billing, plan/credit warnings, payment restriction copy |
 | Sharing and permissions | Warp Drive sharing, shared sessions, access labels, permission prompts |
 | AI and agent surfaces | agent input/output chrome, Oz/cloud handoff, autonomy permissions, MCP/tool permissions, code review UI, agent management |
-| Onboarding binary | first-run onboarding screens and prompts in `crates/onboarding` |
-| Bundled resources | `resources/bundled/locales/en.yml` and `resources/bundled/locales/zh-CN.yml` included in platform release artifacts |
+| Bundled locale resources | `resources/bundled/locales/en.yml` and `resources/bundled/locales/zh-CN.yml` included in platform release artifacts |
 
 Explicit non-goals remain untranslated: PTY output, shell command output, file contents opened by the user, keyboard shortcut glyphs, protocol/log/debug identifiers, telemetry event names, test fixtures, and developer-only tracing.
 
-Coverage is verified by a static extractor that scans Rust call sites for remaining user-visible string literals in the required areas and by locale parity checks against `en.yml`. Any intentional exception must be listed in a checked-in allowlist with a short reason.
+Coverage is verified by a static extractor that scans Rust call sites, macro invocations, platform resource files, and known UI-construction APIs in the required areas. The extractor must include common button/menu/tooltip/modal/toast/settings/action/empty-state constructors and renderer APIs, not only direct `t!()` call sites. Any intentional exception must be listed in a checked-in allowlist with a short reason and an owning surface.
 
 ### 6. Application integration
 
 `init_locale()` is called at the top of `app::run()` (`app/src/lib.rs:610`), before feature flags are initialized and before any UI is created. This ensures translations are available for the entire application lifecycle.
 
-The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the application uses `crate::i18n::t()` without needing to depend on `warp_i18n` directly.
+The `app/src/i18n.rs` file re-exports `warp_i18n::*` for direct function access from app modules. The `t!()` and `t_required!()` macros are imported from `warp_i18n` itself so both the app and onboarding binaries share one macro implementation.
 
 ### 7. Windows compiler support
 
@@ -214,10 +236,14 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
 
 ### Locale file integrity (automated)
 - Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` cause a CI failure.
+- Every `zh-CN.yml` value must be non-empty after trimming whitespace, unless the key is listed in a checked-in empty-value allowlist with a reason.
 - **Interpolation placeholder parity:** for every key whose English value contains `{name}` placeholders, the zh-CN value must contain the exact same set of placeholder names (same count, same names). Mismatched placeholder names (e.g., en has `{count}` but zh-CN has `{number}`) produce runtime rendering bugs and must be rejected at CI time.
 - Both YAML files must parse successfully as valid YAML and produce the expected top-level locale key (`en:` / `zh-CN:`).
 - No orphaned keys: every key referenced by a `t!()` or `t_required!()` call in the codebase must exist in `en.yml`. A static analysis script (e.g., `rg 't(_required)?!\("([^"]+)"' --only-matching | sort -u` diffed against keys extracted from `en.yml`) must run locally and in CI to catch callsite-locale drift.
 - The number of keys in `en.yml` and `zh-CN.yml` must be equal (after accounting for any intentionally untranslatable keys).
+- Copied-English detection: a CI check rejects `zh-CN.yml` values that are byte-identical to their English value, except keys in a checked-in allowlist for brand names, product names, protocol identifiers, keyboard shortcuts, commands, file extensions, URLs, and intentionally untranslated technical terms.
+- zh-CN script coverage: for non-allowlisted values longer than two visible characters, the translation must contain at least one CJK Unified Ideograph or full-width CJK punctuation character. This catches accidental English-only translations without blocking short symbols or brand terms.
+- Security-sensitive translation quality: keys in the security-sensitive checklist must pass the copied-English and CJK checks with no broad section-level allowlist. Any exception requires an inline reason naming the legal/product owner who approved preserving the English text.
 - No stale locale keys: every key in `en.yml` is either referenced by `t!()` / `t_required!()` or listed in a checked-in allowlist for platform/resource-only strings.
 - No unlocalized required-scope strings: the static extractor scans the migration-scope directories for UI literals passed to common label/button/menu/tooltip/modal APIs without `t!()` or `t_required!()`. Remaining literals must be intentionally allowed with a reason.
 - Rich/parsed text interpolation audit: a lint scans call sites that pass translated strings into Markdown, rich text, URL/link-capable text, or formatted-fragment APIs. Interpolated values from file paths, branch names, agent labels, server metadata, repository names, or URLs must either be escaped for that renderer or supplied as structured plain-text fragments. The lint rejects direct string concatenation or direct `t!()`/`t_required!()` interpolation into parsed markup.
@@ -232,6 +258,7 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
   - `t()` with a missing key returns the key string itself
   - `t_required()` with a missing key returns the embedded English fallback, never the raw key
   - `interpolate()` correctly substitutes one and multiple placeholders
+  - exported `t!()` and `t_required!()` macros compile from both `app` and `crates/onboarding` without local macro copies
   - `set_locale("zh-CN")` correctly switches the active locale
   - `set_locale("fr")` falls back to `en`
   - locale normalization handles `zh_CN.UTF-8`, `zh_CN.utf8`, `zh_CN.UTF-8@pinyin`, mixed-case `zh-hans-cn`, and colon-separated `LANGUAGE` lists
@@ -241,6 +268,8 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
   - `zh-TW`, `zh-HK`, and `zh-Hant*` resolve to `en`
   - `load_dir()` correctly parses YAML and produces flattened keys
   - malformed or over-size dev locale files are skipped without panicking
+  - Markdown/rich-text lint rejects unescaped interpolation into parsed renderers and accepts approved escaping or structured-fragment APIs
+  - locale quality checks reject empty zh-CN values, copied-English values, and non-allowlisted English-only zh-CN values
 
 ### Integration / manual verification
 
@@ -266,7 +295,7 @@ Manual verification must cover platform resource loading and locale detection, n
 - The `cargo check` / `cargo build` pipeline for the `warp-oss` binary must pass on macOS, Windows MSVC, and Linux
 - All existing tests must pass after the migration — no test assertions may be broken by i18n
 - Behavior invariants from `PRODUCT.md` map to verification steps above
-- CI must run the locale integrity script, security-sensitive key lint, release bundle check, and locale normalization tests before the implementation PR can merge
+- CI must run the locale integrity script, translation quality checks, security-sensitive key lint, rich/parsed interpolation lint, macro drift lint, release bundle check, and locale normalization tests before the implementation PR can merge
 
 ## Parallelization
 

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -31,7 +31,7 @@ pub fn init_locale()                                    // Resolve & set current
 pub fn set_locale(locale: &str)                         // Force a specific locale
 pub fn t(key: &'static str) -> Cow<'static, str>        // Primary translation lookup
 pub fn t_required(key: &'static str, fallback: &'static str) -> Cow<'static, str>
-pub fn interpolate(template: &str, args: &[(&str, String)]) -> Cow<'static, str>
+pub fn interpolate(template: &str, args: &[(&str, String)]) -> String
 ```
 
 **Locale resolution** (`init_locale`):
@@ -41,9 +41,11 @@ pub fn interpolate(template: &str, args: &[(&str, String)]) -> Cow<'static, str>
    - For `LANGUAGE`, split colon-separated preference lists and evaluate entries in order.
    - Strip encoding and modifier suffixes after `.` or `@` (`zh_CN.UTF-8`, `zh_CN.utf8`, and `zh_CN.UTF-8@pinyin` all normalize to `zh-CN`).
    - Convert `_` to `-`, compare language/script/region subtags case-insensitively, and normalize script/region casing for tests (`zh-hans-cn` → `zh-Hans-CN`).
-3. Classify the first supported normalized candidate: `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, and `zh_Hans*` map to `"zh-CN"`; all other candidates, including `zh-TW`, `zh-HK`, and `zh-Hant*`, map to `"en"` until a Traditional Chinese locale ships.
-4. `WARP_LANG` is an explicit override. If it is set but does not classify to `"zh-CN"`, resolution returns `"en"` and does not fall through to lower-priority system locale sources.
-5. No raw candidate is ever used as a locale key; runtime locale is always one of the two supported values.
+3. Resolve the first non-empty source authoritatively:
+   - `WARP_LANG`: if the normalized value is Simplified Chinese (`zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, or `zh_Hans*`), return `"zh-CN"`; otherwise return `"en"` without consulting lower-priority sources.
+   - `LANGUAGE`: evaluate colon-separated entries in order. Return `"zh-CN"` for the first Simplified Chinese entry. Skip unsupported entries within the list (`fr`, `zh-TW`, `zh-HK`, `zh-Hant*`, etc.); if no entry is Simplified Chinese, return `"en"` without consulting lower-priority sources.
+   - `LC_ALL`, `LC_MESSAGES`, `LANG`, and system locale API: return `"zh-CN"` for Simplified Chinese values; otherwise return `"en"` without consulting lower-priority sources.
+4. No raw candidate is ever used as a locale key; runtime locale is always one of the two supported values.
 
 **Translation lookup** (`t`):
 1. Look up key in `TRANSLATIONS[current_locale]`.
@@ -60,6 +62,7 @@ pub fn interpolate(template: &str, args: &[(&str, String)]) -> Cow<'static, str>
 - Simple `str::replace` of `{name}` placeholders with provided values.
 - Not a template engine — no escaping, no positional arguments, no format specifiers.
 - Values are pre-formatted to `String` by the `t!()` macro before reaching `interpolate`.
+- `interpolate()` returns an owned `String`; the macros wrap it in `Cow::Owned(...)`. This avoids returning a borrowed value tied to a temporary `Cow` from `t()` or `t_required()`.
 - Interpolated values are treated as plain text. Call sites that render into rich, Markdown, link-capable, or otherwise parsed UI must pass interpolated values through the appropriate escaping layer or build the rich UI from structured fragments rather than by concatenating formatted strings. File paths, branch names, agent-provided labels, and server-provided metadata must never be allowed to inject markup, links, or formatting through translation interpolation.
 
 **YAML loading:**
@@ -87,6 +90,15 @@ Release builds (`#[cfg(not(debug_assertions))]`) only search the platform bundle
 | 3 | `$CARGO_MANIFEST_DIR/../resources/bundled/locales` (and up to 4 ancestor levels) | `#[cfg(debug_assertions)]` |
 | 4 | `$PWD/resources/bundled/locales` | `#[cfg(debug_assertions)]` |
 
+The release resource path is platform-specific and must be shared by runtime discovery and bundle validation:
+
+| Platform/artifact | Runtime locale directory |
+|-------------------|--------------------------|
+| macOS `.app` | `<Warp*.app>/Contents/Resources/bundled/locales` |
+| Windows installer output | `<install-dir>\resources\bundled\locales` (Inno `{app}\resources\bundled\locales`) |
+| Linux app packages/AppImage | `/opt/warpdotdev/<package>/resources/bundled/locales` inside the package/AppDir |
+| Linux CLI artifact | `<bundle-output>/resources/bundled/locales` adjacent to the CLI binary bundle |
+
 **Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. In debug builds, locale files loaded from dev-only paths are subject to a size cap (8 MB per file) to prevent intentionally large or malformed YAML from causing excessive startup parsing in poisoned local environments. If a file loaded from a dev-only path exceeds the cap or is malformed, it is silently skipped and the next discovery path is tried — the application does not crash.
 
 **No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. For ordinary non-sensitive UI, the translation map remains empty and `t!()` returns the raw key string as the rendered text. Security-sensitive UI is different: auth, billing, privacy, sharing/permission, and agent-consent surfaces must not render raw dot-path keys. Those call sites must use `t_required!()` with an embedded English fallback, or fail closed by disabling the affected action and showing a readable English error that also uses `t_required!()`.
@@ -109,7 +121,7 @@ t!("terminal.hand_off", environment = name)
 // Expands to:
 match i18n::t("terminal.hand_off") {
     value if value == "terminal.hand_off" => Cow::Owned("terminal.hand_off".to_string()),
-    value => i18n::interpolate(value.as_ref(), &[("environment", format!("{}", name))]),
+    value => Cow::Owned(i18n::interpolate(value.as_ref(), &[("environment", format!("{}", name))])),
 }
 
 // Arm 3: Implicit interpolation (variable name = key name)
@@ -117,7 +129,7 @@ t!("some.key", count)
 // Expands to:
 match i18n::t("some.key") {
     value if value == "some.key" => Cow::Owned("some.key".to_string()),
-    value => i18n::interpolate(value.as_ref(), &[("count", format!("{}", count))]),
+    value => Cow::Owned(i18n::interpolate(value.as_ref(), &[("count", format!("{}", count))])),
 }
 ```
 
@@ -134,7 +146,7 @@ t_required!(
 )
 ```
 
-The required macro expands through `i18n::t_required(key, fallback)`, then applies interpolation to the translated value or embedded fallback. It must never branch back to the raw key. The fallback argument must be a string literal so static analysis can verify that every security-sensitive call site has readable English text even when locale files are missing.
+The required macro expands through `i18n::t_required(key, fallback)`, then applies interpolation to the translated value or embedded fallback and wraps interpolated output with `Cow::Owned(...)`. It must never branch back to the raw key. The fallback argument must be a string literal so static analysis can verify that every security-sensitive call site has readable English text even when locale files are missing.
 
 Duplicate `t!()` and `t_required!()` macros exist in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate. The macro copies are structurally identical — same call shapes, same fallback logic, same interpolation semantics. The only difference is the function reference: `$crate::i18n::*` in the app crate vs `warp_i18n::*` in onboarding. When changes to either macro are needed, both copies must be updated in the same commit. A code comment at each macro location references the other copy's file path to prevent drift.
 
@@ -208,7 +220,8 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
 - The number of keys in `en.yml` and `zh-CN.yml` must be equal (after accounting for any intentionally untranslatable keys).
 - No stale locale keys: every key in `en.yml` is either referenced by `t!()` / `t_required!()` or listed in a checked-in allowlist for platform/resource-only strings.
 - No unlocalized required-scope strings: the static extractor scans the migration-scope directories for UI literals passed to common label/button/menu/tooltip/modal APIs without `t!()` or `t_required!()`. Remaining literals must be intentionally allowed with a reason.
-- Release bundle check: every packaged app artifact must contain both `resources/bundled/locales/en.yml` and `resources/bundled/locales/zh-CN.yml` at the path searched by release builds. CI fails if either file is missing from macOS, Windows, or Linux packaging outputs.
+- Rich/parsed text interpolation audit: a lint scans call sites that pass translated strings into Markdown, rich text, URL/link-capable text, or formatted-fragment APIs. Interpolated values from file paths, branch names, agent labels, server metadata, repository names, or URLs must either be escaped for that renderer or supplied as structured plain-text fragments. The lint rejects direct string concatenation or direct `t!()`/`t_required!()` interpolation into parsed markup.
+- Release bundle check: every packaged app artifact must contain both `en.yml` and `zh-CN.yml` at the exact runtime path for that artifact: macOS `<Warp*.app>/Contents/Resources/bundled/locales`, Windows `{app}\resources\bundled\locales`, Linux app packages/AppImage `/opt/warpdotdev/<package>/resources/bundled/locales`, and Linux CLI `<bundle-output>/resources/bundled/locales`. CI fails if either file is missing from any packaging output or if the validation path differs from runtime discovery.
 - Dev-only locale loading check: release binaries must not reference `$WARP_LOCALES_DIR`, `$PWD/resources/bundled/locales`, or source-tree fallback paths. A binary/string or build-time assertion verifies those discovery paths are compiled out outside `debug_assertions`.
 
 ### Unit tests
@@ -223,6 +236,8 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
   - `set_locale("fr")` falls back to `en`
   - locale normalization handles `zh_CN.UTF-8`, `zh_CN.utf8`, `zh_CN.UTF-8@pinyin`, mixed-case `zh-hans-cn`, and colon-separated `LANGUAGE` lists
   - `WARP_LANG=fr` forces `en` even when lower-priority locale sources are Simplified Chinese
+  - `LANGUAGE=fr:zh_TW:en` resolves to `en` without falling through to `LANG` or system locale
+  - `LC_ALL=fr_FR.UTF-8` with `LANG=zh_CN.UTF-8` resolves to `en` because `LC_ALL` is the first non-empty source
   - `zh-TW`, `zh-HK`, and `zh-Hant*` resolve to `en`
   - `load_dir()` correctly parses YAML and produces flattened keys
   - malformed or over-size dev locale files are skipped without panicking
@@ -240,6 +255,8 @@ Manual verification must cover platform resource loading and locale detection, n
 | Windows MSVC release artifact | `WARP_LANG=fr` on Simplified Chinese system locale | English UI, proving explicit override behavior |
 | Linux release artifact | `LANG=zh_CN.UTF-8` | zh-CN UI |
 | Linux release artifact | `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset | zh-CN UI |
+| Linux release artifact | `LANGUAGE=fr:zh_TW:en` and `LANG=zh_CN.UTF-8` with `WARP_LANG` unset | English UI, proving unsupported `LANGUAGE` preferences do not fall through to `LANG` |
+| Linux release artifact | `LC_ALL=fr_FR.UTF-8` and `LANG=zh_CN.UTF-8` with `WARP_LANG`/`LANGUAGE` unset | English UI, proving first-source-wins fallback semantics |
 | All platforms | bundled locale directory missing or unreadable | app launches; ordinary UI may show raw keys; security-sensitive surfaces show embedded English fallback or disabled fail-closed action |
 | All platforms | terminal PTY output under zh-CN UI | shell output is unchanged |
 | All platforms | deliberate ordinary missing key in a test-only build | raw key renders without panic |

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -30,18 +30,31 @@ A new workspace crate at `crates/i18n/` with dependencies `serde_yaml` (for pars
 pub fn init_locale()                                    // Resolve & set current locale
 pub fn set_locale(locale: &str)                         // Force a specific locale
 pub fn t(key: &'static str) -> Cow<'static, str>        // Primary translation lookup
+pub fn t_required(key: &'static str, fallback: &'static str) -> Cow<'static, str>
 pub fn interpolate(template: &str, args: &[(&str, String)]) -> Cow<'static, str>
 ```
 
 **Locale resolution** (`init_locale`):
-1. Select a candidate locale: first non-empty value from `WARP_LANG` > `LANG` > `LANGUAGE` > `LC_ALL` > `LC_MESSAGES` > system locale API > `"en"` (default).
-2. Classify: `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, and `zh_Hans*` map to `"zh-CN"`; all other candidates, including `zh-TW`, `zh-HK`, and `zh-Hant*`, map to `"en"` until a Traditional Chinese locale ships.
-3. The candidate is NOT used as a raw locale string; it is always mapped to one of the two supported values.
+1. Select candidates from the first non-empty source in priority order: `WARP_LANG` > `LANGUAGE` > `LC_ALL` > `LC_MESSAGES` > `LANG` > system locale API > `"en"` (default). `WARP_LANG` is Warp-specific and has highest priority. `LANGUAGE` is treated as the message-translation preference list on Linux-like environments.
+2. Normalize each candidate before classification:
+   - Trim whitespace.
+   - For `LANGUAGE`, split colon-separated preference lists and evaluate entries in order.
+   - Strip encoding and modifier suffixes after `.` or `@` (`zh_CN.UTF-8`, `zh_CN.utf8`, and `zh_CN.UTF-8@pinyin` all normalize to `zh-CN`).
+   - Convert `_` to `-`, compare language/script/region subtags case-insensitively, and normalize script/region casing for tests (`zh-hans-cn` → `zh-Hans-CN`).
+3. Classify the first supported normalized candidate: `zh`, `zh-CN`, `zh_CN`, `zh-Hans*`, and `zh_Hans*` map to `"zh-CN"`; all other candidates, including `zh-TW`, `zh-HK`, and `zh-Hant*`, map to `"en"` until a Traditional Chinese locale ships.
+4. `WARP_LANG` is an explicit override. If it is set but does not classify to `"zh-CN"`, resolution returns `"en"` and does not fall through to lower-priority system locale sources.
+5. No raw candidate is ever used as a locale key; runtime locale is always one of the two supported values.
 
 **Translation lookup** (`t`):
 1. Look up key in `TRANSLATIONS[current_locale]`.
 2. If missing, fall back to `TRANSLATIONS["en"]`.
 3. If still missing, ordinary non-sensitive UI returns the key string itself as a borrowed `Cow` (never panic, never render empty text). Security-sensitive UI must follow the no-locale fallback rule below instead of rendering raw dot-path keys.
+
+**Required translation lookup** (`t_required`):
+1. Look up key in `TRANSLATIONS[current_locale]`.
+2. If missing, fall back to `TRANSLATIONS["en"]`.
+3. If still missing, return the embedded English fallback passed by the call site.
+4. `t_required` never returns the raw key. Auth, billing, privacy, sharing/permission, and agent-consent surfaces must use this API, either directly or through the `t_required!()` macro.
 
 **Interpolation** (`interpolate`):
 - Simple `str::replace` of `{name}` placeholders with provided values.
@@ -76,11 +89,11 @@ Release builds (`#[cfg(not(debug_assertions))]`) only search the platform bundle
 
 **Security:** Paths 1, 3, and 4 are compiled out of release binaries. This prevents shipped builds from loading arbitrary YAML from environment variables or the current working directory into the startup parsing and UI rendering pipeline. In debug builds, locale files loaded from dev-only paths are subject to a size cap (8 MB per file) to prevent intentionally large or malformed YAML from causing excessive startup parsing in poisoned local environments. If a file loaded from a dev-only path exceeds the cap or is malformed, it is silently skipped and the next discovery path is tried — the application does not crash.
 
-**No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. For ordinary non-sensitive UI, the translation map remains empty and `t!()` returns the raw key string as the rendered text. Security-sensitive UI is different: auth, billing, sharing/permission, and agent-consent surfaces must not render raw dot-path keys. Those call sites must either use embedded English fallback strings that do not depend on locale files, or fail closed by disabling the affected action and showing a readable English error.
+**No-locale fallback:** If no locale file can be loaded from any discovery path (e.g., corrupt installation, missing resource directory), `init_locale()` still completes successfully. For ordinary non-sensitive UI, the translation map remains empty and `t!()` returns the raw key string as the rendered text. Security-sensitive UI is different: auth, billing, privacy, sharing/permission, and agent-consent surfaces must not render raw dot-path keys. Those call sites must use `t_required!()` with an embedded English fallback, or fail closed by disabling the affected action and showing a readable English error that also uses `t_required!()`.
 
-### 2. `t!()` macro (defined in `app/src/lib.rs`)
+### 2. `t!()` and `t_required!()` macros (defined in `app/src/lib.rs`)
 
-A `macro_rules!` macro with three match arms. The actual expansion uses `match` (not combinator chains) to preserve `Cow<'static, str>` type flow:
+`t!()` is a `macro_rules!` macro with three match arms. The actual expansion uses `match` (not combinator chains) to preserve `Cow<'static, str>` type flow:
 
 ```rust
 // Arm 1: Simple lookup
@@ -110,7 +123,20 @@ match i18n::t("some.key") {
 
 The match guard `value if value == key` detects when `t()` returned the key itself (translation missing). In that case, the key string is returned as `Cow::Owned` — interpolation is skipped because there is no template to interpolate into.
 
-A duplicate `t!()` macro exists in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate. The two macros are structurally identical — same three match arms, same fallback logic, same interpolation semantics. The only difference is the function reference: `$crate::i18n::t` in the app crate vs `warp_i18n::t` in onboarding. When changes to the macro are needed, both copies must be updated in the same commit. A code comment at each macro location references the other copy's file path to prevent drift.
+`t_required!()` is the security-sensitive variant. It mirrors the same simple and interpolated call shapes, but requires an embedded English fallback literal:
+
+```rust
+t_required!("auth.require_login_share", "In order to share, please create an account.")
+t_required!(
+    "billing.shared_objects_limit_reached",
+    "Shared {object_type}s limit reached",
+    object_type = object_type_name,
+)
+```
+
+The required macro expands through `i18n::t_required(key, fallback)`, then applies interpolation to the translated value or embedded fallback. It must never branch back to the raw key. The fallback argument must be a string literal so static analysis can verify that every security-sensitive call site has readable English text even when locale files are missing.
+
+Duplicate `t!()` and `t_required!()` macros exist in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate. The macro copies are structurally identical — same call shapes, same fallback logic, same interpolation semantics. The only difference is the function reference: `$crate::i18n::*` in the app crate vs `warp_i18n::*` in onboarding. When changes to either macro are needed, both copies must be updated in the same commit. A code comment at each macro location references the other copy's file path to prevent drift.
 
 ### 3. Locale files
 
@@ -127,23 +153,42 @@ The dot-separated YAML path (e.g., `menu.file`) is the lookup key used in `t!()`
 
 ### 4. Usage patterns in the codebase
 
-All user-facing string literals are replaced with `t!()` calls. ~4,700+ callsites across `app/src/`. Key patterns:
+All user-facing string literals are replaced with `t!()` or `t_required!()` calls. ~4,700+ callsites across `app/src/`. Key patterns:
 
 | Pattern | Example | When |
 |---------|---------|------|
 | Simple string | `t!("common.save")` | Static labels |
 | With interpolation | `t!("ai_output.in_path", path = display_path)` | Dynamic content |
+| Security-sensitive fallback | `t_required!("auth.require_login_share", "In order to share, please create an account.")` | Auth, billing, privacy, sharing, permission, and agent-consent copy |
 | `.to_string()` | `t!("common.save").to_string()` | APIs requiring `String` |
 | In UI components | `ActionButton::new(t!("key"), theme)` | Buttons, menus |
 | In formatted text | `FormattedTextFragment::plain_text(t!("key"))` | Rich text blocks |
 
-### 5. Application integration
+### 5. Migration scope
+
+The migration scope must match the product requirement for the whole Warp UI surface. The implementation PR is not complete until all user-visible string literals in these areas are either localized or explicitly documented as out of scope:
+
+| Area | Required coverage |
+|------|-------------------|
+| macOS app/menu chrome | app menu, tab/window menus, context menus, command palette labels |
+| Core app UI in `app/src/` | workspace, panes, tabs, toolbars, settings, modals, notifications, toasts, tooltips, empty states |
+| Account and monetization | auth, onboarding login, teams, billing, plan/credit warnings, payment restriction copy |
+| Sharing and permissions | Warp Drive sharing, shared sessions, access labels, permission prompts |
+| AI and agent surfaces | agent input/output chrome, Oz/cloud handoff, autonomy permissions, MCP/tool permissions, code review UI, agent management |
+| Onboarding binary | first-run onboarding screens and prompts in `crates/onboarding` |
+| Bundled resources | `resources/bundled/locales/en.yml` and `resources/bundled/locales/zh-CN.yml` included in platform release artifacts |
+
+Explicit non-goals remain untranslated: PTY output, shell command output, file contents opened by the user, keyboard shortcut glyphs, protocol/log/debug identifiers, telemetry event names, test fixtures, and developer-only tracing.
+
+Coverage is verified by a static extractor that scans Rust call sites for remaining user-visible string literals in the required areas and by locale parity checks against `en.yml`. Any intentional exception must be listed in a checked-in allowlist with a short reason.
+
+### 6. Application integration
 
 `init_locale()` is called at the top of `app::run()` (`app/src/lib.rs:610`), before feature flags are initialized and before any UI is created. This ensures translations are available for the entire application lifecycle.
 
 The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the application uses `crate::i18n::t()` without needing to depend on `warp_i18n` directly.
 
-### 6. Windows compiler support
+### 7. Windows compiler support
 
 `windows-rs` crate macros generate code referencing `i18n::t()` on the `app` crate. Windows resource compilation works correctly because no i18n call appears in a const-evaluation context.
 
@@ -153,41 +198,58 @@ The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the applicat
 - Strings in security-relevant UI surfaces must be manually reviewed by a maintainer before merge. These surfaces include: auth dialogs (sign-in, sign-up, permission prompts), billing pages (pricing, plan descriptions, credit consumption warnings), sharing/permission controls (access grant text, visibility labels), and agent-mode consent prompts (data-handling disclosures, handoff confirmations).
 - The reviewer verifies that Chinese translations preserve the legal and behavioral intent of the original English text — warnings are not weakened, consent semantics are not altered, and permission descriptions remain accurate.
 - A checklist of security-sensitive keys is maintained alongside the locale files for targeted review. It must include exact YAML sections and prefixes for auth, billing, sharing, agent consent, and data-handling surfaces: `auth.*`, `billing.*`, `billing_ext.*`, `teams.*`, `privacy.*`, `shared_session.*`, `agent_management.*`, `hoa_onboarding.*`, `ai_ext.grant_access_files`, `ai_ext.grant_access_repository`, `ai_ext.missing_github_auth`, `ai_ext.authenticate_github`, `ai_ext.hand_off_to_cloud`, `ai_ext.handoff_to_cloud`, `ai_ext.hand_off_to_environment`, `ai_output.manage_ai_autonomy_permissions`, `ai_output.read_mcp_resource_permission`, `ai_output.upload_artifact_permission`, `ai_output.manage_agent_permissions`, and `ai_output.use_computer_permission`. When new permission, handoff, data-retention, or account/billing warning keys are added, the checklist must be updated in the same PR.
+- Every key in that checklist must be reached through `t_required!()` or an explicit fail-closed path. A CI lint rejects security-sensitive keys rendered through plain `t!()` and rejects `t_required!()` calls whose fallback is not a string literal.
 
 ### Locale file integrity (automated)
-- Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` should cause a CI failure.
+- Every key present in `en.yml` must have a corresponding key in `zh-CN.yml`. A script or build-time check verifies this invariant — missing keys in `zh-CN.yml` cause a CI failure.
 - **Interpolation placeholder parity:** for every key whose English value contains `{name}` placeholders, the zh-CN value must contain the exact same set of placeholder names (same count, same names). Mismatched placeholder names (e.g., en has `{count}` but zh-CN has `{number}`) produce runtime rendering bugs and must be rejected at CI time.
 - Both YAML files must parse successfully as valid YAML and produce the expected top-level locale key (`en:` / `zh-CN:`).
-- No orphaned keys: every key referenced by a `t!()` call in the codebase must exist in `en.yml`. A static analysis script (e.g., `rg 't!\("([^"]+)"' --only-matching | sort -u` diffed against keys extracted from `en.yml`) should be runnable locally and in CI to catch callsite-locale drift.
+- No orphaned keys: every key referenced by a `t!()` or `t_required!()` call in the codebase must exist in `en.yml`. A static analysis script (e.g., `rg 't(_required)?!\("([^"]+)"' --only-matching | sort -u` diffed against keys extracted from `en.yml`) must run locally and in CI to catch callsite-locale drift.
 - The number of keys in `en.yml` and `zh-CN.yml` must be equal (after accounting for any intentionally untranslatable keys).
+- No stale locale keys: every key in `en.yml` is either referenced by `t!()` / `t_required!()` or listed in a checked-in allowlist for platform/resource-only strings.
+- No unlocalized required-scope strings: the static extractor scans the migration-scope directories for UI literals passed to common label/button/menu/tooltip/modal APIs without `t!()` or `t_required!()`. Remaining literals must be intentionally allowed with a reason.
+- Release bundle check: every packaged app artifact must contain both `resources/bundled/locales/en.yml` and `resources/bundled/locales/zh-CN.yml` at the path searched by release builds. CI fails if either file is missing from macOS, Windows, or Linux packaging outputs.
+- Dev-only locale loading check: release binaries must not reference `$WARP_LOCALES_DIR`, `$PWD/resources/bundled/locales`, or source-tree fallback paths. A binary/string or build-time assertion verifies those discovery paths are compiled out outside `debug_assertions`.
 
 ### Unit tests
 
-- `warp_i18n` should have tests for:
+- `warp_i18n` must include tests for:
   - `t()` with a key present in both locales returns the current locale's value
   - `t()` with a key present only in English falls back to English
   - `t()` with a missing key returns the key string itself
+  - `t_required()` with a missing key returns the embedded English fallback, never the raw key
   - `interpolate()` correctly substitutes one and multiple placeholders
   - `set_locale("zh-CN")` correctly switches the active locale
   - `set_locale("fr")` falls back to `en`
+  - locale normalization handles `zh_CN.UTF-8`, `zh_CN.utf8`, `zh_CN.UTF-8@pinyin`, mixed-case `zh-hans-cn`, and colon-separated `LANGUAGE` lists
+  - `WARP_LANG=fr` forces `en` even when lower-priority locale sources are Simplified Chinese
+  - `zh-TW`, `zh-HK`, and `zh-Hant*` resolve to `en`
   - `load_dir()` correctly parses YAML and produces flattened keys
+  - malformed or over-size dev locale files are skipped without panicking
 
 ### Integration / manual verification
 
-- Launch Warp with `WARP_LANG=zh-CN` on macOS and verify:
-  - Menu bar shows Chinese labels
-  - Settings panels render in Chinese
-  - Agent mode UI texts are in Chinese
-  - Tooltips and notifications are in Chinese
-- Launch without `WARP_LANG` (or with `WARP_LANG=en`) and verify all UI renders in English
-- Verify that terminal PTY output is not affected by locale
-- Verify that a deliberate missing key (present in code but absent from both YAML files) renders as the key string rather than crashing
+Manual verification must cover platform resource loading and locale detection, not just a local dev run:
+
+| Platform | Scenario | Expected result |
+|----------|----------|-----------------|
+| macOS release artifact | `WARP_LANG=zh-CN` | menu bar, settings, agent UI, tooltips, notifications, onboarding entry points render zh-CN |
+| macOS release artifact | `WARP_LANG=zh_CN.UTF-8` | same zh-CN result |
+| macOS release artifact | `WARP_LANG=zh-TW` | English UI |
+| Windows MSVC release artifact | Simplified Chinese system locale with no `WARP_LANG` | zh-CN UI after bundled resource load |
+| Windows MSVC release artifact | `WARP_LANG=fr` on Simplified Chinese system locale | English UI, proving explicit override behavior |
+| Linux release artifact | `LANG=zh_CN.UTF-8` | zh-CN UI |
+| Linux release artifact | `LANGUAGE=fr:zh_CN:en` with `WARP_LANG` unset | zh-CN UI |
+| All platforms | bundled locale directory missing or unreadable | app launches; ordinary UI may show raw keys; security-sensitive surfaces show embedded English fallback or disabled fail-closed action |
+| All platforms | terminal PTY output under zh-CN UI | shell output is unchanged |
+| All platforms | deliberate ordinary missing key in a test-only build | raw key renders without panic |
 
 ### Regression prevention
 
-- The `cargo check` / `cargo build` pipeline for the `warp-oss` binary must pass on both macOS and Windows MSVC
-- All existing tests must pass after the migration — no test assertions should be broken by i18n
+- The `cargo check` / `cargo build` pipeline for the `warp-oss` binary must pass on macOS, Windows MSVC, and Linux
+- All existing tests must pass after the migration — no test assertions may be broken by i18n
 - Behavior invariants from `PRODUCT.md` map to verification steps above
+- CI must run the locale integrity script, security-sensitive key lint, release bundle check, and locale normalization tests before the implementation PR can merge
 
 ## Parallelization
 

--- a/specs/gh-1194/TECH.md
+++ b/specs/gh-1194/TECH.md
@@ -1,0 +1,162 @@
+# TECH: i18n / Multiple Language Support
+
+## Context
+
+Warp has no existing i18n infrastructure. Every user-facing string in the codebase is a hardcoded English literal — `"Save"`, `"File"`, `"Close tab"`, etc. This spec proposes a custom, lightweight i18n framework built directly into the Warp Rust codebase, with zh-CN as the first non-English locale.
+
+**Relevant files:**
+- `crates/i18n/src/lib.rs` — core i18n engine (new crate)
+- `app/src/lib.rs:4-30` — `t!()` macro definition
+- `app/src/lib.rs:610` — `init_locale()` call in application startup
+- `resources/bundled/locales/en.yml` — English locale file (2,944 lines)
+- `resources/bundled/locales/zh-CN.yml` — Chinese locale file (2,944 lines)
+- `crates/onboarding/src/lib.rs:3-29` — duplicate `t!()` macro for onboarding binary
+- `crates/onboarding/src/bin/main.rs:43` — `init_locale()` for onboarding
+
+**Why not a third-party crate?** Existing Rust i18n crates (Fluent, gettext, ICU4X) add significant complexity and dependencies for a feature that currently only needs two locales with simple key-value lookups. A custom solution keeps the surface area small and the build fast.
+
+## Proposed changes
+
+### 1. New crate: `warp_i18n`
+
+A new workspace crate at `crates/i18n/` with dependencies `serde_yaml` (for parsing YAML) and `sys-locale` (for OS-level locale detection).
+
+**Core types:**
+- `Translations`: `HashMap<Locale, HashMap<Key, String>>` — double-map structure where the outer key is locale (`"en"`, `"zh-CN"`) and the inner key is a dot-separated path (e.g., `"menu.file"`).
+- Global state: `TRANSLATIONS` (lazy-initialized via `OnceLock`) and `CURRENT_LOCALE` (backed by `RwLock<&'static str>`).
+
+**Public API:**
+```rust
+pub fn init_locale()                                    // Resolve & set current locale
+pub fn set_locale(locale: &str)                         // Force a specific locale
+pub fn t(key: &'static str) -> Cow<'static, str>        // Primary translation lookup
+pub fn interpolate(template: &str, args: &[(&str, String)]) -> Cow<'static, str>
+```
+
+**Locale resolution pipeline** (`init_locale`):
+1. Check `WARP_LANG` env var → if set and starts with `"zh"`, use `zh-CN`.
+2. Check system locale (`LANG`, `LANGUAGE`, `LC_ALL`, `LC_MESSAGES` on POSIX; native API on Windows/macOS) → if starts with `"zh"`, use `zh-CN`.
+3. Default to `en`.
+
+**Translation lookup** (`t`):
+1. Look up key in `TRANSLATIONS[current_locale]`.
+2. If missing, fall back to `TRANSLATIONS["en"]`.
+3. If still missing, return the key string itself as a borrowed `Cow` (never panic, never render empty text).
+
+**Interpolation** (`interpolate`):
+- Simple `str::replace` of `{name}` placeholders with provided values.
+- Not a template engine — no escaping, no positional arguments, no format specifiers.
+- Values are pre-formatted to `String` by the `t!()` macro before reaching `interpolate`.
+
+**YAML loading:**
+```rust
+fn load_translations() -> Translations {
+    for dir in locale_dirs() {          // Try multiple filesystem paths
+        if let Some(t) = load_dir(dir) { // First successful directory wins
+            return t;
+        }
+    }
+    // On WASM, use include_str!() instead of filesystem access
+}
+```
+
+`load_dir` reads all `.yml`/`.yaml` files in a directory, parses them with `serde_yaml`, identifies the locale from the top-level key, and recursively flattens nested YAML into dot-separated keys via `flatten_value`.
+
+**File discovery order** (non-WASM):
+1. `$WARP_LOCALES_DIR` env var (if set)
+2. Platform bundled resources: `<exe_dir>/resources/bundled/locales`
+3. `$CARGO_MANIFEST_DIR/../resources/bundled/locales` (and up to 4 ancestor levels)
+4. `$PWD/resources/bundled/locales`
+
+### 2. `t!()` macro (defined in `app/src/lib.rs`)
+
+A `macro_rules!` macro with three match arms:
+
+```rust
+// Arm 1: Simple lookup
+t!("menu.file")
+// Expands to: i18n::t("menu.file")
+
+// Arm 2: Explicit interpolation
+t!("terminal.hand_off", environment = name)
+// Expands to: i18n::t("terminal.hand_off")
+//               .map(|v| i18n::interpolate(&v, &[("environment", format!("{}", name))]))
+
+// Arm 3: Implicit interpolation (variable name = key name)
+t!("some.key", count)
+// Expands to: i18n::t("some.key")
+//               .map(|v| i18n::interpolate(&v, &[("count", format!("{}", count))]))
+```
+
+All arms include the English fallback check: if `t()` returns the key itself (meaning no translation was found), no interpolation is performed — the raw key is returned.
+
+A duplicate `t!()` macro exists in `crates/onboarding/src/lib.rs` so the onboarding binary can use translations without depending on the full `app` crate.
+
+### 3. Locale files
+
+Two YAML files at `resources/bundled/locales/`:
+
+| File | Locale | Keys | Lines |
+|------|--------|------|-------|
+| `en.yml` | English (fallback) | ~2,732 | 2,944 |
+| `zh-CN.yml` | Simplified Chinese | ~2,732 | 2,944 |
+
+Both files share identical structure — 94 top-level YAML sections corresponding to UI areas: `menu`, `tab`, `workspace`, `auth`, `billing`, `settings`, `ai_settings_page`, `terminal`, `shared_session`, `common`, etc.
+
+Each string value in `en.yml` serves as the canonical key identifier. The `zh-CN.yml` file has the same keys with Chinese translations.
+
+### 4. Usage patterns in the codebase
+
+All user-facing string literals are replaced with `t!()` calls. ~4,700+ callsites across `app/src/`. Key patterns:
+
+| Pattern | Example | When |
+|---------|---------|------|
+| Simple string | `t!("common.save")` | Static labels |
+| With interpolation | `t!("ai_output.in_path", path = display_path)` | Dynamic content |
+| `.to_string()` | `t!("common.save").to_string()` | APIs requiring `String` |
+| In UI components | `ActionButton::new(t!("key"), theme)` | Buttons, menus |
+| In formatted text | `FormattedTextFragment::plain_text(t!("key"))` | Rich text blocks |
+
+### 5. Application integration
+
+`init_locale()` is called at the top of `app::run()` (`app/src/lib.rs:610`), before feature flags are initialized and before any UI is created. This ensures translations are available for the entire application lifecycle.
+
+The `app/src/i18n.rs` file re-exports `warp_i18n::*` so the rest of the application uses `crate::i18n::t()` without needing to depend on `warp_i18n` directly.
+
+### 6. Windows compiler support
+
+`windows-rs` crate macros generate code referencing `i18n::t()` on the `app` crate. Windows resource compilation works correctly because no i18n call appears in a const-evaluation context.
+
+## Testing and validation
+
+### Unit tests
+
+- `warp_i18n` should have tests for:
+  - `t()` with a key present in both locales returns the current locale's value
+  - `t()` with a key present only in English falls back to English
+  - `t()` with a missing key returns the key string itself
+  - `interpolate()` correctly substitutes one and multiple placeholders
+  - `set_locale("zh-CN")` correctly switches the active locale
+  - `set_locale("fr")` falls back to `en`
+  - `load_dir()` correctly parses YAML and produces flattened keys
+
+### Integration / manual verification
+
+- Launch Warp with `WARP_LANG=zh-CN` on macOS and verify:
+  - Menu bar shows Chinese labels
+  - Settings panels render in Chinese
+  - Agent mode UI texts are in Chinese
+  - Tooltips and notifications are in Chinese
+- Launch without `WARP_LANG` (or with `WARP_LANG=en`) and verify all UI renders in English
+- Verify that terminal PTY output is not affected by locale
+- Verify that a deliberate missing key (present in code but absent from both YAML files) renders as the key string rather than crashing
+
+### Regression prevention
+
+- The `cargo check` / `cargo build` pipeline for the `warp-oss` binary must pass on both macOS and Windows MSVC
+- All existing tests must pass after the migration — no test assertions should be broken by i18n
+- Behavior invariants from `PRODUCT.md` map to verification steps above
+
+## Parallelization
+
+Not applicable. The i18n work is a single cohesive change across the codebase — string replacements, locale file authoring, and framework implementation are all tightly coupled and should be done in a single branch by a single author.


### PR DESCRIPTION
## Description

Product and technical specifications for adding i18n support to Warp with Simplified Chinese (zh-CN) as the first non-English locale. This PR contains only the spec documents (no code).

Closes #1194

### Documents

- `specs/gh-1194/PRODUCT.md` — User-facing behavior spec: locale detection, translation rendering, interpolation, fallback strategy, locale file format, and platform consistency requirements. Written as numbered, testable invariants.
- `specs/gh-1194/TECH.md` — Implementation plan: custom `warp_i18n` crate architecture, `t!()` macro design, YAML loading pipeline, locale resolution logic, usage patterns in the codebase (~4,700 callsites, 2,732 keys), and testing strategy.

### What this covers

The i18n framework is a custom, lightweight system:
- YAML-based locale files under `resources/bundled/locales/`
- Lazy initialization via `OnceLock`
- `WARP_LANG` env var → system locale → English fallback
- Simple `{key}` interpolation
- ~2,700 translatable strings across 94 UI surface areas

CHANGELOG-NEW-FEATURE: Add i18n framework with Simplified Chinese (zh-CN) locale support (spec)