### PR TITLE
Fix API key agent dropdown background

### DIFF
--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -125,6 +125,9 @@ pub struct Menu<A: Action + Clone = ()> {
     /// Optional overrides for the depth-0 menu content padding.
     content_top_padding_override: Option<f32>,
     content_bottom_padding_override: Option<f32>,
+    /// Optional override for the menu surface background. Defaults to
+    /// `theme.surface_2()`.
+    background: Option<Fill>,
     /// If false, selecting a menu item updates selection and emits menu events
     /// without dispatching the item's typed action directly from the menu.
     dispatch_item_actions: bool,
@@ -2144,6 +2147,7 @@ impl<A: Action + Clone> Menu<A> {
             pinned_header_builder: None,
             content_top_padding_override: None,
             content_bottom_padding_override: None,
+            background: None,
             dispatch_item_actions: true,
         }
     }
@@ -2269,6 +2273,10 @@ impl<A: Action + Clone> Menu<A> {
     ) {
         self.content_top_padding_override = top_padding;
         self.content_bottom_padding_override = bottom_padding;
+    }
+
+    pub fn set_background(&mut self, background: Option<Fill>) {
+        self.background = background;
     }
 
     pub fn set_height(&mut self, height: f32) {
@@ -2616,13 +2624,13 @@ impl<A: Action + Clone> SubMenu<A> {
         pinned_header_builder: Option<&PinnedHeaderBuilder>,
         content_top_padding_override: Option<f32>,
         content_bottom_padding_override: Option<f32>,
+        background: Option<Fill>,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let selected_row_index = self.selected_row_index;
         let selected_item_index = self.selected_item_index;
-
-        let background_color = appearance.theme().surface_2();
+        let background_color = background.unwrap_or_else(|| appearance.theme().surface_2());
         let submenus = self.render_submenus(
             submenu_width,
             background_color,
@@ -2794,6 +2802,7 @@ impl<A: Action + Clone> View for Menu<A> {
             self.pinned_header_builder.as_deref(),
             self.content_top_padding_override,
             self.content_bottom_padding_override,
+            self.background,
             app,
         )
     }

--- a/app/src/settings_view/platform/create_api_key_modal.rs
+++ b/app/src/settings_view/platform/create_api_key_modal.rs
@@ -165,8 +165,10 @@ impl CreateApiKeyModal {
         let agent_dropdown =
             ctx.add_typed_action_view(DropdownView::<CreateApiKeyModalAction>::new);
         agent_dropdown.update(ctx, |dropdown, ctx| {
+            let menu_background = Appearance::as_ref(ctx).theme().surface_3();
             dropdown.set_top_bar_max_width(INPUT_WIDTH);
             dropdown.set_menu_width(INPUT_WIDTH, ctx);
+            dropdown.set_menu_background(menu_background, ctx);
         });
 
         let api_key_type_control = ctx.add_typed_action_view(move |ctx| {

--- a/app/src/view_components/dropdown.rs
+++ b/app/src/view_components/dropdown.rs
@@ -22,6 +22,7 @@ use warpui::{
 use crate::{
     appearance::Appearance,
     menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuVariant},
+    themes::theme::Fill as ThemeFill,
 };
 
 pub const TOP_MENU_BAR_HEIGHT: f32 = 30.;
@@ -269,6 +270,13 @@ where
 
     pub fn set_background(&mut self, background: Fill, ctx: &mut ViewContext<Self>) {
         self.background = Some(background);
+        ctx.notify();
+    }
+    pub fn set_menu_background(&mut self, background: ThemeFill, ctx: &mut ViewContext<Self>) {
+        self.dropdown.update(ctx, |menu, ctx| {
+            menu.set_background(Some(background));
+            ctx.notify();
+        });
         ctx.notify();
     }
 


### PR DESCRIPTION
## Description
Fixes the Rust client API key agent selector dropdown rendering with a transparent-looking menu background by letting `Menu` accept an explicit themed background override and applying an opaque elevated `surface_3()` background to the API key modal's agent dropdown.

## Linked Issue
Slack report in `#feedback-platform`.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- [x] `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all --check`
- [x] `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp menu` (148 passed, 4109 skipped)
- [ ] I have manually tested my changes locally with `./script/run`

Manual visual testing was not run in this sandbox.

### Screenshots / Videos
Not included; this sandbox cannot launch the full UI for visual verification.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the API key agent selector dropdown rendering with a transparent background in the Rust client.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/78041795-c33a-48b2-8e44-bb7e2628432f_
_Run: https://oz.staging.warp.dev/runs/019e2a72-d493-700c-8da9-8152c6613d9d_
_This PR was generated with [Oz](https://warp.dev/oz)._
