### PR TITLE
Enter the agent view for third-party harnesses started outside of cloud mode.

### DIFF
--- a/app/src/terminal/shared_session/shared_handlers.rs
+++ b/app/src/terminal/shared_session/shared_handlers.rs
@@ -426,6 +426,10 @@ pub(crate) fn apply_cli_agent_state_update(
                     }
                 });
             }
+
+            view.update(ctx, |view, ctx| {
+                view.sync_agent_view_for_shared_third_party_viewer(ctx);
+            });
         }
         CLIAgentSessionState::Inactive => {
             // Session cleanup is handled by BlockCompleted events on the

--- a/app/src/terminal/shared_session/viewer/event_loop.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop.rs
@@ -248,13 +248,6 @@ impl EventLoop {
                             reconstructed_ai_metadata.clone(),
                         );
 
-                    // The harness command block now exists, so a third-party cloud viewer can enter agent view.
-                    if let Some(view) = self.terminal_view.upgrade(ctx) {
-                        view.update(ctx, |view, ctx| {
-                            view.sync_agent_view_for_shared_third_party_viewer(ctx);
-                        });
-                    }
-
                     // Notify the action model that the action is now executing on the sharer's side
                     // This allows the viewer's UI to show the command as running rather than queued
                     // (which is essential for long running commands to be expandable in the UI).

--- a/app/src/terminal/shared_session/viewer/event_loop.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop.rs
@@ -248,6 +248,13 @@ impl EventLoop {
                             reconstructed_ai_metadata.clone(),
                         );
 
+                    // The harness command block now exists, so a third-party cloud viewer can enter agent view.
+                    if let Some(view) = self.terminal_view.upgrade(ctx) {
+                        view.update(ctx, |view, ctx| {
+                            view.sync_agent_view_for_shared_third_party_viewer(ctx);
+                        });
+                    }
+
                     // Notify the action model that the action is now executing on the sharer's side
                     // This allows the viewer's UI to show the command as running rather than queued
                     // (which is essential for long running commands to be expandable in the UI).

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -124,6 +124,7 @@ pub fn create_cloud_mode_view(
                 | AmbientAgentViewModelEvent::NeedsGithubAuth
                 | AmbientAgentViewModelEvent::Cancelled
                 | AmbientAgentViewModelEvent::HarnessSelected
+                | AmbientAgentViewModelEvent::ViewerHarnessUpdated
                 | AmbientAgentViewModelEvent::HostSelected
                 | AmbientAgentViewModelEvent::HarnessModelSelected
                 | AmbientAgentViewModelEvent::HarnessCommandStarted { .. }

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -124,7 +124,7 @@ pub fn create_cloud_mode_view(
                 | AmbientAgentViewModelEvent::NeedsGithubAuth
                 | AmbientAgentViewModelEvent::Cancelled
                 | AmbientAgentViewModelEvent::HarnessSelected
-                | AmbientAgentViewModelEvent::ViewerHarnessUpdated
+                | AmbientAgentViewModelEvent::ViewerHarnessResolved
                 | AmbientAgentViewModelEvent::HostSelected
                 | AmbientAgentViewModelEvent::HarnessModelSelected
                 | AmbientAgentViewModelEvent::HarnessCommandStarted { .. }

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -852,6 +852,7 @@ impl AmbientAgentViewModel {
 
                     me.set_environment_id(environment_id, ctx);
                     me.set_harness(harness, ctx);
+                    ctx.emit(AmbientAgentViewModelEvent::ViewerHarnessUpdated);
                 }
                 Err(err) => {
                     log::warn!("Failed to fetch ambient agent task for shared session: {err}");
@@ -1555,6 +1556,8 @@ pub enum AmbientAgentViewModelEvent {
     Cancelled,
     /// The selected execution harness (Oz / Claude Code) changed.
     HarnessSelected,
+    /// A shared-session viewer resolved the run harness from the server task.
+    ViewerHarnessUpdated,
     /// The selected worker host changed via the HostSelector.
     HostSelected,
     /// The selected third-party harness model id changed (e.g. user picked `"opus"` for Claude).

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -852,7 +852,7 @@ impl AmbientAgentViewModel {
 
                     me.set_environment_id(environment_id, ctx);
                     me.set_harness(harness, ctx);
-                    ctx.emit(AmbientAgentViewModelEvent::ViewerHarnessUpdated);
+                    ctx.emit(AmbientAgentViewModelEvent::ViewerHarnessResolved);
                 }
                 Err(err) => {
                     log::warn!("Failed to fetch ambient agent task for shared session: {err}");
@@ -1557,7 +1557,7 @@ pub enum AmbientAgentViewModelEvent {
     /// The selected execution harness (Oz / Claude Code) changed.
     HarnessSelected,
     /// A shared-session viewer resolved the run harness from the server task.
-    ViewerHarnessUpdated,
+    ViewerHarnessResolved,
     /// The selected worker host changed via the HostSelector.
     HostSelected,
     /// The selected third-party harness model id changed (e.g. user picked `"opus"` for Claude).

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -302,7 +302,7 @@ impl TerminalView {
                 ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
                 ctx.notify();
             }
-            AmbientAgentViewModelEvent::ViewerHarnessUpdated => {
+            AmbientAgentViewModelEvent::ViewerHarnessResolved => {
                 // Once we know which harness we're using from the server, try and enter the agent
                 // view if we haven't already.
                 self.sync_agent_view_for_shared_third_party_viewer(ctx);

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -17,6 +17,7 @@ use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEn
 use crate::ai::blocklist::{agent_view::AgentViewEntryOrigin, BlocklistAIHistoryModel};
 use crate::ai::conversation_details_panel::ConversationDetailsData;
 use crate::pane_group::TerminalViewResources;
+use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::view::rich_content::{RichContentInsertionPosition, RichContentMetadata};
 use crate::terminal::view::TerminalView;
 use crate::terminal::CLIAgent;
@@ -297,7 +298,7 @@ impl TerminalView {
                 ctx.notify();
             }
             AmbientAgentViewModelEvent::HarnessSelected => {
-                self.maybe_enter_agent_view_for_shared_third_party_viewer(ctx);
+                self.sync_agent_view_for_shared_third_party_viewer(ctx);
                 self.update_pane_configuration(ctx);
                 ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
                 ctx.notify();
@@ -490,10 +491,30 @@ impl TerminalView {
         );
     }
 
-    /// Enters agent view for a live shared-session viewer of a non-oz cloud run, so every
+    /// Returns whether this view is a live shared-session viewer for a non-Oz cloud run.
+    fn is_third_party_cloud_agent_viewer(&self, ctx: &AppContext) -> bool {
+        // We try to detect a third-party harness however we can; because there are a few different
+		// events that may cause it to be set when viewing a shared session, we handle multiple below.
+        let has_third_party_harness = match self.ambient_agent_view_model.as_ref() {
+            // We set the harness on the AmbientAgentViewModel after fetching task data from the server.
+            Some(model) => model.as_ref(ctx).is_third_party_harness(),
+            // When we join a shared session, if the harness is currently active in the sharer,
+			// we should be starting a new CLI agent via the CLIAgentSessionsModel.
+            None => {
+                FeatureFlag::AgentHarness.is_enabled()
+                    && CLIAgentSessionsModel::as_ref(ctx)
+                        .session(self.view_id)
+                        .is_some()
+            }
+        };
+
+        has_third_party_harness && self.is_shared_ambient_agent_session()
+    }
+
+    /// Syncs agent view for a live shared-session viewer of a non-oz cloud run, so every
     /// viewer lands in the same agent-view chrome regardless of which entry point opened the
-    /// conversation. Called from the `HarnessSelected` handler once the viewer has resolved
-    /// the run's harness asynchronously.
+    /// conversation. Called once the viewer has resolved the run's harness asynchronously, and
+    /// after later shared-session block starts.
     ///
     /// Transcript viewer entry is handled directly in `load_data_into_transcript_viewer` so
     /// the snapshot block exists before we retag — we intentionally do not trigger that path
@@ -502,31 +523,21 @@ impl TerminalView {
     /// The viewer-context guard is load-bearing: `HarnessSelected` also fires when the local
     /// spawner picks a harness from the dropdown, and in that case the cloud-mode setup flow
     /// handles agent view entry instead.
-    fn maybe_enter_agent_view_for_shared_third_party_viewer(
+    pub(crate) fn sync_agent_view_for_shared_third_party_viewer(
         &mut self,
         ctx: &mut ViewContext<Self>,
-    ) {
-        if self
+    ) -> Option<AIConversationId> {
+        if !self.is_third_party_cloud_agent_viewer(ctx) {
+            return None;
+        }
+        if let Some(conversation_id) = self
             .agent_view_controller
             .as_ref(ctx)
             .agent_view_state()
-            .is_active()
+            .active_conversation_id()
         {
-            return;
+            return Some(conversation_id);
         }
-        let Some(ambient_agent_view_model) = self.ambient_agent_view_model.as_ref() else {
-            return;
-        };
-        if !ambient_agent_view_model
-            .as_ref(ctx)
-            .is_third_party_harness()
-        {
-            return;
-        }
-        if !self.is_shared_ambient_agent_session() {
-            return;
-        }
-
         self.enter_agent_view_for_new_conversation(
             None,
             AgentViewEntryOrigin::ThirdPartyCloudAgent,
@@ -539,7 +550,7 @@ impl TerminalView {
             .agent_view_state()
             .active_conversation_id()
         else {
-            return;
+            return None;
         };
 
         // Retag existing non-setup blocks so the harness content passes the agent view filter.
@@ -561,6 +572,8 @@ impl TerminalView {
         for view_id in ids_to_retag {
             self.set_rich_content_agent_view_conversation_id(view_id, vehicle_conversation_id);
         }
+
+        Some(vehicle_conversation_id)
     }
 
     /// Returns `true` when the block's command is the CLI for the run's configured

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -298,6 +298,13 @@ impl TerminalView {
                 ctx.notify();
             }
             AmbientAgentViewModelEvent::HarnessSelected => {
+                self.update_pane_configuration(ctx);
+                ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
+                ctx.notify();
+            }
+            AmbientAgentViewModelEvent::ViewerHarnessUpdated => {
+                // Once we know which harness we're using from the server, try and enter the agent
+                // view if we haven't already.
                 self.sync_agent_view_for_shared_third_party_viewer(ctx);
                 self.update_pane_configuration(ctx);
                 ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
@@ -493,9 +500,9 @@ impl TerminalView {
 
     /// Returns whether this view is a live shared-session viewer for a non-Oz cloud run.
     fn is_third_party_cloud_agent_viewer(&self, ctx: &AppContext) -> bool {
-        // The ambient model's harness resolves asynchronously after join, when we fetch the task. 
-		// Until then, use the synced CLI-agent session (which we get on shared session join, if the 
-		// CLI agent is currently active) as the live third-party harness signal.
+        // The ambient model's harness resolves asynchronously after join, when we fetch the task.
+        // Until then, use the synced CLI-agent session (which we get on shared session join, if the
+        // CLI agent is currently active) as the live third-party harness signal.
         let has_ambient_third_party_harness = self
             .ambient_agent_view_model
             .as_ref()
@@ -505,9 +512,10 @@ impl TerminalView {
                 .session(self.view_id)
                 .is_some()
         };
+        let is_shared_ambient_agent_session = self.is_shared_ambient_agent_session();
 
         (has_ambient_third_party_harness || has_cli_agent_session)
-            && self.is_shared_ambient_agent_session()
+            && is_shared_ambient_agent_session
     }
 
     /// Syncs agent view for a live shared-session viewer of a non-oz cloud run, so every
@@ -519,9 +527,8 @@ impl TerminalView {
     /// the snapshot block exists before we retag — we intentionally do not trigger that path
     /// here.
     ///
-    /// The viewer-context guard is load-bearing: `HarnessSelected` also fires when the local
-    /// spawner picks a harness from the dropdown, and in that case the cloud-mode setup flow
-    /// handles agent view entry instead.
+    /// The viewer-context guard is load-bearing because this is also called from shared-session
+    /// block replay, before all server task state may be resolved.
     pub(crate) fn sync_agent_view_for_shared_third_party_viewer(
         &mut self,
         ctx: &mut ViewContext<Self>,

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -493,22 +493,21 @@ impl TerminalView {
 
     /// Returns whether this view is a live shared-session viewer for a non-Oz cloud run.
     fn is_third_party_cloud_agent_viewer(&self, ctx: &AppContext) -> bool {
-        // We try to detect a third-party harness however we can; because there are a few different
-        // events that may cause it to be set when viewing a shared session, we handle multiple below.
-        let has_third_party_harness = match self.ambient_agent_view_model.as_ref() {
-            // We set the harness on the AmbientAgentViewModel after fetching task data from the server.
-            Some(model) => model.as_ref(ctx).is_third_party_harness(),
-            // When we join a shared session, if the harness is currently active in the sharer,
-            // we should be starting a new CLI agent via the CLIAgentSessionsModel.
-            None => {
-                FeatureFlag::AgentHarness.is_enabled()
-                    && CLIAgentSessionsModel::as_ref(ctx)
-                        .session(self.view_id)
-                        .is_some()
-            }
+        // The ambient model's harness resolves asynchronously after join, when we fetch the task. 
+		// Until then, use the synced CLI-agent session (which we get on shared session join, if the 
+		// CLI agent is currently active) as the live third-party harness signal.
+        let has_ambient_third_party_harness = self
+            .ambient_agent_view_model
+            .as_ref()
+            .is_some_and(|model| model.as_ref(ctx).is_third_party_harness());
+        let has_cli_agent_session = FeatureFlag::AgentHarness.is_enabled() && {
+            CLIAgentSessionsModel::as_ref(ctx)
+                .session(self.view_id)
+                .is_some()
         };
 
-        has_third_party_harness && self.is_shared_ambient_agent_session()
+        (has_ambient_third_party_harness || has_cli_agent_session)
+            && self.is_shared_ambient_agent_session()
     }
 
     /// Syncs agent view for a live shared-session viewer of a non-oz cloud run, so every

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -520,15 +520,13 @@ impl TerminalView {
 
     /// Syncs agent view for a live shared-session viewer of a non-oz cloud run, so every
     /// viewer lands in the same agent-view chrome regardless of which entry point opened the
-    /// conversation. Called once the viewer has resolved the run's harness asynchronously, and
-    /// after later shared-session block starts.
+    /// conversation. Called from two independent signals that race:
+    /// - `ViewerHarnessUpdated`: ambient model resolved the harness from the task fetch
+    /// - `apply_cli_agent_state_update`: CLI session synced on viewer join/reconnect
     ///
     /// Transcript viewer entry is handled directly in `load_data_into_transcript_viewer` so
     /// the snapshot block exists before we retag — we intentionally do not trigger that path
     /// here.
-    ///
-    /// The viewer-context guard is load-bearing because this is also called from shared-session
-    /// block replay, before all server task state may be resolved.
     pub(crate) fn sync_agent_view_for_shared_third_party_viewer(
         &mut self,
         ctx: &mut ViewContext<Self>,

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -494,12 +494,12 @@ impl TerminalView {
     /// Returns whether this view is a live shared-session viewer for a non-Oz cloud run.
     fn is_third_party_cloud_agent_viewer(&self, ctx: &AppContext) -> bool {
         // We try to detect a third-party harness however we can; because there are a few different
-		// events that may cause it to be set when viewing a shared session, we handle multiple below.
+        // events that may cause it to be set when viewing a shared session, we handle multiple below.
         let has_third_party_harness = match self.ambient_agent_view_model.as_ref() {
             // We set the harness on the AmbientAgentViewModel after fetching task data from the server.
             Some(model) => model.as_ref(ctx).is_third_party_harness(),
             // When we join a shared session, if the harness is currently active in the sharer,
-			// we should be starting a new CLI agent via the CLIAgentSessionsModel.
+            // we should be starting a new CLI agent via the CLIAgentSessionsModel.
             None => {
                 FeatureFlag::AgentHarness.is_enabled()
                     && CLIAgentSessionsModel::as_ref(ctx)
@@ -544,14 +544,11 @@ impl TerminalView {
             ctx,
         );
 
-        let Some(vehicle_conversation_id) = self
+        let vehicle_conversation_id = self
             .agent_view_controller
             .as_ref(ctx)
             .agent_view_state()
-            .active_conversation_id()
-        else {
-            return None;
-        };
+            .active_conversation_id()?;
 
         // Retag existing non-setup blocks so the harness content passes the agent view filter.
         self.model

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -6,6 +6,8 @@ use crate::ai::agent::{
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use chrono::Local;
 use parking_lot::FairMutex;
+use session_sharing_protocol::common::CLIAgentSessionState;
+use session_sharing_protocol::sharer::SessionSourceType;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -13,6 +15,7 @@ use std::pin::pin;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
+use warp_cli::agent::Harness;
 use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
 use warpui::{
     notification::UserNotification, platform::WindowStyle, Presenter, WindowInvalidation,
@@ -22,8 +25,8 @@ use warpui::{App, ReadModel};
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
 use crate::ai::blocklist::{
-    agent_view::AgentViewEntryOrigin, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
-    InputConfig, InputType, ResponseStreamId,
+    agent_view::{AgentViewEntryOrigin, AgentViewState},
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, InputConfig, InputType, ResponseStreamId,
 };
 use crate::ai::llms::LLMId;
 use crate::context_chips::prompt::Prompt;
@@ -48,10 +51,14 @@ use crate::terminal::cli_agent_sessions::{
 
 use crate::terminal::model::ansi::{self, InitShellValue};
 use crate::terminal::model::ansi::{BootstrappedValue, PreexecValue};
+use crate::terminal::model::block::AgentViewVisibility;
 use crate::terminal::model::blocks::{insert_block, TotalIndex};
 use crate::terminal::model::grid::Dimensions as _;
 use crate::terminal::model::terminal_model::WithinBlock;
 use crate::terminal::session_settings::AgentToolbarChipSelection;
+use crate::terminal::shared_session::shared_handlers::{
+    apply_cli_agent_state_update, RemoteUpdateGuard,
+};
 use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent;
 use crate::terminal::view::load_ai_conversation::RestoredAIConversation;
@@ -916,6 +923,152 @@ fn fresh_cloud_mode_setup_enters_agent_view_when_view_pending() {
     });
 }
 
+#[test]
+fn shared_third_party_viewer_sync_enters_agent_view_and_retags_existing_block() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _agent_harness = FeatureFlag::AgentHarness.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+
+        terminal.update(&mut app, |view, ctx| {
+            let harness_block_id = {
+                let mut model = view.model.lock();
+                model.set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                    task_id: None,
+                });
+                model.set_shared_session_status(SharedSessionStatus::ActiveViewer {
+                    role: Default::default(),
+                });
+                model.simulate_block("claude", "running");
+                model
+                    .block_list()
+                    .blocks()
+                    .iter()
+                    .find(|block| block.command_to_string() == "claude")
+                    .expect("harness block should exist")
+                    .id()
+                    .clone()
+            };
+
+            view.ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .update(ctx, |model, ctx| {
+                    model.set_harness(Harness::Claude, ctx);
+                });
+
+            let conversation_id = view
+                .sync_agent_view_for_shared_third_party_viewer(ctx)
+                .expect("shared third-party viewer should sync");
+            let idempotent_conversation_id = view
+                .sync_agent_view_for_shared_third_party_viewer(ctx)
+                .expect("sync should be idempotent");
+            assert_eq!(conversation_id, idempotent_conversation_id);
+
+            match view.agent_view_controller().as_ref(ctx).agent_view_state() {
+                AgentViewState::Active {
+                    conversation_id: active_conversation_id,
+                    origin,
+                    ..
+                } => {
+                    assert_eq!(*active_conversation_id, conversation_id);
+                    assert_eq!(*origin, AgentViewEntryOrigin::ThirdPartyCloudAgent);
+                }
+                state => panic!("expected active agent view, got {state:?}"),
+            }
+
+            let model = view.model.lock();
+            let block = model
+                .block_list()
+                .block_with_id(&harness_block_id)
+                .expect("harness block should still exist");
+            assert!(!block.should_hide_block(model.block_list().agent_view_state()));
+            match block.agent_view_visibility() {
+                AgentViewVisibility::Terminal {
+                    conversation_ids,
+                    pending_conversation_ids,
+                } => {
+                    assert!(pending_conversation_ids.is_empty());
+                    assert!(conversation_ids.contains(&conversation_id));
+                }
+                visibility => panic!("expected terminal block visibility, got {visibility:?}"),
+            }
+        });
+    });
+}
+
+#[test]
+fn shared_third_party_viewer_syncs_from_cli_agent_state_without_ambient_model() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _agent_harness = FeatureFlag::AgentHarness.override_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        let harness_block_id = terminal.update(&mut app, |view, _| {
+            assert!(view.ambient_agent_view_model().is_none());
+            let mut model = view.model.lock();
+            model.set_shared_session_source_type(SessionSourceType::AmbientAgent { task_id: None });
+            model.set_shared_session_status(SharedSessionStatus::ActiveViewer {
+                role: Default::default(),
+            });
+            model.simulate_block("claude", "running");
+            model
+                .block_list()
+                .blocks()
+                .iter()
+                .find(|block| block.command_to_string() == "claude")
+                .expect("harness block should exist")
+                .id()
+                .clone()
+        });
+
+        app.update(|ctx| {
+            let guard = RemoteUpdateGuard::new();
+            let active_update = guard.start_remote_update();
+            apply_cli_agent_state_update(
+                &terminal.downgrade(),
+                &CLIAgentSessionState::Active {
+                    cli_agent: CLIAgent::Claude.to_serialized_name(),
+                    is_rich_input_open: false,
+                },
+                &active_update,
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let AgentViewState::Active {
+                conversation_id,
+                origin,
+                ..
+            } = view.agent_view_controller().as_ref(ctx).agent_view_state()
+            else {
+                panic!("expected active agent view");
+            };
+            assert_eq!(*origin, AgentViewEntryOrigin::ThirdPartyCloudAgent);
+
+            let model = view.model.lock();
+            let block = model
+                .block_list()
+                .block_with_id(&harness_block_id)
+                .expect("harness block should still exist");
+            assert!(!block.should_hide_block(model.block_list().agent_view_state()));
+            match block.agent_view_visibility() {
+                AgentViewVisibility::Terminal {
+                    conversation_ids,
+                    pending_conversation_ids,
+                } => {
+                    assert!(pending_conversation_ids.is_empty());
+                    assert!(conversation_ids.contains(conversation_id));
+                }
+                visibility => panic!("expected terminal block visibility, got {visibility:?}"),
+            }
+        });
+    });
+}
 #[test]
 fn cloud_mode_followup_input_uses_explicit_submit_event_even_when_view_pending() {
     App::test((), |mut app| async move {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -999,6 +999,74 @@ fn shared_third_party_viewer_sync_enters_agent_view_and_retags_existing_block() 
 }
 
 #[test]
+fn shared_third_party_viewer_syncs_from_viewer_harness_updated_when_harness_unchanged() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _agent_harness = FeatureFlag::AgentHarness.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+
+        terminal.update(&mut app, |view, ctx| {
+            let harness_block_id = {
+                let mut model = view.model.lock();
+                model.set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                    task_id: None,
+                });
+                model.set_shared_session_status(SharedSessionStatus::ActiveViewer {
+                    role: Default::default(),
+                });
+                model.simulate_block("claude", "running");
+                model
+                    .block_list()
+                    .blocks()
+                    .iter()
+                    .find(|block| block.command_to_string() == "claude")
+                    .expect("harness block should exist")
+                    .id()
+                    .clone()
+            };
+
+            view.ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .update(ctx, |model, ctx| {
+                    model.set_harness(Harness::Claude, ctx);
+                    model.set_harness(Harness::Claude, ctx);
+                });
+            assert!(!view.agent_view_controller().as_ref(ctx).is_active());
+
+            view.handle_ambient_agent_event(&AmbientAgentViewModelEvent::ViewerHarnessUpdated, ctx);
+
+            let AgentViewState::Active {
+                conversation_id,
+                origin,
+                ..
+            } = view.agent_view_controller().as_ref(ctx).agent_view_state()
+            else {
+                panic!("expected active agent view");
+            };
+            assert_eq!(*origin, AgentViewEntryOrigin::ThirdPartyCloudAgent);
+
+            let model = view.model.lock();
+            let block = model
+                .block_list()
+                .block_with_id(&harness_block_id)
+                .expect("harness block should still exist");
+            assert!(!block.should_hide_block(model.block_list().agent_view_state()));
+            match block.agent_view_visibility() {
+                AgentViewVisibility::Terminal {
+                    conversation_ids,
+                    pending_conversation_ids,
+                } => {
+                    assert!(pending_conversation_ids.is_empty());
+                    assert!(conversation_ids.contains(conversation_id));
+                }
+                visibility => panic!("expected terminal block visibility, got {visibility:?}"),
+            }
+        });
+    });
+}
+#[test]
 fn shared_third_party_viewer_syncs_from_cli_agent_state_without_ambient_model() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -1035,7 +1035,10 @@ fn shared_third_party_viewer_syncs_from_viewer_harness_updated_when_harness_unch
                 });
             assert!(!view.agent_view_controller().as_ref(ctx).is_active());
 
-            view.handle_ambient_agent_event(&AmbientAgentViewModelEvent::ViewerHarnessUpdated, ctx);
+            view.handle_ambient_agent_event(
+                &AmbientAgentViewModelEvent::ViewerHarnessResolved,
+                ctx,
+            );
 
             let AgentViewState::Active {
                 conversation_id,

--- a/specs/REMOTE-1674/TECH.md
+++ b/specs/REMOTE-1674/TECH.md
@@ -7,7 +7,8 @@ Current relevant flow:
 - `app/src/terminal/shared_session/shared_handlers.rs (356-435)` applies remote `CLIAgentSessionState`. It creates a pane-scoped `CLIAgentSession`, shows the CLI agent footer, manages rich input, and now has enough signal to infer a 3p harness even without an ambient model.
 - `app/src/terminal/shared_session/viewer/event_loop.rs (184-259)` processes ordered viewer terminal events. `CommandExecutionStarted` inserts the remote command into the viewer terminal model, then the viewer can sync agent view around that newly started block.
 - `app/src/terminal/shared_session/viewer/terminal_manager.rs (686-766)` applies the initial `universal_developer_input_context` before calling `enter_viewing_existing_session`, so CLI-agent state can arrive before the ambient model has the task harness.
-- `app/src/terminal/view/ambient_agent/model.rs (812-861)` fetches the ambient task, reads `agent_config_snapshot.harness`, calls `set_harness`, and emits `HarnessSelected`.
+- `app/src/terminal/view/ambient_agent/model.rs (816-861)` fetches the ambient task, reads `agent_config_snapshot.harness`, calls `set_harness`, and emits `ViewerHarnessUpdated` after the server-resolved harness is applied.
+- `app/src/terminal/view/ambient_agent/view_impl.rs (291-315)` handles `ViewerHarnessUpdated` by syncing agent view, updating pane configuration, and notifying the view.
 - `app/src/terminal/view/ambient_agent/view_impl.rs (489-565)` owns the shared 3p viewer sync helper. It checks `is_third_party_cloud_agent_viewer`, enters agent view with `AgentViewEntryOrigin::ThirdPartyCloudAgent` only if not already active, then retags existing blocks and rich content onto the vehicle conversation.
 - `app/src/terminal/model/terminal_model.rs (1426-1444)` identifies shared ambient-agent sessions via `SessionSourceType::AmbientAgent`.
 - `app/src/terminal/cli_agent_sessions/mod.rs (289-315)` stores pane-scoped CLI agent sessions. A session on a shared ambient viewer is the fallback signal for a web-started 3p harness.
@@ -28,24 +29,26 @@ The former gets set when we receive task data from the server, the latter is set
 - On first entry, retag terminal-mode rich content with no conversation id via `set_rich_content_agent_view_conversation_id`.
 
 Call the helper from three signal points:
-- `HarnessSelected` in `app/src/terminal/view/ambient_agent/view_impl.rs (293-299)` for the existing desktop live-viewer path where the ambient model resolves the harness asynchronously.
+- `ViewerHarnessUpdated` in `app/src/terminal/view/ambient_agent/view_impl.rs (305-315)` for the desktop live-viewer path where the ambient model resolves the harness asynchronously. This event fires after `enter_viewing_existing_session` fetches task config, even when `set_harness` is a no-op because the local harness already matches the server harness.
 - `apply_cli_agent_state_update` in `app/src/terminal/shared_session/shared_handlers.rs (356-435)` for web-started or otherwise pre-harness viewer paths where the remote side broadcasts a CLI agent session.
 - `CommandExecutionStarted` in `app/src/terminal/shared_session/viewer/event_loop.rs (184-259)` after the viewer model starts the block, so late-arriving command blocks are attached to the vehicle conversation immediately.
 
 This keeps the implementation local to viewer synchronization. It does not change transcript viewer entry, Oz harness behavior, CLI agent serialization, or shared-session protocol fields.
 
 ## Testing and validation
-Unit tests in `app/src/terminal/view_tests.rs (922-1073)` cover the important invariants:
+Unit tests in `app/src/terminal/view_tests.rs (922-1139)` cover the important invariants:
 - `shared_third_party_viewer_sync_enters_agent_view_and_retags_existing_block` verifies a shared ambient viewer with an ambient model and `Harness::Claude` enters agent view, is idempotent, uses `ThirdPartyCloudAgent`, and keeps the existing harness block visible.
+- `shared_third_party_viewer_syncs_from_viewer_harness_updated_when_harness_unchanged` verifies `ViewerHarnessUpdated` enters agent view and retags the harness block even when `set_harness` does not emit `HarnessSelected` because the harness is unchanged.
 - `shared_third_party_viewer_syncs_from_cli_agent_state_without_ambient_model` verifies a plain terminal viewer with shared ambient session metadata enters agent view after `apply_cli_agent_state_update`, even with no ambient model.
 Additional validation:
 - `cargo test -p warp shared_third_party_viewer_sync --lib` passes.
 - Manually start a Claude/Codex/Gemini cloud task from web, open the desktop shared-session viewer, and confirm it lands in agent view with the harness block visible.
-- Repeat a desktop-started 3p shared-session viewer to ensure the `HarnessSelected` path still works.
+- Repeat a desktop-started 3p shared-session viewer to ensure the `ViewerHarnessUpdated` path works.
 - Repeat an Oz shared-session viewer to confirm no new 3p sync path activates.
 - Confirm a non-shared local harness picker change does not enter agent view.
 ## Risks and mitigations
 - `CLIAgentSessionsModel::session(view_id).is_some()` is broader than an explicit harness enum. The shared ambient-session guard and `AgentHarness` flag keep the fallback scoped to 3p shared viewer contexts.
 - `apply_cli_agent_state_update` can run before `enter_viewing_existing_session` finishes fetching task config and setting `AmbientAgentViewModel.harness`. The CLI-session fallback covers that race.
+- `set_harness` intentionally no-ops when the harness is already selected. `ViewerHarnessUpdated` is the viewer-specific signal that still runs shared-viewer sync after server task hydration.
 - Sync can run before and after command blocks exist. First entry retags existing blocks. Later calls are cheap if agent view is already active, and subsequent blocks inherit the active conversation from `BlockList::create_new_block`.
 - Fullscreen agent view filtering is strict. Tests assert both `should_hide_block` and `AgentViewVisibility::Terminal.conversation_ids` so regressions are visible.

--- a/specs/REMOTE-1674/TECH.md
+++ b/specs/REMOTE-1674/TECH.md
@@ -1,0 +1,51 @@
+# REMOTE-1674: Tech Spec — Agent view entry for web-started 3p harness shared sessions
+
+## Context
+REMOTE-1674 makes live shared-session viewers enter agent view for third-party harness conversations started outside the Warp desktop flow, such as from the web. This extends the REMOTE-1459 viewer-entry work to cases where the desktop viewer may not have an `AmbientAgentViewModel` with a resolved harness yet.
+Linear: https://linear.app/warpdotdev/issue/REMOTE-1674/make-sure-that-we-enter-the-agent-view-for-3p-harness-conversations
+Current relevant flow:
+- `app/src/terminal/shared_session/shared_handlers.rs (356-435)` applies remote `CLIAgentSessionState`. It creates a pane-scoped `CLIAgentSession`, shows the CLI agent footer, manages rich input, and now has enough signal to infer a 3p harness even without an ambient model.
+- `app/src/terminal/shared_session/viewer/event_loop.rs (184-259)` processes ordered viewer terminal events. `CommandExecutionStarted` inserts the remote command into the viewer terminal model, then the viewer can sync agent view around that newly started block.
+- `app/src/terminal/shared_session/viewer/terminal_manager.rs (686-766)` applies the initial `universal_developer_input_context` before calling `enter_viewing_existing_session`, so CLI-agent state can arrive before the ambient model has the task harness.
+- `app/src/terminal/view/ambient_agent/model.rs (812-861)` fetches the ambient task, reads `agent_config_snapshot.harness`, calls `set_harness`, and emits `HarnessSelected`.
+- `app/src/terminal/view/ambient_agent/view_impl.rs (489-565)` owns the shared 3p viewer sync helper. It checks `is_third_party_cloud_agent_viewer`, enters agent view with `AgentViewEntryOrigin::ThirdPartyCloudAgent` only if not already active, then retags existing blocks and rich content onto the vehicle conversation.
+- `app/src/terminal/model/terminal_model.rs (1426-1444)` identifies shared ambient-agent sessions via `SessionSourceType::AmbientAgent`.
+- `app/src/terminal/cli_agent_sessions/mod.rs (289-315)` stores pane-scoped CLI agent sessions. A session on a shared ambient viewer is the fallback signal for a web-started 3p harness.
+- `app/src/terminal/model/block.rs (1405-1435)` hides blocks in fullscreen agent view unless their `AgentViewVisibility` includes the active conversation.
+- `app/src/terminal/model/blocks.rs (1586-1621)` tags the current unfinished block when agent view activates, `app/src/terminal/model/blocks.rs (1666-1694)` attaches existing non-startup blocks to a conversation, and `app/src/terminal/model/blocks.rs (2545-2588)` tags newly-created blocks with the active conversation.
+- `app/src/terminal/view/agent_view.rs (374-396)` retags rich content with an agent-view conversation id.
+
+## Implementation
+Shared 3p viewer entry is centralized in `TerminalView::sync_agent_view_for_shared_third_party_viewer`.
+The helper:
+- Detect a 3p harness with `is_third_party_cloud_agent_viewer`. This checks both `AmbientAgentViewModel::is_third_party_harness()` and `CLIAgentSessionsModel::session(view_id).is_some()` to determine if we are in a 3p harness convo.
+The former gets set when we receive task data from the server, the latter is set when we receive join info in a shared session that contains an actively running CLIAgent.
+- Require `is_shared_ambient_agent_session()` so local harness picker changes do not enter agent view.
+- Enter agent view only when not already active, using `AgentViewEntryOrigin::ThirdPartyCloudAgent`.
+- Return immediately with the active conversation id if the viewer is already in agent view. This keeps duplicate sync calls cheap.
+- Return the active vehicle conversation id for tests and idempotency checks.
+- On first entry, retag non-startup terminal blocks via `attach_non_startup_blocks_to_conversation`.
+- On first entry, retag terminal-mode rich content with no conversation id via `set_rich_content_agent_view_conversation_id`.
+
+Call the helper from three signal points:
+- `HarnessSelected` in `app/src/terminal/view/ambient_agent/view_impl.rs (293-299)` for the existing desktop live-viewer path where the ambient model resolves the harness asynchronously.
+- `apply_cli_agent_state_update` in `app/src/terminal/shared_session/shared_handlers.rs (356-435)` for web-started or otherwise pre-harness viewer paths where the remote side broadcasts a CLI agent session.
+- `CommandExecutionStarted` in `app/src/terminal/shared_session/viewer/event_loop.rs (184-259)` after the viewer model starts the block, so late-arriving command blocks are attached to the vehicle conversation immediately.
+
+This keeps the implementation local to viewer synchronization. It does not change transcript viewer entry, Oz harness behavior, CLI agent serialization, or shared-session protocol fields.
+
+## Testing and validation
+Unit tests in `app/src/terminal/view_tests.rs (922-1073)` cover the important invariants:
+- `shared_third_party_viewer_sync_enters_agent_view_and_retags_existing_block` verifies a shared ambient viewer with an ambient model and `Harness::Claude` enters agent view, is idempotent, uses `ThirdPartyCloudAgent`, and keeps the existing harness block visible.
+- `shared_third_party_viewer_syncs_from_cli_agent_state_without_ambient_model` verifies a plain terminal viewer with shared ambient session metadata enters agent view after `apply_cli_agent_state_update`, even with no ambient model.
+Additional validation:
+- `cargo test -p warp shared_third_party_viewer_sync --lib` passes.
+- Manually start a Claude/Codex/Gemini cloud task from web, open the desktop shared-session viewer, and confirm it lands in agent view with the harness block visible.
+- Repeat a desktop-started 3p shared-session viewer to ensure the `HarnessSelected` path still works.
+- Repeat an Oz shared-session viewer to confirm no new 3p sync path activates.
+- Confirm a non-shared local harness picker change does not enter agent view.
+## Risks and mitigations
+- `CLIAgentSessionsModel::session(view_id).is_some()` is broader than an explicit harness enum. The shared ambient-session guard and `AgentHarness` flag keep the fallback scoped to 3p shared viewer contexts.
+- `apply_cli_agent_state_update` can run before `enter_viewing_existing_session` finishes fetching task config and setting `AmbientAgentViewModel.harness`. The CLI-session fallback covers that race.
+- Sync can run before and after command blocks exist. First entry retags existing blocks. Later calls are cheap if agent view is already active, and subsequent blocks inherit the active conversation from `BlockList::create_new_block`.
+- Fullscreen agent view filtering is strict. Tests assert both `should_hide_block` and `AgentViewVisibility::Terminal.conversation_ids` so regressions are visible.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR adds support for entering the agent view more consistently when viewing a session with a third-party harness cloud agent:
- When we get harness data from the server, enter the agent view
- When we detect a third-party CLI harness command running, enter the agent view

We also switch away from using `HarnessSelected` to try to enter the agent view to using a new event to track this. `HarnessSelected` was an overloaded event: it was called in `set_harness`, which is used to update the UI when a user changes the dropdown OR when we receive harness data for a task from an ambient task fetch on joining a new cloud session. This doesn't really make sense for two reasons:
- We shouldn't be trying to enter an agent view when toggling a harness in the cloud mode input
- `set_harness` early returns when the harness is unchanged, which means that `HarnessSelected` doesn't _consistently_ fire on session join. The harness setting doesn't just default/reset to Oz with every run, it retains prior selections, so it was not uncommon that you'd find a 3p harness run coming in and hitting the early return for `set_harness`. 

We fix this by handling entering the agent view using a new event, `ViewerHarnessUpdated`, which is triggered when we pull in task data on a session join. 

Loom: https://www.loom.com/share/bfa261c9392947b09442561792175d5a

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

Tested locally, joining a session before the agent has begun running setup commands, joining while it is in progress, and joining after it's done, but idling.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
