### PR TITLE
CLI commands for API key management

### DIFF
--- a/app/src/ai/agent_sdk/api_key.rs
+++ b/app/src/ai/agent_sdk/api_key.rs
@@ -1,0 +1,492 @@
+use std::{
+    cmp::Reverse,
+    fmt,
+    io::{self, IsTerminal as _},
+};
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use comfy_table::Cell;
+use inquire::{Confirm, InquireError, Select};
+use serde::Serialize;
+use warp_cli::{
+    agent::OutputFormat,
+    api_key::{
+        ApiKeyCommand, ApiKeyExpirationArgs, ApiKeySortByArg, ApiKeySortOrderArg, CreateApiKeyArgs,
+        ExpireApiKeyArgs, ListApiKeysArgs,
+    },
+    GlobalOptions,
+};
+use warp_graphql::{
+    mutations::{expire_api_key::ExpireApiKeyResult, generate_api_key::GenerateApiKeyResult},
+    queries::api_keys::ApiKeyProperties,
+    scalars::Time,
+};
+use warpui::{platform::TerminationMode, AppContext, ModelContext, SingletonEntity};
+
+use crate::{
+    server::{ids::ApiKeyUid, server_api::auth::AuthClient},
+    util::time_format::format_approx_duration_from_now_utc,
+    ServerApiProvider,
+};
+
+use super::output::{self, TableFormat};
+
+/// Run API key-related commands.
+pub fn run(
+    ctx: &mut AppContext,
+    global_options: GlobalOptions,
+    command: ApiKeyCommand,
+) -> Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| ApiKeyCommandRunner);
+    match command {
+        ApiKeyCommand::List(args) => {
+            runner.update(ctx, |runner, ctx| {
+                runner.list(global_options.output_format, args, ctx)
+            });
+            Ok(())
+        }
+        ApiKeyCommand::Create(args) => {
+            runner.update(ctx, |runner, ctx| {
+                runner.create(global_options.output_format, args, ctx)
+            });
+            Ok(())
+        }
+        ApiKeyCommand::Expire(args) => {
+            runner.update(ctx, |runner, ctx| {
+                runner.expire(global_options.output_format, args, ctx)
+            });
+            Ok(())
+        }
+    }
+}
+
+struct ApiKeyCommandRunner;
+
+impl ApiKeyCommandRunner {
+    fn list(
+        &self,
+        output_format: OutputFormat,
+        args: ListApiKeysArgs,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let server_api = ServerApiProvider::as_ref(ctx).get();
+
+        ctx.spawn(
+            async move {
+                let mut keys: Vec<_> = server_api
+                    .list_api_keys()
+                    .await?
+                    .into_iter()
+                    .map(ApiKeyInfo::from)
+                    .collect();
+                sort_api_keys(&mut keys, args.sort_by, args.sort_order);
+                if args.json_output.force_json_output() {
+                    output::print_raw_json(serde_json::to_value(&keys)?, &args.json_output)?;
+                } else {
+                    output::print_list(keys, output_format);
+                }
+                Ok(())
+            },
+            |_, result: Result<()>, ctx| finish_command(result, ctx),
+        );
+    }
+
+    fn create(
+        &self,
+        output_format: OutputFormat,
+        args: CreateApiKeyArgs,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let server_api = ServerApiProvider::as_ref(ctx).get();
+
+        ctx.spawn(
+            async move {
+                let json_output = args.json_output;
+                let expires_at = expires_at_from_args(args.expiration)?;
+                let agent_uid = args.agent_uid.map(cynic::Id::new);
+                let result = server_api
+                    .create_api_key(args.name, None, agent_uid, expires_at)
+                    .await?;
+                let result = match result {
+                    GenerateApiKeyResult::GenerateApiKeyOutput(output) => CreatedApiKeyInfo {
+                        raw_api_key: output.raw_api_key,
+                        api_key: ApiKeyInfo::from(output.api_key),
+                    },
+                    GenerateApiKeyResult::UserFacingError(e) => {
+                        return Err(anyhow!(
+                            warp_graphql::client::get_user_facing_error_message(e)
+                        ));
+                    }
+                    GenerateApiKeyResult::Unknown => {
+                        return Err(anyhow!("failed to create API key"))
+                    }
+                };
+                print_created_api_key(result, output_format, json_output)?;
+                Ok(())
+            },
+            |_, result: Result<()>, ctx| finish_command(result, ctx),
+        );
+    }
+
+    fn expire(
+        &self,
+        output_format: OutputFormat,
+        args: ExpireApiKeyArgs,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let key_identifier = args.key_uid;
+        let force = args.force;
+        let json_output = args.json_output;
+        let server_api = ServerApiProvider::as_ref(ctx).get();
+
+        ctx.spawn(
+            async move {
+                let keys = server_api
+                    .list_api_keys()
+                    .await?
+                    .into_iter()
+                    .map(ApiKeyInfo::from)
+                    .collect();
+                Ok(keys)
+            },
+            move |_, result: Result<Vec<ApiKeyInfo>>, ctx| {
+                let keys = match result {
+                    Ok(keys) => keys,
+                    Err(err) => {
+                        super::report_fatal_error(err, ctx);
+                        return;
+                    }
+                };
+
+                let key = match resolve_api_key_identifier(&keys, &key_identifier) {
+                    Ok(Some(key)) => key,
+                    Ok(None) => {
+                        ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                        return;
+                    }
+                    Err(err) => {
+                        super::report_fatal_error(err, ctx);
+                        return;
+                    }
+                };
+
+                if !force {
+                    if !io::stdin().is_terminal() {
+                        super::report_fatal_error(
+                            anyhow!(
+                                "Refusing to expire API key without confirmation in non-interactive mode (use --force to bypass)"
+                            ),
+                            ctx,
+                        );
+                        return;
+                    }
+
+                    let prompt = format!("Expire API key '{key}'?");
+                    let should_expire = match Confirm::new(&prompt)
+                        .with_default(false)
+                        .with_help_message("This action takes effect immediately")
+                        .prompt()
+                    {
+                        Ok(should_expire) => should_expire,
+                        Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                            ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                            return;
+                        }
+                        Err(err) => {
+                            super::report_fatal_error(err.into(), ctx);
+                            return;
+                        }
+                    };
+
+                    if !should_expire {
+                        println!("Expiration cancelled");
+                        ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                        return;
+                    }
+                }
+
+                let uid = ApiKeyUid::from(key.uid);
+                let server_api = ServerApiProvider::as_ref(ctx).get();
+                ctx.spawn(
+                    async move {
+                        let result = server_api.expire_api_key(&uid).await?;
+                        let expired = match result {
+                            ExpireApiKeyResult::ExpireApiKeyOutput(output) => output.success,
+                            ExpireApiKeyResult::UserFacingError(e) => {
+                                return Err(anyhow!(
+                                    warp_graphql::client::get_user_facing_error_message(e)
+                                ));
+                            }
+                            ExpireApiKeyResult::Unknown => {
+                                return Err(anyhow!("failed to expire API key"))
+                            }
+                        };
+                        print_expire_api_key_result(
+                            uid.to_string(),
+                            expired,
+                            output_format,
+                            json_output,
+                        )?;
+                        Ok(())
+                    },
+                    |_, result: Result<()>, ctx| finish_command(result, ctx),
+                );
+            },
+        );
+    }
+}
+
+impl warpui::Entity for ApiKeyCommandRunner {
+    type Event = ();
+}
+
+impl SingletonEntity for ApiKeyCommandRunner {}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ApiKeyInfo {
+    uid: String,
+    name: String,
+    key_suffix: String,
+    scope: String,
+    created_at: DateTime<Utc>,
+    last_used_at: Option<DateTime<Utc>>,
+    expires_at: Option<DateTime<Utc>>,
+}
+
+impl From<ApiKeyProperties> for ApiKeyInfo {
+    fn from(key: ApiKeyProperties) -> Self {
+        Self {
+            uid: key.uid.into_inner(),
+            name: key.name,
+            key_suffix: key.key_suffix,
+            scope: key.owner_type.to_string(),
+            created_at: key.created_at.utc(),
+            last_used_at: key.last_used_at.map(|t| t.utc()),
+            expires_at: key.expires_at.map(|t| t.utc()),
+        }
+    }
+}
+
+impl fmt::Display for ApiKeyInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = &self.name;
+        let uid = &self.uid;
+        let created_at = self.created_at.format("%Y-%m-%d %H:%M:%S UTC");
+        write!(f, "{name} ({uid}, created {created_at})")
+    }
+}
+
+impl TableFormat for ApiKeyInfo {
+    fn header() -> Vec<Cell> {
+        vec![
+            Cell::new("UID"),
+            Cell::new("Name"),
+            Cell::new("Key"),
+            Cell::new("Scope"),
+            Cell::new("Created"),
+            Cell::new("Last Used"),
+            Cell::new("Expires At"),
+        ]
+    }
+
+    fn row(&self) -> Vec<Cell> {
+        vec![
+            Cell::new(&self.uid),
+            Cell::new(&self.name),
+            Cell::new(format!("wk-**{}", self.key_suffix)),
+            Cell::new(&self.scope),
+            Cell::new(format_approx_duration_from_now_utc(self.created_at)),
+            Cell::new(
+                self.last_used_at
+                    .map(format_approx_duration_from_now_utc)
+                    .unwrap_or_else(|| "Never".to_string()),
+            ),
+            Cell::new(
+                self.expires_at
+                    .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+                    .unwrap_or_else(|| "Never".to_string()),
+            ),
+        ]
+    }
+}
+
+fn resolve_api_key_identifier(
+    keys: &[ApiKeyInfo],
+    key_identifier: &str,
+) -> Result<Option<ApiKeyInfo>> {
+    if let Some(key) = keys.iter().find(|key| key.uid == key_identifier) {
+        return Ok(Some(key.clone()));
+    }
+
+    let mut matches = keys
+        .iter()
+        .filter(|key| key.name == key_identifier)
+        .cloned()
+        .collect::<Vec<_>>();
+    matches.sort_by_key(|key| Reverse(key.created_at));
+
+    if matches.is_empty() {
+        return Err(anyhow!("API key '{key_identifier}' not found"));
+    } else if matches.len() == 1 {
+        return Ok(Some(matches[0].clone()));
+    }
+
+    if io::stdin().is_terminal() {
+        return match Select::new(
+            &format!("Multiple API keys match '{key_identifier}'. Select a key to expire:"),
+            matches,
+        )
+        .prompt()
+        {
+            Ok(key) => Ok(Some(key)),
+            Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => Ok(None),
+            Err(err) => Err(err.into()),
+        };
+    }
+    println!("Multiple API keys match '{key_identifier}':");
+    for key in matches {
+        println!("  {key}");
+    }
+
+    Err(anyhow!(
+        "Multiple API keys match '{key_identifier}'; specify the key by UID"
+    ))
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CreatedApiKeyInfo {
+    raw_api_key: String,
+    api_key: ApiKeyInfo,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ExpiredApiKeyInfo {
+    key_uid: String,
+    expired: bool,
+}
+
+fn sort_api_keys(
+    keys: &mut [ApiKeyInfo],
+    sort_by: Option<ApiKeySortByArg>,
+    sort_order: Option<ApiKeySortOrderArg>,
+) {
+    let Some(sort_by) = sort_by else {
+        return;
+    };
+    let descending = matches!(sort_order, Some(ApiKeySortOrderArg::Desc));
+    match sort_by {
+        ApiKeySortByArg::Name => {
+            if descending {
+                keys.sort_by_key(|k| Reverse(k.name.to_lowercase()));
+            } else {
+                keys.sort_by_key(|k| k.name.to_lowercase());
+            }
+        }
+        ApiKeySortByArg::CreatedAt => {
+            if descending {
+                keys.sort_by_key(|k| Reverse(k.created_at));
+            } else {
+                keys.sort_by_key(|k| k.created_at);
+            }
+        }
+        ApiKeySortByArg::LastUsedAt => {
+            if descending {
+                keys.sort_by_key(|k| Reverse(k.last_used_at));
+            } else {
+                keys.sort_by_key(|k| k.last_used_at);
+            }
+        }
+        ApiKeySortByArg::ExpiresAt => {
+            if descending {
+                keys.sort_by_key(|k| Reverse(k.expires_at));
+            } else {
+                keys.sort_by_key(|k| k.expires_at);
+            }
+        }
+        ApiKeySortByArg::Scope => {
+            if descending {
+                keys.sort_by_key(|k| Reverse(k.scope.clone()));
+            } else {
+                keys.sort_by_key(|k| k.scope.clone());
+            }
+        }
+    }
+}
+
+fn expires_at_from_args(args: ApiKeyExpirationArgs) -> Result<Option<Time>> {
+    if args.no_expiration {
+        return Ok(None);
+    }
+
+    if let Some(expires_at) = args.expires_at {
+        return Ok(Some(Time::from(expires_at)));
+    }
+
+    if let Some(expires_in) = args.expires_in {
+        let duration = chrono::Duration::from_std(expires_in.into())
+            .map_err(|_| anyhow!("expiration duration is too large"))?;
+        return Ok(Some(Time::from(Utc::now() + duration)));
+    }
+
+    Err(anyhow!("expiration behavior is required"))
+}
+
+fn print_created_api_key(
+    result: CreatedApiKeyInfo,
+    output_format: OutputFormat,
+    json_output: warp_cli::json_filter::JsonOutput,
+) -> Result<()> {
+    if json_output.force_json_output() {
+        output::print_raw_json(serde_json::to_value(&result)?, &json_output)?;
+        return Ok(());
+    }
+    match output_format {
+        OutputFormat::Json => output::write_json(&result, std::io::stdout())?,
+        OutputFormat::Ndjson => output::write_json_line(&result, std::io::stdout())?,
+        OutputFormat::Pretty | OutputFormat::Text => {
+            println!("API key '{}' created.", result.api_key.name);
+            println!("UID: {}", result.api_key.uid);
+            println!("Raw API key: {}", result.raw_api_key);
+            println!("This secret key is shown only once. Store it securely.");
+        }
+    }
+    Ok(())
+}
+
+fn print_expire_api_key_result(
+    key_uid: String,
+    expired: bool,
+    output_format: OutputFormat,
+    json_output: warp_cli::json_filter::JsonOutput,
+) -> Result<()> {
+    let result = ExpiredApiKeyInfo { key_uid, expired };
+    if json_output.force_json_output() {
+        output::print_raw_json(serde_json::to_value(&result)?, &json_output)?;
+        return Ok(());
+    }
+
+    match output_format {
+        OutputFormat::Json => output::write_json(&result, std::io::stdout())?,
+        OutputFormat::Ndjson => output::write_json_line(&result, std::io::stdout())?,
+        OutputFormat::Pretty | OutputFormat::Text => {
+            if expired {
+                println!("API key '{}' expired.", result.key_uid);
+            } else {
+                println!("API key '{}' was not expired.", result.key_uid);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn finish_command(result: Result<()>, ctx: &mut ModelContext<ApiKeyCommandRunner>) {
+    match result {
+        Ok(()) => ctx.terminate_app(TerminationMode::ForceTerminate, None),
+        Err(err) => super::report_fatal_error(err, ctx),
+    }
+}
+
+#[cfg(test)]
+#[path = "api_key_tests.rs"]
+mod tests;

--- a/app/src/ai/agent_sdk/api_key_tests.rs
+++ b/app/src/ai/agent_sdk/api_key_tests.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+fn key(name: &str, scope: &str, created_at: DateTime<Utc>) -> ApiKeyInfo {
+    key_with_uid(name, name, scope, created_at)
+}
+
+fn key_with_uid(uid: &str, name: &str, scope: &str, created_at: DateTime<Utc>) -> ApiKeyInfo {
+    ApiKeyInfo {
+        uid: uid.to_string(),
+        name: name.to_string(),
+        key_suffix: "abcd".to_string(),
+        scope: scope.to_string(),
+        created_at,
+        last_used_at: None,
+        expires_at: None,
+    }
+}
+
+#[test]
+fn sort_api_keys_sorts_by_name_ascending() {
+    let created_at = Utc::now();
+    let mut keys = vec![
+        key("beta", "Team", created_at),
+        key("alpha", "Personal", created_at),
+    ];
+
+    sort_api_keys(
+        &mut keys,
+        Some(ApiKeySortByArg::Name),
+        Some(ApiKeySortOrderArg::Asc),
+    );
+
+    assert_eq!(keys[0].name, "alpha");
+    assert_eq!(keys[1].name, "beta");
+}
+
+#[test]
+fn sort_api_keys_sorts_by_created_at_descending() {
+    let older = Utc::now() - chrono::Duration::days(1);
+    let newer = Utc::now();
+    let mut keys = vec![key("older", "Team", older), key("newer", "Personal", newer)];
+
+    sort_api_keys(
+        &mut keys,
+        Some(ApiKeySortByArg::CreatedAt),
+        Some(ApiKeySortOrderArg::Desc),
+    );
+
+    assert_eq!(keys[0].name, "newer");
+    assert_eq!(keys[1].name, "older");
+}
+
+#[test]
+fn resolve_api_key_identifier_prefers_uid_match() {
+    let created_at = Utc::now();
+    let keys = vec![
+        key_with_uid("target", "other-name", "Team", created_at),
+        key_with_uid("other-uid", "target", "Team", created_at),
+    ];
+
+    assert_eq!(
+        resolve_api_key_identifier(&keys, "target")
+            .unwrap()
+            .unwrap(),
+        keys[0].clone()
+    );
+}
+
+#[test]
+fn resolve_api_key_identifier_falls_back_to_name_match() {
+    let created_at = Utc::now();
+    let keys = vec![key_with_uid("uid-1", "deploy-key", "Team", created_at)];
+
+    assert_eq!(
+        resolve_api_key_identifier(&keys, "deploy-key")
+            .unwrap()
+            .unwrap(),
+        keys[0].clone()
+    );
+}
+
+#[test]
+fn resolve_api_key_identifier_errors_for_ambiguous_name_matches() {
+    let created_at = Utc::now();
+    let keys = vec![
+        key_with_uid("uid-1", "deploy-key", "Team", created_at),
+        key_with_uid("uid-2", "deploy-key", "Personal", created_at),
+    ];
+    let err = resolve_api_key_identifier(&keys, "deploy-key").unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Multiple API keys match 'deploy-key'; specify the key by UID"
+    );
+}
+
+#[test]
+fn resolve_api_key_identifier_errors_when_not_found() {
+    let created_at = Utc::now();
+    let keys = vec![key_with_uid("uid-1", "deploy-key", "Team", created_at)];
+    let err = resolve_api_key_identifier(&keys, "missing-key").unwrap_err();
+
+    assert_eq!(err.to_string(), "API key 'missing-key' not found");
+}
+
+#[test]
+fn api_key_display_includes_creation_date() {
+    let created_at = "2026-01-02T03:04:05Z".parse().unwrap();
+    let key = key_with_uid("uid-1", "deploy-key", "Team", created_at);
+
+    assert_eq!(
+        key.to_string(),
+        "deploy-key (uid-1, created 2026-01-02 03:04:05 UTC)"
+    );
+}

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -26,6 +26,7 @@ use ai::api_keys::{ApiKeyManager, AwsCredentialsRefreshStrategy};
 use anyhow::Context;
 use warp_cli::{
     agent::{AgentCommand, AgentProfileCommand, OutputFormat},
+    api_key::ApiKeyCommand,
     artifact::ArtifactCommand,
     environment::{EnvironmentCommand, ImageCommand},
     federate::FederateCommand,
@@ -76,6 +77,7 @@ use warp_cli::OZ_HARNESS_ENV;
 mod admin;
 mod agent_config;
 mod ambient;
+mod api_key;
 mod artifact;
 pub(crate) mod artifact_upload;
 mod common;
@@ -195,6 +197,12 @@ fn dispatch_command(
                 return Err(anyhow::anyhow!("invalid value 'artifact'"));
             }
             artifact::run(ctx, global_options, artifact_cmd)
+        }
+        CliCommand::ApiKey(api_key_cmd) => {
+            if !FeatureFlag::APIKeyManagement.is_enabled() {
+                return Err(anyhow::anyhow!("invalid value 'api-key'"));
+            }
+            api_key::run(ctx, global_options, api_key_cmd)
         }
     }
 }
@@ -1387,6 +1395,7 @@ fn command_requires_auth(command: &CliCommand) -> bool {
         CliCommand::Federate(_) => true,
         CliCommand::HarnessSupport(_) => true,
         CliCommand::Artifact(_) => true,
+        CliCommand::ApiKey(_) => true,
     }
 }
 
@@ -1610,6 +1619,11 @@ fn command_to_telemetry_event(command: &CliCommand) -> CliTelemetryEvent {
             ArtifactCommand::Upload(_) => CliTelemetryEvent::ArtifactUpload,
             ArtifactCommand::Get(_) => CliTelemetryEvent::ArtifactGet,
             ArtifactCommand::Download(_) => CliTelemetryEvent::ArtifactDownload,
+        },
+        CliCommand::ApiKey(api_key_cmd) => match api_key_cmd {
+            ApiKeyCommand::List(_) => CliTelemetryEvent::ApiKeyList,
+            ApiKeyCommand::Create(_) => CliTelemetryEvent::ApiKeyCreate,
+            ApiKeyCommand::Expire(_) => CliTelemetryEvent::ApiKeyExpire,
         },
     }
 }

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -78,6 +78,12 @@ pub(super) enum CliTelemetryEvent {
     ArtifactGet,
     /// Executing `warp artifact download`
     ArtifactDownload,
+    /// Executing `warp api-key list`
+    ApiKeyList,
+    /// Executing `warp api-key create`
+    ApiKeyCreate,
+    /// Executing `warp api-key expire`
+    ApiKeyExpire,
     /// Executing `warp schedule create`
     ScheduleCreate,
     /// Executing `warp schedule list`
@@ -169,6 +175,9 @@ impl TelemetryEvent for CliTelemetryEvent {
             CliTelemetryEvent::ArtifactUpload => None,
             CliTelemetryEvent::ArtifactGet => None,
             CliTelemetryEvent::ArtifactDownload => None,
+            CliTelemetryEvent::ApiKeyList => None,
+            CliTelemetryEvent::ApiKeyCreate => None,
+            CliTelemetryEvent::ApiKeyExpire => None,
             CliTelemetryEvent::ScheduleCreate => None,
             CliTelemetryEvent::ScheduleList => None,
             CliTelemetryEvent::ScheduleGet => None,
@@ -252,6 +261,9 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::ArtifactUpload => "CLI.Execute.Artifact.Upload",
             CliTelemetryEventDiscriminants::ArtifactGet => "CLI.Execute.Artifact.Get",
             CliTelemetryEventDiscriminants::ArtifactDownload => "CLI.Execute.Artifact.Download",
+            CliTelemetryEventDiscriminants::ApiKeyList => "CLI.Execute.ApiKey.List",
+            CliTelemetryEventDiscriminants::ApiKeyCreate => "CLI.Execute.ApiKey.Create",
+            CliTelemetryEventDiscriminants::ApiKeyExpire => "CLI.Execute.ApiKey.Expire",
             CliTelemetryEventDiscriminants::ScheduleCreate => "CLI.Execute.Schedule.Create",
             CliTelemetryEventDiscriminants::ScheduleList => "CLI.Execute.Schedule.List",
             CliTelemetryEventDiscriminants::ScheduleGet => "CLI.Execute.Schedule.Get",
@@ -359,6 +371,9 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::ArtifactDownload => {
                 "Downloaded an artifact from the Warp CLI"
             }
+            CliTelemetryEventDiscriminants::ApiKeyList => "Listed API keys from the Warp CLI",
+            CliTelemetryEventDiscriminants::ApiKeyCreate => "Created an API key from the Warp CLI",
+            CliTelemetryEventDiscriminants::ApiKeyExpire => "Expired an API key from the Warp CLI",
             CliTelemetryEventDiscriminants::ScheduleCreate => {
                 "Created a scheduled agent from the Warp CLI"
             }
@@ -419,6 +434,9 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             | Self::HarnessSupportFinishTask => EnablementState::Flag(FeatureFlag::AgentHarness),
             Self::ArtifactUpload | Self::ArtifactGet | Self::ArtifactDownload => {
                 EnablementState::Flag(FeatureFlag::ArtifactCommand)
+            }
+            Self::ApiKeyList | Self::ApiKeyCreate | Self::ApiKeyExpire => {
+                EnablementState::Flag(FeatureFlag::APIKeyManagement)
             }
             Self::RunMessageWatch
             | Self::RunMessageSend

--- a/crates/graphql/src/api/object_permissions.rs
+++ b/crates/graphql/src/api/object_permissions.rs
@@ -1,6 +1,7 @@
 use super::object::{Container, Space};
 use crate::scalars::Time;
 use crate::schema;
+use std::fmt;
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ObjectPermissions {
@@ -30,6 +31,16 @@ pub enum OwnerType {
     Team,
     #[cynic(rename = "User")]
     User,
+}
+
+impl fmt::Display for OwnerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let owner_type = match self {
+            OwnerType::Team => "Team",
+            OwnerType::User => "Personal",
+        };
+        write!(f, "{owner_type}")
+    }
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]

--- a/crates/warp_cli/src/api_key.rs
+++ b/crates/warp_cli/src/api_key.rs
@@ -1,0 +1,109 @@
+use crate::date_time::parse_rfc3339;
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand, ValueEnum};
+
+use crate::json_filter::JsonOutput;
+
+/// API key-related subcommands.
+#[derive(Debug, Clone, Subcommand)]
+pub enum ApiKeyCommand {
+    /// List active API keys.
+    List(ListApiKeysArgs),
+    /// Create a new API key.
+    Create(CreateApiKeyArgs),
+    /// Immediately expire an API key.
+    #[command(alias = "delete")]
+    Expire(ExpireApiKeyArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ListApiKeysArgs {
+    /// Sort field.
+    #[arg(long = "sort-by", value_enum, value_name = "FIELD")]
+    pub sort_by: Option<ApiKeySortByArg>,
+
+    /// Sort direction.
+    #[arg(long = "sort-order", value_enum, value_name = "DIR")]
+    pub sort_order: Option<ApiKeySortOrderArg>,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct CreateApiKeyArgs {
+    /// Name of the API key to create.
+    pub name: String,
+
+    /// UID of the agent to authenticate as.
+    #[arg(long = "agent", value_name = "UID")]
+    pub agent_uid: Option<String>,
+
+    #[command(flatten)]
+    pub expiration: ApiKeyExpirationArgs,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+/// API key expiration arguments. Exactly one expiration decision is required.
+#[derive(Debug, Clone, Args)]
+#[group(required = true, multiple = false)]
+pub struct ApiKeyExpirationArgs {
+    /// Expire the API key after this duration, such as "30d", "12h", or "90m".
+    #[arg(long = "expires-in", value_name = "DURATION")]
+    pub expires_in: Option<humantime::Duration>,
+
+    /// Expire the API key at a specific time.
+    #[arg(long = "expires-at", value_name = "RFC3339", value_parser = parse_rfc3339)]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// Create an API key with no expiration.
+    #[arg(long = "no-expiration")]
+    pub no_expiration: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ExpireApiKeyArgs {
+    /// Name or UID of the API key to expire.
+    #[arg(value_name = "NAME_OR_UID")]
+    pub key_uid: String,
+
+    /// Expire without asking for confirmation.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+/// Sort-by values accepted by `--sort-by`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ApiKeySortByArg {
+    #[value(name = "name")]
+    Name,
+    #[value(name = "created-at")]
+    CreatedAt,
+    #[value(name = "last-used-at")]
+    LastUsedAt,
+    #[value(name = "expires-at")]
+    ExpiresAt,
+    #[value(name = "scope")]
+    Scope,
+}
+
+/// Sort-order values accepted by `--sort-order`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ApiKeySortOrderArg {
+    #[value(name = "asc")]
+    Asc,
+    #[value(name = "desc")]
+    Desc,
+}
+
+#[cfg(test)]
+#[path = "api_key_tests.rs"]
+mod tests;

--- a/crates/warp_cli/src/api_key_tests.rs
+++ b/crates/warp_cli/src/api_key_tests.rs
@@ -1,0 +1,87 @@
+use clap::Parser;
+
+use super::*;
+#[derive(Debug, Parser)]
+struct TestApiKey {
+    #[command(subcommand)]
+    command: ApiKeyCommand,
+}
+
+#[derive(Debug, Parser)]
+struct TestCreate {
+    #[clap(flatten)]
+    args: CreateApiKeyArgs,
+}
+
+fn parse_command(argv: &[&str]) -> ApiKeyCommand {
+    let mut full = vec!["test"];
+    full.extend_from_slice(argv);
+    TestApiKey::try_parse_from(full)
+        .expect("parse succeeds")
+        .command
+}
+
+fn parse_create(argv: &[&str]) -> CreateApiKeyArgs {
+    let mut full = vec!["test"];
+    full.extend_from_slice(argv);
+    TestCreate::try_parse_from(full)
+        .expect("parse succeeds")
+        .args
+}
+
+fn parse_create_err(argv: &[&str]) -> clap::Error {
+    let mut full = vec!["test"];
+    full.extend_from_slice(argv);
+    TestCreate::try_parse_from(full).expect_err("parse fails")
+}
+
+#[test]
+fn create_requires_expiration_decision() {
+    let err = parse_create_err(&["ci-key"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn create_rejects_multiple_expiration_decisions() {
+    let err = parse_create_err(&["ci-key", "--expires-in", "30d", "--no-expiration"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn create_accepts_expires_in() {
+    let args = parse_create(&["ci-key", "--expires-in", "30d", "--agent", "agent-123"]);
+    assert_eq!(args.name, "ci-key");
+    assert_eq!(args.agent_uid.as_deref(), Some("agent-123"));
+    assert!(args.expiration.expires_in.is_some());
+    assert!(args.expiration.expires_at.is_none());
+    assert!(!args.expiration.no_expiration);
+}
+
+#[test]
+fn create_accepts_no_expiration() {
+    let args = parse_create(&["ci-key", "--no-expiration"]);
+    assert_eq!(args.name, "ci-key");
+    assert!(args.expiration.expires_in.is_none());
+    assert!(args.expiration.expires_at.is_none());
+    assert!(args.expiration.no_expiration);
+}
+
+#[test]
+fn create_accepts_rfc3339_expiration() {
+    let args = parse_create(&["ci-key", "--expires-at", "2026-06-01T12:00:00Z"]);
+    assert_eq!(args.name, "ci-key");
+    assert!(args.expiration.expires_in.is_none());
+    assert!(args.expiration.expires_at.is_some());
+    assert!(!args.expiration.no_expiration);
+}
+
+#[test]
+fn delete_is_alias_for_expire() {
+    let command = parse_command(&["delete", "deploy-key", "--force"]);
+    let ApiKeyCommand::Expire(args) = command else {
+        panic!("Expected expire command");
+    };
+
+    assert_eq!(args.key_uid, "deploy-key");
+    assert!(args.force);
+}

--- a/crates/warp_cli/src/date_time.rs
+++ b/crates/warp_cli/src/date_time.rs
@@ -1,0 +1,8 @@
+use chrono::{DateTime, Utc};
+
+/// Parse an RFC 3339 timestamp into a UTC `DateTime`.
+pub(crate) fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("invalid RFC 3339 timestamp '{s}': {e}"))
+}

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -18,8 +18,10 @@ pub mod scope;
 pub mod skill;
 
 pub mod agent;
+pub mod api_key;
 pub mod completions;
 pub mod config_file;
+mod date_time;
 pub mod environment;
 pub mod federate;
 pub mod harness_support;
@@ -243,6 +245,15 @@ impl Args {
                     }
                 }
 
+                if !FeatureFlag::APIKeyManagement.is_enabled() {
+                    let args: Vec<String> = env::args().collect();
+                    if args.len() > 1 && args[1] == "api-key" {
+                        eprintln!("error: unrecognized subcommand 'api-key'\n");
+                        eprintln!("For more information, try '--help'");
+                        std::process::exit(2);
+                    }
+                }
+
                 let command = Self::clap_command();
 
                 command.try_get_matches()
@@ -347,6 +358,11 @@ impl Args {
         // Hide the artifact subcommand from help text.
         if !FeatureFlag::ArtifactCommand.is_enabled() {
             command = command.mut_subcommand("artifact", |c| c.hide(true));
+        }
+
+        // Hide the api-key subcommand from help text.
+        if !FeatureFlag::APIKeyManagement.is_enabled() {
+            command = command.mut_subcommand("api-key", |c| c.hide(true));
         }
 
         // Wire up `--version` / `-V` using the same version metadata used elsewhere in the
@@ -535,6 +551,10 @@ pub enum CliCommand {
     /// Manage artifacts.
     #[command(subcommand)]
     Artifact(crate::artifact::ArtifactCommand),
+
+    /// Manage API keys.
+    #[command(subcommand)]
+    ApiKey(crate::api_key::ApiKeyCommand),
 }
 
 /// A subcommand of the main Warp application. This includes all [`WorkerCommand`]s as well as app-specific debugging tools.

--- a/crates/warp_cli/src/task.rs
+++ b/crates/warp_cli/src/task.rs
@@ -1,3 +1,4 @@
+use crate::date_time::parse_rfc3339;
 use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand, ValueEnum};
 
@@ -199,13 +200,6 @@ pub struct ListTasksArgs {
     /// JSON formatting configuration.
     #[command(flatten)]
     pub json_output: JsonOutput,
-}
-
-/// Parse an RFC 3339 timestamp into a UTC `DateTime`.
-fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>, String> {
-    DateTime::parse_from_rfc3339(s)
-        .map(|dt| dt.with_timezone(&Utc))
-        .map_err(|e| format!("invalid RFC 3339 timestamp '{s}': {e}"))
 }
 
 /// Run state values accepted by `--state`. Repeatable; multiple values match any of them.


### PR DESCRIPTION
## Description

This adds a set of CLI commands for managing API keys:
* `oz api-key list`: list all keys, with support for JSON output and `jq` filtering
* `oz api-key create`: create a new API key, either personal or for an agent. Choosing an expiry option is required
* `oz api-key expire`: immediately delete/expire an API key, prompting for confirmation first

As the number of uses for API keys grows, I figured this would be useful as a quick way to manage them, especially for creating agent-specific keys.

Plan: https://staging.warp.dev/drive/notebook/Add-Oz-CLI-API-key-management-commands-NmCZta9GAiXjQEcQJJRERl

## Testing

- [x] Added unit tests for sorting and for more complicated parsing logic
- [x] I have manually tested my changes locally with `./script/run` 

### Screenshots / Videos

https://www.loom.com/share/d5d5000e975a48699ade8290079f5f0f (used staging, so restricted to Warp team)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
