### PR TITLE
Keep branch chip visible during handoff

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -155,6 +155,7 @@ impl AgentToolbarItemKind {
     /// Only items relevant to composing a cloud run are shown.
     pub(super) fn is_available_during_handoff_compose(&self) -> bool {
         match self {
+            Self::ContextChip(ContextChipKind::ShellGitBranch) => true,
             Self::ModelSelector | Self::VoiceInput | Self::FileAttach => true,
             Self::ContextChip(_)
             | Self::NLDToggle
@@ -320,6 +321,38 @@ impl AgentToolbarItemKind {
                 Self::all_available_for_cli_input(),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handoff_compose_keeps_branch_chip_available() {
+        assert!(
+            AgentToolbarItemKind::ContextChip(ContextChipKind::ShellGitBranch)
+                .is_available_during_handoff_compose()
+        );
+    }
+
+    #[test]
+    fn handoff_compose_keeps_non_context_controls_available() {
+        assert!(AgentToolbarItemKind::ModelSelector.is_available_during_handoff_compose());
+        assert!(AgentToolbarItemKind::VoiceInput.is_available_during_handoff_compose());
+        assert!(AgentToolbarItemKind::FileAttach.is_available_during_handoff_compose());
+    }
+
+    #[test]
+    fn handoff_compose_hides_unrelated_context_chips() {
+        assert!(
+            !AgentToolbarItemKind::ContextChip(ContextChipKind::WorkingDirectory)
+                .is_available_during_handoff_compose()
+        );
+        assert!(
+            !AgentToolbarItemKind::ContextChip(ContextChipKind::GitDiffStats)
+                .is_available_during_handoff_compose()
+        );
     }
 }
 

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -324,38 +324,6 @@ impl AgentToolbarItemKind {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn handoff_compose_keeps_branch_chip_available() {
-        assert!(
-            AgentToolbarItemKind::ContextChip(ContextChipKind::ShellGitBranch)
-                .is_available_during_handoff_compose()
-        );
-    }
-
-    #[test]
-    fn handoff_compose_keeps_non_context_controls_available() {
-        assert!(AgentToolbarItemKind::ModelSelector.is_available_during_handoff_compose());
-        assert!(AgentToolbarItemKind::VoiceInput.is_available_during_handoff_compose());
-        assert!(AgentToolbarItemKind::FileAttach.is_available_during_handoff_compose());
-    }
-
-    #[test]
-    fn handoff_compose_hides_unrelated_context_chips() {
-        assert!(
-            !AgentToolbarItemKind::ContextChip(ContextChipKind::WorkingDirectory)
-                .is_available_during_handoff_compose()
-        );
-        assert!(
-            !AgentToolbarItemKind::ContextChip(ContextChipKind::GitDiffStats)
-                .is_available_during_handoff_compose()
-        );
-    }
-}
-
 impl From<ContextChipKind> for AgentToolbarItemKind {
     fn from(kind: ContextChipKind) -> Self {
         Self::ContextChip(kind)


### PR DESCRIPTION
## Description

WISOTT. There's no reason not to do this, and it's helpful to know what will be passed to the cloud agent.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/10da1e4c58964dfbb3204df502e79c01

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/4c4bad14-29f4-4ab3-8ede-a6b826e991a0_
_Run: https://oz.staging.warp.dev/runs/019e2bce-39e3-7b8a-adff-115efd7548df_
_This PR was generated with [Oz](https://warp.dev/oz)._
