### PR TITLE
Surface descriptive errors for local-to-cloud handoff failures

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13244,17 +13244,6 @@ impl Workspace {
     }
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    fn show_handoff_error_toast(
-        message: String,
-        window_id: WindowId,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-            toast_stack.add_ephemeral_toast(DismissibleToast::error(message), window_id, ctx);
-        });
-    }
-
-    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn restore_source_handoff_draft(
         source_view: &ViewHandle<TerminalView>,
         launch: Option<PendingCloudLaunch>,
@@ -13379,12 +13368,17 @@ impl Workspace {
                 "start_local_to_cloud_handoff: failed to push fresh cloud-mode pane over the active session"
             );
             Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-            Self::show_handoff_error_toast(
-                "Couldn't open a cloud pane for handoff. Try again, or restart Warp if this keeps happening."
-                    .to_owned(),
-                ctx.window_id(),
-                ctx,
-            );
+            let window_id = ctx.window_id();
+            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                toast_stack.add_ephemeral_toast(
+                    DismissibleToast::error(
+                        "Couldn't open a cloud pane for handoff. Try again, or restart Warp if this keeps happening."
+                            .to_owned(),
+                    ),
+                    window_id,
+                    ctx,
+                );
+            });
             return;
         };
 
@@ -13436,11 +13430,17 @@ impl Workspace {
             log::warn!(
                 "start_local_to_cloud_handoff: no active session view in the active tab to hand off"
             );
-            Self::show_handoff_error_toast(
-                "No active terminal session to hand off. Focus a pane and try again.".to_owned(),
-                ctx.window_id(),
-                ctx,
-            );
+            let window_id = ctx.window_id();
+            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                toast_stack.add_ephemeral_toast(
+                    DismissibleToast::error(
+                        "No active terminal session to hand off. Focus a pane and try again."
+                            .to_owned(),
+                    ),
+                    window_id,
+                    ctx,
+                );
+            });
             return;
         };
 
@@ -13502,12 +13502,17 @@ impl Workspace {
                 source_conversation.id()
             );
             Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-            Self::show_handoff_error_toast(
-                "This conversation hasn't synced to the cloud yet. Wait a moment, then try again."
-                    .to_owned(),
-                ctx.window_id(),
-                ctx,
-            );
+            let window_id = ctx.window_id();
+            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                toast_stack.add_ephemeral_toast(
+                    DismissibleToast::error(
+                        "This conversation hasn't synced to the cloud yet. Wait a moment, then try again."
+                            .to_owned(),
+                    ),
+                    window_id,
+                    ctx,
+                );
+            });
             return;
         };
 
@@ -13538,13 +13543,16 @@ impl Workspace {
                         "start_local_to_cloud_handoff: fork_conversation RPC failed: {err:#}"
                     );
                     Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-                    Self::show_handoff_error_toast(
-                        format!(
-                            "Couldn't fork the conversation on the server: {err}. Check your connection and try again."
-                        ),
-                        ctx.window_id(),
-                        ctx,
-                    );
+                    let window_id = ctx.window_id();
+                    WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                        toast_stack.add_ephemeral_toast(
+                            DismissibleToast::error(format!(
+                                "Couldn't fork the conversation on the server: {err}. Check your connection and try again."
+                            )),
+                            window_id,
+                            ctx,
+                        );
+                    });
                 }
             },
         );
@@ -13582,13 +13590,16 @@ impl Workspace {
                     "complete_local_to_cloud_handoff_open: failed to materialize local fork of conversation {:?} for handoff: {err:#}",
                     source_conversation.id()
                 );
-                Self::show_handoff_error_toast(
-                    format!(
-                        "Couldn't save a local copy of the forked conversation: {err}. Try again."
-                    ),
-                    ctx.window_id(),
-                    ctx,
-                );
+                let window_id = ctx.window_id();
+                WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(format!(
+                            "Couldn't save a local copy of the forked conversation: {err}. Try again."
+                        )),
+                        window_id,
+                        ctx,
+                    );
+                });
                 return;
             }
         };
@@ -13601,12 +13612,17 @@ impl Workspace {
             log::warn!(
                 "complete_local_to_cloud_handoff_open: failed to push cloud-mode pane after forking conversation (forked_conversation_id={forked_conversation_id}, local_fork_id={local_fork_id:?})"
             );
-            Self::show_handoff_error_toast(
-                "Couldn't open a cloud pane for the forked conversation. Try again, or restart Warp if this keeps happening."
-                    .to_owned(),
-                ctx.window_id(),
-                ctx,
-            );
+            let window_id = ctx.window_id();
+            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                toast_stack.add_ephemeral_toast(
+                    DismissibleToast::error(
+                        "Couldn't open a cloud pane for the forked conversation. Try again, or restart Warp if this keeps happening."
+                            .to_owned(),
+                    ),
+                    window_id,
+                    ctx,
+                );
+            });
             return;
         };
         // Restore the forked conversation into the newly-created pane.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13244,11 +13244,13 @@ impl Workspace {
     }
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-    fn show_handoff_prepare_failed_toast(window_id: WindowId, ctx: &mut ViewContext<Self>) {
+    fn show_handoff_error_toast(
+        message: String,
+        window_id: WindowId,
+        ctx: &mut ViewContext<Self>,
+    ) {
         WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-            let toast =
-                DismissibleToast::error("Failed to prepare handoff. Please try again.".to_owned());
-            toast_stack.add_ephemeral_toast(toast, window_id, ctx);
+            toast_stack.add_ephemeral_toast(DismissibleToast::error(message), window_id, ctx);
         });
     }
 
@@ -13373,9 +13375,16 @@ impl Workspace {
         let Some((new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
             view.start_local_to_cloud_handoff_pane(view_ctx)
         }) else {
-            log::warn!("start_local_to_cloud_handoff: failed to push fresh cloud-mode pane");
+            log::warn!(
+                "start_local_to_cloud_handoff: failed to push fresh cloud-mode pane over the active session"
+            );
             Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-            Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+            Self::show_handoff_error_toast(
+                "Couldn't open a cloud pane for handoff. Try again, or restart Warp if this keeps happening."
+                    .to_owned(),
+                ctx.window_id(),
+                ctx,
+            );
             return;
         };
 
@@ -13424,7 +13433,14 @@ impl Workspace {
             .as_ref(ctx)
             .active_session_view(ctx)
         else {
-            Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+            log::warn!(
+                "start_local_to_cloud_handoff: no active session view in the active tab to hand off"
+            );
+            Self::show_handoff_error_toast(
+                "No active terminal session to hand off. Focus a pane and try again.".to_owned(),
+                ctx.window_id(),
+                ctx,
+            );
             return;
         };
 
@@ -13481,8 +13497,17 @@ impl Workspace {
         }
 
         let Some(source_token) = source_conversation.server_conversation_token().cloned() else {
+            log::warn!(
+                "start_local_to_cloud_handoff: source conversation {:?} has no server token yet; cloud sync may not have completed",
+                source_conversation.id()
+            );
             Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-            Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+            Self::show_handoff_error_toast(
+                "This conversation hasn't synced to the cloud yet. Wait a moment, then try again."
+                    .to_owned(),
+                ctx.window_id(),
+                ctx,
+            );
             return;
         };
 
@@ -13509,9 +13534,17 @@ impl Workspace {
                     );
                 }
                 Err(err) => {
-                    log::warn!("fork_conversation failed: {err:#}");
+                    log::warn!(
+                        "start_local_to_cloud_handoff: fork_conversation RPC failed: {err:#}"
+                    );
                     Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-                    Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+                    Self::show_handoff_error_toast(
+                        format!(
+                            "Couldn't fork the conversation on the server: {err}. Check your connection and try again."
+                        ),
+                        ctx.window_id(),
+                        ctx,
+                    );
                 }
             },
         );
@@ -13545,8 +13578,17 @@ impl Workspace {
         }) {
             Ok(forked) => forked,
             Err(err) => {
-                log::warn!("Failed to materialize local fork for handoff: {err:#}");
-                Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+                log::warn!(
+                    "complete_local_to_cloud_handoff_open: failed to materialize local fork of conversation {:?} for handoff: {err:#}",
+                    source_conversation.id()
+                );
+                Self::show_handoff_error_toast(
+                    format!(
+                        "Couldn't save a local copy of the forked conversation: {err}. Try again."
+                    ),
+                    ctx.window_id(),
+                    ctx,
+                );
                 return;
             }
         };
@@ -13556,8 +13598,15 @@ impl Workspace {
         let Some((new_pane_view, model_handle)) = source_view.update(ctx, |view, view_ctx| {
             view.start_local_to_cloud_handoff_pane(view_ctx)
         }) else {
-            log::warn!("start_local_to_cloud_handoff: failed to push cloud-mode pane");
-            Self::show_handoff_prepare_failed_toast(ctx.window_id(), ctx);
+            log::warn!(
+                "complete_local_to_cloud_handoff_open: failed to push cloud-mode pane after forking conversation (forked_conversation_id={forked_conversation_id}, local_fork_id={local_fork_id:?})"
+            );
+            Self::show_handoff_error_toast(
+                "Couldn't open a cloud pane for the forked conversation. Try again, or restart Warp if this keeps happening."
+                    .to_owned(),
+                ctx.window_id(),
+                ctx,
+            );
             return;
         };
         // Restore the forked conversation into the newly-created pane.


### PR DESCRIPTION
## Summary
- Replaced the generic `show_handoff_prepare_failed_toast` helper (which always rendered _\"Failed to prepare handoff. Please try again.\"_) with `show_handoff_error_toast`, which takes a per-site message.
- At each of the six handoff failure sites in `app/src/workspace/view.rs`, surfaced a toast that names the actual failure (and, when applicable, what the user can do about it) and added/expanded a `log::warn!` with site-specific context (conversation id, fork id, underlying error, etc.).

## Why
The previous flow funneled six distinct failure modes — no active session, conversation not yet synced, fork RPC failure, local fork materialization failure, fresh-launch pane push failure, post-fork pane push failure — through a single toast string, and two of those sites had no log line at all. That made user reports and debugging guess-work. Each site now produces a distinct toast and a distinct warn-level log line.

## Sites updated
| Where | New toast | New log |
|---|---|---|
| `start_fresh_cloud_launch` — push fresh pane fails | _Couldn't open a cloud pane for handoff. Try again, or restart Warp if this keeps happening._ | _failed to push fresh cloud-mode pane over the active session_ |
| `start_local_to_cloud_handoff` — no active session view | _No active terminal session to hand off. Focus a pane and try again._ | _no active session view in the active tab to hand off_ (new) |
| `start_local_to_cloud_handoff` — conversation has no server token | _This conversation hasn't synced to the cloud yet. Wait a moment, then try again._ | _source conversation {id} has no server token yet; cloud sync may not have completed_ (new) |
| `start_local_to_cloud_handoff` — fork RPC error | _Couldn't fork the conversation on the server: {err}. Check your connection and try again._ | _fork_conversation RPC failed: {err:#}_ |
| `complete_local_to_cloud_handoff_open` — local fork materialization fails | _Couldn't save a local copy of the forked conversation: {err}. Try again._ | _failed to materialize local fork of conversation {id} for handoff: {err:#}_ |
| `complete_local_to_cloud_handoff_open` — push pane after fork | _Couldn't open a cloud pane for the forked conversation. Try again, or restart Warp if this keeps happening._ | _failed to push cloud-mode pane after forking conversation (forked_conversation_id=…, local_fork_id=…)_ |

## Test plan
- [ ] `cargo check -p warp --lib` (run, passes locally)
- [ ] Manual: trigger \`/move-to-cloud\` with no active session → confirm the focus-a-pane toast appears
- [ ] Manual: trigger handoff on an unsynced conversation → confirm the not-yet-synced toast appears
- [ ] Manual: force a fork RPC failure (offline) → confirm the connection-error toast surfaces the underlying error
- [ ] Manual: spot-check log output to confirm each warn line is unique and identifies the site

_This PR was created by [Oz](https://warp.dev/oz) (running Claude Code)._