### PR TITLE
Show cloud agent env name and setup status for vertical tabs pwd

### DIFF
--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -890,13 +890,7 @@ impl BlocklistAIStatusBar {
             .map(|ambient_agent_view_model| ambient_agent_view_model.as_ref(app))?;
 
         let progress = ambient_agent_model.agent_progress()?;
-        let progress_text = if progress.harness_started_at.is_some() {
-            "Starting Environment (Step 3/3)"
-        } else if progress.claimed_at.is_some() {
-            "Creating Environment (Step 2/3)"
-        } else {
-            "Connecting to Host (Step 1/3)"
-        };
+        let progress_text = progress.setup_status_text();
         Some(render_warping_indicator_base(
             WarpingIndicatorProps {
                 icon: None,

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -68,6 +68,16 @@ impl AgentProgress {
             stopped_at: None,
         }
     }
+
+    pub fn setup_status_text(&self) -> &'static str {
+        if self.harness_started_at.is_some() {
+            "Starting Environment (Step 3/3)"
+        } else if self.claimed_at.is_some() {
+            "Creating Environment (Step 2/3)"
+        } else {
+            "Connecting to Host (Step 1/3)"
+        }
+    }
 }
 
 /// Identifies what kind of session startup the model is currently waiting on.

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -846,13 +846,7 @@ impl TerminalView {
             )
         } else {
             // Show loading screen - determine the message based on progress state
-            let message = if progress.harness_started_at.is_some() {
-                "Starting Environment (Step 3/3)"
-            } else if progress.claimed_at.is_some() {
-                "Creating Environment (Step 2/3)"
-            } else {
-                "Connecting to Host (Step 1/3)"
-            };
+            let message = progress.setup_status_text();
 
             render_cloud_mode_loading_screen(
                 message,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2734,10 +2734,7 @@ fn build_vertical_tabs_summary_data(
                 let terminal_view = terminal_pane.terminal_view(app);
                 let terminal_view = terminal_view.as_ref(app);
                 let title_text = terminal_view.terminal_title_from_shell();
-                let working_directory = terminal_view.display_working_directory(app);
-                let working_directory =
-                    cloud_agent_working_directory(terminal_view, working_directory.as_deref(), app)
-                        .or(working_directory);
+                let working_directory = resolved_terminal_working_directory(terminal_view, app);
                 let working_directory_text = working_directory
                     .clone()
                     .filter(|wd| !wd.trim().is_empty())
@@ -2997,9 +2994,7 @@ fn terminal_pane_search_text_fragments(
     let terminal_view = terminal_pane.terminal_view(app);
     let terminal_view = terminal_view.as_ref(app);
     let title_text = terminal_view.terminal_title_from_shell();
-    let working_directory = terminal_view
-        .display_working_directory(app)
-        .filter(|wd| !wd.trim().is_empty())
+    let working_directory = resolved_terminal_working_directory(terminal_view, app)
         .unwrap_or_else(|| title_text.clone());
     let agent_text = terminal_agent_text(terminal_view, app);
     let (conversation_display_title, cli_agent_title) =
@@ -3263,7 +3258,22 @@ impl PaneGroup {
     }
 }
 
-fn cloud_agent_working_directory(
+/// Returns the best available working-directory string for a terminal pane,
+/// incorporating cloud environment name and setup status for ambient agent sessions.
+fn resolved_terminal_working_directory(
+    terminal_view: &TerminalView,
+    app: &AppContext,
+) -> Option<String> {
+    let working_directory = terminal_view
+        .display_working_directory(app)
+        .filter(|wd| !wd.trim().is_empty());
+    cloud_agent_working_directory_and_env(terminal_view, working_directory.as_deref(), app)
+        .or(working_directory)
+}
+
+/// For cloud agent panes, builds a composite string from the environment name,
+/// setup status, and/or working directory. Returns `None` for non-cloud sessions.
+fn cloud_agent_working_directory_and_env(
     terminal_view: &TerminalView,
     working_directory: Option<&str>,
     app: &AppContext,
@@ -3271,8 +3281,7 @@ fn cloud_agent_working_directory(
     if !terminal_view.is_ambient_agent_session(app) {
         return None;
     }
-    let model = terminal_view.ambient_agent_view_model()?;
-    let model_ref = model.as_ref(app);
+    let model_ref = terminal_view.ambient_agent_view_model()?.as_ref(app);
 
     let env_name = model_ref
         .selected_environment_id()
@@ -3282,8 +3291,8 @@ fn cloud_agent_working_directory(
     let setup_status: Option<&str> = model_ref.agent_progress().map(|p| p.setup_status_text());
 
     match (env_name, setup_status, working_directory) {
-        (Some(env), Some(status), _) => Some(format!("{env} \u{00B7} {status}")),
-        (Some(env), None, Some(wd)) => Some(format!("{env} \u{00B7} {wd}")),
+        (Some(env), Some(status), _) => Some(format!("{env} · {status}")),
+        (Some(env), None, Some(wd)) => Some(format!("{env} · {wd}")),
         (Some(env), None, None) => Some(env),
         (None, Some(status), _) => Some(status.to_string()),
         (None, None, _) => None,
@@ -3302,13 +3311,8 @@ fn render_terminal_row_content(
     let primary_info = *TabSettings::as_ref(app).vertical_tabs_primary_info.value();
 
     let title_text = terminal_view.terminal_title_from_shell();
-    let working_directory = terminal_view
-        .display_working_directory(app)
-        .filter(|wd| !wd.trim().is_empty());
-    let working_directory =
-        cloud_agent_working_directory(terminal_view, working_directory.as_deref(), app)
-            .or(working_directory)
-            .unwrap_or_else(|| title_text.clone());
+    let working_directory = resolved_terminal_working_directory(terminal_view, app)
+        .unwrap_or_else(|| title_text.clone());
 
     let git_branch = terminal_view.current_git_branch(app);
 
@@ -4106,9 +4110,7 @@ fn render_terminal_primary_line_for_view(
     app: &AppContext,
 ) -> Box<dyn Element> {
     let title_text = terminal_view.terminal_title_from_shell();
-    let working_directory = terminal_view
-        .display_working_directory(app)
-        .filter(|wd| !wd.trim().is_empty())
+    let working_directory = resolved_terminal_working_directory(terminal_view, app)
         .unwrap_or_else(|| title_text.clone());
     let agent_text = terminal_agent_text(terminal_view, app);
     let (conversation_display_title, cli_agent_title) =
@@ -5631,7 +5633,7 @@ fn render_terminal_detail_section(
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
     let text_colors = detail_sidecar_text_colors(theme);
-    let working_directory = terminal_view.display_working_directory(app);
+    let working_directory = resolved_terminal_working_directory(terminal_view, app);
     let git_branch = terminal_view.current_git_branch(app);
     let cli_agent_session = CLIAgentSessionsModel::as_ref(app).session(terminal_view.id());
     let agent_text = terminal_agent_text(terminal_view, app);
@@ -6095,12 +6097,7 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
             let terminal_view = terminal_pane.terminal_view(app).as_ref(app);
             let terminal_title = terminal_view.terminal_title_from_shell();
             let git_branch = terminal_view.current_git_branch(app);
-            let working_directory = terminal_view
-                .display_working_directory(app)
-                .filter(|wd| !wd.trim().is_empty());
-            let working_directory =
-                cloud_agent_working_directory(terminal_view, working_directory.as_deref(), app)
-                    .or(working_directory);
+            let working_directory = resolved_terminal_working_directory(terminal_view, app);
             let working_directory_text = working_directory
                 .clone()
                 .unwrap_or_else(|| terminal_title.clone());

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2,7 +2,9 @@ pub mod telemetry;
 
 use crate::ai::agent::conversation::{ConversationStatus, StatusColorStyle};
 use crate::ai::agent_management::AgentNotificationsModel;
+use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::conversation_status_ui::render_status_element;
+use crate::cloud_object::model::generic_string_model::StringModel;
 use crate::code::editor::{add_color, remove_color};
 use crate::code::icon_from_file_path;
 use crate::safe_triangle::SafeTriangle;
@@ -2733,6 +2735,9 @@ fn build_vertical_tabs_summary_data(
                 let terminal_view = terminal_view.as_ref(app);
                 let title_text = terminal_view.terminal_title_from_shell();
                 let working_directory = terminal_view.display_working_directory(app);
+                let working_directory =
+                    cloud_agent_working_directory(terminal_view, working_directory.as_deref(), app)
+                        .or(working_directory);
                 let working_directory_text = working_directory
                     .clone()
                     .filter(|wd| !wd.trim().is_empty())
@@ -3258,6 +3263,33 @@ impl PaneGroup {
     }
 }
 
+fn cloud_agent_working_directory(
+    terminal_view: &TerminalView,
+    working_directory: Option<&str>,
+    app: &AppContext,
+) -> Option<String> {
+    if !terminal_view.is_ambient_agent_session(app) {
+        return None;
+    }
+    let model = terminal_view.ambient_agent_view_model()?;
+    let model_ref = model.as_ref(app);
+
+    let env_name = model_ref
+        .selected_environment_id()
+        .and_then(|id| CloudAmbientAgentEnvironment::get_by_id(id, app))
+        .map(|env| env.model().string_model.display_name());
+
+    let setup_status: Option<&str> = model_ref.agent_progress().map(|p| p.setup_status_text());
+
+    match (env_name, setup_status, working_directory) {
+        (Some(env), Some(status), _) => Some(format!("{env} \u{00B7} {status}")),
+        (Some(env), None, Some(wd)) => Some(format!("{env} \u{00B7} {wd}")),
+        (Some(env), None, None) => Some(env),
+        (None, Some(status), _) => Some(status.to_string()),
+        (None, None, _) => None,
+    }
+}
+
 fn render_terminal_row_content(
     props: &PaneProps<'_>,
     terminal_view: &TerminalView,
@@ -3272,8 +3304,11 @@ fn render_terminal_row_content(
     let title_text = terminal_view.terminal_title_from_shell();
     let working_directory = terminal_view
         .display_working_directory(app)
-        .filter(|wd| !wd.trim().is_empty())
-        .unwrap_or_else(|| title_text.clone());
+        .filter(|wd| !wd.trim().is_empty());
+    let working_directory =
+        cloud_agent_working_directory(terminal_view, working_directory.as_deref(), app)
+            .or(working_directory)
+            .unwrap_or_else(|| title_text.clone());
 
     let git_branch = terminal_view.current_git_branch(app);
 
@@ -6063,6 +6098,9 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
             let working_directory = terminal_view
                 .display_working_directory(app)
                 .filter(|wd| !wd.trim().is_empty());
+            let working_directory =
+                cloud_agent_working_directory(terminal_view, working_directory.as_deref(), app)
+                    .or(working_directory);
             let working_directory_text = working_directory
                 .clone()
                 .unwrap_or_else(|| terminal_title.clone());


### PR DESCRIPTION
## Summary

There was a weird UI pattern where, after kicking off a cloud run, the directory and branch (which falls back to the directory when there's no branch info) in the vertical tabs would be empty. This looked especially bad if the directory was your vertical tabs title, as then the title would just be empty.

The fix is to show:
* "Environment <dot> setup status text" while the environment is starting up and
* "Environment <dot> pwd" when the environment is set up (this isn't solving the first problem, but it's nice to know what env you're in from vertical tabs so @zachbai and I figured it made sense to add)

## Demo

https://www.loom.com/share/1104c17370df4e0f9e1f8e7adfe20b93

---

_Conversation: https://staging.warp.dev/conversation/f142b97d-c442-4ec1-ac77-653ace48f2e2_
_This PR was generated with [Oz](https://warp.dev/oz)._
