### PR TITLE
Log invalid GraphQL enum values as warnings instead of errors

### DIFF
--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2489,9 +2489,9 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmModelHost> for LL
                 LLMModelHost::CustomEndpoint
             }
             warp_graphql::queries::get_feature_model_choices::LlmModelHost::Other(value) => {
-                report_error!(anyhow!(
+                log::warn!(
                     "Unknown LlmModelHost '{value}'. Make sure to update client GraphQL types!"
-                ));
+                );
                 LLMModelHost::Unknown
             }
         }
@@ -2515,9 +2515,9 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmProvider> for LLM
                 LLMProvider::Unknown
             }
             warp_graphql::queries::get_feature_model_choices::LlmProvider::Other(value) => {
-                report_error!(anyhow!(
+                log::warn!(
                     "Invalid LlmProvider '{value}'. Make sure to update client GraphQL types!"
-                ));
+                );
                 LLMProvider::Unknown
             }
         }
@@ -2533,9 +2533,9 @@ impl From<warp_graphql::workspace::LlmProvider> for LLMProvider {
             warp_graphql::workspace::LlmProvider::Xai => LLMProvider::Xai,
             warp_graphql::workspace::LlmProvider::Unknown => LLMProvider::Unknown,
             warp_graphql::workspace::LlmProvider::Other(value) => {
-                report_error!(anyhow!(
+                log::warn!(
                     "Invalid LlmProvider '{value}'. Make sure to update client GraphQL types!"
-                ));
+                );
                 LLMProvider::Unknown
             }
         }
@@ -2625,9 +2625,7 @@ fn convert_harness(harness: warp_graphql::ai::AgentHarness) -> AIAgentHarness {
         warp_graphql::ai::AgentHarness::Gemini => AIAgentHarness::Gemini,
         warp_graphql::ai::AgentHarness::Codex => AIAgentHarness::Codex,
         warp_graphql::ai::AgentHarness::Other(value) => {
-            report_error!(anyhow!(
-                "Invalid AgentHarness '{value}'. Make sure to update client GraphQL types!"
-            ));
+            log::warn!("Invalid AgentHarness '{value}'. Make sure to update client GraphQL types!");
             AIAgentHarness::Unknown
         }
     }

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -237,9 +237,9 @@ impl From<GqlUgcCollectionEnablementSetting> for UgcCollectionEnablementSetting 
                 UgcCollectionEnablementSetting::RespectUserSetting
             }
             GqlUgcCollectionEnablementSetting::Other(value) => {
-                report_error!(anyhow!(
+                log::warn!(
                     "Invalid UgcCollectionEnablementSetting '{value}'. Make sure to update client GraphQL types!"
-                ));
+                );
                 UgcCollectionEnablementSetting::RespectUserSetting
             }
         }
@@ -278,9 +278,9 @@ impl From<GqlAdminEnablementSetting> for AdminEnablementSetting {
                 AdminEnablementSetting::RespectUserSetting
             }
             GqlAdminEnablementSetting::Other(value) => {
-                report_error!(anyhow!(
+                log::warn!(
                     "Invalid AdminEnablementSetting '{value}'. Make sure to update client GraphQL types!"
-                ));
+                );
                 AdminEnablementSetting::RespectUserSetting
             }
         }
@@ -295,9 +295,9 @@ impl From<GqlHostEnablementSetting> for HostEnablementSetting {
                 HostEnablementSetting::RespectUserSetting
             }
             GqlHostEnablementSetting::Other(value) => {
-                report_error!(anyhow!(
+                log::warn!(
                     "Invalid HostEnablementSetting '{value}'. Make sure to update client GraphQL types!"
-                ));
+                );
                 HostEnablementSetting::RespectUserSetting
             }
         }
@@ -578,9 +578,9 @@ fn convert_gql_ai_autonomy_value_to_action_permission(
         GqlAiAutonomyValue::AlwaysAsk => Some(ActionPermission::AlwaysAsk),
         GqlAiAutonomyValue::RespectUserSetting => None,
         GqlAiAutonomyValue::Other(value) => {
-            report_error!(anyhow!(
+            log::warn!(
                 "Invalid AiAutonomyValue '{value}'. Make sure to update client GraphQL types!"
-            ));
+            );
             None
         }
     }
@@ -595,9 +595,9 @@ fn convert_gql_write_to_pty_autonomy_value_to_write_to_pty_permission(
         GqlWriteToPtyAutonomyValue::AskOnFirstWrite => Some(WriteToPtyPermission::AskOnFirstWrite),
         GqlWriteToPtyAutonomyValue::RespectUserSetting => None,
         GqlWriteToPtyAutonomyValue::Other(value) => {
-            report_error!(anyhow!(
+            log::warn!(
                 "Invalid WriteToPtyAutonomyValue '{value}'. Make sure to update client GraphQL types!"
-            ));
+            );
             None
         }
     }
@@ -612,9 +612,9 @@ fn convert_gql_computer_use_autonomy_value_to_computer_use_permission(
         GqlComputerUseAutonomyValue::AlwaysAllow => Some(ComputerUsePermission::AlwaysAllow),
         GqlComputerUseAutonomyValue::RespectUserSetting => None,
         GqlComputerUseAutonomyValue::Other(value) => {
-            report_error!(anyhow!(
+            log::warn!(
                 "Invalid ComputerUseAutonomyValue '{value}'. Make sure to update client GraphQL types!"
-            ));
+            );
             None
         }
     }
@@ -659,9 +659,9 @@ impl From<warp_graphql::workspace::LlmModelHost> for crate::ai::llms::LLMModelHo
             GqlLlmModelHost::AwsBedrock => Self::AwsBedrock,
             GqlLlmModelHost::CustomEndpoint => Self::CustomEndpoint,
             GqlLlmModelHost::Other(value) => {
-                report_error!(anyhow!(
+                log::warn!(
                     "Unknown LlmModelHost '{value}'. Make sure to update client GraphQL types!"
-                ));
+                );
                 Self::Unknown
             }
         }


### PR DESCRIPTION
Downgrades all of the `Make sure to update client GraphQL types!` errors to warnings.

These end up flooding sentry (consuming our quota and/ or causing us to get rate limited). There's no reason they need to hit Sentry because they aren't actually user visible changes.
