### PR TITLE
Disable model selector for cloud -> cloud follow ups

### DIFF
--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -82,6 +82,11 @@ const MAX_PROFILE_NAME_WIDTH_SCALE_FACTOR: f32 = 10.0;
 
 const PROFILE_SELECTOR_POSITION_ID: &str = "profile_selector";
 
+const PROFILE_PICKER_TOOLTIP: &str = "Choose an AI execution profile";
+const MODEL_PICKER_TOOLTIP: &str = "Choose an agent model";
+const MODEL_LOCKED_FOR_FOLLOWUP_TOOLTIP: &str = "Follow-ups use the original run's model";
+const MODEL_REQUIRES_EDIT_ACCESS_TOOLTIP: &str = "Request edit access to change model";
+
 pub fn calculate_scaled_font_size(appearance: &warp_core::ui::appearance::Appearance) -> f32 {
     if FeatureFlag::AgentView.is_enabled() {
         udi_font_size(appearance)
@@ -258,7 +263,7 @@ impl ProfileModelSelector {
                 ),
                 is_blurred: false,
             })
-            .with_tooltip("Choose an AI execution profile")
+            .with_tooltip(PROFILE_PICKER_TOOLTIP)
             .with_size(ButtonSize::UDIButton)
             .with_icon(Icon::Psychology)
         });
@@ -286,14 +291,14 @@ impl ProfileModelSelector {
                 ),
                 is_blurred: false,
             })
-            .with_tooltip("Choose an agent model")
+            .with_tooltip(MODEL_PICKER_TOOLTIP)
             .with_size(ButtonSize::UDIButton)
         });
 
         let profile_compact_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("", PromptIconButtonTheme::new(false))
                 .with_icon(Icon::Psychology)
-                .with_tooltip("Choose an AI execution profile")
+                .with_tooltip(PROFILE_PICKER_TOOLTIP)
                 .with_size(ButtonSize::UDIButton)
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(ProfileModelSelectorAction::ToggleProfileMenu);
@@ -303,7 +308,7 @@ impl ProfileModelSelector {
         let model_compact_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("", PromptIconButtonTheme::new(false))
                 .with_icon(Icon::Neurology)
-                .with_tooltip("Choose an agent model")
+                .with_tooltip(MODEL_PICKER_TOOLTIP)
                 .with_size(ButtonSize::UDIButton)
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(ProfileModelSelectorAction::ToggleModelMenu);
@@ -609,22 +614,33 @@ impl ProfileModelSelector {
         format!("{PROFILE_SELECTOR_POSITION_ID}_{llm_id}")
     }
 
-    /// Returns true when the model selector should be locked (disabled and
-    /// non-interactive). The selector is locked when either:
-    /// - The session has ended and the user is composing a follow-up (all
-    ///   harnesses), because the server inherits the original task's config.
-    /// - A non-Oz cloud run has been spawned (live or ended), because
-    ///   changing the harness model locally has no effect.
-    fn is_model_locked(&self, app: &AppContext) -> bool {
+    /// Locked because the user is composing a follow-up to a Cloud Mode run
+    /// that has ended. The server inherits the original task's model config
+    /// when accepting the follow-up, so changing the model locally is
+    /// meaningless.
+    fn is_locked_for_cloud_followup(&self, app: &AppContext) -> bool {
+        self.ambient_agent_view_model
+            .as_ref()
+            .is_some_and(|m| m.as_ref(app).is_ready_for_cloud_followup_prompt())
+    }
+
+    /// Locked because a non-Oz cloud run (e.g. Claude Code, Codex) has been
+    /// spawned. The harness owns model selection, so changing the model
+    /// locally has no effect on the run. We lock silently in this case
+    /// because the harness selection itself communicates the lock.
+    fn is_locked_for_non_oz_run(&self, app: &AppContext) -> bool {
         self.ambient_agent_view_model.as_ref().is_some_and(|m| {
             let model = m.as_ref(app);
-            model.is_ready_for_cloud_followup_prompt()
-                || (model.task_id().is_some()
-                    && !matches!(
-                        model.selected_harness(),
-                        warp_cli::agent::Harness::Oz | warp_cli::agent::Harness::Unknown
-                    ))
+            model.task_id().is_some()
+                && !matches!(
+                    model.selected_harness(),
+                    warp_cli::agent::Harness::Oz | warp_cli::agent::Harness::Unknown
+                )
         })
+    }
+
+    fn is_model_locked(&self, app: &AppContext) -> bool {
+        self.is_locked_for_cloud_followup(app) || self.is_locked_for_non_oz_run(app)
     }
 
     fn refresh_state(&mut self, ctx: &mut ViewContext<Self>) {
@@ -666,20 +682,30 @@ impl ProfileModelSelector {
             }
         };
 
-        let locked = self.is_model_locked(ctx);
-        let model_tooltip = if locked {
-            "Model is locked for follow-up runs"
+        // Non-Oz runs lock silently: the harness owns model selection, and the
+        // user already knows that, so no tooltip is shown.
+        let model_tooltip: Option<&str> = if self.is_locked_for_cloud_followup(ctx) {
+            Some(MODEL_LOCKED_FOR_FOLLOWUP_TOOLTIP)
+        } else if self.is_locked_for_non_oz_run(ctx) {
+            None
         } else {
-            "Choose an agent model"
+            Some(MODEL_PICKER_TOOLTIP)
         };
+        let locked = self.is_model_locked(ctx);
         self.model_button.update(ctx, |button, ctx| {
             button.set_label(model_name, ctx);
             button.set_disabled(locked, ctx);
-            button.set_tooltip(Some(model_tooltip), ctx);
+            match model_tooltip {
+                Some(t) => button.set_tooltip(Some(t), ctx),
+                None => button.clear_tooltip(ctx),
+            }
         });
         self.model_compact_button.update(ctx, |button, ctx| {
             button.set_disabled(locked, ctx);
-            button.set_tooltip(Some(model_tooltip), ctx);
+            match model_tooltip {
+                Some(t) => button.set_tooltip(Some(t), ctx),
+                None => button.clear_tooltip(ctx),
+            }
         });
         ctx.notify();
     }
@@ -1455,16 +1481,16 @@ impl ProfileModelSelector {
                     )))
                     .finish();
 
-                let tooltip_text = "Choose an AI execution profile".to_owned();
-
-                let tooltip = appearance.ui_builder().tool_tip(tooltip_text);
+                let tooltip = appearance
+                    .ui_builder()
+                    .tool_tip(PROFILE_PICKER_TOOLTIP.to_owned());
                 let mut stack = Stack::new();
                 stack.add_child(button_with_hover);
-                stack.add_positioned_child(
+                stack.add_positioned_overlay_child(
                     tooltip.build().finish(),
                     OffsetPositioning::offset_from_parent(
                         vec2f(0., -10.),
-                        ParentOffsetBounds::Unbounded,
+                        ParentOffsetBounds::WindowByPosition,
                         ParentAnchor::TopLeft,
                         ChildAnchor::BottomLeft,
                     ),
@@ -1587,7 +1613,9 @@ impl ProfileModelSelector {
         let button_with_save_position =
             SavePosition::new(button, "profile_model_selector_model_button").finish();
 
-        let is_locked = self.is_model_locked(app);
+        let is_locked_for_followup = self.is_locked_for_cloud_followup(app);
+        let is_locked_for_non_oz = self.is_locked_for_non_oz_run(app);
+        let is_locked = is_locked_for_followup || is_locked_for_non_oz;
         let can_interact = has_edit_access && !is_locked;
 
         let hoverable = Hoverable::new(self.model_mouse_state.clone(), move |state| {
@@ -1599,41 +1627,48 @@ impl ProfileModelSelector {
                     )))
                     .finish();
 
-                let tooltip_text = "Choose an agent model".to_owned();
-
-                let tooltip = appearance.ui_builder().tool_tip(tooltip_text);
+                let tooltip = appearance
+                    .ui_builder()
+                    .tool_tip(MODEL_PICKER_TOOLTIP.to_owned());
                 let mut stack = Stack::new();
                 stack.add_child(button_with_hover);
-                stack.add_positioned_child(
+                stack.add_positioned_overlay_child(
                     tooltip.build().finish(),
                     OffsetPositioning::offset_from_parent(
                         vec2f(0., -10.),
-                        ParentOffsetBounds::Unbounded,
+                        ParentOffsetBounds::WindowByPosition,
                         ParentAnchor::TopLeft,
                         ChildAnchor::BottomLeft,
                     ),
                 );
                 stack.finish()
             } else if state.is_hovered() {
-                let tooltip_text = if is_locked {
-                    "Model is locked for follow-up runs"
+                // Non-Oz runs lock silently — skip the tooltip entirely.
+                let tooltip_text: Option<&str> = if is_locked_for_followup {
+                    Some(MODEL_LOCKED_FOR_FOLLOWUP_TOOLTIP)
+                } else if is_locked_for_non_oz {
+                    None
                 } else {
-                    "Request edit access to change model"
+                    Some(MODEL_REQUIRES_EDIT_ACCESS_TOOLTIP)
                 };
 
-                let tooltip = appearance.ui_builder().tool_tip(tooltip_text.to_owned());
-                let mut stack = Stack::new();
-                stack.add_child(button_with_save_position);
-                stack.add_positioned_child(
-                    tooltip.build().finish(),
-                    OffsetPositioning::offset_from_parent(
-                        vec2f(0., -10.),
-                        ParentOffsetBounds::Unbounded,
-                        ParentAnchor::TopLeft,
-                        ChildAnchor::BottomLeft,
-                    ),
-                );
-                stack.finish()
+                if let Some(text) = tooltip_text {
+                    let tooltip = appearance.ui_builder().tool_tip(text.to_owned());
+                    let mut stack = Stack::new();
+                    stack.add_child(button_with_save_position);
+                    stack.add_positioned_overlay_child(
+                        tooltip.build().finish(),
+                        OffsetPositioning::offset_from_parent(
+                            vec2f(0., -10.),
+                            ParentOffsetBounds::WindowByPosition,
+                            ParentAnchor::TopLeft,
+                            ChildAnchor::BottomLeft,
+                        ),
+                    );
+                    stack.finish()
+                } else {
+                    button_with_save_position
+                }
             } else {
                 button_with_save_position
             }

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -505,6 +505,20 @@ impl ProfileModelSelector {
             },
         );
 
+        if let Some(ref ambient_model) = ambient_agent_view_model {
+            ctx.subscribe_to_model(ambient_model, |me, _, event, ctx| {
+                use crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent;
+                if matches!(
+                    event,
+                    AmbientAgentViewModelEvent::RunLifecycleChanged
+                        | AmbientAgentViewModelEvent::SessionReady { .. }
+                        | AmbientAgentViewModelEvent::FollowupDispatched
+                ) {
+                    me.refresh_state(ctx);
+                }
+            });
+        }
+
         let manage_api_key_button = ctx.add_typed_action_view(|_ctx| {
             ActionButton::new("Manage", SecondaryTheme)
                 .with_tooltip("Manage API keys")
@@ -595,6 +609,24 @@ impl ProfileModelSelector {
         format!("{PROFILE_SELECTOR_POSITION_ID}_{llm_id}")
     }
 
+    /// Returns true when the model selector should be locked (disabled and
+    /// non-interactive). The selector is locked when either:
+    /// - The session has ended and the user is composing a follow-up (all
+    ///   harnesses), because the server inherits the original task's config.
+    /// - A non-Oz cloud run has been spawned (live or ended), because
+    ///   changing the harness model locally has no effect.
+    fn is_model_locked(&self, app: &AppContext) -> bool {
+        self.ambient_agent_view_model.as_ref().is_some_and(|m| {
+            let model = m.as_ref(app);
+            model.is_ready_for_cloud_followup_prompt()
+                || (model.task_id().is_some()
+                    && !matches!(
+                        model.selected_harness(),
+                        warp_cli::agent::Harness::Oz | warp_cli::agent::Harness::Unknown
+                    ))
+        })
+    }
+
     fn refresh_state(&mut self, ctx: &mut ViewContext<Self>) {
         self.refresh_profile_menu(ctx);
         self.refresh_model_menu(ctx);
@@ -633,8 +665,21 @@ impl ProfileModelSelector {
                 active_llm.display_name.clone()
             }
         };
+
+        let locked = self.is_model_locked(ctx);
+        let model_tooltip = if locked {
+            "Model is locked for follow-up runs"
+        } else {
+            "Choose an agent model"
+        };
         self.model_button.update(ctx, |button, ctx| {
             button.set_label(model_name, ctx);
+            button.set_disabled(locked, ctx);
+            button.set_tooltip(Some(model_tooltip), ctx);
+        });
+        self.model_compact_button.update(ctx, |button, ctx| {
+            button.set_disabled(locked, ctx);
+            button.set_tooltip(Some(model_tooltip), ctx);
         });
         ctx.notify();
     }
@@ -1542,8 +1587,11 @@ impl ProfileModelSelector {
         let button_with_save_position =
             SavePosition::new(button, "profile_model_selector_model_button").finish();
 
+        let is_locked = self.is_model_locked(app);
+        let can_interact = has_edit_access && !is_locked;
+
         let hoverable = Hoverable::new(self.model_mouse_state.clone(), move |state| {
-            if state.is_hovered() {
+            if state.is_hovered() && can_interact {
                 let button_with_hover = Container::new(button_with_save_position)
                     .with_background(theme.surface_2())
                     .with_corner_radius(CornerRadius::with_right(Radius::Pixels(
@@ -1551,15 +1599,31 @@ impl ProfileModelSelector {
                     )))
                     .finish();
 
-                let tooltip_text = if !has_edit_access {
-                    "Request edit access to change model".to_owned()
-                } else {
-                    "Choose an agent model".to_owned()
-                };
+                let tooltip_text = "Choose an agent model".to_owned();
 
                 let tooltip = appearance.ui_builder().tool_tip(tooltip_text);
                 let mut stack = Stack::new();
                 stack.add_child(button_with_hover);
+                stack.add_positioned_child(
+                    tooltip.build().finish(),
+                    OffsetPositioning::offset_from_parent(
+                        vec2f(0., -10.),
+                        ParentOffsetBounds::Unbounded,
+                        ParentAnchor::TopLeft,
+                        ChildAnchor::BottomLeft,
+                    ),
+                );
+                stack.finish()
+            } else if state.is_hovered() {
+                let tooltip_text = if is_locked {
+                    "Model is locked for follow-up runs"
+                } else {
+                    "Request edit access to change model"
+                };
+
+                let tooltip = appearance.ui_builder().tool_tip(tooltip_text.to_owned());
+                let mut stack = Stack::new();
+                stack.add_child(button_with_save_position);
                 stack.add_positioned_child(
                     tooltip.build().finish(),
                     OffsetPositioning::offset_from_parent(
@@ -1575,16 +1639,15 @@ impl ProfileModelSelector {
             }
         });
 
-        // Only make clickable if the user can click to open the menu (i.e. has edit access)
-        if !has_edit_access {
-            hoverable.finish()
-        } else {
+        if can_interact {
             hoverable
                 .on_click(|ctx, _app, _position| {
                     ctx.dispatch_typed_action(ProfileModelSelectorAction::ToggleModelMenu);
                 })
                 .with_cursor(Cursor::PointingHand)
                 .finish()
+        } else {
+            hoverable.finish()
         }
     }
 
@@ -1913,6 +1976,9 @@ impl TypedActionView for ProfileModelSelector {
                 self.set_profile_menu_visibility(!self.is_profile_menu_open, ctx);
             }
             ProfileModelSelectorAction::ToggleModelMenu => {
+                if self.is_model_locked(ctx) {
+                    return;
+                }
                 if FeatureFlag::InlineMenuHeaders.is_enabled() {
                     ctx.emit(ProfileModelSelectorEvent::ToggleInlineModelSelector);
                 } else {

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1698,8 +1698,8 @@ impl TerminalManager {
                 if let Some(ambient_agent_view_model) =
                     terminal_view.ambient_agent_view_model().cloned()
                 {
-                    ambient_agent_view_model.update(ctx, |model, _| {
-                        model.record_ambient_execution_ended(ended_session_id);
+                    ambient_agent_view_model.update(ctx, |model, ctx| {
+                        model.record_ambient_execution_ended(ended_session_id, ctx);
                     });
                 }
                 terminal_view.on_ambient_agent_execution_ended(ctx);

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -131,7 +131,8 @@ pub fn create_cloud_mode_view(
                 | AmbientAgentViewModelEvent::PendingHandoffChanged
                 | AmbientAgentViewModelEvent::HandoffSnapshotUploadFailed { .. }
                 | AmbientAgentViewModelEvent::UpdatedSetupCommandVisibility
-                | AmbientAgentViewModelEvent::AuthSecretSelected => {}
+                | AmbientAgentViewModelEvent::AuthSecretSelected
+                | AmbientAgentViewModelEvent::RunLifecycleChanged => {}
             }
         });
     });

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -851,6 +851,7 @@ impl AmbientAgentViewModel {
         self.task_id = Some(task_id);
 
         self.status = Status::AgentRunning;
+        ctx.emit(AmbientAgentViewModelEvent::RunLifecycleChanged);
 
         // Fetch the task so we can set the correct environment (instead of defaulting to the most
         // recently-used one) and the correct harness (so non-oz viewers know to use the
@@ -881,9 +882,14 @@ impl AmbientAgentViewModel {
         );
     }
 
-    pub fn record_ambient_execution_ended(&mut self, session_id: SessionId) {
+    pub fn record_ambient_execution_ended(
+        &mut self,
+        session_id: SessionId,
+        ctx: &mut ModelContext<Self>,
+    ) {
         if self.active_execution_session_id.as_ref() == Some(&session_id) {
             self.active_execution_session_id = None;
+            ctx.emit(AmbientAgentViewModelEvent::RunLifecycleChanged);
         }
         self.last_ended_execution_session_id = Some(session_id);
     }
@@ -1628,6 +1634,11 @@ pub enum AmbientAgentViewModelEvent {
     UpdatedSetupCommandVisibility,
     /// The selected harness auth secret changed.
     AuthSecretSelected,
+    /// The run's task association or execution liveness changed in a way that
+    /// may affect lock-dependent UI (e.g. the model selector). Fired when
+    /// a task is attached to the view (transcript restore) or when an
+    /// execution ends.
+    RunLifecycleChanged,
 }
 
 pub(crate) fn should_disable_snapshot(ctx: &AppContext) -> bool {

--- a/app/src/terminal/view/ambient_agent/model_selector.rs
+++ b/app/src/terminal/view/ambient_agent/model_selector.rs
@@ -214,6 +214,11 @@ impl ModelSelector {
                     me.refresh_button(ctx);
                     me.refresh_menu(ctx);
                 }
+                AmbientAgentViewModelEvent::SessionReady { .. }
+                | AmbientAgentViewModelEvent::FollowupDispatched
+                | AmbientAgentViewModelEvent::RunLifecycleChanged => {
+                    me.refresh_button(ctx);
+                }
                 _ => {}
             });
         }

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -398,7 +398,8 @@ impl TerminalView {
                 ctx.notify();
             }
             AmbientAgentViewModelEvent::UpdatedSetupCommandVisibility
-            | AmbientAgentViewModelEvent::AuthSecretSelected => (),
+            | AmbientAgentViewModelEvent::AuthSecretSelected
+            | AmbientAgentViewModelEvent::RunLifecycleChanged => (),
         }
     }
 


### PR DESCRIPTION
## Description

While making a PR for fixing the model selector for 3p harnesses with cloud -> cloud handoff, I realized that the model selector doesn't really do anything for regular cloud -> cloud handoff ( confirmed w/ testing). So we should just disable it for now (threading it through the server is a much bigger job)

## Testing

- [x] I have manually tested my changes locally with `./script/run`


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/275febf2-b6ab-4a9b-9423-4938b0eda56d_
_Run: https://oz.staging.warp.dev/runs/019e2c5c-ae72-7bb7-ad71-a5c70e717870_
_Plans:_
- _[Fix model options for 3P harness cloud-to-cloud follow-ups](https://staging.warp.dev/drive/notebook/24jDZdgxkSDSxRlKf7LpMn)_

_This PR was generated with [Oz](https://warp.dev/oz)._
