### PR TITLE
[REMOTE-1702] Gate DetectedRepositories usage for WASM

### DIFF
--- a/app/src/code/opened_files.rs
+++ b/app/src/code/opened_files.rs
@@ -14,6 +14,7 @@ impl OpenedFilesInRepo {
         self.0.get(file_path)
     }
 
+    #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     pub fn iter(&self) -> impl Iterator<Item = (&PathBuf, &Instant)> {
         self.0.iter()
     }

--- a/app/src/search/ai_context_menu/files/data_source.rs
+++ b/app/src/search/ai_context_menu/files/data_source.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 use super::search_item::FileSearchItem;
+#[cfg(feature = "local_fs")]
 use crate::code::opened_files::OpenedFilesModel;
 use crate::search::ai_context_menu::mixer::AIContextMenuSearchableAction;
 use crate::search::async_snapshot_data_source::AsyncSnapshotDataSource;
@@ -7,15 +8,20 @@ use crate::search::data_source::{Query, QueryResult};
 use crate::search::files::model::FileSearchModel;
 use crate::search::files::search_item::FileSearchResult;
 use crate::search::mixer::{BoxFuture, DataSourceRunErrorWrapper};
+#[cfg(feature = "local_fs")]
 use crate::workspace::ActiveSession;
 use futures_lite::future::yield_now;
 use fuzzy_match::FuzzyMatchResult;
 use itertools::Itertools;
+#[cfg(feature = "local_fs")]
 use repo_metadata::repositories::DetectedRepositories;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "local_fs")]
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
+#[cfg(feature = "local_fs")]
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, SingletonEntity};
 
@@ -105,6 +111,7 @@ pub fn file_data_source_for_pwd(
 
 /// Captures last-opened timestamps from `OpenedFilesModel` for the active
 /// repo at snapshot time. Returns an empty map when no repo is active.
+#[cfg(feature = "local_fs")]
 fn snapshot_last_opened(app: &AppContext) -> HashMap<String, instant::Instant> {
     let git_repo_path = app
         .windows()
@@ -134,6 +141,12 @@ fn snapshot_last_opened(app: &AppContext) -> HashMap<String, instant::Instant> {
         .iter()
         .map(|(path, ts)| (path.to_string_lossy().to_string(), *ts))
         .collect()
+}
+
+/// File-open recency is unavailable without a local filesystem.
+#[cfg(not(feature = "local_fs"))]
+fn snapshot_last_opened(_app: &AppContext) -> HashMap<String, instant::Instant> {
+    HashMap::new()
 }
 
 /// Routes file matching to zero-state ranking or query-based fuzzy scoring.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -186,6 +186,7 @@ pub use init::{
     TOGGLE_HIDE_CLI_RESPONSES_KEYBINDING, TOGGLE_QUEUE_NEXT_PROMPT_KEYBINDING,
 };
 pub use inline_banner::{NotificationsDiscoveryBannerAction, NotificationsErrorBannerAction};
+#[cfg(not(target_family = "wasm"))]
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repositories::RepoDetectionSource;
 use session_sharing_protocol::common::LongRunningCommandAgentInteractionState;
@@ -4629,6 +4630,9 @@ impl TerminalView {
                         );
                     }
                     RemoteServerManagerEvent::HostDisconnected { host_id } => {
+                        #[cfg(target_family = "wasm")]
+                        let _ = host_id;
+                        #[cfg(not(target_family = "wasm"))]
                         DetectedRepositories::handle(ctx).update(ctx, |repos, _| {
                             repos.remove_roots_for_host(host_id);
                         });
@@ -11617,6 +11621,7 @@ impl TerminalView {
 
                                 match &repo_path_opt {
                                     Some(LocalOrRemotePath::Remote(remote_path)) => {
+                                        #[cfg(not(target_family = "wasm"))]
                                         DetectedRepositories::handle(ctx).update(
                                             ctx,
                                             |repos, _| {

--- a/app/src/util/repo_detection.rs
+++ b/app/src/util/repo_detection.rs
@@ -7,12 +7,19 @@
 
 use std::future::Future;
 
-use futures::future::{ready, Either};
-use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
+use futures::future::ready;
+#[cfg(not(target_family = "wasm"))]
+use futures::future::Either;
+#[cfg(not(target_family = "wasm"))]
+use repo_metadata::repositories::DetectedRepositories;
+use repo_metadata::repositories::RepoDetectionSource;
 use warp_core::SessionId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warpui::{SingletonEntity, View, ViewContext};
+#[cfg(not(target_family = "wasm"))]
+use warpui::SingletonEntity;
+use warpui::{View, ViewContext};
 
+#[cfg(not(target_family = "wasm"))]
 use crate::remote_server::manager::RemoteServerManager;
 
 /// Describes whether the active session is local or remote.
@@ -32,6 +39,7 @@ pub enum RepoDetectionSessionType {
 /// The caller is responsible for registering remote repo roots in
 /// `DetectedRepositories` and triggering downstream side effects (git status,
 /// code review, etc.) in the spawn callback.
+#[cfg(not(target_family = "wasm"))]
 pub fn detect_possible_git_repo<V: View>(
     session_type: RepoDetectionSessionType,
     active_directory: &str,
@@ -63,4 +71,16 @@ pub fn detect_possible_git_repo<V: View>(
     DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
         repos.detect_possible_git_repo(active_directory, source, remote_detect, ctx)
     })
+}
+
+/// Repository detection is not available in WASM builds because
+/// `DetectedRepositories` is not registered there.
+#[cfg(target_family = "wasm")]
+pub fn detect_possible_git_repo<V: View>(
+    _session_type: RepoDetectionSessionType,
+    _active_directory: &str,
+    _source: RepoDetectionSource,
+    _ctx: &mut ViewContext<V>,
+) -> impl Future<Output = Option<LocalOrRemotePath>> {
+    ready(None)
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -402,6 +402,7 @@ use futures::Future;
 use itertools::Itertools;
 use parking_lot::FairMutex;
 use pathfinder_geometry::rect::RectF;
+#[cfg(feature = "local_fs")]
 use repo_metadata::repositories::DetectedRepositories;
 use session_sharing_protocol::common::SessionId as SharedSessionId;
 use std::collections::{HashMap, HashSet};
@@ -8671,19 +8672,28 @@ impl Workspace {
     }
 
     fn should_include_worktree_sidecar_repo(repo_path: &Path, ctx: &AppContext) -> bool {
-        // This performs one repo-metadata lookup per persisted workspace while the
-        // sidecar items are rebuilt. That's acceptable for now given the expected
-        // repo counts here, and it keeps linked-worktree filtering scoped to the
-        // only UI that currently needs it.
-        let Some(repository) =
-            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(repo_path, ctx)
-        else {
-            return true;
-        };
-        // Linked worktrees (and submodules) have an external gitdir; exclude
-        // them so only primary repository checkouts appear in the list.
+        #[cfg(not(feature = "local_fs"))]
+        {
+            let _ = (repo_path, ctx);
+            true
+        }
 
-        repository.as_ref(ctx).external_git_directory().is_none()
+        #[cfg(feature = "local_fs")]
+        {
+            // This performs one repo-metadata lookup per persisted workspace while the
+            // sidecar items are rebuilt. That's acceptable for now given the expected
+            // repo counts here, and it keeps linked-worktree filtering scoped to the
+            // only UI that currently needs it.
+            let Some(repository) =
+                DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(repo_path, ctx)
+            else {
+                return true;
+            };
+            // Linked worktrees (and submodules) have an external gitdir; exclude
+            // them so only primary repository checkouts appear in the list.
+
+            repository.as_ref(ctx).external_git_directory().is_none()
+        }
     }
 
     fn build_worktree_sidecar_items(


### PR DESCRIPTION
## Description
Gates `DetectedRepositories` access in WASM/non-local-fs code paths where the singleton is not registered.

Changes include:
- Add a WASM no-op fallback for terminal repo detection.
- Guard direct terminal remote repo registration/removal with `not(target_family = "wasm")`.
- Avoid file-recency snapshot lookups against `DetectedRepositories` without `local_fs`.
- Avoid worktree sidecar filtering against `DetectedRepositories` without `local_fs`.

## Linked Issue

We've observed a couple session-sharing crashes tied to this.

## Testing
- `cargo fmt`
- `cargo clippy --target wasm32-unknown-unknown --profile release-wasm-debug_assertions --no-deps`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not applicable; compile-time gating only.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/ff46092c-17cd-40d3-942d-56100aa84cd1_
_Run: https://oz.staging.warp.dev/runs/019e2c99-018d-716a-b39b-6859070c97a2_
_This PR was generated with [Oz](https://warp.dev/oz)._
