### PR TITLE
Promote multi-harness flag to prod

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -622,6 +622,7 @@ default = [
     "vertical_tabs",
     "vertical_tabs_summary_mode",
     "tab_configs",
+    "agent_harness",
     "hoa_onboarding_flow",
     "hoa_remote_control",
     "codex_notifications",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -933,7 +933,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     // End manually enabled Code features.
     FeatureFlag::EditableMarkdownMermaid,
     FeatureFlag::CodeReviewScrollPreservation,
-    FeatureFlag::AgentHarness,
     FeatureFlag::RememberFastForwardState,
     FeatureFlag::HOANotifications,
     FeatureFlag::OrchestrationViewerPillBar,


### PR DESCRIPTION
## Summary
Enable `agent_harness` by default for stable clients, for orchestration launch.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/8a0111a3-0ada-4e49-aa47-928c5fff2f3e_
_Run: https://oz.staging.warp.dev/runs/019e2c9c-6df1-75dc-b32e-794e3ab11b69_
_This PR was generated with [Oz](https://warp.dev/oz)._
