### PR TITLE
Revert "Enable IME on Linux/Wayland (#9602)"

### DIFF
--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -1502,13 +1502,6 @@ fn create_window(
         }
     }
 
-    #[cfg(target_os = "linux")]
-    if let Ok(window) = created_window.as_ref() {
-        // On Linux/Wayland, winit only sends `zwp_text_input_v3.enable()` when IME is allowed,
-        // so without this call IME stays inactive and non-Latin input (CJK, etc.) is unusable.
-        window.set_ime_allowed(true);
-    }
-
     created_window
 }
 


### PR DESCRIPTION
## Description

Reverts #9602 ("Enable IME on Linux/Wayland").

This reverts merge commit `543d54ecc6766a1c863419ded39c26d97307f5b4`, which added a `#[cfg(target_os = "linux")]` block in `crates/warpui/src/windowing/winit/window.rs::create_window` calling `window.set_ime_allowed(true)`.

## Linked Issue

Revert of #9602 (originally closed #9383).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

This is a pure `git revert` of the original commit, restoring the previous behavior on Linux/Wayland.

I can't really reproduce this but it's the only commit that seems to affect IME on Linux and Wayland in the last release.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/4326abed-5c34-4366-8ddd-5eb51039886d)

<!--
CHANGELOG-NONE
-->