### PR TITLE
Fix WASM repo detection singleton crash

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -163,10 +163,9 @@ use voice::transcriber::VoiceTranscriber;
 use warp_cli::GlobalOptions;
 use warp_cli::{agent::AgentCommand, CliCommand};
 
+use repo_metadata::repositories::DetectedRepositories;
 #[cfg(feature = "local_fs")]
-use repo_metadata::{
-    repositories::DetectedRepositories, watcher::DirectoryWatcher, RepoMetadataModel,
-};
+use repo_metadata::{watcher::DirectoryWatcher, RepoMetadataModel};
 #[cfg(feature = "local_fs")]
 use watcher::HomeDirectoryWatcher;
 
@@ -1458,10 +1457,11 @@ pub(crate) fn initialize_app(
         );
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    ctx.add_singleton_model(|_| DetectedRepositories::default());
+
+    #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
     {
         ctx.add_singleton_model(DirectoryWatcher::new);
-        ctx.add_singleton_model(|_| DetectedRepositories::default());
         if let Some(home_dir) = dirs::home_dir() {
             ctx.add_singleton_model(|ctx| HomeDirectoryWatcher::new(home_dir, ctx));
         } else {


### PR DESCRIPTION
## Description
Fixes a WASM crash when web/shared-session runs receive block metadata and hit repo detection.

`DetectedRepositories` is now registered for all app targets. `DirectoryWatcher` remains desktop/local-fs only.

## Linked Issue
https://linear.app/warpdotdev/issue/REMOTE-1702/wasm-crash-detectedrepositories-singleton-model-missing

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --check`
- `./script/wasm/bundle --channel oss --check-only`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a WASM crash when web runs tried to access repo detection state.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/5207c273-8881-4d2b-a8d0-43d2111e1b72_
_Run: https://oz.staging.warp.dev/runs/019e2d0d-4d35-787a-b720-99f62739b242_
_This PR was generated with [Oz](https://warp.dev/oz)._
