### PR TITLE
Make /environment slash command available in & handoff compose mode

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -909,6 +909,12 @@ impl AgentInputFooter {
         }
     }
 
+    pub fn open_handoff_environment_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        self.handoff_environment_selector
+            .clone()
+            .update(ctx, |s, ctx| s.open_menu(ctx));
+    }
+
     fn should_render_cloud_mode_v2(&self, app: &AppContext) -> bool {
         FeatureFlag::CloudModeInputV2.is_enabled()
             && FeatureFlag::CloudMode.is_enabled()

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -330,9 +330,7 @@ pub static ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand
     name: "/environment",
     description: "Switch the cloud agent environment",
     icon_path: "bundled/svg/globe-04.svg",
-    availability: Availability::AGENT_VIEW
-        | Availability::AI_ENABLED
-        | Availability::CLOUD_AGENT_V2,
+    availability: Availability::AGENT_VIEW | Availability::AI_ENABLED,
     auto_enter_ai_mode: true,
     argument: None,
 });

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3217,6 +3217,7 @@ impl Input {
                 cli_subagent_controller: cli_subagent_controller.clone(),
                 terminal_view_id,
                 ambient_agent_view_model: ambient_agent_view_model.clone(),
+                handoff_compose_state: handoff_compose_state.clone(),
             };
             SlashCommandDataSource::new(args, ctx)
         });
@@ -3229,6 +3230,7 @@ impl Input {
                     cli_subagent_controller: cli_subagent_controller.clone(),
                     terminal_view_id,
                     ambient_agent_view_model: ambient_agent_view_model.clone(),
+                    handoff_compose_state: handoff_compose_state.clone(),
                 };
                 Some(ctx.add_model(|ctx| SlashCommandDataSource::for_cloud_mode_v2(args, ctx)))
             } else {
@@ -3701,6 +3703,12 @@ impl Input {
         self.agent_input_footer
             .clone()
             .update(ctx, |footer, ctx| footer.open_v2_environment_selector(ctx));
+    }
+
+    pub(super) fn open_handoff_environment_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        self.agent_input_footer.clone().update(ctx, |footer, ctx| {
+            footer.open_handoff_environment_selector(ctx)
+        });
     }
 
     /// Restores the `&` handoff compose draft after a workspace failure.

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -25,6 +25,7 @@ use crate::search::slash_command_menu::static_commands::Availability;
 use crate::terminal::cli_agent_sessions::{
     CLIAgentInputState, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
 };
+use crate::terminal::input::handoff_compose::HandoffComposeState;
 use crate::terminal::model::session::SessionType;
 use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 #[cfg(not(target_family = "wasm"))]
@@ -59,6 +60,7 @@ pub struct DataSourceArgs {
     pub cli_subagent_controller: ModelHandle<CLISubagentController>,
     pub terminal_view_id: EntityId,
     pub ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
+    pub handoff_compose_state: ModelHandle<HandoffComposeState>,
 }
 
 /// Context needed to decide which slash commands are enabled.
@@ -71,6 +73,7 @@ struct ActiveCommandsContext {
     active_conversation_is_cloud_oz: bool,
     has_default_host: bool,
     is_cli_agent_input: bool,
+    is_handoff_compose_active: bool,
 }
 
 pub struct SlashCommandDataSource {
@@ -81,6 +84,7 @@ pub struct SlashCommandDataSource {
     active_commands_by_id: HashMap<SlashCommandId, StaticCommand>,
     active_repo_root: Option<PathBuf>,
     ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
+    handoff_compose_state: ModelHandle<HandoffComposeState>,
     is_cloud_mode_v2: bool,
 }
 
@@ -100,6 +104,7 @@ impl SlashCommandDataSource {
             cli_subagent_controller,
             terminal_view_id,
             ambient_agent_view_model,
+            handoff_compose_state,
         } = args;
         ctx.subscribe_to_model(&active_session, |me, event, ctx| match event {
             ActiveSessionEvent::UpdatedPwd | ActiveSessionEvent::Bootstrapped => {
@@ -192,6 +197,9 @@ impl SlashCommandDataSource {
                 me.recompute_active_commands(ctx);
             }
         });
+        ctx.subscribe_to_model(&handoff_compose_state, |me, _, ctx| {
+            me.recompute_active_commands(ctx);
+        });
 
         let mut me = Self {
             active_session,
@@ -201,6 +209,7 @@ impl SlashCommandDataSource {
             active_commands_by_id: Default::default(),
             active_repo_root: None,
             ambient_agent_view_model,
+            handoff_compose_state,
             is_cloud_mode_v2,
         };
         me.recompute_active_commands(ctx);
@@ -326,6 +335,7 @@ impl SlashCommandDataSource {
             active_conversation_is_cloud_oz: self.active_conversation_is_cloud_oz(ctx),
             has_default_host,
             is_cli_agent_input,
+            is_handoff_compose_active: self.handoff_compose_state.as_ref(ctx).is_active(),
         }
     }
 
@@ -360,6 +370,15 @@ impl SlashCommandDataSource {
         }
         // /host is only useful when a default self-hosted host is configured.
         if command.name == commands::HOST.name && !context.has_default_host {
+            return false;
+        }
+        // /environment requires either the V2 cloud-mode input or active handoff compose.
+        if command.name == commands::ENVIRONMENT.name
+            && !context
+                .session_context
+                .contains(Availability::CLOUD_AGENT_V2)
+            && !context.is_handoff_compose_active
+        {
             return false;
         }
         // When CLI agent input is open, restrict to the explicit allowlist.

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -786,14 +786,20 @@ impl Input {
                 return true;
             }
             environment if command.name == commands::ENVIRONMENT.name => {
-                if !self.is_cloud_mode_input_v2_composing(ctx) {
+                let is_v2 = self.is_cloud_mode_input_v2_composing(ctx);
+                let is_handoff = self.handoff_compose_state.as_ref(ctx).is_active();
+                if !is_v2 && !is_handoff {
                     return false;
                 }
                 self.suggestions_mode_model.update(ctx, |model, ctx| {
                     model.set_mode(InputSuggestionsMode::Closed, ctx);
                 });
                 self.clear_buffer_and_reset_undo_stack(ctx);
-                self.open_v2_environment_selector(ctx);
+                if is_handoff {
+                    self.open_handoff_environment_selector(ctx);
+                } else {
+                    self.open_v2_environment_selector(ctx);
+                }
                 return true;
             }
             models if command.name == commands::MODEL.name => {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -794,10 +794,15 @@ impl Input {
                 self.suggestions_mode_model.update(ctx, |model, ctx| {
                     model.set_mode(InputSuggestionsMode::Closed, ctx);
                 });
-                self.clear_buffer_and_reset_undo_stack(ctx);
                 if is_handoff {
+                    // Only clear the editor text — `clear_buffer_and_reset_undo_stack`
+                    // exits handoff compose, which would tear down the selector.
+                    self.editor.update(ctx, |editor, ctx| {
+                        editor.clear_buffer(ctx);
+                    });
                     self.open_handoff_environment_selector(ctx);
                 } else {
+                    self.clear_buffer_and_reset_undo_stack(ctx);
                     self.open_v2_environment_selector(ctx);
                 }
                 return true;


### PR DESCRIPTION
## Description

Makes the `/environment` slash command available in the `&` handoff compose mode, not just the V2 cloud-mode composing input.

Previously, `/environment` was gated on `CLOUD_AGENT_V2` availability, which is only set for the V2 cloud-mode data source. The handoff compose mode (`&`) explicitly opts out of V2 composing, so `/environment` was never shown there. Users had to use the footer environment chip to switch environments during handoff compose.

**Changes:**
- Removed `CLOUD_AGENT_V2` from `/environment`'s availability flags (now `AGENT_VIEW | AI_ENABLED`)
- Added `handoff_compose_state` to `SlashCommandDataSource` so it can track when handoff is active
- Added a custom `command_is_active_in_context` check that requires either `CLOUD_AGENT_V2` or active handoff compose for `/environment`
- Updated the `/environment` execution handler to open the handoff environment selector (instead of the V2 one) when handoff compose is active
- Added `open_handoff_environment_selector` to `Input` and `AgentInputFooter`

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

---

_Conversation: https://staging.warp.dev/conversation/243232a0-a86b-4776-be28-4dea0996b05a_
_Run: https://oz.staging.warp.dev/runs/019e2d12-bf61-7d71-9e58-1e01229b18dd_
_This PR was generated with [Oz](https://warp.dev/oz)._
