### PR TITLE
[QUALITY-729] Promote orchestration client flags to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -631,6 +631,10 @@ default = [
     "configurable_context_window",
     "oz_handoff",
     "handoff_local_cloud",
+    "orchestration_v2",
+    "orchestration_pill_bar",
+    "orchestration_viewer_pill_bar",
+    "run_agents_tool",
     "pending_user_query_indicator",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
@@ -912,6 +916,8 @@ incremental_auto_reload = []
 orchestration = []
 orchestration_v2 = ["orchestration"]
 orchestration_pill_bar = []
+orchestration_viewer_pill_bar = []
+run_agents_tool = []
 pending_user_query_indicator = []
 queue_slash_command = []
 inline_menu_headers = []

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2884,6 +2884,10 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::OrchestrationV2,
         #[cfg(feature = "orchestration_pill_bar")]
         FeatureFlag::OrchestrationPillBar,
+        #[cfg(feature = "orchestration_viewer_pill_bar")]
+        FeatureFlag::OrchestrationViewerPillBar,
+        #[cfg(feature = "run_agents_tool")]
+        FeatureFlag::RunAgentsTool,
         #[cfg(feature = "pending_user_query_indicator")]
         FeatureFlag::PendingUserQueryIndicator,
         #[cfg(feature = "queue_slash_command")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -939,7 +939,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::ConversationApi,
     FeatureFlag::RememberFastForwardState,
     FeatureFlag::HOANotifications,
-    FeatureFlag::OrchestrationViewerPillBar,
     FeatureFlag::GeminiNotifications,
     FeatureFlag::LocalDockerSandbox,
     FeatureFlag::CloudModeSetupV2,
@@ -958,11 +957,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
 pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
-    FeatureFlag::Orchestration,
-    FeatureFlag::OrchestrationV2,
-    FeatureFlag::OrchestrationPillBar,
-    FeatureFlag::OrchestrationViewerPillBar,
-    FeatureFlag::RunAgentsTool,
     FeatureFlag::BlocklistMarkdownTableRendering,
     FeatureFlag::MarkdownTables,
     FeatureFlag::GitOperationsInCodeReview,


### PR DESCRIPTION
## Description
Promotes orchestration client flags to stable defaults: orchestration v2, orchestration pill bar, shared-session viewer pill bar, and the run_agents tool call UI. Adds missing Cargo feature declarations and runtime bridges for viewer pill bar and run_agents so stable builds enable the corresponding FeatureFlags. Removes these flags from Preview/Dogfood runtime lists now that they are enabled by default.

## Testing
- [x] `cargo fmt --check --manifest-path /Users/matthew/src/prod-flag-flips/warp/Cargo.toml --package warp`
- [x] `cargo check --manifest-path /Users/matthew/src/prod-flag-flips/warp/Cargo.toml -p warp_features`
- [x] `git --no-pager -C /Users/matthew/src/prod-flag-flips/warp diff --check origin/master...HEAD`

Not manually tested with `./script/run`; this is a feature-flag promotion/configuration change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent Mode conversation: https://staging.warp.dev/conversation/b829bb7c-66d9-4f95-ada5-8d3efe85b94a

Co-Authored-By: Oz <oz-agent@warp.dev>

## Changelog Entries for Stable
CHANGELOG-OZ: Agent orchestration enabled for Stable.
