### PR TITLE
feat: make /environment slash command available in & handoff compose mode

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -909,6 +909,12 @@ impl AgentInputFooter {
         }
     }
 
+    pub fn open_handoff_environment_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        self.handoff_environment_selector
+            .clone()
+            .update(ctx, |s, ctx| s.open_menu(ctx));
+    }
+
     fn should_render_cloud_mode_v2(&self, app: &AppContext) -> bool {
         FeatureFlag::CloudModeInputV2.is_enabled()
             && FeatureFlag::CloudMode.is_enabled()

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -330,9 +330,9 @@ pub static ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand
     name: "/environment",
     description: "Switch the cloud agent environment",
     icon_path: "bundled/svg/globe-04.svg",
-    availability: Availability::AGENT_VIEW
-        | Availability::AI_ENABLED
-        | Availability::CLOUD_AGENT_V2,
+    // Requires AGENT_VIEW + AI_ENABLED; further gated by a soft-check in
+    // `command_is_active_in_context` to V2 cloud-mode composing or handoff compose.
+    availability: Availability::AGENT_VIEW | Availability::AI_ENABLED,
     auto_enter_ai_mode: true,
     argument: None,
 });

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3217,6 +3217,7 @@ impl Input {
                 cli_subagent_controller: cli_subagent_controller.clone(),
                 terminal_view_id,
                 ambient_agent_view_model: ambient_agent_view_model.clone(),
+                handoff_compose_state: handoff_compose_state.clone(),
             };
             SlashCommandDataSource::new(args, ctx)
         });
@@ -3229,6 +3230,7 @@ impl Input {
                     cli_subagent_controller: cli_subagent_controller.clone(),
                     terminal_view_id,
                     ambient_agent_view_model: ambient_agent_view_model.clone(),
+                    handoff_compose_state: handoff_compose_state.clone(),
                 };
                 Some(ctx.add_model(|ctx| SlashCommandDataSource::for_cloud_mode_v2(args, ctx)))
             } else {
@@ -3701,6 +3703,12 @@ impl Input {
         self.agent_input_footer
             .clone()
             .update(ctx, |footer, ctx| footer.open_v2_environment_selector(ctx));
+    }
+
+    pub(super) fn open_handoff_environment_selector(&mut self, ctx: &mut ViewContext<Self>) {
+        self.agent_input_footer
+            .clone()
+            .update(ctx, |footer, ctx| footer.open_handoff_environment_selector(ctx));
     }
 
     /// Restores the `&` handoff compose draft after a workspace failure.

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -25,6 +25,7 @@ use crate::search::slash_command_menu::static_commands::Availability;
 use crate::terminal::cli_agent_sessions::{
     CLIAgentInputState, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
 };
+use crate::terminal::input::handoff_compose::HandoffComposeState;
 use crate::terminal::model::session::SessionType;
 use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 #[cfg(not(target_family = "wasm"))]
@@ -59,6 +60,7 @@ pub struct DataSourceArgs {
     pub cli_subagent_controller: ModelHandle<CLISubagentController>,
     pub terminal_view_id: EntityId,
     pub ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
+    pub handoff_compose_state: ModelHandle<HandoffComposeState>,
 }
 
 /// Context needed to decide which slash commands are enabled.
@@ -71,6 +73,7 @@ struct ActiveCommandsContext {
     active_conversation_is_cloud_oz: bool,
     has_default_host: bool,
     is_cli_agent_input: bool,
+    is_handoff_compose_active: bool,
 }
 
 pub struct SlashCommandDataSource {
@@ -81,6 +84,7 @@ pub struct SlashCommandDataSource {
     active_commands_by_id: HashMap<SlashCommandId, StaticCommand>,
     active_repo_root: Option<PathBuf>,
     ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
+    handoff_compose_state: ModelHandle<HandoffComposeState>,
     is_cloud_mode_v2: bool,
 }
 
@@ -100,6 +104,7 @@ impl SlashCommandDataSource {
             cli_subagent_controller,
             terminal_view_id,
             ambient_agent_view_model,
+            handoff_compose_state,
         } = args;
         ctx.subscribe_to_model(&active_session, |me, event, ctx| match event {
             ActiveSessionEvent::UpdatedPwd | ActiveSessionEvent::Bootstrapped => {
@@ -193,6 +198,10 @@ impl SlashCommandDataSource {
             }
         });
 
+        ctx.subscribe_to_model(&handoff_compose_state, |me, _, ctx| {
+            me.recompute_active_commands(ctx);
+        });
+
         let mut me = Self {
             active_session,
             agent_view_controller,
@@ -201,6 +210,7 @@ impl SlashCommandDataSource {
             active_commands_by_id: Default::default(),
             active_repo_root: None,
             ambient_agent_view_model,
+            handoff_compose_state,
             is_cloud_mode_v2,
         };
         me.recompute_active_commands(ctx);
@@ -316,6 +326,8 @@ impl SlashCommandDataSource {
             .is_some()
             || UserWorkspaces::as_ref(ctx).default_host_slug().is_some();
 
+        let is_handoff_compose_active = self.handoff_compose_state.as_ref(ctx).is_active();
+
         let ai_settings = AISettings::as_ref(ctx);
         ActiveCommandsContext {
             session_context,
@@ -326,6 +338,7 @@ impl SlashCommandDataSource {
             active_conversation_is_cloud_oz: self.active_conversation_is_cloud_oz(ctx),
             has_default_host,
             is_cli_agent_input,
+            is_handoff_compose_active,
         }
     }
 
@@ -360,6 +373,13 @@ impl SlashCommandDataSource {
         }
         // /host is only useful when a default self-hosted host is configured.
         if command.name == commands::HOST.name && !context.has_default_host {
+            return false;
+        }
+        // /environment is available in V2 cloud-mode composing or handoff compose mode.
+        if command.name == commands::ENVIRONMENT.name
+            && !context.session_context.contains(Availability::CLOUD_AGENT_V2)
+            && !context.is_handoff_compose_active
+        {
             return false;
         }
         // When CLI agent input is open, restrict to the explicit allowlist.

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -786,14 +786,25 @@ impl Input {
                 return true;
             }
             environment if command.name == commands::ENVIRONMENT.name => {
-                if !self.is_cloud_mode_input_v2_composing(ctx) {
+                let is_v2 = self.is_cloud_mode_input_v2_composing(ctx);
+                let is_handoff = self.handoff_compose_state.as_ref(ctx).is_active();
+                if !is_v2 && !is_handoff {
                     return false;
                 }
                 self.suggestions_mode_model.update(ctx, |model, ctx| {
                     model.set_mode(InputSuggestionsMode::Closed, ctx);
                 });
-                self.clear_buffer_and_reset_undo_stack(ctx);
-                self.open_v2_environment_selector(ctx);
+                if is_handoff {
+                    // Only clear the editor text — `clear_buffer_and_reset_undo_stack`
+                    // exits handoff compose, which would tear down the selector.
+                    self.editor.update(ctx, |editor, ctx| {
+                        editor.clear_buffer(ctx);
+                    });
+                    self.open_handoff_environment_selector(ctx);
+                } else {
+                    self.clear_buffer_and_reset_undo_stack(ctx);
+                    self.open_v2_environment_selector(ctx);
+                }
                 return true;
             }
             models if command.name == commands::MODEL.name => {


### PR DESCRIPTION
## Description

Make the `/environment` slash command available in the `&` (handoff) compose mode, so users can switch cloud agent environments while drafting a handoff prompt.

**Approach:**
- Relaxed `/environment` availability from requiring `CLOUD_AGENT_V2` to `AGENT_VIEW + AI_ENABLED`, adding a soft-gate in `command_is_active_in_context` that requires either V2 cloud-mode composing or handoff compose active.
- Passed `handoff_compose_state` into the regular `SlashCommandDataSource` so it subscribes to `ActiveChanged` events and recomputes command visibility when `&` mode activates/deactivates.
- Updated the `/environment` execution handler to open the `handoff_environment_selector` when handoff compose is active, or the V2 environment selector otherwise.
- Added `open_handoff_environment_selector` to `AgentInputFooter` and `Input`.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: `/environment` slash command is now available in the `&` handoff compose mode
-->

_Conversation: https://staging.warp.dev/conversation/bdbc48a2-8339-41a3-832b-d450997ce46d_
_Run: https://oz.staging.warp.dev/runs/019e2d2a-bc98-794f-a524-89c7ec61bdde_

_This PR was generated with [Oz](https://warp.dev/oz)._
