### PR TITLE
Fix theme picker tab bar traffic light padding

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18550,23 +18550,22 @@ impl Workspace {
     fn compute_tab_bar_left_padding(&self, ctx: &AppContext) -> f32 {
         let zoom_factor = WindowSettings::as_ref(ctx).zoom_level.as_zoom_factor();
         let traffic_light_data = traffic_light_data(ctx, self.window_id);
+        let left_traffic_light_width = traffic_light_data
+            .as_ref()
+            .filter(|data| data.side == TrafficLightSide::Left)
+            .map(|data| data.width(zoom_factor));
         let is_window_fullscreen = ctx
             .windows()
             .platform_window(self.window_id)
             .map(|window| window.fullscreen_state() == FullscreenState::Fullscreen)
             .unwrap_or(false);
-        if self.current_workspace_state.is_left_panel_open() {
+        if self.current_workspace_state.is_left_panel_open() && left_traffic_light_width.is_none() {
             0.
         } else if is_window_fullscreen && cfg!(target_os = "macos") {
             // Full-screen mode on MacOS does not need as much padding (traffic lights are hidden).
             TAB_BAR_PADDING_LEFT
         } else {
-            traffic_light_data
-                .as_ref()
-                .filter(|data| data.side == TrafficLightSide::Left)
-                .map(|data| data.width(zoom_factor))
-                .unwrap_or(0.)
-                + 16.
+            left_traffic_light_width.unwrap_or(0.) + 16.
         }
     }
 


### PR DESCRIPTION
## Description
Fixes the tab/top bar padding while the theme picker is open by continuing to reserve left-side traffic-light space when native macOS window controls are present.

Previously, opening the theme picker made the workspace state report a left panel as open, causing `compute_tab_bar_left_padding` to return `0` and allowing the tab bar to pass underneath the macOS traffic lights.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --all-targets --tests -- -D warnings`
- Attempted `cargo clippy --manifest-path /workspace/warp/Cargo.toml --workspace --all-targets --all-features --tests -- -D warnings`, but it is blocked in this sandbox because the `release_bundle` build expects generated `dev_config.json` from `warp-channel-config`.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not captured; this sandbox cannot run the macOS UI.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed tab bar and top bar padding while the theme picker is open so macOS traffic lights no longer overlap the UI.

_Conversation: https://staging.warp.dev/conversation/7e735cc1-fe9d-4375-aefd-786cc52b65c6_
_Run: https://oz.staging.warp.dev/runs/019e2d4d-48ed-7bb1-9cdf-5c102e11cbca_
_This PR was generated with [Oz](https://warp.dev/oz)._
