### PR TITLE
Agent attempt on whitelisting approve

### DIFF
--- a/app/src/ai/blocklist/input_model.rs
+++ b/app/src/ai/blocklist/input_model.rs
@@ -8,7 +8,9 @@
 use std::sync::Arc;
 
 use futures::stream::AbortHandle;
-use input_classifier::util::{is_agent_follow_up_input, is_one_off_natural_language_word};
+use input_classifier::util::{
+    is_agent_follow_up_input, is_agent_follow_up_shell_input, is_one_off_natural_language_word,
+};
 use instant::Instant;
 use parking_lot::FairMutex;
 use serde::{Deserialize, Serialize};
@@ -701,6 +703,9 @@ impl BlocklistAIInputModel {
                         && is_one_off_natural_language_word(first_token_str.to_lowercase().as_str())
                     {
                         return InputType::AI;
+                    }
+                    if is_agent_follow_up && is_agent_follow_up_shell_input(&buffer_cloned) {
+                        return InputType::Shell;
                     }
 
                     // If this is clearly intended to be a follow-up to an AI block, classify it as AI.

--- a/crates/input_classifier/src/heuristic_classifier/mod.rs
+++ b/crates/input_classifier/src/heuristic_classifier/mod.rs
@@ -9,7 +9,8 @@ use crate::{
     ClassificationResult, Context, InputClassifier, InputType,
     parser::parse_query_into_tokens,
     util::{
-        is_installed_binary, is_likely_shell_command, is_one_off_natural_language_word_or_prefix,
+        is_agent_follow_up_shell_input, is_installed_binary, is_likely_shell_command,
+        is_one_off_natural_language_word_or_prefix,
     },
 };
 
@@ -42,6 +43,9 @@ impl InputClassifier for HeuristicClassifier {
     async fn detect_input_type(&self, input: ParsedTokensSnapshot, context: &Context) -> InputType {
         let word_tokens = parse_query_into_tokens(input.buffer_text.as_str());
         let total_word_token_count = word_tokens.len();
+        if context.is_agent_follow_up && is_agent_follow_up_shell_input(&input.buffer_text) {
+            return InputType::Shell;
+        }
 
         if total_word_token_count == 1
             && is_one_off_natural_language_word_or_prefix(&word_tokens[0].to_lowercase())

--- a/crates/input_classifier/src/onnx/mod.rs
+++ b/crates/input_classifier/src/onnx/mod.rs
@@ -14,7 +14,8 @@ use crate::{
     ClassificationResult, Context, InputClassifier, InputType,
     parser::parse_query_into_tokens,
     util::{
-        is_likely_shell_command, is_one_off_natural_language_word, is_one_off_shell_command_keyword,
+        is_agent_follow_up_shell_input, is_likely_shell_command, is_one_off_natural_language_word,
+        is_one_off_shell_command_keyword,
     },
 };
 
@@ -94,6 +95,9 @@ impl InputClassifier for OnnxClassifier {
         let word_tokens = parse_query_into_tokens(input.buffer_text.as_str());
 
         let total_word_token_count = word_tokens.len();
+        if context.is_agent_follow_up && is_agent_follow_up_shell_input(&input.buffer_text) {
+            return InputType::Shell;
+        }
 
         // Start by applying some simple heuristics before running the full classifier.
         if let Some(first_word) = word_tokens.first() {

--- a/crates/input_classifier/src/util.rs
+++ b/crates/input_classifier/src/util.rs
@@ -26,10 +26,17 @@ lazy_static! {
     /// A set of words that should trigger an AI classification if they are the entire input
     /// and the input is a follow-up to an agent response.
     static ref AGENT_FOLLOW_UP_INPUTS: HashSet<&'static str> = HashSet::from(["yes", "continue", "do it"]);
+
+    /// A set of words that should trigger a shell classification if they are the entire input
+    /// and the input is a follow-up to an agent response.
+    static ref AGENT_FOLLOW_UP_SHELL_INPUTS: HashSet<&'static str> = HashSet::from(["approve"]);
 }
 
 pub fn is_agent_follow_up_input(input: &str) -> bool {
     AGENT_FOLLOW_UP_INPUTS.contains(input)
+}
+pub fn is_agent_follow_up_shell_input(input: &str) -> bool {
+    AGENT_FOLLOW_UP_SHELL_INPUTS.contains(input.trim().to_lowercase().as_str())
 }
 
 pub fn is_one_off_shell_command_keyword(word: &str) -> bool {
@@ -132,6 +139,6 @@ pub fn is_installed_binary(input: &ParsedTokensSnapshot) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(all(test, any(feature = "nld_heuristic_v1", feature = "nld_heuristic_v2")))]
+#[cfg(test)]
 #[path = "util_tests.rs"]
 mod tests;

--- a/crates/input_classifier/src/util_tests.rs
+++ b/crates/input_classifier/src/util_tests.rs
@@ -16,6 +16,12 @@ fn clear_all_token_descriptions(snapshot: &mut ParsedTokensSnapshot) {
         token.token_description = None;
     }
 }
+#[test]
+fn test_agent_follow_up_shell_input() {
+    assert!(is_agent_follow_up_shell_input("approve"));
+    assert!(is_agent_follow_up_shell_input(" APPROVE "));
+    assert!(!is_agent_follow_up_shell_input("yes"));
+}
 
 async fn one_off_keyword_short_circuits() {
     let mut token = mock_parsed_input_token("sudo apt update".to_string()).await;


### PR DESCRIPTION
## Description
Whitelists `approve` as shell input only when it is entered as an agent follow-up. The override is shared by the app-level NLD path and the heuristic/ONNX classifier entry points so the model does not reclassify this follow-up as AI.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

No linked issue.

## Testing
- [x] `cargo fmt --all`
- [x] `cargo fmt -- --check`
- [x] `cargo test -p input_classifier test_agent_follow_up_shell_input --features nld_heuristic_v2`
- [x] `cargo check -p warp --tests`
- [x] `cargo clippy -p input_classifier --features nld_heuristic_v2 --tests -- -D warnings`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; this is a classifier-only change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>