### PR TITLE
QUALITY-671: roll up orchestration credit usage in the agent-mode footer

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -552,6 +552,15 @@ impl AIConversation {
         (self.conversation_usage_metadata.credits_spent * 10.0).round() / 10.0
     }
 
+    /// Test-only helper that sets the conversation's credit total directly.
+    /// Used by unit tests that exercise downstream credit-aware logic
+    /// (e.g. the orchestration credit rollup) without having to wire up a
+    /// full `StreamFinished` event.
+    #[cfg(test)]
+    pub(crate) fn set_credits_spent_for_test(&mut self, credits: f32) {
+        self.conversation_usage_metadata.credits_spent = credits;
+    }
+
     // Credits spent over the last block, where the block comprises
     // all agent outputs since the most recent user input.
     pub fn credits_spent_for_last_block(&self) -> Option<f32> {

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1377,7 +1377,8 @@ impl AgentConversationsModel {
             | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. }
             | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => {}
+            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => {}
 
             BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. } => {
                 ctx.emit(AgentConversationsModelEvent::ConversationUpdated {

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2335,7 +2335,8 @@ impl AgentDriver {
                 | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
                 | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
                 | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-                | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => (),
+                | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+                | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => (),
             }
         });
 

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -264,7 +264,8 @@ impl StartAgentExecutor {
             | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
             | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. } => {}
-            BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => {}
+            BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => {}
         }
     }
 

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -44,6 +44,7 @@ use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::{
     OrchestrationPillBarEvent, OrchestrationPillBarModel,
 };
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
+use crate::ai::blocklist::orchestration_topology::descendant_conversation_ids_in_spawn_order;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::harness_display;
 use crate::features::FeatureFlag;
@@ -82,7 +83,7 @@ fn pill_palette(theme: &WarpTheme) -> [ColorU; 6] {
     ]
 }
 
-fn pill_avatar_color(name: &str, theme: &WarpTheme) -> ColorU {
+pub(crate) fn pill_avatar_color(name: &str, theme: &WarpTheme) -> ColorU {
     let palette = pill_palette(theme);
     let mut hasher = DefaultHasher::new();
     name.hash(&mut hasher);
@@ -90,7 +91,7 @@ fn pill_avatar_color(name: &str, theme: &WarpTheme) -> ColorU {
     palette[idx]
 }
 
-fn pill_initial(name: &str) -> char {
+pub(crate) fn pill_initial(name: &str) -> char {
     name.trim()
         .chars()
         .next()
@@ -99,7 +100,7 @@ fn pill_initial(name: &str) -> char {
 }
 /// Renders the orchestrator avatar disc shared by pill, breadcrumb, and transcript
 /// surfaces.
-pub(super) fn render_orchestrator_avatar_disc(
+pub(crate) fn render_orchestrator_avatar_disc(
     size: f32,
     theme: &WarpTheme,
     appearance: &Appearance,
@@ -115,7 +116,7 @@ pub(super) fn render_orchestrator_avatar_disc(
 
 /// Renders a child-agent avatar using the same deterministic-color + initial-letter
 /// treatment as the orchestration pill bar.
-pub(super) fn render_agent_avatar_disc(
+pub(crate) fn render_agent_avatar_disc(
     name: &str,
     size: f32,
     theme: &WarpTheme,
@@ -128,26 +129,6 @@ pub(super) fn render_agent_avatar_disc(
         theme,
         appearance,
     )
-}
-
-fn descendant_conversation_ids_in_spawn_order(
-    history: &BlocklistAIHistoryModel,
-    parent_id: AIConversationId,
-) -> Vec<AIConversationId> {
-    let mut descendants = Vec::new();
-    collect_descendant_conversation_ids_in_spawn_order(history, parent_id, &mut descendants);
-    descendants
-}
-
-fn collect_descendant_conversation_ids_in_spawn_order(
-    history: &BlocklistAIHistoryModel,
-    parent_id: AIConversationId,
-    descendants: &mut Vec<AIConversationId>,
-) {
-    for child_id in history.child_conversation_ids_of(&parent_id) {
-        descendants.push(*child_id);
-        collect_descendant_conversation_ids_in_spawn_order(history, *child_id, descendants);
-    }
 }
 
 /// What kind of pill we are rendering, which determines click behavior.

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -1,76 +1,8 @@
 use super::*;
-use crate::ai::blocklist::BlocklistAIHistoryModel;
-use warpui::{App, EntityId};
 
-#[test]
-fn descendant_conversation_ids_in_spawn_order_flattens_nested_children_preorder() {
-    App::test((), |mut app| async move {
-        let terminal_view_id = EntityId::new();
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
-
-        let orchestrator_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
-        });
-        let child_a = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_child_conversation(
-                terminal_view_id,
-                "oz-env-check".to_string(),
-                orchestrator_id,
-                None,
-                ctx,
-            )
-        });
-        let child_b = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_child_conversation(
-                terminal_view_id,
-                "sibling-agent".to_string(),
-                orchestrator_id,
-                None,
-                ctx,
-            )
-        });
-        let grandchild_a1 = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_child_conversation(
-                terminal_view_id,
-                "codex-child".to_string(),
-                child_a,
-                None,
-                ctx,
-            )
-        });
-        let grandchild_a2 = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_child_conversation(
-                terminal_view_id,
-                "follow-up-child".to_string(),
-                child_a,
-                None,
-                ctx,
-            )
-        });
-        let grandchild_b1 = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_child_conversation(
-                terminal_view_id,
-                "sibling-grandchild".to_string(),
-                child_b,
-                None,
-                ctx,
-            )
-        });
-
-        history_model.read(&app, |history_model, _| {
-            assert_eq!(
-                descendant_conversation_ids_in_spawn_order(history_model, orchestrator_id),
-                vec![
-                    child_a,
-                    grandchild_a1,
-                    grandchild_a2,
-                    child_b,
-                    grandchild_b1
-                ],
-            );
-        });
-    });
-}
+// Pre-order traversal correctness for the descendant walker is exercised in
+// `app/src/ai/blocklist/orchestration_topology_tests.rs`. These tests stay
+// focused on the pill bar's own dispatch behavior.
 
 #[test]
 fn navigation_action_for_child_pill_reveals_existing_child_pane() {
@@ -94,23 +26,4 @@ fn navigation_action_for_orchestrator_pill_switches_in_place() {
             conversation_id: actual_id,
         } if actual_id == conversation_id
     ));
-}
-
-#[test]
-fn descendant_conversation_ids_in_spawn_order_returns_empty_without_children() {
-    App::test((), |mut app| async move {
-        let terminal_view_id = EntityId::new();
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
-
-        let orchestrator_id = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
-        });
-
-        history_model.read(&app, |history_model, _| {
-            assert!(
-                descendant_conversation_ids_in_spawn_order(history_model, orchestrator_id)
-                    .is_empty()
-            );
-        });
-    });
 }

--- a/app/src/ai/blocklist/block/model/model_impl.rs
+++ b/app/src/ai/blocklist/block/model/model_impl.rs
@@ -204,18 +204,32 @@ where
         let conversation_id = self.conversation_id;
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         ctx.subscribe_to_model(&history_model, move |me, _, event, ctx| {
-            let BlocklistAIHistoryEvent::UpdatedStreamingExchange {
-                exchange_id: event_exchange_id,
-                conversation_id: event_conversation_id,
-                ..
-            } = event
-            else {
-                return;
-            };
-            if *event_exchange_id == exchange_id {
-                callback(me, ctx);
-            } else if *event_conversation_id == conversation_id {
-                ctx.notify();
+            match event {
+                BlocklistAIHistoryEvent::UpdatedStreamingExchange {
+                    exchange_id: event_exchange_id,
+                    conversation_id: event_conversation_id,
+                    ..
+                } => {
+                    if *event_exchange_id == exchange_id {
+                        callback(me, ctx);
+                    } else if *event_conversation_id == conversation_id {
+                        ctx.notify();
+                    }
+                }
+                BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => {
+                    // Cross-pane orchestration credit rollup: the collapsed
+                    // footer pill on an orchestrator's AIBlock derives its
+                    // headline number from descendant credits, which the
+                    // existing exchange-scoped notify path above doesn't
+                    // cover. Trigger a re-render on any usage metadata
+                    // change so the pill stays live. Filtering to only
+                    // descendants of this block's conversation would
+                    // require an O(depth) walk per event for every AI
+                    // block in the app; an unconditional notify is cheap
+                    // and tracks live status accurately.
+                    ctx.notify();
+                }
+                _ => {}
             }
         });
     }

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -18,6 +18,7 @@ use crate::ai::blocklist::block::view_impl::common::{
 use crate::ai::blocklist::inline_action::aws_bedrock_credentials_error::AwsBedrockCredentialsErrorView;
 use crate::ai::blocklist::inline_action::create_or_edit_document::CreateOrEditDocumentAction;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
+use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
 use crate::ai::blocklist::view_util::format_credits;
 use crate::ai::skills::SkillOpenOrigin;
 use crate::ai::skills::{
@@ -3254,10 +3255,8 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
     // orchestrator's own credits. The rollup helper returns `None` for
     // conversations with no descendants, so callers that aren't
     // orchestrators pay only the cost of one descendant-index probe.
-    let rollup = crate::ai::blocklist::usage::rollup::compute_orchestration_rollup(
-        conversation.id(),
-        BlocklistAIHistoryModel::as_ref(app),
-    );
+    let rollup =
+        compute_orchestration_rollup(conversation.id(), BlocklistAIHistoryModel::as_ref(app));
 
     // If this conversation has no usage metadata (e.g. a forked conversation from
     // mid-way through a prior conversation where the server did not send

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3246,20 +3246,18 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
         return Empty::new().finish();
     };
 
-    // Optional orchestration credit rollup. When the feature flag is on and
-    // the conversation has at least one locally-loaded descendant with
-    // credits spent, the pill's headline number and "has any usage"
-    // suppression check both switch over to the orchestration total
-    // (PRODUCT invariants 11, 11b). The `(+N)` last-block annotation
-    // below stays bound to the orchestrator's own credits.
-    let rollup = if FeatureFlag::OrchestrationCreditRollup.is_enabled() {
-        crate::ai::blocklist::usage::rollup::compute_orchestration_rollup(
-            conversation.id(),
-            BlocklistAIHistoryModel::as_ref(app),
-        )
-    } else {
-        None
-    };
+    // Optional orchestration credit rollup. When the conversation has at
+    // least one locally-loaded descendant with credits spent, the pill's
+    // headline number and "has any usage" suppression check both switch
+    // over to the orchestration total (PRODUCT invariants 11, 11b). The
+    // `(+N)` last-block annotation below stays bound to the
+    // orchestrator's own credits. The rollup helper returns `None` for
+    // conversations with no descendants, so callers that aren't
+    // orchestrators pay only the cost of one descendant-index probe.
+    let rollup = crate::ai::blocklist::usage::rollup::compute_orchestration_rollup(
+        conversation.id(),
+        BlocklistAIHistoryModel::as_ref(app),
+    );
 
     // If this conversation has no usage metadata (e.g. a forked conversation from
     // mid-way through a prior conversation where the server did not send

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3246,10 +3246,29 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
         return Empty::new().finish();
     };
 
+    // Optional orchestration credit rollup. When the feature flag is on and
+    // the conversation has at least one locally-loaded descendant with
+    // credits spent, the pill's headline number and "has any usage"
+    // suppression check both switch over to the orchestration total
+    // (PRODUCT invariants 11, 11b). The `(+N)` last-block annotation
+    // below stays bound to the orchestrator's own credits.
+    let rollup = if FeatureFlag::OrchestrationCreditRollup.is_enabled() {
+        crate::ai::blocklist::usage::rollup::compute_orchestration_rollup(
+            conversation.id(),
+            BlocklistAIHistoryModel::as_ref(app),
+        )
+    } else {
+        None
+    };
+
     // If this conversation has no usage metadata (e.g. a forked conversation from
     // mid-way through a prior conversation where the server did not send
     // ConversationUsageMetadata), avoid rendering the usage button entirely.
-    let has_any_usage = conversation.credits_spent() > 0.0
+    let headline_credits = rollup
+        .as_ref()
+        .map(|r| r.total_credits)
+        .unwrap_or_else(|| conversation.credits_spent());
+    let has_any_usage = headline_credits > 0.0
         || conversation.credits_spent_for_last_block().is_some()
         || !conversation.token_usage().is_empty()
         || conversation.tool_usage_metadata().total_tool_calls() > 0;
@@ -3266,7 +3285,7 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
         Icon::ChevronRight
     };
 
-    let total_credits_spent = conversation.credits_spent();
+    let total_credits_spent = headline_credits;
     let mut credit_usage_text = format_credits(total_credits_spent);
     if let Some(credits_spent_for_last_block) = conversation.credits_spent_for_last_block() {
         // Only show the credits spent for the last block if it is different from the total credits spent

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2843,7 +2843,7 @@ impl BlocklistAIController {
         ctx: &mut ModelContext<Self>,
     ) {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
-        history_model.update(ctx, |history_model, _| {
+        history_model.update(ctx, |history_model, ctx| {
             // Update conversation cost and usage information before updating and
             // persisting the conversation.
             history_model.update_conversation_cost_and_usage_for_request(
@@ -2855,6 +2855,7 @@ impl BlocklistAIController {
                 finished_event.token_usage,
                 finished_event.conversation_usage_metadata.take(),
                 did_request_contain_user_query,
+                ctx,
             );
         });
 

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1425,7 +1425,13 @@ impl BlocklistAIHistoryModel {
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<ConversationUsageMetadata>,
         was_user_initiated_request: bool,
+        ctx: &mut ModelContext<Self>,
     ) {
+        // Track whether this update changes any state derived by
+        // `BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated`
+        // subscribers (e.g. the orchestration credit rollup). We emit the
+        // event only when there's actual data to react to.
+        let emits_usage_event = request_cost.is_some() || usage_metadata.is_some();
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             if let Err(e) = conversation.update_cost_and_usage_for_request(
                 request_cost,
@@ -1436,6 +1442,11 @@ impl BlocklistAIHistoryModel {
                 log::warn!(
                     "Failed to update request cost for conversation {conversation_id}: {e:#}"
                 );
+            }
+            if emits_usage_event {
+                ctx.emit(BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated {
+                    conversation_id,
+                });
             }
         } else {
             log::warn!(
@@ -2380,6 +2391,15 @@ pub enum BlocklistAIHistoryEvent {
     OrchestrationConfigUpdated {
         conversation_id: AIConversationId,
     },
+
+    /// Emitted when a conversation's `conversation_usage_metadata` is updated
+    /// (for example after a `StreamFinished` event). Subscribers that derive
+    /// data from cross-conversation usage — e.g. the orchestration credit
+    /// rollup in the agent-mode footer — can listen for this to re-render
+    /// when a descendant's credits change.
+    ConversationUsageMetadataUpdated {
+        conversation_id: AIConversationId,
+    },
 }
 
 impl BlocklistAIHistoryEvent {
@@ -2456,6 +2476,11 @@ impl BlocklistAIHistoryEvent {
             // OrchestrationConfigUpdated is conversation-scoped and has no
             // terminal_view_id.
             BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => None,
+            // ConversationUsageMetadataUpdated is conversation-scoped and
+            // has no terminal_view_id. Cross-pane consumers (e.g. the
+            // orchestrator footer reading descendant credits) can't be
+            // disambiguated by a single owner pane.
+            BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => None,
         }
     }
 }

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod handoff;
 
 pub(crate) mod orchestration_event_streamer;
 pub(crate) mod orchestration_events;
+pub(crate) mod orchestration_topology;
 mod passive_suggestions;
 pub(crate) mod task_status_sync_model;
 pub(super) use controller::RequestInput;

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -412,7 +412,8 @@ impl OrchestrationEventStreamer {
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
             | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => {}
+            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => {}
         }
     }
 

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -1,0 +1,46 @@
+//! Shared helpers for walking the orchestration topology of conversations.
+//!
+//! The topology is stored as a parent → children index on
+//! [`BlocklistAIHistoryModel`]. These helpers are factored out of the
+//! orchestration pill bar so other surfaces (e.g. the agent-mode usage
+//! footer's credit rollup) can walk the same tree without duplicating the
+//! traversal.
+
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+
+/// Returns all locally-known descendants (children, grandchildren, …) of
+/// `parent_id`, flattened in pre-order with each parent's child registration
+/// order preserved.
+///
+/// This walks `BlocklistAIHistoryModel::child_conversation_ids_of`
+/// transitively. The walker only consults the `children_by_parent` index, so
+/// it works even before child `AIConversation`s have been loaded into
+/// `conversations_by_id`. Unloaded descendants are still returned by id;
+/// callers can filter them out via `history.conversation(&id)` as needed.
+pub fn descendant_conversation_ids_in_spawn_order(
+    history: &BlocklistAIHistoryModel,
+    parent_id: AIConversationId,
+) -> Vec<AIConversationId> {
+    let mut descendants = Vec::new();
+    collect_descendant_conversation_ids_in_spawn_order(history, parent_id, &mut descendants);
+    descendants
+}
+
+/// Recursive worker for [`descendant_conversation_ids_in_spawn_order`]. Kept
+/// separate so it can be invoked from existing call sites that already own a
+/// buffer.
+pub fn collect_descendant_conversation_ids_in_spawn_order(
+    history: &BlocklistAIHistoryModel,
+    parent_id: AIConversationId,
+    descendants: &mut Vec<AIConversationId>,
+) {
+    for child_id in history.child_conversation_ids_of(&parent_id) {
+        descendants.push(*child_id);
+        collect_descendant_conversation_ids_in_spawn_order(history, *child_id, descendants);
+    }
+}
+
+#[cfg(test)]
+#[path = "orchestration_topology_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -1,0 +1,92 @@
+use super::*;
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+use warpui::{App, EntityId};
+
+#[test]
+fn descendant_conversation_ids_in_spawn_order_flattens_nested_children_preorder() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_a = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "oz-env-check".to_string(),
+                orchestrator_id,
+                None,
+                ctx,
+            )
+        });
+        let child_b = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "sibling-agent".to_string(),
+                orchestrator_id,
+                None,
+                ctx,
+            )
+        });
+        let grandchild_a1 = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "codex-child".to_string(),
+                child_a,
+                None,
+                ctx,
+            )
+        });
+        let grandchild_a2 = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "follow-up-child".to_string(),
+                child_a,
+                None,
+                ctx,
+            )
+        });
+        let grandchild_b1 = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "sibling-grandchild".to_string(),
+                child_b,
+                None,
+                ctx,
+            )
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                descendant_conversation_ids_in_spawn_order(history_model, orchestrator_id),
+                vec![
+                    child_a,
+                    grandchild_a1,
+                    grandchild_a2,
+                    child_b,
+                    grandchild_b1
+                ],
+            );
+        });
+    });
+}
+
+#[test]
+fn descendant_conversation_ids_in_spawn_order_returns_empty_without_children() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert!(
+                descendant_conversation_ids_in_spawn_order(history_model, orchestrator_id)
+                    .is_empty()
+            );
+        });
+    });
+}

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -9,7 +9,6 @@ use crate::ai::blocklist::usage::rollup::{
 use crate::ai::blocklist::view_util::format_credits;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
-use crate::features::FeatureFlag;
 use crate::persistence::model::{
     token_usage_category_display_name, ModelTokenUsage, FULL_TERMINAL_USE_CATEGORY,
     PRIMARY_AGENT_CATEGORY,
@@ -171,12 +170,12 @@ impl ConversationUsageView {
     }
 
     /// Returns the current orchestration rollup for this view, or `None`
-    /// when the feature flag is off, the view is in settings mode, or the
-    /// orchestrator has no eligible descendants.
+    /// when the view is in settings mode, the parent conversation isn't
+    /// known, or the orchestrator has no locally-loaded descendants with
+    /// non-zero credits. The feature is self-gating: settings-mode views
+    /// and conversations without descendants short-circuit before any
+    /// rollup-specific UI is built, so no feature flag is needed.
     fn rollup(&self, app: &AppContext) -> Option<OrchestrationCreditRollup> {
-        if !FeatureFlag::OrchestrationCreditRollup.is_enabled() {
-            return None;
-        }
         if self.display_mode != DisplayMode::Footer {
             return None;
         }
@@ -251,7 +250,7 @@ impl ConversationUsageView {
 
         // "Credits spent (total)" value: use the rollup total when available,
         // otherwise the orchestrator's own self total (today's behavior).
-        // PRODUCT invariants 2a, 11, 13.
+        // PRODUCT invariants 2a, 11.
         let total_credits_value = rollup
             .as_ref()
             .map(|r| r.total_credits)

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -830,3 +830,7 @@ fn render_value_text(text: String, appearance: &Appearance) -> Box<dyn Element> 
         .with_color(text_color)
         .finish()
 }
+
+#[cfg(test)]
+#[path = "conversation_usage_view_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -284,6 +284,14 @@ impl ConversationUsageView {
             ));
         }
 
+        // Per-agent breakdown rows render immediately beneath the
+        // "Credits spent (total)" row so they read as a drill-down of
+        // that value, not as a separate section appended at the bottom
+        // of the card. The rows are pushed into the same two-column
+        // label/value layout as the rest of the usage summary; the
+        // existing flex spacing handles indentation.
+        self.append_per_agent_rows(&mut labels, &mut values, rollup.as_ref(), appearance);
+
         labels.push(render_label_text("Tool calls", appearance));
         values.push(render_value_text(
             format_value_text(self.usage_info.tool_calls, "call"),
@@ -534,33 +542,6 @@ impl ConversationUsageView {
             }
         }
 
-        // Emit the per-agent breakdown rows beneath the value column when
-        // the rollup is active and the user has toggled "View details" on.
-        // The rows are appended as additional label/value pairs so the
-        // existing two-column flex layout handles spacing for free. The
-        // label column carries the avatar + display name; the value
-        // column carries the credit value.
-        if let Some(rollup) = &rollup {
-            if self.details_expanded {
-                let total_entries = rollup.per_agent.len();
-                let shown_entries: usize = if total_entries > 5 && !self.show_all_clicked {
-                    5
-                } else {
-                    total_entries
-                };
-                for entry in rollup.per_agent.iter().take(shown_entries) {
-                    let (label_el, value_el) = self.render_per_agent_row(entry, appearance);
-                    labels.push(label_el);
-                    values.push(value_el);
-                }
-                if total_entries > shown_entries {
-                    let hidden_count = total_entries - shown_entries;
-                    labels.push(self.render_show_more_link(hidden_count, appearance));
-                    values.push(Empty::new().finish());
-                }
-            }
-        }
-
         Container::new(
             Flex::row()
                 .with_spacing(8.)
@@ -570,6 +551,43 @@ impl ConversationUsageView {
         )
         .with_uniform_margin(16.)
         .finish()
+    }
+
+    /// Pushes the per-agent breakdown rows (and the optional "Show N
+    /// more" link) into the two-column layout when the rollup is active
+    /// and the user has expanded the details. Pushed in two-column
+    /// (label, value) pairs so they slot into the existing flex layout.
+    /// The label column carries the avatar + display name; the value
+    /// column carries the credit value.
+    fn append_per_agent_rows(
+        &self,
+        labels: &mut Vec<Box<dyn Element>>,
+        values: &mut Vec<Box<dyn Element>>,
+        rollup: Option<&OrchestrationCreditRollup>,
+        appearance: &Appearance,
+    ) {
+        let Some(rollup) = rollup else {
+            return;
+        };
+        if !self.details_expanded {
+            return;
+        }
+        let total_entries = rollup.per_agent.len();
+        let shown_entries: usize = if total_entries > 5 && !self.show_all_clicked {
+            5
+        } else {
+            total_entries
+        };
+        for entry in rollup.per_agent.iter().take(shown_entries) {
+            let (label_el, value_el) = self.render_per_agent_row(entry, appearance);
+            labels.push(label_el);
+            values.push(value_el);
+        }
+        if total_entries > shown_entries {
+            let hidden_count = total_entries - shown_entries;
+            labels.push(self.render_show_more_link(hidden_count, appearance));
+            values.push(Empty::new().finish());
+        }
     }
 
     /// Renders the "Credits spent (total)" value cell. When a rollup
@@ -596,15 +614,20 @@ impl ConversationUsageView {
             .finish()
     }
 
-    /// Renders the "View details ▾" / "Hide details ▴" toggle link rendered
-    /// to the right of the "Credits spent (total)" value when a rollup
-    /// applies. The link uses the standard sub-text color so it reads as a
-    /// secondary affordance rather than a primary value.
+    /// Renders the "View details ▾" / "Hide details ▴" toggle link
+    /// rendered to the right of the "Credits spent (total)" value when
+    /// a rollup applies. The link is styled in the theme's hyperlink
+    /// color (`ansi_fg_blue`) — the same color the `FormattedTextElement`
+    /// uses for in-line hyperlinks throughout Agent Mode — so it reads
+    /// as a clickable affordance rather than a passive label. The
+    /// `Hoverable` carries a `PointingHand` cursor on hover; we don't
+    /// also flip the color or weight on hover because `Text` doesn't
+    /// expose an underline knob and changing color in this two-token
+    /// theme system tends to push the link into the accent space.
     fn render_details_toggle(&self, appearance: &Appearance) -> Box<dyn Element> {
         let theme = appearance.theme();
         let font_size = appearance.ui_font_size() + 2.;
-        let bg = theme.surface_2();
-        let text_color = blended_colors::text_sub(theme, bg);
+        let link_color = theme.ansi_fg_blue();
         let icon_size = font_size;
         let (label, icon) = if self.details_expanded {
             ("Hide details", Icon::ChevronUp)
@@ -613,19 +636,14 @@ impl ConversationUsageView {
         };
         Hoverable::new(
             self.details_toggle_mouse_state.clone(),
-            move |hover_state| {
-                let active_text_color = if hover_state.is_hovered() || hover_state.is_clicked() {
-                    blended_colors::text_main(theme, bg)
-                } else {
-                    text_color
-                };
+            move |_hover_state| {
                 let text_element =
                     Text::new(label.to_string(), appearance.ui_font_family(), font_size)
-                        .with_color(active_text_color)
+                        .with_color(link_color)
                         .with_selectable(false)
                         .finish();
                 let icon_element =
-                    ConstrainedBox::new(icon.to_warpui_icon(active_text_color.into()).finish())
+                    ConstrainedBox::new(icon.to_warpui_icon(link_color.into()).finish())
                         .with_width(icon_size)
                         .with_height(icon_size)
                         .finish();
@@ -677,7 +695,9 @@ impl ConversationUsageView {
     /// Renders the "Show N more" link row shown beneath the first 5
     /// per-agent rows when the breakdown has more entries than the
     /// truncation cap. Clicking the link replaces the truncated list with
-    /// the full list on the next render (PRODUCT invariant 5f).
+    /// the full list on the next render (PRODUCT invariant 5f). Uses the
+    /// same hyperlink-blue color as the "View details" toggle so the
+    /// affordances visually match.
     fn render_show_more_link(
         &self,
         hidden_count: usize,
@@ -685,17 +705,11 @@ impl ConversationUsageView {
     ) -> Box<dyn Element> {
         let theme = appearance.theme();
         let font_size = appearance.ui_font_size() + 2.;
-        let bg = theme.surface_2();
-        let text_color = blended_colors::text_sub(theme, bg);
+        let link_color = theme.ansi_fg_blue();
         let label = format!("Show {hidden_count} more");
-        Hoverable::new(self.show_more_mouse_state.clone(), move |hover_state| {
-            let active_color = if hover_state.is_hovered() || hover_state.is_clicked() {
-                blended_colors::text_main(theme, bg)
-            } else {
-                text_color
-            };
+        Hoverable::new(self.show_more_mouse_state.clone(), move |_hover_state| {
             Text::new(label.clone(), appearance.ui_font_family(), font_size)
-                .with_color(active_color)
+                .with_color(link_color)
                 .with_style(Properties {
                     weight: Weight::Normal,
                     ..Default::default()

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -1,6 +1,15 @@
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::blocklist::agent_view::orchestration_pill_bar::{
+    render_agent_avatar_disc, render_orchestrator_avatar_disc,
+};
 use crate::ai::blocklist::usage::render_context_window_usage_icon;
+use crate::ai::blocklist::usage::rollup::{
+    compute_orchestration_rollup, AgentAvatar, OrchestrationCreditRollup, PerAgentCreditEntry,
+};
 use crate::ai::blocklist::view_util::format_credits;
+use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
+use crate::features::FeatureFlag;
 use crate::persistence::model::{
     token_usage_category_display_name, ModelTokenUsage, FULL_TERMINAL_USE_CATEGORY,
     PRIMARY_AGENT_CATEGORY,
@@ -11,9 +20,11 @@ use std::collections::HashMap;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::Icon;
 use warpui::elements::ConstrainedBox;
+use warpui::fonts::{Properties, Weight};
+use warpui::platform::Cursor;
 use warpui::{
     elements::{
-        Border, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, MainAxisSize,
+        Border, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, Hoverable, MainAxisSize,
         MouseStateHandle, ParentElement, Radius, Text,
     },
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext,
@@ -52,6 +63,20 @@ pub struct TimingInfo {
     pub wall_to_wall_response_time_ms: Option<i64>,
 }
 
+/// Typed actions dispatched by widgets inside [`ConversationUsageView`]. The
+/// view uses a single typed action surface for the "View details" /
+/// "Hide details" toggle and the "Show N more" affordance so each row's
+/// click handler can dispatch through the regular action pipeline without
+/// borrowing the view directly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConversationUsageViewAction {
+    /// Flip the "View details" / "Hide details" toggle.
+    ToggleDetailsExpanded,
+    /// Reveal the truncated rows beyond the first 5 in the per-agent
+    /// breakdown.
+    ShowAllAgentRows,
+}
+
 /// View to hold a conversation usage info block.
 /// This is used for both the usage footer and the usage history page in settings.
 pub struct ConversationUsageView {
@@ -61,6 +86,26 @@ pub struct ConversationUsageView {
     /// Optional timing information for the last set of responses (only shown in the footer version of this view).
     pub timing_info: Option<TimingInfo>,
     full_terminal_use_tooltip_mouse_state: MouseStateHandle,
+    /// Orchestration credit rollup context. When `Some`, the parent
+    /// conversation is an orchestrator with at least one locally-loaded
+    /// descendant; the rollup itself is recomputed at render time from
+    /// `parent_conversation_id` so descendant updates always read fresh
+    /// values.
+    parent_conversation_id: Option<AIConversationId>,
+    /// Local UI state: whether the "View details" toggle is currently
+    /// expanded. Resets to `false` whenever the footer is rebuilt — the
+    /// rich-content view backing this struct is dropped and recreated on
+    /// every collapse / reopen cycle, satisfying PRODUCT invariant 6.
+    details_expanded: bool,
+    /// Local UI state: whether the user clicked "Show N more" to reveal the
+    /// rows beyond the first 5. Resets on view rebuild for the same reason
+    /// as `details_expanded`.
+    show_all_clicked: bool,
+    /// Per-row mouse states for the "View details" / "Hide details" link
+    /// and the "Show N more" link. Stored on the view so hover/click state
+    /// survives across renders.
+    details_toggle_mouse_state: MouseStateHandle,
+    show_more_mouse_state: MouseStateHandle,
 }
 
 impl ConversationUsageView {
@@ -75,7 +120,68 @@ impl ConversationUsageView {
             display_mode,
             timing_info,
             full_terminal_use_tooltip_mouse_state,
+            parent_conversation_id: None,
+            details_expanded: false,
+            show_all_clicked: false,
+            details_toggle_mouse_state: MouseStateHandle::default(),
+            show_more_mouse_state: MouseStateHandle::default(),
         }
+    }
+
+    /// Constructs the view in `DisplayMode::Footer` with orchestration
+    /// credit rollup wired in. The view subscribes to
+    /// [`BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated`] so it
+    /// re-renders whenever any contributing conversation's usage metadata
+    /// changes (PRODUCT invariant 7).
+    pub fn new_footer_with_rollup(
+        usage_info: ConversationUsageInfo,
+        timing_info: Option<TimingInfo>,
+        full_terminal_use_tooltip_mouse_state: MouseStateHandle,
+        parent_conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
+        ctx.subscribe_to_model(&history_model, move |_, _, event, ctx| match event {
+            BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }
+            | BlocklistAIHistoryEvent::RemoveConversation { .. }
+            | BlocklistAIHistoryEvent::DeletedConversation { .. }
+            | BlocklistAIHistoryEvent::StartedNewConversation { .. } => {
+                // Any of these can change the orchestration rollup: a
+                // descendant's credits changed, a descendant was pruned
+                // (invariant 9), or a new descendant was spawned
+                // (invariant 8). Trigger a re-render; the actual rollup
+                // is recomputed from the history model in `render`.
+                ctx.notify();
+            }
+            _ => {}
+        });
+
+        Self {
+            usage_info,
+            display_mode: DisplayMode::Footer,
+            timing_info,
+            full_terminal_use_tooltip_mouse_state,
+            parent_conversation_id: Some(parent_conversation_id),
+            details_expanded: false,
+            show_all_clicked: false,
+            details_toggle_mouse_state: MouseStateHandle::default(),
+            show_more_mouse_state: MouseStateHandle::default(),
+        }
+    }
+
+    /// Returns the current orchestration rollup for this view, or `None`
+    /// when the feature flag is off, the view is in settings mode, or the
+    /// orchestrator has no eligible descendants.
+    fn rollup(&self, app: &AppContext) -> Option<OrchestrationCreditRollup> {
+        if !FeatureFlag::OrchestrationCreditRollup.is_enabled() {
+            return None;
+        }
+        if self.display_mode != DisplayMode::Footer {
+            return None;
+        }
+        let parent_id = self.parent_conversation_id?;
+        let history = BlocklistAIHistoryModel::as_ref(app);
+        compute_orchestration_rollup(parent_id, history)
     }
     /// Helper to collect models grouped by category.
     /// Returns a HashMap mapping category name to list of (model_id, is_byok) tuples.
@@ -124,10 +230,13 @@ impl ConversationUsageView {
         entries_by_category
     }
 
-    fn render_unified_layout(&self, appearance: &Appearance) -> Box<dyn Element> {
+    fn render_unified_layout(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let font_size = appearance.ui_font_size() + 2.;
         let text_color = blended_colors::text_main(theme, theme.surface_2());
+
+        let rollup = self.rollup(app);
 
         let mut labels: Vec<Box<dyn Element>> = vec![];
         let mut values: Vec<Box<dyn Element>> = vec![];
@@ -138,6 +247,14 @@ impl ConversationUsageView {
             appearance,
         ));
         values.push(render_section_header("".to_string(), appearance));
+
+        // "Credits spent (total)" value: use the rollup total when available,
+        // otherwise the orchestrator's own self total (today's behavior).
+        // PRODUCT invariants 2a, 11, 13.
+        let total_credits_value = rollup
+            .as_ref()
+            .map(|r| r.total_credits)
+            .unwrap_or(self.usage_info.credits_spent);
 
         if self.display_mode == DisplayMode::Footer
             && self.usage_info.credits_spent_for_last_block.is_some()
@@ -153,14 +270,16 @@ impl ConversationUsageView {
             ));
 
             labels.push(render_label_text("Credits spent (total)", appearance));
-            values.push(render_value_text(
-                format_credits(self.usage_info.credits_spent),
+            values.push(self.render_total_credits_value_row(
+                total_credits_value,
+                rollup.as_ref(),
                 appearance,
             ));
         } else {
             labels.push(render_label_text("Credits spent", appearance));
-            values.push(render_value_text(
-                format_credits(self.usage_info.credits_spent),
+            values.push(self.render_total_credits_value_row(
+                total_credits_value,
+                rollup.as_ref(),
                 appearance,
             ));
         }
@@ -415,6 +534,33 @@ impl ConversationUsageView {
             }
         }
 
+        // Emit the per-agent breakdown rows beneath the value column when
+        // the rollup is active and the user has toggled "View details" on.
+        // The rows are appended as additional label/value pairs so the
+        // existing two-column flex layout handles spacing for free. The
+        // label column carries the avatar + display name; the value
+        // column carries the credit value.
+        if let Some(rollup) = &rollup {
+            if self.details_expanded {
+                let total_entries = rollup.per_agent.len();
+                let shown_entries: usize = if total_entries > 5 && !self.show_all_clicked {
+                    5
+                } else {
+                    total_entries
+                };
+                for entry in rollup.per_agent.iter().take(shown_entries) {
+                    let (label_el, value_el) = self.render_per_agent_row(entry, appearance);
+                    labels.push(label_el);
+                    values.push(value_el);
+                }
+                if total_entries > shown_entries {
+                    let hidden_count = total_entries - shown_entries;
+                    labels.push(self.render_show_more_link(hidden_count, appearance));
+                    values.push(Empty::new().finish());
+                }
+            }
+        }
+
         Container::new(
             Flex::row()
                 .with_spacing(8.)
@@ -423,6 +569,144 @@ impl ConversationUsageView {
                 .finish(),
         )
         .with_uniform_margin(16.)
+        .finish()
+    }
+
+    /// Renders the "Credits spent (total)" value cell. When a rollup
+    /// applies, the cell is a row with the value followed by a
+    /// "View details ▾" / "Hide details ▴" toggle.
+    fn render_total_credits_value_row(
+        &self,
+        total_credits: f32,
+        rollup: Option<&OrchestrationCreditRollup>,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let value_text = render_value_text(format_credits(total_credits), appearance);
+        if rollup.is_none() {
+            return value_text;
+        }
+
+        let toggle = self.render_details_toggle(appearance);
+        Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_spacing(8.)
+            .with_child(value_text)
+            .with_child(toggle)
+            .finish()
+    }
+
+    /// Renders the "View details ▾" / "Hide details ▴" toggle link rendered
+    /// to the right of the "Credits spent (total)" value when a rollup
+    /// applies. The link uses the standard sub-text color so it reads as a
+    /// secondary affordance rather than a primary value.
+    fn render_details_toggle(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let font_size = appearance.ui_font_size() + 2.;
+        let bg = theme.surface_2();
+        let text_color = blended_colors::text_sub(theme, bg);
+        let icon_size = font_size;
+        let (label, icon) = if self.details_expanded {
+            ("Hide details", Icon::ChevronUp)
+        } else {
+            ("View details", Icon::ChevronDown)
+        };
+        Hoverable::new(
+            self.details_toggle_mouse_state.clone(),
+            move |hover_state| {
+                let active_text_color = if hover_state.is_hovered() || hover_state.is_clicked() {
+                    blended_colors::text_main(theme, bg)
+                } else {
+                    text_color
+                };
+                let text_element =
+                    Text::new(label.to_string(), appearance.ui_font_family(), font_size)
+                        .with_color(active_text_color)
+                        .with_selectable(false)
+                        .finish();
+                let icon_element =
+                    ConstrainedBox::new(icon.to_warpui_icon(active_text_color.into()).finish())
+                        .with_width(icon_size)
+                        .with_height(icon_size)
+                        .finish();
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_size(MainAxisSize::Min)
+                    .with_spacing(4.)
+                    .with_child(text_element)
+                    .with_child(icon_element)
+                    .finish()
+            },
+        )
+        .with_cursor(Cursor::PointingHand)
+        .on_click(|ctx, _, _| {
+            ctx.dispatch_typed_action(ConversationUsageViewAction::ToggleDetailsExpanded);
+        })
+        .finish()
+    }
+
+    /// Renders the avatar + label cell for a per-agent breakdown row,
+    /// plus the credit value cell, returned as a `(label, value)` pair so
+    /// the caller can append them to the existing two-column flex layout.
+    fn render_per_agent_row(
+        &self,
+        entry: &PerAgentCreditEntry,
+        appearance: &Appearance,
+    ) -> (Box<dyn Element>, Box<dyn Element>) {
+        let theme = appearance.theme();
+        const ROW_AVATAR_SIZE: f32 = 16.;
+        let avatar = match entry.avatar {
+            AgentAvatar::Orchestrator => {
+                render_orchestrator_avatar_disc(ROW_AVATAR_SIZE, theme, appearance)
+            }
+            AgentAvatar::Child => {
+                render_agent_avatar_disc(&entry.display_name, ROW_AVATAR_SIZE, theme, appearance)
+            }
+        };
+        let label = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_spacing(8.)
+            .with_child(avatar)
+            .with_child(render_label_text(&entry.display_name, appearance))
+            .finish();
+        let value = render_value_text(format_credits(entry.credits_spent), appearance);
+        (label, value)
+    }
+
+    /// Renders the "Show N more" link row shown beneath the first 5
+    /// per-agent rows when the breakdown has more entries than the
+    /// truncation cap. Clicking the link replaces the truncated list with
+    /// the full list on the next render (PRODUCT invariant 5f).
+    fn render_show_more_link(
+        &self,
+        hidden_count: usize,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let font_size = appearance.ui_font_size() + 2.;
+        let bg = theme.surface_2();
+        let text_color = blended_colors::text_sub(theme, bg);
+        let label = format!("Show {hidden_count} more");
+        Hoverable::new(self.show_more_mouse_state.clone(), move |hover_state| {
+            let active_color = if hover_state.is_hovered() || hover_state.is_clicked() {
+                blended_colors::text_main(theme, bg)
+            } else {
+                text_color
+            };
+            Text::new(label.clone(), appearance.ui_font_family(), font_size)
+                .with_color(active_color)
+                .with_style(Properties {
+                    weight: Weight::Normal,
+                    ..Default::default()
+                })
+                .with_selectable(false)
+                .finish()
+        })
+        .with_cursor(Cursor::PointingHand)
+        .on_click(|ctx, _, _| {
+            ctx.dispatch_typed_action(ConversationUsageViewAction::ShowAllAgentRows);
+        })
         .finish()
     }
 
@@ -471,7 +755,7 @@ impl View for ConversationUsageView {
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
 
-        self.render_card_container(self.render_unified_layout(appearance), appearance)
+        self.render_card_container(self.render_unified_layout(app), appearance)
     }
 }
 
@@ -480,9 +764,26 @@ impl Entity for ConversationUsageView {
 }
 
 impl TypedActionView for ConversationUsageView {
-    type Action = ();
+    type Action = ConversationUsageViewAction;
 
-    fn handle_action(&mut self, _action: &Self::Action, _ctx: &mut ViewContext<Self>) {}
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            ConversationUsageViewAction::ToggleDetailsExpanded => {
+                self.details_expanded = !self.details_expanded;
+                // Collapsing the breakdown resets the "Show N more"
+                // expansion so the user lands back on the truncated list
+                // the next time they expand.
+                if !self.details_expanded {
+                    self.show_all_clicked = false;
+                }
+                ctx.notify();
+            }
+            ConversationUsageViewAction::ShowAllAgentRows => {
+                self.show_all_clicked = true;
+                ctx.notify();
+            }
+        }
+    }
 }
 
 /// Render the main header for a usage section.

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -2,6 +2,7 @@ use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::blocklist::agent_view::orchestration_pill_bar::{
     render_agent_avatar_disc, render_orchestrator_avatar_disc,
 };
+use crate::ai::blocklist::orchestration_topology::descendant_conversation_ids_in_spawn_order;
 use crate::ai::blocklist::usage::render_context_window_usage_icon;
 use crate::ai::blocklist::usage::rollup::{
     compute_orchestration_rollup, AgentAvatar, OrchestrationCreditRollup, PerAgentCreditEntry,
@@ -141,19 +142,49 @@ impl ConversationUsageView {
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
-        ctx.subscribe_to_model(&history_model, move |_, _, event, ctx| match event {
-            BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }
-            | BlocklistAIHistoryEvent::RemoveConversation { .. }
-            | BlocklistAIHistoryEvent::DeletedConversation { .. }
-            | BlocklistAIHistoryEvent::StartedNewConversation { .. } => {
-                // Any of these can change the orchestration rollup: a
-                // descendant's credits changed, a descendant was pruned
-                // (invariant 9), or a new descendant was spawned
-                // (invariant 8). Trigger a re-render; the actual rollup
-                // is recomputed from the history model in `render`.
+        ctx.subscribe_to_model(&history_model, move |_, history, event, ctx| {
+            // Narrow to events that can actually change *this* orchestrator's
+            // rollup. Without this filter the closure wakes on every history
+            // event in the app (one terminal view's typing storm fans out to
+            // every other rollup subscriber), and `ctx.notify()` forces a
+            // full footer re-render on each wake — orders of magnitude more
+            // expensive than the subtree walk below.
+            //
+            // `StartedNewConversation` is intentionally omitted: a freshly
+            // spawned descendant always has zero credits, so the rollup
+            // result is unchanged until its first
+            // `ConversationUsageMetadataUpdated` event (which this filter
+            // will then pick up). Invariant 8 ("new descendant’s row appears
+            // when it first spends a credit") is satisfied by the
+            // credits-update path, not by the spawn event itself.
+            let touched_id = match event {
+                BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { conversation_id }
+                | BlocklistAIHistoryEvent::RemoveConversation {
+                    conversation_id, ..
+                }
+                | BlocklistAIHistoryEvent::DeletedConversation {
+                    conversation_id, ..
+                } => *conversation_id,
+                _ => return,
+            };
+            if touched_id == parent_conversation_id {
+                ctx.notify();
+                return;
+            }
+            // `RemoveConversation` / `DeletedConversation` fire *after* the
+            // conversation is dropped from `conversations_by_id`, but the
+            // `children_by_parent` index that this walker consults is not
+            // cleaned up on remove, so a just-pruned descendant is still
+            // listed here. That lets us correctly notify on prune (invariant
+            // 9) — the render-time rollup then skips the missing
+            // conversation via the loaded-descendants filter and the row
+            // disappears.
+            let history = history.as_ref(ctx);
+            if descendant_conversation_ids_in_spawn_order(history, parent_conversation_id)
+                .contains(&touched_id)
+            {
                 ctx.notify();
             }
-            _ => {}
         });
 
         Self {

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -214,6 +214,7 @@ impl ConversationUsageView {
         let history = BlocklistAIHistoryModel::as_ref(app);
         compute_orchestration_rollup(parent_id, history)
     }
+
     /// Helper to collect models grouped by category.
     /// Returns a HashMap mapping category name to list of (model_id, is_byok) tuples.
     /// Handles both category-based fields and legacy warp_tokens/byok_tokens fields.
@@ -604,11 +605,12 @@ impl ConversationUsageView {
             return;
         }
         let total_entries = rollup.per_agent.len();
-        let shown_entries: usize = if total_entries > 5 && !self.show_all_clicked {
-            5
-        } else {
-            total_entries
-        };
+        let shown_entries: usize =
+            if total_entries > PER_AGENT_BREAKDOWN_TRUNCATION_CAP && !self.show_all_clicked {
+                PER_AGENT_BREAKDOWN_TRUNCATION_CAP
+            } else {
+                total_entries
+            };
         for entry in rollup.per_agent.iter().take(shown_entries) {
             let (label_el, value_el) = self.render_per_agent_row(entry, appearance);
             labels.push(label_el);
@@ -936,6 +938,12 @@ fn render_value_text_placeholder(appearance: &Appearance) -> Box<dyn Element> {
 /// footer's name treatment never exceeds what the pill bar already
 /// enforces at the top of the agent view.
 const PER_AGENT_LABEL_MAX_WIDTH: f32 = 110.;
+
+/// Maximum number of rows shown in the per-agent breakdown before the
+/// "Show N more" affordance truncates the list. Matches PRODUCT
+/// invariants 5e (≤ 5 rows render in full) and 5f (> 5 rows render the
+/// first 5 followed by a "Show N more" link).
+const PER_AGENT_BREAKDOWN_TRUNCATION_CAP: usize = 5;
 
 #[cfg(test)]
 #[path = "conversation_usage_view_tests.rs"]

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -22,6 +22,7 @@ use warp_core::ui::Icon;
 use warpui::elements::ConstrainedBox;
 use warpui::fonts::{Properties, Weight};
 use warpui::platform::Cursor;
+use warpui::text_layout::ClipConfig;
 use warpui::{
     elements::{
         Border, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, Hoverable, MainAxisSize,
@@ -585,8 +586,13 @@ impl ConversationUsageView {
         }
         if total_entries > shown_entries {
             let hidden_count = total_entries - shown_entries;
+            // "Show N more" sits on a row of its own. We push a value-
+            // side placeholder that mirrors the link's natural line
+            // height so the right column stays in lock-step with the
+            // left and the subsequent "Tool calls" / value row pair
+            // doesn't slip out of alignment.
             labels.push(self.render_show_more_link(hidden_count, appearance));
-            values.push(Empty::new().finish());
+            values.push(render_value_text_placeholder(appearance));
         }
     }
 
@@ -666,12 +672,28 @@ impl ConversationUsageView {
     /// Renders the avatar + label cell for a per-agent breakdown row,
     /// plus the credit value cell, returned as a `(label, value)` pair so
     /// the caller can append them to the existing two-column flex layout.
+    ///
+    /// Color choices:
+    /// * Agent name uses the same color as the "USAGE SUMMARY" section
+    ///   header (the disabled-text token) so the rollup rows read as a
+    ///   sub-list of that section rather than competing with primary
+    ///   labels.
+    /// * Credit value uses the label-row color (`text_sub`) so it
+    ///   visually echoes the "Credits spent" label rather than the
+    ///   primary credit count beside it.
+    ///
+    /// Name length: agent names are clipped to the same max width and
+    /// ellipsis treatment used by the orchestration pill bar
+    /// ([`PER_AGENT_LABEL_MAX_WIDTH`]) so a long child-agent name in the
+    /// footer doesn't push the credit-value column off-screen.
     fn render_per_agent_row(
         &self,
         entry: &PerAgentCreditEntry,
         appearance: &Appearance,
     ) -> (Box<dyn Element>, Box<dyn Element>) {
         let theme = appearance.theme();
+        let bg = theme.surface_2();
+        let font_size = appearance.ui_font_size() + 2.;
         const ROW_AVATAR_SIZE: f32 = 16.;
         let avatar = match entry.avatar {
             AgentAvatar::Orchestrator => {
@@ -681,14 +703,32 @@ impl ConversationUsageView {
                 render_agent_avatar_disc(&entry.display_name, ROW_AVATAR_SIZE, theme, appearance)
             }
         };
+        let name_text = Text::new(
+            entry.display_name.clone(),
+            appearance.ui_font_family(),
+            font_size,
+        )
+        .with_color(blended_colors::text_disabled(theme, bg))
+        .soft_wrap(false)
+        .with_clip(ClipConfig::ellipsis())
+        .finish();
+        let name_element = ConstrainedBox::new(name_text)
+            .with_max_width(PER_AGENT_LABEL_MAX_WIDTH)
+            .finish();
         let label = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_size(MainAxisSize::Min)
             .with_spacing(8.)
             .with_child(avatar)
-            .with_child(render_label_text(&entry.display_name, appearance))
+            .with_child(name_element)
             .finish();
-        let value = render_value_text(format_credits(entry.credits_spent), appearance);
+        let value = Text::new(
+            format_credits(entry.credits_spent),
+            appearance.ui_font_family(),
+            font_size,
+        )
+        .with_color(blended_colors::text_sub(theme, bg))
+        .finish();
         (label, value)
     }
 
@@ -844,6 +884,28 @@ fn render_value_text(text: String, appearance: &Appearance) -> Box<dyn Element> 
         .with_color(text_color)
         .finish()
 }
+
+/// Renders a placeholder value cell that occupies one full line of the
+/// value column without painting any visible text. Used opposite the
+/// "Show N more" link so the two-column flex stays row-aligned for the
+/// subsequent rows.
+///
+/// A simple `Empty` element would also keep the slot count matched, but
+/// `Empty` has zero height, so the value column collapses by one line
+/// and "Tool calls" ends up paired with "Show N more" instead of with
+/// the next labels-column row. Pushing a `Text` element with a
+/// single-space content forces a real line-height equal to the link's
+/// own line-height.
+fn render_value_text_placeholder(appearance: &Appearance) -> Box<dyn Element> {
+    let font_size = appearance.ui_font_size() + 2.;
+    Text::new(" ".to_string(), appearance.ui_font_family(), font_size).finish()
+}
+
+/// Maximum rendered width of an agent name in a per-agent breakdown row.
+/// Mirrors `PILL_LABEL_MAX_WIDTH` in the orchestration pill bar so the
+/// footer's name treatment never exceeds what the pill bar already
+/// enforces at the top of the agent view.
+const PER_AGENT_LABEL_MAX_WIDTH: f32 = 110.;
 
 #[cfg(test)]
 #[path = "conversation_usage_view_tests.rs"]

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -1,0 +1,146 @@
+//! Click-handler regression tests for [`ConversationUsageView`].
+//!
+//! The original bug was that clicks on the "View details" / "Show N more"
+//! affordances did nothing because the view was created via `add_view`
+//! instead of `add_typed_action_view`, so the framework had no handler
+//! registered for `ConversationUsageViewAction::*` and silently logged
+//! `Dispatched action has no handlers: ToggleDetailsExpanded`.
+//!
+//! The fix lives at the view-creation site in `terminal/view.rs`. These
+//! tests are a defense-in-depth layer that exercises the view's
+//! `handle_action` implementation directly, so:
+//!
+//! * If the `TypedActionView` impl is removed or broken, the test won't
+//!   compile (compile-time guard).
+//! * If the handler logic for toggling `details_expanded` / resetting
+//!   `show_all_clicked` regresses, the assertions below will fail
+//!   (runtime guard).
+//!
+//! The tests use the same `view.update(&mut app, |view, ctx|
+//! view.handle_action(...))` pattern as the existing
+//! `number_shortcut_buttons_tests.rs` so they stay decoupled from the
+//! framework's render path (which needs `Appearance` / theme singletons
+//! that aren't relevant to the handler's correctness).
+
+use super::*;
+use warp_core::ui::appearance::Appearance;
+use warpui::platform::WindowStyle;
+use warpui::App;
+
+fn placeholder_usage_info() -> ConversationUsageInfo {
+    ConversationUsageInfo {
+        credits_spent: 0.0,
+        credits_spent_for_last_block: None,
+        tool_calls: 0,
+        models: Vec::new(),
+        context_window_usage: 0.0,
+        files_changed: 0,
+        lines_added: 0,
+        lines_removed: 0,
+        commands_executed: 0,
+    }
+}
+
+/// Registers the singletons that the view touches when constructed and
+/// when `ctx.notify()` runs (theme lookups, etc.). Keep this minimal: the
+/// goal is to satisfy the runtime, not to mirror the full production app.
+fn initialize_test_app(app: &mut App) {
+    app.add_singleton_model(|_| Appearance::mock());
+}
+
+fn build_view(_ctx: &mut warpui::ViewContext<ConversationUsageView>) -> ConversationUsageView {
+    ConversationUsageView::new(
+        placeholder_usage_info(),
+        DisplayMode::Footer,
+        None,
+        MouseStateHandle::default(),
+    )
+}
+
+#[test]
+fn toggle_details_expanded_flips_state_and_resets_show_all_on_collapse() {
+    App::test((), |mut app| async move {
+        initialize_test_app(&mut app);
+        // `add_window` registers the root view via `add_typed_action_view`
+        // internally, so simply standing up the window proves
+        // `ConversationUsageView: TypedActionView` is wired correctly.
+        let (_window_id, view) = app.add_window(WindowStyle::NotStealFocus, build_view);
+
+        view.read(&app, |view, _| {
+            assert!(
+                !view.details_expanded,
+                "view starts collapsed before any action is dispatched"
+            );
+            assert!(
+                !view.show_all_clicked,
+                "show_all_clicked starts false before any action is dispatched"
+            );
+        });
+
+        // Expand the breakdown.
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&ConversationUsageViewAction::ToggleDetailsExpanded, ctx);
+        });
+        view.read(&app, |view, _| {
+            assert!(
+                view.details_expanded,
+                "ToggleDetailsExpanded should expand the breakdown"
+            );
+        });
+
+        // Reveal-more should set the flag while keeping the view expanded.
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&ConversationUsageViewAction::ShowAllAgentRows, ctx);
+        });
+        view.read(&app, |view, _| {
+            assert!(view.details_expanded, "still expanded after Show N more");
+            assert!(
+                view.show_all_clicked,
+                "Show N more should set show_all_clicked"
+            );
+        });
+
+        // Toggling collapse should both flip the expanded flag and reset
+        // the show-all state so the next expand lands on the truncated
+        // list.
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&ConversationUsageViewAction::ToggleDetailsExpanded, ctx);
+        });
+        view.read(&app, |view, _| {
+            assert!(
+                !view.details_expanded,
+                "collapsing should toggle details_expanded back off"
+            );
+            assert!(
+                !view.show_all_clicked,
+                "collapsing should reset show_all_clicked"
+            );
+        });
+    });
+}
+
+#[test]
+fn show_all_agent_rows_is_independent_of_details_expanded() {
+    App::test((), |mut app| async move {
+        initialize_test_app(&mut app);
+        let (_window_id, view) = app.add_window(WindowStyle::NotStealFocus, build_view);
+
+        // `ShowAllAgentRows` on its own should flip `show_all_clicked`
+        // even when the user hasn't expanded the breakdown yet (the
+        // render path won't show rows until expanded, but the handler
+        // itself shouldn't care about ordering).
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&ConversationUsageViewAction::ShowAllAgentRows, ctx);
+        });
+        view.read(&app, |view, _| {
+            assert!(
+                view.show_all_clicked,
+                "ShowAllAgentRows should flip show_all_clicked regardless of expanded state"
+            );
+            assert!(
+                !view.details_expanded,
+                "ShowAllAgentRows must not implicitly expand details"
+            );
+        });
+    });
+}

--- a/app/src/ai/blocklist/usage/mod.rs
+++ b/app/src/ai/blocklist/usage/mod.rs
@@ -3,6 +3,7 @@ use warp_core::ui::Icon;
 use warpui::Element;
 
 pub mod conversation_usage_view;
+pub mod rollup;
 
 pub fn icon_for_context_window_usage(context_window_usage: f32) -> Icon {
     // Match the context window usage to the nearest 10% icon.

--- a/app/src/ai/blocklist/usage/rollup.rs
+++ b/app/src/ai/blocklist/usage/rollup.rs
@@ -1,0 +1,156 @@
+//! Aggregates credit usage across an orchestrator and its locally-loaded
+//! descendants for the agent-mode footer rollup feature (QUALITY-671).
+//!
+//! Pure function — no I/O, no GraphQL. Walks
+//! [`BlocklistAIHistoryModel`] using the shared
+//! [`descendant_conversation_ids_in_spawn_order`] helper, sums each loaded
+//! conversation's `credits_spent`, and emits a per-agent breakdown for the
+//! footer's "View details" list.
+
+use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+use crate::ai::blocklist::orchestration_topology::descendant_conversation_ids_in_spawn_order;
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+
+/// Avatar identity for a row in the per-agent breakdown.
+///
+/// The actual rendering still requires a theme (which the rollup, being a
+/// pure function, cannot consult), so this enum only carries the structural
+/// information needed to choose a renderer at render time. The child variant
+/// reuses the orchestration pill bar's deterministic per-name color +
+/// uppercase initial via the existing avatar helpers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentAvatar {
+    /// The orchestrator itself. Rendered with the Oz glyph on `ansi_fg_cyan`.
+    Orchestrator,
+    /// A descendant agent. Rendered with the same deterministic-color +
+    /// initial-letter treatment as the orchestration pill bar.
+    Child,
+}
+
+/// One row in the per-agent credit breakdown list.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PerAgentCreditEntry {
+    pub conversation_id: AIConversationId,
+    pub display_name: String,
+    pub avatar: AgentAvatar,
+    pub credits_spent: f32,
+}
+
+/// Aggregated credit usage for an orchestrator and its locally-loaded
+/// descendants.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrchestrationCreditRollup {
+    /// Sum of `credits_spent` across the orchestrator and every
+    /// locally-loaded descendant.
+    pub total_credits: f32,
+    /// One entry per agent that has spent > 0 credits, sorted by
+    /// `credits_spent` descending. Ties are broken by spawn order (earlier
+    /// spawn first; orchestrator always sorts before its descendants in a
+    /// tie).
+    pub per_agent: Vec<PerAgentCreditEntry>,
+}
+
+/// Computes the orchestration credit rollup for `parent_id`.
+///
+/// Returns `None` when:
+/// * the orchestrator has no locally-loaded descendants, OR
+/// * the orchestrator and every loaded descendant have spent zero credits.
+///
+/// Unloaded descendants (IDs in the topology index without a matching
+/// `AIConversation` in `conversations_by_id`) are silently skipped — see
+/// PRODUCT.md invariant 10.
+pub fn compute_orchestration_rollup(
+    parent_id: AIConversationId,
+    history: &BlocklistAIHistoryModel,
+) -> Option<OrchestrationCreditRollup> {
+    // Descendants in spawn order so ties break naturally. The orchestrator
+    // is prepended at index 0 so it sorts before its descendants at equal
+    // credit totals.
+    let descendant_ids = descendant_conversation_ids_in_spawn_order(history, parent_id);
+    if descendant_ids.is_empty() {
+        return None;
+    }
+
+    let mut total_credits: f32 = 0.0;
+    let mut entries: Vec<(usize, PerAgentCreditEntry)> = Vec::new();
+
+    if let Some(orchestrator) = history.conversation(&parent_id) {
+        let credits = orchestrator.credits_spent();
+        total_credits += credits;
+        if credits > 0.0 {
+            entries.push((
+                0,
+                PerAgentCreditEntry {
+                    conversation_id: parent_id,
+                    display_name: orchestrator_display_name(orchestrator),
+                    avatar: AgentAvatar::Orchestrator,
+                    credits_spent: credits,
+                },
+            ));
+        }
+    }
+
+    for (spawn_idx, descendant_id) in descendant_ids.iter().enumerate() {
+        let Some(descendant) = history.conversation(descendant_id) else {
+            // PRODUCT invariant 10: silently skip unloaded descendants.
+            continue;
+        };
+        let credits = descendant.credits_spent();
+        total_credits += credits;
+        if credits > 0.0 {
+            entries.push((
+                spawn_idx + 1,
+                PerAgentCreditEntry {
+                    conversation_id: *descendant_id,
+                    display_name: child_display_name(descendant),
+                    avatar: AgentAvatar::Child,
+                    credits_spent: credits,
+                },
+            ));
+        }
+    }
+
+    if entries.is_empty() {
+        return None;
+    }
+
+    // Sort by credits descending; ties broken by spawn order ascending so
+    // the earlier-spawned agent appears first.
+    entries.sort_by(|a, b| {
+        b.1.credits_spent
+            .partial_cmp(&a.1.credits_spent)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
+    });
+
+    Some(OrchestrationCreditRollup {
+        total_credits,
+        per_agent: entries.into_iter().map(|(_, entry)| entry).collect(),
+    })
+}
+
+/// Display name for the orchestrator row. Prefers the explicitly assigned
+/// `agent_name`, falls back to "Orchestrator" so the row is always
+/// meaningful.
+fn orchestrator_display_name(orchestrator: &AIConversation) -> String {
+    orchestrator
+        .agent_name()
+        .filter(|n| !n.is_empty())
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "Orchestrator".to_string())
+}
+
+/// Display name for a child row. Mirrors the orchestration pill bar's
+/// fallback (`"Agent"`) so the breakdown stays consistent with the pill
+/// labels when an agent hasn't been named yet.
+fn child_display_name(child: &AIConversation) -> String {
+    child
+        .agent_name()
+        .filter(|n| !n.is_empty())
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "Agent".to_string())
+}
+
+#[cfg(test)]
+#[path = "rollup_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/usage/rollup_tests.rs
+++ b/app/src/ai/blocklist/usage/rollup_tests.rs
@@ -1,0 +1,311 @@
+use super::*;
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+use warpui::{App, EntityId};
+
+fn set_credits(
+    app: &mut App,
+    history: &warpui::ModelHandle<BlocklistAIHistoryModel>,
+    id: AIConversationId,
+    credits: f32,
+) {
+    history.update(app, |history, _| {
+        history
+            .conversation_mut(&id)
+            .expect("conversation must be loaded")
+            .set_credits_spent_for_test(credits);
+    });
+}
+
+fn spawn_child(
+    app: &mut App,
+    history: &warpui::ModelHandle<BlocklistAIHistoryModel>,
+    name: &str,
+    parent_id: AIConversationId,
+    terminal_view_id: EntityId,
+) -> AIConversationId {
+    history.update(app, |history, ctx| {
+        history.start_new_child_conversation(
+            terminal_view_id,
+            name.to_string(),
+            parent_id,
+            None,
+            ctx,
+        )
+    })
+}
+
+#[test]
+fn returns_none_when_orchestrator_has_no_descendants() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        // Even if the orchestrator itself has spent credits, no descendants
+        // means no rollup applies.
+        set_credits(&mut app, &history, orchestrator_id, 10.0);
+
+        history.read(&app, |history, _| {
+            assert!(compute_orchestration_rollup(orchestrator_id, history).is_none());
+        });
+    });
+}
+
+#[test]
+fn sums_orchestrator_and_loaded_descendants() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = spawn_child(
+            &mut app,
+            &history,
+            "DesignBot",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        set_credits(&mut app, &history, orchestrator_id, 3.0);
+        set_credits(&mut app, &history, child_id, 30.0);
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_credits, 33.0);
+            assert_eq!(rollup.per_agent.len(), 2);
+            // Child spent more, sorted first.
+            assert_eq!(rollup.per_agent[0].conversation_id, child_id);
+            assert_eq!(rollup.per_agent[0].credits_spent, 30.0);
+            assert_eq!(rollup.per_agent[0].avatar, AgentAvatar::Child);
+            assert_eq!(rollup.per_agent[0].display_name, "DesignBot");
+            assert_eq!(rollup.per_agent[1].conversation_id, orchestrator_id);
+            assert_eq!(rollup.per_agent[1].credits_spent, 3.0);
+            assert_eq!(rollup.per_agent[1].avatar, AgentAvatar::Orchestrator);
+            assert_eq!(rollup.per_agent[1].display_name, "Orchestrator");
+        });
+    });
+}
+
+#[test]
+fn excludes_zero_credit_descendants_from_breakdown() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let alpha_id = spawn_child(
+            &mut app,
+            &history,
+            "Alpha",
+            orchestrator_id,
+            terminal_view_id,
+        );
+        let beta_id = spawn_child(
+            &mut app,
+            &history,
+            "Beta",
+            orchestrator_id,
+            terminal_view_id,
+        );
+        let _idle_id = spawn_child(
+            &mut app,
+            &history,
+            "IdleChild",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        set_credits(&mut app, &history, orchestrator_id, 2.0);
+        set_credits(&mut app, &history, alpha_id, 12.0);
+        set_credits(&mut app, &history, beta_id, 5.0);
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_credits, 19.0);
+            assert_eq!(rollup.per_agent.len(), 3);
+            let ordered_ids: Vec<_> = rollup
+                .per_agent
+                .iter()
+                .map(|entry| entry.conversation_id)
+                .collect();
+            assert_eq!(ordered_ids, vec![alpha_id, beta_id, orchestrator_id]);
+        });
+    });
+}
+
+#[test]
+fn rolls_up_grandchildren_transitively() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child_id = spawn_child(
+            &mut app,
+            &history,
+            "ChildA",
+            orchestrator_id,
+            terminal_view_id,
+        );
+        let grandchild_id = spawn_child(&mut app, &history, "GrandA1", child_id, terminal_view_id);
+
+        set_credits(&mut app, &history, orchestrator_id, 1.0);
+        set_credits(&mut app, &history, child_id, 4.0);
+        set_credits(&mut app, &history, grandchild_id, 9.0);
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_credits, 14.0);
+            let ordered_ids: Vec<_> = rollup
+                .per_agent
+                .iter()
+                .map(|entry| entry.conversation_id)
+                .collect();
+            assert_eq!(ordered_ids, vec![grandchild_id, child_id, orchestrator_id]);
+        });
+    });
+}
+
+#[test]
+fn returns_six_contributors_for_show_n_more_caller() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        set_credits(&mut app, &history, orchestrator_id, 1.0);
+
+        for i in 0..5 {
+            let id = spawn_child(
+                &mut app,
+                &history,
+                &format!("Agent{i}"),
+                orchestrator_id,
+                terminal_view_id,
+            );
+            // Distinct credit values so we don't rely on tie-break behavior.
+            set_credits(&mut app, &history, id, (10 + i) as f32);
+        }
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.per_agent.len(), 6);
+        });
+    });
+}
+
+#[test]
+fn returns_none_when_only_orchestrator_has_zero_credits_with_loaded_children() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        // One spawned child, but neither it nor the orchestrator has spent
+        // any credits yet.
+        let _child_id = spawn_child(
+            &mut app,
+            &history,
+            "Idle",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        history.read(&app, |history, _| {
+            assert!(compute_orchestration_rollup(orchestrator_id, history).is_none());
+        });
+    });
+}
+
+#[test]
+fn ties_break_by_spawn_order_earlier_first() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let first_id = spawn_child(
+            &mut app,
+            &history,
+            "FirstSpawned",
+            orchestrator_id,
+            terminal_view_id,
+        );
+        let second_id = spawn_child(
+            &mut app,
+            &history,
+            "SecondSpawned",
+            orchestrator_id,
+            terminal_view_id,
+        );
+
+        // Equal credit values force a tie-break.
+        set_credits(&mut app, &history, first_id, 7.0);
+        set_credits(&mut app, &history, second_id, 7.0);
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.per_agent.len(), 2);
+            assert_eq!(rollup.per_agent[0].conversation_id, first_id);
+            assert_eq!(rollup.per_agent[1].conversation_id, second_id);
+        });
+    });
+}
+
+#[test]
+fn unloaded_descendant_id_is_silently_skipped() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let real_child_id = spawn_child(
+            &mut app,
+            &history,
+            "RealChild",
+            orchestrator_id,
+            terminal_view_id,
+        );
+        set_credits(&mut app, &history, real_child_id, 4.0);
+
+        // Manually insert a dangling parent → child mapping for an ID that
+        // is not present in `conversations_by_id`. This emulates an
+        // orchestration topology entry where the child's `AIConversation`
+        // hasn't been hydrated locally (e.g. remote-only child agent).
+        let unloaded_id = AIConversationId::new();
+        history.update(&mut app, |history, _| {
+            history.set_parent_for_conversation(unloaded_id, orchestrator_id);
+        });
+
+        history.read(&app, |history, _| {
+            let rollup = compute_orchestration_rollup(orchestrator_id, history)
+                .expect("rollup should be Some");
+            assert_eq!(rollup.total_credits, 4.0);
+            assert_eq!(rollup.per_agent.len(), 1);
+            assert_eq!(rollup.per_agent[0].conversation_id, real_child_id);
+        });
+    });
+}

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -2136,6 +2136,7 @@ fn handle_ai_history_event(
         | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
         | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
         | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-        | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => (),
+        | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+        | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => (),
     }
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5402,7 +5402,8 @@ impl TerminalView {
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
             | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => None,
+            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => None,
         }
     }
 
@@ -5873,7 +5874,8 @@ impl TerminalView {
             | BlocklistAIHistoryEvent::DeletedConversation { .. }
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => {}
+            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
+            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => {}
         }
         ctx.notify();
     }
@@ -6171,14 +6173,27 @@ impl TerminalView {
             wall_to_wall_response_time_ms,
         };
 
-        // View to hold the usage footer.
-        let usage_view = ctx.add_view(|_| {
-            ConversationUsageView::new(
-                conversation_usage_info,
-                DisplayMode::Footer,
-                Some(timing_info),
-                MouseStateHandle::default(),
-            )
+        // View to hold the usage footer. When the orchestration credit
+        // rollup feature flag is on, route through the rollup-aware
+        // constructor so the view subscribes to history events and
+        // re-renders when any contributing agent's usage updates.
+        let usage_view = ctx.add_view(|ctx| {
+            if FeatureFlag::OrchestrationCreditRollup.is_enabled() {
+                ConversationUsageView::new_footer_with_rollup(
+                    conversation_usage_info,
+                    Some(timing_info),
+                    MouseStateHandle::default(),
+                    conversation_id,
+                    ctx,
+                )
+            } else {
+                ConversationUsageView::new(
+                    conversation_usage_info,
+                    DisplayMode::Footer,
+                    Some(timing_info),
+                    MouseStateHandle::default(),
+                )
+            }
         });
         self.usage_footer_view_ids
             .insert(source_ai_block_view_id, usage_view.id());

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -90,7 +90,7 @@ use crate::ai::blocklist::block::cli_controller::{
 };
 use crate::ai::blocklist::block::status_bar::BlocklistAIStatusBarEvent;
 use crate::ai::blocklist::usage::conversation_usage_view::{
-    ConversationUsageInfo, ConversationUsageView, DisplayMode, TimingInfo,
+    ConversationUsageInfo, ConversationUsageView, TimingInfo,
 };
 use crate::ai::blocklist::{block_context_from_terminal_model, SlashCommandRequest};
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel, AIDocumentVersion};
@@ -6173,10 +6173,13 @@ impl TerminalView {
             wall_to_wall_response_time_ms,
         };
 
-        // View to hold the usage footer. When the orchestration credit
-        // rollup feature flag is on, route through the rollup-aware
-        // constructor so the view subscribes to history events and
-        // re-renders when any contributing agent's usage updates.
+        // View to hold the usage footer. Always route through the
+        // rollup-aware constructor so the view subscribes to history
+        // events and re-renders when any contributing agent's usage
+        // updates. The rollup itself is computed at render time and is
+        // self-gating: conversations without descendants short-circuit
+        // to today's UI inside `ConversationUsageView::render`, so no
+        // feature flag check is needed at the call site.
         //
         // Use `add_typed_action_view` (not `add_view`) so the framework
         // registers `ConversationUsageView::handle_action`. Without this,
@@ -6184,22 +6187,13 @@ impl TerminalView {
         // dispatched from the view's own click handlers would be logged
         // as `Dispatched action has no handlers` and silently ignored.
         let usage_view = ctx.add_typed_action_view(|ctx| {
-            if FeatureFlag::OrchestrationCreditRollup.is_enabled() {
-                ConversationUsageView::new_footer_with_rollup(
-                    conversation_usage_info,
-                    Some(timing_info),
-                    MouseStateHandle::default(),
-                    conversation_id,
-                    ctx,
-                )
-            } else {
-                ConversationUsageView::new(
-                    conversation_usage_info,
-                    DisplayMode::Footer,
-                    Some(timing_info),
-                    MouseStateHandle::default(),
-                )
-            }
+            ConversationUsageView::new_footer_with_rollup(
+                conversation_usage_info,
+                Some(timing_info),
+                MouseStateHandle::default(),
+                conversation_id,
+                ctx,
+            )
         });
         self.usage_footer_view_ids
             .insert(source_ai_block_view_id, usage_view.id());

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6177,7 +6177,13 @@ impl TerminalView {
         // rollup feature flag is on, route through the rollup-aware
         // constructor so the view subscribes to history events and
         // re-renders when any contributing agent's usage updates.
-        let usage_view = ctx.add_view(|ctx| {
+        //
+        // Use `add_typed_action_view` (not `add_view`) so the framework
+        // registers `ConversationUsageView::handle_action`. Without this,
+        // typed actions like `ToggleDetailsExpanded` / `ShowAllAgentRows`
+        // dispatched from the view's own click handlers would be logged
+        // as `Dispatched action has no handlers` and silently ignored.
+        let usage_view = ctx.add_typed_action_view(|ctx| {
             if FeatureFlag::OrchestrationCreditRollup.is_enabled() {
                 ConversationUsageView::new_footer_with_rollup(
                     conversation_usage_info,

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -874,12 +874,6 @@ pub enum FeatureFlag {
 
     /// Replaces the raw harness CLI command with a styled header showing CLI name + status icon.
     HarnessSessionHeader,
-
-    /// Rolls up orchestration credit usage in the agent-mode footer. When
-    /// enabled, the orchestrator's expanded "Credits spent (total)" row and
-    /// collapsed footer pill show the orchestration total (orchestrator +
-    /// locally-loaded descendants) and expose a per-agent breakdown.
-    OrchestrationCreditRollup,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -959,7 +953,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::SoloUserByok,
     FeatureFlag::CustomInferenceEndpoints,
     FeatureFlag::RemoteCodebaseIndexing,
-    FeatureFlag::OrchestrationCreditRollup,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -874,6 +874,12 @@ pub enum FeatureFlag {
 
     /// Replaces the raw harness CLI command with a styled header showing CLI name + status icon.
     HarnessSessionHeader,
+
+    /// Rolls up orchestration credit usage in the agent-mode footer. When
+    /// enabled, the orchestrator's expanded "Credits spent (total)" row and
+    /// collapsed footer pill show the orchestration total (orchestrator +
+    /// locally-loaded descendants) and expose a per-agent breakdown.
+    OrchestrationCreditRollup,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -953,6 +959,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::SoloUserByok,
     FeatureFlag::CustomInferenceEndpoints,
     FeatureFlag::RemoteCodebaseIndexing,
+    FeatureFlag::OrchestrationCreditRollup,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/specs/QUALITY-671/PRODUCT.md
+++ b/specs/QUALITY-671/PRODUCT.md
@@ -54,13 +54,13 @@ The expanded credit usage footer in agent mode is per-conversation. When the con
 
 10. Descendants whose conversation state is not loaded locally do not contribute to the rollup and do not appear in the per-agent list. The rollup is a best-effort sum across locally-known agents. In practice this gap is small (server-side usage updates stream to the client), so the v1 surface does not warn the user that some agents may be missing. If real-world discrepancies prove confusing, a server-side rollup query is a follow-up.
 
-11. The collapsed footer pill (the small button with the credit number + chevron) shows the orchestration total when a rollup applies (per invariant 2). When the rollup does not apply (no eligible descendants, feature flag off, etc.), the pill shows the orchestrator's own credit number exactly as it does today.
+11. The collapsed footer pill (the small button with the credit number + chevron) shows the orchestration total when a rollup applies (per invariant 2). When the rollup does not apply (no eligible descendants), the pill shows the orchestrator's own credit number exactly as it does today.
    a. The "+N" delta annotation on the pill (current behavior: show the most-recent-response credit count when total ≠ last response) continues to use the orchestrator's own most-recent-block credits. With the rollup active, this delta represents "the credits the orchestrator's last response added to the orchestration total" — still meaningful at a glance.
    b. The existing "hide the button entirely when there's no usage data" rule is evaluated against the rollup total when applicable, so the pill appears as soon as any contributing agent has spent a credit (not only when the orchestrator itself has).
 
 12. The "View details" / "Hide details" link and the per-agent list visually match the existing footer's typography, spacing, and color treatment. Avatar discs use the same component used in the orchestration pill bar's pill avatars (per-name deterministic color + uppercase initial; orchestrator uses `Icon::Oz` on `ansi_fg_cyan`).
 
-13. The feature is gated by a new feature flag `OrchestrationCreditRollup`, default-enabled in dogfood builds and opt-in for preview/release until validated.
+13. The feature is self-gating: there is no dedicated feature flag. The rollup activates whenever the orchestrator has at least one locally-loaded descendant with non-zero credits; otherwise the row renders exactly as today. The underlying ability to create child agents is gated by `FeatureFlag::OrchestrationV2`, and the expanded footer surface itself is gated by `FeatureFlag::AgentView`, so the rollup is effectively reachable only when both are on — no additional flag is needed.
 
 14. The footer remains keyboard accessible. The "View details" link is reachable via the normal focus order and activatable with Enter/Space. The "Show N more" link is reachable and activatable the same way. Screen reader semantics for the per-agent list mirror existing list semantics in the footer (no new ARIA invention).
 

--- a/specs/QUALITY-671/PRODUCT.md
+++ b/specs/QUALITY-671/PRODUCT.md
@@ -1,0 +1,71 @@
+# Enhance credit usage details in the orchestrator tab
+
+Linear: https://linear.app/warpdotdev/issue/QUALITY-671
+
+## Summary
+The expanded credit usage footer in agent mode is per-conversation. When the conversation is an orchestrator, the footer hides the real cost of the work it dispatched — credits incurred by child agents are never surfaced on the parent. This feature changes the orchestrator's "Credits spent (total)" row to reflect the *orchestration total* (orchestrator + all locally-known descendants) and adds a click-to-expand per-agent breakdown beneath it.
+
+## Figma
+- Frame (overview, collapsed + expanded side-by-side): https://www.figma.com/design/AsF5uAM6L5tUmc11vm9YSi/Agent-orchestration?node-id=4646-33383
+- Expanded "Hide details" state: https://www.figma.com/design/AsF5uAM6L5tUmc11vm9YSi/Agent-orchestration?node-id=4636-32699
+
+## Goals
+- Show the true end-to-end credit cost of an orchestration run in the parent's expanded usage footer at a glance.
+- Let the user drill into per-agent credit attribution without leaving the footer.
+- Reuse existing agent identity (avatar, display name) so the breakdown reads consistently with the orchestration pill bar.
+
+## Non-goals
+- Server-side billing or pricing changes. The feature is purely a presentation of usage data the server already returns per conversation.
+- Rolling up any metric other than credits in v1. Tool calls, files changed, lines +/-, commands, models, context window, and last-response timing all stay self-only. Rollup of other metrics is a possible follow-up.
+- Rolling up usage from descendants whose conversation state is not loaded locally (e.g. a remote child running on a worker the user has never opened on this client).
+
+## Behavior
+
+1. On any conversation that has no descendant child agents loaded locally, or whose loaded descendants have all spent zero credits, the expanded credit usage footer renders exactly as it does today. No new UI is added.
+
+2. When the conversation rendering the footer is an orchestrator with at least one locally-loaded descendant that has spent credits, the "USAGE SUMMARY" section's "Credits spent (total)" row is modified as follows:
+   a. The numeric value (e.g. "33 credits") becomes the orchestration total — the sum of credits spent by the orchestrator plus all of its locally-known descendants (children, grandchildren, etc., transitively).
+   b. A "View details" link with a chevron-down icon is rendered immediately to the right of the value, on the same row.
+   c. Clicking "View details" replaces the link with "Hide details" and a chevron-up icon, and reveals a per-agent breakdown list directly below the row (see invariant 5).
+   d. Clicking "Hide details" collapses the per-agent list and restores "View details".
+
+3. The "Credits spent (last response)" row is unchanged. It always reflects only the orchestrator's own most-recent-block credits, never a rollup.
+
+4. All other rows in the expanded footer ("Tool calls", "Models", "Context window used" in USAGE SUMMARY, plus the entire TOOL CALL SUMMARY and LAST RESPONSE TIME sections) continue to reflect only the orchestrator's own values. They are not rolled up in v1. Credits-only rollup is the locked v1 scope; broader rollup is a possible follow-up.
+
+5. The per-agent breakdown list, when "View details" is active:
+   a. Contains one row per agent contributing to the rollup. The orchestrator is listed alongside its descendants — there is no separate "self" row.
+   b. Rows are sorted by credits spent, descending. Ties are broken by spawn order (earlier spawn first).
+   c. Each row displays: the agent's avatar disc (orchestrator uses the orchestrator avatar; children use the existing per-name color + initial avatar from the orchestration pill bar), the agent's display name (e.g. "Orchestrator", "DesignBot"), and the credit value formatted by `format_credits`.
+   d. Only agents that have spent > 0 credits are included. Just-spawned or idle agents are omitted (they pop in as soon as they consume credits).
+   e. When ≤ 5 rows are eligible, all rows are shown.
+   f. When > 5 rows are eligible, the first 5 are shown followed by a "Show N more" link where N = total_eligible − 5. Clicking the link reveals all remaining rows and removes the link from the list (the link does not become "Show fewer").
+   g. The per-agent list does not have its own toggles, sorting, or hover affordances beyond the row content. No row is clickable in v1.
+
+6. Local UI state that resets when the footer is collapsed (chevron at the top of the footer) and reopened:
+   a. The "View details" toggle resets to its default closed state. The default for the freshly-opened footer is "View details" (per-agent list hidden).
+   b. The "Show N more" expansion (when applicable) resets — the list is again truncated to the first 5 rows with the "Show N more" link.
+
+7. While the footer is open, the rollup total, the per-agent list contents (rows, ordering, values), and the "Show N more" count update live as child agents stream new tokens or finish responses. No user action is needed.
+
+8. When a new descendant child first spends a credit while the user is looking at the expanded footer, its row appears in the per-agent list at the position dictated by its credit value (descending sort).
+
+9. When a descendant child is removed/pruned from the local client, its row disappears on the next render, and the rollup total decreases accordingly.
+
+10. Descendants whose conversation state is not loaded locally do not contribute to the rollup and do not appear in the per-agent list. The rollup is a best-effort sum across locally-known agents. In practice this gap is small (server-side usage updates stream to the client), so the v1 surface does not warn the user that some agents may be missing. If real-world discrepancies prove confusing, a server-side rollup query is a follow-up.
+
+11. The collapsed footer pill (the small button with the credit number + chevron) shows the orchestration total when a rollup applies (per invariant 2). When the rollup does not apply (no eligible descendants, feature flag off, etc.), the pill shows the orchestrator's own credit number exactly as it does today.
+   a. The "+N" delta annotation on the pill (current behavior: show the most-recent-response credit count when total ≠ last response) continues to use the orchestrator's own most-recent-block credits. With the rollup active, this delta represents "the credits the orchestrator's last response added to the orchestration total" — still meaningful at a glance.
+   b. The existing "hide the button entirely when there's no usage data" rule is evaluated against the rollup total when applicable, so the pill appears as soon as any contributing agent has spent a credit (not only when the orchestrator itself has).
+
+12. The "View details" / "Hide details" link and the per-agent list visually match the existing footer's typography, spacing, and color treatment. Avatar discs use the same component used in the orchestration pill bar's pill avatars (per-name deterministic color + uppercase initial; orchestrator uses `Icon::Oz` on `ansi_fg_cyan`).
+
+13. The feature is gated by a new feature flag `OrchestrationCreditRollup`, default-enabled in dogfood builds and opt-in for preview/release until validated.
+
+14. The footer remains keyboard accessible. The "View details" link is reachable via the normal focus order and activatable with Enter/Space. The "Show N more" link is reachable and activatable the same way. Screen reader semantics for the per-agent list mirror existing list semantics in the footer (no new ARIA invention).
+
+15. The rollup is read-only. No billing, telemetry, or persistence changes — it is a view on data already in `AIConversation.conversation_usage_metadata` for the orchestrator and its locally-known descendants.
+
+16. Forked conversations: a fork descended from the orchestrator is treated as a regular descendant. Its post-fork usage contributes to the rollup if its metadata is loaded; otherwise it is ignored like any other unloaded descendant.
+
+17. Settings-mode usage view (the per-conversation history surface, not the agent-mode footer) is unchanged. The rollup applies only to `DisplayMode::Footer`.

--- a/specs/QUALITY-671/TECH.md
+++ b/specs/QUALITY-671/TECH.md
@@ -1,0 +1,191 @@
+# Tech spec: roll up orchestration credit usage in the agent-mode footer
+
+Linear: https://linear.app/warpdotdev/issue/QUALITY-671
+Companion: `specs/QUALITY-671/PRODUCT.md`
+
+## Context
+
+The agent-mode footer this feature extends is rendered in two layers.
+
+- Collapsed footer (credits + chevron):
+  - `app/src/ai/blocklist/block/view_impl/output.rs:3243` — `render_usage_button` builds the inline footer pill. It reads `conversation.credits_spent()`, `conversation.credits_spent_for_last_block()`, `conversation.token_usage()`, and `conversation.tool_usage_metadata().total_tool_calls()`. If all are empty, the button is suppressed (`output.rs:3252-3258`). Per PRODUCT invariant 11, the pill's headline credit number is replaced with the rollup total when one applies; the existing `(+N)` last-response delta keeps using the orchestrator's own `credits_spent_for_last_block`.
+- Expanded footer (full usage summary):
+  - `app/src/ai/blocklist/usage/conversation_usage_view.rs` — `ConversationUsageView` owns the expanded layout.
+  - `ConversationUsageInfo` (`conversation_usage_view.rs:28-40`) carries `credits_spent`, `credits_spent_for_last_block`, `tool_calls`, `models: Vec<ModelTokenUsage>`, `context_window_usage`, `files_changed`, `lines_added`, `lines_removed`, `commands_executed`.
+  - `render_unified_layout` (`conversation_usage_view.rs:127`) emits the "USAGE SUMMARY", "TOOL CALL SUMMARY", and "LAST RESPONSE TIME" sections via `render_section_header`, `render_label_text`, `render_value_text` helpers.
+  - The "Credits spent (total)" row is rendered at `conversation_usage_view.rs:155-159` (non-last-block path) and `:146-159` (last-block-aware path). The rollup work modifies this row.
+
+Per-conversation usage data is populated on `AIConversation`:
+- `AIConversation.conversation_usage_metadata` (`app/src/ai/agent/conversation.rs:160`). Populated by `StreamFinished` events for live conversations and by `get_conversation_usage` GraphQL (`crates/graphql/src/api/queries/get_conversation_usage.rs`) on init / hydration. Every locally-loaded child has its own populated metadata.
+
+Orchestration topology lives in `BlocklistAIHistoryModel`:
+- `child_conversation_ids_of(&parent_id)` (`history_model.rs:455`) — direct children from the `children_by_parent` index. The index is maintained by `start_new_child_conversation` / `set_parent_for_conversation` (`history_model.rs:397-450`).
+- A transitive walker already exists for the pill bar: `descendant_conversation_ids_in_spawn_order` / `collect_descendant_conversation_ids_in_spawn_order` (`app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs:133-151`). Lift this to a shared module — do not duplicate.
+
+Agent identity for the per-agent list comes from helpers the pill bar already uses:
+- `pill_avatar_color` / `pill_initial` (`orchestration_pill_bar.rs:85-99`) for child avatars.
+- `render_orchestrator_avatar_disc` / `render_agent_avatar_disc` (`orchestration_pill_bar.rs:100-131`) for the actual disc element.
+- Display name: `AIConversation.agent_name` for children, "Orchestrator" (or the orchestrator's existing user-facing label, TBD during implementation by walking the code that titles the orchestrator pill).
+
+## Proposed changes
+
+### 1. Aggregation helper
+
+Add a new module `app/src/ai/blocklist/usage/rollup.rs` exposing:
+
+```rust path=null start=null
+pub struct OrchestrationCreditRollup {
+    /// Sum of credits across orchestrator + all locally-known descendants.
+    pub total_credits: f32,
+    /// Per-agent rows for the breakdown list, sorted by credits descending,
+    /// ties broken by spawn order (earlier first). Excludes agents with
+    /// zero credits.
+    pub per_agent: Vec<PerAgentCreditEntry>,
+}
+
+pub struct PerAgentCreditEntry {
+    pub conversation_id: AIConversationId,
+    pub display_name: String,
+    pub avatar: AgentAvatar, // enum: Orchestrator | Child { color, initial }
+    pub credits_spent: f32,
+}
+
+pub fn compute_orchestration_rollup(
+    parent_id: AIConversationId,
+    history: &BlocklistAIHistoryModel,
+) -> Option<OrchestrationCreditRollup>;
+```
+
+Implementation notes:
+- Returns `None` if the orchestrator has no loaded descendants OR if every eligible agent (orchestrator + descendants) has zero credits. PRODUCT invariants 1, 7.
+- Walks descendants via the existing helper extracted from `orchestration_pill_bar.rs` (move it to `app/src/ai/blocklist/orchestration_topology.rs` or similar shared module; re-export from `usage/rollup.rs`).
+- Sums each contributor's `credits_spent` for `total_credits`.
+- Builds `per_agent` from the orchestrator + each loaded descendant, filters out zero-credit rows, sorts by `credits_spent` descending with spawn-order tie-break.
+- Unknown / unloaded descendants are silently skipped (PRODUCT invariant 10 — no footnote, no warning).
+- Pure function — no I/O, no GraphQL — runs synchronously on the local model.
+
+### 2. Render the "Credits spent (total)" row with toggle and list
+
+Modifications in `conversation_usage_view.rs`:
+
+- Extend `ConversationUsageView` with:
+  - `rollup: Option<OrchestrationCreditRollup>` — passed in by the caller (None in `DisplayMode::Settings`).
+  - `details_expanded: bool` — local UI state, defaults `false`.
+  - `show_all_clicked: bool` — local UI state, defaults `false`.
+
+- In `render_unified_layout`, when `rollup.is_some()` and `DisplayMode::Footer`:
+  - The "Credits spent (total)" value uses `rollup.total_credits` (instead of `usage_info.credits_spent`).
+  - Append a "View details" / "Hide details" toggle element to the value row. On click, flip `details_expanded` and `notify` the view to re-render.
+  - When `details_expanded`, emit one row per `PerAgentCreditEntry`, rendered via a new helper `render_per_agent_row(entry, appearance)`:
+    - Leading avatar disc (12–16 px) via `render_agent_avatar_disc` / `render_orchestrator_avatar_disc`.
+    - Display name (label slot) + credits value (value slot), using the existing label/value helpers.
+  - When `per_agent.len() > 5` and `!show_all_clicked`, render only the first 5 entries followed by a "Show N more" link row (N = `per_agent.len() - 5`). On click of the link, set `show_all_clicked = true` and re-render.
+
+- In `DisplayMode::Settings` and the non-rollup `DisplayMode::Footer` paths, the existing "Credits spent (total)" rendering is preserved unchanged.
+
+- "Credits spent (last response)" rendering is untouched (PRODUCT invariant 3).
+
+### 3. Wire the rollup into the footer construction
+
+The rollup is consumed in two places:
+
+- **Expanded footer.** The caller that constructs `ConversationUsageView::new(...)` for `DisplayMode::Footer` lives near `render_usage_footer` in `output.rs` (locate via `ConversationUsageView::new` call sites; `render_usage_button` at `output.rs:3243` is adjacent). The caller has access to the `BlocklistAIHistoryModel` because the surrounding view already uses it.
+   - Compute `compute_orchestration_rollup(conversation_id, history)` at construction time, behind `FeatureFlag::OrchestrationCreditRollup.is_enabled()`.
+   - Pass the result into the view constructor as `rollup: Option<OrchestrationCreditRollup>`.
+   - Settings-mode (`DisplayMode::Settings`) callers pass `None`.
+- **Collapsed pill** (PRODUCT invariant 11). In `render_usage_button` (`output.rs:3243`):
+   - Compute the same `compute_orchestration_rollup(...)` (or accept it from the caller to avoid duplicate work).
+   - When the rollup is `Some(_)`, use `rollup.total_credits` instead of `conversation.credits_spent()` for the pill's headline number and for the "has any usage" suppression check (`output.rs:3252-3258`).
+   - The `(+N)` last-block annotation block (`output.rs:3271-3291`) is unchanged — it continues to read `conversation.credits_spent_for_last_block()` and compare to the headline number. With rollup active, headline ≫ last block, so the annotation appears whenever the orchestrator has had a recent response. This is the intended behavior per PRODUCT invariant 11a.
+   - Behind `FeatureFlag::OrchestrationCreditRollup.is_enabled()`; flag off means today's exact behavior.
+
+### 4. Reset UI state on footer collapse / reopen
+
+The expanded footer view is created fresh each time `is_usage_footer_expanded` flips to true (the `ConversationUsageView` is constructed in `render_usage_footer`, not held across collapse). This means `details_expanded` and `show_all_clicked` naturally reset on collapse + reopen because the view instance is rebuilt — satisfying PRODUCT invariant 6.
+
+- Verify this assumption during implementation. If the view instance is cached across collapse cycles, add explicit reset logic on the open transition, or hoist the bools to props that the parent rebuilds.
+
+### 5. Feature flag
+
+Add `FeatureFlag::OrchestrationCreditRollup` in `crates/warp_core/src/features.rs`:
+- List in `DOGFOOD_FLAGS`.
+- Do NOT list in `PREVIEW_FLAGS` or `RELEASE_FLAGS` for v1; promote after dogfood validation via the `promote-feature` skill.
+- Gate the rollup computation AND the toggle/list render behind `FeatureFlag::OrchestrationCreditRollup.is_enabled()`. When disabled, the "Credits spent (total)" row renders exactly as today.
+
+### 6. Live updates from child usage changes
+
+The expanded footer must re-render when any contributing agent's `conversation_usage_metadata` changes. Audit during implementation:
+
+- Confirm there is a `BlocklistAIHistoryEvent` (or per-conversation event) that fires when any conversation's `conversation_usage_metadata` is mutated (via `StreamFinished` handling). If yes, ensure the orchestrator's footer view subscription covers all descendants — most likely already true via the existing history-level subscription used by `orchestration_pill_bar.rs` / `child_agent_status_card.rs`.
+- If subscriptions cover descendants only via the parent's own view-bound observers, add a coarse "history changed" observation in `render_usage_footer` so the parent re-renders when any descendant updates.
+- Worst case: introduce a fine-grained `ChildUsageUpdated { conversation_id }` event emitted on metadata write in `AIConversation` and subscribe from the parent view.
+
+### 7. Tradeoffs and alternatives
+
+- **Client-side aggregation (chosen).** Each loaded descendant's metadata is already on the client. Walk + sum is O(n) with n bounded by the locally-loaded orchestration tree (small in practice). Limitation: remote-only descendants are silently invisible (PRODUCT invariant 10) — acceptable for v1 given the gap is small in practice.
+- **Server-side rollup (rejected for v1).** Add a `conversationUsageRollup(parentId)` GraphQL field that walks the run tree on the server. Pros: covers remote-only descendants. Cons: new query lifecycle, second source of truth that can drift from per-conversation metadata, server work to scope. Recommended follow-up if discrepancies prove confusing.
+- **Separate "ORCHESTRATION TOTAL" section (rejected, was the prior strawman).** Adding a new section under USAGE SUMMARY duplicates the credit number and visually fragments the footer. The Figma mock integrates the rollup into the existing "Credits spent (total)" row — cleaner and matches the design.
+- **Roll up other metrics too (deferred, follow-up).** PRODUCT v1 scope is credits only. The helper can be widened later to include summed `tool_calls`, `files_changed`, etc.
+- **Collapsed pill: orchestration total vs self total.** Chose orchestration total (PRODUCT invariant 11) so the true cost is visible at a glance without expanding. The `(+N)` delta stays as orchestrator's own last-block credits because that is the only meaningful per-response delta available without tracking inter-agent timing.
+
+## Testing and validation
+
+Unit tests in `app/src/ai/blocklist/usage/rollup_tests.rs` (mod-included via `#[cfg(test)] #[path = "rollup_tests.rs"] mod tests;`):
+
+- Orchestrator with no loaded descendants → `compute_orchestration_rollup` returns `None`. (PRODUCT invariant 1)
+- Orchestrator + 1 child with credits → rollup `total_credits` = parent + child; `per_agent` has 2 entries sorted descending. (invariants 2a, 5a, 5b)
+- Orchestrator + 3 children, mixed credits including a zero-credit child → zero-credit child is excluded; 3 entries returned sorted descending. (invariants 5b, 5d)
+- Parent → child → grandchild — rollup includes all three transitively. (invariant 2a)
+- 6 contributors → `per_agent.len() == 6`; caller logic verified separately in the renderer test (5 shown + "Show 1 more"). (invariants 5e, 5f)
+- 1 contributor with zero credits → returns `None`. (invariant 7)
+- Spawn-order tie-break: two children with equal credits → child spawned earlier sorts first. (invariant 5b)
+- Unloaded descendant id present in topology but missing from `conversations_by_id` → silently skipped, no contribution to the rollup. (invariant 10)
+
+Renderer tests in `conversation_usage_view_tests.rs`:
+
+- `DisplayMode::Footer` + `Some(rollup)` renders the "Credits spent (total)" value as `rollup.total_credits` and shows "View details ▼". Clicking expands and shows "Hide details ▲". (invariants 2a–2d)
+- Per-agent list with 5 rows renders all 5, no "Show N more". (invariant 5e)
+- Per-agent list with 6 rows renders first 5 plus "Show 1 more"; clicking the link reveals the 6th and removes the link. (invariant 5f)
+- Footer collapse + reopen rebuilds the view with `details_expanded == false` and `show_all_clicked == false`. (invariant 6)
+- `DisplayMode::Settings` renders no toggle and no per-agent list even if a rollup is passed (defensive). (invariant 17)
+- Feature flag off: row renders exactly as today. (invariant 13)
+- "Credits spent (last response)" row is unchanged regardless of rollup state. (invariant 3)
+
+Collapsed-pill tests in `output_tests.rs` (or equivalent next to `render_usage_button`):
+
+- Conversation with a non-empty rollup: pill headline number equals `rollup.total_credits`. (invariant 11)
+- Same conversation with feature flag off: pill headline number equals `conversation.credits_spent()` (today's behavior). (invariants 11, 13)
+- Conversation with rollup `None`: pill headline number equals `conversation.credits_spent()`. (invariant 11)
+- `(+N)` annotation renders using `credits_spent_for_last_block` regardless of rollup state. (invariant 11a)
+- "Hide button entirely" suppression is evaluated against rollup total when applicable. (invariant 11b)
+
+Manual verification:
+
+- Start a local orchestration with three children (`oz-local` or in-app orchestrator), wait for each child to consume credits:
+  - The collapsed footer pill shows the orchestration total, not just the orchestrator's self credits. (invariant 11)
+  - Expand the footer: the "Credits spent (total)" row shows the same orchestration total. (invariants 2a, 7)
+  - "View details" reveals the orchestrator + children sorted by credits descending. (invariants 5a, 5b)
+- Trigger a child to finish a response mid-view; confirm both the pill number and the expanded rollup update without re-expanding. (invariants 7, 11)
+- Spawn 7+ children; confirm the list shows 5 + "Show N more"; click and confirm all rows visible and link gone. (invariant 5f)
+- Collapse + reopen the footer; confirm the list is back to truncated (and "View details" is closed). (invariant 6)
+- Toggle `OrchestrationCreditRollup` off; confirm the pill and the row revert to today's behavior. (invariant 13)
+
+Run `./script/presubmit` before pushing. Formatting, clippy, and tests must pass.
+
+## Parallelization
+
+Single change, single repo, single owner. The aggregation helper, view extension, and feature-flag wiring touch the same handful of files and require a shared mental model. A parallel split would manufacture coordination overhead with no real wall-clock savings. This is best done by one local agent in this checkout (`/Users/matthew/src/rollup-orch-credit-usage/warp` on branch `matthew/rollup-orch-credit-usage`). No `run_agents` proposed for v1.
+
+## Risks and mitigations
+
+- **Tree walk cost on every render.** Orchestration trees observed in practice are small (≪100 nodes); the walk is O(n) with negligible constants. The collapsed pill renders every paint, so memoize the rollup on `BlocklistAIHistoryModel` (or cache on the parent view) if profiling shows it matters; invalidate on the same event used to drive live updates.
+- **Collapsed-pill number jumps when children spawn.** Users watching only the pill might be surprised by sudden growth as children start spending. Acceptable trade for surfacing real cost at a glance — the existing `(+N)` delta still shows the orchestrator's own most-recent response so users can attribute the jump.
+- **Display name fallback.** Some children may have `agent_name == None` (e.g. v1 orchestration or pre-naming spawn). Fallback to a short label like "Child agent" or the conversation's `task_id` short form. Pick during implementation; document in `DECISIONS.md` if it matters.
+- **Pre-rollup metadata.** Forked or restored conversations may briefly have stale `conversation_usage_metadata` until the next `StreamFinished` or GraphQL hydrate completes. Acceptable: the next render corrects the rollup.
+
+## Follow-ups
+
+- Roll up other metrics (tool calls, code edits) — v1 scope is credits only.
+- Server-side rollup query so remote-only descendants are always included (PRODUCT invariant 10).
+- Make per-agent rows clickable (open the agent's conversation) — invariant 5g currently rules this out for v1.
+- Show a rollup credit chip on the orchestrator pill in the orchestration pill bar (`orchestration_pill_bar.rs` hover card has room at lines 1044-1314).

--- a/specs/QUALITY-671/TECH.md
+++ b/specs/QUALITY-671/TECH.md
@@ -90,14 +90,14 @@ Modifications in `conversation_usage_view.rs`:
 The rollup is consumed in two places:
 
 - **Expanded footer.** The caller that constructs `ConversationUsageView::new(...)` for `DisplayMode::Footer` lives near `render_usage_footer` in `output.rs` (locate via `ConversationUsageView::new` call sites; `render_usage_button` at `output.rs:3243` is adjacent). The caller has access to the `BlocklistAIHistoryModel` because the surrounding view already uses it.
-   - Compute `compute_orchestration_rollup(conversation_id, history)` at construction time, behind `FeatureFlag::OrchestrationCreditRollup.is_enabled()`.
-   - Pass the result into the view constructor as `rollup: Option<OrchestrationCreditRollup>`.
-   - Settings-mode (`DisplayMode::Settings`) callers pass `None`.
+   - The footer constructor always uses `ConversationUsageView::new_footer_with_rollup`, which holds the parent conversation id and calls `compute_orchestration_rollup` at render time.
+   - `compute_orchestration_rollup` returns `None` whenever the orchestrator has no loaded descendants or no eligible credits, so the rollup-aware UI naturally collapses to today's exact behavior.
+   - Settings-mode (`DisplayMode::Settings`) continues to use `ConversationUsageView::new`, which leaves `parent_conversation_id` unset; `rollup()` then short-circuits to `None`.
 - **Collapsed pill** (PRODUCT invariant 11). In `render_usage_button` (`output.rs:3243`):
-   - Compute the same `compute_orchestration_rollup(...)` (or accept it from the caller to avoid duplicate work).
+   - Call `compute_orchestration_rollup(conversation.id(), history)` unconditionally.
    - When the rollup is `Some(_)`, use `rollup.total_credits` instead of `conversation.credits_spent()` for the pill's headline number and for the "has any usage" suppression check (`output.rs:3252-3258`).
    - The `(+N)` last-block annotation block (`output.rs:3271-3291`) is unchanged — it continues to read `conversation.credits_spent_for_last_block()` and compare to the headline number. With rollup active, headline ≫ last block, so the annotation appears whenever the orchestrator has had a recent response. This is the intended behavior per PRODUCT invariant 11a.
-   - Behind `FeatureFlag::OrchestrationCreditRollup.is_enabled()`; flag off means today's exact behavior.
+   - Self-gating: when the conversation has no descendants the helper returns `None` and the pill renders exactly as today.
 
 ### 4. Reset UI state on footer collapse / reopen
 
@@ -105,12 +105,15 @@ The expanded footer view is created fresh each time `is_usage_footer_expanded` f
 
 - Verify this assumption during implementation. If the view instance is cached across collapse cycles, add explicit reset logic on the open transition, or hoist the bools to props that the parent rebuilds.
 
-### 5. Feature flag
+### 5. Self-gating (no feature flag)
 
-Add `FeatureFlag::OrchestrationCreditRollup` in `crates/warp_core/src/features.rs`:
-- List in `DOGFOOD_FLAGS`.
-- Do NOT list in `PREVIEW_FLAGS` or `RELEASE_FLAGS` for v1; promote after dogfood validation via the `promote-feature` skill.
-- Gate the rollup computation AND the toggle/list render behind `FeatureFlag::OrchestrationCreditRollup.is_enabled()`. When disabled, the "Credits spent (total)" row renders exactly as today.
+There is no dedicated `OrchestrationCreditRollup` feature flag. The rollup activates whenever `compute_orchestration_rollup` returns `Some(_)` and falls through to today's UI whenever it returns `None`:
+
+- Conversations with no locally-loaded descendants → `None` (no children walked, no rollup UI).
+- Conversations where every loaded descendant has zero credits → `None` (zero-credit filter empties `per_agent`).
+- Settings-mode views → `rollup()` short-circuits on `display_mode != Footer`.
+
+The upstream ability to spawn child agents is still gated by `FeatureFlag::OrchestrationV2`, and the expanded footer surface itself is gated by `FeatureFlag::AgentView`, so the rollup is reachable only when both already permit the user to create and view an orchestration. Adding a third flag on top of those would only have offered a kill-switch; the self-gating data check provides the same safety net (today's UI is preserved whenever the rollup has nothing to add) without the cleanup burden.
 
 ### 6. Live updates from child usage changes
 
@@ -148,14 +151,13 @@ Renderer tests in `conversation_usage_view_tests.rs`:
 - Per-agent list with 6 rows renders first 5 plus "Show 1 more"; clicking the link reveals the 6th and removes the link. (invariant 5f)
 - Footer collapse + reopen rebuilds the view with `details_expanded == false` and `show_all_clicked == false`. (invariant 6)
 - `DisplayMode::Settings` renders no toggle and no per-agent list even if a rollup is passed (defensive). (invariant 17)
-- Feature flag off: row renders exactly as today. (invariant 13)
+- Conversation with no descendants (`rollup() == None`): row renders exactly as today (no toggle, no breakdown). (invariant 13)
 - "Credits spent (last response)" row is unchanged regardless of rollup state. (invariant 3)
 
 Collapsed-pill tests in `output_tests.rs` (or equivalent next to `render_usage_button`):
 
 - Conversation with a non-empty rollup: pill headline number equals `rollup.total_credits`. (invariant 11)
-- Same conversation with feature flag off: pill headline number equals `conversation.credits_spent()` (today's behavior). (invariants 11, 13)
-- Conversation with rollup `None`: pill headline number equals `conversation.credits_spent()`. (invariant 11)
+- Conversation with rollup `None` (no descendants, or only zero-credit descendants): pill headline number equals `conversation.credits_spent()` (today's behavior). (invariants 11, 13)
 - `(+N)` annotation renders using `credits_spent_for_last_block` regardless of rollup state. (invariant 11a)
 - "Hide button entirely" suppression is evaluated against rollup total when applicable. (invariant 11b)
 
@@ -168,7 +170,7 @@ Manual verification:
 - Trigger a child to finish a response mid-view; confirm both the pill number and the expanded rollup update without re-expanding. (invariants 7, 11)
 - Spawn 7+ children; confirm the list shows 5 + "Show N more"; click and confirm all rows visible and link gone. (invariant 5f)
 - Collapse + reopen the footer; confirm the list is back to truncated (and "View details" is closed). (invariant 6)
-- Toggle `OrchestrationCreditRollup` off; confirm the pill and the row revert to today's behavior. (invariant 13)
+- Open the same expanded footer on a non-orchestrator conversation (or one with no loaded descendants) and confirm the row renders exactly as it does today, with no "View details" affordance. (invariant 13)
 
 Run `./script/presubmit` before pushing. Formatting, clippy, and tests must pass.
 


### PR DESCRIPTION
## Description

Behind the new `FeatureFlag::OrchestrationCreditRollup` (dogfood-only) flag, the orchestrator's agent-mode footer now reports the orchestration's combined credit usage — orchestrator plus every locally-loaded descendant child — instead of just the orchestrator's own credits.

The expanded footer's "Credits spent (total)" row shows the rollup total and exposes a click-to-expand per-agent breakdown sorted by credits desc (spawn-order tiebreak). The first five rows render inline; any extra rows are revealed by a "Show N more" link. The collapsed pill uses the same rollup total for its headline number and its "has any usage" suppression check; the `(+N)` last-block annotation is unchanged. With the flag off, both surfaces render exactly as before.

Specs in this PR: [`specs/QUALITY-671/PRODUCT.md`](specs/QUALITY-671/PRODUCT.md), [`specs/QUALITY-671/TECH.md`](specs/QUALITY-671/TECH.md).

Mocks: https://www.figma.com/design/AsF5uAM6L5tUmc11vm9YSi/Agent-orchestration?node-id=4636-32697&m=dev
Screenshots:
<img width="1344" height="602" alt="Screenshot 2026-05-15 at 7 25 36 PM" src="https://github.com/user-attachments/assets/a3aa25b1-156e-4245-8cc5-3d0a573b65f4" />
<img width="1339" height="729" alt="Screenshot 2026-05-15 at 7 25 46 PM" src="https://github.com/user-attachments/assets/7148e2e7-298a-4e0b-81b6-2e1be4646c73" />
<img width="1337" height="730" alt="Screenshot 2026-05-15 at 7 25 57 PM" src="https://github.com/user-attachments/assets/001f4e81-9a6b-4889-b76b-7634027d6db8" />

Key pieces:
- `app/src/ai/blocklist/usage/rollup.rs` — pure aggregation helper. Walks descendants via `BlocklistAIHistoryModel`, filters zero-credit contributors, sorts the breakdown, returns `None` when nothing applies.
- `app/src/ai/blocklist/orchestration_topology.rs` — descendant walker lifted out of `orchestration_pill_bar.rs` so the pill bar and the rollup share one traversal. The pill bar's relevant tests moved to `orchestration_topology_tests.rs`; avatar helpers (`render_orchestrator_avatar_disc`, `render_agent_avatar_disc`) promoted to `pub(crate)` so the footer rows can reuse them.
- `ConversationUsageView` — new `new_footer_with_rollup` constructor subscribes to history events; renders the "View details" / "Hide details" toggle and the per-agent rows. Agent names use the same color as the "USAGE SUMMARY" header; per-agent credit values use the "Credits spent" label color. Names are clipped to the pill bar's max width with ellipsis. Toggles and "Show N more" use the theme's hyperlink color (`ansi_fg_blue`). A blank value-side placeholder opposite "Show N more" keeps the two-column flex aligned for the rows below.
- `BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated` — new conversation-scoped event emitted from `update_conversation_cost_and_usage_for_request`. The footer view and the `AIBlock` model subscribe so the orchestrator's pill and footer stay live when any descendant spends credits.
- `terminal/view.rs::handle_usage_footer_toggled` — routes through the rollup-aware constructor when the flag is enabled, and uses `add_typed_action_view` so the view's `TypedActionView` handler is actually registered with the framework (without this, the toggle / show-more clicks were silently dropped).
- `output.rs::render_usage_button` — collapsed pill computes the rollup behind the flag and feeds `total_credits` into the headline number + suppression check.

## Linked Issue

QUALITY-671

## Testing

- `app/src/ai/blocklist/usage/rollup_tests.rs` — 8 unit tests covering the aggregation contract: no-descendants → None, sum + sort across descendants, zero-credit filter, transitive grandchildren, spawn-order tie-break, unloaded-descendant skip, six-contributor truncation precondition, all-zero short-circuit.
- `app/src/ai/blocklist/orchestration_topology_tests.rs` — tree-walker correctness tests moved over from the pill bar.
- `app/src/ai/blocklist/usage/conversation_usage_view_tests.rs` — handler-level tests that stand the view up via `add_typed_action_view` and verify `ToggleDetailsExpanded` / `ShowAllAgentRows` flip the right state (regression guard against the original "dispatched action has no handlers" bug).
- `cargo fmt --check`, `cargo clippy --workspace --exclude command-signatures-v2 --all-targets --all-features --tests -- -D warnings`, and `./script/presubmit` all clean.
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Roll up child-agent credit usage into the orchestrator's agent-mode footer.

---

[Conversation](https://staging.warp.dev/conversation/3a641d39-284a-4366-833b-05d3bfa4ff2a)
