### PR TITLE
Add sleep auto handoff to cloud

### DIFF
--- a/app/src/ai/active_agent_views_model.rs
+++ b/app/src/ai/active_agent_views_model.rs
@@ -109,6 +109,34 @@ impl ActiveAgentViewsModel {
         }
     }
 
+    fn update_focused_conversation_for_terminal(
+        &mut self,
+        terminal_view_id: EntityId,
+        conversation_id: Option<ConversationOrTaskId>,
+    ) {
+        for focused_terminal_state in self.focused_terminal_states.values_mut() {
+            if focused_terminal_state.focused_terminal_id == terminal_view_id
+                && !matches!(
+                    focused_terminal_state.active_conversation_id,
+                    Some(ConversationOrTaskId::TaskId(_))
+                )
+            {
+                focused_terminal_state.active_conversation_id = conversation_id;
+            }
+        }
+
+        if let Some(last_focused_terminal_state) = &mut self.last_focused_terminal_state {
+            if last_focused_terminal_state.focused_terminal_id == terminal_view_id
+                && !matches!(
+                    last_focused_terminal_state.active_conversation_id,
+                    Some(ConversationOrTaskId::TaskId(_))
+                )
+            {
+                last_focused_terminal_state.active_conversation_id = conversation_id;
+            }
+        }
+    }
+
     /// Register an agent view controller to track when the agent view is entered/exited.
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub fn register_agent_view_controller(
@@ -159,16 +187,7 @@ impl ActiveAgentViewsModel {
                 // Update the focused conversation in whichever window owns this terminal view.
                 // We ignore agent view changes if we are focused on an ambient conversation,
                 // as ambient conversation navigation operates at the task level instead of the conversation level.
-                for focused_terminal_state in model.focused_terminal_states.values_mut() {
-                    if focused_terminal_state.focused_terminal_id == terminal_view_id
-                        && !matches!(
-                            focused_terminal_state.active_conversation_id,
-                            Some(ConversationOrTaskId::TaskId(_))
-                        )
-                    {
-                        focused_terminal_state.active_conversation_id = Some(conv_id);
-                    }
-                }
+                model.update_focused_conversation_for_terminal(terminal_view_id, Some(conv_id));
                 // Bridge the controller's lifecycle into the streamer's
                 // per-conversation consumer registry.
                 register_agent_event_consumer(*conversation_id, terminal_view_id, ctx);
@@ -191,16 +210,7 @@ impl ActiveAgentViewsModel {
                     .remove(&ConversationOrTaskId::ConversationId(*conversation_id));
 
                 // Clear the focused conversation in whichever window owns this terminal view.
-                for state in model.focused_terminal_states.values_mut() {
-                    if state.focused_terminal_id == terminal_view_id
-                        && !matches!(
-                            state.active_conversation_id,
-                            Some(ConversationOrTaskId::TaskId(_))
-                        )
-                    {
-                        state.active_conversation_id = None;
-                    }
-                }
+                model.update_focused_conversation_for_terminal(terminal_view_id, None);
                 unregister_agent_event_consumer(*conversation_id, terminal_view_id, ctx);
                 // Emit so subscribers can move this conversation to the Past section.
                 ctx.emit(ActiveAgentViewsEvent::ConversationClosed {
@@ -305,6 +315,14 @@ impl ActiveAgentViewsModel {
         self.last_focused_terminal_state
             .as_ref()
             .map(|state| state.focused_terminal_id)
+    }
+
+    /// Get the most recent focused conversation or ambient task ID, persisted
+    /// across non-terminal focus changes.
+    pub fn get_last_focused_conversation(&self) -> Option<ConversationOrTaskId> {
+        self.last_focused_terminal_state
+            .as_ref()
+            .and_then(|state| state.active_conversation_id)
     }
 
     /// Returns the focused conversation ID if it's a new/empty conversation view.

--- a/app/src/ai/active_agent_views_model_tests.rs
+++ b/app/src/ai/active_agent_views_model_tests.rs
@@ -13,6 +13,46 @@ fn new_task_id() -> AmbientAgentTaskId {
 }
 
 #[test]
+fn conversation_switch_updates_last_focused_terminal_state() {
+    App::test((), |mut app| async move {
+        let model = setup_model(&mut app);
+        let window = WindowId::new();
+        let terminal = EntityId::new();
+        let conversation_1 = AIConversationId::new();
+        let conversation_2 = AIConversationId::new();
+
+        model.update(&mut app, |model, ctx| {
+            model.handle_pane_focus_change(window, Some(terminal), None, ctx);
+            model.update_focused_conversation_for_terminal(
+                terminal,
+                Some(ConversationOrTaskId::ConversationId(conversation_1)),
+            );
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(model.get_last_focused_terminal_id(), Some(terminal));
+            assert_eq!(
+                model.get_last_focused_conversation(),
+                Some(ConversationOrTaskId::ConversationId(conversation_1))
+            );
+        });
+
+        model.update(&mut app, |model, _| {
+            model.update_focused_conversation_for_terminal(
+                terminal,
+                Some(ConversationOrTaskId::ConversationId(conversation_2)),
+            );
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(model.get_last_focused_terminal_id(), Some(terminal));
+            assert_eq!(
+                model.get_last_focused_conversation(),
+                Some(ConversationOrTaskId::ConversationId(conversation_2))
+            );
+        });
+    });
+}
+
+#[test]
 fn per_window_focused_state_is_independent() {
     App::test((), |mut app| async move {
         let model = setup_model(&mut app);
@@ -88,6 +128,10 @@ fn last_focused_terminal_tracks_most_recent_globally() {
         });
         model.read(&app, |model, _| {
             assert_eq!(model.get_last_focused_terminal_id(), Some(terminal_a));
+            assert_eq!(
+                model.get_last_focused_conversation(),
+                Some(ConversationOrTaskId::TaskId(task_a))
+            );
         });
 
         model.update(&mut app, |model, ctx| {
@@ -95,6 +139,10 @@ fn last_focused_terminal_tracks_most_recent_globally() {
         });
         model.read(&app, |model, _| {
             assert_eq!(model.get_last_focused_terminal_id(), Some(terminal_b));
+            assert_eq!(
+                model.get_last_focused_conversation(),
+                Some(ConversationOrTaskId::TaskId(task_b))
+            );
         });
 
         // Clearing window B's focus should NOT clear last_focused (it persists).
@@ -103,6 +151,10 @@ fn last_focused_terminal_tracks_most_recent_globally() {
         });
         model.read(&app, |model, _| {
             assert_eq!(model.get_last_focused_terminal_id(), Some(terminal_b));
+            assert_eq!(
+                model.get_last_focused_conversation(),
+                Some(ConversationOrTaskId::TaskId(task_b))
+            );
         });
     });
 }

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -83,6 +83,8 @@ impl ServerOutputId {
 pub enum CancellationReason {
     /// The user explicitly cancelled without providing a follow-up.
     ManuallyCancelled,
+    /// Warp automatically cancelled the local run so it could continue in Cloud Mode.
+    AutomaticCloudHandoff,
 
     /// The user submitted a follow-up query during streaming which implicitly cancelled the current one.
     FollowUpSubmitted {
@@ -107,6 +109,7 @@ impl Display for CancellationReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CancellationReason::ManuallyCancelled => write!(f, "manual cancellation"),
+            CancellationReason::AutomaticCloudHandoff => write!(f, "automatic cloud handoff"),
             CancellationReason::FollowUpSubmitted { .. } => write!(f, "follow-up submission"),
             CancellationReason::UserCommandExecuted => write!(f, "user command execution"),
             CancellationReason::Reverted => write!(f, "revert"),

--- a/app/src/ai/ambient_agents/telemetry.rs
+++ b/app/src/ai/ambient_agents/telemetry.rs
@@ -20,7 +20,7 @@ pub enum CloudModeEntryPoint {
 }
 
 /// The entry point through which a local-to-cloud handoff was initiated.
-#[derive(Clone, Copy, Debug, Default, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HandoffEntryPoint {
     /// User typed `&` in the input to enter handoff compose mode.
@@ -30,6 +30,8 @@ pub enum HandoffEntryPoint {
     SlashCommand,
     /// User clicked the "Hand off to cloud" chip in the footer toolbar.
     FooterChip,
+    /// The client automatically initiated handoff for an eligible local agent.
+    Automatic,
 }
 
 /// Telemetry events for client interactions with cloud agents.

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1641,6 +1641,7 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(|_| GitHubAuthNotifier::new());
     ctx.add_singleton_model(|_| NetworkStatus::new());
     ctx.add_singleton_model(|_| SystemStats::new());
+    workspace::auto_handoff::init(ctx);
     ctx.add_singleton_model(|_| KeybindingChangedNotifier::new());
     ctx.add_singleton_model(|_| search::command_palette::SelectedItems::new());
     ctx.add_singleton_model(search::files::model::FileSearchModel::new);

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1751,7 +1751,11 @@ impl AISettings {
     }
 
     pub fn is_auto_handoff_on_sleep_enabled(&self, app: &warpui::AppContext) -> bool {
-        self.is_cloud_handoff_enabled(app) && *self.auto_handoff_on_sleep_enabled
+        self.is_cloud_handoff_enabled(app)
+            && self
+                .auto_handoff_on_sleep_enabled
+                .is_supported_on_current_platform()
+            && *self.auto_handoff_on_sleep_enabled
     }
 
     /// Determines whether a quota reset banner should be displayed to the user.

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1497,6 +1497,16 @@ define_settings_group!(AISettings, settings: [
         toml_path: "agents.warp_agent.other.should_force_disable_ampersand_handoff",
         description: "Whether to force-disable the & prefix for cloud handoff compose mode.",
     }
+
+    auto_handoff_on_sleep_enabled: AutoHandoffOnSleepEnabled {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::MAC,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "agents.warp_agent.other.auto_handoff_on_sleep_enabled",
+        description: "Whether Warp automatically hands off local agent conversations to cloud when the computer is about to sleep.",
+    }
 ]);
 
 impl AISettings {
@@ -1738,6 +1748,10 @@ impl AISettings {
     ) -> bool {
         self.is_cloud_handoff_enabled_for_terminal_view(terminal_view_id, app)
             && !*self.should_force_disable_ampersand_handoff
+    }
+
+    pub fn is_auto_handoff_on_sleep_enabled(&self, app: &warpui::AppContext) -> bool {
+        self.is_cloud_handoff_enabled(app) && *self.auto_handoff_on_sleep_enabled
     }
 
     /// Determines whether a quota reset banner should be displayed to the user.

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -2677,6 +2677,7 @@ pub enum AISettingsPageAction {
     SetConversationLayout(crate::util::file::external_editor::settings::OpenConversationPreference),
     ToggleCloudHandoff,
     ToggleAmpersandHandoff,
+    ToggleAutoHandoffOnSleep,
     ToggleShowConversationHistory,
     ToggleAutoToggleRichInput,
     ToggleAutoOpenRichInputOnCLIAgentStart,
@@ -3435,6 +3436,14 @@ impl TypedActionView for AISettingsPageView {
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings
                         .should_force_disable_ampersand_handoff
+                        .toggle_and_save_value(ctx));
+                });
+                ctx.notify();
+            }
+            AISettingsPageAction::ToggleAutoHandoffOnSleep => {
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings
+                        .auto_handoff_on_sleep_enabled
                         .toggle_and_save_value(ctx));
                 });
                 ctx.notify();
@@ -6712,6 +6721,7 @@ impl SettingsWidget for CloudAgentComputerUseWidget {
 #[derive(Default)]
 struct CloudHandoffWidget {
     handoff_toggle: SwitchStateHandle,
+    auto_handoff_on_sleep_toggle: SwitchStateHandle,
     ampersand_toggle: SwitchStateHandle,
 }
 
@@ -6719,7 +6729,7 @@ impl SettingsWidget for CloudHandoffWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "cloud handoff ampersand & move to cloud local"
+        "cloud handoff auto sleep ampersand & move to cloud local"
     }
 
     fn should_render(&self, _app: &AppContext) -> bool {
@@ -6806,6 +6816,38 @@ impl SettingsWidget for CloudHandoffWidget {
             ));
 
         if ai_settings.is_cloud_handoff_enabled(app) {
+            if ai_settings
+                .auto_handoff_on_sleep_enabled
+                .is_supported_on_current_platform()
+            {
+                let auto_handoff_on_sleep_toggle = ui_builder
+                    .switch(self.auto_handoff_on_sleep_toggle.clone())
+                    .check(*ai_settings.auto_handoff_on_sleep_enabled)
+                    .build()
+                    .on_click(move |ctx, _, _| {
+                        ctx.dispatch_typed_action(AISettingsPageAction::ToggleAutoHandoffOnSleep);
+                    })
+                    .finish();
+                let auto_handoff_on_sleep_row = build_toggle_element(
+                    render_body_item_label::<AISettingsPageAction>(
+                        "Continue local agents in Cloud Mode before sleep".to_string(),
+                        Some(styles::header_font_color(true, app)),
+                        None,
+                        LocalOnlyIconState::Hidden,
+                        ToggleState::Enabled,
+                        appearance,
+                    ),
+                    auto_handoff_on_sleep_toggle,
+                    appearance,
+                    None,
+                );
+                column.add_child(auto_handoff_on_sleep_row);
+                column.add_child(render_ai_setting_description(
+                    "When macOS is about to sleep, automatically moves the most recently focused running local Warp Agent conversation to Cloud Mode so it can keep working.",
+                    true,
+                    app,
+                ));
+            }
             let ampersand_toggle = ui_builder
                 .switch(self.ampersand_toggle.clone())
                 .check(!*ai_settings.should_force_disable_ampersand_handoff)

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -6830,7 +6830,7 @@ impl SettingsWidget for CloudHandoffWidget {
                     .finish();
                 let auto_handoff_on_sleep_row = build_toggle_element(
                     render_body_item_label::<AISettingsPageAction>(
-                        "Continue local agents in Cloud Mode before sleep".to_string(),
+                        "Auto-handoff before sleep".to_string(),
                         Some(styles::header_font_color(true, app)),
                         None,
                         LocalOnlyIconState::Hidden,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20318,6 +20318,14 @@ impl TerminalView {
         active_block.index() == block_index && active_block.is_active_and_long_running()
     }
 
+    pub fn has_active_long_running_command(&self) -> bool {
+        let model = self.model.lock();
+        model
+            .block_list()
+            .active_block()
+            .is_active_and_long_running()
+    }
+
     /// If password notification settings enabled, send a notification.
     /// Otherwise, set the banner trigger so that we show the banner the next
     /// time a block completes.

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -18,7 +18,10 @@ use crate::util::openable_file_type::{
     is_file_openable_in_warp, is_markdown_file, is_runnable_shell_script, starts_with_shebang,
 };
 use crate::workspace::util::PaneViewLocator;
-use crate::workspace::{Workspace, WorkspaceAction, WorkspaceRegistry};
+use crate::workspace::{
+    auto_handoff::trigger_auto_handoff_to_cloud, AutoCloudHandoffTrigger, Workspace,
+    WorkspaceAction, WorkspaceRegistry,
+};
 use crate::{cloud_object::ObjectType, workspace::ToastStack};
 use crate::{drive::OpenWarpDriveObjectArgs, view_components::DismissibleToast};
 use crate::{features::FeatureFlag, workspace::active_terminal_in_window};
@@ -802,6 +805,19 @@ fn parse_tab_path(url: &Url) -> Option<PathBuf> {
     Some(PathBuf::from(shellexpand::tilde(&raw).into_owned()))
 }
 
+fn parse_auto_handoff_trigger(url: &Url) -> AutoCloudHandoffTrigger {
+    match url
+        .query_pairs()
+        .find(|(k, _)| k == "trigger")
+        .map(|(_, v)| v)
+    {
+        Some(trigger) if matches!(trigger.as_ref(), "sleep" | "macos_sleep" | "macos-sleep") => {
+            AutoCloudHandoffTrigger::MacOsSleep
+        }
+        Some(_) | None => AutoCloudHandoffTrigger::Uri,
+    }
+}
+
 #[derive(Debug)]
 enum Action {
     NewTab,
@@ -813,6 +829,7 @@ enum Action {
     NewAgentConversation,
     CreateEnvironment { repos: Vec<String> },
     FocusCloudMode,
+    AutoHandoffToCloud { trigger: AutoCloudHandoffTrigger },
 }
 
 impl Action {
@@ -834,6 +851,9 @@ impl Action {
                 Ok(Self::CreateEnvironment { repos })
             }
             "/focus_cloud_mode" => Ok(Self::FocusCloudMode),
+            "/auto_handoff_to_cloud" | "/auto-handoff-to-cloud" => Ok(Self::AutoHandoffToCloud {
+                trigger: parse_auto_handoff_trigger(url),
+            }),
             _ => Err(anyhow!(
                 "Received \"action\" intent with unexpected action: {}",
                 url.path()
@@ -1046,6 +1066,9 @@ impl Action {
                     ctx,
                 );
             }
+            Action::AutoHandoffToCloud { trigger } => {
+                trigger_auto_handoff_to_cloud(*trigger, ctx);
+            }
         }
     }
 
@@ -1060,7 +1083,8 @@ impl Action {
             | Self::CloudAgentSetup
             | Self::NewCloudAgentConversation
             | Self::NewAgentConversation
-            | Self::FocusCloudMode => W::default(),
+            | Self::FocusCloudMode
+            | Self::AutoHandoffToCloud { .. } => W::default(),
             Self::NewTab => W::ShowPrimaryWindow(WindowActivationFallbackBehavior::Notify {
                 title: "New tab created".to_owned(),
                 description: "Go to Warp to see your new tab.".to_owned(),

--- a/app/src/uri/uri_tests.rs
+++ b/app/src/uri/uri_tests.rs
@@ -319,6 +319,56 @@ fn test_action_cloud_agent_setup_parse() {
     let action = Action::parse(&url).unwrap();
     assert!(matches!(action, Action::CloudAgentSetup));
 }
+#[test]
+fn test_action_auto_handoff_to_cloud_parse_default_trigger() {
+    let url = Url::parse(&format!(
+        "{}://action/auto_handoff_to_cloud",
+        ChannelState::url_scheme()
+    ))
+    .unwrap();
+
+    let action = Action::parse(&url).unwrap();
+    assert!(matches!(
+        action,
+        Action::AutoHandoffToCloud {
+            trigger: AutoCloudHandoffTrigger::Uri,
+        }
+    ));
+}
+
+#[test]
+fn test_action_auto_handoff_to_cloud_parse_alias_path() {
+    let url = Url::parse(&format!(
+        "{}://action/auto-handoff-to-cloud",
+        ChannelState::url_scheme()
+    ))
+    .unwrap();
+
+    let action = Action::parse(&url).unwrap();
+    assert!(matches!(
+        action,
+        Action::AutoHandoffToCloud {
+            trigger: AutoCloudHandoffTrigger::Uri,
+        }
+    ));
+}
+
+#[test]
+fn test_action_auto_handoff_to_cloud_parse_sleep_trigger() {
+    let url = Url::parse(&format!(
+        "{}://action/auto_handoff_to_cloud?trigger=sleep",
+        ChannelState::url_scheme()
+    ))
+    .unwrap();
+
+    let action = Action::parse(&url).unwrap();
+    assert!(matches!(
+        action,
+        Action::AutoHandoffToCloud {
+            trigger: AutoCloudHandoffTrigger::MacOsSleep,
+        }
+    ));
+}
 
 #[test]
 fn test_action_new_cloud_agent_conversation_parse() {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -95,6 +95,12 @@ impl VerticalTabsPaneContextMenuTarget {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoCloudHandoffTrigger {
+    MacOsSleep,
+    Uri,
+}
+
 #[derive(Debug, Clone)]
 pub enum WorkspaceAction {
     ActivateTab(usize),
@@ -496,6 +502,13 @@ pub enum WorkspaceAction {
         launch: Option<()>,
         environment_id: Option<crate::server::ids::SyncId>,
         entry_point: crate::ai::ambient_agents::telemetry::HandoffEntryPoint,
+    },
+    /// Automatically hand off the active running local agent conversation in the
+    /// given terminal view to Cloud Mode.
+    AutoHandoffActiveAgentToCloud {
+        terminal_view_id: EntityId,
+        conversation_id: AIConversationId,
+        trigger: AutoCloudHandoffTrigger,
     },
     /// Show the environment creation modal during `&` handoff compose when no
     /// environments exist.
@@ -963,6 +976,7 @@ impl WorkspaceAction {
             | OpenSettingsFile
             | FixSettingsWithOz { .. }
             | OpenLocalToCloudHandoffPane { .. }
+            | AutoHandoffActiveAgentToCloud { .. }
             | ShowHandoffEnvironmentCreationModal
             | ShowCloudModeV2EnvironmentCreationModal
             | OpenCreateAuthSecretModal { .. }

--- a/app/src/workspace/auto_handoff.rs
+++ b/app/src/workspace/auto_handoff.rs
@@ -1,0 +1,264 @@
+use std::collections::HashMap;
+
+use warpui::{
+    AppContext, Entity, EntityId, ModelContext, SingletonEntity, TypedActionView, ViewHandle,
+    WindowId,
+};
+
+use crate::ai::active_agent_views_model::{ActiveAgentViewsModel, ConversationOrTaskId};
+use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+use crate::settings::AISettings;
+use crate::system::{SystemStats, SystemStatsEvent};
+use crate::terminal::view::TerminalView;
+use crate::BlocklistAIHistoryModel;
+
+use super::{AutoCloudHandoffTrigger, Workspace, WorkspaceAction, WorkspaceRegistry};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutoCloudHandoffSkipReason {
+    EmptyConversation,
+    NotInProgress,
+    MissingServerConversationToken,
+    SharedSessionViewer,
+    AlreadyAttempted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutoCloudHandoffAttemptState {
+    InFlight,
+    Succeeded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AutoCloudHandoffEligibility {
+    pub(crate) is_empty: bool,
+    pub(crate) is_in_progress: bool,
+    pub(crate) has_server_conversation_token: bool,
+    pub(crate) is_viewing_shared_session: bool,
+    pub(crate) already_attempted: bool,
+}
+
+impl AutoCloudHandoffEligibility {
+    pub(crate) fn from_conversation(
+        conversation: &AIConversation,
+        already_attempted: bool,
+    ) -> Self {
+        Self {
+            is_empty: conversation.is_empty(),
+            is_in_progress: conversation.status().is_in_progress(),
+            has_server_conversation_token: conversation.server_conversation_token().is_some(),
+            is_viewing_shared_session: conversation.is_viewing_shared_session(),
+            already_attempted,
+        }
+    }
+
+    pub(crate) fn skip_reason(self) -> Option<AutoCloudHandoffSkipReason> {
+        if self.already_attempted {
+            return Some(AutoCloudHandoffSkipReason::AlreadyAttempted);
+        }
+        if self.is_viewing_shared_session {
+            return Some(AutoCloudHandoffSkipReason::SharedSessionViewer);
+        }
+        if self.is_empty {
+            return Some(AutoCloudHandoffSkipReason::EmptyConversation);
+        }
+        if !self.is_in_progress {
+            return Some(AutoCloudHandoffSkipReason::NotInProgress);
+        }
+        if !self.has_server_conversation_token {
+            return Some(AutoCloudHandoffSkipReason::MissingServerConversationToken);
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AutoCloudHandoffTriggerSettings {
+    pub(crate) cloud_handoff_enabled: bool,
+    pub(crate) auto_handoff_on_sleep_enabled: bool,
+}
+
+impl AutoCloudHandoffTriggerSettings {
+    pub(crate) fn is_enabled_for(self, trigger: AutoCloudHandoffTrigger) -> bool {
+        match trigger {
+            AutoCloudHandoffTrigger::MacOsSleep => {
+                self.cloud_handoff_enabled && self.auto_handoff_on_sleep_enabled
+            }
+            AutoCloudHandoffTrigger::Uri => {
+                self.cloud_handoff_enabled && self.auto_handoff_on_sleep_enabled
+            }
+        }
+    }
+}
+pub(crate) struct AutoCloudHandoffController {
+    attempted_conversation_ids: HashMap<AIConversationId, AutoCloudHandoffAttemptState>,
+}
+
+impl AutoCloudHandoffController {
+    pub(crate) fn new(ctx: &mut ModelContext<Self>) -> Self {
+        ctx.subscribe_to_model(&SystemStats::handle(ctx), |controller, event, ctx| {
+            controller.handle_system_stats_event(event, ctx);
+        });
+
+        Self {
+            attempted_conversation_ids: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn record_handoff_succeeded(&mut self, conversation_id: AIConversationId) {
+        self.attempted_conversation_ids
+            .insert(conversation_id, AutoCloudHandoffAttemptState::Succeeded);
+    }
+
+    pub(crate) fn record_handoff_failed(&mut self, conversation_id: AIConversationId) {
+        self.attempted_conversation_ids.remove(&conversation_id);
+    }
+
+    fn handle_system_stats_event(
+        &mut self,
+        event: &SystemStatsEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match event {
+            SystemStatsEvent::CpuWillSleep => {
+                self.trigger(AutoCloudHandoffTrigger::MacOsSleep, ctx);
+            }
+            SystemStatsEvent::CpuWasAwakened => {}
+        }
+    }
+
+    fn trigger(&mut self, trigger: AutoCloudHandoffTrigger, ctx: &mut ModelContext<Self>) {
+        if !Self::trigger_settings(ctx).is_enabled_for(trigger) {
+            log::debug!("Skipping auto handoff to cloud via {trigger:?}: trigger is disabled");
+            return;
+        }
+
+        let Some((terminal_view_id, conversation_id)) = Self::last_focused_local_conversation(ctx)
+        else {
+            log::debug!("Skipping auto handoff to cloud: no focused local agent conversation");
+            return;
+        };
+
+        let Some((window_id, workspace, terminal_view)) =
+            Self::find_workspace_and_terminal(terminal_view_id, ctx)
+        else {
+            log::debug!(
+                "Skipping auto handoff to cloud: terminal view {terminal_view_id:?} is not open"
+            );
+            return;
+        };
+
+        if terminal_view
+            .as_ref(ctx)
+            .ambient_agent_view_model()
+            .is_some()
+        {
+            log::debug!(
+                "Skipping auto handoff to cloud: terminal view {terminal_view_id:?} is Cloud Mode"
+            );
+            return;
+        }
+
+        if terminal_view.as_ref(ctx).has_active_long_running_command() {
+            log::debug!(
+                "Skipping auto handoff to cloud: terminal view {terminal_view_id:?} has a long-running command"
+            );
+            return;
+        }
+
+        let skip_reason = {
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            let Some(conversation) = history.conversation(&conversation_id) else {
+                log::debug!(
+                    "Skipping auto handoff to cloud: conversation {conversation_id:?} is not loaded"
+                );
+                return;
+            };
+            AutoCloudHandoffEligibility::from_conversation(
+                conversation,
+                self.attempted_conversation_ids
+                    .contains_key(&conversation_id),
+            )
+            .skip_reason()
+        };
+
+        if let Some(reason) = skip_reason {
+            log::debug!(
+                "Skipping auto handoff to cloud for conversation {conversation_id:?}: {reason:?}"
+            );
+            return;
+        }
+
+        self.attempted_conversation_ids
+            .insert(conversation_id, AutoCloudHandoffAttemptState::InFlight);
+
+        log::info!(
+            "Triggering auto handoff to cloud for conversation {conversation_id:?} in window {window_id:?} via {trigger:?}"
+        );
+        workspace.update(ctx, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::AutoHandoffActiveAgentToCloud {
+                    terminal_view_id,
+                    conversation_id,
+                    trigger,
+                },
+                ctx,
+            );
+        });
+    }
+
+    fn last_focused_local_conversation(
+        ctx: &ModelContext<Self>,
+    ) -> Option<(EntityId, AIConversationId)> {
+        let active_agent_views = ActiveAgentViewsModel::as_ref(ctx);
+        let terminal_view_id = active_agent_views.get_last_focused_terminal_id()?;
+        let conversation_id = match active_agent_views.get_last_focused_conversation()? {
+            ConversationOrTaskId::ConversationId(conversation_id) => conversation_id,
+            ConversationOrTaskId::TaskId(_) => return None,
+        };
+        Some((terminal_view_id, conversation_id))
+    }
+
+    fn trigger_settings(ctx: &ModelContext<Self>) -> AutoCloudHandoffTriggerSettings {
+        let ai_settings = AISettings::as_ref(ctx);
+        AutoCloudHandoffTriggerSettings {
+            cloud_handoff_enabled: ai_settings.is_cloud_handoff_enabled(ctx),
+            auto_handoff_on_sleep_enabled: ai_settings.is_auto_handoff_on_sleep_enabled(ctx),
+        }
+    }
+    fn find_workspace_and_terminal(
+        terminal_view_id: EntityId,
+        ctx: &ModelContext<Self>,
+    ) -> Option<(WindowId, ViewHandle<Workspace>, ViewHandle<TerminalView>)> {
+        WorkspaceRegistry::as_ref(ctx)
+            .all_workspaces(ctx)
+            .into_iter()
+            .find_map(|(window_id, workspace)| {
+                let terminal_view = workspace.as_ref(ctx).terminal_view(terminal_view_id, ctx)?;
+                Some((window_id, workspace, terminal_view))
+            })
+    }
+}
+
+impl Entity for AutoCloudHandoffController {
+    type Event = ();
+}
+
+impl SingletonEntity for AutoCloudHandoffController {}
+
+pub(crate) fn init(app: &mut AppContext) {
+    app.add_singleton_model(AutoCloudHandoffController::new);
+}
+
+pub(crate) fn trigger_auto_handoff_to_cloud(
+    trigger: AutoCloudHandoffTrigger,
+    ctx: &mut AppContext,
+) {
+    AutoCloudHandoffController::handle(ctx).update(ctx, |controller, ctx| {
+        controller.trigger(trigger, ctx);
+    });
+}
+
+#[cfg(test)]
+#[path = "auto_handoff_tests.rs"]
+mod tests;

--- a/app/src/workspace/auto_handoff.rs
+++ b/app/src/workspace/auto_handoff.rs
@@ -79,6 +79,28 @@ impl AutoCloudHandoffEligibility {
         None
     }
 }
+
+pub(crate) struct AutoCloudHandoffRequest {
+    workspace: ViewHandle<Workspace>,
+    terminal_view_id: EntityId,
+    conversation_id: AIConversationId,
+    trigger: AutoCloudHandoffTrigger,
+}
+
+impl AutoCloudHandoffRequest {
+    fn dispatch(&self, ctx: &mut AppContext) {
+        self.workspace.update(ctx, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::AutoHandoffActiveAgentToCloud {
+                    terminal_view_id: self.terminal_view_id,
+                    conversation_id: self.conversation_id,
+                    trigger: self.trigger,
+                },
+                ctx,
+            );
+        });
+    }
+}
 pub(crate) struct AutoCloudHandoffController {
     attempted_conversation_ids: HashMap<AIConversationId, AutoCloudHandoffAttemptState>,
 }
@@ -118,38 +140,40 @@ impl AutoCloudHandoffController {
     }
 
     fn trigger(&mut self, trigger: AutoCloudHandoffTrigger, ctx: &mut ModelContext<Self>) {
+        if let Some(request) = self.prepare_handoff_request(trigger, ctx) {
+            ctx.emit(request);
+        }
+    }
+
+    fn prepare_handoff_request(
+        &mut self,
+        trigger: AutoCloudHandoffTrigger,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<AutoCloudHandoffRequest> {
         if !Self::is_trigger_enabled(trigger, ctx) {
-            return;
+            return None;
         }
 
-        let Some((terminal_view_id, conversation_id)) = Self::last_focused_local_conversation(ctx)
-        else {
-            return;
-        };
+        let (terminal_view_id, conversation_id) = Self::last_focused_local_conversation(ctx)?;
 
-        let Some((window_id, workspace, terminal_view)) =
-            Self::find_workspace_and_terminal(terminal_view_id, ctx)
-        else {
-            return;
-        };
+        let (window_id, workspace, terminal_view) =
+            Self::find_workspace_and_terminal(terminal_view_id, ctx)?;
 
         if terminal_view
             .as_ref(ctx)
             .ambient_agent_view_model()
             .is_some()
         {
-            return;
+            return None;
         }
 
         if terminal_view.as_ref(ctx).has_active_long_running_command() {
-            return;
+            return None;
         }
 
         let skip_reason = {
             let history = BlocklistAIHistoryModel::as_ref(ctx);
-            let Some(conversation) = history.conversation(&conversation_id) else {
-                return;
-            };
+            let conversation = history.conversation(&conversation_id)?;
             let can_handoff_to_cloud = AISettings::as_ref(ctx)
                 .is_cloud_handoff_enabled_for_conversation(Some(conversation), ctx);
             AutoCloudHandoffEligibility::from_conversation(
@@ -162,7 +186,7 @@ impl AutoCloudHandoffController {
         };
 
         if skip_reason.is_some() {
-            return;
+            return None;
         }
 
         self.attempted_conversation_ids
@@ -171,16 +195,12 @@ impl AutoCloudHandoffController {
         log::info!(
             "Triggering auto handoff to cloud for conversation {conversation_id:?} in window {window_id:?} via {trigger:?}"
         );
-        workspace.update(ctx, |workspace, ctx| {
-            workspace.handle_action(
-                &WorkspaceAction::AutoHandoffActiveAgentToCloud {
-                    terminal_view_id,
-                    conversation_id,
-                    trigger,
-                },
-                ctx,
-            );
-        });
+        Some(AutoCloudHandoffRequest {
+            workspace,
+            terminal_view_id,
+            conversation_id,
+            trigger,
+        })
     }
 
     fn last_focused_local_conversation(
@@ -217,13 +237,16 @@ impl AutoCloudHandoffController {
 }
 
 impl Entity for AutoCloudHandoffController {
-    type Event = ();
+    type Event = AutoCloudHandoffRequest;
 }
 
 impl SingletonEntity for AutoCloudHandoffController {}
 
 pub(crate) fn init(app: &mut AppContext) {
-    app.add_singleton_model(AutoCloudHandoffController::new);
+    let controller = app.add_singleton_model(AutoCloudHandoffController::new);
+    app.subscribe_to_model(&controller, |_, request, ctx| {
+        request.dispatch(ctx);
+    });
 }
 
 pub(crate) fn trigger_auto_handoff_to_cloud(

--- a/app/src/workspace/auto_handoff.rs
+++ b/app/src/workspace/auto_handoff.rs
@@ -20,6 +20,7 @@ pub(crate) enum AutoCloudHandoffSkipReason {
     NotInProgress,
     MissingServerConversationToken,
     SharedSessionViewer,
+    CloudHandoffUnavailable,
     AlreadyAttempted,
 }
 
@@ -35,12 +36,14 @@ pub(crate) struct AutoCloudHandoffEligibility {
     pub(crate) is_in_progress: bool,
     pub(crate) has_server_conversation_token: bool,
     pub(crate) is_viewing_shared_session: bool,
+    pub(crate) can_handoff_to_cloud: bool,
     pub(crate) already_attempted: bool,
 }
 
 impl AutoCloudHandoffEligibility {
     pub(crate) fn from_conversation(
         conversation: &AIConversation,
+        can_handoff_to_cloud: bool,
         already_attempted: bool,
     ) -> Self {
         Self {
@@ -48,6 +51,7 @@ impl AutoCloudHandoffEligibility {
             is_in_progress: conversation.status().is_in_progress(),
             has_server_conversation_token: conversation.server_conversation_token().is_some(),
             is_viewing_shared_session: conversation.is_viewing_shared_session(),
+            can_handoff_to_cloud,
             already_attempted,
         }
     }
@@ -68,26 +72,10 @@ impl AutoCloudHandoffEligibility {
         if !self.has_server_conversation_token {
             return Some(AutoCloudHandoffSkipReason::MissingServerConversationToken);
         }
-        None
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct AutoCloudHandoffTriggerSettings {
-    pub(crate) cloud_handoff_enabled: bool,
-    pub(crate) auto_handoff_on_sleep_enabled: bool,
-}
-
-impl AutoCloudHandoffTriggerSettings {
-    pub(crate) fn is_enabled_for(self, trigger: AutoCloudHandoffTrigger) -> bool {
-        match trigger {
-            AutoCloudHandoffTrigger::MacOsSleep => {
-                self.cloud_handoff_enabled && self.auto_handoff_on_sleep_enabled
-            }
-            AutoCloudHandoffTrigger::Uri => {
-                self.cloud_handoff_enabled && self.auto_handoff_on_sleep_enabled
-            }
+        if !self.can_handoff_to_cloud {
+            return Some(AutoCloudHandoffSkipReason::CloudHandoffUnavailable);
         }
+        None
     }
 }
 pub(crate) struct AutoCloudHandoffController {
@@ -128,23 +116,18 @@ impl AutoCloudHandoffController {
     }
 
     fn trigger(&mut self, trigger: AutoCloudHandoffTrigger, ctx: &mut ModelContext<Self>) {
-        if !Self::trigger_settings(ctx).is_enabled_for(trigger) {
-            log::debug!("Skipping auto handoff to cloud via {trigger:?}: trigger is disabled");
+        if !Self::is_trigger_enabled(trigger, ctx) {
             return;
         }
 
         let Some((terminal_view_id, conversation_id)) = Self::last_focused_local_conversation(ctx)
         else {
-            log::debug!("Skipping auto handoff to cloud: no focused local agent conversation");
             return;
         };
 
         let Some((window_id, workspace, terminal_view)) =
             Self::find_workspace_and_terminal(terminal_view_id, ctx)
         else {
-            log::debug!(
-                "Skipping auto handoff to cloud: terminal view {terminal_view_id:?} is not open"
-            );
             return;
         };
 
@@ -153,39 +136,30 @@ impl AutoCloudHandoffController {
             .ambient_agent_view_model()
             .is_some()
         {
-            log::debug!(
-                "Skipping auto handoff to cloud: terminal view {terminal_view_id:?} is Cloud Mode"
-            );
             return;
         }
 
         if terminal_view.as_ref(ctx).has_active_long_running_command() {
-            log::debug!(
-                "Skipping auto handoff to cloud: terminal view {terminal_view_id:?} has a long-running command"
-            );
             return;
         }
 
         let skip_reason = {
             let history = BlocklistAIHistoryModel::as_ref(ctx);
             let Some(conversation) = history.conversation(&conversation_id) else {
-                log::debug!(
-                    "Skipping auto handoff to cloud: conversation {conversation_id:?} is not loaded"
-                );
                 return;
             };
+            let can_handoff_to_cloud = AISettings::as_ref(ctx)
+                .is_cloud_handoff_enabled_for_conversation(Some(conversation), ctx);
             AutoCloudHandoffEligibility::from_conversation(
                 conversation,
+                can_handoff_to_cloud,
                 self.attempted_conversation_ids
                     .contains_key(&conversation_id),
             )
             .skip_reason()
         };
 
-        if let Some(reason) = skip_reason {
-            log::debug!(
-                "Skipping auto handoff to cloud for conversation {conversation_id:?}: {reason:?}"
-            );
+        if skip_reason.is_some() {
             return;
         }
 
@@ -219,11 +193,11 @@ impl AutoCloudHandoffController {
         Some((terminal_view_id, conversation_id))
     }
 
-    fn trigger_settings(ctx: &ModelContext<Self>) -> AutoCloudHandoffTriggerSettings {
-        let ai_settings = AISettings::as_ref(ctx);
-        AutoCloudHandoffTriggerSettings {
-            cloud_handoff_enabled: ai_settings.is_cloud_handoff_enabled(ctx),
-            auto_handoff_on_sleep_enabled: ai_settings.is_auto_handoff_on_sleep_enabled(ctx),
+    fn is_trigger_enabled(trigger: AutoCloudHandoffTrigger, ctx: &ModelContext<Self>) -> bool {
+        match trigger {
+            AutoCloudHandoffTrigger::MacOsSleep | AutoCloudHandoffTrigger::Uri => {
+                AISettings::as_ref(ctx).is_auto_handoff_on_sleep_enabled(ctx)
+            }
         }
     }
     fn find_workspace_and_terminal(

--- a/app/src/workspace/auto_handoff.rs
+++ b/app/src/workspace/auto_handoff.rs
@@ -27,6 +27,7 @@ pub(crate) enum AutoCloudHandoffSkipReason {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AutoCloudHandoffAttemptState {
     InFlight,
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     Succeeded,
 }
 
@@ -93,11 +94,12 @@ impl AutoCloudHandoffController {
         }
     }
 
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     pub(crate) fn record_handoff_succeeded(&mut self, conversation_id: AIConversationId) {
         self.attempted_conversation_ids
             .insert(conversation_id, AutoCloudHandoffAttemptState::Succeeded);
     }
-
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     pub(crate) fn record_handoff_failed(&mut self, conversation_id: AIConversationId) {
         self.attempted_conversation_ids.remove(&conversation_id);
     }

--- a/app/src/workspace/auto_handoff_tests.rs
+++ b/app/src/workspace/auto_handoff_tests.rs
@@ -1,7 +1,4 @@
-use super::{
-    AutoCloudHandoffEligibility, AutoCloudHandoffSkipReason, AutoCloudHandoffTriggerSettings,
-};
-use crate::workspace::AutoCloudHandoffTrigger;
+use super::{AutoCloudHandoffEligibility, AutoCloudHandoffSkipReason};
 
 fn eligibility() -> AutoCloudHandoffEligibility {
     AutoCloudHandoffEligibility {
@@ -9,6 +6,7 @@ fn eligibility() -> AutoCloudHandoffEligibility {
         is_in_progress: true,
         has_server_conversation_token: true,
         is_viewing_shared_session: false,
+        can_handoff_to_cloud: true,
         already_attempted: false,
     }
 }
@@ -83,41 +81,15 @@ fn auto_handoff_skips_already_attempted_conversations() {
     );
 }
 
-fn trigger_settings(
-    cloud_handoff_enabled: bool,
-    auto_handoff_on_sleep_enabled: bool,
-) -> AutoCloudHandoffTriggerSettings {
-    AutoCloudHandoffTriggerSettings {
-        cloud_handoff_enabled,
-        auto_handoff_on_sleep_enabled,
-    }
-}
-
 #[test]
-fn sleep_trigger_requires_auto_handoff_on_sleep_setting() {
-    let settings = trigger_settings(true, false);
+fn auto_handoff_skips_conversations_that_cannot_handoff_to_cloud() {
+    let eligibility = AutoCloudHandoffEligibility {
+        can_handoff_to_cloud: false,
+        ..eligibility()
+    };
 
-    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::MacOsSleep));
-}
-
-#[test]
-fn uri_trigger_requires_auto_handoff_on_sleep_setting() {
-    let settings = trigger_settings(true, false);
-    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::Uri));
-}
-
-#[test]
-fn triggers_are_enabled_when_cloud_handoff_and_auto_handoff_on_sleep_are_enabled() {
-    let settings = trigger_settings(true, true);
-
-    assert!(settings.is_enabled_for(AutoCloudHandoffTrigger::MacOsSleep));
-    assert!(settings.is_enabled_for(AutoCloudHandoffTrigger::Uri));
-}
-
-#[test]
-fn triggers_require_cloud_handoff_setting() {
-    let settings = trigger_settings(false, true);
-
-    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::MacOsSleep));
-    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::Uri));
+    assert_eq!(
+        eligibility.skip_reason(),
+        Some(AutoCloudHandoffSkipReason::CloudHandoffUnavailable)
+    );
 }

--- a/app/src/workspace/auto_handoff_tests.rs
+++ b/app/src/workspace/auto_handoff_tests.rs
@@ -1,0 +1,123 @@
+use super::{
+    AutoCloudHandoffEligibility, AutoCloudHandoffSkipReason, AutoCloudHandoffTriggerSettings,
+};
+use crate::workspace::AutoCloudHandoffTrigger;
+
+fn eligibility() -> AutoCloudHandoffEligibility {
+    AutoCloudHandoffEligibility {
+        is_empty: false,
+        is_in_progress: true,
+        has_server_conversation_token: true,
+        is_viewing_shared_session: false,
+        already_attempted: false,
+    }
+}
+
+#[test]
+fn eligible_running_synced_conversation_is_not_skipped() {
+    assert_eq!(eligibility().skip_reason(), None);
+}
+
+#[test]
+fn auto_handoff_skips_empty_conversations() {
+    let eligibility = AutoCloudHandoffEligibility {
+        is_empty: true,
+        ..eligibility()
+    };
+
+    assert_eq!(
+        eligibility.skip_reason(),
+        Some(AutoCloudHandoffSkipReason::EmptyConversation)
+    );
+}
+
+#[test]
+fn auto_handoff_skips_idle_conversations() {
+    let eligibility = AutoCloudHandoffEligibility {
+        is_in_progress: false,
+        ..eligibility()
+    };
+
+    assert_eq!(
+        eligibility.skip_reason(),
+        Some(AutoCloudHandoffSkipReason::NotInProgress)
+    );
+}
+
+#[test]
+fn auto_handoff_skips_unsynced_conversations() {
+    let eligibility = AutoCloudHandoffEligibility {
+        has_server_conversation_token: false,
+        ..eligibility()
+    };
+
+    assert_eq!(
+        eligibility.skip_reason(),
+        Some(AutoCloudHandoffSkipReason::MissingServerConversationToken)
+    );
+}
+
+#[test]
+fn auto_handoff_skips_shared_session_viewers() {
+    let eligibility = AutoCloudHandoffEligibility {
+        is_viewing_shared_session: true,
+        ..eligibility()
+    };
+
+    assert_eq!(
+        eligibility.skip_reason(),
+        Some(AutoCloudHandoffSkipReason::SharedSessionViewer)
+    );
+}
+
+#[test]
+fn auto_handoff_skips_already_attempted_conversations() {
+    let eligibility = AutoCloudHandoffEligibility {
+        already_attempted: true,
+        ..eligibility()
+    };
+
+    assert_eq!(
+        eligibility.skip_reason(),
+        Some(AutoCloudHandoffSkipReason::AlreadyAttempted)
+    );
+}
+
+fn trigger_settings(
+    cloud_handoff_enabled: bool,
+    auto_handoff_on_sleep_enabled: bool,
+) -> AutoCloudHandoffTriggerSettings {
+    AutoCloudHandoffTriggerSettings {
+        cloud_handoff_enabled,
+        auto_handoff_on_sleep_enabled,
+    }
+}
+
+#[test]
+fn sleep_trigger_requires_auto_handoff_on_sleep_setting() {
+    let settings = trigger_settings(true, false);
+
+    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::MacOsSleep));
+}
+
+#[test]
+fn uri_trigger_requires_auto_handoff_on_sleep_setting() {
+    let settings = trigger_settings(true, false);
+    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::Uri));
+}
+
+#[test]
+fn triggers_are_enabled_when_cloud_handoff_and_auto_handoff_on_sleep_are_enabled() {
+    let settings = trigger_settings(true, true);
+
+    assert!(settings.is_enabled_for(AutoCloudHandoffTrigger::MacOsSleep));
+    assert!(settings.is_enabled_for(AutoCloudHandoffTrigger::Uri));
+}
+
+#[test]
+fn triggers_require_cloud_handoff_setting() {
+    let settings = trigger_settings(false, true);
+
+    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::MacOsSleep));
+    assert!(!settings.is_enabled_for(AutoCloudHandoffTrigger::Uri));
+}

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -1,5 +1,6 @@
 mod action;
 mod active_session;
+pub(crate) mod auto_handoff;
 pub mod bonus_grant_notification_model;
 #[cfg(target_os = "macos")]
 mod cli_install;
@@ -53,8 +54,8 @@ use warpui::keymap::{BindingDescription, EditableBinding};
 use warpui::AppContext;
 
 pub use action::{
-    CommandSearchOptions, InitContent, RestoreConversationLayout, TabContextMenuAnchor,
-    VerticalTabsPaneContextMenuTarget, WorkspaceAction,
+    AutoCloudHandoffTrigger, CommandSearchOptions, InitContent, RestoreConversationLayout,
+    TabContextMenuAnchor, VerticalTabsPaneContextMenuTarget, WorkspaceAction,
 };
 pub use active_session::ActiveSession;
 pub use global_actions::{

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -810,13 +810,6 @@ impl LocalToCloudHandoffIntent {
             } => Some(conversation_id),
         }
     }
-
-    fn automatic_trigger(self) -> Option<AutoCloudHandoffTrigger> {
-        match self {
-            Self::UserInitiated(_) => None,
-            Self::Automatic { trigger, .. } => Some(trigger),
-        }
-    }
 }
 
 /// Categorization of how the tab bar should be rendered.
@@ -13780,23 +13773,11 @@ impl Workspace {
                     let Some(active_conversation) =
                         history_model.active_conversation(terminal_view_id)
                     else {
-                        if let Some(trigger) = intent.automatic_trigger() {
-                            log::debug!(
-                                "Skipping automatic local-to-cloud handoff via {trigger:?}: terminal view {terminal_view_id:?} has no active conversation"
-                            );
-                        }
                         Self::record_automatic_handoff_failed(intent, ctx);
                         return;
                     };
 
                     if active_conversation.id() != expected_conversation_id {
-                        if let Some(trigger) = intent.automatic_trigger() {
-                            log::debug!(
-                                "Skipping automatic local-to-cloud handoff via {trigger:?}: terminal view {terminal_view_id:?} active conversation changed from {:?} to {:?}",
-                                expected_conversation_id,
-                                active_conversation.id(),
-                            );
-                        }
                         Self::record_automatic_handoff_failed(intent, ctx);
                         return;
                     }
@@ -13823,11 +13804,7 @@ impl Workspace {
                         ctx,
                     );
                 });
-            } else if let Some(trigger) = intent.automatic_trigger() {
-                log::debug!(
-                    "Skipping automatic local-to-cloud handoff via {trigger:?}: cloud handoff is not available for conversation {:?}",
-                    source_conversation.as_ref().map(|conversation| conversation.id()),
-                );
+            } else {
                 Self::record_automatic_handoff_failed(intent, ctx);
             }
             return;
@@ -13851,10 +13828,7 @@ impl Workspace {
                     "start_local_to_cloud_handoff: no non-empty source conversation found; starting a fresh cloud launch"
                 );
                 self.start_fresh_cloud_launch(source_view, launch, environment_id, ctx);
-            } else if let Some(trigger) = intent.automatic_trigger() {
-                log::debug!(
-                    "Skipping automatic local-to-cloud handoff via {trigger:?}: source conversation is empty"
-                );
+            } else {
                 Self::record_automatic_handoff_failed(intent, ctx);
             }
             return;
@@ -13863,10 +13837,6 @@ impl Workspace {
         if intent.expected_conversation_id().is_some()
             && !source_conversation.status().is_in_progress()
         {
-            log::debug!(
-                "Skipping automatic local-to-cloud handoff for conversation {:?}: not in progress",
-                source_conversation.id()
-            );
             Self::record_automatic_handoff_failed(intent, ctx);
             return;
         }
@@ -13891,10 +13861,7 @@ impl Workspace {
                             ctx,
                         );
                     });
-                } else if let Some(trigger) = intent.automatic_trigger() {
-                    log::debug!(
-                        "Skipping automatic local-to-cloud handoff via {trigger:?}: terminal has a long-running command"
-                    );
+                } else {
                     Self::record_automatic_handoff_failed(intent, ctx);
                 }
                 return;
@@ -13931,11 +13898,7 @@ impl Workspace {
                         ctx,
                     );
                 });
-            } else if let Some(trigger) = intent.automatic_trigger() {
-                log::debug!(
-                    "Skipping automatic local-to-cloud handoff via {trigger:?} for conversation {:?}: missing server token",
-                    source_conversation.id(),
-                );
+            } else {
                 Self::record_automatic_handoff_failed(intent, ctx);
             }
             return;
@@ -13988,10 +13951,6 @@ impl Workspace {
                                 ctx,
                             );
                         });
-                    } else if let Some(trigger) = intent.automatic_trigger() {
-                        log::debug!(
-                            "Automatic local-to-cloud handoff via {trigger:?} failed while forking conversation"
-                        );
                     }
                     Self::record_automatic_handoff_failed(intent, ctx);
                 }
@@ -14048,10 +14007,6 @@ impl Workspace {
                             ctx,
                         );
                     });
-                } else if let Some(trigger) = intent.automatic_trigger() {
-                    log::debug!(
-                        "Automatic local-to-cloud handoff via {trigger:?} failed while materializing local fork"
-                    );
                 }
                 Self::record_automatic_handoff_failed(intent, ctx);
                 return;
@@ -14078,10 +14033,6 @@ impl Workspace {
                         ctx,
                     );
                 });
-            } else if let Some(trigger) = intent.automatic_trigger() {
-                log::debug!(
-                    "Automatic local-to-cloud handoff via {trigger:?} failed while opening cloud pane"
-                );
             }
             Self::record_automatic_handoff_failed(intent, ctx);
             return;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -58,7 +58,7 @@ use crate::ai::blocklist::handoff::touched_repos::{
     derive_touched_workspace, extract_paths_from_conversation,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::handoff::PendingCloudLaunch;
+use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
 use crate::ai::blocklist::history_model::{load_conversation_from_server, CloudConversationData};
 use crate::ai::blocklist::suggested_agent_mode_workflow_modal::SuggestedAgentModeWorkflowAndId;
 use crate::ai::blocklist::suggested_rule_modal::{
@@ -435,6 +435,10 @@ use warpui::{elements::MouseStateHandle, fonts::Properties};
 
 use crate::{autoupdate, channel::ChannelState};
 
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use super::action::AutoCloudHandoffTrigger;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use super::auto_handoff::AutoCloudHandoffController;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, PendingQueryState, SerializedBlockListItem};
 use crate::editor::{
     EditorView, Event as EditorEvent, PropagateAndNoOpNavigationKeys, SingleLineEditorOptions,
@@ -676,6 +680,10 @@ const MAX_FORK_TOAST_TITLE_LENGTH: usize = 100;
 // The max length of the window title (matching conversation title truncation).
 const MAX_WINDOW_TITLE_LENGTH: usize = 80;
 
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+const AUTO_CLOUD_HANDOFF_PROMPT: &str =
+    "Continue this local Warp Agent task in the cloud from the current conversation state.";
+
 /// The default display name used for the user if they have no associated display name.
 pub const DEFAULT_USER_DISPLAY_NAME: &str = "User";
 
@@ -762,6 +770,53 @@ pub struct TabPaneGroupIdentifiers {
     pub tab_idx: usize,
     pub pane_group_id: EntityId,
     pub terminal_ids: Vec<EntityId>,
+}
+
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LocalToCloudHandoffIntent {
+    UserInitiated(HandoffEntryPoint),
+    Automatic {
+        trigger: AutoCloudHandoffTrigger,
+        conversation_id: AIConversationId,
+    },
+}
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+struct LocalToCloudHandoffOpenParams {
+    forked_conversation_id: String,
+    launch: Option<PendingCloudLaunch>,
+    environment_id: Option<SyncId>,
+    intent: LocalToCloudHandoffIntent,
+}
+
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+impl LocalToCloudHandoffIntent {
+    fn entry_point(self) -> HandoffEntryPoint {
+        match self {
+            Self::UserInitiated(entry_point) => entry_point,
+            Self::Automatic { .. } => HandoffEntryPoint::Automatic,
+        }
+    }
+
+    fn shows_user_feedback(self) -> bool {
+        matches!(self, Self::UserInitiated(_))
+    }
+
+    fn expected_conversation_id(self) -> Option<AIConversationId> {
+        match self {
+            Self::UserInitiated(_) => None,
+            Self::Automatic {
+                conversation_id, ..
+            } => Some(conversation_id),
+        }
+    }
+
+    fn automatic_trigger(self) -> Option<AutoCloudHandoffTrigger> {
+        match self {
+            Self::UserInitiated(_) => None,
+            Self::Automatic { trigger, .. } => Some(trigger),
+        }
+    }
 }
 
 /// Categorization of how the tab bar should be rendered.
@@ -5391,6 +5446,20 @@ impl Workspace {
                 }
             })
             .collect::<Vec<_>>()
+    }
+
+    pub(crate) fn terminal_view(
+        &self,
+        terminal_view_id: EntityId,
+        app: &AppContext,
+    ) -> Option<ViewHandle<TerminalView>> {
+        self.tabs.iter().find_map(|tab| {
+            tab.pane_group
+                .as_ref(app)
+                .terminal_views(app)
+                .into_iter()
+                .find(|terminal_view| terminal_view.id() == terminal_view_id)
+        })
     }
 
     /// Focuses the given pane, revealing it first if it is hidden behind a
@@ -13633,10 +13702,6 @@ impl Workspace {
         entry_point: HandoffEntryPoint,
         ctx: &mut ViewContext<Self>,
     ) {
-        if !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx) {
-            return;
-        }
-
         let Some(source_view) = self
             .active_tab_pane_group()
             .as_ref(ctx)
@@ -13659,26 +13724,112 @@ impl Workspace {
             return;
         };
 
+        self.start_local_to_cloud_handoff_from_source(
+            source_view,
+            launch,
+            environment_id,
+            LocalToCloudHandoffIntent::UserInitiated(entry_point),
+            ctx,
+        );
+    }
+
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    fn record_automatic_handoff_succeeded(
+        intent: LocalToCloudHandoffIntent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(conversation_id) = intent.expected_conversation_id() {
+            AutoCloudHandoffController::handle(ctx).update(ctx, |controller, _| {
+                controller.record_handoff_succeeded(conversation_id);
+            });
+        }
+    }
+
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    fn record_automatic_handoff_failed(
+        intent: LocalToCloudHandoffIntent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(conversation_id) = intent.expected_conversation_id() {
+            AutoCloudHandoffController::handle(ctx).update(ctx, |controller, _| {
+                controller.record_handoff_failed(conversation_id);
+            });
+        }
+    }
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    fn start_local_to_cloud_handoff_from_source(
+        &mut self,
+        source_view: ViewHandle<TerminalView>,
+        launch: Option<PendingCloudLaunch>,
+        environment_id: Option<SyncId>,
+        intent: LocalToCloudHandoffIntent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let show_user_feedback = intent.shows_user_feedback();
+
+        if !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx) {
+            Self::record_automatic_handoff_failed(intent, ctx);
+            return;
+        }
+
         let terminal_view_id = source_view.id();
-        let source_conversation = BlocklistAIHistoryModel::handle(ctx)
-            .as_ref(ctx)
-            .active_conversation(terminal_view_id)
-            .cloned();
+        let source_conversation = {
+            let history_model = BlocklistAIHistoryModel::as_ref(ctx);
+            match intent.expected_conversation_id() {
+                Some(expected_conversation_id) => {
+                    let Some(active_conversation) =
+                        history_model.active_conversation(terminal_view_id)
+                    else {
+                        if let Some(trigger) = intent.automatic_trigger() {
+                            log::debug!(
+                                "Skipping automatic local-to-cloud handoff via {trigger:?}: terminal view {terminal_view_id:?} has no active conversation"
+                            );
+                        }
+                        Self::record_automatic_handoff_failed(intent, ctx);
+                        return;
+                    };
+
+                    if active_conversation.id() != expected_conversation_id {
+                        if let Some(trigger) = intent.automatic_trigger() {
+                            log::debug!(
+                                "Skipping automatic local-to-cloud handoff via {trigger:?}: terminal view {terminal_view_id:?} active conversation changed from {:?} to {:?}",
+                                expected_conversation_id,
+                                active_conversation.id(),
+                            );
+                        }
+                        Self::record_automatic_handoff_failed(intent, ctx);
+                        return;
+                    }
+
+                    Some(active_conversation.clone())
+                }
+                None => history_model.active_conversation(terminal_view_id).cloned(),
+            }
+        };
+
         if !AISettings::as_ref(ctx)
             .is_cloud_handoff_enabled_for_conversation(source_conversation.as_ref(), ctx)
         {
-            Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-            let window_id = ctx.window_id();
-            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                toast_stack.add_ephemeral_toast(
-                    DismissibleToast::error(
-                        "Cloud handoff isn't available for orchestrated agent conversations."
-                            .to_owned(),
-                    ),
-                    window_id,
-                    ctx,
+            if show_user_feedback {
+                Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
+                let window_id = ctx.window_id();
+                WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(
+                            "Cloud handoff isn't available for orchestrated agent conversations."
+                                .to_owned(),
+                        ),
+                        window_id,
+                        ctx,
+                    );
+                });
+            } else if let Some(trigger) = intent.automatic_trigger() {
+                log::debug!(
+                    "Skipping automatic local-to-cloud handoff via {trigger:?}: cloud handoff is not available for conversation {:?}",
+                    source_conversation.as_ref().map(|conversation| conversation.id()),
                 );
-            });
+                Self::record_automatic_handoff_failed(intent, ctx);
+            }
             return;
         }
 
@@ -13686,7 +13837,7 @@ impl Workspace {
 
         send_telemetry_from_ctx!(
             CloudAgentTelemetryEvent::HandoffInitiated {
-                entry_point,
+                entry_point: intent.entry_point(),
                 forked_existing_conversation: has_existing_conversation,
             },
             ctx
@@ -13695,43 +13846,71 @@ impl Workspace {
         let Some(source_conversation) =
             source_conversation.filter(|conversation| !conversation.is_empty())
         else {
-            self.start_fresh_cloud_launch(source_view, launch, environment_id, ctx);
+            if show_user_feedback {
+                log::warn!(
+                    "start_local_to_cloud_handoff: no non-empty source conversation found; starting a fresh cloud launch"
+                );
+                self.start_fresh_cloud_launch(source_view, launch, environment_id, ctx);
+            } else if let Some(trigger) = intent.automatic_trigger() {
+                log::debug!(
+                    "Skipping automatic local-to-cloud handoff via {trigger:?}: source conversation is empty"
+                );
+                Self::record_automatic_handoff_failed(intent, ctx);
+            }
             return;
         };
+
+        if intent.expected_conversation_id().is_some()
+            && !source_conversation.status().is_in_progress()
+        {
+            log::debug!(
+                "Skipping automatic local-to-cloud handoff for conversation {:?}: not in progress",
+                source_conversation.id()
+            );
+            Self::record_automatic_handoff_failed(intent, ctx);
+            return;
+        }
 
         if source_conversation.status().is_in_progress()
             || source_conversation.status().is_blocked()
         {
-            let has_long_running_command = source_view
-                .as_ref(ctx)
-                .model
-                .lock()
-                .block_list()
-                .active_block()
-                .is_active_and_long_running();
+            let has_long_running_command =
+                source_view.as_ref(ctx).has_active_long_running_command();
 
             if has_long_running_command {
-                Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-                let window_id = ctx.window_id();
-                WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                    toast_stack.add_ephemeral_toast(
-                        DismissibleToast::error(
-                            "Can't hand off while a command is running. Cancel the command or wait for it to finish."
-                                .to_owned(),
-                        ),
-                        window_id,
-                        ctx,
+                if show_user_feedback {
+                    Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
+                    let window_id = ctx.window_id();
+                    WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                        toast_stack.add_ephemeral_toast(
+                            DismissibleToast::error(
+                                "Can't hand off while a command is running. Cancel the command or wait for it to finish."
+                                    .to_owned(),
+                            ),
+                            window_id,
+                            ctx,
+                        );
+                    });
+                } else if let Some(trigger) = intent.automatic_trigger() {
+                    log::debug!(
+                        "Skipping automatic local-to-cloud handoff via {trigger:?}: terminal has a long-running command"
                     );
-                });
+                    Self::record_automatic_handoff_failed(intent, ctx);
+                }
                 return;
             }
 
             let conversation_id = source_conversation.id();
+            let cancellation_reason = if intent.expected_conversation_id().is_some() {
+                CancellationReason::AutomaticCloudHandoff
+            } else {
+                CancellationReason::ManuallyCancelled
+            };
             source_view.update(ctx, |view, ctx| {
                 view.ai_controller().update(ctx, |controller, ctx| {
                     controller.cancel_conversation_progress(
                         conversation_id,
-                        CancellationReason::ManuallyCancelled,
+                        cancellation_reason,
                         ctx,
                     );
                 });
@@ -13739,22 +13918,26 @@ impl Workspace {
         }
 
         let Some(source_token) = source_conversation.server_conversation_token().cloned() else {
-            log::warn!(
-                "start_local_to_cloud_handoff: source conversation {:?} has no server token yet; cloud sync may not have completed",
-                source_conversation.id()
-            );
-            Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-            let window_id = ctx.window_id();
-            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                toast_stack.add_ephemeral_toast(
-                    DismissibleToast::error(
-                        "Your conversation hasn't synced to the cloud yet. Try sending another message, then hand off again."
-                            .to_owned(),
-                    ),
-                    window_id,
-                    ctx,
+            if show_user_feedback {
+                Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
+                let window_id = ctx.window_id();
+                WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(
+                            "Your conversation hasn't synced to the cloud yet. Try sending another message, then hand off again."
+                                .to_owned(),
+                        ),
+                        window_id,
+                        ctx,
+                    );
+                });
+            } else if let Some(trigger) = intent.automatic_trigger() {
+                log::debug!(
+                    "Skipping automatic local-to-cloud handoff via {trigger:?} for conversation {:?}: missing server token",
+                    source_conversation.id(),
                 );
-            });
+                Self::record_automatic_handoff_failed(intent, ctx);
+            }
             return;
         };
 
@@ -13774,9 +13957,12 @@ impl Workspace {
                     me.complete_local_to_cloud_handoff_open(
                         source_view,
                         source_conversation,
-                        response.forked_conversation_id,
-                        launch,
-                        environment_id,
+                        LocalToCloudHandoffOpenParams {
+                            forked_conversation_id: response.forked_conversation_id,
+                            launch,
+                            environment_id,
+                            intent,
+                        },
                         ctx,
                     );
                 }
@@ -13784,18 +13970,30 @@ impl Workspace {
                     log::warn!(
                         "start_local_to_cloud_handoff: fork_conversation RPC failed: {err:#}"
                     );
-                    Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
-                    let window_id = ctx.window_id();
-                    WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                        toast_stack.add_ephemeral_toast(
-                            DismissibleToast::error(
-                                "Couldn't start the handoff. Check your network connection and try again."
-                                    .to_owned(),
-                            ),
-                            window_id,
+                    if show_user_feedback {
+                        Self::restore_source_handoff_draft(
+                            &source_view,
+                            launch,
+                            environment_id,
                             ctx,
                         );
-                    });
+                        let window_id = ctx.window_id();
+                        WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                            toast_stack.add_ephemeral_toast(
+                                DismissibleToast::error(
+                                    "Couldn't start the handoff. Check your network connection and try again."
+                                        .to_owned(),
+                                ),
+                                window_id,
+                                ctx,
+                            );
+                        });
+                    } else if let Some(trigger) = intent.automatic_trigger() {
+                        log::debug!(
+                            "Automatic local-to-cloud handoff via {trigger:?} failed while forking conversation"
+                        );
+                    }
+                    Self::record_automatic_handoff_failed(intent, ctx);
                 }
             },
         );
@@ -13808,11 +14006,16 @@ impl Workspace {
         &mut self,
         source_view: ViewHandle<TerminalView>,
         source_conversation: AIConversation,
-        forked_conversation_id: String,
-        launch: Option<PendingCloudLaunch>,
-        environment_id: Option<SyncId>,
+        params: LocalToCloudHandoffOpenParams,
         ctx: &mut ViewContext<Self>,
     ) {
+        let LocalToCloudHandoffOpenParams {
+            forked_conversation_id,
+            launch,
+            environment_id,
+            intent,
+        } = params;
+        let show_user_feedback = intent.shows_user_feedback();
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         // Materialize the fork locally so the new pane can restore it.
         let title_override = source_conversation
@@ -13833,17 +14036,24 @@ impl Workspace {
                     "complete_local_to_cloud_handoff_open: failed to materialize local fork of conversation {:?} for handoff: {err:#}",
                     source_conversation.id()
                 );
-                let window_id = ctx.window_id();
-                WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                    toast_stack.add_ephemeral_toast(
-                        DismissibleToast::error(
-                        "Couldn't save your conversation locally. Try sending another message, then hand off again."
-                                .to_owned(),
-                        ),
-                        window_id,
-                        ctx,
+                if show_user_feedback {
+                    let window_id = ctx.window_id();
+                    WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                        toast_stack.add_ephemeral_toast(
+                            DismissibleToast::error(
+                                "Couldn't save your conversation locally. Try sending another message, then hand off again."
+                                    .to_owned(),
+                            ),
+                            window_id,
+                            ctx,
+                        );
+                    });
+                } else if let Some(trigger) = intent.automatic_trigger() {
+                    log::debug!(
+                        "Automatic local-to-cloud handoff via {trigger:?} failed while materializing local fork"
                     );
-                });
+                }
+                Self::record_automatic_handoff_failed(intent, ctx);
                 return;
             }
         };
@@ -13856,17 +14066,24 @@ impl Workspace {
             log::warn!(
                 "complete_local_to_cloud_handoff_open: failed to push cloud-mode pane after forking conversation"
             );
-            let window_id = ctx.window_id();
-            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                toast_stack.add_ephemeral_toast(
-                    DismissibleToast::error(
-                        "Couldn't open a cloud pane for handoff. Try again, or restart Warp if this keeps happening."
-                            .to_owned(),
-                    ),
-                    window_id,
-                    ctx,
+            if show_user_feedback {
+                let window_id = ctx.window_id();
+                WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(
+                            "Couldn't open a cloud pane for handoff. Try again, or restart Warp if this keeps happening."
+                                .to_owned(),
+                        ),
+                        window_id,
+                        ctx,
+                    );
+                });
+            } else if let Some(trigger) = intent.automatic_trigger() {
+                log::debug!(
+                    "Automatic local-to-cloud handoff via {trigger:?} failed while opening cloud pane"
                 );
-            });
+            }
+            Self::record_automatic_handoff_failed(intent, ctx);
             return;
         };
         // Restore the forked conversation into the newly-created pane.
@@ -13915,8 +14132,11 @@ impl Workspace {
         model_handle.update(ctx, |model, model_ctx| {
             model.set_pending_handoff(Some(pending), model_ctx);
         });
+        Self::record_automatic_handoff_succeeded(intent, ctx);
 
-        Self::show_handoff_success_toast(ctx);
+        if show_user_feedback {
+            Self::show_handoff_success_toast(ctx);
+        }
         model_handle.update(ctx, |model, ctx| {
             model.queue_handoff_auto_submit(ctx);
         });
@@ -21165,6 +21385,43 @@ impl TypedActionView for Workspace {
                 #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
                 {
                     let _ = (launch, environment_id, entry_point);
+                }
+            }
+            AutoHandoffActiveAgentToCloud {
+                terminal_view_id,
+                conversation_id,
+                trigger,
+            } => {
+                #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+                {
+                    let intent = LocalToCloudHandoffIntent::Automatic {
+                        trigger: *trigger,
+                        conversation_id: *conversation_id,
+                    };
+                    let launch = Some(PendingCloudLaunch {
+                        prompt: AUTO_CLOUD_HANDOFF_PROMPT.to_owned(),
+                        attachments: HandoffLaunchAttachments::default(),
+                    });
+                    if let Some(source_view) = self.terminal_view(*terminal_view_id, ctx) {
+                        self.start_local_to_cloud_handoff_from_source(
+                            source_view,
+                            launch,
+                            None,
+                            intent,
+                            ctx,
+                        );
+                    } else {
+                        log::debug!(
+                            "Skipping automatic local-to-cloud handoff via {:?}: terminal view {:?} is no longer open",
+                            trigger,
+                            terminal_view_id,
+                        );
+                        Self::record_automatic_handoff_failed(intent, ctx);
+                    }
+                }
+                #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
+                {
+                    let _ = (terminal_view_id, conversation_id, trigger);
                 }
             }
             ShowHandoffEnvironmentCreationModal => {


### PR DESCRIPTION
## Description
Adds a macOS-only **Auto handoff on sleep** setting under Warp Agent → Cloud Handoff.

When enabled, Warp listens for macOS sleep events and attempts to hand off the last-focused eligible local Warp Agent session to Cloud Mode using the existing local-to-cloud handoff flow. This also adds a `warplocal://action/auto_handoff_to_cloud` trigger for testing and hook-driven invocation; the trigger now respects the same **Auto handoff on sleep** opt-in setting.

The setting defaults to off so existing users do not silently enable automatic cloud handoff or workspace snapshot upload.

https://github.com/user-attachments/assets/38161805-065a-49b4-a4e6-18403de5b0a1

<img width="906" height="238" alt="Screenshot 2026-05-15 at 5 06 56 PM" src="https://github.com/user-attachments/assets/ccf951e4-3749-4add-a30f-868af3f41183" />

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] `cargo nextest run -p warp auto_handoff --no-fail-fast` — 13 passed
- [x] `cargo nextest run -p warp last_focused_terminal_tracks_most_recent_globally conversation_switch_updates_last_focused_terminal_state --no-fail-fast` — 2 passed
- [x] `git --no-pager diff --check origin/master...HEAD`
- [x] Manual smoke test with `./script/run --open_with_launchd` and `warplocal://action/auto_handoff_to_cloud` in the original implementation checkout

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included in this update. The PR now notes the setting is opt-in and the URI trigger respects that opt-in; please attach UI media from a local app session if required for review.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Added a macOS setting to automatically hand off active local Warp Agent sessions to Cloud Mode before sleep.

Co-Authored-By: Oz <oz-agent@warp.dev>
