### PR TITLE
fix: allow non-owner cloud conversation continuation

### DIFF
--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -197,6 +197,23 @@ impl TerminalView {
         ctx.notify();
     }
 
+    fn enable_cloud_followup_input_after_conversation_end(
+        &mut self,
+        task_id: AmbientAgentTaskId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.remove_conversation_ended_tombstone(ctx);
+
+        {
+            let mut model = self.model.lock();
+            if model.shared_session_status().is_finished_viewer() {
+                model.set_shared_session_status(SharedSessionStatus::NotShared);
+            }
+        }
+
+        self.enable_cloud_followup_input(task_id, ctx);
+    }
+
     pub(super) fn handle_viewer_role_change_menu_event(
         &mut self,
         event: &MenuEvent,
@@ -879,9 +896,8 @@ impl TerminalView {
                 self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
             }
             CloudConversationContinuationUiState::FollowupInput => {
-                self.remove_conversation_ended_tombstone(ctx);
                 if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
-                    self.enable_cloud_followup_input(task_id, ctx);
+                    self.enable_cloud_followup_input_after_conversation_end(task_id, ctx);
                 }
             }
         }
@@ -906,8 +922,7 @@ impl TerminalView {
             self.show_error_toast("Couldn't continue this cloud task.".to_string(), ctx);
             return;
         }
-        self.remove_conversation_ended_tombstone(ctx);
-        self.enable_cloud_followup_input(task_id, ctx);
+        self.enable_cloud_followup_input_after_conversation_end(task_id, ctx);
         self.focus_input_box(ctx);
         ctx.notify();
     }
@@ -1765,9 +1780,8 @@ impl TerminalView {
                 self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
             }
             Some(CloudConversationContinuationUiState::FollowupInput) => {
-                self.remove_conversation_ended_tombstone(ctx);
                 if let Some(task_id) = self.ambient_agent_task_id_for_details_panel(ctx) {
-                    self.enable_cloud_followup_input(task_id, ctx);
+                    self.enable_cloud_followup_input_after_conversation_end(task_id, ctx);
                 } else {
                     self.insert_conversation_ended_tombstone_with_cta(None, ctx);
                 }

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -76,6 +76,64 @@ fn test_prompt_context_menu_items_shared_session_viewer_no_edit_prompt() {
 }
 
 #[test]
+fn test_on_ambient_agent_execution_ended_enables_followup_input_for_editable_non_owner_finished_view(
+) {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = terminal_view_for_viewer(&mut app);
+        let task = create_cloud_mode_task_for_user("another-user");
+        let task_id = task.task_id;
+
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
+        let initial_block_height_items = terminal.read(&app, |view, _| {
+            view.model.lock().block_list().block_heights().items().len()
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let mut model = view.model.lock();
+            model.set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                task_id: Some(task_id.to_string()),
+            });
+            model.set_shared_session_status(SharedSessionStatus::FinishedViewer);
+            drop(model);
+
+            view.on_ambient_agent_execution_ended(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            assert_eq!(
+                model.block_list().block_heights().items().len(),
+                initial_block_height_items
+            );
+            assert!(matches!(
+                model.shared_session_status(),
+                SharedSessionStatus::NotShared
+            ));
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
+            assert!(view.is_input_box_visible(&model, ctx));
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Editable
+            );
+        });
+    });
+}
+
+#[test]
 fn test_shared_session_banners() {
     let _flag = FeatureFlag::CreatingSharedSessions.override_enabled(true);
 
@@ -565,7 +623,7 @@ fn test_restored_ambient_view_resolves_cta_from_view_model_task_id() {
 
     App::test((), |mut app| async move {
         let terminal = cloud_mode_terminal_for_test(&mut app);
-        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task = create_cloud_mode_task_for_user("another-user");
         let task_id = task.task_id;
 
         insert_cloud_mode_task_with_server_metadata(
@@ -605,13 +663,13 @@ fn test_restored_ambient_view_resolves_cta_from_view_model_task_id() {
 }
 
 #[test]
-fn test_restored_oz_edit_access_view_uses_followup_input_without_tombstone() {
+fn test_restored_oz_edit_access_non_owner_finished_view_uses_followup_input_without_tombstone() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
     App::test((), |mut app| async move {
         let terminal = cloud_mode_terminal_for_test(&mut app);
-        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task = create_cloud_mode_task_for_user("another-user");
         let task_id = task.task_id;
 
         insert_cloud_mode_task_with_server_metadata(
@@ -635,8 +693,11 @@ fn test_restored_oz_edit_access_view_uses_followup_input_without_tombstone() {
             ambient_agent_view_model.update(ctx, |model, ctx| {
                 model.enter_viewing_existing_session(task_id, ctx);
             });
-            let initial_block_height_items =
-                view.model.lock().block_list().block_heights().items().len();
+            let initial_block_height_items = {
+                let mut model = view.model.lock();
+                model.set_shared_session_status(SharedSessionStatus::FinishedViewer);
+                model.block_list().block_heights().items().len()
+            };
 
             view.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
 
@@ -648,6 +709,10 @@ fn test_restored_oz_edit_access_view_uses_followup_input_without_tombstone() {
             assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
             {
                 let model = view.model.lock();
+                assert!(matches!(
+                    model.shared_session_status(),
+                    SharedSessionStatus::NotShared
+                ));
                 assert!(view.is_input_box_visible(&model, ctx));
             }
             assert_eq!(
@@ -1284,10 +1349,13 @@ fn test_non_owned_tombstone_is_removed_for_followup_and_reinserted_after_complet
         let terminal = cloud_mode_terminal_for_test(&mut app);
         let task = create_cloud_mode_task_for_user("another-user");
         let task_id = task.task_id;
-
-        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
-            model.insert_task_for_test(task);
-        });
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::ClaudeCode,
+            current_user_owner_permissions(),
+        );
 
         terminal.update(&mut app, |view, ctx| {
             let mut model = view.model.lock();
@@ -1307,8 +1375,7 @@ fn test_non_owned_tombstone_is_removed_for_followup_and_reinserted_after_complet
 
             let initial_block_height_items =
                 view.model.lock().block_list().block_heights().items().len();
-
-            view.insert_conversation_ended_tombstone_with_cta(None, ctx);
+            view.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
             assert!(view.conversation_ended_tombstone_view_id.is_some());
             assert_eq!(
                 view.model.lock().block_list().block_heights().items().len(),
@@ -1318,9 +1385,25 @@ fn test_non_owned_tombstone_is_removed_for_followup_and_reinserted_after_complet
             view.start_cloud_followup_from_tombstone(task_id, ctx);
             assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
             assert!(view.conversation_ended_tombstone_view_id.is_none());
+            {
+                let model = view.model.lock();
+                assert!(matches!(
+                    model.shared_session_status(),
+                    SharedSessionStatus::NotShared
+                ));
+                assert!(view.is_input_box_visible(&model, ctx));
+                assert_eq!(
+                    model.block_list().block_heights().items().len(),
+                    initial_block_height_items
+                );
+            }
             assert_eq!(
-                view.model.lock().block_list().block_heights().items().len(),
-                initial_block_height_items
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Editable
             );
 
             view.handle_ambient_agent_event(


### PR DESCRIPTION
## Description
This PR fixes a release-blocking follow-up issue for ended cloud agent conversations that are opened by a user who did not create the conversation but does have edit-capable access.

Before this change, the UI could resolve the user as allowed to continue the conversation, remove the ended-conversation tombstone, and set up pending cloud follow-up state while the underlying terminal model remained in `FinishedViewer`. Since `FinishedViewer` makes the terminal read-only, the interactive input still stayed hidden after clicking `Continue`.

The fix is intentionally localized for release safety:

- Adds a helper that represents the specific transition from an ended shared-session viewer state into authorized cloud follow-up composition.
- The helper removes the conversation-ended tombstone, clears `FinishedViewer` back to `NotShared` only for this follow-up path, then delegates to the existing cloud follow-up input setup.
- Updates the relevant ended-session entrypoints to use the helper rather than directly enabling follow-up input.
- Adds coverage for editable non-owner ended sessions so the input becomes visible/editable while view-only cases remain read-only.

Demo Loom: https://www.loom.com/share/6fa7ea249b29466e9a0ba0e4c33277d4

Related context:

- Agent conversation: https://staging.warp.dev/conversation/8036ed8f-ca79-430f-a6fd-20ba9e79d82f
- Implementation plan: https://staging.warp.dev/drive/notebook/FA1x9RDCk0Zn7XTuiUaLAe

### Current limitations and follow-ups

This PR only fixes the client-side state transition after the client has enough server metadata to know the current user can edit/continue the conversation. It does not change server-side conversation object permissions or metadata lookup behavior.

During testing, we found a separate third-party harness edge case: a third-party conversation can render an ended tombstone without a `Continue` CTA if the server filters the conversation metadata as inaccessible. The current evidence points to a server-side access inheritance gap for third-party conversation objects: Warp-native/Oz conversation object creation copies shared-session ACLs, while the third-party conversation creation path does not reliably inherit those ACLs. That should be handled in `warp-server` as follow-up work by copying shared-session/run-visible ACLs onto third-party conversation objects when they are created.

## Linked Issue
N/A — release bug fix identified during validation.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --all --manifest-path /Users/captainsafia/code/warp/Cargo.toml`
- `cargo clippy --manifest-path /Users/captainsafia/code/warp/Cargo.toml --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo test --manifest-path /Users/captainsafia/code/warp/Cargo.toml -p warp --lib terminal::view::shared_session::view_impl::tests`
- `cargo test --manifest-path /Users/captainsafia/code/warp/Cargo.toml -p warp --lib terminal::view::shared_session::cloud_conversation_continuation::tests`

Manual/demo coverage is captured in the Loom linked above.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
- https://www.loom.com/share/6fa7ea249b29466e9a0ba0e4c33277d4

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed an issue where continuing an ended cloud agent conversation shared by another team member could leave the input hidden.

Co-Authored-By: Oz <oz-agent@warp.dev>
