### PR TITLE
Fix theme picker traffic light padding

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18139,7 +18139,7 @@ impl Workspace {
         let config = TabSettings::as_ref(ctx)
             .header_toolbar_chip_selection
             .clone();
-        if knowledge_center_closed && !self.is_theme_chooser_open() {
+        if knowledge_center_closed {
             let left_toolbar_buttons = config
                 .left_items()
                 .into_iter()

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18555,7 +18555,7 @@ impl Workspace {
             .platform_window(self.window_id)
             .map(|window| window.fullscreen_state() == FullscreenState::Fullscreen)
             .unwrap_or(false);
-        if self.current_workspace_state.is_left_panel_open() {
+        if self.is_left_panel_open(ctx) {
             0.
         } else if is_window_fullscreen && cfg!(target_os = "macos") {
             // Full-screen mode on MacOS does not need as much padding (traffic lights are hidden).

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -298,6 +298,35 @@ fn test_tab_bar_traffic_light_space_regression_for_resource_center_overlap() {
     }
 }
 
+#[test]
+fn test_theme_chooser_does_not_suppress_tab_bar_traffic_light_padding() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            let closed_padding = workspace.compute_tab_bar_left_padding(ctx);
+            assert!(
+                closed_padding > 0.,
+                "Tab bar should reserve left padding when no left panel is open"
+            );
+
+            workspace.current_workspace_state.is_theme_chooser_open = true;
+            assert_eq!(
+                workspace.compute_tab_bar_left_padding(ctx),
+                closed_padding,
+                "Theme chooser should not be treated as a left panel for tab bar padding"
+            );
+
+            workspace.open_left_panel(ctx);
+            assert_eq!(
+                workspace.compute_tab_bar_left_padding(ctx),
+                0.,
+                "Actual left panel should still suppress tab bar left padding"
+            );
+        });
+    });
+}
 #[cfg(feature = "local_fs")]
 fn open_worktree_sidecar(workspace: &ViewHandle<Workspace>, app: &mut App) {
     workspace.update(app, |workspace, ctx| {


### PR DESCRIPTION
## Description
Fixes theme picker traffic-light overlap by making tab bar left padding depend on the active pane group's actual tools-panel state instead of `WorkspaceState::is_left_panel_open()`, which treats the theme chooser as a left panel.

This preserves traffic-light padding while the theme picker is open, while still removing the padding when the real left panel is open.


https://github.com/user-attachments/assets/01a3b6da-6370-43d1-9b07-197dabe60bf2



## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt --all --manifest-path /workspace/warp/Cargo.toml -- --check`
- [x] `cargo test -p warp test_theme_chooser_does_not_suppress_tab_bar_traffic_light_padding`
- [x] `cargo clippy -p warp --lib --tests -- -D warnings`
- [ ] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` (blocked in this sandbox because generated channel config files were missing for the `dev`, `preview`, and `local` binary test targets: `dev_config.json`, `preview_config.json`, and `local_config.json` under `target/debug/build/warp-*/out/`)
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not captured in this Linux sandbox; change is covered by a regression unit test.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the theme picker causing the top tab bar to pass underneath macOS traffic light buttons.

_Conversation: https://staging.warp.dev/conversation/9a24ca19-69b6-4fbb-bdf2-1332d81cb348_
_Run: https://oz.staging.warp.dev/runs/019e2d5f-c76c-7bda-b369-518f9d37744e_
_This PR was generated with [Oz](https://warp.dev/oz)._
