### PR TITLE
Add more logging around starting shared sessions

### DIFF
--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -212,6 +212,7 @@ impl TerminalDriver {
                 let _ = tx.send(Err(ShareSessionError::Disabled));
                 (None, Some(rx))
             } else {
+                log::info!("Waiting for requested session sharing to start");
                 let (tx, rx) = oneshot::channel();
                 (Some(tx), Some(rx))
             }

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -334,12 +334,22 @@ impl TerminalManager {
         // If this session should be a shared-session creator, configure its initial
         // shared-session state before we construct the view, so that bootstrap
         // events can observe the correct pending status and source type.
-        if FeatureFlag::CreatingSharedSessions.is_enabled() {
-            if let IsSharedSessionCreator::Yes { source_type } = is_shared_session_creator {
+        match is_shared_session_creator {
+            IsSharedSessionCreator::Yes { source_type }
+                if FeatureFlag::CreatingSharedSessions.is_enabled() =>
+            {
                 model.lock().set_shared_session_status(
                     SharedSessionStatus::SharePendingPreBootstrap { source_type },
                 );
+                log::info!("Configured terminal to start sharing after bootstrap");
             }
+            IsSharedSessionCreator::Yes { .. } => {
+                log::warn!(
+                    "Session sharing was requested, but CreatingSharedSessions is disabled; \
+                     skipping shared-session startup"
+                );
+            }
+            IsSharedSessionCreator::No => {}
         }
 
         // Initialize the PtyController.
@@ -1313,6 +1323,7 @@ impl TerminalManager {
             log::warn!("Tried to share a session that's already being shared.");
             return;
         }
+        log::info!("Starting shared session");
 
         // Record the source type on the model so we can distinguish ambient agent
         // sessions from user-initiated shared sessions in the UI logic.
@@ -2266,6 +2277,12 @@ impl TerminalManager {
                     window_id,
                     sharer_remote_update_guard.clone(),
                     ctx,
+                );
+            }
+            TerminalViewEvent::StartSharingCurrentSession { .. } => {
+                log::warn!(
+                    "Ignoring request to start sharing current session because \
+                     CreatingSharedSessions is disabled"
                 );
             }
             TerminalViewEvent::StopSharingCurrentSession { reason } => {

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -235,11 +235,6 @@ impl Network {
         let scrollback = scrollback_type.to_scrollback(&model.lock());
         let num_bytes_scrollback = scrollback.num_bytes();
         let max_session_size = max_session_size(ctx);
-        log::info!(
-            "Initializing session sharer network: scrollback_bytes={}, max_session_size={}",
-            num_bytes_scrollback.as_u64(),
-            max_session_size.as_u64()
-        );
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let init_block_id = model.lock().block_list().active_block_id().clone();
@@ -288,7 +283,6 @@ impl Network {
                 cause: None,
             });
         } else {
-            log::info!("Starting session sharing websocket task");
             network.start_ordered_terminal_events_listener(ordered_events_rx, ctx);
             network.start_websocket(
                 ws_proxy_rx,

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -234,6 +234,12 @@ impl Network {
         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
         let scrollback = scrollback_type.to_scrollback(&model.lock());
         let num_bytes_scrollback = scrollback.num_bytes();
+        let max_session_size = max_session_size(ctx);
+        log::info!(
+            "Initializing session sharer network: scrollback_bytes={}, max_session_size={}",
+            num_bytes_scrollback.as_u64(),
+            max_session_size.as_u64()
+        );
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let init_block_id = model.lock().block_list().active_block_id().clone();
@@ -249,7 +255,7 @@ impl Network {
             ws_proxy_rx: ws_proxy_rx.clone(),
             selection_throttled_tx,
             num_bytes_shared: num_bytes_scrollback,
-            max_session_size: max_session_size(ctx),
+            max_session_size,
             pty_bytes_batch_status: PtyBytesBatchStatus::NotBatching {
                 last_sent_at: Instant::now(),
             },
@@ -276,11 +282,13 @@ impl Network {
 
         // We should validate the scrollback is under the limit before creating the Network, but check here just to be safe.
         if num_bytes_scrollback > network.max_session_size {
+            log::warn!("Session sharing scrollback exceeds max session size; failing startup");
             ctx.emit(NetworkEvent::FailedToCreateSharedSession {
                 reason: FailedToInitializeSessionReason::ScrollbackTooLarge {},
                 cause: None,
             });
         } else {
+            log::info!("Starting session sharing websocket task");
             network.start_ordered_terminal_events_listener(ordered_events_rx, ctx);
             network.start_websocket(
                 ws_proxy_rx,
@@ -605,6 +613,7 @@ impl Network {
 
         ctx.spawn(
             async move {
+                log::info!("Connecting to session sharing server");
                 let Some(create_endpoint) = connect_endpoint("/sessions/create".to_owned()) else {
                     anyhow::bail!("This channel does not support session-sharing.");
                 };
@@ -617,6 +626,7 @@ impl Network {
                         .and_then(|token| token.bearer_token()),
                 };
                 let socket = WebSocket::connect(create_endpoint, None).await?;
+                log::info!("Connected to session sharing server; preparing initialization");
                 anyhow::Ok((socket.split().await, user_id))
             },
             move |network, conn, ctx| match conn {
@@ -651,6 +661,7 @@ impl Network {
                         log::error!("Sharer failed to send initialization message: {e}");
                         return;
                     }
+                    log::info!("Sent session sharing initialization message");
 
                     network.on_websocket_connected(ws_proxy_rx, sink, stream, ctx);
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -12709,6 +12709,7 @@ impl TerminalView {
             _ => None,
         };
         if let Some(source_type) = source_type_opt {
+            log::info!("Terminal bootstrapped with pending shared session; attempting to share");
             self.attempt_to_share_session(
                 SharedSessionScrollbackType::All,
                 None,

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -547,6 +547,7 @@ impl TerminalView {
         self.model
             .lock()
             .set_shared_session_status(SharedSessionStatus::SharePending);
+        log::info!("Emitting request to start sharing current session");
 
         ctx.emit(Event::StartSharingCurrentSession {
             scrollback_type,


### PR DESCRIPTION
## Description

We should have more logs to debug cases we time out waiting to start a shared session, especially for oz runs. It's not a frequent event so it's okay to have more detailed logs.

## Testing

Ran locally and started a shared session. Logs are reasonable and not too verbose
```
15:02:40.422 [INFO] [warpui_core::core::app] dispatching typed action: warp::terminal::shared_session::share_modal::body::BodyAction::StartSharing
15:02:40.423 [INFO] [warp::terminal::view::shared_session::view_impl] Emitting request to start sharing current session
15:02:40.423 [INFO] [warp::terminal::local_tty::terminal_manager] Starting shared session
15:02:40.423 [INFO] [warp::terminal::shared_session::sharer::network] Connecting to session sharing server
15:02:41.055 [INFO] [warp::terminal::shared_session::sharer::network] Connected to session sharing server; preparing initialization
15:02:41.055 [INFO] [warp::terminal::shared_session::sharer::network] Sent session sharing initialization message
15:02:41.160 [INFO] [warpui_core::core::app] notifying view observers and updating windows for timer id 153
15:02:41.276 [INFO] [warp::terminal::shared_session::sharer::network] Successfully created shared session.
```