### PR TITLE
Send retained message IDs to server when forking at exchange boundary

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1214,6 +1214,36 @@ impl BlocklistAIHistoryModel {
         Ok(forked_conversation)
     }
 
+    /// Computes the flattened set of message IDs that would be retained when forking
+    /// a conversation at a specific exchange boundary. Used to tell the server which
+    /// messages to keep when truncating the server-side fork.
+    pub fn compute_retained_message_ids(
+        source_conversation: &AIConversation,
+        from_exchange_id: AIAgentExchangeId,
+        fork_from_exact_exchange: bool,
+    ) -> Vec<String> {
+        let exchanges_by_task = source_conversation.all_exchanges_by_task();
+        let root_task_id = source_conversation.get_root_task_id().clone();
+
+        let mut all_ids: Vec<String> = Vec::new();
+        let mut found_from_exchange_id = false;
+        'outer: for (task_id, task_exchanges) in exchanges_by_task.into_iter() {
+            for exchange in task_exchanges {
+                if found_from_exchange_id && task_id == root_task_id && exchange.has_user_query() {
+                    break 'outer;
+                }
+                all_ids.extend(exchange.added_message_ids.iter().map(|id| id.to_string()));
+                if exchange.id == from_exchange_id {
+                    if fork_from_exact_exchange {
+                        break 'outer;
+                    }
+                    found_from_exchange_id = true;
+                }
+            }
+        }
+        all_ids
+    }
+
     /// Forks an existing conversation at a specific exchange boundary. When `exact_exchange`
     /// is true, the fork includes all messages up to and including the selected exchange.
     /// Otherwise, it extends through the full response (every message after the user's query

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -296,6 +296,8 @@ pub struct UploadLocalHandoffSnapshotResponse {
 pub(crate) struct ForkConversationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_ids: Option<Vec<String>>,
 }
 
 /// Response body for `POST /agent/conversations/{conversation_id}/fork`. The returned id is sent
@@ -943,6 +945,7 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         conversation_id: String,
         title: Option<String>,
+        message_ids: Option<Vec<String>>,
     ) -> anyhow::Result<ForkConversationResponse, anyhow::Error>;
 
     async fn list_ambient_agent_tasks(
@@ -1714,8 +1717,9 @@ impl AIClient for ServerApi {
         &self,
         conversation_id: String,
         title: Option<String>,
+        message_ids: Option<Vec<String>>,
     ) -> anyhow::Result<ForkConversationResponse, anyhow::Error> {
-        let request = ForkConversationRequest { title };
+        let request = ForkConversationRequest { title, message_ids };
         let response: ForkConversationResponse = self
             .post_public_api(&build_fork_conversation_url(&conversation_id), &request)
             .await?;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11778,12 +11778,22 @@ impl Workspace {
                 .map(|t| t.as_str().to_string());
             let title_for_fork = source_conversation.title();
 
+            // Compute retained message IDs for exchange-based forks so the
+            // server can truncate its copy to match the local truncation point.
+            let message_ids_for_server = fork_from_exchange.as_ref().map(|fork_from| {
+                BlocklistAIHistoryModel::compute_retained_message_ids(
+                    &source_conversation,
+                    fork_from.exchange_id,
+                    fork_from.fork_from_exact_exchange,
+                )
+            });
+
             if let Some(source_token) = source_server_token.filter(|_| cloud_storage_enabled) {
                 let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
                 ctx.spawn(
                     async move {
                         ai_client
-                            .fork_conversation(source_token, title_for_fork)
+                            .fork_conversation(source_token, title_for_fork, message_ids_for_server)
                             .await
                     },
                     move |workspace, result, ctx| {
@@ -13677,7 +13687,7 @@ impl Workspace {
         ctx.spawn(
             async move {
                 ai_client
-                    .fork_conversation(source_conversation_id, title_for_fork)
+                    .fork_conversation(source_conversation_id, title_for_fork, None)
                     .await
             },
             move |me, result, ctx| match result {


### PR DESCRIPTION
## Description

When forking a conversation at a specific exchange boundary (e.g. "Fork from exact exchange"), the client truncates the conversation locally to only include messages up to that exchange. However, the server's `ForkConversation` endpoint copies the **entire** GCS conversation data — including exchanges after the fork point. This mismatch causes the server-side fork to have more exchanges than the local fork, leading to `TaskNotFound` errors and transcript corruption during cloud-to-cloud handoff session sharing replay.

This PR adds an optional `message_ids` field to the `ForkConversationRequest`. When the client forks at an exchange boundary, it computes the flattened set of retained message IDs and sends them to the server so the server can truncate its copy to match.

### Changes
- **`ForkConversationRequest`**: Added optional `message_ids: Option<Vec<String>>` field (serialized with `skip_serializing_if`)
- **`AIClient::fork_conversation`**: Added `message_ids` parameter to the trait method and implementation
- **`BlocklistAIHistoryModel::compute_retained_message_ids`**: New helper that computes the flat list of message IDs to retain when forking at a specific exchange — mirrors the truncation logic in `fork_conversation_at_exchange`
- **`fork_ai_conversation`** (workspace/view.rs): Computes `message_ids_for_server` from the source conversation before the async server fork call
- Full-fork callers (handoff, rewind backup) pass `None` since they copy the entire conversation

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Server-side counterpart required to actually truncate. This PR only sends the IDs; the server needs to read and filter them.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed server-side conversation fork including exchanges beyond the fork point, which could cause transcript corruption during cloud handoff.
-->

_Conversation: https://staging.warp.dev/conversation/e0c9487c-9002-412e-a111-d9bcc83c1532_
_Run: https://oz.staging.warp.dev/runs/019e2dae-62d5-7985-b442-bdb183f9508e_
_This PR was generated with [Oz](https://warp.dev/oz)._
