### PR TITLE
don't fork in the cloud for fork-from

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11778,7 +11778,14 @@ impl Workspace {
                 .map(|t| t.as_str().to_string());
             let title_for_fork = source_conversation.title();
 
-            if let Some(source_token) = source_server_token.filter(|_| cloud_storage_enabled) {
+            // Skip the server-side fork when forking from a specific exchange.
+            // The server's ForkConversation copies the entire GCS conversation
+            // data, which includes exchanges after the fork point. This creates
+            // a mismatch with the locally-truncated fork and causes TaskNotFound
+            // errors during cloud-to-cloud handoff replay.
+            let should_server_fork =
+                cloud_storage_enabled && fork_from_exchange.is_none();
+            if let Some(source_token) = source_server_token.filter(|_| should_server_fork) {
                 let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
                 ctx.spawn(
                     async move {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

The fork endpoint doesn't allow you to specify a specific request ID to stop at, and even if it did I don't really think we want to do that (because right now the endpoint just copies all GCS data and calls it a day). To fix this, we should just not fork in the cloud for when we fork from a specific request.

I don't think this feature is used much anyways, and even if it was all this disables is forking from a specific query and then immediately handing off (as opposed to sending one more request and then handing off)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
