### PR TITLE
fix: strip surrounding quotes from tab path in parse_tab_path function

### DIFF
--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -799,7 +799,24 @@ fn find_matching_tab_config(target: &str, configs: Vec<TabConfig>) -> Option<Tab
 /// user's home directory.
 fn parse_tab_path(url: &Url) -> Option<PathBuf> {
     let raw = url.query_pairs().find(|(k, _)| k == "path")?.1;
-    Some(PathBuf::from(shellexpand::tilde(&raw).into_owned()))
+    let raw = strip_surrounding_path_quotes(raw.as_ref());
+    Some(PathBuf::from(shellexpand::tilde(raw).into_owned()))
+}
+
+fn strip_surrounding_path_quotes(raw: &str) -> &str {
+    if raw.len() < 2 {
+        return raw;
+    }
+
+    let bytes = raw.as_bytes();
+    if matches!(
+        (bytes.first(), bytes.last()),
+        (Some(b'"'), Some(b'"')) | (Some(b'\''), Some(b'\''))
+    ) {
+        &raw[1..raw.len() - 1]
+    } else {
+        raw
+    }
 }
 
 #[derive(Debug)]

--- a/app/src/uri/uri_tests.rs
+++ b/app/src/uri/uri_tests.rs
@@ -629,6 +629,22 @@ fn test_parse_tab_path_bare_tilde() {
     assert_eq!(parse_tab_path(&url), Some(home));
 }
 
+#[test]
+fn test_parse_tab_path_strips_surrounding_quotes() {
+    let url = Url::parse("warp://action/new_tab?path=%22C:%5CProjects%5Cmy-app%22").unwrap();
+    assert_eq!(
+        parse_tab_path(&url),
+        Some(PathBuf::from(r"C:\Projects\my-app"))
+    );
+}
+
+#[test]
+fn test_parse_tab_path_strips_quotes_before_expanding_tilde() {
+    let url = Url::parse("warp://action/new_tab?path=%22~%2FProjects%22").unwrap();
+    let home = dirs::home_dir().expect("HOME must be set for this test");
+    assert_eq!(parse_tab_path(&url), Some(home.join("Projects")));
+}
+
 // Regression coverage for issue #9005: shell scripts opened via `file://` should run,
 // not open in the editor. Exercised through the pure routing helper to avoid standing
 // up a full `AppContext`.


### PR DESCRIPTION
Fixes Windows Explorer "Open Warp in new tab" path handling when the path query value arrives wrapped
  in quotes. The URI parser now strips matching surrounding quotes before tilde expansion and path
  conversion, so valid Windows directory paths are not dropped and do not fall back to the home
  directory.