### PR TITLE
Add keybinding to toggle file navigation in Code Review

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -7027,12 +7027,11 @@ impl View for CodeReviewView {
     fn keymap_context(&self, ctx: &AppContext) -> warpui::keymap::Context {
         let mut context = Self::default_keymap_context();
 
-        // Surface a context flag that is true only when no descendant text editor
-        // is focused. This lets us register single-letter shortcuts on the pane
-        // (e.g. `F` to toggle file navigation) without stealing keystrokes from
-        // file editors or comment composers within the pane. Note that the inline
-        // file diff editors call `ctx.focus_self()` on `CodeEditorView`, so we
-        // check that variant in addition to the lower-level editor view names.
+        // Suppress pane-level shortcuts (e.g. `F`) when a descendant text editor
+        // is focused; otherwise the binding fires before the editor receives
+        // the keystroke as text input. Covers the three text-input surfaces in
+        // this pane: diff editor (`CodeEditorView`), comment composers
+        // (`RichTextEditorView`), and the find bar (`EditorView`).
         let editor_focused = ctx
             .focused_view_id(self.window_id)
             .and_then(|view_id| ctx.view_name(self.window_id, view_id))

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -75,7 +75,7 @@ use crate::{
     quit_warning::UnsavedStateSummary,
     terminal::input::MenuPositioning,
     terminal::view::{CliAgentRouting, InitProjectModel, TerminalAction, TerminalView},
-    util::bindings::{custom_tag_to_keystroke, CustomAction},
+    util::bindings::{custom_tag_to_keystroke, keybinding_name_to_display_string, CustomAction},
     view_components::{
         action_button::{
             ActionButton, ActionButtonTheme, AdjoinedSide, ButtonSize, DangerPrimaryTheme,
@@ -337,6 +337,20 @@ pub fn get_discard_button_disabled_tooltip(git_operation_blocked: bool) -> Strin
             .to_string()
     } else {
         "No changes to discard".to_string()
+    }
+}
+
+/// Builds the tooltip text for the file navigation toggle button, including the
+/// live shortcut for `code_review:toggle_file_navigation` when one is bound.
+fn file_nav_button_tooltip(is_sidebar_expanded: bool, app: &AppContext) -> String {
+    let label = if is_sidebar_expanded {
+        "Hide file navigation"
+    } else {
+        "Show file navigation"
+    };
+    match keybinding_name_to_display_string("code_review:toggle_file_navigation", app) {
+        Some(shortcut) => format!("{label} ({shortcut})"),
+        None => label.to_string(),
     }
 }
 
@@ -1141,10 +1155,10 @@ impl CodeReviewView {
                 .on_click(|ctx| ctx.dispatch_typed_action(CodeReviewAction::OpenHeaderMenu))
         });
 
-        let file_nav_button = ctx.add_typed_action_view(|_ctx| {
+        let file_nav_button = ctx.add_typed_action_view(|ctx| {
             ActionButton::new("", NakedTheme)
                 .with_icon(Icon::FileCopy)
-                .with_tooltip("Show file navigation")
+                .with_tooltip(file_nav_button_tooltip(false, ctx))
                 .on_click(|ctx| ctx.dispatch_typed_action(CodeReviewAction::ToggleFileSidebar))
         });
 
@@ -1412,11 +1426,7 @@ impl CodeReviewView {
     }
 
     fn update_file_nav_button_tooltip(&self, ctx: &mut ViewContext<Self>) {
-        let tooltip = if self.file_sidebar_expanded {
-            "Hide file navigation"
-        } else {
-            "Show file navigation"
-        };
+        let tooltip = file_nav_button_tooltip(self.file_sidebar_expanded, ctx);
         self.file_nav_button.update(ctx, |button, ctx| {
             button.set_tooltip(Some(tooltip), ctx);
         });
@@ -7012,6 +7022,28 @@ impl View for CodeReviewView {
 
     fn ui_name() -> &'static str {
         "CodeReviewView"
+    }
+
+    fn keymap_context(&self, ctx: &AppContext) -> warpui::keymap::Context {
+        let mut context = Self::default_keymap_context();
+
+        // Surface a context flag that is true only when no descendant text editor
+        // is focused. This lets us register single-letter shortcuts on the pane
+        // (e.g. `F` to toggle file navigation) without stealing keystrokes from
+        // file editors or comment composers within the pane. Note that the inline
+        // file diff editors call `ctx.focus_self()` on `CodeEditorView`, so we
+        // check that variant in addition to the lower-level editor view names.
+        let editor_focused = ctx
+            .focused_view_id(self.window_id)
+            .and_then(|view_id| ctx.view_name(self.window_id, view_id))
+            .is_some_and(|name| {
+                matches!(name, "EditorView" | "RichTextEditorView" | "CodeEditorView")
+            });
+        if !editor_focused {
+            context.set.insert("CodeReviewView_NotEditing");
+        }
+
+        context
     }
 }
 

--- a/app/src/code_review/mod.rs
+++ b/app/src/code_review/mod.rs
@@ -70,6 +70,14 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(id!("CodeReviewView"))
         .with_key_binding("cmdorctrl-f")
         .with_enabled(|| crate::features::FeatureFlag::CodeReviewFind.is_enabled()),
+        EditableBinding::new(
+            "code_review:toggle_file_navigation",
+            "Toggle file navigation in code review",
+            CodeReviewAction::ToggleFileSidebar,
+        )
+        .with_context_predicate(id!("CodeReviewView_NotEditing"))
+        .with_key_binding("f")
+        .with_enabled(|| crate::features::FeatureFlag::GitOperationsInCodeReview.is_enabled()),
     ]);
 
     app.register_fixed_bindings([FixedBinding::custom(


### PR DESCRIPTION
## Description
Adds an `F` keyboard shortcut for toggling the file navigation sidebar in the Code Review pane. Fires only when the Code Review pane is in scope **and** no descendant text editor (file diff editor, find bar, or comment composer) is focused, so typing `f` inside any of those still inserts the character.

### Implementation notes
- `CodeReviewView::keymap_context` now adds a `"CodeReviewView_NotEditing"` flag when the focused view is not `EditorView`, `RichTextEditorView`, or `CodeEditorView` (the inline diff editor focuses itself).
- New editable binding `code_review:toggle_file_navigation` → `CodeReviewAction::ToggleFileSidebar`, scoped to that flag and gated behind `FeatureFlag::GitOperationsInCodeReview` so the shortcut only registers when the file-nav button is live. Users can rebind it from Settings → Keybindings.
- The file-nav button's tooltip is built dynamically and includes the live shortcut (e.g. `Show file navigation (F)` / `Hide file navigation (F)`), via `keybinding_name_to_display_string` so it honors user customizations.

## Linked Issue
N/A. Sourced from internal #feedback-app channel.

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- Opened Code Review, pressed `F` → sidebar toggles (and tooltip updates between Show/Hide with the `(F)` hint).
- Clicked into an inline file diff editor, pressed `f` → letter is typed, sidebar untouched.
- Opened the comment composer, pressed `f` → letter is typed.
- Focused the find bar input, pressed `f` → letter is typed.
- Verified `cargo fmt --check` and `cargo clippy --workspace --all-targets --tests -- -D warnings` pass.

### Screenshots / Videos
Demo [here](https://www.loom.com/share/0651f16a324f4680bdbf34cf081c1e92).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Agent conversation](https://staging.warp.dev/conversation/ff84dcc9-b89b-4e66-9e57-1a73e74cbfb7) · [Plan](https://staging.warp.dev/drive/notebook/RmsWhzB4TBXERsAzMEGFv2)

<!--
CHANGELOG-IMPROVEMENT: Press `F` in the Code Review pane to toggle the file navigation sidebar.
-->
