### PR TITLE
Fix dormant Claude wake message race

### DIFF
--- a/app/src/ai/agent_events/driver.rs
+++ b/app/src/ai/agent_events/driver.rs
@@ -83,6 +83,27 @@ pub(crate) enum AgentEventDriverState {
     ProactiveReconnect,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AgentMessageEventMetadata {
+    pub sequence: i64,
+    pub message_id: String,
+    pub occurred_at: String,
+}
+
+impl AgentMessageEventMetadata {
+    pub(crate) fn from_event(event: &AgentRunEvent) -> Option<Self> {
+        if event.event_type != "new_message" {
+            return None;
+        }
+
+        Some(Self {
+            sequence: event.sequence,
+            message_id: event.ref_id.clone()?,
+            occurred_at: event.occurred_at.clone(),
+        })
+    }
+}
+
 /// Parsed items emitted by an [`AgentEventSource`].
 pub(crate) enum AgentEventSourceItem {
     Open,

--- a/app/src/ai/agent_events/message_hydrator.rs
+++ b/app/src/ai/agent_events/message_hydrator.rs
@@ -6,13 +6,21 @@ use anyhow::{anyhow, Context, Result};
 #[cfg(not(target_family = "wasm"))]
 use futures::future::Either;
 #[cfg(not(target_family = "wasm"))]
+use instant::Instant;
+#[cfg(not(target_family = "wasm"))]
 use warpui::r#async::Timer;
 
 use crate::ai::agent::ReceivedMessageInput;
+#[cfg(not(target_family = "wasm"))]
+use crate::server::retry_strategies::is_transient_http_error;
 use crate::server::server_api::ai::{AIClient, AgentRunEvent, ReadAgentMessageResponse};
+#[cfg(not(target_family = "wasm"))]
+use crate::server::server_api::presigned_upload::HttpStatusError;
 use crate::server::server_api::ServerApi;
 
 pub(crate) const DEFAULT_AGENT_MESSAGE_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(not(target_family = "wasm"))]
+const DEFAULT_AGENT_MESSAGE_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 /// Hydrates `new_message` agent events into full message payloads and delivery
 /// acknowledgements.
@@ -23,6 +31,8 @@ pub(crate) struct MessageHydrator {
     task_id: Option<AmbientAgentTaskId>,
     #[cfg_attr(target_family = "wasm", allow(dead_code))]
     fetch_timeout: Duration,
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    retry_delay: Duration,
 }
 
 impl MessageHydrator {
@@ -37,6 +47,22 @@ impl MessageHydrator {
             task_scoped_server_api: Some(server_api),
             task_id: Some(task_id),
             fetch_timeout: DEFAULT_AGENT_MESSAGE_FETCH_TIMEOUT,
+            retry_delay: DEFAULT_AGENT_MESSAGE_RETRY_DELAY,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_fetch_timing(
+        ai_client: Arc<dyn AIClient>,
+        fetch_timeout: Duration,
+        retry_delay: Duration,
+    ) -> Self {
+        Self {
+            ai_client,
+            task_scoped_server_api: None,
+            task_id: None,
+            fetch_timeout,
+            retry_delay,
         }
     }
 
@@ -49,6 +75,7 @@ impl MessageHydrator {
             task_scoped_server_api: None,
             task_id: None,
             fetch_timeout,
+            retry_delay: DEFAULT_AGENT_MESSAGE_RETRY_DELAY,
         }
     }
 
@@ -109,14 +136,35 @@ impl MessageHydrator {
         &self,
         message_id: &str,
     ) -> Result<ReadAgentMessageResponse> {
-        let read_message = self.read_message(message_id);
-        let timeout = Timer::after(self.fetch_timeout);
-        futures::pin_mut!(read_message);
-        futures::pin_mut!(timeout);
+        let deadline = Instant::now() + self.fetch_timeout;
+        let mut last_error = None;
 
-        match futures::future::select(read_message, timeout).await {
-            Either::Left((result, _)) => result,
-            Either::Right(_) => Err(anyhow!("Timed out reading agent message {message_id}")),
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(message_read_timeout_error(message_id, last_error));
+            }
+
+            let read_message = self.read_message(message_id);
+            let timeout = Timer::after(remaining);
+            futures::pin_mut!(read_message);
+            futures::pin_mut!(timeout);
+
+            match futures::future::select(read_message, timeout).await {
+                Either::Left((Ok(message), _)) => return Ok(message),
+                Either::Left((Err(err), _)) if should_retry_message_read_error(&err) => {
+                    last_error = Some(err);
+                    let sleep_duration = self
+                        .retry_delay
+                        .min(deadline.saturating_duration_since(Instant::now()));
+                    if sleep_duration.is_zero() {
+                        return Err(message_read_timeout_error(message_id, last_error));
+                    }
+                    Timer::after(sleep_duration).await;
+                }
+                Either::Left((Err(err), _)) => return Err(err),
+                Either::Right(_) => return Err(message_read_timeout_error(message_id, last_error)),
+            }
         }
     }
 
@@ -167,5 +215,31 @@ impl MessageHydrator {
             }
         }
         failures
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn should_retry_message_read_error(err: &anyhow::Error) -> bool {
+    // Immediate read-after-event lag can surface as a short-lived 404 before
+    // the message row becomes readable. Treat that the same as the existing
+    // transient transport errors and keep retrying within the caller's timeout
+    // window.
+    for cause in err.chain() {
+        if let Some(http_err) = cause.downcast_ref::<HttpStatusError>() {
+            return matches!(http_err.status, 404 | 408 | 429 | 500..=599);
+        }
+    }
+    is_transient_http_error(err)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn message_read_timeout_error(
+    message_id: &str,
+    last_error: Option<anyhow::Error>,
+) -> anyhow::Error {
+    let timeout_error = anyhow!("Timed out reading agent message {message_id}");
+    match last_error {
+        Some(err) => timeout_error.context(err),
+        None => timeout_error,
     }
 }

--- a/app/src/ai/agent_events/message_hydrator.rs
+++ b/app/src/ai/agent_events/message_hydrator.rs
@@ -8,18 +8,17 @@ use futures::future::Either;
 #[cfg(not(target_family = "wasm"))]
 use instant::Instant;
 #[cfg(not(target_family = "wasm"))]
+use reqwest::Error as ReqwestError;
+#[cfg(not(target_family = "wasm"))]
 use warpui::r#async::Timer;
 
 use crate::ai::agent::ReceivedMessageInput;
-#[cfg(not(target_family = "wasm"))]
-use crate::server::retry_strategies::is_transient_http_error;
 use crate::server::server_api::ai::{AIClient, AgentRunEvent, ReadAgentMessageResponse};
 #[cfg(not(target_family = "wasm"))]
 use crate::server::server_api::presigned_upload::HttpStatusError;
 use crate::server::server_api::ServerApi;
 
 pub(crate) const DEFAULT_AGENT_MESSAGE_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
-#[cfg(not(target_family = "wasm"))]
 const DEFAULT_AGENT_MESSAGE_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 /// Hydrates `new_message` agent events into full message payloads and delivery
@@ -221,15 +220,32 @@ impl MessageHydrator {
 #[cfg(not(target_family = "wasm"))]
 fn should_retry_message_read_error(err: &anyhow::Error) -> bool {
     // Immediate read-after-event lag can surface as a short-lived 404 before
-    // the message row becomes readable. Treat that the same as the existing
-    // transient transport errors and keep retrying within the caller's timeout
-    // window.
-    for cause in err.chain() {
-        if let Some(http_err) = cause.downcast_ref::<HttpStatusError>() {
-            return matches!(http_err.status, 404 | 408 | 429 | 500..=599);
-        }
+    // the message row becomes readable. Restrict retries to status-preserving
+    // eventual-consistency/server responses plus clearly transient transport
+    // failures so permanent 4xxs fail fast instead of timing out.
+    if let Some(status) = message_read_error_status(err) {
+        return matches!(status, 404 | 408 | 429 | 500..=599);
     }
-    is_transient_http_error(err)
+
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<ReqwestError>()
+            .is_some_and(is_transient_message_read_transport_error)
+    })
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn message_read_error_status(err: &anyhow::Error) -> Option<u16> {
+    err.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<HttpStatusError>()
+            .map(|http_err| http_err.status)
+    })
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn is_transient_message_read_transport_error(err: &ReqwestError) -> bool {
+    err.is_timeout() || err.is_connect()
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/app/src/ai/agent_events/message_hydrator_tests.rs
+++ b/app/src/ai/agent_events/message_hydrator_tests.rs
@@ -1,4 +1,6 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use mockall::predicate::eq;
 
@@ -6,6 +8,7 @@ use super::*;
 use crate::server::server_api::ai::{
     AIClient, AgentRunEvent, MockAIClient, ReadAgentMessageResponse,
 };
+use crate::server::server_api::presigned_upload::HttpStatusError;
 
 fn make_run_event(
     sequence: i64,
@@ -23,6 +26,25 @@ fn make_run_event(
     }
 }
 
+fn make_message_response(message_id: &str) -> ReadAgentMessageResponse {
+    ReadAgentMessageResponse {
+        message_id: message_id.to_string(),
+        sender_run_id: "parent-run".to_string(),
+        subject: "Need a redirect".to_string(),
+        body: "Switch to the failing test first.".to_string(),
+        sent_at: "2026-01-01T00:00:00Z".to_string(),
+        delivered_at: None,
+        read_at: Some("2026-01-01T00:00:01Z".to_string()),
+    }
+}
+
+fn transient_read_error(status: u16) -> anyhow::Error {
+    anyhow::Error::new(HttpStatusError {
+        status,
+        body: format!("status {status} body"),
+    })
+}
+
 #[tokio::test]
 async fn hydrator_reads_new_message_for_matching_run() {
     let mut ai_client = MockAIClient::new();
@@ -30,17 +52,7 @@ async fn hydrator_reads_new_message_for_matching_run() {
         .expect_read_agent_message()
         .with(eq("msg-123"))
         .times(1)
-        .returning(|_| {
-            Ok(ReadAgentMessageResponse {
-                message_id: "msg-123".to_string(),
-                sender_run_id: "parent-run".to_string(),
-                subject: "Need a redirect".to_string(),
-                body: "Switch to the failing test first.".to_string(),
-                sent_at: "2026-01-01T00:00:00Z".to_string(),
-                delivered_at: None,
-                read_at: Some("2026-01-01T00:00:01Z".to_string()),
-            })
-        });
+        .returning(|_| Ok(make_message_response("msg-123")));
 
     let ai_client: Arc<dyn AIClient> = Arc::new(ai_client);
     let hydrator = MessageHydrator::new(ai_client);
@@ -68,4 +80,72 @@ async fn hydrator_ignores_events_for_other_runs() {
         .hydrate_event_for_recipient(&event, "child-run")
         .await
         .is_none());
+}
+
+#[tokio::test]
+async fn read_message_with_timeout_retries_transient_failures_until_success() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_clone = attempts.clone();
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_read_agent_message()
+        .with(eq("msg-123"))
+        .times(2)
+        .returning(move |_| {
+            let attempt = attempts_clone.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                Err(transient_read_error(404))
+            } else {
+                Ok(make_message_response("msg-123"))
+            }
+        });
+
+    let ai_client: Arc<dyn AIClient> = Arc::new(ai_client);
+    let hydrator = MessageHydrator::with_fetch_timing(
+        ai_client,
+        Duration::from_millis(100),
+        Duration::from_millis(5),
+    );
+
+    let message = hydrator.read_message_with_timeout("msg-123").await.unwrap();
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(message.message_id, "msg-123");
+    assert_eq!(message.body, "Switch to the failing test first.");
+}
+
+#[tokio::test]
+async fn read_message_with_timeout_times_out_after_retrying_transient_failures() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_clone = attempts.clone();
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_read_agent_message()
+        .with(eq("msg-123"))
+        .returning(move |_| {
+            attempts_clone.fetch_add(1, Ordering::SeqCst);
+            Err(transient_read_error(404))
+        });
+
+    let ai_client: Arc<dyn AIClient> = Arc::new(ai_client);
+    let hydrator = MessageHydrator::with_fetch_timing(
+        ai_client,
+        Duration::from_millis(120),
+        Duration::from_millis(20),
+    );
+
+    let err = hydrator
+        .read_message_with_timeout("msg-123")
+        .await
+        .expect_err("expected timeout after transient retries");
+    let err_chain = format!("{err:#}");
+
+    assert!(
+        err_chain.contains("Timed out reading agent message msg-123"),
+        "{err:#}"
+    );
+    assert!(
+        attempts.load(Ordering::SeqCst) >= 2,
+        "expected at least one retry before timeout"
+    );
 }

--- a/app/src/ai/agent_events/message_hydrator_tests.rs
+++ b/app/src/ai/agent_events/message_hydrator_tests.rs
@@ -38,7 +38,7 @@ fn make_message_response(message_id: &str) -> ReadAgentMessageResponse {
     }
 }
 
-fn transient_read_error(status: u16) -> anyhow::Error {
+fn http_status_read_error(status: u16) -> anyhow::Error {
     anyhow::Error::new(HttpStatusError {
         status,
         body: format!("status {status} body"),
@@ -94,7 +94,7 @@ async fn read_message_with_timeout_retries_transient_failures_until_success() {
         .returning(move |_| {
             let attempt = attempts_clone.fetch_add(1, Ordering::SeqCst);
             if attempt == 0 {
-                Err(transient_read_error(404))
+                Err(http_status_read_error(404))
             } else {
                 Ok(make_message_response("msg-123"))
             }
@@ -124,7 +124,7 @@ async fn read_message_with_timeout_times_out_after_retrying_transient_failures()
         .with(eq("msg-123"))
         .returning(move |_| {
             attempts_clone.fetch_add(1, Ordering::SeqCst);
-            Err(transient_read_error(404))
+            Err(http_status_read_error(404))
         });
 
     let ai_client: Arc<dyn AIClient> = Arc::new(ai_client);
@@ -147,5 +147,43 @@ async fn read_message_with_timeout_times_out_after_retrying_transient_failures()
     assert!(
         attempts.load(Ordering::SeqCst) >= 2,
         "expected at least one retry before timeout"
+    );
+}
+
+#[tokio::test]
+async fn read_message_with_timeout_does_not_retry_permanent_http_failures() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_clone = attempts.clone();
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_read_agent_message()
+        .with(eq("msg-123"))
+        .times(1)
+        .returning(move |_| {
+            attempts_clone.fetch_add(1, Ordering::SeqCst);
+            Err(http_status_read_error(403))
+        });
+
+    let ai_client: Arc<dyn AIClient> = Arc::new(ai_client);
+    let hydrator = MessageHydrator::with_fetch_timing(
+        ai_client,
+        Duration::from_millis(100),
+        Duration::from_millis(5),
+    );
+
+    let err = hydrator
+        .read_message_with_timeout("msg-123")
+        .await
+        .expect_err("expected permanent failure to fail fast");
+    let err_chain = format!("{err:#}");
+
+    assert!(
+        err_chain.contains("HTTP request failed with status 403"),
+        "{err:#}"
+    );
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "permanent 4xx errors should not retry"
     );
 }

--- a/app/src/ai/agent_events/mod.rs
+++ b/app/src/ai/agent_events/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use driver::{
 };
 pub(crate) use driver::{
     run_agent_event_driver, AgentEventConsumer, AgentEventConsumerControlFlow,
-    AgentEventDriverConfig, ServerApiAgentEventSource,
+    AgentEventDriverConfig, AgentMessageEventMetadata, ServerApiAgentEventSource,
 };
 pub(crate) use message_hydrator::MessageHydrator;
 

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -46,17 +46,16 @@ use parent_bridge::{
     parent_bridge_char_count, parent_bridge_event_cursor_file, parent_bridge_hook_output_ack_file,
     parent_bridge_hook_output_file, parent_bridge_root, parent_bridge_staged_message_path,
     parent_bridge_surfaced_message_path, prepare_parent_bridge_hook_output,
-    read_parent_bridge_event_cursor, render_parent_bridge_message_block,
-    stage_parent_bridge_message, write_parent_bridge_event_cursor, MessageBridgeHookOutput,
-    MessageBridgeMessageRecord, MESSAGE_BRIDGE_CONTEXT_PREAMBLE,
+    prime_parent_bridge_for_wake, read_parent_bridge_event_cursor,
+    render_parent_bridge_message_block, stage_parent_bridge_message,
+    write_parent_bridge_event_cursor, MessageBridgeHookOutput, MessageBridgeMessageRecord,
+    MESSAGE_BRIDGE_CONTEXT_PREAMBLE,
 };
 use parent_bridge::{MessageBridge, MessageBridgeCleanupDisposition};
 #[cfg(test)]
 use shell_words::quote as shell_quote;
 #[cfg(test)]
-use wake_driver::{
-    prime_parent_bridge_state_for_wake, ClaudeWakeRemoteContext, CLAUDE_WAKE_PROMPT_FILE_NAME,
-};
+use wake_driver::{ClaudeWakeRemoteContext, CLAUDE_WAKE_PROMPT_FILE_NAME};
 
 pub(crate) struct ClaudeHarness;
 #[cfg_attr(not(target_family = "wasm"), async_trait)]

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -54,7 +54,9 @@ use parent_bridge::{MessageBridge, MessageBridgeCleanupDisposition};
 #[cfg(test)]
 use shell_words::quote as shell_quote;
 #[cfg(test)]
-use wake_driver::{ClaudeWakeRemoteContext, CLAUDE_WAKE_PROMPT_FILE_NAME};
+use wake_driver::{
+    prime_parent_bridge_state_for_wake, ClaudeWakeRemoteContext, CLAUDE_WAKE_PROMPT_FILE_NAME,
+};
 
 pub(crate) struct ClaudeHarness;
 #[cfg_attr(not(target_family = "wasm"), async_trait)]

--- a/app/src/ai/agent_sdk/driver/harness/claude_code/parent_bridge.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code/parent_bridge.rs
@@ -25,7 +25,7 @@ use warpui::ModelSpawner;
 
 use crate::ai::agent_events::{
     run_agent_event_driver, AgentEventConsumer, AgentEventConsumerControlFlow,
-    AgentEventDriverConfig, MessageHydrator, ServerApiAgentEventSource,
+    AgentEventDriverConfig, AgentMessageEventMetadata, MessageHydrator, ServerApiAgentEventSource,
 };
 use crate::ai::agent_sdk::driver::{AgentDriver, OZ_MESSAGE_LISTENER_STATE_ROOT_ENV};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -340,6 +340,32 @@ pub(super) fn stage_parent_bridge_message(
         write_parent_bridge_json_atomically(&target, record)?;
     }
     Ok(())
+}
+
+pub(super) async fn prime_parent_bridge_for_wake(
+    hydrator: &MessageHydrator,
+    state_dir: &Path,
+    wake_message: Option<&AgentMessageEventMetadata>,
+) -> Result<()> {
+    acknowledge_parent_bridge_hook_output(hydrator, state_dir).await?;
+
+    let Some(wake_message) = wake_message else {
+        return Ok(());
+    };
+
+    stage_parent_bridge_message(
+        state_dir,
+        &MessageBridgeMessageRecord {
+            sequence: wake_message.sequence,
+            message_id: wake_message.message_id.clone(),
+            sender_run_id: String::new(),
+            subject: String::new(),
+            body: String::new(),
+            occurred_at: wake_message.occurred_at.clone(),
+        },
+    )?;
+    write_parent_bridge_event_cursor(state_dir, wake_message.sequence)?;
+    prepare_parent_bridge_hook_output(hydrator, state_dir, parent_bridge_max_context_chars()).await
 }
 
 pub(super) fn parent_bridge_max_context_chars() -> usize {

--- a/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
@@ -21,9 +21,7 @@ use super::super::claude_transcript::{
 };
 use super::super::task_env_vars;
 use super::parent_bridge::{
-    acknowledge_parent_bridge_hook_output, ensure_parent_bridge_state_dir,
-    parent_bridge_max_context_chars, parent_bridge_root, prepare_parent_bridge_hook_output,
-    stage_parent_bridge_message, write_parent_bridge_event_cursor, MessageBridgeMessageRecord,
+    ensure_parent_bridge_state_dir, parent_bridge_root, prime_parent_bridge_for_wake,
 };
 use super::{claude_command, prepare_claude_environment_config, ClaudeHarness};
 
@@ -212,10 +210,7 @@ impl ClaudeHarness {
         let state_dir = parent_bridge_root()?.join(remote.session_id.to_string());
         ensure_parent_bridge_state_dir(&state_dir)?;
         let hydrator = MessageHydrator::for_task(server_api, task_id);
-        acknowledge_parent_bridge_hook_output(&hydrator, &state_dir).await?;
-        if let Some(wake_message) = wake_message.as_ref() {
-            prime_parent_bridge_state_for_wake(&hydrator, &state_dir, wake_message).await?;
-        }
+        prime_parent_bridge_for_wake(&hydrator, &state_dir, wake_message.as_ref()).await?;
         let prompt_path = state_dir.join(CLAUDE_WAKE_PROMPT_FILE_NAME);
         std::fs::write(&prompt_path, remote.wake_prompt.as_bytes())
             .with_context(|| format!("Failed to write {}", prompt_path.display()))?;
@@ -232,26 +227,6 @@ impl ClaudeHarness {
 
         Ok(prefix_command_with_env_vars(command, env_vars))
     }
-}
-
-pub(super) async fn prime_parent_bridge_state_for_wake(
-    hydrator: &MessageHydrator,
-    state_dir: &std::path::Path,
-    wake_message: &AgentMessageEventMetadata,
-) -> Result<()> {
-    stage_parent_bridge_message(
-        state_dir,
-        &MessageBridgeMessageRecord {
-            sequence: wake_message.sequence,
-            message_id: wake_message.message_id.clone(),
-            sender_run_id: String::new(),
-            subject: String::new(),
-            body: String::new(),
-            occurred_at: wake_message.occurred_at.clone(),
-        },
-    )?;
-    write_parent_bridge_event_cursor(state_dir, wake_message.sequence)?;
-    prepare_parent_bridge_hook_output(hydrator, state_dir, parent_bridge_max_context_chars()).await
 }
 
 fn local_wake_task_env_vars(

--- a/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code/wake_driver.rs
@@ -4,25 +4,26 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
+use crate::ai::agent_events::{AgentMessageEventMetadata, MessageHydrator};
+use crate::ai::ambient_agents::{AmbientAgentTaskId, AmbientAgentTaskState};
+use crate::server::server_api::ai::AIClient;
+use crate::server::server_api::harness_support::ResolvePromptRequest;
+use crate::server::server_api::ServerApi;
+use crate::terminal::CLIAgent;
 use anyhow::{Context, Result};
 use shell_words::quote as shell_quote;
 use uuid::Uuid;
 use warp_cli::agent::Harness;
 use warp_graphql::ai::AgentTaskState;
 
-use crate::ai::agent_events::MessageHydrator;
-use crate::ai::ambient_agents::{AmbientAgentTaskId, AmbientAgentTaskState};
-use crate::server::server_api::ai::AIClient;
-use crate::server::server_api::harness_support::ResolvePromptRequest;
-use crate::server::server_api::ServerApi;
-use crate::terminal::CLIAgent;
-
 use super::super::claude_transcript::{
     claude_config_dir, write_envelope, write_session_index_entry, ClaudeTranscriptEnvelope,
 };
 use super::super::task_env_vars;
 use super::parent_bridge::{
-    acknowledge_parent_bridge_hook_output, ensure_parent_bridge_state_dir, parent_bridge_root,
+    acknowledge_parent_bridge_hook_output, ensure_parent_bridge_state_dir,
+    parent_bridge_max_context_chars, parent_bridge_root, prepare_parent_bridge_hook_output,
+    stage_parent_bridge_message, write_parent_bridge_event_cursor, MessageBridgeMessageRecord,
 };
 use super::{claude_command, prepare_claude_environment_config, ClaudeHarness};
 
@@ -53,6 +54,7 @@ impl ClaudeHarness {
         conversation: AIConversation,
         parent_conversation: Option<AIConversation>,
         working_dir: Option<PathBuf>,
+        wake_message: Option<AgentMessageEventMetadata>,
     ) -> Result<Option<String>> {
         let Some(candidate) =
             Self::local_wake_candidate(&conversation, parent_conversation.as_ref(), working_dir)
@@ -90,6 +92,7 @@ impl ClaudeHarness {
             parent_run_id,
             working_dir,
             remote,
+            wake_message,
         )
         .await?;
 
@@ -191,6 +194,7 @@ impl ClaudeHarness {
         parent_run_id: Option<String>,
         working_dir: Option<PathBuf>,
         mut remote: ClaudeWakeRemoteContext,
+        wake_message: Option<AgentMessageEventMetadata>,
     ) -> Result<String> {
         let working_dir = working_dir.unwrap_or_else(|| remote.envelope.cwd.clone());
         prepare_claude_environment_config(&working_dir, &HashMap::new())
@@ -209,6 +213,9 @@ impl ClaudeHarness {
         ensure_parent_bridge_state_dir(&state_dir)?;
         let hydrator = MessageHydrator::for_task(server_api, task_id);
         acknowledge_parent_bridge_hook_output(&hydrator, &state_dir).await?;
+        if let Some(wake_message) = wake_message.as_ref() {
+            prime_parent_bridge_state_for_wake(&hydrator, &state_dir, wake_message).await?;
+        }
         let prompt_path = state_dir.join(CLAUDE_WAKE_PROMPT_FILE_NAME);
         std::fs::write(&prompt_path, remote.wake_prompt.as_bytes())
             .with_context(|| format!("Failed to write {}", prompt_path.display()))?;
@@ -225,6 +232,26 @@ impl ClaudeHarness {
 
         Ok(prefix_command_with_env_vars(command, env_vars))
     }
+}
+
+pub(super) async fn prime_parent_bridge_state_for_wake(
+    hydrator: &MessageHydrator,
+    state_dir: &std::path::Path,
+    wake_message: &AgentMessageEventMetadata,
+) -> Result<()> {
+    stage_parent_bridge_message(
+        state_dir,
+        &MessageBridgeMessageRecord {
+            sequence: wake_message.sequence,
+            message_id: wake_message.message_id.clone(),
+            sender_run_id: String::new(),
+            subject: String::new(),
+            body: String::new(),
+            occurred_at: wake_message.occurred_at.clone(),
+        },
+    )?;
+    write_parent_bridge_event_cursor(state_dir, wake_message.sequence)?;
+    prepare_parent_bridge_hook_output(hydrator, state_dir, parent_bridge_max_context_chars()).await
 }
 
 fn local_wake_task_env_vars(

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -9,10 +9,10 @@ use uuid::Uuid;
 use warp_cli::{OZ_HARNESS_ENV, OZ_PARENT_RUN_ID_ENV, OZ_RUN_ID_ENV};
 
 use super::*;
-use crate::ai::agent_events::MessageHydrator;
+use crate::ai::agent_events::{AgentMessageEventMetadata, MessageHydrator};
 use crate::ai::agent_sdk::driver::harness::claude_transcript::encode_cwd;
 use crate::ai::agent_sdk::driver::OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV;
-use crate::server::server_api::ai::{MockAIClient, ReadAgentMessageResponse};
+use crate::server::server_api::ai::{AIClient, MockAIClient, ReadAgentMessageResponse};
 use crate::server::server_api::ServerApiProvider;
 
 fn sample_parent_bridge_message(
@@ -727,6 +727,7 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
         Some(parent_run_id.clone()),
         Some(working_dir.clone()),
         remote,
+        None,
     ))
     .unwrap();
 
@@ -770,6 +771,96 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
     std::env::remove_var("HOME");
     std::env::remove_var("CLAUDE_CONFIG_DIR");
     std::env::remove_var(OZ_MESSAGE_LISTENER_STATE_ROOT_ENV);
+}
+
+#[tokio::test]
+async fn prime_parent_bridge_state_for_wake_clears_acked_output_and_surfaces_new_message() {
+    let tmp = TempDir::new().unwrap();
+    let state_dir = tmp.path().join("session-123");
+    ensure_parent_bridge_state_dir(&state_dir).unwrap();
+
+    let stale = sample_parent_bridge_message(
+        41,
+        "stale-msg",
+        "Old direction",
+        "This message should be acknowledged and cleared.",
+    );
+    write_surfaced_parent_bridge_message(&state_dir, &stale);
+    fs::write(
+        parent_bridge_hook_output_file(&state_dir),
+        serde_json::to_vec(&MessageBridgeHookOutput {
+            additional_context: "stale context".to_string(),
+            remaining_staged_count: 0,
+            surfaced_count: 1,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(parent_bridge_hook_output_ack_file(&state_dir), "").unwrap();
+
+    let wake_message = AgentMessageEventMetadata {
+        sequence: 42,
+        message_id: "msg-123".to_string(),
+        occurred_at: "2026-04-17T15:47:00Z".to_string(),
+    };
+    let expected = sample_parent_bridge_message(
+        42,
+        "msg-123",
+        "Please pivot",
+        "Inspect the failing tests first.",
+    );
+
+    let mut ai_client = MockAIClient::new();
+    ai_client
+        .expect_mark_message_delivered()
+        .with(eq("stale-msg"))
+        .times(1)
+        .returning(|_| Ok(()));
+    let expected_message = expected.clone();
+    ai_client
+        .expect_read_agent_message()
+        .with(eq("msg-123"))
+        .times(1)
+        .returning(move |_| {
+            Ok(ReadAgentMessageResponse {
+                message_id: expected_message.message_id.clone(),
+                sender_run_id: expected_message.sender_run_id.clone(),
+                subject: expected_message.subject.clone(),
+                body: expected_message.body.clone(),
+                sent_at: "2026-04-17T15:46:00Z".to_string(),
+                delivered_at: None,
+                read_at: Some("2026-04-17T15:46:02Z".to_string()),
+            })
+        });
+    let hydrator = MessageHydrator::new(Arc::new(ai_client) as Arc<dyn AIClient>);
+    acknowledge_parent_bridge_hook_output(&hydrator, &state_dir)
+        .await
+        .unwrap();
+
+    prime_parent_bridge_state_for_wake(&hydrator, &state_dir, &wake_message)
+        .await
+        .unwrap();
+
+    assert_eq!(read_parent_bridge_event_cursor(&state_dir).unwrap(), 42);
+    assert!(!parent_bridge_hook_output_ack_file(&state_dir).exists());
+    assert!(!parent_bridge_surfaced_message_path(&state_dir, 41, "stale-msg").exists());
+
+    let surfaced_path = parent_bridge_surfaced_message_path(&state_dir, 42, "msg-123");
+    assert!(surfaced_path.exists());
+    assert!(!parent_bridge_staged_message_path(&state_dir, 42, "msg-123").exists());
+
+    let hook_output: MessageBridgeHookOutput =
+        serde_json::from_slice(&fs::read(parent_bridge_hook_output_file(&state_dir)).unwrap())
+            .unwrap();
+    assert_eq!(hook_output.surfaced_count, 1);
+    assert_eq!(hook_output.remaining_staged_count, 0);
+    assert!(hook_output.additional_context.contains("Please pivot"));
+
+    let surfaced_record: MessageBridgeMessageRecord =
+        serde_json::from_slice(&fs::read(&surfaced_path).unwrap()).unwrap();
+    assert_eq!(surfaced_record.subject, expected.subject);
+    assert_eq!(surfaced_record.body, expected.body);
+    assert_eq!(surfaced_record.occurred_at, wake_message.occurred_at);
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code_tests.rs
@@ -774,7 +774,7 @@ fn prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener()
 }
 
 #[tokio::test]
-async fn prime_parent_bridge_state_for_wake_clears_acked_output_and_surfaces_new_message() {
+async fn prime_parent_bridge_for_wake_clears_acked_output_and_surfaces_new_message() {
     let tmp = TempDir::new().unwrap();
     let state_dir = tmp.path().join("session-123");
     ensure_parent_bridge_state_dir(&state_dir).unwrap();
@@ -833,11 +833,7 @@ async fn prime_parent_bridge_state_for_wake_clears_acked_output_and_surfaces_new
             })
         });
     let hydrator = MessageHydrator::new(Arc::new(ai_client) as Arc<dyn AIClient>);
-    acknowledge_parent_bridge_hook_output(&hydrator, &state_dir)
-        .await
-        .unwrap();
-
-    prime_parent_bridge_state_for_wake(&hydrator, &state_dir, &wake_message)
+    prime_parent_bridge_for_wake(&hydrator, &state_dir, Some(&wake_message))
         .await
         .unwrap();
 

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -377,19 +377,19 @@ enum FollowUpTrigger {
     Auto,
     UserRequested,
 }
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum LocalClaudeWakeTrigger {
     PendingEvents,
-    WakeOnlyStream,
+    WakeOnlyStream {
+        wake_message: AgentMessageEventMetadata,
+    },
 }
 
 impl LocalClaudeWakeTrigger {
-    #[cfg(not(target_family = "wasm"))]
-    fn requires_pending_events(self) -> bool {
+    fn requires_pending_events(&self) -> bool {
         match self {
             Self::PendingEvents => true,
-            Self::WakeOnlyStream => false,
+            Self::WakeOnlyStream { .. } => false,
         }
     }
 }
@@ -1576,7 +1576,6 @@ impl BlocklistAIController {
         &mut self,
         _conversation_id: AIConversationId,
         _trigger: LocalClaudeWakeTrigger,
-        _wake_message: Option<AgentMessageEventMetadata>,
         _ctx: &mut ModelContext<Self>,
     ) -> bool {
         false
@@ -1587,7 +1586,6 @@ impl BlocklistAIController {
         &mut self,
         conversation_id: AIConversationId,
         trigger: LocalClaudeWakeTrigger,
-        wake_message: Option<AgentMessageEventMetadata>,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
         if self
@@ -1627,8 +1625,11 @@ impl BlocklistAIController {
             .cloned()
             .map(PathBuf::from);
         let task_id = conversation.task_id();
-        let wake_message_for_prepare = wake_message.clone();
-        let wake_message_for_retry = wake_message;
+        let wake_message_for_prepare = match &trigger {
+            LocalClaudeWakeTrigger::PendingEvents => None,
+            LocalClaudeWakeTrigger::WakeOnlyStream { wake_message } => Some(wake_message.clone()),
+        };
+        let trigger_for_callback = trigger.clone();
 
         let server_api = ServerApiProvider::as_ref(ctx).get();
         let handle = ctx.spawn(
@@ -1649,6 +1650,20 @@ impl BlocklistAIController {
                 me.pending_local_claude_wakes.remove(&conversation_id);
                 match result {
                     Ok(Some(command)) => {
+                        if let LocalClaudeWakeTrigger::WakeOnlyStream { wake_message } =
+                            &trigger_for_callback
+                        {
+                            OrchestrationEventStreamer::handle(ctx).update(
+                                ctx,
+                                |streamer, ctx| {
+                                    streamer.persist_dormant_claude_wake_cursor(
+                                        conversation_id,
+                                        wake_message,
+                                        ctx,
+                                    );
+                                },
+                            );
+                        }
                         log::info!(
                             "Executing dormant Claude wake command: conversation_id={conversation_id:?} task_id={task_id:?}"
                         );
@@ -1668,26 +1683,20 @@ impl BlocklistAIController {
                         });
                     }
                     Ok(None) => {
-                        match trigger {
+                        match &trigger_for_callback {
                             LocalClaudeWakeTrigger::PendingEvents => {
                                 log::info!(
                                     "Falling back to generic pending-event injection after dormant Claude wake eligibility check: conversation_id={conversation_id:?} task_id={task_id:?}"
                                 );
                                 me.inject_pending_events_for_request(conversation_id, ctx);
                             }
-                            LocalClaudeWakeTrigger::WakeOnlyStream => {
+                            LocalClaudeWakeTrigger::WakeOnlyStream { wake_message } => {
                                 log::info!(
                                     "Retrying wake-only dormant Claude eligibility check: conversation_id={conversation_id:?} task_id={task_id:?}"
                                 );
-                                let Some(wake_message) = wake_message_for_retry.clone() else {
-                                    log::warn!(
-                                        "Cannot retry dormant Claude wake without wake message metadata: conversation_id={conversation_id:?} task_id={task_id:?}"
-                                    );
-                                    return;
-                                };
                                 me.schedule_dormant_claude_wake_ready_retry(
                                     conversation_id,
-                                    wake_message,
+                                    wake_message.clone(),
                                     ctx,
                                 );
                             }
@@ -1697,20 +1706,14 @@ impl BlocklistAIController {
                         log::warn!(
                             "Failed to prepare dormant Claude wake command for {conversation_id:?} task_id={task_id:?}: {err:#}"
                         );
-                        match trigger {
+                        match &trigger_for_callback {
                             LocalClaudeWakeTrigger::PendingEvents => {
                                 me.schedule_pending_events_ready_retry(conversation_id, ctx);
                             }
-                            LocalClaudeWakeTrigger::WakeOnlyStream => {
-                                let Some(wake_message) = wake_message_for_retry.clone() else {
-                                    log::warn!(
-                                        "Cannot retry dormant Claude wake without wake message metadata: conversation_id={conversation_id:?} task_id={task_id:?}"
-                                    );
-                                    return;
-                                };
+                            LocalClaudeWakeTrigger::WakeOnlyStream { wake_message } => {
                                 me.schedule_dormant_claude_wake_ready_retry(
                                     conversation_id,
-                                    wake_message,
+                                    wake_message.clone(),
                                     ctx,
                                 );
                             }
@@ -1809,7 +1812,6 @@ impl BlocklistAIController {
         if self.maybe_prepare_local_claude_wake(
             conversation_id,
             LocalClaudeWakeTrigger::PendingEvents,
-            None,
             ctx,
         ) {
             return;
@@ -1826,8 +1828,7 @@ impl BlocklistAIController {
     ) {
         if !self.maybe_prepare_local_claude_wake(
             conversation_id,
-            LocalClaudeWakeTrigger::WakeOnlyStream,
-            Some(wake_message),
+            LocalClaudeWakeTrigger::WakeOnlyStream { wake_message },
             ctx,
         ) {
             log::info!(

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -386,6 +386,7 @@ enum LocalClaudeWakeTrigger {
 }
 
 impl LocalClaudeWakeTrigger {
+    #[cfg(not(target_family = "wasm"))]
     fn requires_pending_events(&self) -> bool {
         match self {
             Self::PendingEvents => true,

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -30,6 +30,7 @@ use crate::ai::agent::{
     PassiveSuggestionTriggerType, RunningCommand,
 };
 use crate::ai::agent::{DocumentContentAttachmentSource, FileContext};
+use crate::ai::agent_events::AgentMessageEventMetadata;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_sdk::ClaudeHarness;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -588,9 +589,11 @@ impl BlocklistAIController {
         if FeatureFlag::OrchestrationV2.is_enabled() {
             let streamer = OrchestrationEventStreamer::handle(ctx);
             ctx.subscribe_to_model(&streamer, move |me, event, ctx| {
-                let OrchestrationEventStreamerEvent::DormantClaudeWakeReady { conversation_id } =
-                    event;
-                me.handle_dormant_claude_wake_ready(*conversation_id, ctx);
+                let OrchestrationEventStreamerEvent::DormantClaudeWakeReady {
+                    conversation_id,
+                    wake_message,
+                } = event;
+                me.handle_dormant_claude_wake_ready(*conversation_id, wake_message.clone(), ctx);
             });
         }
         Self {
@@ -1573,6 +1576,7 @@ impl BlocklistAIController {
         &mut self,
         _conversation_id: AIConversationId,
         _trigger: LocalClaudeWakeTrigger,
+        _wake_message: Option<AgentMessageEventMetadata>,
         _ctx: &mut ModelContext<Self>,
     ) -> bool {
         false
@@ -1583,6 +1587,7 @@ impl BlocklistAIController {
         &mut self,
         conversation_id: AIConversationId,
         trigger: LocalClaudeWakeTrigger,
+        wake_message: Option<AgentMessageEventMetadata>,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
         if self
@@ -1622,6 +1627,8 @@ impl BlocklistAIController {
             .cloned()
             .map(PathBuf::from);
         let task_id = conversation.task_id();
+        let wake_message_for_prepare = wake_message.clone();
+        let wake_message_for_retry = wake_message;
 
         let server_api = ServerApiProvider::as_ref(ctx).get();
         let handle = ctx.spawn(
@@ -1634,6 +1641,7 @@ impl BlocklistAIController {
                     conversation,
                     parent_conversation,
                     working_dir,
+                    wake_message_for_prepare,
                 )
                 .await
             },
@@ -1671,7 +1679,17 @@ impl BlocklistAIController {
                                 log::info!(
                                     "Retrying wake-only dormant Claude eligibility check: conversation_id={conversation_id:?} task_id={task_id:?}"
                                 );
-                                me.schedule_dormant_claude_wake_ready_retry(conversation_id, ctx);
+                                let Some(wake_message) = wake_message_for_retry.clone() else {
+                                    log::warn!(
+                                        "Cannot retry dormant Claude wake without wake message metadata: conversation_id={conversation_id:?} task_id={task_id:?}"
+                                    );
+                                    return;
+                                };
+                                me.schedule_dormant_claude_wake_ready_retry(
+                                    conversation_id,
+                                    wake_message,
+                                    ctx,
+                                );
                             }
                         }
                     }
@@ -1684,7 +1702,17 @@ impl BlocklistAIController {
                                 me.schedule_pending_events_ready_retry(conversation_id, ctx);
                             }
                             LocalClaudeWakeTrigger::WakeOnlyStream => {
-                                me.schedule_dormant_claude_wake_ready_retry(conversation_id, ctx);
+                                let Some(wake_message) = wake_message_for_retry.clone() else {
+                                    log::warn!(
+                                        "Cannot retry dormant Claude wake without wake message metadata: conversation_id={conversation_id:?} task_id={task_id:?}"
+                                    );
+                                    return;
+                                };
+                                me.schedule_dormant_claude_wake_ready_retry(
+                                    conversation_id,
+                                    wake_message,
+                                    ctx,
+                                );
                             }
                         }
                     }
@@ -1714,12 +1742,13 @@ impl BlocklistAIController {
     fn schedule_dormant_claude_wake_ready_retry(
         &mut self,
         conversation_id: AIConversationId,
+        wake_message: AgentMessageEventMetadata,
         ctx: &mut ModelContext<Self>,
     ) {
         ctx.spawn(
             async move { Timer::after(Duration::from_secs(2)).await },
             move |me, _, ctx| {
-                me.handle_dormant_claude_wake_ready(conversation_id, ctx);
+                me.handle_dormant_claude_wake_ready(conversation_id, wake_message.clone(), ctx);
             },
         );
     }
@@ -1780,6 +1809,7 @@ impl BlocklistAIController {
         if self.maybe_prepare_local_claude_wake(
             conversation_id,
             LocalClaudeWakeTrigger::PendingEvents,
+            None,
             ctx,
         ) {
             return;
@@ -1791,11 +1821,13 @@ impl BlocklistAIController {
     fn handle_dormant_claude_wake_ready(
         &mut self,
         conversation_id: AIConversationId,
+        wake_message: AgentMessageEventMetadata,
         ctx: &mut ModelContext<Self>,
     ) {
         if !self.maybe_prepare_local_claude_wake(
             conversation_id,
             LocalClaudeWakeTrigger::WakeOnlyStream,
+            Some(wake_message),
             ctx,
         ) {
             log::info!(

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -255,6 +255,7 @@ impl OrchestrationEventStreamer {
         }
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub(crate) fn persist_dormant_claude_wake_cursor(
         &mut self,
         conversation_id: AIConversationId,

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -9,7 +9,7 @@ use crate::ai::agent::{
 };
 use crate::ai::agent_events::{
     run_agent_event_driver, AgentEventConsumer, AgentEventConsumerControlFlow,
-    AgentEventDriverConfig, MessageHydrator, ServerApiAgentEventSource,
+    AgentEventDriverConfig, AgentMessageEventMetadata, MessageHydrator, ServerApiAgentEventSource,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::server::retry_strategies::is_transient_http_error;
@@ -66,9 +66,9 @@ struct SseForwardingConsumer {
 }
 
 /// State for a wake-only listener. Unlike `SseConnectionState`, this listener
-/// never forwards or persists events; it stops on the first event and asks the
-/// controller to cold-start the dormant Claude run so the parent bridge can
-/// take over delivery.
+/// observes the first wake-triggering message event, then asks the controller
+/// to cold-start the dormant Claude run so the parent bridge can take over
+/// delivery.
 struct WakeConnectionState {
     generation: u64,
     task: SpawnedFutureHandle,
@@ -76,14 +76,14 @@ struct WakeConnectionState {
 
 struct DormantClaudeWakeConsumer {
     run_id: String,
-    wake_sequence: Option<i64>,
+    wake_message: Option<AgentMessageEventMetadata>,
 }
 
 impl DormantClaudeWakeConsumer {
     fn new(run_id: String) -> Self {
         Self {
             run_id,
-            wake_sequence: None,
+            wake_message: None,
         }
     }
 }
@@ -98,8 +98,11 @@ impl AgentEventConsumer for DormantClaudeWakeConsumer {
         if event.run_id != self.run_id {
             return Ok(AgentEventConsumerControlFlow::Continue);
         }
+        let Some(wake_message) = AgentMessageEventMetadata::from_event(&event) else {
+            return Ok(AgentEventConsumerControlFlow::Continue);
+        };
 
-        self.wake_sequence = Some(event.sequence);
+        self.wake_message = Some(wake_message);
         Ok(AgentEventConsumerControlFlow::Stop)
     }
 }
@@ -196,7 +199,10 @@ pub struct OrchestrationEventStreamer {
 }
 
 pub enum OrchestrationEventStreamerEvent {
-    DormantClaudeWakeReady { conversation_id: AIConversationId },
+    DormantClaudeWakeReady {
+        conversation_id: AIConversationId,
+        wake_message: AgentMessageEventMetadata,
+    },
 }
 
 impl OrchestrationEventStreamer {
@@ -204,6 +210,48 @@ impl OrchestrationEventStreamer {
         match run_id.parse::<AmbientAgentTaskId>() {
             Ok(task_id) => MessageHydrator::for_task(self.server_api.clone(), task_id),
             Err(_) => MessageHydrator::new(self.ai_client.clone()),
+        }
+    }
+
+    fn persist_event_cursor(
+        &mut self,
+        conversation_id: AIConversationId,
+        sequence: i64,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let sequence = self
+            .streams
+            .get(&conversation_id)
+            .map(|stream| stream.event_cursor.max(sequence))
+            .unwrap_or(sequence);
+        self.streams
+            .entry(conversation_id)
+            .or_default()
+            .event_cursor = sequence;
+
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
+            model.update_event_sequence(conversation_id, sequence, ctx);
+        });
+
+        let own_run_id = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|conversation| conversation.run_id());
+        if let Some(run_id) = own_run_id {
+            let ai_client = self.ai_client.clone();
+            ctx.spawn(
+                async move {
+                    ai_client
+                        .update_event_sequence_on_server(&run_id, sequence)
+                        .await
+                },
+                move |_, result, _| {
+                    if let Err(err) = result {
+                        log::warn!(
+                            "Failed to persist event cursor to server for {conversation_id:?}: {err:#}"
+                        );
+                    }
+                },
+            );
         }
     }
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
@@ -1003,9 +1051,8 @@ impl OrchestrationEventStreamer {
 
     /// Opens a wake-only listener for a dormant local Claude child. The
     /// listener observes the child's run_id, stops on the first event, and
-    /// emits a controller signal without enqueueing any event data or
-    /// persisting any cursor. The Claude parent bridge will consume the event
-    /// after the CLI has been relaunched.
+    /// emits the triggering message metadata so the controller can prime the
+    /// Claude parent bridge before the CLI resumes.
     fn start_dormant_claude_wake_listener(
         &mut self,
         conversation_id: AIConversationId,
@@ -1045,7 +1092,7 @@ impl OrchestrationEventStreamer {
                 );
                 let mut consumer = DormantClaudeWakeConsumer::new(task_run_id);
                 run_agent_event_driver(source, config, &mut consumer).await?;
-                Ok::<_, anyhow::Error>(consumer.wake_sequence)
+                Ok::<_, anyhow::Error>(consumer.wake_message)
             },
             move |me, result, ctx| {
                 let is_current = me
@@ -1062,13 +1109,17 @@ impl OrchestrationEventStreamer {
                 }
 
                 match result {
-                    Ok(Some(sequence)) => {
+                    Ok(Some(wake_message)) => {
                         log::info!(
-                            "Dormant Claude wake listener observed event for \
-                             {conversation_id:?} at sequence {sequence}"
+                            "Dormant Claude wake listener observed wake message for \
+                             {conversation_id:?} at sequence {} message_id={}",
+                            wake_message.sequence,
+                            wake_message.message_id
                         );
+                        me.persist_event_cursor(conversation_id, wake_message.sequence, ctx);
                         ctx.emit(OrchestrationEventStreamerEvent::DormantClaudeWakeReady {
                             conversation_id,
+                            wake_message,
                         });
                     }
                     Ok(None) => {
@@ -1273,43 +1324,9 @@ impl OrchestrationEventStreamer {
             .map(|e| e.sequence)
             .max()
             .unwrap_or(previous_cursor);
-        self.streams
-            .entry(conversation_id)
-            .or_default()
-            .event_cursor = max_seq;
-
         // Advance the cursor before filtering so dropped killed-run events
         // are not replayed later.
-        BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
-            model.update_event_sequence(conversation_id, max_seq, ctx);
-        });
-
-        // Also persist the cursor to the server so driver / cloud
-        // restarts can resume without local SQLite state. Fire-and-forget:
-        // log on failure, don't block event delivery. The server persists
-        // the cursor on `ai_tasks.last_event_sequence`.
-        let own_run_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .conversation(&conversation_id)
-            .and_then(|c| c.run_id());
-        if let Some(run_id) = own_run_id {
-            // TODO: consider debouncing this server write (see
-            // specs/replay-agent-events-on-restore/TECH.md Risks).
-            let ai_client = self.ai_client.clone();
-            ctx.spawn(
-                async move {
-                    ai_client
-                        .update_event_sequence_on_server(&run_id, max_seq)
-                        .await
-                },
-                move |_, result, _| {
-                    if let Err(err) = result {
-                        log::warn!(
-                            "Failed to persist event cursor to server for {conversation_id:?}: {err:#}"
-                        );
-                    }
-                },
-            );
-        }
+        self.persist_event_cursor(conversation_id, max_seq, ctx);
 
         if !self.killed_run_ids.is_empty() {
             let dropped_message_ids: HashSet<String> = events

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -254,6 +254,15 @@ impl OrchestrationEventStreamer {
             );
         }
     }
+
+    pub(crate) fn persist_dormant_claude_wake_cursor(
+        &mut self,
+        conversation_id: AIConversationId,
+        wake_message: &AgentMessageEventMetadata,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.persist_event_cursor(conversation_id, wake_message.sequence, ctx);
+    }
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         let provider = ServerApiProvider::as_ref(ctx);
         let ai_client = provider.get_ai_client();
@@ -1104,43 +1113,7 @@ impl OrchestrationEventStreamer {
                     return;
                 }
 
-                if let Some(stream) = me.streams.get_mut(&conversation_id) {
-                    stream.wake_connection = None;
-                }
-
-                match result {
-                    Ok(Some(wake_message)) => {
-                        log::info!(
-                            "Dormant Claude wake listener observed wake message for \
-                             {conversation_id:?} at sequence {} message_id={}",
-                            wake_message.sequence,
-                            wake_message.message_id
-                        );
-                        me.persist_event_cursor(conversation_id, wake_message.sequence, ctx);
-                        ctx.emit(OrchestrationEventStreamerEvent::DormantClaudeWakeReady {
-                            conversation_id,
-                            wake_message,
-                        });
-                    }
-                    Ok(None) => {
-                        log::warn!(
-                            "Dormant Claude wake listener stopped for {conversation_id:?} \
-                             without observing an event"
-                        );
-                        if me.is_dormant_claude_wake_listener_eligible(conversation_id, ctx) {
-                            me.start_dormant_claude_wake_listener(conversation_id, ctx);
-                        }
-                    }
-                    Err(err) => {
-                        log::warn!(
-                            "Dormant Claude wake listener failed for {conversation_id:?} \
-                             (gen={generation}): {err:#}"
-                        );
-                        if me.is_dormant_claude_wake_listener_eligible(conversation_id, ctx) {
-                            me.start_dormant_claude_wake_listener(conversation_id, ctx);
-                        }
-                    }
-                }
+                me.finish_dormant_claude_wake_listener(conversation_id, generation, result, ctx);
             },
         );
 
@@ -1149,6 +1122,55 @@ impl OrchestrationEventStreamer {
             generation,
             task: handle,
         });
+    }
+
+    fn finish_dormant_claude_wake_listener(
+        &mut self,
+        conversation_id: AIConversationId,
+        generation: u64,
+        result: anyhow::Result<Option<AgentMessageEventMetadata>>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if let Some(stream) = self.streams.get_mut(&conversation_id) {
+            stream.wake_connection = None;
+        }
+
+        match result {
+            Ok(Some(wake_message)) => {
+                log::info!(
+                    "Dormant Claude wake listener observed wake message for \
+                     {conversation_id:?} at sequence {} message_id={}",
+                    wake_message.sequence,
+                    wake_message.message_id
+                );
+                // Leave the durable cursor untouched here. The controller only
+                // persists the wake sequence after Claude wake preparation
+                // successfully stages/surfaces the message into the parent
+                // bridge, so failed prepares can still replay the event.
+                ctx.emit(OrchestrationEventStreamerEvent::DormantClaudeWakeReady {
+                    conversation_id,
+                    wake_message,
+                });
+            }
+            Ok(None) => {
+                log::warn!(
+                    "Dormant Claude wake listener stopped for {conversation_id:?} \
+                     without observing an event"
+                );
+                if self.is_dormant_claude_wake_listener_eligible(conversation_id, ctx) {
+                    self.start_dormant_claude_wake_listener(conversation_id, ctx);
+                }
+            }
+            Err(err) => {
+                log::warn!(
+                    "Dormant Claude wake listener failed for {conversation_id:?} \
+                     (gen={generation}): {err:#}"
+                );
+                if self.is_dormant_claude_wake_listener_eligible(conversation_id, ctx) {
+                    self.start_dormant_claude_wake_listener(conversation_id, ctx);
+                }
+            }
+        }
     }
 
     fn teardown_dormant_claude_wake_listener(&mut self, conversation_id: AIConversationId) {

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -9,6 +9,7 @@ use crate::server::server_api::ai::MockAIClient;
 use crate::server::server_api::ServerApiProvider;
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::{GlobalResourceHandles, GlobalResourceHandlesProvider};
+use mockall::predicate::eq;
 use std::sync::Arc;
 use warpui::App;
 
@@ -302,6 +303,75 @@ fn dormant_local_claude_child_skips_generic_sse_but_allows_wake_listener() {
 }
 
 #[test]
+fn persist_event_cursor_keeps_the_max_sequence_and_updates_history_model() {
+    use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+    use crate::persistence::ModelEvent;
+    use crate::server::server_api::ai::MockAIClient;
+    use crate::server::server_api::ServerApiProvider;
+    use crate::test_util::settings::initialize_settings_for_tests;
+    use crate::{GlobalResourceHandles, GlobalResourceHandlesProvider};
+    use std::sync::Arc;
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
+
+        initialize_settings_for_tests(&mut app);
+        let (sender, receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let run_id = "550e8400-e29b-41d4-a716-446655440201".to_string();
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(run_id.clone());
+        let conversation_id: AIConversationId = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mut mock = MockAIClient::new();
+        mock.expect_update_event_sequence_on_server()
+            .with(eq(run_id.clone()), eq(42))
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        streamer.update(&mut app, |me, ctx| {
+            me.streams.entry(conversation_id).or_default().event_cursor = 42;
+            me.persist_event_cursor(conversation_id, 17, ctx);
+        });
+
+        streamer.read(&app, |me, _| {
+            assert_eq!(
+                me.streams
+                    .get(&conversation_id)
+                    .map(|stream| stream.event_cursor),
+                Some(42)
+            );
+        });
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .and_then(|conversation| conversation.last_event_sequence()),
+                Some(42)
+            );
+        });
+
+        let _ = receiver.recv_timeout(std::time::Duration::from_secs(1));
+    });
+}
+
+#[test]
 fn dormant_local_claude_child_uses_task_harness_when_server_metadata_missing() {
     use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
     use crate::server::server_api::ai::MockAIClient;
@@ -392,7 +462,21 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         consumer.on_event(ignored_event).await.unwrap(),
         AgentEventConsumerControlFlow::Continue
     );
-    assert_eq!(consumer.wake_sequence, None);
+    assert_eq!(consumer.wake_message, None);
+
+    let ignored_same_run_lifecycle = AgentRunEvent {
+        event_type: "run_restarted".to_string(),
+        run_id: "target-run".to_string(),
+        ref_id: None,
+        execution_id: None,
+        occurred_at: "2026-01-01T00:00:00Z".to_string(),
+        sequence: 7,
+    };
+    assert_eq!(
+        consumer.on_event(ignored_same_run_lifecycle).await.unwrap(),
+        AgentEventConsumerControlFlow::Continue
+    );
+    assert_eq!(consumer.wake_message, None);
 
     // The wake consumer uses the default no-op cursor persistence hook; it
     // should not persist SQLite or server cursors while waiting to wake Claude.
@@ -410,7 +494,10 @@ async fn dormant_claude_wake_consumer_stops_on_first_target_event() {
         consumer.on_event(target_event).await.unwrap(),
         AgentEventConsumerControlFlow::Stop
     );
-    assert_eq!(consumer.wake_sequence, Some(8));
+    let wake_message = consumer.wake_message.expect("wake message");
+    assert_eq!(wake_message.sequence, 8);
+    assert_eq!(wake_message.message_id, "message-2");
+    assert_eq!(wake_message.occurred_at, "2026-01-01T00:00:01Z");
 }
 
 #[test]

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -372,6 +372,69 @@ fn persist_event_cursor_keeps_the_max_sequence_and_updates_history_model() {
 }
 
 #[test]
+fn wake_ready_does_not_advance_cursor_before_wake_preparation() {
+    use crate::ai::agent::conversation::AIConversation;
+    use crate::ai::agent_events::AgentMessageEventMetadata;
+    use crate::server::server_api::ai::{AIClient, MockAIClient};
+    use crate::server::server_api::ServerApiProvider;
+    use std::sync::Arc;
+    use warpui::App;
+
+    App::test((), |mut app| async move {
+        let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_last_event_sequence(17);
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let mock = MockAIClient::new();
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+
+        let streamer = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        streamer.update(&mut app, |me, ctx| {
+            me.streams.entry(conversation_id).or_default().event_cursor = 17;
+            me.finish_dormant_claude_wake_listener(
+                conversation_id,
+                1,
+                Ok(Some(AgentMessageEventMetadata {
+                    sequence: 42,
+                    message_id: "message-123".to_string(),
+                    occurred_at: "2026-01-01T00:00:01Z".to_string(),
+                })),
+                ctx,
+            );
+        });
+
+        streamer.read(&app, |me, _| {
+            assert_eq!(
+                me.streams
+                    .get(&conversation_id)
+                    .map(|stream| stream.event_cursor),
+                Some(17)
+            );
+        });
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .and_then(|conversation| conversation.last_event_sequence()),
+                Some(17)
+            );
+        });
+    });
+}
+
+#[test]
 fn dormant_local_claude_child_uses_task_harness_when_server_metadata_missing() {
     use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
     use crate::server::server_api::ai::MockAIClient;


### PR DESCRIPTION
## Description
Fix a race in the dormant local Claude child wake flow where the child could resume before the triggering lead-agent message was readable and surfaced.

This change:
- threads wake-triggering message metadata through the dormant wake path and persists the wake cursor before relaunch
- primes the Claude parent-bridge state before the resumed wake command runs
- retries message hydration during immediate read-after-event lag
- adds focused regression coverage for the wake path and hydrator retries

## Linked Issue
N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt -- --check`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo nextest run -p warp dormant_claude_wake_consumer_stops_on_first_target_event`
- `cargo nextest run -p warp persist_event_cursor_keeps_the_max_sequence_and_updates_history_model`
- `cargo nextest run -p warp handle_event_batch_persists_max_seq_to_history_model`
- `cargo nextest run -p warp prepare_local_wake_command_rehydrates_transcript_with_self_managed_listener`
- `cargo nextest run -p warp prime_parent_bridge_state_for_wake_clears_acked_output_and_surfaces_new_message`
- `cargo nextest run -p warp read_message_with_timeout_`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Artifacts
- Conversation: https://app.warp.dev/conversation/81704264-2d81-452d-bc61-5616acc4ea39
- Plan: https://app.warp.dev/drive/notebook/xoam9fPJAH9InaGf64EJTm

CHANGELOG-BUG-FIX: Fixed a race where dormant local Claude child sessions could resume before the triggering lead-agent message was surfaced.
Co-Authored-By: Oz <oz-agent@warp.dev>
