### PR TITLE
Fix auth secret "New" sidecar not dismissing on hover-away

### DIFF
--- a/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
@@ -119,17 +119,6 @@ impl AuthSecretSelector {
             MenuEvent::ItemSelected => {}
         });
 
-        // Note: the sidecar menu intentionally does NOT use
-        // `prevent_interaction_with_other_elements()`. The main menu already
-        // has it, which is sufficient for outside-click dismissal. Adding it
-        // here would cause the sidecar's `Dismiss` to draw a window-spanning
-        // hit-recording rect at a higher z-index than the main menu, which
-        // would intercept all `MouseMoved` events while the sidecar is open
-        // and prevent the main menu items from firing hover events. That
-        // would break `update_sidecar_visibility_from_hover` and leave the
-        // sidecar visible until the user clicked outside. This mirrors the
-        // pattern in `profile_model_selector.rs`, where only the primary
-        // dropdown uses `prevent_interaction_with_other_elements()`.
         let new_type_sidecar = ctx
             .add_typed_action_view(|_ctx| Menu::new().with_width(SIDECAR_WIDTH).with_drop_shadow());
 

--- a/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_selector.rs
@@ -119,12 +119,19 @@ impl AuthSecretSelector {
             MenuEvent::ItemSelected => {}
         });
 
-        let new_type_sidecar = ctx.add_typed_action_view(|_ctx| {
-            Menu::new()
-                .with_width(SIDECAR_WIDTH)
-                .with_drop_shadow()
-                .prevent_interaction_with_other_elements()
-        });
+        // Note: the sidecar menu intentionally does NOT use
+        // `prevent_interaction_with_other_elements()`. The main menu already
+        // has it, which is sufficient for outside-click dismissal. Adding it
+        // here would cause the sidecar's `Dismiss` to draw a window-spanning
+        // hit-recording rect at a higher z-index than the main menu, which
+        // would intercept all `MouseMoved` events while the sidecar is open
+        // and prevent the main menu items from firing hover events. That
+        // would break `update_sidecar_visibility_from_hover` and leave the
+        // sidecar visible until the user clicked outside. This mirrors the
+        // pattern in `profile_model_selector.rs`, where only the primary
+        // dropdown uses `prevent_interaction_with_other_elements()`.
+        let new_type_sidecar = ctx
+            .add_typed_action_view(|_ctx| Menu::new().with_width(SIDECAR_WIDTH).with_drop_shadow());
 
         ctx.subscribe_to_view(&new_type_sidecar, |me, _, event, ctx| match event {
             MenuEvent::Close { .. } => {


### PR DESCRIPTION
## Description

Loom: https://www.loom.com/share/4b2e47c1aec64a5e884d6f4687f389d1

Fixes [REMOTE-1710](https://linear.app/warpdotdev/issue/REMOTE-1710/submenu-for-new-api-key-creation-doesnt-dismiss-correctly): the auth-secret "New" sidecar in the cloud-mode-v2 input only dismissed on click-outside, never when hovering away.

### Root cause

The `new_type_sidecar` menu was created with `prevent_interaction_with_other_elements()`. While the sidecar was open, its `Dismiss` element painted a window-spanning hit-recording rect at a z-index above the main menu, intercepting every `MouseMoved` event before it could reach the main menu's items. Because `update_sidecar_visibility_from_hover` is driven by `MenuEvent::ItemHovered` from the main menu, it was never re-invoked once the sidecar opened — so hovering a non-"New" item no longer closed the sidecar.

### Fix

Drop `prevent_interaction_with_other_elements()` from the sidecar. The main menu still has it, which is sufficient for outside-click dismissal. With the sidecar's `Dismiss` no longer swallowing pointer movement everywhere else in the window, hover events flow back to main-menu items, and the existing dismissal logic does the right thing:

- Hovering inside the sidecar keeps it open (the main menu's last hover index stays on "New" because no hover-out fires while the cursor is over the sidecar overlay).
- Hovering "New" keeps the sidecar open.
- Hovering any other main-menu item closes it.

This matches the precedent in `profile_model_selector.rs`, where only the primary dropdown uses `prevent_interaction_with_other_elements()` and the sidecar dropdown does not.

## Linked Issue

[REMOTE-1710](https://linear.app/warpdotdev/issue/REMOTE-1710/submenu-for-new-api-key-creation-doesnt-dismiss-correctly)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo check -p warp` — passes
- `cargo clippy -p warp --tests -- -D warnings` — passes
- `cargo fmt -p warp` — clean

No unit test added: this is a pure UI hover-dismiss interaction in the WarpUI menu/sidecar layer, which is not meaningfully covered by unit tests in this codebase.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

_Manual verification recommended in `./script/run --features with_local_server` against the cloud-mode-v2 input:_

1. Click the API key chip → main menu opens.
2. Hover "New" → sidecar opens to the right.
3. Move cursor onto the sidecar items → sidecar stays open. ✔
4. Move cursor back to "New" → sidecar stays open. ✔
5. Move cursor to any other item ("Inherit key from environment", an existing secret) → sidecar dismisses. ✔

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed the "New API key" sidecar in the cloud-agent API key picker not dismissing when hovering away.
-->

_Conversation: https://staging.warp.dev/conversation/725723e4-4c24-4a28-a5b1-1c2bd2115b3a_
_Run: https://oz.staging.warp.dev/runs/019e2e22-3851-78dd-a349-54ee8e40df37_

_This PR was generated with [Oz](https://warp.dev/oz)._
