### PR TITLE
[REMOTE-1709] Back off harness auth secret fetch retries

### DIFF
--- a/app/src/ai/agent_sdk/retry.rs
+++ b/app/src/ai/agent_sdk/retry.rs
@@ -9,7 +9,9 @@ pub(crate) use crate::server::retry_strategies::with_bounded_retry;
 
 // Re-export for tests only; the canonical definitions live in retry_strategies.
 #[cfg(test)]
-pub(crate) use crate::server::retry_strategies::{is_transient_http_error, MAX_ATTEMPTS};
+pub(crate) use crate::server::retry_strategies::{
+    is_transient_graphql_or_http_error, is_transient_http_error, MAX_ATTEMPTS,
+};
 
 #[cfg(test)]
 #[path = "retry_tests.rs"]

--- a/app/src/ai/agent_sdk/retry_tests.rs
+++ b/app/src/ai/agent_sdk/retry_tests.rs
@@ -3,12 +3,22 @@ use std::rc::Rc;
 
 use anyhow::{anyhow, Result};
 use futures::executor::block_on;
+use http::StatusCode;
 
 use super::*;
+use crate::server::graphql::GraphQLError;
 use crate::server::server_api::presigned_upload::HttpStatusError;
 
 fn http_err(status: u16) -> anyhow::Error {
     HttpStatusError {
+        status,
+        body: format!("status {status} body"),
+    }
+    .into()
+}
+
+fn graphql_http_err(status: StatusCode) -> anyhow::Error {
+    GraphQLError::HttpError {
         status,
         body: format!("status {status} body"),
     }
@@ -43,6 +53,40 @@ fn errors_without_http_status_are_treated_as_transient() {
 
     let err = anyhow!("Failed to send request: timed out");
     assert!(is_transient_http_error(&err));
+}
+
+#[test]
+fn graphql_status_classifier_retries_transient_statuses() {
+    assert!(is_transient_graphql_or_http_error(&graphql_http_err(
+        StatusCode::SERVICE_UNAVAILABLE
+    )));
+    assert!(is_transient_graphql_or_http_error(&graphql_http_err(
+        StatusCode::REQUEST_TIMEOUT
+    )));
+    assert!(is_transient_graphql_or_http_error(&graphql_http_err(
+        StatusCode::TOO_MANY_REQUESTS
+    )));
+}
+
+#[test]
+fn graphql_status_classifier_fails_fast_on_permanent_statuses() {
+    assert!(!is_transient_graphql_or_http_error(&graphql_http_err(
+        StatusCode::UNAUTHORIZED
+    )));
+    assert!(!is_transient_graphql_or_http_error(&graphql_http_err(
+        StatusCode::FORBIDDEN
+    )));
+    assert!(!is_transient_graphql_or_http_error(&graphql_http_err(
+        StatusCode::NOT_FOUND
+    )));
+}
+
+#[test]
+fn graphql_status_classifier_fails_fast_without_typed_transport_error() {
+    // GraphQL user-facing errors are converted to plain anyhow errors at the operation
+    // layer, so GraphQL retry call sites should not treat unknown errors as transient.
+    let err = anyhow!("user-facing GraphQL error");
+    assert!(!is_transient_graphql_or_http_error(&err));
 }
 
 #[test]

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -1,21 +1,27 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
+use instant::Instant;
 use serde::{Deserialize, Serialize};
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
 use warp_core::user_preferences::GetUserPreferences;
-use warp_managed_secrets::{client::SecretOwner, ManagedSecretManager, ManagedSecretValue};
-use warpui::{Entity, ModelContext, SingletonEntity};
+use warp_managed_secrets::{ManagedSecretManager, ManagedSecretValue, client::SecretOwner};
+use warpui::{Entity, ModelContext, RequestState, SingletonEntity};
 
 use crate::ai::harness_display;
-use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::AuthStateProvider;
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind};
 use crate::report_error;
+use crate::server::retry_strategies::{
+    OUT_OF_BAND_REQUEST_RETRY_STRATEGY, is_transient_http_error,
+};
 use crate::server::server_api::ServerApiProvider;
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 
 const CACHE_KEY: &str = "AvailableHarnesses";
+const AUTH_SECRET_FETCH_FAILURE_COOLDOWN: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct HarnessModelInfo {
@@ -77,6 +83,7 @@ pub enum HarnessAvailabilityEvent {
 pub struct HarnessAvailabilityModel {
     harnesses: Vec<HarnessAvailability>,
     auth_secrets: HashMap<Harness, AuthSecretFetchState>,
+    auth_secret_retry_after: HashMap<Harness, Instant>,
 }
 
 impl HarnessAvailabilityModel {
@@ -111,6 +118,7 @@ impl HarnessAvailabilityModel {
         let me = Self {
             harnesses,
             auth_secrets: HashMap::new(),
+            auth_secret_retry_after: HashMap::new(),
         };
         me.refresh(ctx);
         me
@@ -160,11 +168,14 @@ impl HarnessAvailabilityModel {
     }
 
     pub fn ensure_auth_secrets_fetched(&mut self, harness: Harness, ctx: &mut ModelContext<Self>) {
-        if matches!(
-            self.auth_secrets_for(harness),
-            AuthSecretFetchState::NotFetched | AuthSecretFetchState::Failed(_)
-        ) {
-            self.fetch_auth_secrets(harness, ctx);
+        match self.auth_secrets_for(harness) {
+            AuthSecretFetchState::NotFetched => self.fetch_auth_secrets(harness, ctx),
+            AuthSecretFetchState::Failed(_) if self.can_retry_auth_secret_fetch(harness) => {
+                self.fetch_auth_secrets(harness, ctx);
+            }
+            AuthSecretFetchState::Failed(_)
+            | AuthSecretFetchState::Loading
+            | AuthSecretFetchState::Loaded(_) => {}
         }
     }
 
@@ -179,38 +190,59 @@ impl HarnessAvailabilityModel {
 
         self.auth_secrets
             .insert(harness, AuthSecretFetchState::Loading);
+        self.auth_secret_retry_after.remove(&harness);
 
         let api = ServerApiProvider::as_ref(ctx).get_managed_secrets_client();
-        ctx.spawn(
-            async move { api.list_harness_auth_secrets(agent_harness).await },
-            move |me, result: Result<Vec<warp_graphql::managed_secrets::ManagedSecret>, _>, ctx| {
-                match result {
-                    Ok(secrets) => {
-                        let entries = secrets
-                            .into_iter()
-                            .map(|s| AuthSecretEntry { name: s.name })
-                            .collect();
-                        me.auth_secrets
-                            .insert(harness, AuthSecretFetchState::Loaded(entries));
-                        ctx.emit(HarnessAvailabilityEvent::AuthSecretsLoaded);
-                    }
-                    Err(e) => {
-                        let msg = e.to_string();
-                        report_error!(e.context("Failed to fetch harness auth secrets"));
-                        me.auth_secrets
-                            .insert(harness, AuthSecretFetchState::Failed(msg));
-                        // Notify subscribers so they can drop any
-                        // "Loading…" placeholder rendered during the
-                        // in-flight fetch and surface the error state.
-                        ctx.emit(HarnessAvailabilityEvent::AuthSecretsFetchFailed);
-                    }
+        ctx.spawn_with_retry_on_error_when(
+            move || {
+                let api = api.clone();
+                let agent_harness = agent_harness.clone();
+                async move { api.list_harness_auth_secrets(agent_harness).await }
+            },
+            OUT_OF_BAND_REQUEST_RETRY_STRATEGY,
+            is_transient_http_error,
+            move |me,
+                  result: RequestState<Vec<warp_graphql::managed_secrets::ManagedSecret>>,
+                  ctx| match result {
+                RequestState::RequestSucceeded(secrets) => {
+                    let entries = secrets
+                        .into_iter()
+                        .map(|s| AuthSecretEntry { name: s.name })
+                        .collect();
+                    me.auth_secrets
+                        .insert(harness, AuthSecretFetchState::Loaded(entries));
+                    me.auth_secret_retry_after.remove(&harness);
+                    ctx.emit(HarnessAvailabilityEvent::AuthSecretsLoaded);
+                }
+                RequestState::RequestFailedRetryPending(e) => {
+                    log::warn!("Failed to fetch harness auth secrets; retrying: {e:#}");
+                }
+                RequestState::RequestFailed(e) => {
+                    let msg = e.to_string();
+                    report_error!(e.context("Failed to fetch harness auth secrets"));
+                    me.auth_secrets
+                        .insert(harness, AuthSecretFetchState::Failed(msg));
+                    me.auth_secret_retry_after
+                        .insert(harness, Instant::now() + AUTH_SECRET_FETCH_FAILURE_COOLDOWN);
+                    // Notify subscribers so they can drop any
+                    // "Loading…" placeholder rendered during the
+                    // in-flight fetch and surface the error state.
+                    ctx.emit(HarnessAvailabilityEvent::AuthSecretsFetchFailed);
                 }
             },
         );
     }
 
+    fn can_retry_auth_secret_fetch(&self, harness: Harness) -> bool {
+        self.auth_secret_retry_after
+            .get(&harness)
+            .map(|retry_after| Instant::now() >= *retry_after)
+            .unwrap_or(true)
+    }
+
     pub fn invalidate_auth_secrets(&mut self, harness: Harness) {
         self.auth_secrets.remove(&harness);
+        self.auth_secret_retry_after.remove(&harness);
     }
 
     pub fn create_auth_secret(

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -6,16 +6,16 @@ use serde::{Deserialize, Serialize};
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
 use warp_core::user_preferences::GetUserPreferences;
-use warp_managed_secrets::{ManagedSecretManager, ManagedSecretValue, client::SecretOwner};
+use warp_managed_secrets::{client::SecretOwner, ManagedSecretManager, ManagedSecretValue};
 use warpui::{Entity, ModelContext, RequestState, SingletonEntity};
 
 use crate::ai::harness_display;
-use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::auth::AuthStateProvider;
 use crate::network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind};
 use crate::report_error;
 use crate::server::retry_strategies::{
-    OUT_OF_BAND_REQUEST_RETRY_STRATEGY, is_transient_http_error,
+    is_transient_graphql_or_http_error, OUT_OF_BAND_REQUEST_RETRY_STRATEGY,
 };
 use crate::server::server_api::ServerApiProvider;
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
@@ -200,7 +200,7 @@ impl HarnessAvailabilityModel {
                 async move { api.list_harness_auth_secrets(agent_harness).await }
             },
             OUT_OF_BAND_REQUEST_RETRY_STRATEGY,
-            is_transient_http_error,
+            is_transient_graphql_or_http_error,
             move |me,
                   result: RequestState<Vec<warp_graphql::managed_secrets::ManagedSecret>>,
                   ctx| match result {

--- a/app/src/server/retry_strategies.rs
+++ b/app/src/server/retry_strategies.rs
@@ -6,6 +6,7 @@ use warpui::duration_with_jitter;
 use warpui::r#async::Timer;
 use warpui::RetryOption;
 
+use crate::server::graphql::GraphQLError;
 use crate::server::server_api::presigned_upload::HttpStatusError;
 
 /// Common duration for a periodic poll. In our app, we generally have the following to update the same data:
@@ -55,10 +56,38 @@ pub(crate) fn is_transient_http_error(e: &anyhow::Error) -> bool {
     // the top-level error object — walk the chain.
     for cause in e.chain() {
         if let Some(http_err) = cause.downcast_ref::<HttpStatusError>() {
-            return matches!(http_err.status, 408 | 429 | 500..=599);
+            return is_transient_status(http_err.status);
         }
     }
     true
+}
+
+/// Classify GraphQL/public-API status errors as transient or permanent.
+///
+/// Unlike [`is_transient_http_error`], errors without a typed HTTP/GraphQL transport
+/// cause are treated as permanent. This is intended for GraphQL operations where
+/// user-facing GraphQL errors are converted into plain `anyhow` errors at the
+/// operation layer and should not be retried or placed into transient cooldowns.
+pub(crate) fn is_transient_graphql_or_http_error(e: &anyhow::Error) -> bool {
+    for cause in e.chain() {
+        if let Some(graphql_err) = cause.downcast_ref::<GraphQLError>() {
+            return match graphql_err {
+                GraphQLError::RequestError(_) => true,
+                GraphQLError::HttpError { status, .. } => is_transient_status(status.as_u16()),
+                GraphQLError::StagingAccessBlocked | GraphQLError::ResponseError(_) => false,
+            };
+        }
+
+        if let Some(http_err) = cause.downcast_ref::<HttpStatusError>() {
+            return is_transient_status(http_err.status);
+        }
+    }
+
+    false
+}
+
+fn is_transient_status(status: u16) -> bool {
+    matches!(status, 408 | 429 | 500..=599)
 }
 
 /// Maximum total attempts per operation (initial attempt plus retries on transient errors).


### PR DESCRIPTION
## Description
- Adds bounded retry with the shared out-of-band request retry strategy for `list_harness_auth_secrets`.
- Keeps auth secret fetch state as `Loading` while retry attempts are pending, avoiding intermediate failure events.
- Adds a 60s per-harness cooldown after final failure so picker repopulation/subscriber loops do not immediately start another retry chain while the server is down.

## Linked Issue
REMOTE-1709

## Testing
- `cargo fmt -- app/src/ai/harness_availability.rs`
- `cargo check -p warp`
- `cargo clippy -p warp --all-targets`

- [X] I have manually tested my changes locally with `./script/run`

works locally without spamming the server anymore!

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
