### PR TITLE
QUALITY-731: round-trip orchestrator agent short name through task records

### DIFF
--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -360,6 +360,12 @@ pub struct TaskAttachment {
     pub mime_type: String,
 }
 
+/// Returns the trimmed orchestrator agent name, or `None` when empty / whitespace-only.
+pub fn normalize_orchestrator_agent_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 impl AmbientAgentTask {
     pub fn run_id(&self) -> AmbientAgentTaskId {
         self.task_id

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -365,13 +365,8 @@ impl AmbientAgentTask {
         self.task_id
     }
 
-    /// Returns the short orchestrator-supplied label for this task, if any,
-    /// falling back to the descriptive `title` and then the literal `"Agent"`.
-    ///
-    /// QUALITY-731: the label is sourced from the existing
-    /// `agent_config_snapshot.name` field rather than a parallel top-level
-    /// `name` field on the task. Each layer is trimmed; whitespace-only values
-    /// are treated as absent so we fall through to the next fallback.
+    /// Returns the short label for this task: trimmed `agent_config_snapshot.name`,
+    /// trimmed `title`, or `"Agent"`.
     pub fn display_name(&self) -> &str {
         if let Some(name) = self
             .agent_config_snapshot

--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -365,6 +365,31 @@ impl AmbientAgentTask {
         self.task_id
     }
 
+    /// Returns the short orchestrator-supplied label for this task, if any,
+    /// falling back to the descriptive `title` and then the literal `"Agent"`.
+    ///
+    /// QUALITY-731: the label is sourced from the existing
+    /// `agent_config_snapshot.name` field rather than a parallel top-level
+    /// `name` field on the task. Each layer is trimmed; whitespace-only values
+    /// are treated as absent so we fall through to the next fallback.
+    pub fn display_name(&self) -> &str {
+        if let Some(name) = self
+            .agent_config_snapshot
+            .as_ref()
+            .and_then(|c| c.name.as_deref())
+        {
+            let trimmed = name.trim();
+            if !trimmed.is_empty() {
+                return trimmed;
+            }
+        }
+        let trimmed_title = self.title.trim();
+        if !trimmed_title.is_empty() {
+            return trimmed_title;
+        }
+        "Agent"
+    }
+
     pub fn conversation_id(&self) -> Option<&str> {
         self.conversation_id.as_deref()
     }

--- a/app/src/ai/ambient_agents/task_tests.rs
+++ b/app/src/ai/ambient_agents/task_tests.rs
@@ -61,6 +61,12 @@ fn display_name_returns_literal_agent_when_both_sources_are_empty() {
 }
 
 #[test]
+fn display_name_returns_literal_agent_for_whitespace_only_title() {
+    let task = make_task(None, "   \t\n  ");
+    assert_eq!(task.display_name(), "Agent");
+}
+
+#[test]
 fn display_name_trims_whitespace_at_each_layer() {
     let task = make_task(Some("  frontend-tests  "), "  Long descriptive title  ");
     assert_eq!(task.display_name(), "frontend-tests");

--- a/app/src/ai/ambient_agents/task_tests.rs
+++ b/app/src/ai/ambient_agents/task_tests.rs
@@ -1,4 +1,73 @@
-use super::{TaskStatusErrorCode, TaskStatusMessage};
+use chrono::Utc;
+
+use super::{
+    AgentConfigSnapshot, AmbientAgentTask, AmbientAgentTaskState, TaskStatusErrorCode,
+    TaskStatusMessage,
+};
+
+fn make_task(snapshot_name: Option<&str>, title: &str) -> AmbientAgentTask {
+    let now = Utc::now();
+    let agent_config_snapshot = snapshot_name.map(|name| AgentConfigSnapshot {
+        name: Some(name.to_string()),
+        ..Default::default()
+    });
+    AmbientAgentTask {
+        task_id: "11111111-1111-1111-1111-111111111111".parse().unwrap(),
+        parent_run_id: None,
+        title: title.to_string(),
+        state: AmbientAgentTaskState::InProgress,
+        prompt: String::new(),
+        created_at: now,
+        started_at: Some(now),
+        updated_at: now,
+        status_message: None,
+        source: None,
+        session_id: None,
+        session_link: None,
+        creator: None,
+        executor: None,
+        conversation_id: None,
+        request_usage: None,
+        is_sandbox_running: false,
+        agent_config_snapshot,
+        artifacts: vec![],
+        last_event_sequence: None,
+        children: vec![],
+    }
+}
+
+#[test]
+fn display_name_prefers_agent_config_snapshot_name_over_title() {
+    let task = make_task(Some("frontend-tests"), "Long descriptive task title");
+    assert_eq!(task.display_name(), "frontend-tests");
+}
+
+#[test]
+fn display_name_falls_back_to_title_when_snapshot_name_is_missing() {
+    let task = make_task(None, "Long descriptive task title");
+    assert_eq!(task.display_name(), "Long descriptive task title");
+}
+
+#[test]
+fn display_name_falls_back_to_title_when_snapshot_name_is_whitespace() {
+    let task = make_task(Some("   "), "Long descriptive task title");
+    assert_eq!(task.display_name(), "Long descriptive task title");
+}
+
+#[test]
+fn display_name_returns_literal_agent_when_both_sources_are_empty() {
+    let task = make_task(None, "");
+    assert_eq!(task.display_name(), "Agent");
+}
+
+#[test]
+fn display_name_trims_whitespace_at_each_layer() {
+    let task = make_task(Some("  frontend-tests  "), "  Long descriptive title  ");
+    assert_eq!(task.display_name(), "frontend-tests");
+
+    let task = make_task(None, "  Long descriptive title  ");
+    assert_eq!(task.display_name(), "Long descriptive title");
+}
 
 #[test]
 fn task_status_error_code_deserializes_public_api_casing() {

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -373,6 +373,10 @@ impl ConversationDetailsData {
                 environment_id,
                 conversation_id: task.conversation_id().map(str::to_string),
             },
+            // QUALITY-731: side-pane header intentionally keeps `task.title`
+            // (descriptive) rather than `task.display_name()` (the short
+            // orchestrator label) while product evaluates whether to show
+            // both. See specs/QUALITY-731/TECH.md before changing this.
             title: task.title.clone(),
             created_at: Some(task.created_at.with_timezone(&Local)),
             artifacts: task.artifacts.clone(),

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -373,10 +373,8 @@ impl ConversationDetailsData {
                 environment_id,
                 conversation_id: task.conversation_id().map(str::to_string),
             },
-            // QUALITY-731: side-pane header intentionally keeps `task.title`
-            // (descriptive) rather than `task.display_name()` (the short
-            // orchestrator label) while product evaluates whether to show
-            // both. See specs/QUALITY-731/TECH.md before changing this.
+            // Intentionally uses task.title; revisit when product decides
+            // whether to also show the short orchestrator label here.
             title: task.title.clone(),
             created_at: Some(task.created_at.with_timezone(&Local)),
             artifacts: task.artifacts.clone(),

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -69,13 +69,7 @@ pub(super) fn build_local_codex_child_command(prompt: &str) -> String {
     format!("codex --dangerously-bypass-approvals-and-sandbox {quoted_prompt}")
 }
 
-/// Normalizes the orchestrator-supplied short name for QUALITY-731 round-trip.
-///
-/// Trims leading/trailing whitespace and treats empty / whitespace-only
-/// strings as absent. Use this at every site that converts an external
-/// orchestrator-supplied name into the `Option<String>` stored on
-/// `AgentConfigSnapshot.name` so the same input always normalizes to the
-/// same value across paths.
+/// Returns the trimmed orchestrator agent name, or `None` when empty / whitespace-only.
 pub(super) fn normalize_orchestrator_agent_name(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
@@ -85,7 +79,6 @@ pub(super) fn local_child_task_config(
     harness: Harness,
     agent_name: Option<String>,
 ) -> Option<AgentConfigSnapshot> {
-    // Re-normalize defensively in case a caller passed `Some("  ")`.
     let agent_name = agent_name
         .as_deref()
         .and_then(normalize_orchestrator_agent_name);

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -69,11 +69,20 @@ pub(super) fn build_local_codex_child_command(prompt: &str) -> String {
     format!("codex --dangerously-bypass-approvals-and-sandbox {quoted_prompt}")
 }
 
-fn local_child_task_config(harness: Harness) -> Option<AgentConfigSnapshot> {
+pub(super) fn local_child_task_config(
+    harness: Harness,
+    agent_name: Option<String>,
+) -> Option<AgentConfigSnapshot> {
+    // Normalize whitespace-only/empty orchestrator names to absent.
+    let agent_name = agent_name.and_then(|name| {
+        let trimmed = name.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    });
     match harness {
         Harness::Oz | Harness::Unknown => None,
         Harness::Claude | Harness::OpenCode | Harness::Gemini | Harness::Codex => {
             Some(AgentConfigSnapshot {
+                name: agent_name,
                 harness: Some(HarnessConfig::from_harness_type(harness)),
                 ..Default::default()
             })
@@ -81,11 +90,13 @@ fn local_child_task_config(harness: Harness) -> Option<AgentConfigSnapshot> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn prepare_local_harness_child_launch(
     prompt: String,
     harness_type: String,
     model_id: Option<String>,
     parent_run_id: Option<String>,
+    agent_name: Option<String>,
     shell_type: Option<ShellType>,
     startup_directory: Option<PathBuf>,
     ai_client: Arc<dyn AIClient>,
@@ -177,7 +188,7 @@ pub(super) async fn prepare_local_harness_child_launch(
             prompt.clone(),
             None,
             parent_run_id.clone(),
-            local_child_task_config(harness),
+            local_child_task_config(harness, agent_name),
         )
         .await
         .map_err(|error| {

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -13,7 +13,7 @@ use crate::ai::{
         task_env_vars, validate_cli_installed,
     },
     ambient_agents::{
-        task::{HarnessConfig, HarnessModelConfig},
+        task::{normalize_orchestrator_agent_name, HarnessConfig, HarnessModelConfig},
         AgentConfigSnapshot, AmbientAgentTaskId,
     },
 };
@@ -67,12 +67,6 @@ pub(super) fn build_local_opencode_child_command(prompt: &str) -> String {
 pub(super) fn build_local_codex_child_command(prompt: &str) -> String {
     let quoted_prompt = shell_quote(prompt);
     format!("codex --dangerously-bypass-approvals-and-sandbox {quoted_prompt}")
-}
-
-/// Returns the trimmed orchestrator agent name, or `None` when empty / whitespace-only.
-pub(super) fn normalize_orchestrator_agent_name(raw: &str) -> Option<String> {
-    let trimmed = raw.trim();
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 pub(super) fn local_child_task_config(

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -69,15 +69,26 @@ pub(super) fn build_local_codex_child_command(prompt: &str) -> String {
     format!("codex --dangerously-bypass-approvals-and-sandbox {quoted_prompt}")
 }
 
+/// Normalizes the orchestrator-supplied short name for QUALITY-731 round-trip.
+///
+/// Trims leading/trailing whitespace and treats empty / whitespace-only
+/// strings as absent. Use this at every site that converts an external
+/// orchestrator-supplied name into the `Option<String>` stored on
+/// `AgentConfigSnapshot.name` so the same input always normalizes to the
+/// same value across paths.
+pub(super) fn normalize_orchestrator_agent_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 pub(super) fn local_child_task_config(
     harness: Harness,
     agent_name: Option<String>,
 ) -> Option<AgentConfigSnapshot> {
-    // Normalize whitespace-only/empty orchestrator names to absent.
-    let agent_name = agent_name.and_then(|name| {
-        let trimmed = name.trim();
-        (!trimmed.is_empty()).then(|| trimmed.to_string())
-    });
+    // Re-normalize defensively in case a caller passed `Some("  ")`.
+    let agent_name = agent_name
+        .as_deref()
+        .and_then(normalize_orchestrator_agent_name);
     match harness {
         Harness::Oz | Harness::Unknown => None,
         Harness::Claude | Harness::OpenCode | Harness::Gemini | Harness::Codex => {

--- a/app/src/pane_group/pane/local_harness_launch_tests.rs
+++ b/app/src/pane_group/pane/local_harness_launch_tests.rs
@@ -150,13 +150,53 @@ fn build_local_codex_child_command_quotes_the_prompt() {
 fn local_child_task_config_records_supported_third_party_harnesses() {
     for harness in [Harness::Claude, Harness::OpenCode, Harness::Codex] {
         assert_eq!(
-            local_child_task_config(harness),
+            local_child_task_config(harness, None),
             Some(crate::ai::ambient_agents::task::AgentConfigSnapshot {
                 harness: Some(HarnessConfig::from_harness_type(harness)),
                 ..Default::default()
             }),
         );
     }
+}
+
+#[test]
+fn local_child_task_config_stamps_orchestrator_name() {
+    for harness in [Harness::Claude, Harness::OpenCode, Harness::Codex] {
+        assert_eq!(
+            local_child_task_config(harness, Some("frontend-tests".to_string())),
+            Some(crate::ai::ambient_agents::task::AgentConfigSnapshot {
+                name: Some("frontend-tests".to_string()),
+                harness: Some(HarnessConfig::from_harness_type(harness)),
+                ..Default::default()
+            }),
+        );
+    }
+}
+
+#[test]
+fn local_child_task_config_trims_whitespace_only_name() {
+    assert_eq!(
+        local_child_task_config(Harness::Claude, Some("  frontend-tests  ".to_string())),
+        Some(crate::ai::ambient_agents::task::AgentConfigSnapshot {
+            name: Some("frontend-tests".to_string()),
+            harness: Some(HarnessConfig::from_harness_type(Harness::Claude)),
+            ..Default::default()
+        }),
+    );
+    assert_eq!(
+        local_child_task_config(Harness::Claude, Some("   ".to_string())),
+        Some(crate::ai::ambient_agents::task::AgentConfigSnapshot {
+            name: None,
+            harness: Some(HarnessConfig::from_harness_type(Harness::Claude)),
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn local_child_task_config_returns_none_for_oz_and_unknown() {
+    assert!(local_child_task_config(Harness::Oz, Some("name".to_string())).is_none());
+    assert!(local_child_task_config(Harness::Unknown, Some("name".to_string())).is_none());
 }
 
 #[tokio::test]
@@ -183,6 +223,7 @@ async fn prepare_local_codex_child_launch_does_not_rewrite_global_codex_state() 
         "codex".to_string(),
         None,
         Some("parent-run".to_string()),
+        None,
         Some(ShellType::Zsh),
         Some(working_dir),
         Arc::new(ai_client),
@@ -221,6 +262,7 @@ async fn prepare_local_claude_child_merges_anthropic_model_env_var() {
         "claude".to_string(),
         Some("opus".to_string()),
         Some("parent-run".to_string()),
+        None,
         Some(ShellType::Zsh),
         Some(working_dir),
         Arc::new(ai_client),
@@ -258,6 +300,7 @@ async fn prepare_local_claude_child_no_anthropic_model_when_empty() {
         "claude".to_string(),
         None,
         Some("parent-run".to_string()),
+        None,
         Some(ShellType::Zsh),
         Some(working_dir),
         Arc::new(ai_client),
@@ -278,6 +321,7 @@ async fn prepare_local_harness_child_launch_rejects_disabled_claude_before_shell
         "claude".to_string(),
         None,
         Some("parent-run".to_string()),
+        None,
         None,
         None,
         ai_client,

--- a/app/src/pane_group/pane/local_harness_launch_tests.rs
+++ b/app/src/pane_group/pane/local_harness_launch_tests.rs
@@ -6,7 +6,8 @@ use warp_cli::agent::Harness;
 use super::{
     build_local_claude_child_command, build_local_codex_child_command,
     build_local_opencode_child_command, local_child_task_config, normalize_local_child_harness,
-    prepare_local_harness_child_launch, validate_local_harness_shell,
+    normalize_orchestrator_agent_name, prepare_local_harness_child_launch,
+    validate_local_harness_shell,
 };
 use crate::ai::ambient_agents::task::HarnessConfig;
 use crate::server::server_api::ai::MockAIClient;
@@ -197,6 +198,21 @@ fn local_child_task_config_trims_whitespace_only_name() {
 fn local_child_task_config_returns_none_for_oz_and_unknown() {
     assert!(local_child_task_config(Harness::Oz, Some("name".to_string())).is_none());
     assert!(local_child_task_config(Harness::Unknown, Some("name".to_string())).is_none());
+}
+
+#[test]
+fn normalize_orchestrator_agent_name_trims_and_drops_empty() {
+    assert_eq!(
+        normalize_orchestrator_agent_name("frontend-tests"),
+        Some("frontend-tests".to_string())
+    );
+    assert_eq!(
+        normalize_orchestrator_agent_name("  frontend-tests  "),
+        Some("frontend-tests".to_string())
+    );
+    assert_eq!(normalize_orchestrator_agent_name(""), None);
+    assert_eq!(normalize_orchestrator_agent_name("   "), None);
+    assert_eq!(normalize_orchestrator_agent_name("\t\n  "), None);
 }
 
 #[tokio::test]

--- a/app/src/pane_group/pane/local_harness_launch_tests.rs
+++ b/app/src/pane_group/pane/local_harness_launch_tests.rs
@@ -6,10 +6,9 @@ use warp_cli::agent::Harness;
 use super::{
     build_local_claude_child_command, build_local_codex_child_command,
     build_local_opencode_child_command, local_child_task_config, normalize_local_child_harness,
-    normalize_orchestrator_agent_name, prepare_local_harness_child_launch,
-    validate_local_harness_shell,
+    prepare_local_harness_child_launch, validate_local_harness_shell,
 };
-use crate::ai::ambient_agents::task::HarnessConfig;
+use crate::ai::ambient_agents::task::{normalize_orchestrator_agent_name, HarnessConfig};
 use crate::server::server_api::ai::MockAIClient;
 use crate::terminal::shell::ShellType;
 use warp_core::features::FeatureFlag;

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1714,10 +1714,26 @@ fn launch_local_no_harness_child(
         .and_then(|view| host_terminal_shared_session_source_type(&view, ctx));
 
     let prompt_for_create = prompt.clone();
+    // QUALITY-731: stamp the orchestrator-supplied short name into the
+    // task's AgentConfigSnapshot so a viewer reconstructing the child can
+    // recover it via `AmbientAgentTask::display_name()`. Trim whitespace at
+    // the construction site; treat empty/whitespace-only as absent.
+    let agent_name_for_create = {
+        let trimmed = request_name.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    };
     let _ = ctx.spawn(
         async move {
             ai_client
-                .create_agent_task(prompt_for_create, None, parent_run_id, None)
+                .create_agent_task(
+                    prompt_for_create,
+                    None,
+                    parent_run_id,
+                    Some(AgentConfigSnapshot {
+                        name: agent_name_for_create,
+                        ..Default::default()
+                    }),
+                )
                 .await
         },
         move |group, result, ctx| match result {
@@ -1861,6 +1877,10 @@ fn launch_local_harness_child(
         .and_then(|view| host_terminal_shared_session_source_type(&view, ctx));
 
     let model_id_for_harness_env = model_id.clone();
+    // QUALITY-731: forward the orchestrator's short name into the
+    // local-harness task's AgentConfigSnapshot.name. Trim is handled inside
+    // `local_child_task_config`.
+    let agent_name_for_task = Some(request_name.clone());
     let _ = ctx.spawn(
         async move {
             prepare_local_harness_child_launch(
@@ -1868,6 +1888,7 @@ fn launch_local_harness_child(
                 harness_type,
                 model_id_for_harness_env,
                 parent_run_id,
+                agent_name_for_task,
                 shell_type,
                 startup_directory,
                 ai_client,
@@ -2034,6 +2055,11 @@ fn launch_remote_child(
         return None;
     };
 
+    // QUALITY-731: clone the orchestrator-supplied short name before it is
+    // moved into `start_new_child_conversation`. The clone is stamped into
+    // `AgentConfigSnapshot.name` on the outbound `SpawnAgentRequest` below.
+    let request_name = request.name.clone();
+
     let new_pane_id = group.insert_ambient_agent_pane_hidden_for_child_agent(parent_pane_id, ctx);
 
     let Some(new_terminal_view) = group.terminal_view_from_pane_id(new_pane_id, ctx) else {
@@ -2133,10 +2159,18 @@ fn launch_remote_child(
             }),
             Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Unknown => None,
         });
+    // QUALITY-731: stamp the orchestrator-supplied short name into the
+    // outbound `AgentConfigSnapshot.name`. Trim whitespace at the
+    // construction site; treat empty/whitespace-only as absent.
+    let agent_name = {
+        let trimmed = request_name.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    };
     let spawn_request = SpawnAgentRequest {
         prompt: request.prompt,
         mode: UserQueryMode::Normal,
         config: Some(AgentConfigSnapshot {
+            name: agent_name,
             environment_id,
             model_id: (!model_id.is_empty()).then_some(model_id),
             worker_host: (!worker_host.is_empty()).then_some(worker_host),

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1701,13 +1701,6 @@ fn launch_local_no_harness_child(
 ) {
     let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
     let request_id = request.id;
-    // QUALITY-731: normalize the orchestrator-supplied short name once and
-    // use the same trimmed value at every site (the hidden child
-    // conversation's `agent_name`, the task snapshot's
-    // `agent_config_snapshot.name`, and any error-fallback conversation).
-    // Without this, a `request.name` of `"  frontend-tests  "` would set
-    // the conversation's `agent_name` to the untrimmed value while the
-    // snapshot dropped the whitespace, producing inconsistent labels.
     let agent_name = normalize_orchestrator_agent_name(&request.name);
     let request_name = agent_name.clone().unwrap_or_default();
     let parent_conversation_id = request.parent_conversation_id;
@@ -1861,7 +1854,6 @@ fn launch_local_harness_child(
     let startup_directory = group.startup_path_for_new_session(Some(terminal_pane_id), ctx);
     let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
     let request_id = request.id;
-    // QUALITY-731: same normalize-once treatment as launch_local_no_harness_child.
     let agent_name = normalize_orchestrator_agent_name(&request.name);
     let request_name = agent_name.clone().unwrap_or_default();
     let parent_conversation_id = request.parent_conversation_id;
@@ -2058,11 +2050,6 @@ fn launch_remote_child(
         return None;
     };
 
-    // QUALITY-731: normalize the orchestrator-supplied short name once and
-    // use the same trimmed value for both the hidden child conversation's
-    // `agent_name` (via `start_new_child_conversation`) and the task
-    // snapshot's `agent_config_snapshot.name` on the outbound
-    // `SpawnAgentRequest`.
     let agent_name = normalize_orchestrator_agent_name(&request.name);
     let request_name = agent_name.clone().unwrap_or_default();
 

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -21,7 +21,10 @@ use crate::{
             conversation::{AIConversationId, ConversationStatus},
             StartAgentExecutionMode,
         },
-        ambient_agents::{task::HarnessConfig, AgentConfigSnapshot, AmbientAgentTaskId},
+        ambient_agents::{
+            task::{normalize_orchestrator_agent_name, HarnessConfig},
+            AgentConfigSnapshot, AmbientAgentTaskId,
+        },
         blocklist::{
             agent_view::{AgentViewControllerEvent, AgentViewEntryOrigin},
             orchestration_event_streamer::OrchestrationEventStreamer,
@@ -81,10 +84,7 @@ use session_sharing_protocol::sharer::SessionSourceType;
 use warp_core::execution_mode::AppExecutionMode;
 
 #[cfg(not(target_family = "wasm"))]
-use super::local_harness_launch::{
-    normalize_orchestrator_agent_name, prepare_local_harness_child_launch,
-    PreparedLocalHarnessLaunch,
-};
+use super::local_harness_launch::{prepare_local_harness_child_launch, PreparedLocalHarnessLaunch};
 use super::{
     DetachType, PaneConfiguration, PaneContent, PaneId, PaneStackEvent, PaneView, ShareableLink,
     ShareableLinkError, TerminalPaneId,

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -81,7 +81,10 @@ use session_sharing_protocol::sharer::SessionSourceType;
 use warp_core::execution_mode::AppExecutionMode;
 
 #[cfg(not(target_family = "wasm"))]
-use super::local_harness_launch::{prepare_local_harness_child_launch, PreparedLocalHarnessLaunch};
+use super::local_harness_launch::{
+    normalize_orchestrator_agent_name, prepare_local_harness_child_launch,
+    PreparedLocalHarnessLaunch,
+};
 use super::{
     DetachType, PaneConfiguration, PaneContent, PaneId, PaneStackEvent, PaneView, ShareableLink,
     ShareableLinkError, TerminalPaneId,
@@ -1698,7 +1701,15 @@ fn launch_local_no_harness_child(
 ) {
     let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
     let request_id = request.id;
-    let request_name = request.name.clone();
+    // QUALITY-731: normalize the orchestrator-supplied short name once and
+    // use the same trimmed value at every site (the hidden child
+    // conversation's `agent_name`, the task snapshot's
+    // `agent_config_snapshot.name`, and any error-fallback conversation).
+    // Without this, a `request.name` of `"  frontend-tests  "` would set
+    // the conversation's `agent_name` to the untrimmed value while the
+    // snapshot dropped the whitespace, producing inconsistent labels.
+    let agent_name = normalize_orchestrator_agent_name(&request.name);
+    let request_name = agent_name.clone().unwrap_or_default();
     let parent_conversation_id = request.parent_conversation_id;
     let parent_run_id = request.parent_run_id.clone();
     let prompt = request.prompt.clone();
@@ -1714,14 +1725,7 @@ fn launch_local_no_harness_child(
         .and_then(|view| host_terminal_shared_session_source_type(&view, ctx));
 
     let prompt_for_create = prompt.clone();
-    // QUALITY-731: stamp the orchestrator-supplied short name into the
-    // task's AgentConfigSnapshot so a viewer reconstructing the child can
-    // recover it via `AmbientAgentTask::display_name()`. Trim whitespace at
-    // the construction site; treat empty/whitespace-only as absent.
-    let agent_name_for_create = {
-        let trimmed = request_name.trim();
-        (!trimmed.is_empty()).then(|| trimmed.to_string())
-    };
+    let agent_name_for_create = agent_name.clone();
     let _ = ctx.spawn(
         async move {
             ai_client
@@ -1857,7 +1861,9 @@ fn launch_local_harness_child(
     let startup_directory = group.startup_path_for_new_session(Some(terminal_pane_id), ctx);
     let ai_client = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
     let request_id = request.id;
-    let request_name = request.name.clone();
+    // QUALITY-731: same normalize-once treatment as launch_local_no_harness_child.
+    let agent_name = normalize_orchestrator_agent_name(&request.name);
+    let request_name = agent_name.clone().unwrap_or_default();
     let parent_conversation_id = request.parent_conversation_id;
     let parent_run_id = request.parent_run_id.clone();
     let prompt = request.prompt.clone();
@@ -1877,10 +1883,7 @@ fn launch_local_harness_child(
         .and_then(|view| host_terminal_shared_session_source_type(&view, ctx));
 
     let model_id_for_harness_env = model_id.clone();
-    // QUALITY-731: forward the orchestrator's short name into the
-    // local-harness task's AgentConfigSnapshot.name. Trim is handled inside
-    // `local_child_task_config`.
-    let agent_name_for_task = Some(request_name.clone());
+    let agent_name_for_task = agent_name.clone();
     let _ = ctx.spawn(
         async move {
             prepare_local_harness_child_launch(
@@ -2055,10 +2058,13 @@ fn launch_remote_child(
         return None;
     };
 
-    // QUALITY-731: clone the orchestrator-supplied short name before it is
-    // moved into `start_new_child_conversation`. The clone is stamped into
-    // `AgentConfigSnapshot.name` on the outbound `SpawnAgentRequest` below.
-    let request_name = request.name.clone();
+    // QUALITY-731: normalize the orchestrator-supplied short name once and
+    // use the same trimmed value for both the hidden child conversation's
+    // `agent_name` (via `start_new_child_conversation`) and the task
+    // snapshot's `agent_config_snapshot.name` on the outbound
+    // `SpawnAgentRequest`.
+    let agent_name = normalize_orchestrator_agent_name(&request.name);
+    let request_name = agent_name.clone().unwrap_or_default();
 
     let new_pane_id = group.insert_ambient_agent_pane_hidden_for_child_agent(parent_pane_id, ctx);
 
@@ -2072,7 +2078,7 @@ fn launch_remote_child(
     let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
         let id = history_model.start_new_child_conversation(
             terminal_view_id,
-            request.name,
+            request_name.clone(),
             request.parent_conversation_id,
             Some(orchestration_harness),
             ctx,
@@ -2159,13 +2165,6 @@ fn launch_remote_child(
             }),
             Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Unknown => None,
         });
-    // QUALITY-731: stamp the orchestrator-supplied short name into the
-    // outbound `AgentConfigSnapshot.name`. Trim whitespace at the
-    // construction site; treat empty/whitespace-only as absent.
-    let agent_name = {
-        let trimmed = request_name.trim();
-        (!trimmed.is_empty()).then(|| trimmed.to_string())
-    };
     let spawn_request = SpawnAgentRequest {
         prompt: request.prompt,
         mode: UserQueryMode::Normal,

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -302,8 +302,14 @@ impl OrchestrationViewerModel {
             // the descriptive `task.title` as the conversation's fallback
             // display title so `AIConversation::title()` still surfaces it
             // when no task description or initial query exists.
+            //
+            // Trim before checking AND before storing so a whitespace-only
+            // `task.title` (e.g. `"   "`) does not desync from
+            // `display_name()` (which also trims): without this,
+            // `agent_name()` would return `"Agent"` while `title()` returned
+            // the untrimmed whitespace string.
             let name = task.display_name().to_string();
-            let fallback_title = task.title.clone();
+            let fallback_title = task.title.trim().to_string();
             let harness = task
                 .agent_config_snapshot
                 .as_ref()

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -297,11 +297,13 @@ impl OrchestrationViewerModel {
                 continue;
             };
 
-            let name = if task.title.is_empty() {
-                "Agent".to_string()
-            } else {
-                task.title.clone()
-            };
+            // QUALITY-731: prefer the orchestrator-supplied short name (carried
+            // on `agent_config_snapshot.name`) for the child pill label; keep
+            // the descriptive `task.title` as the conversation's fallback
+            // display title so `AIConversation::title()` still surfaces it
+            // when no task description or initial query exists.
+            let name = task.display_name().to_string();
+            let fallback_title = task.title.clone();
             let harness = task
                 .agent_config_snapshot
                 .as_ref()
@@ -323,6 +325,9 @@ impl OrchestrationViewerModel {
                 history.set_viewing_shared_session_for_conversation(conversation_id, true);
                 if let Some(conversation) = history.conversation_mut(&conversation_id) {
                     conversation.set_task_id(task_id);
+                    if !fallback_title.is_empty() {
+                        conversation.set_fallback_display_title(fallback_title);
+                    }
                 }
                 history.update_conversation_status(
                     terminal_view_id,

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -297,18 +297,10 @@ impl OrchestrationViewerModel {
                 continue;
             };
 
-            // QUALITY-731: prefer the orchestrator-supplied short name (carried
-            // on `agent_config_snapshot.name`) for the child pill label; keep
-            // the descriptive `task.title` as the conversation's fallback
-            // display title so `AIConversation::title()` still surfaces it
-            // when no task description or initial query exists.
-            //
-            // Trim before checking AND before storing so a whitespace-only
-            // `task.title` (e.g. `"   "`) does not desync from
-            // `display_name()` (which also trims): without this,
-            // `agent_name()` would return `"Agent"` while `title()` returned
-            // the untrimmed whitespace string.
             let name = task.display_name().to_string();
+            // Trim to stay in sync with `display_name()`, which also trims;
+            // the descriptive title flows through `set_fallback_display_title`
+            // so `AIConversation::title()` keeps surfacing it.
             let fallback_title = task.title.trim().to_string();
             let harness = task
                 .agent_config_snapshot

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -504,13 +504,18 @@ fn registers_child_agent_name_falls_back_to_title_when_snapshot_name_is_missing(
         let (_, parent_conv_id, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
 
+        // Use a long descriptive title (distinct from any short name) so a
+        // regression that wires `fallback_display_title = display_name()` —
+        // or that fails to set the fallback at all — is observable: in that
+        // case both channels would collapse to `agent_name()` or the title
+        // surface would be `None`.
         model_handle.update(&mut app, |model, ctx| {
             model.apply_children_fetch(
                 vec![make_task_with_name(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     None,
-                    "Worker",
+                    "Long descriptive task title",
                     None,
                 )],
                 ctx,
@@ -523,8 +528,51 @@ fn registers_child_agent_name_falls_back_to_title_when_snapshot_name_is_missing(
             let child = history
                 .conversation(&child_ids[0])
                 .expect("child conversation exists");
-            assert_eq!(child.agent_name(), Some("Worker"));
-            assert_eq!(child.title().as_deref(), Some("Worker"));
+            assert_eq!(child.agent_name(), Some("Long descriptive task title"));
+            assert_eq!(
+                child.title().as_deref(),
+                Some("Long descriptive task title")
+            );
+        });
+    });
+}
+
+#[test]
+fn registers_child_agent_name_does_not_set_fallback_for_whitespace_only_title() {
+    App::test((), |mut app| async move {
+        let parent = task_id(PARENT_TASK_ID);
+        let (_, parent_conv_id, model) = setup_model(&mut app, parent);
+        let model_handle = app.add_model(|_| model);
+
+        // QUALITY-731 finding 3: `display_name()` trims, so the pill label
+        // collapses to `"Agent"` for a whitespace-only title. The conversation
+        // fallback must trim too, or `title()` would return `"  "` while
+        // `agent_name()` returns `"Agent"`.
+        model_handle.update(&mut app, |model, ctx| {
+            model.apply_children_fetch(
+                vec![make_task_with_name(
+                    CHILD_A_TASK_ID,
+                    AmbientAgentTaskState::InProgress,
+                    None,
+                    "   ",
+                    None,
+                )],
+                ctx,
+            );
+        });
+
+        let history = BlocklistAIHistoryModel::handle(&app);
+        history.read(&app, |history, _| {
+            let child_ids = history.child_conversation_ids_of(&parent_conv_id);
+            let child = history
+                .conversation(&child_ids[0])
+                .expect("child conversation exists");
+            assert_eq!(child.agent_name(), Some("Agent"));
+            assert_eq!(
+                child.title(),
+                None,
+                "whitespace-only title must not become a fallback display title"
+            );
         });
     });
 }

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -106,8 +106,7 @@ fn make_task(
 }
 
 /// Builds an [`AmbientAgentTask`] whose `agent_config_snapshot.name` is
-/// populated when `snapshot_name` is `Some`. Used by QUALITY-731 tests that
-/// exercise the `display_name()` precedence.
+/// populated when `snapshot_name` is `Some`.
 fn make_task_with_name(
     id: &str,
     state: AmbientAgentTaskState,
@@ -457,7 +456,7 @@ fn materialization_gate_flips_on_session_id_transition() {
     });
 }
 
-// ---- QUALITY-731 display_name precedence -----------------------------------
+// ---- display_name precedence -----------------------------------------------
 
 #[test]
 fn registers_child_agent_name_from_snapshot_name() {
@@ -544,10 +543,9 @@ fn registers_child_agent_name_does_not_set_fallback_for_whitespace_only_title() 
         let (_, parent_conv_id, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
 
-        // QUALITY-731 finding 3: `display_name()` trims, so the pill label
-        // collapses to `"Agent"` for a whitespace-only title. The conversation
-        // fallback must trim too, or `title()` would return `"  "` while
-        // `agent_name()` returns `"Agent"`.
+        // Whitespace-only title: `display_name()` trims to `"Agent"`, so the
+        // fallback gate must trim too — otherwise `title()` would return the
+        // raw whitespace while `agent_name()` returns `"Agent"`.
         model_handle.update(&mut app, |model, ctx| {
             model.apply_children_fetch(
                 vec![make_task_with_name(

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -16,7 +16,7 @@ use super::*;
 use chrono::Utc;
 use warpui::{App, EntityId, SingletonEntity};
 
-use crate::ai::ambient_agents::task::AmbientAgentTask;
+use crate::ai::ambient_agents::task::{AgentConfigSnapshot, AmbientAgentTask};
 use crate::test_util::{add_window_with_terminal, terminal::initialize_app_for_terminal_view};
 
 // ---- Pure-function tests ----------------------------------------------------
@@ -102,7 +102,24 @@ fn make_task(
     title: &str,
     session_id: Option<&str>,
 ) -> AmbientAgentTask {
+    make_task_with_name(id, state, None, title, session_id)
+}
+
+/// Builds an [`AmbientAgentTask`] whose `agent_config_snapshot.name` is
+/// populated when `snapshot_name` is `Some`. Used by QUALITY-731 tests that
+/// exercise the `display_name()` precedence.
+fn make_task_with_name(
+    id: &str,
+    state: AmbientAgentTaskState,
+    snapshot_name: Option<&str>,
+    title: &str,
+    session_id: Option<&str>,
+) -> AmbientAgentTask {
     let now = Utc::now();
+    let agent_config_snapshot = snapshot_name.map(|name| AgentConfigSnapshot {
+        name: Some(name.to_string()),
+        ..Default::default()
+    });
     AmbientAgentTask {
         task_id: task_id(id),
         parent_run_id: Some(PARENT_TASK_ID.to_string()),
@@ -121,7 +138,7 @@ fn make_task(
         conversation_id: None,
         request_usage: None,
         is_sandbox_running: false,
-        agent_config_snapshot: None,
+        agent_config_snapshot,
         artifacts: vec![],
         last_event_sequence: None,
         children: vec![],
@@ -436,6 +453,146 @@ fn materialization_gate_flips_on_session_id_transition() {
             let entry = model.children.get(&task_id(CHILD_A_TASK_ID)).unwrap();
             assert_eq!(entry.session_id, Some(SESSION_A.parse().unwrap()));
             assert!(entry.pane_materialization_requested);
+        });
+    });
+}
+
+// ---- QUALITY-731 display_name precedence -----------------------------------
+
+#[test]
+fn registers_child_agent_name_from_snapshot_name() {
+    App::test((), |mut app| async move {
+        let parent = task_id(PARENT_TASK_ID);
+        let (_, parent_conv_id, model) = setup_model(&mut app, parent);
+        let model_handle = app.add_model(|_| model);
+
+        model_handle.update(&mut app, |model, ctx| {
+            model.apply_children_fetch(
+                vec![make_task_with_name(
+                    CHILD_A_TASK_ID,
+                    AmbientAgentTaskState::InProgress,
+                    Some("frontend-tests"),
+                    "Long descriptive task title",
+                    None,
+                )],
+                ctx,
+            );
+        });
+
+        let history = BlocklistAIHistoryModel::handle(&app);
+        history.read(&app, |history, _| {
+            let child_ids = history.child_conversation_ids_of(&parent_conv_id);
+            assert_eq!(child_ids.len(), 1, "expected one child conversation");
+            let child = history
+                .conversation(&child_ids[0])
+                .expect("child conversation exists");
+            // Pill label prefers the orchestrator-supplied short name.
+            assert_eq!(child.agent_name(), Some("frontend-tests"));
+            // The descriptive title flows through the fallback path.
+            assert_eq!(
+                child.title().as_deref(),
+                Some("Long descriptive task title")
+            );
+        });
+    });
+}
+
+#[test]
+fn registers_child_agent_name_falls_back_to_title_when_snapshot_name_is_missing() {
+    App::test((), |mut app| async move {
+        let parent = task_id(PARENT_TASK_ID);
+        let (_, parent_conv_id, model) = setup_model(&mut app, parent);
+        let model_handle = app.add_model(|_| model);
+
+        model_handle.update(&mut app, |model, ctx| {
+            model.apply_children_fetch(
+                vec![make_task_with_name(
+                    CHILD_A_TASK_ID,
+                    AmbientAgentTaskState::InProgress,
+                    None,
+                    "Worker",
+                    None,
+                )],
+                ctx,
+            );
+        });
+
+        let history = BlocklistAIHistoryModel::handle(&app);
+        history.read(&app, |history, _| {
+            let child_ids = history.child_conversation_ids_of(&parent_conv_id);
+            let child = history
+                .conversation(&child_ids[0])
+                .expect("child conversation exists");
+            assert_eq!(child.agent_name(), Some("Worker"));
+            assert_eq!(child.title().as_deref(), Some("Worker"));
+        });
+    });
+}
+
+#[test]
+fn registers_child_agent_name_uses_literal_agent_when_both_are_empty() {
+    App::test((), |mut app| async move {
+        let parent = task_id(PARENT_TASK_ID);
+        let (_, parent_conv_id, model) = setup_model(&mut app, parent);
+        let model_handle = app.add_model(|_| model);
+
+        model_handle.update(&mut app, |model, ctx| {
+            model.apply_children_fetch(
+                vec![make_task_with_name(
+                    CHILD_A_TASK_ID,
+                    AmbientAgentTaskState::InProgress,
+                    None,
+                    "",
+                    None,
+                )],
+                ctx,
+            );
+        });
+
+        let history = BlocklistAIHistoryModel::handle(&app);
+        history.read(&app, |history, _| {
+            let child_ids = history.child_conversation_ids_of(&parent_conv_id);
+            let child = history
+                .conversation(&child_ids[0])
+                .expect("child conversation exists");
+            assert_eq!(child.agent_name(), Some("Agent"));
+            // Empty title: no fallback was set, so title() resolves to None.
+            assert_eq!(child.title(), None);
+        });
+    });
+}
+
+#[test]
+fn registers_child_agent_name_trims_whitespace() {
+    App::test((), |mut app| async move {
+        let parent = task_id(PARENT_TASK_ID);
+        let (_, parent_conv_id, model) = setup_model(&mut app, parent);
+        let model_handle = app.add_model(|_| model);
+
+        model_handle.update(&mut app, |model, ctx| {
+            model.apply_children_fetch(
+                vec![make_task_with_name(
+                    CHILD_A_TASK_ID,
+                    AmbientAgentTaskState::InProgress,
+                    Some("  frontend-tests  "),
+                    "Long descriptive task title",
+                    None,
+                )],
+                ctx,
+            );
+        });
+
+        let history = BlocklistAIHistoryModel::handle(&app);
+        history.read(&app, |history, _| {
+            let child_ids = history.child_conversation_ids_of(&parent_conv_id);
+            let child = history
+                .conversation(&child_ids[0])
+                .expect("child conversation exists");
+            assert_eq!(child.agent_name(), Some("frontend-tests"));
+            assert_eq!(
+                child.title().as_deref(),
+                Some("Long descriptive task title")
+            );
         });
     });
 }

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -123,13 +123,7 @@ impl TombstoneDisplayData {
             self.source = Some(source.display_name().to_string());
         }
         if let Some(config) = &task.agent_config_snapshot {
-            // QUALITY-731 follow-up: `config.name` now doubles as the
-            // orchestrator-supplied short agent name (e.g. "frontend-tests")
-            // when set via the round-trip path. Treating it as a skill name
-            // here can mis-label tombstones for orchestrated children whose
-            // skill is actually carried on `config.skill_spec`. Tracked
-            // separately; do not rename this field without updating
-            // tombstone rendering callers.
+            // FIXME: this can be the orchestrator agent name, not a skill.
             self.skill_name = config.name.clone();
         }
 

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -123,6 +123,13 @@ impl TombstoneDisplayData {
             self.source = Some(source.display_name().to_string());
         }
         if let Some(config) = &task.agent_config_snapshot {
+            // QUALITY-731 follow-up: `config.name` now doubles as the
+            // orchestrator-supplied short agent name (e.g. "frontend-tests")
+            // when set via the round-trip path. Treating it as a skill name
+            // here can mis-label tombstones for orchestrated children whose
+            // skill is actually carried on `config.skill_spec`. Tracked
+            // separately; do not rename this field without updating
+            // tombstone rendering callers.
             self.skill_name = config.name.clone();
         }
 

--- a/specs/QUALITY-731/TECH.md
+++ b/specs/QUALITY-731/TECH.md
@@ -1,0 +1,97 @@
+# QUALITY-731 — Agent name round trip client spec
+## Context
+QUALITY-731 is a shared-session viewer bug: the orchestrator's own client labels children with `agent_run_configs[i].name`, but a viewer reconstructs child conversations from server task records and currently does not have access to that short name. As a result, viewer-side pills, hover cards, breadcrumbs, status cards, and transcript participant labels fall back to `title`, which can be a long descriptive sentence or a truncated prompt.
+The fix sources the orchestrator's short label from the existing `agent_config_snapshot.name` field instead of introducing a parallel top-level `name` field on the task or request types. This aligns with the paired warp-server spec, which uses `AgentConfigSnapshot.Name` as the canonical home for the orchestrator-supplied label.
+Relevant existing client surfaces:
+- `app/src/server/server_api/ai.rs` — `SpawnAgentRequest.config: Option<AgentConfigSnapshot>` already exists. `CreateAgentTaskInput.agent_config_snapshot: Option<String>` (serialized JSON) already exists. Both REST and GraphQL channels can carry an `AgentConfigSnapshot` payload today.
+- `app/src/ai/ambient_agents/task.rs` — `AgentConfigSnapshot.name: Option<String>` (`#[serde(default, skip_serializing_if = "Option::is_none")]`) already exists. `AmbientAgentTask.agent_config_snapshot: Option<AgentConfigSnapshot>` already deserializes from the server.
+- `app/src/ai/blocklist/action_model/execute/run_agents.rs` — `RunAgentsExecutor` fans out each `RunAgentsAgentRunConfig`; `cfg.name` is the source of truth on the client side.
+- `app/src/pane_group/pane/terminal_pane.rs` — `launch_remote_child` builds a `SpawnAgentRequest` with an `AgentConfigSnapshot` for `config`. `launch_local_no_harness_child` and `launch_local_harness_child` build the local Oz / harness child task via `AIClient::create_agent_task` and the harness's `local_child_task_config(harness)`.
+- `app/src/pane_group/pane/local_harness_launch.rs` — `prepare_local_harness_child_launch` constructs the `local_child_task_config` snapshot.
+- `app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs` — `apply_children_fetch` calls `task.display_name()` for the child conversation's `agent_name`. That helper currently reads from the QUALITY-731 v1 `AmbientAgentTask.name` field.
+- `app/src/ai/blocklist/history_model.rs` — `start_new_child_conversation` writes its `name` argument directly into `AIConversation::agent_name`.
+- `app/src/ai/agent/conversation.rs` — `agent_name()` backs orchestration label surfaces; `title()` falls back to `fallback_display_title`.
+- `app/src/ai/conversation_details_panel.rs` — `ConversationDetailsData::from_task` reads `task.title` for the side-pane header.
+Design options considered:
+- Parallel scalar fields on the task (the QUALITY-731 v1 approach: `AmbientAgentTask.name`, `SpawnAgentRequest.name`, `AIClient::create_agent_task` `agent_name`, GraphQL `CreateAgentTaskInput.agentName`). Required two name-like fields on the wire and in the model. Rejected per reviewer.
+- Reuse `agent_config_snapshot.name` (selected). No new fields. Outbound paths stamp the orchestrator name inside the existing `AgentConfigSnapshot { ... }` builder. The viewer's `display_name()` reads from `agent_config_snapshot.name`. Backward-compatible with any task that already populates the field through some other means.
+## Proposed changes
+### Outbound request wiring
+Stamp the orchestrator-supplied short name into the existing `AgentConfigSnapshot` payload at request-construction boundaries. Trim whitespace at the construction site; treat empty/whitespace-only as absent.
+1. `launch_remote_child` in `app/src/pane_group/pane/terminal_pane.rs` builds the `AgentConfigSnapshot` it puts on `SpawnAgentRequest.config`. Add `name: ...` to that struct literal with the trimmed `request.name`, filtered for empty. No more top-level `request.name` clone or `SpawnAgentRequest.name` field.
+2. `launch_local_no_harness_child` (local Oz path) in `terminal_pane.rs` currently passes `None` for the config snapshot to `create_agent_task`. Replace with `Some(AgentConfigSnapshot { name: trimmed(request_name), ..Default::default() })`.
+3. `launch_local_harness_child` / `prepare_local_harness_child_launch` in `app/src/pane_group/pane/local_harness_launch.rs` build their snapshot via `local_child_task_config(harness)`. Extend `local_child_task_config` to take `agent_name: Option<String>` and stamp it inside the returned snapshot. Drop the QUALITY-731 v1 `agent_name` parameter on `AIClient::create_agent_task` and the trim inside its impl; the construction site is now the single source.
+4. `agent_sdk/ambient.rs` CLI `agent run-cloud` (REST) already sets `config.name = args.name`. No change needed.
+5. `build_handoff_spawn_request` (handoff) and `spawn_agent` (standalone cloud-mode) don't supply a name today. No change.
+### Inbound response read
+Rewrite `AmbientAgentTask::display_name(&self) -> &str` in `app/src/ai/ambient_agents/task.rs`. Lookup order:
+1. Trimmed `agent_config_snapshot.as_ref().and_then(|c| c.name.as_deref())` when present and non-empty.
+2. Trimmed `title` when non-empty.
+3. The literal `"Agent"`.
+`OrchestrationViewerModel::apply_children_fetch` keeps its existing `let name = task.display_name().to_string();` line. The downstream `conversation.set_fallback_display_title(task.title.clone())` call remains so the descriptive title stays available via `AIConversation::title()` fallback.
+### Removals (QUALITY-731 v1 rollback)
+Source code:
+- `app/src/server/server_api/ai.rs`: remove `SpawnAgentRequest.name` field and its serde attrs. Remove the `agent_name: Option<String>` parameter from the `AIClient::create_agent_task` trait method and its impl, including the trim block and the `agent_name` line inside `CreateAgentTaskVariables`.
+- `app/src/ai/ambient_agents/task.rs`: remove the `AmbientAgentTask.name: Option<String>` field and its serde default. Keep `display_name()` as a helper, but rewrite its body per the above section.
+- `app/src/pane_group/pane/terminal_pane.rs`: remove the `request.name.clone()` plumbing in `launch_remote_child`, the `agent_name_for_create = Some(request_name.clone())` line and the corresponding 5th positional arg in `launch_local_no_harness_child`, and the `agent_name_for_task = Some(request_name.clone())` line + 5th arg in `launch_local_harness_child`.
+- `app/src/pane_group/pane/local_harness_launch.rs`: remove the `agent_name: Option<String>` parameter from `prepare_local_harness_child_launch` and the 5th positional arg threaded into `create_agent_task`. The `#[allow(clippy::too_many_arguments)]` attribute on this function becomes unnecessary; remove it if so.
+- `app/src/ai/conversation_details_panel.rs`: keep the deferral comment QUALITY-731 v1 added on `from_task`; the surface remains on `task.title` (unchanged behavior).
+- `crates/warp_graphql_schema/api/schema.graphql`: remove the `agentName: String` field + docstring under `CreateAgentTaskInput`.
+- All `name: None` literals on `SpawnAgentRequest { ... }` builders added in QUALITY-731 v1 (in `agent_sdk/ambient.rs`, `terminal/view/ambient_agent/model.rs`, `terminal/view_tests.rs`, `agent_sdk/mcp_config_tests.rs`, `ambient_agents/spawn_tests.rs`, `terminal/view/ambient_agent/model_tests.rs`): remove.
+- All `name: None` literals on `AmbientAgentTask { ... }` test fixtures added in QUALITY-731 v1 (in `agent_conversations_model_tests.rs`, `cloud_conversation_continuation_tests.rs`, `conversation_ended_tombstone_view_tests.rs`, `view_impl_tests.rs`, `spawn_tests.rs` `task_with` helper, `pane_group/mod_tests.rs`, `conversation_details_panel_tests.rs`, `orchestration_event_streamer_tests.rs`): remove.
+Tests:
+- `app/src/server/server_api/ai_tests.rs`: remove `spawn_agent_request_serializes_name_when_present`, `spawn_agent_request_omits_name_when_none`, and the `name: None` line in the `make_spawn_agent_request` fixture.
+- `app/src/ai/ambient_agents/task_tests.rs`: rewrite the five `display_name_*` tests to construct an `AmbientAgentTask` with an `agent_config_snapshot.name` value (or `None`) instead of a top-level `name`. Keep the same precedence-coverage shape (name+title, name=None falls back to title, name=whitespace falls back to title, empty title returns "Agent", trimming).
+- `app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs`: rewrite the four `registers_child_agent_name_*` tests to populate `task.agent_config_snapshot.name` instead of `task.name`. The `make_task` / `make_task_with_name` helpers move the name into the config snapshot fixture.
+- `app/src/pane_group/pane/local_harness_launch_tests.rs`: rewrite `prepare_local_codex_child_forwards_agent_name_to_create_agent_task` and `prepare_local_codex_child_passes_none_agent_name_when_unset` to assert that `local_child_task_config` (or the constructed snapshot) carries `name` correctly. Or drop them in favor of a single test on `local_child_task_config` directly.
+## End-to-end flow
+```mermaid
+flowchart LR
+    A[run_agents cfg.name/cfg.title] --> B[RunAgentsExecutor]
+    B --> C[StartAgentRequest name + Remote title]
+    C --> D[SpawnAgentRequest config.name + title]
+    C --> E[createAgentTask agentConfigSnapshot.name for local harness]
+    D --> F[warp-server agent_config_snapshot.name + title]
+    E --> F
+    F --> G[GET /agent/runs returns agent_config_snapshot.name + title]
+    G --> H[OrchestrationViewerModel]
+    H --> I[display_name = agent_config_snapshot.name]
+    H --> J[fallback_display_title = title]
+```
+## Testing and validation
+Unit/client tests:
+- `app/src/ai/ambient_agents/task_tests.rs`: `display_name()` precedence (snapshot.name > title > "Agent") and trim behavior.
+- `app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs`: viewer registration of orchestrator name via `agent_config_snapshot.name`, fallback to title, "Agent" final fallback.
+- `app/src/pane_group/pane/local_harness_launch_tests.rs`: `local_child_task_config` carries the orchestrator name in its snapshot.
+- Add a focused test (in `terminal_pane`'s test file or via integration) that `launch_remote_child` constructs `SpawnAgentRequest.config.name` with the trimmed orchestrator name.
+Manual validation:
+1. Start or load an orchestrated shared session where the orchestrator's outbound spawn populates `agent_config_snapshot.name = "frontend-tests"` and a long descriptive `title`.
+2. Open the session as a viewer.
+3. Verify the pill label, hover card participant label, breadcrumb, child status card, and transcript participant all show `frontend-tests`.
+4. Verify the long title remains available as `AIConversation::title()` fallback wherever the existing fallback path is used.
+5. Verify a child whose orchestrator did not set a name still shows the skill-derived default (provided by the server).
+6. The conversation details side pane intentionally remains on `task.title` per the QUALITY-731 v1 deferral.
+Commands to run after implementation:
+- Targeted Rust tests for any modules touched, for example:
+  - `cargo test -p warp -- ai::ambient_agents::task`
+  - `cargo test -p warp -- terminal::shared_session::viewer::orchestration_viewer_model_tests`
+  - `cargo test -p warp -- pane_group::pane::local_harness_launch_tests`
+- `cargo fmt`
+- `./script/presubmit` before pushing (skip the `command-signatures-v2` step locally only if the corepack/yarn-4 setup blocks it on this machine; CI is authoritative).
+- Manual UI verification against a local client connected to a server with the paired pivot changes.
+## Parallelization
+Server agent: local, `/Users/matthew/src/roundtrip-agent-name/warp-server`, branch `matthew/roundtrip-agent-name`, base `origin/matthew/restore-remote-orch-conversations`, draft PR target #11223. Owns server-side rollback + helper + REST/GraphQL contract drops.
+Client agent: local, `/Users/matthew/src/roundtrip-agent-name/warp`, branch `matthew/roundtrip-agent-name`, base `origin/master`, draft PR target #11090. Owns client-side rollback + outbound snapshot stamping + `display_name()` rewrite.
+Sequencing:
+- Both PRs can be force-pushed in parallel — the wire contract (use existing `agent_config_snapshot` envelope, drop QUALITY-731 v1 parallel fields) is fully agreed upfront.
+- End-to-end manual validation must wait for both branches to be on the pivoted contract.
+PR hygiene:
+- Force-push removes the QUALITY-731 v1 commits from each PR. Rewrite the PR descriptions to call out the pivot and link to the paired PR.
+- Mark the `Warp Agent Mode` checkbox on the client PR template.
+- Keep both PRs in draft.
+## Risks and mitigations
+- `display_name()` change: anywhere that read `AmbientAgentTask.name` directly (instead of going through the helper) must be moved to the helper to pick up the new source. Mitigation: deleting the field forces a compile error at every direct read; fix them at the call site.
+- Existing test fixtures with explicit `name: None` will no longer compile. Mitigation: blanket-revert the `name: None` lines as part of the same change.
+- A future caller that sets both `agent_config.name` and an orchestrator name via some other channel: server enforces the always-override precedence; client only stamps when an orchestrator name is provided. No client-side collision.
+- The details panel surface stays on `task.title` per the v1 deferral. Mitigation: the deferral comment in `conversation_details_panel.rs` remains.
+- Force-push removes the v1 commits from the PR history; existing reviewer comments on those commits stay attached to the orphaned commits. Mitigation: PR description rewrite explains the pivot and links to the v1 review history.

--- a/specs/QUALITY-731/TECH.md
+++ b/specs/QUALITY-731/TECH.md
@@ -2,6 +2,8 @@
 ## Context
 QUALITY-731 is a shared-session viewer bug: the orchestrator's own client labels children with `agent_run_configs[i].name`, but a viewer reconstructs child conversations from server task records and currently does not have access to that short name. As a result, viewer-side pills, hover cards, breadcrumbs, status cards, and transcript participant labels fall back to `title`, which can be a long descriptive sentence or a truncated prompt.
 The fix sources the orchestrator's short label from the existing `agent_config_snapshot.name` field instead of introducing a parallel top-level `name` field on the task or request types. This aligns with the paired warp-server spec, which uses `AgentConfigSnapshot.Name` as the canonical home for the orchestrator-supplied label.
+## Scope
+This PR delivers the orchestrator → server → viewer round-trip plus the single highest-value display surface: the orchestration pill bar in `OrchestrationViewerModel::apply_children_fetch`. Other surfaces that still render `task.title` (or `entry.display.title`) directly are left for follow-up work, tracked under "Out of scope (follow-ups)" below. The wire contract and `display_name()` helper this PR introduces are the prerequisites those follow-ups will consume.
 Relevant existing client surfaces:
 - `app/src/server/server_api/ai.rs` — `SpawnAgentRequest.config: Option<AgentConfigSnapshot>` already exists. `CreateAgentTaskInput.agent_config_snapshot: Option<String>` (serialized JSON) already exists. Both REST and GraphQL channels can carry an `AgentConfigSnapshot` payload today.
 - `app/src/ai/ambient_agents/task.rs` — `AgentConfigSnapshot.name: Option<String>` (`#[serde(default, skip_serializing_if = "Option::is_none")]`) already exists. `AmbientAgentTask.agent_config_snapshot: Option<AgentConfigSnapshot>` already deserializes from the server.
@@ -60,10 +62,10 @@ flowchart LR
 ```
 ## Testing and validation
 Unit/client tests:
-- `app/src/ai/ambient_agents/task_tests.rs`: `display_name()` precedence (snapshot.name > title > "Agent") and trim behavior.
-- `app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs`: viewer registration of orchestrator name via `agent_config_snapshot.name`, fallback to title, "Agent" final fallback.
-- `app/src/pane_group/pane/local_harness_launch_tests.rs`: `local_child_task_config` carries the orchestrator name in its snapshot.
-- Add a focused test (in `terminal_pane`'s test file or via integration) that `launch_remote_child` constructs `SpawnAgentRequest.config.name` with the trimmed orchestrator name.
+- `app/src/ai/ambient_agents/task_tests.rs`: `display_name()` precedence (snapshot.name > title > "Agent") and trim behavior, including whitespace-only title.
+- `app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs`: viewer registration of orchestrator name via `agent_config_snapshot.name`, fallback to title (using distinct snapshot/title values so the two channels are distinguishable), "Agent" final fallback, whitespace-only title gating of `set_fallback_display_title`.
+- `app/src/pane_group/pane/local_harness_launch_tests.rs`: `local_child_task_config` carries the orchestrator name in its snapshot, trims whitespace, returns `None` for Oz/Unknown harnesses. `normalize_orchestrator_agent_name` covers the trim/empty-vs-Some contract.
+- The construction-site wiring in `launch_remote_child` (the `SpawnAgentRequest.config.name` field is stamped with the result of `normalize_orchestrator_agent_name(&request.name)`) is covered indirectly by the `normalize_orchestrator_agent_name` unit tests + visible inspection of the struct literal in `terminal_pane.rs::launch_remote_child`. A dedicated test for the assembled `SpawnAgentRequest` would require factoring out a `build_spawn_request` helper, which is deferred as out of scope here (the function takes a `&mut PaneGroup` + `ViewContext<PaneGroup>` and resolves runtime skills + snapshot-disabled flag through them, none of which are unit-testable as-is).
 Manual validation:
 1. Start or load an orchestrated shared session where the orchestrator's outbound spawn populates `agent_config_snapshot.name = "frontend-tests"` and a long descriptive `title`.
 2. Open the session as a viewer.
@@ -89,9 +91,18 @@ PR hygiene:
 - Force-push removes the QUALITY-731 v1 commits from each PR. Rewrite the PR descriptions to call out the pivot and link to the paired PR.
 - Mark the `Warp Agent Mode` checkbox on the client PR template.
 - Keep both PRs in draft.
+## Out of scope (follow-ups)
+The pivot delivers the wire contract and the orchestration viewer pill. The following surfaces still render `task.title` (or the denormalized `entry.display.title`) directly and would benefit from a follow-up that fans `display_name()` through them, but each requires an additional plumbing decision (the entry-based ones in particular don't have access to `agent_config_snapshot` today):
+- `app/src/ai/agent_conversations_model/entry.rs` — `AgentConversationEntry` is hydrated from `ListConversationsItem` and only carries `display.title` today. Routing `display_name()` here means denormalizing `agent_config_snapshot.name` onto the entry (or fetching the task) before render time.
+- `app/src/ai/conversation_details_panel.rs::from_agent_conversation_entry` — same source as above; downstream of the entry.
+- `app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs` — the tombstone reuses `task.title` for its header and reuses `agent_config_snapshot.name` as `skill_name`; the latter is now mislabeled (an inline `QUALITY-731 follow-up` comment marks this). Splitting orchestrator-supplied agent name from skill-spec rendering belongs to a follow-up.
+- `app/src/ai/agent_sdk/ambient.rs` (~line 845) — CLI/SDK-side surface that already reads task records; can adopt `display_name()` once the helper is publicly reachable from that path.
+- `app/src/workspace/view/conversation_list/item.rs` and `app/src/workspace/view.rs` — workspace conversation list labels flow from `entry.display.title`; same plumbing decision as the entry-based surfaces.
+The `ConversationDetailsData::from_task` side-pane header is intentionally not in scope: product still evaluates whether to show both the short name and the descriptive title. The inline deferral comment remains in place.
 ## Risks and mitigations
 - `display_name()` change: anywhere that read `AmbientAgentTask.name` directly (instead of going through the helper) must be moved to the helper to pick up the new source. Mitigation: deleting the field forces a compile error at every direct read; fix them at the call site.
 - Existing test fixtures with explicit `name: None` will no longer compile. Mitigation: blanket-revert the `name: None` lines as part of the same change.
 - A future caller that sets both `agent_config.name` and an orchestrator name via some other channel: server enforces the always-override precedence; client only stamps when an orchestrator name is provided. No client-side collision.
 - The details panel surface stays on `task.title` per the v1 deferral. Mitigation: the deferral comment in `conversation_details_panel.rs` remains.
+- Whitespace-only `task.title` would desync `agent_name()` (trimmed → `"Agent"`) from `title()` (untrimmed) if the viewer fallback gate were not also trimmed. Mitigation: the gate in `OrchestrationViewerModel::apply_children_fetch` calls `task.title.trim().to_string()` before checking and before storing on the conversation. A dedicated test (`registers_child_agent_name_does_not_set_fallback_for_whitespace_only_title`) locks this in.
 - Force-push removes the v1 commits from the PR history; existing reviewer comments on those commits stay attached to the orphaned commits. Mitigation: PR description rewrite explains the pivot and links to the v1 review history.


### PR DESCRIPTION
## Description
**Why.** In shared-session viewers, child agent pills, hover cards, and breadcrumbs were rendering the descriptive `task.title` (often a long sentence or a truncated prompt) instead of the short orchestrator-supplied agent name. The orchestrator's own client labels each child via `agent_run_configs[i].name`, but a viewer reconstructing children from server task records had no access to that label.

**What.** The orchestrator-supplied short name now round-trips through the existing `agent_config_snapshot.name` field on `AgentConfigSnapshot`.

Outbound: all three child-spawn sites stamp `agent_config_snapshot.name` via the shared `normalize_orchestrator_agent_name(&str) -> Option<String>` helper (trim, treat empty / whitespace-only as absent):
- `launch_remote_child` (`SpawnAgentRequest.config.name`)
- `launch_local_no_harness_child` (`create_agent_task`'s config snapshot)
- `prepare_local_harness_child_launch` / `local_child_task_config` (new `agent_name` parameter)

The same trimmed value also flows into the hidden child conversation's `agent_name` and any error-fallback conversation, so the two channels can't desync on whitespace.

Inbound: `AmbientAgentTask::display_name(&self) -> &str` returns the trimmed `agent_config_snapshot.name`, falling back to trimmed `title`, then `"Agent"`. `OrchestrationViewerModel::apply_children_fetch` uses `display_name()` for the pill label and stores the trimmed `task.title` on the conversation via `set_fallback_display_title`, so `AIConversation::title()` keeps surfacing the descriptive title.

The conversation details side pane intentionally still uses `task.title` pending product feedback on whether to show both surfaces; a one-line note marks the deferral inline.

**Server side.** No code change required in warp-server: `agent_config_snapshot.name` already round-trips through both REST (`POST /agent/run`) and GraphQL (`createAgentTask`). The paired warp-server PR is warpdotdev/warp-server#11223. Full design trace is in `specs/QUALITY-731/TECH.md`.

## Linked Issue
QUALITY-731 (Linear).
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Automated coverage:
- `display_name()` precedence and trim behavior (snapshot.name > title > "Agent"), including whitespace-only inputs.
- Viewer registration via `agent_config_snapshot.name`: snapshot-name wins, falls back to title, "Agent" final fallback, trimming, and a guard that whitespace-only titles don't bleed into `AIConversation::title()`.
- `local_child_task_config` carries the orchestrator name (stamp + trim + `None` for Oz/Unknown). `normalize_orchestrator_agent_name` covers the empty/whitespace contract directly.

Manual end-to-end verification with a paired client+server build is pending warpdotdev/warp-server#11223.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
