### PR TITLE
[4/5] Add remote codebase incremental sync

### DIFF
--- a/app/src/ai/get_relevant_files/remote_search/native.rs
+++ b/app/src/ai/get_relevant_files/remote_search/native.rs
@@ -66,10 +66,6 @@ pub(super) fn send_request(
         RemoteCodebaseSearchAvailability::Ready(search_context) => {
             if search_context.is_stale {
                 let remote_path = search_context.remote_path.clone();
-                log::debug!(
-                    "[Remote codebase indexing] Remote search triggering incremental sync for stale index: repo_path={}",
-                    remote_path.path.as_str()
-                );
                 remote_server::manager::RemoteServerManager::handle(ctx).update(
                     ctx,
                     |manager, ctx| {

--- a/app/src/ai/get_relevant_files/remote_search/native.rs
+++ b/app/src/ai/get_relevant_files/remote_search/native.rs
@@ -64,6 +64,29 @@ pub(super) fn send_request(
         .active_repo_availability(&session_context, requested_codebase_path.as_deref());
     match availability {
         RemoteCodebaseSearchAvailability::Ready(search_context) => {
+            if search_context.is_stale {
+                let remote_path = search_context.remote_path.clone();
+                log::debug!(
+                    "[Remote codebase indexing] Remote search triggering incremental sync for stale index: repo_path={}",
+                    remote_path.path.as_str()
+                );
+                remote_server::manager::RemoteServerManager::handle(ctx).update(
+                    ctx,
+                    |manager, ctx| {
+                        manager.trigger_codebase_incremental_sync(remote_path, ctx);
+                    },
+                );
+                let result =
+                    remote_availability_failure(RemoteCodebaseSearchAvailability::Indexing {
+                        remote_path: search_context.remote_path,
+                    });
+                return RemoteSearchRequest::Ready(remote_search_response_from_result(
+                    result,
+                    search_start.elapsed(),
+                    None,
+                    None,
+                ));
+            }
             let Some(client) = remote_server::manager::RemoteServerManager::as_ref(ctx)
                 .client_for_host(&search_context.remote_path.host_id)
                 .cloned()

--- a/app/src/ai/get_relevant_files/remote_search/native.rs
+++ b/app/src/ai/get_relevant_files/remote_search/native.rs
@@ -80,10 +80,9 @@ pub(super) fn send_request(
                         manager.trigger_codebase_incremental_sync(remote_path, ctx)
                     });
                 if !sync_requested {
-                    return RemoteSearchRequest::Ready(SearchCodebaseResult::Failed {
-                        reason: SearchCodebaseFailureReason::ClientError,
-                        message: "Remote codebase search is unavailable because the remote server is not connected.".to_string(),
-                    });
+                    log::warn!(
+                        "Remote codebase search is using a stale index because incremental sync could not be requested"
+                    );
                 }
             }
             let store_client = ServerApiProvider::as_ref(ctx).get();

--- a/app/src/ai/get_relevant_files/remote_search/native.rs
+++ b/app/src/ai/get_relevant_files/remote_search/native.rs
@@ -64,25 +64,6 @@ pub(super) fn send_request(
         .active_repo_availability(&session_context, requested_codebase_path.as_deref());
     match availability {
         RemoteCodebaseSearchAvailability::Ready(search_context) => {
-            if search_context.is_stale {
-                let remote_path = search_context.remote_path.clone();
-                remote_server::manager::RemoteServerManager::handle(ctx).update(
-                    ctx,
-                    |manager, ctx| {
-                        manager.trigger_codebase_incremental_sync(remote_path, ctx);
-                    },
-                );
-                let result =
-                    remote_availability_failure(RemoteCodebaseSearchAvailability::Indexing {
-                        remote_path: search_context.remote_path,
-                    });
-                return RemoteSearchRequest::Ready(remote_search_response_from_result(
-                    result,
-                    search_start.elapsed(),
-                    None,
-                    None,
-                ));
-            }
             let Some(client) = remote_server::manager::RemoteServerManager::as_ref(ctx)
                 .client_for_host(&search_context.remote_path.host_id)
                 .cloned()
@@ -92,6 +73,19 @@ pub(super) fn send_request(
                     message: "Remote codebase search is unavailable because the remote server is not connected.".to_string(),
                 });
             };
+            if search_context.is_stale {
+                let remote_path = search_context.remote_path.clone();
+                let sync_requested = remote_server::manager::RemoteServerManager::handle(ctx)
+                    .update(ctx, |manager, ctx| {
+                        manager.trigger_codebase_incremental_sync(remote_path, ctx)
+                    });
+                if !sync_requested {
+                    return RemoteSearchRequest::Ready(SearchCodebaseResult::Failed {
+                        reason: SearchCodebaseFailureReason::ClientError,
+                        message: "Remote codebase search is unavailable because the remote server is not connected.".to_string(),
+                    });
+                }
+            }
             let store_client = ServerApiProvider::as_ref(ctx).get();
             let abort_handle = ctx
                 .spawn(

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1285,7 +1285,7 @@ pub(crate) fn initialize_app(
 
     if matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. }) {
         let codebase_index_count = persisted_workspaces.len();
-        log::info!(
+        log::debug!(
             "[Remote codebase indexing] Restored daemon codebase index metadata: metadata_count={codebase_index_count}"
         );
         cloud_objects = Default::default();

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -17,7 +17,7 @@ use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::TelemetryEvent;
 
 use super::manager::{
-    RemoteCodebaseIndexMutationKind, RemoteCodebaseIndexStatusWithPath, RemoteServerManager,
+    RemoteCodebaseIndexStatusWithPath, RemoteCodebaseIndexUpdateOperation, RemoteServerManager,
     RemoteServerManagerEvent,
 };
 
@@ -187,7 +187,9 @@ impl RemoteCodebaseIndexModel {
         RemoteServerManager::handle(ctx).update(ctx, |manager, ctx| {
             manager.ensure_codebase_indexed(
                 remote_path,
-                RemoteCodebaseIndexMutationKind::Request,
+                RemoteCodebaseIndexUpdateOperation::IndexNewRepo {
+                    is_auto_index: false,
+                },
                 ctx,
             );
         });
@@ -217,7 +219,9 @@ impl RemoteCodebaseIndexModel {
         RemoteServerManager::handle(ctx).update(ctx, |manager, ctx| {
             manager.ensure_codebase_indexed(
                 remote_path,
-                RemoteCodebaseIndexMutationKind::Request,
+                RemoteCodebaseIndexUpdateOperation::IndexNewRepo {
+                    is_auto_index: false,
+                },
                 ctx,
             );
         });
@@ -311,7 +315,9 @@ impl RemoteCodebaseIndexModel {
                     RemoteServerManager::handle(ctx).update(ctx, |manager, ctx| {
                         manager.ensure_codebase_indexed(
                             remote_path,
-                            RemoteCodebaseIndexMutationKind::AutoIndex,
+                            RemoteCodebaseIndexUpdateOperation::IndexNewRepo {
+                                is_auto_index: true,
+                            },
                             ctx,
                         );
                     });
@@ -681,7 +687,7 @@ fn remote_codebase_auto_indexing_enabled(
 }
 fn emit_status_changed_telemetry(
     update: RemoteCodebaseIndexStatusTelemetryUpdate,
-    mutation_kind: Option<RemoteCodebaseIndexMutationKind>,
+    mutation_kind: Option<RemoteCodebaseIndexUpdateOperation>,
     source: RemoteCodebaseIndexStatusTelemetrySource,
     ctx: &mut ModelContext<RemoteCodebaseIndexModel>,
 ) {

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -10,17 +10,22 @@ use warpui::{Entity, ModelContext, SingletonEntity};
 
 use crate::ai::blocklist::SessionContext;
 use crate::features::FeatureFlag;
+use crate::send_telemetry_from_ctx;
+use crate::server::telemetry::RemoteCodebaseIndexStatusTelemetrySource;
 use crate::settings::CodeSettings;
 use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::TelemetryEvent;
 
 use super::manager::{
-    RemoteCodebaseIndexStatusWithPath, RemoteServerManager, RemoteServerManagerEvent,
+    RemoteCodebaseIndexMutationKind, RemoteCodebaseIndexStatusWithPath, RemoteServerManager,
+    RemoteServerManagerEvent,
 };
 
 #[derive(Clone, Debug)]
 pub struct RemoteCodebaseSearchContext {
     pub remote_path: RemotePath,
     pub root_hash: NodeHash,
+    pub is_stale: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -95,6 +100,38 @@ pub struct RemoteCodebaseIndexSettingsEntry {
     pub host_label: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RemoteCodebaseIndexStatusTelemetryUpdate {
+    state: RemoteCodebaseIndexState,
+    previous_state: Option<RemoteCodebaseIndexState>,
+    has_root_hash: bool,
+    has_failure_message: bool,
+    progress_completed: Option<u64>,
+    progress_total: Option<u64>,
+}
+
+impl RemoteCodebaseIndexStatusTelemetryUpdate {
+    fn new(
+        status: &RemoteCodebaseIndexStatus,
+        previous_state: Option<RemoteCodebaseIndexState>,
+    ) -> Self {
+        Self {
+            state: status.state,
+            previous_state,
+            has_root_hash: status
+                .root_hash
+                .as_deref()
+                .is_some_and(|root_hash| !root_hash.is_empty()),
+            has_failure_message: status
+                .failure_message
+                .as_deref()
+                .is_some_and(|message| !message.is_empty()),
+            progress_completed: status.progress_completed,
+            progress_total: status.progress_total,
+        }
+    }
+}
+
 impl RemoteCodebaseIndexModel {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         let manager = RemoteServerManager::handle(ctx);
@@ -148,7 +185,11 @@ impl RemoteCodebaseIndexModel {
         };
 
         RemoteServerManager::handle(ctx).update(ctx, |manager, ctx| {
-            manager.ensure_codebase_indexed(remote_path, ctx);
+            manager.ensure_codebase_indexed(
+                remote_path,
+                RemoteCodebaseIndexMutationKind::Request,
+                ctx,
+            );
         });
         true
     }
@@ -174,7 +215,11 @@ impl RemoteCodebaseIndexModel {
 
     pub fn request_index(&self, remote_path: RemotePath, ctx: &mut ModelContext<Self>) {
         RemoteServerManager::handle(ctx).update(ctx, |manager, ctx| {
-            manager.ensure_codebase_indexed(remote_path, ctx);
+            manager.ensure_codebase_indexed(
+                remote_path,
+                RemoteCodebaseIndexMutationKind::Request,
+                ctx,
+            );
         });
     }
 
@@ -218,15 +263,35 @@ impl RemoteCodebaseIndexModel {
     ) {
         match event {
             RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { host_id, statuses } => {
-                if self.apply_statuses_snapshot(host_id, statuses) {
+                let (changed, telemetry_updates) =
+                    self.apply_statuses_snapshot_with_telemetry(host_id, statuses);
+                for update in telemetry_updates {
+                    emit_status_changed_telemetry(
+                        update,
+                        None,
+                        RemoteCodebaseIndexStatusTelemetrySource::Snapshot,
+                        ctx,
+                    );
+                }
+                if changed {
                     ctx.emit(RemoteCodebaseIndexModelEvent::SettingsEntriesChanged);
                 }
             }
             RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
                 remote_path,
                 status,
+                mutation_kind,
+                session_id: _,
             } => {
-                if self.apply_status_update(remote_path.clone(), status.clone()) {
+                if let Some(update) =
+                    self.apply_status_update_with_telemetry(remote_path.clone(), status.clone())
+                {
+                    let source = if mutation_kind.is_some() {
+                        RemoteCodebaseIndexStatusTelemetrySource::MutationResponse
+                    } else {
+                        RemoteCodebaseIndexStatusTelemetrySource::PushUpdate
+                    };
+                    emit_status_changed_telemetry(update, *mutation_kind, source, ctx);
                     ctx.emit(RemoteCodebaseIndexModelEvent::SettingsEntriesChanged);
                 }
             }
@@ -244,7 +309,11 @@ impl RemoteCodebaseIndexModel {
                     // only when the shared auto-index setting allows it.
                     let remote_path = remote_path.clone();
                     RemoteServerManager::handle(ctx).update(ctx, |manager, ctx| {
-                        manager.ensure_codebase_indexed(remote_path, ctx);
+                        manager.ensure_codebase_indexed(
+                            remote_path,
+                            RemoteCodebaseIndexMutationKind::AutoIndex,
+                            ctx,
+                        );
                     });
                 }
             }
@@ -285,6 +354,7 @@ impl RemoteCodebaseIndexModel {
             | RemoteServerManagerEvent::BinaryCheckComplete { .. }
             | RemoteServerManagerEvent::BinaryInstallComplete { .. }
             | RemoteServerManagerEvent::ClientRequestFailed { .. }
+            | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
             | RemoteServerManagerEvent::ServerMessageDecodingError { .. } => {}
         }
     }
@@ -308,8 +378,17 @@ impl RemoteCodebaseIndexModel {
         host_id: &HostId,
         statuses: &[RemoteCodebaseIndexStatusWithPath],
     ) -> bool {
+        self.apply_statuses_snapshot_with_telemetry(host_id, statuses)
+            .0
+    }
+
+    fn apply_statuses_snapshot_with_telemetry(
+        &mut self,
+        host_id: &HostId,
+        statuses: &[RemoteCodebaseIndexStatusWithPath],
+    ) -> (bool, Vec<RemoteCodebaseIndexStatusTelemetryUpdate>) {
         let status_count = statuses.len();
-        log::info!(
+        log::debug!(
             "[Remote codebase indexing] Client received bootstrap codebase index statuses snapshot: host_id={host_id} status_count={status_count}"
         );
         for status_with_path in statuses {
@@ -345,13 +424,32 @@ impl RemoteCodebaseIndexModel {
                 .filter(|(remote_path, _)| remote_path.host_id == *host_id)
                 .all(|(remote_path, status)| incoming_statuses.get(remote_path) == Some(status));
         if snapshot_is_unchanged {
-            return false;
+            return (false, vec![]);
         }
+        let previous_statuses = self
+            .statuses
+            .iter()
+            .filter(|(remote_path, _)| remote_path.host_id == *host_id)
+            .map(|(remote_path, status)| (remote_path.clone(), status.clone()))
+            .collect::<HashMap<_, _>>();
         self.statuses.retain(|key, _| key.host_id != *host_id);
+        let mut telemetry_updates = vec![];
         for (remote_path, status) in incoming_statuses {
-            self.apply_status_update(remote_path, status);
+            if previous_statuses.get(&remote_path) == Some(&status) {
+                self.statuses.insert(remote_path, status);
+                continue;
+            }
+            let previous_state = previous_statuses
+                .get(&remote_path)
+                .map(|previous_status| previous_status.state);
+            self.log_status_update(&remote_path, &status);
+            self.statuses.insert(remote_path, status.clone());
+            telemetry_updates.push(RemoteCodebaseIndexStatusTelemetryUpdate::new(
+                &status,
+                previous_state,
+            ));
         }
-        true
+        (true, telemetry_updates)
     }
 
     fn apply_status_update(
@@ -359,25 +457,41 @@ impl RemoteCodebaseIndexModel {
         remote_path: RemotePath,
         status: RemoteCodebaseIndexStatus,
     ) -> bool {
+        self.apply_status_update_with_telemetry(remote_path, status)
+            .is_some()
+    }
+
+    fn apply_status_update_with_telemetry(
+        &mut self,
+        remote_path: RemotePath,
+        status: RemoteCodebaseIndexStatus,
+    ) -> Option<RemoteCodebaseIndexStatusTelemetryUpdate> {
         if self.statuses.get(&remote_path) == Some(&status) {
-            return false;
+            return None;
         }
+        let previous_state = self
+            .statuses
+            .get(&remote_path)
+            .map(|previous_status| previous_status.state);
+        self.log_status_update(&remote_path, &status);
+        self.statuses.insert(remote_path, status.clone());
+        Some(RemoteCodebaseIndexStatusTelemetryUpdate::new(
+            &status,
+            previous_state,
+        ))
+    }
+
+    fn log_status_update(&self, remote_path: &RemotePath, status: &RemoteCodebaseIndexStatus) {
         log::info!(
-            "[Remote codebase indexing] Client applying codebase index status update: host_id={} state={:?} has_root_hash={}",
+            "[Remote codebase indexing] Client applying codebase index status update: host_id={} repo_path={} state={:?} has_root_hash={}",
             remote_path.host_id,
+            status.repo_path,
             status.state,
             status
                 .root_hash
                 .as_deref()
                 .is_some_and(|root_hash| !root_hash.is_empty()),
         );
-        log::debug!(
-            "[Remote codebase indexing] Client applying codebase index status update: repo_path={} state={:?}",
-            status.repo_path,
-            status.state,
-        );
-        self.statuses.insert(remote_path, status);
-        true
     }
 
     fn record_navigated_directory(&mut self, remote_path: &RemotePath) {
@@ -530,6 +644,7 @@ fn search_availability_for_status(
             RemoteCodebaseSearchAvailability::Ready(RemoteCodebaseSearchContext {
                 remote_path,
                 root_hash,
+                is_stale: status.state == RemoteCodebaseIndexState::Stale,
             })
         }
         RemoteCodebaseIndexState::Queued | RemoteCodebaseIndexState::Indexing => {
@@ -563,6 +678,28 @@ fn remote_codebase_auto_indexing_enabled(
         && FeatureFlag::FullSourceCodeEmbedding.is_enabled()
         && codebase_context_enabled
         && auto_indexing_enabled
+}
+fn emit_status_changed_telemetry(
+    update: RemoteCodebaseIndexStatusTelemetryUpdate,
+    mutation_kind: Option<RemoteCodebaseIndexMutationKind>,
+    source: RemoteCodebaseIndexStatusTelemetrySource,
+    ctx: &mut ModelContext<RemoteCodebaseIndexModel>,
+) {
+    send_telemetry_from_ctx!(
+        TelemetryEvent::RemoteCodebaseIndexStatusChanged {
+            state: update.state,
+            previous_state: update.previous_state,
+            has_root_hash: update.has_root_hash,
+            has_failure_message: update.has_failure_message,
+            progress_completed: update.progress_completed,
+            progress_total: update.progress_total,
+            mutation_kind,
+            source,
+            remote_os: None,
+            remote_arch: None,
+        },
+        ctx
+    );
 }
 
 #[cfg(test)]

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -388,7 +388,7 @@ impl RemoteCodebaseIndexModel {
         statuses: &[RemoteCodebaseIndexStatusWithPath],
     ) -> (bool, Vec<RemoteCodebaseIndexStatusTelemetryUpdate>) {
         let status_count = statuses.len();
-        log::debug!(
+        log::info!(
             "[Remote codebase indexing] Client received bootstrap codebase index statuses snapshot: host_id={host_id} status_count={status_count}"
         );
         for status_with_path in statuses {

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -832,14 +832,21 @@ impl ServerModel {
         ctx: &mut ModelContext<Self>,
     ) {
         if !FeatureFlag::RemoteCodebaseIndexing.is_enabled() {
-            log::debug!(
+            log::info!(
                 "[Remote codebase indexing] Daemon skipping bootstrap codebase index statuses snapshot because remote indexing is disabled: conn_id={conn_id}"
             );
             return;
         }
         let snapshot = self.codebase_index_statuses_snapshot(ctx);
         let status_count = snapshot.statuses.len();
+<<<<<<< HEAD
         log::debug!(
+=======
+        for status in &snapshot.statuses {
+            self.record_codebase_index_status_push(status);
+        }
+        log::info!(
+>>>>>>> 4a6c64b20e (cleanup)
             "[Remote codebase indexing] Daemon pushing bootstrap codebase index statuses snapshot: conn_id={conn_id} bootstrap_status_count={status_count}"
         );
         self.send_server_message(

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -943,7 +943,12 @@ impl ServerModel {
             auth_token,
             mode,
         } = msg;
-        let mode = CodebaseResyncMode::try_from(mode).unwrap_or(CodebaseResyncMode::Unspecified);
+        let mode = match CodebaseResyncMode::try_from(mode) {
+            Ok(mode) => mode,
+            Err(_) => {
+                return invalid_request_response(format!("Invalid ResyncCodebase mode: {mode}"));
+            }
+        };
         let request = match self.prepare_codebase_index_request(
             CodebaseIndexRequestParams {
                 operation_name: "ResyncCodebase",
@@ -964,7 +969,7 @@ impl ServerModel {
                 &repo_path,
                 |manager, indexed_repo_path, ctx| {
                     match mode {
-                        CodebaseResyncMode::Unspecified | CodebaseResyncMode::Full => {
+                        CodebaseResyncMode::Full => {
                             manager.try_manual_resync_codebase(indexed_repo_path, ctx);
                         }
                         CodebaseResyncMode::Incremental => {

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -52,8 +52,8 @@ use super::proto::{
     OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
     ResolveConflictSuccess, ResyncCodebase, RunCommandError, RunCommandErrorCode,
     RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
-    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, WriteFile, WriteFileResponse,
-    WriteFileSuccess,
+    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit,
+    TriggerCodebaseIncrementalSync, WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 
@@ -741,6 +741,9 @@ impl ServerModel {
             Some(client_message::Message::ResyncCodebase(msg)) => {
                 self.handle_resync_codebase(msg, &request_id, conn_id, ctx)
             }
+            Some(client_message::Message::TriggerCodebaseIncrementalSync(msg)) => {
+                self.handle_trigger_codebase_incremental_sync(msg, &request_id, conn_id, ctx)
+            }
             Some(client_message::Message::DropCodebaseIndex(msg)) => {
                 self.handle_drop_codebase_index(msg, &request_id, conn_id, ctx)
             }
@@ -829,14 +832,14 @@ impl ServerModel {
         ctx: &mut ModelContext<Self>,
     ) {
         if !FeatureFlag::RemoteCodebaseIndexing.is_enabled() {
-            log::info!(
+            log::debug!(
                 "[Remote codebase indexing] Daemon skipping bootstrap codebase index statuses snapshot because remote indexing is disabled: conn_id={conn_id}"
             );
             return;
         }
         let snapshot = self.codebase_index_statuses_snapshot(ctx);
         let status_count = snapshot.statuses.len();
-        log::info!(
+        log::debug!(
             "[Remote codebase indexing] Daemon pushing bootstrap codebase index statuses snapshot: conn_id={conn_id} bootstrap_status_count={status_count}"
         );
         self.send_server_message(
@@ -903,8 +906,22 @@ impl ServerModel {
                     Self::current_codebase_index_status_or_queued(manager, indexed_repo_path, ctx)
                 },
                 |manager, repo_path, ctx| {
-                    manager.index_directory(repo_path.to_path_buf(), ctx);
-                    queued_codebase_index_status(repo_path.to_string_lossy().to_string())
+                    if manager.index_directory(repo_path.to_path_buf(), ctx) {
+                        Self::current_codebase_index_status_or_queued(manager, repo_path, ctx)
+                    } else if !manager.is_indexing_enabled() {
+                        not_enabled_codebase_index_status(repo_path.to_string_lossy().to_string())
+                    } else if !manager.can_create_new_indices() {
+                        unavailable_codebase_index_status(
+                            repo_path.to_string_lossy().to_string(),
+                            "Cannot index remote codebase because the maximum number of codebase indexes has been reached.".to_string(),
+                        )
+                    } else {
+                        unavailable_codebase_index_status(
+                            repo_path.to_string_lossy().to_string(),
+                            "Cannot index remote codebase because indexing did not start."
+                                .to_string(),
+                        )
+                    }
                 },
                 ctx,
             )
@@ -954,6 +971,64 @@ impl ServerModel {
                     unavailable_codebase_index_status(
                         repo_path.to_string_lossy().to_string(),
                         "Cannot resync remote codebase because it has not been indexed."
+                            .to_string(),
+                    )
+                },
+                ctx,
+            )
+        });
+
+        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
+            CodebaseIndexStatusUpdated {
+                status: Some(status),
+            },
+        ))
+    }
+
+    fn handle_trigger_codebase_incremental_sync(
+        &mut self,
+        msg: TriggerCodebaseIncrementalSync,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let TriggerCodebaseIncrementalSync {
+            repo_path,
+            auth_token,
+        } = msg;
+        let request = match self.prepare_codebase_index_request(
+            CodebaseIndexRequestParams {
+                operation_name: "TriggerCodebaseIncrementalSync",
+                repo_path,
+                auth_token,
+                auth_operation: "remote codebase incremental sync",
+                path_kind: CodebaseIndexRequestPathKind::Canonicalized,
+            },
+            request_id,
+            conn_id,
+        ) {
+            Ok(request) => request,
+            Err(outcome) => return *outcome,
+        };
+        let repo_path = request.repo_path;
+        let status = CodebaseIndexManager::handle(ctx).update(ctx, |manager, ctx| {
+            manager.with_indexed_codebase(
+                &repo_path,
+                |manager, indexed_repo_path, ctx| {
+                    if let Err(error) =
+                        manager.trigger_incremental_sync_for_path(indexed_repo_path, ctx)
+                    {
+                        log::warn!(
+                            "Failed to trigger remote codebase incremental sync: repo_path={} error={error}",
+                            indexed_repo_path.display()
+                        );
+                    }
+                    Self::current_codebase_index_status_or_queued(manager, indexed_repo_path, ctx)
+                },
+                |_, repo_path, _| {
+                    unavailable_codebase_index_status(
+                        repo_path.to_string_lossy().to_string(),
+                        "Cannot trigger remote codebase incremental sync because it has not been indexed."
                             .to_string(),
                     )
                 },

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -40,10 +40,10 @@ use super::proto::{
     get_fragment_metadata_from_hash_response, resolve_conflict_response, run_command_response,
     save_buffer_response, server_message, write_file_response, Abort, Authenticate, BranchInfo,
     BufferEdit, BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexStatus,
-    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, DeleteFile, DeleteFileResponse,
-    DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse, DiscardFilesSuccess,
-    DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead, FileContextProto,
-    FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
+    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, CodebaseResyncMode, DeleteFile,
+    DeleteFileResponse, DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse,
+    DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
+    FileContextProto, FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
     FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
@@ -52,8 +52,8 @@ use super::proto::{
     OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
     ResolveConflictSuccess, ResyncCodebase, RunCommandError, RunCommandErrorCode,
     RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
-    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit,
-    TriggerCodebaseIncrementalSync, WriteFile, WriteFileResponse, WriteFileSuccess,
+    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, WriteFile, WriteFileResponse,
+    WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 
@@ -741,9 +741,6 @@ impl ServerModel {
             Some(client_message::Message::ResyncCodebase(msg)) => {
                 self.handle_resync_codebase(msg, &request_id, conn_id, ctx)
             }
-            Some(client_message::Message::TriggerCodebaseIncrementalSync(msg)) => {
-                self.handle_trigger_codebase_incremental_sync(msg, &request_id, conn_id, ctx)
-            }
             Some(client_message::Message::DropCodebaseIndex(msg)) => {
                 self.handle_drop_codebase_index(msg, &request_id, conn_id, ctx)
             }
@@ -839,14 +836,7 @@ impl ServerModel {
         }
         let snapshot = self.codebase_index_statuses_snapshot(ctx);
         let status_count = snapshot.statuses.len();
-<<<<<<< HEAD
         log::debug!(
-=======
-        for status in &snapshot.statuses {
-            self.record_codebase_index_status_push(status);
-        }
-        log::info!(
->>>>>>> 4a6c64b20e (cleanup)
             "[Remote codebase indexing] Daemon pushing bootstrap codebase index statuses snapshot: conn_id={conn_id} bootstrap_status_count={status_count}"
         );
         self.send_server_message(
@@ -951,7 +941,9 @@ impl ServerModel {
         let ResyncCodebase {
             repo_path,
             auth_token,
+            mode,
         } = msg;
+        let mode = CodebaseResyncMode::try_from(mode).unwrap_or(CodebaseResyncMode::Unspecified);
         let request = match self.prepare_codebase_index_request(
             CodebaseIndexRequestParams {
                 operation_name: "ResyncCodebase",
@@ -971,71 +963,27 @@ impl ServerModel {
             manager.with_indexed_codebase(
                 &repo_path,
                 |manager, indexed_repo_path, ctx| {
-                    manager.try_manual_resync_codebase(indexed_repo_path, ctx);
-                    Self::current_codebase_index_status_or_queued(manager, indexed_repo_path, ctx)
-                },
-                |_, repo_path, _| {
-                    unavailable_codebase_index_status(
-                        repo_path.to_string_lossy().to_string(),
-                        "Cannot resync remote codebase because it has not been indexed."
-                            .to_string(),
-                    )
-                },
-                ctx,
-            )
-        });
-
-        HandlerOutcome::Sync(server_message::Message::CodebaseIndexStatusUpdated(
-            CodebaseIndexStatusUpdated {
-                status: Some(status),
-            },
-        ))
-    }
-
-    fn handle_trigger_codebase_incremental_sync(
-        &mut self,
-        msg: TriggerCodebaseIncrementalSync,
-        request_id: &RequestId,
-        conn_id: ConnectionId,
-        ctx: &mut ModelContext<Self>,
-    ) -> HandlerOutcome {
-        let TriggerCodebaseIncrementalSync {
-            repo_path,
-            auth_token,
-        } = msg;
-        let request = match self.prepare_codebase_index_request(
-            CodebaseIndexRequestParams {
-                operation_name: "TriggerCodebaseIncrementalSync",
-                repo_path,
-                auth_token,
-                auth_operation: "remote codebase incremental sync",
-                path_kind: CodebaseIndexRequestPathKind::Canonicalized,
-            },
-            request_id,
-            conn_id,
-        ) {
-            Ok(request) => request,
-            Err(outcome) => return *outcome,
-        };
-        let repo_path = request.repo_path;
-        let status = CodebaseIndexManager::handle(ctx).update(ctx, |manager, ctx| {
-            manager.with_indexed_codebase(
-                &repo_path,
-                |manager, indexed_repo_path, ctx| {
-                    if let Err(error) =
-                        manager.trigger_incremental_sync_for_path(indexed_repo_path, ctx)
-                    {
-                        log::warn!(
-                            "Failed to trigger remote codebase incremental sync: repo_path={} error={error}",
-                            indexed_repo_path.display()
-                        );
+                    match mode {
+                        CodebaseResyncMode::Unspecified | CodebaseResyncMode::Full => {
+                            manager.try_manual_resync_codebase(indexed_repo_path, ctx);
+                        }
+                        CodebaseResyncMode::Incremental => {
+                            if let Err(error) =
+                                manager.trigger_incremental_sync_for_path(indexed_repo_path, ctx)
+                            {
+                                log::warn!(
+                                    "Failed to trigger remote codebase incremental sync: repo_path={} error={error}",
+                                    indexed_repo_path.display()
+                                );
+                            }
+                        }
                     }
                     Self::current_codebase_index_status_or_queued(manager, indexed_repo_path, ctx)
                 },
                 |_, repo_path, _| {
                     unavailable_codebase_index_status(
                         repo_path.to_string_lossy().to_string(),
-                        "Cannot trigger remote codebase incremental sync because it has not been indexed."
+                        "Cannot resync remote codebase because it has not been indexed."
                             .to_string(),
                     )
                 },

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -2906,7 +2906,7 @@ pub enum TelemetryEvent {
         has_failure_message: bool,
         progress_completed: Option<u64>,
         progress_total: Option<u64>,
-        mutation_kind: Option<remote_server::manager::RemoteCodebaseIndexMutationKind>,
+        mutation_kind: Option<remote_server::manager::RemoteCodebaseIndexUpdateOperation>,
         source: RemoteCodebaseIndexStatusTelemetrySource,
         remote_os: Option<String>,
         remote_arch: Option<String>,

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1237,6 +1237,13 @@ pub enum CLISubagentControlState {
     AgentTaggedIn,
     AgentTaggedOut,
 }
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteCodebaseIndexStatusTelemetrySource {
+    Snapshot,
+    PushUpdate,
+    MutationResponse,
+}
 
 #[derive(Clone, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumIter))]
@@ -2891,6 +2898,19 @@ pub enum TelemetryEvent {
         exit_code: Option<i32>,
         signal_killed: Option<bool>,
     },
+    /// Emitted when the remote codebase index status changes.
+    RemoteCodebaseIndexStatusChanged {
+        state: remote_server::codebase_index_proto::RemoteCodebaseIndexState,
+        previous_state: Option<remote_server::codebase_index_proto::RemoteCodebaseIndexState>,
+        has_root_hash: bool,
+        has_failure_message: bool,
+        progress_completed: Option<u64>,
+        progress_total: Option<u64>,
+        mutation_kind: Option<remote_server::manager::RemoteCodebaseIndexMutationKind>,
+        source: RemoteCodebaseIndexStatusTelemetrySource,
+        remote_os: Option<String>,
+        remote_arch: Option<String>,
+    },
 }
 
 impl TelemetryEventTrait for TelemetryEvent {
@@ -4268,6 +4288,29 @@ impl TelemetryEvent {
                 "remote_os": remote_os,
                 "remote_arch": remote_arch,
             })),
+            TelemetryEvent::RemoteCodebaseIndexStatusChanged {
+                state,
+                previous_state,
+                has_root_hash,
+                has_failure_message,
+                progress_completed,
+                progress_total,
+                mutation_kind,
+                source,
+                remote_os,
+                remote_arch,
+            } => Some(json!({
+                "state": state,
+                "previous_state": previous_state,
+                "has_root_hash": has_root_hash,
+                "has_failure_message": has_failure_message,
+                "progress_completed": progress_completed,
+                "progress_total": progress_total,
+                "mutation_kind": mutation_kind,
+                "source": source,
+                "remote_os": remote_os,
+                "remote_arch": remote_arch,
+            })),
             TelemetryEvent::RemoteServerSetupDuration {
                 duration_ms,
                 installed_binary,
@@ -5137,7 +5180,8 @@ impl TelemetryEvent {
             | TelemetryEvent::RemoteServerSetupDuration { .. }
             | TelemetryEvent::RemoteServerHostUnsupported { .. }
             | TelemetryEvent::RemoteServerReconnection { .. }
-            | TelemetryEvent::RemoteServerReconnectExhausted { .. } => false,
+            | TelemetryEvent::RemoteServerReconnectExhausted { .. }
+            | TelemetryEvent::RemoteCodebaseIndexStatusChanged { .. } => false,
             #[cfg(feature = "local_fs")]
             TelemetryEvent::CodePaneOpened { .. }
             | TelemetryEvent::CodePanelsFileOpened { .. }
@@ -5708,7 +5752,8 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             | Self::RemoteServerSetupDuration
             | Self::RemoteServerHostUnsupported
             | Self::RemoteServerReconnection
-            | Self::RemoteServerReconnectExhausted => {
+            | Self::RemoteServerReconnectExhausted
+            | Self::RemoteCodebaseIndexStatusChanged => {
                 EnablementState::Flag(FeatureFlag::SshRemoteServer)
             }
         }
@@ -6120,6 +6165,7 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::RemoteServerHostUnsupported => "RemoteServer.HostUnsupported",
             Self::RemoteServerReconnection => "RemoteServer.Reconnection",
             Self::RemoteServerReconnectExhausted => "RemoteServer.ReconnectExhausted",
+            Self::RemoteCodebaseIndexStatusChanged => "RemoteCodebaseIndex.StatusChanged",
             #[cfg(windows)]
             Self::WSLRegistryError => "WSL Distribution Registry Error",
             #[cfg(windows)]
@@ -7178,6 +7224,7 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::RemoteServerReconnectExhausted => {
                 "All reconnection attempts were exhausted after a spontaneous disconnect"
             }
+            Self::RemoteCodebaseIndexStatusChanged => "The remote codebase index status changed",
         }
     }
 }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -180,7 +180,6 @@ impl Sessions {
                 | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
-                | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
                 | RemoteServerManagerEvent::BinaryCheckComplete { .. }
                 | RemoteServerManagerEvent::BinaryInstallComplete { .. }
                 | RemoteServerManagerEvent::ClientRequestFailed { .. }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -180,6 +180,7 @@ impl Sessions {
                 | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
+                | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
                 | RemoteServerManagerEvent::BinaryCheckComplete { .. }
                 | RemoteServerManagerEvent::BinaryInstallComplete { .. }
                 | RemoteServerManagerEvent::ClientRequestFailed { .. }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4659,6 +4659,7 @@ impl TerminalView {
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
+                    | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
                     | RemoteServerManagerEvent::BufferUpdated { .. }
                     | RemoteServerManagerEvent::BufferConflictDetected { .. }
                     | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -146,7 +146,6 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
-            | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
             | RemoteServerManagerEvent::SetupStateChanged { .. }
             | RemoteServerManagerEvent::ClientRequestFailed { .. }
             | RemoteServerManagerEvent::ServerMessageDecodingError { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -146,6 +146,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
+            | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
             | RemoteServerManagerEvent::SetupStateChanged { .. }
             | RemoteServerManagerEvent::ClientRequestFailed { .. }
             | RemoteServerManagerEvent::ServerMessageDecodingError { .. }

--- a/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
+++ b/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
@@ -1377,11 +1377,18 @@ impl CodebaseIndex {
     pub(super) fn codebase_index_status(&self) -> CodebaseIndexStatus {
         let root_hash = self.last_server_synced_root_node();
         let has_synced_version = root_hash.is_some();
+        #[cfg(feature = "local_fs")]
+        let has_pending_file_changes = self
+            .pending_file_changes
+            .as_ref()
+            .is_some_and(|changes| !changes.is_empty());
+        #[cfg(not(feature = "local_fs"))]
+        let has_pending_file_changes = false;
         match &self.tree_sync_state {
             TreeSourceSyncState::Synced {
                 server_sync_result, ..
             } => CodebaseIndexStatus {
-                has_pending: false,
+                has_pending: has_pending_file_changes,
                 has_synced_version,
                 last_sync_successful: Some(match server_sync_result {
                     ServerSyncResult::Success => CodebaseIndexFinishedStatus::Completed,

--- a/crates/ai/src/index/full_source_code_embedding/codebase_index_tests.rs
+++ b/crates/ai/src/index/full_source_code_embedding/codebase_index_tests.rs
@@ -26,7 +26,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::{App, SingletonEntity};
 
 use super::{
-    CodebaseIndex, CodebaseIndexTimeStampMetadata, TreeSourceSyncState,
+    CodebaseIndex, CodebaseIndexTimeStampMetadata, ServerSyncResult, TreeSourceSyncState,
     DEFAULT_INCREMENAL_SYNC_FLUSH_INTERVAL,
 };
 
@@ -104,6 +104,45 @@ fn create_test_metadata(
     }
 }
 
+#[test]
+fn synced_index_with_queued_file_changes_reports_pending_status() {
+    VirtualFS::test(
+        "synced_index_with_queued_file_changes_reports_pending_status",
+        |dirs, mut sandbox| {
+            App::test((), |mut app| async move {
+                app.add_singleton_model(DirectoryWatcher::new);
+
+                let repo_name = "warp-virtual";
+                sandbox.mkdir(repo_name);
+                sandbox.with_files(vec![Stub::FileWithContent(
+                    format!("{repo_name}/existing_file").as_str(),
+                    "existing content",
+                )]);
+
+                let repo_path = dunce::canonicalize(dirs.tests().join(repo_name)).unwrap();
+                let build_file_tree_result =
+                    block_on(CodebaseIndex::build_file_tree(repo_path.clone(), None)).unwrap();
+                let (tree, _) =
+                    block_on(MerkleTree::try_new(build_file_tree_result.file_tree)).unwrap();
+
+                let mut index = CodebaseIndex::new_for_test(Default::default(), &mut app);
+                index.tree_sync_state = TreeSourceSyncState::Synced {
+                    tree,
+                    server_sync_result: ServerSyncResult::Success,
+                };
+
+                let mut changed_files = ChangedFiles::default();
+                changed_files.upsertions.insert(repo_path.join("new_file"));
+                index.pending_file_changes = Some(changed_files);
+
+                let status = index.codebase_index_status();
+                assert!(status.has_pending());
+                assert!(status.has_synced_version());
+                assert_eq!(status.last_sync_successful(), Some(true));
+            });
+        },
+    );
+}
 #[test]
 fn test_empty_fragments() {
     App::test((), |mut app| async move {

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -815,19 +815,22 @@ impl CodebaseIndexManager {
         self.indexing_enabled
     }
 
-    pub fn index_directory(&mut self, directory: PathBuf, ctx: &mut ModelContext<Self>) {
+    pub fn index_directory(&mut self, directory: PathBuf, ctx: &mut ModelContext<Self>) -> bool {
         if !self.is_indexing_enabled() {
-            return;
+            return false;
         }
         let directory = dunce::canonicalize(&directory).unwrap_or(directory);
         if !self.codebase_indices.contains_key(&directory) {
-            self.build_and_sync_codebase_index(BuildSource::FromPath(&directory), ctx);
+            if !self.build_and_sync_codebase_index(BuildSource::FromPath(&directory), ctx) {
+                return false;
+            }
             self.record_codebase_index_status(&directory, ctx);
             // Starting a new codebase index should be considered into sync state updates.
             ctx.emit(CodebaseIndexManagerEvent::NewIndexCreated {
                 root_path: directory,
             });
         }
+        true
     }
 
     #[cfg(feature = "local_fs")]
@@ -867,12 +870,12 @@ impl CodebaseIndexManager {
         &mut self,
         build_source: BuildSource,
         ctx: &mut ModelContext<Self>,
-    ) {
+    ) -> bool {
         if !self.is_indexing_enabled() {
-            return;
+            return false;
         }
         if !self.can_create_new_indices() {
-            return;
+            return false;
         }
 
         let repo_path = match build_source {
@@ -887,7 +890,7 @@ impl CodebaseIndexManager {
                 Ok(path) => path,
                 Err(e) => {
                     log::error!("Failed to canonicalize repository path: {e:?}");
-                    return;
+                    return false;
                 }
             };
 
@@ -898,7 +901,7 @@ impl CodebaseIndexManager {
             Ok(handle) => handle,
             Err(e) => {
                 log::error!("Failed to start tracking repository: {e:?}");
-                return;
+                return false;
             }
         };
 
@@ -933,6 +936,7 @@ impl CodebaseIndexManager {
                 index.update_timestamps_from_metadata(metadata);
             });
         }
+        true
     }
 
     /// Checks whether a snapshot exists for the index and attempts to load it;
@@ -1303,7 +1307,7 @@ impl CodebaseIndexManager {
         codebase_index.update(ctx, |index, _ctx| {
             // Check if the index is in a state where it can perform incremental updates
             let status = index.codebase_index_status();
-            if status.has_pending {
+            if status.last_sync_successful() != Some(true) {
                 return;
             }
 

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -819,15 +819,17 @@ impl CodebaseIndexManager {
         if !self.is_indexing_enabled() {
             return false;
         }
-        let directory = dunce::canonicalize(&directory).unwrap_or(directory);
-        if !self.codebase_indices.contains_key(&directory) {
+        if self.root_path_for_codebase(&directory).is_none() {
             if !self.build_and_sync_codebase_index(BuildSource::FromPath(&directory), ctx) {
                 return false;
             }
-            self.record_codebase_index_status(&directory, ctx);
+            let indexed_directory = self
+                .root_path_for_codebase(&directory)
+                .unwrap_or_else(|| directory.clone());
+            self.record_codebase_index_status(&indexed_directory, ctx);
             // Starting a new codebase index should be considered into sync state updates.
             ctx.emit(CodebaseIndexManagerEvent::NewIndexCreated {
-                root_path: directory,
+                root_path: indexed_directory,
             });
         }
         true

--- a/crates/ai/src/index/full_source_code_embedding/manager_tests.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager_tests.rs
@@ -215,7 +215,29 @@ fn index_directory_is_noop_when_indexing_disabled() {
         });
 
         manager.update(&mut app, |manager, ctx| {
-            manager.index_directory(PathBuf::from("repo"), ctx);
+            assert!(!manager.index_directory(PathBuf::from("repo"), ctx));
+            assert_eq!(manager.num_active_indices(), 0);
+        });
+    });
+}
+
+#[test]
+fn index_directory_reports_when_max_index_limit_prevents_creation() {
+    App::test((), |mut app| async move {
+        let manager = app.add_singleton_model(|ctx| {
+            CodebaseIndexManager::new(
+                Vec::new(),
+                Some(0),
+                1000,
+                32,
+                Arc::new(MockStoreClient),
+                true,
+                ctx,
+            )
+        });
+
+        manager.update(&mut app, |manager, ctx| {
+            assert!(!manager.index_directory(PathBuf::from("repo"), ctx));
             assert_eq!(manager.num_active_indices(), 0);
         });
     });
@@ -237,7 +259,8 @@ fn build_and_sync_is_noop_when_indexing_disabled() {
         });
 
         manager.update(&mut app, |manager, ctx| {
-            manager.build_and_sync_codebase_index(BuildSource::FromPath(Path::new("repo")), ctx);
+            assert!(!manager
+                .build_and_sync_codebase_index(BuildSource::FromPath(Path::new("repo")), ctx));
             assert_eq!(manager.num_active_indices(), 0);
         });
     });

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -39,7 +39,6 @@ message ClientMessage {
     GetFragmentMetadataFromHash get_fragment_metadata_from_hash = 23;
     GetBranches get_branches = 24;
     ResyncCodebase resync_codebase = 25;
-    TriggerCodebaseIncrementalSync trigger_codebase_incremental_sync = 26;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -344,10 +343,12 @@ message IndexCodebase {
 message ResyncCodebase {
   string repo_path = 1;
   string auth_token = 2;
+  CodebaseResyncMode mode = 3;
 }
-message TriggerCodebaseIncrementalSync {
-  string repo_path = 1;
-  string auth_token = 2;
+enum CodebaseResyncMode {
+  CODEBASE_RESYNC_MODE_UNSPECIFIED = 0;
+  CODEBASE_RESYNC_MODE_FULL = 1;
+  CODEBASE_RESYNC_MODE_INCREMENTAL = 2;
 }
 
 message DropCodebaseIndex {

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -39,6 +39,7 @@ message ClientMessage {
     GetFragmentMetadataFromHash get_fragment_metadata_from_hash = 23;
     GetBranches get_branches = 24;
     ResyncCodebase resync_codebase = 25;
+    TriggerCodebaseIncrementalSync trigger_codebase_incremental_sync = 26;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -341,6 +342,10 @@ message IndexCodebase {
   string auth_token = 2;
 }
 message ResyncCodebase {
+  string repo_path = 1;
+  string auth_token = 2;
+}
+message TriggerCodebaseIncrementalSync {
   string repo_path = 1;
   string auth_token = 2;
 }

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -346,9 +346,8 @@ message ResyncCodebase {
   CodebaseResyncMode mode = 3;
 }
 enum CodebaseResyncMode {
-  CODEBASE_RESYNC_MODE_UNSPECIFIED = 0;
-  CODEBASE_RESYNC_MODE_FULL = 1;
-  CODEBASE_RESYNC_MODE_INCREMENTAL = 2;
+  CODEBASE_RESYNC_MODE_FULL = 0;
+  CODEBASE_RESYNC_MODE_INCREMENTAL = 1;
 }
 
 message DropCodebaseIndex {

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -23,7 +23,7 @@ use crate::proto::{
     InitializeResponse, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse,
     OpenBuffer, OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse,
     ResyncCodebase, RunCommandRequest, RunCommandResponse, SaveBuffer, ServerMessage,
-    SessionBootstrapped, TextEdit, UnsubscribeDiffState, WriteFile,
+    SessionBootstrapped, TextEdit, TriggerCodebaseIncrementalSync, UnsubscribeDiffState, WriteFile,
 };
 use crate::repo_metadata_proto::{proto_snapshot_to_update, proto_to_repo_metadata_update};
 
@@ -361,6 +361,38 @@ impl RemoteServerClient {
             )
             .await?;
         Self::codebase_index_status_from_response("ResyncCodebase", response)
+    }
+
+    /// Sends a `TriggerCodebaseIncrementalSync` request and awaits the current status update.
+    pub async fn trigger_codebase_incremental_sync(
+        &self,
+        repo_path: String,
+        auth_token: String,
+    ) -> Result<RemoteCodebaseIndexStatus, ClientError> {
+        let request_id = RequestId::new();
+        let repo_path_for_log = repo_path.clone();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::TriggerCodebaseIncrementalSync(
+                TriggerCodebaseIncrementalSync {
+                    repo_path,
+                    auth_token,
+                },
+            )),
+        };
+        log::debug!(
+            "[Remote codebase indexing] Client sending TriggerCodebaseIncrementalSync: request_id={request_id} \
+             repo_path={repo_path_for_log}"
+        );
+
+        let response = self
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::TriggerCodebaseIncrementalSync,
+            )
+            .await?;
+        Self::codebase_index_status_from_response("TriggerCodebaseIncrementalSync", response)
     }
 
     fn codebase_index_status_from_response(

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -16,14 +16,14 @@ use warpui::r#async::{executor, FutureExt as _};
 use crate::proto::{
     client_message, get_branches_response, get_fragment_metadata_from_hash_response,
     server_message, Abort, Authenticate, BranchInfo, BufferEdit, ClientMessage, CloseBuffer,
-    DeleteFile, DiffMode, DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot,
-    DiscardFilesRequest, DropCodebaseIndex, ErrorCode, FileStatusInfo,
+    CodebaseResyncMode, DeleteFile, DiffMode, DiffStateFileDelta, DiffStateMetadataUpdate,
+    DiffStateSnapshot, DiscardFilesRequest, DropCodebaseIndex, ErrorCode, FileStatusInfo,
     FragmentMetadataLookupErrorCode, GetBranches, GetDiffState, GetDiffStateResponse,
     GetFragmentMetadataFromHash, GetFragmentMetadataFromHashSuccess, IndexCodebase, Initialize,
     InitializeResponse, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse,
     OpenBuffer, OpenBufferResponse, ReadFileContextRequest, ReadFileContextResponse,
     ResyncCodebase, RunCommandRequest, RunCommandResponse, SaveBuffer, ServerMessage,
-    SessionBootstrapped, TextEdit, TriggerCodebaseIncrementalSync, UnsubscribeDiffState, WriteFile,
+    SessionBootstrapped, TextEdit, UnsubscribeDiffState, WriteFile,
 };
 use crate::repo_metadata_proto::{proto_snapshot_to_update, proto_to_repo_metadata_update};
 
@@ -339,6 +339,26 @@ impl RemoteServerClient {
         repo_path: String,
         auth_token: String,
     ) -> Result<RemoteCodebaseIndexStatus, ClientError> {
+        self.send_resync_codebase(repo_path, auth_token, CodebaseResyncMode::Full)
+            .await
+    }
+
+    /// Sends a `ResyncCodebase` request in incremental mode and awaits the current status update.
+    pub async fn trigger_codebase_incremental_sync(
+        &self,
+        repo_path: String,
+        auth_token: String,
+    ) -> Result<RemoteCodebaseIndexStatus, ClientError> {
+        self.send_resync_codebase(repo_path, auth_token, CodebaseResyncMode::Incremental)
+            .await
+    }
+
+    async fn send_resync_codebase(
+        &self,
+        repo_path: String,
+        auth_token: String,
+        mode: CodebaseResyncMode,
+    ) -> Result<RemoteCodebaseIndexStatus, ClientError> {
         let request_id = RequestId::new();
         let repo_path_for_log = repo_path.clone();
         let msg = ClientMessage {
@@ -346,11 +366,12 @@ impl RemoteServerClient {
             message: Some(client_message::Message::ResyncCodebase(ResyncCodebase {
                 repo_path,
                 auth_token,
+                mode: mode.into(),
             })),
         };
         log::info!(
             "[Remote codebase indexing] Client sending ResyncCodebase: request_id={request_id} \
-             repo_path={repo_path_for_log}"
+             repo_path={repo_path_for_log} mode={mode:?}"
         );
 
         let response = self
@@ -361,38 +382,6 @@ impl RemoteServerClient {
             )
             .await?;
         Self::codebase_index_status_from_response("ResyncCodebase", response)
-    }
-
-    /// Sends a `TriggerCodebaseIncrementalSync` request and awaits the current status update.
-    pub async fn trigger_codebase_incremental_sync(
-        &self,
-        repo_path: String,
-        auth_token: String,
-    ) -> Result<RemoteCodebaseIndexStatus, ClientError> {
-        let request_id = RequestId::new();
-        let repo_path_for_log = repo_path.clone();
-        let msg = ClientMessage {
-            request_id: request_id.to_string(),
-            message: Some(client_message::Message::TriggerCodebaseIncrementalSync(
-                TriggerCodebaseIncrementalSync {
-                    repo_path,
-                    auth_token,
-                },
-            )),
-        };
-        log::debug!(
-            "[Remote codebase indexing] Client sending TriggerCodebaseIncrementalSync: request_id={request_id} \
-             repo_path={repo_path_for_log}"
-        );
-
-        let response = self
-            .send_request(
-                request_id,
-                msg,
-                crate::manager::RemoteServerOperation::TriggerCodebaseIncrementalSync,
-            )
-            .await?;
-        Self::codebase_index_status_from_response("TriggerCodebaseIncrementalSync", response)
     }
 
     fn codebase_index_status_from_response(

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -274,6 +274,7 @@ async fn resync_codebase_round_trip() {
             Some(client_message::Message::ResyncCodebase(request)) => {
                 assert_eq!(request.repo_path, "/repo");
                 assert_eq!(request.auth_token, "auth-token");
+                assert_eq!(request.mode, CodebaseResyncMode::Full as i32);
             }
             other => panic!("Expected ResyncCodebase, got {other:?}"),
         }
@@ -294,11 +295,12 @@ async fn resync_codebase_round_trip() {
 async fn trigger_codebase_incremental_sync_round_trip() {
     let (client, _disconnect_rx, _executor) = setup_mock_client(|msg| {
         match &msg.message {
-            Some(client_message::Message::TriggerCodebaseIncrementalSync(request)) => {
+            Some(client_message::Message::ResyncCodebase(request)) => {
                 assert_eq!(request.repo_path, "/repo");
                 assert_eq!(request.auth_token, "auth-token");
+                assert_eq!(request.mode, CodebaseResyncMode::Incremental as i32);
             }
-            other => panic!("Expected TriggerCodebaseIncrementalSync, got {other:?}"),
+            other => panic!("Expected incremental ResyncCodebase, got {other:?}"),
         }
         server_message::Message::CodebaseIndexStatusUpdated(CodebaseIndexStatusUpdated {
             status: Some(not_enabled_codebase_status("/repo")),

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -291,6 +291,28 @@ async fn resync_codebase_round_trip() {
 }
 
 #[tokio::test]
+async fn trigger_codebase_incremental_sync_round_trip() {
+    let (client, _disconnect_rx, _executor) = setup_mock_client(|msg| {
+        match &msg.message {
+            Some(client_message::Message::TriggerCodebaseIncrementalSync(request)) => {
+                assert_eq!(request.repo_path, "/repo");
+                assert_eq!(request.auth_token, "auth-token");
+            }
+            other => panic!("Expected TriggerCodebaseIncrementalSync, got {other:?}"),
+        }
+        server_message::Message::CodebaseIndexStatusUpdated(CodebaseIndexStatusUpdated {
+            status: Some(not_enabled_codebase_status("/repo")),
+        })
+    });
+
+    let status = client
+        .trigger_codebase_incremental_sync("/repo".to_string(), "auth-token".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(status.repo_path, "/repo");
+}
+#[tokio::test]
 async fn get_fragment_metadata_from_hash_error_maps_to_typed_client_error() {
     let (client, _disconnect_rx, _executor) = setup_mock_client(|msg| {
         match &msg.message {

--- a/crates/remote_server/src/codebase_index_proto.rs
+++ b/crates/remote_server/src/codebase_index_proto.rs
@@ -1,6 +1,7 @@
 //! Conversion between remote codebase indexing domain types and proto-generated types.
 
 use crate::proto;
+use serde::Serialize;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteCodebaseIndexStatus {
@@ -13,7 +14,8 @@ pub struct RemoteCodebaseIndexStatus {
     pub root_hash: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum RemoteCodebaseIndexState {
     NotEnabled,
     Unavailable,

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -114,7 +114,6 @@ pub enum RemoteServerOperation {
     LoadRepoMetadataDirectory,
     IndexCodebase,
     ResyncCodebase,
-    TriggerCodebaseIncrementalSync,
     DropCodebaseIndex,
     OpenBuffer,
     SaveBuffer,
@@ -142,8 +141,7 @@ impl RemoteCodebaseIndexMutationKind {
     fn operation(self) -> RemoteServerOperation {
         match self {
             Self::Request | Self::AutoIndex => RemoteServerOperation::IndexCodebase,
-            Self::IncrementalSync => RemoteServerOperation::TriggerCodebaseIncrementalSync,
-            Self::Resync => RemoteServerOperation::ResyncCodebase,
+            Self::IncrementalSync | Self::Resync => RemoteServerOperation::ResyncCodebase,
             Self::Drop => RemoteServerOperation::DropCodebaseIndex,
         }
     }
@@ -1491,17 +1489,17 @@ impl RemoteServerManager {
         self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutationKind::Resync, ctx);
     }
 
-    /// Sends a `TriggerCodebaseIncrementalSync` request to a connected daemon for this remote path.
+    /// Sends a `ResyncCodebase` request in incremental mode to a connected daemon for this remote path.
     pub fn trigger_codebase_incremental_sync(
         &mut self,
         remote_path: RemotePath,
         ctx: &mut ModelContext<Self>,
-    ) {
+    ) -> bool {
         self.mutate_codebase_index(
             remote_path,
             RemoteCodebaseIndexMutationKind::IncrementalSync,
             ctx,
-        );
+        )
     }
 
     /// Sends a `DropCodebaseIndex` request to a connected daemon for this remote path.
@@ -1514,7 +1512,7 @@ impl RemoteServerManager {
         remote_path: RemotePath,
         mutation_kind: RemoteCodebaseIndexMutationKind,
         ctx: &mut ModelContext<Self>,
-    ) {
+    ) -> bool {
         let operation = mutation_kind.operation();
         let host_id = remote_path.host_id.clone();
         let repo_path = remote_path.path.as_str().to_string();
@@ -1524,7 +1522,7 @@ impl RemoteServerManager {
                 "Remote server codebase index mutation: no auth context \
                  operation={operation:?} host={host_id} repo_path={repo_path}"
             );
-            return;
+            return false;
         };
         let current_identity_key = auth_context.remote_server_identity_key();
         let Some((session_id, client, remote_identity_key)) =
@@ -1534,7 +1532,7 @@ impl RemoteServerManager {
                 "Remote server codebase index mutation: no connected client for current identity \
                  operation={operation:?} host={host_id} repo_path={repo_path}"
             );
-            return;
+            return false;
         };
         log::info!(
             "[Remote codebase indexing] Manager requesting codebase index mutation: \
@@ -1612,6 +1610,7 @@ impl RemoteServerManager {
                 }
             })
             .detach();
+        true
     }
 
     /// Sends a `NavigatedToDirectory` request to the remote server for

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -129,19 +129,25 @@ pub enum RemoteServerOperation {
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum RemoteCodebaseIndexMutationKind {
-    Request,
-    AutoIndex,
-    IncrementalSync,
-    Resync,
+pub enum RemoteCodebaseIndexUpdateOperation {
+    IndexNewRepo { is_auto_index: bool },
+    Sync { is_full_sync: bool },
     Drop,
 }
 
-impl RemoteCodebaseIndexMutationKind {
+impl RemoteCodebaseIndexUpdateOperation {
     fn operation(self) -> RemoteServerOperation {
         match self {
-            Self::Request | Self::AutoIndex => RemoteServerOperation::IndexCodebase,
-            Self::IncrementalSync | Self::Resync => RemoteServerOperation::ResyncCodebase,
+            Self::IndexNewRepo {
+                is_auto_index: true,
+            }
+            | Self::IndexNewRepo {
+                is_auto_index: false,
+            } => RemoteServerOperation::IndexCodebase,
+            Self::Sync { is_full_sync: true }
+            | Self::Sync {
+                is_full_sync: false,
+            } => RemoteServerOperation::ResyncCodebase,
             Self::Drop => RemoteServerOperation::DropCodebaseIndex,
         }
     }
@@ -153,13 +159,22 @@ impl RemoteCodebaseIndexMutationKind {
         auth_token: String,
     ) -> Result<RemoteCodebaseIndexStatus, crate::client::ClientError> {
         match self {
-            Self::Request | Self::AutoIndex => client.index_codebase(repo_path, auth_token).await,
-            Self::IncrementalSync => {
+            Self::IndexNewRepo {
+                is_auto_index: true,
+            }
+            | Self::IndexNewRepo {
+                is_auto_index: false,
+            } => client.index_codebase(repo_path, auth_token).await,
+            Self::Sync {
+                is_full_sync: false,
+            } => {
                 client
                     .trigger_codebase_incremental_sync(repo_path, auth_token)
                     .await
             }
-            Self::Resync => client.resync_codebase(repo_path, auth_token).await,
+            Self::Sync { is_full_sync: true } => {
+                client.resync_codebase(repo_path, auth_token).await
+            }
             Self::Drop => client.drop_codebase_index(repo_path, auth_token).await,
         }
     }
@@ -452,7 +467,7 @@ pub enum RemoteServerManagerEvent {
         session_id: Option<SessionId>,
         remote_path: RemotePath,
         status: RemoteCodebaseIndexStatus,
-        mutation_kind: Option<RemoteCodebaseIndexMutationKind>,
+        mutation_kind: Option<RemoteCodebaseIndexUpdateOperation>,
     },
     /// A buffer was updated on the remote host (file changed on disk).
     /// The app layer should forward this to `GlobalBufferModel::handle_buffer_updated_push`.
@@ -554,7 +569,7 @@ pub enum RemoteServerManagerEvent {
     /// A remote codebase-index mutation failed before yielding a status update.
     CodebaseIndexMutationFailed {
         session_id: SessionId,
-        mutation_kind: RemoteCodebaseIndexMutationKind,
+        mutation_kind: RemoteCodebaseIndexUpdateOperation,
         error_kind: RemoteServerErrorKind,
     },
     /// A server message could not be decoded (no parseable request_id).
@@ -1478,7 +1493,7 @@ impl RemoteServerManager {
     pub fn ensure_codebase_indexed(
         &mut self,
         remote_path: RemotePath,
-        mutation_kind: RemoteCodebaseIndexMutationKind,
+        mutation_kind: RemoteCodebaseIndexUpdateOperation,
         ctx: &mut ModelContext<Self>,
     ) {
         self.mutate_codebase_index(remote_path, mutation_kind, ctx);
@@ -1486,7 +1501,11 @@ impl RemoteServerManager {
 
     /// Sends a `ResyncCodebase` request to a connected daemon for this remote path.
     pub fn resync_codebase(&mut self, remote_path: RemotePath, ctx: &mut ModelContext<Self>) {
-        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutationKind::Resync, ctx);
+        self.mutate_codebase_index(
+            remote_path,
+            RemoteCodebaseIndexUpdateOperation::Sync { is_full_sync: true },
+            ctx,
+        );
     }
 
     /// Sends a `ResyncCodebase` request in incremental mode to a connected daemon for this remote path.
@@ -1497,20 +1516,22 @@ impl RemoteServerManager {
     ) -> bool {
         self.mutate_codebase_index(
             remote_path,
-            RemoteCodebaseIndexMutationKind::IncrementalSync,
+            RemoteCodebaseIndexUpdateOperation::Sync {
+                is_full_sync: false,
+            },
             ctx,
         )
     }
 
     /// Sends a `DropCodebaseIndex` request to a connected daemon for this remote path.
     pub fn drop_codebase_index(&mut self, remote_path: RemotePath, ctx: &mut ModelContext<Self>) {
-        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutationKind::Drop, ctx);
+        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexUpdateOperation::Drop, ctx);
     }
 
     fn mutate_codebase_index(
         &mut self,
         remote_path: RemotePath,
-        mutation_kind: RemoteCodebaseIndexMutationKind,
+        mutation_kind: RemoteCodebaseIndexUpdateOperation,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
         let operation = mutation_kind.operation();

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -114,6 +114,7 @@ pub enum RemoteServerOperation {
     LoadRepoMetadataDirectory,
     IndexCodebase,
     ResyncCodebase,
+    TriggerCodebaseIncrementalSync,
     DropCodebaseIndex,
     OpenBuffer,
     SaveBuffer,
@@ -127,17 +128,21 @@ pub enum RemoteServerOperation {
     GetBranches,
 }
 
-#[derive(Clone, Copy, Debug)]
-enum RemoteCodebaseIndexMutation {
-    EnsureIndexed,
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteCodebaseIndexMutationKind {
+    Request,
+    AutoIndex,
+    IncrementalSync,
     Resync,
     Drop,
 }
 
-impl RemoteCodebaseIndexMutation {
+impl RemoteCodebaseIndexMutationKind {
     fn operation(self) -> RemoteServerOperation {
         match self {
-            Self::EnsureIndexed => RemoteServerOperation::IndexCodebase,
+            Self::Request | Self::AutoIndex => RemoteServerOperation::IndexCodebase,
+            Self::IncrementalSync => RemoteServerOperation::TriggerCodebaseIncrementalSync,
             Self::Resync => RemoteServerOperation::ResyncCodebase,
             Self::Drop => RemoteServerOperation::DropCodebaseIndex,
         }
@@ -150,7 +155,12 @@ impl RemoteCodebaseIndexMutation {
         auth_token: String,
     ) -> Result<RemoteCodebaseIndexStatus, crate::client::ClientError> {
         match self {
-            Self::EnsureIndexed => client.index_codebase(repo_path, auth_token).await,
+            Self::Request | Self::AutoIndex => client.index_codebase(repo_path, auth_token).await,
+            Self::IncrementalSync => {
+                client
+                    .trigger_codebase_incremental_sync(repo_path, auth_token)
+                    .await
+            }
             Self::Resync => client.resync_codebase(repo_path, auth_token).await,
             Self::Drop => client.drop_codebase_index(repo_path, auth_token).await,
         }
@@ -438,10 +448,13 @@ pub enum RemoteServerManagerEvent {
         host_id: HostId,
         statuses: Vec<RemoteCodebaseIndexStatusWithPath>,
     },
-    /// A single remote codebase-index status update was pushed by the daemon.
+    /// A single remote codebase-index status update was pushed by the daemon
+    /// or returned by an index mutation request.
     CodebaseIndexStatusUpdated {
+        session_id: Option<SessionId>,
         remote_path: RemotePath,
         status: RemoteCodebaseIndexStatus,
+        mutation_kind: Option<RemoteCodebaseIndexMutationKind>,
     },
     /// A buffer was updated on the remote host (file changed on disk).
     /// The app layer should forward this to `GlobalBufferModel::handle_buffer_updated_push`.
@@ -540,6 +553,12 @@ pub enum RemoteServerManagerEvent {
         operation: RemoteServerOperation,
         error_kind: RemoteServerErrorKind,
     },
+    /// A remote codebase-index mutation failed before yielding a status update.
+    CodebaseIndexMutationFailed {
+        session_id: SessionId,
+        mutation_kind: RemoteCodebaseIndexMutationKind,
+        error_kind: RemoteServerErrorKind,
+    },
     /// A server message could not be decoded (no parseable request_id).
     ServerMessageDecodingError { session_id: SessionId },
 }
@@ -560,6 +579,7 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::BinaryCheckComplete { session_id, .. }
             | RemoteServerManagerEvent::BinaryInstallComplete { session_id, .. }
             | RemoteServerManagerEvent::ClientRequestFailed { session_id, .. }
+            | RemoteServerManagerEvent::CodebaseIndexMutationFailed { session_id, .. }
             | RemoteServerManagerEvent::ServerMessageDecodingError { session_id }
             | RemoteServerManagerEvent::GetBranchesResponse { session_id, .. } => Some(*session_id),
             RemoteServerManagerEvent::HostConnected { .. }
@@ -568,12 +588,18 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
-            | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
+            | RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
+                session_id: None, ..
+            }
             | RemoteServerManagerEvent::BufferUpdated { .. }
             | RemoteServerManagerEvent::BufferConflictDetected { .. }
             | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
             | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
             | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. } => None,
+            RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
+                session_id: Some(session_id),
+                ..
+            } => Some(*session_id),
         }
     }
 }
@@ -1219,8 +1245,8 @@ impl RemoteServerManager {
             )));
         }
 
-        log::info!(
-            "[Remote codebase indexing] Remote server initialize handshake complete: session={session_id:?} \
+        log::debug!(
+            "Remote server initialize handshake complete: session={session_id:?} \
              host={} server_version={:?}",
             resp.host_id,
             resp.server_version,
@@ -1454,28 +1480,42 @@ impl RemoteServerManager {
     pub fn ensure_codebase_indexed(
         &mut self,
         remote_path: RemotePath,
+        mutation_kind: RemoteCodebaseIndexMutationKind,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutation::EnsureIndexed, ctx);
+        self.mutate_codebase_index(remote_path, mutation_kind, ctx);
     }
 
     /// Sends a `ResyncCodebase` request to a connected daemon for this remote path.
     pub fn resync_codebase(&mut self, remote_path: RemotePath, ctx: &mut ModelContext<Self>) {
-        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutation::Resync, ctx);
+        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutationKind::Resync, ctx);
+    }
+
+    /// Sends a `TriggerCodebaseIncrementalSync` request to a connected daemon for this remote path.
+    pub fn trigger_codebase_incremental_sync(
+        &mut self,
+        remote_path: RemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.mutate_codebase_index(
+            remote_path,
+            RemoteCodebaseIndexMutationKind::IncrementalSync,
+            ctx,
+        );
     }
 
     /// Sends a `DropCodebaseIndex` request to a connected daemon for this remote path.
     pub fn drop_codebase_index(&mut self, remote_path: RemotePath, ctx: &mut ModelContext<Self>) {
-        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutation::Drop, ctx);
+        self.mutate_codebase_index(remote_path, RemoteCodebaseIndexMutationKind::Drop, ctx);
     }
 
     fn mutate_codebase_index(
         &mut self,
         remote_path: RemotePath,
-        mutation: RemoteCodebaseIndexMutation,
+        mutation_kind: RemoteCodebaseIndexMutationKind,
         ctx: &mut ModelContext<Self>,
     ) {
-        let operation = mutation.operation();
+        let operation = mutation_kind.operation();
         let host_id = remote_path.host_id.clone();
         let repo_path = remote_path.path.as_str().to_string();
 
@@ -1496,7 +1536,7 @@ impl RemoteServerManager {
             );
             return;
         };
-        log::info!(
+        log::debug!(
             "[Remote codebase indexing] Manager requesting codebase index mutation: \
              operation={operation:?} host={host_id} session={session_id:?} \
              remote_identity_key={remote_identity_key} repo_path={repo_path}"
@@ -1519,14 +1559,19 @@ impl RemoteServerManager {
                                 operation,
                                 error_kind: RemoteServerErrorKind::Other,
                             });
+                            ctx.emit(RemoteServerManagerEvent::CodebaseIndexMutationFailed {
+                                session_id,
+                                mutation_kind,
+                                error_kind: RemoteServerErrorKind::Other,
+                            });
                         })
                         .await;
                     return;
                 };
 
-                match mutation.send(client, repo_path, auth_token).await {
+                match mutation_kind.send(client, repo_path, auth_token).await {
                     Ok(status) => {
-                        log::info!(
+                        log::debug!(
                             "[Remote codebase indexing] Manager received codebase index mutation response: \
                              operation={operation:?} host={host_id} session={session_id:?} \
                              remote_identity_key={remote_identity_key} repo_path={} state={:?}",
@@ -1537,8 +1582,10 @@ impl RemoteServerManager {
                         let _ = spawner
                             .spawn(move |_me, ctx| {
                                 ctx.emit(RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
+                                    session_id: Some(session_id),
                                     remote_path,
                                     status,
+                                    mutation_kind: Some(mutation_kind),
                                 });
                             })
                             .await;
@@ -1549,6 +1596,16 @@ impl RemoteServerManager {
                              operation={operation:?} host={host_id} session={session_id:?} \
                              repo_path={repo_path_for_log} error={e}"
                         );
+                        let error_kind = RemoteServerErrorKind::from_client_error(&e);
+                        let _ = spawner
+                            .spawn(move |_me, ctx| {
+                                ctx.emit(RemoteServerManagerEvent::CodebaseIndexMutationFailed {
+                                    session_id,
+                                    mutation_kind,
+                                    error_kind,
+                                });
+                            })
+                            .await;
                         // Transport-level telemetry is emitted automatically
                         // by send_tracked_request via ClientEvent::RequestFailed.
                     }
@@ -2000,8 +2057,10 @@ impl RemoteServerManager {
                     return;
                 };
                 ctx.emit(RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
+                    session_id: Some(session_id),
                     remote_path,
                     status,
+                    mutation_kind: None,
                 });
             }
             ClientEvent::MessageDecodingError => {

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -1245,8 +1245,8 @@ impl RemoteServerManager {
             )));
         }
 
-        log::debug!(
-            "Remote server initialize handshake complete: session={session_id:?} \
+        log::info!(
+            "[Remote codebase indexing] Remote server initialize handshake complete: session={session_id:?} \
              host={} server_version={:?}",
             resp.host_id,
             resp.server_version,
@@ -1536,7 +1536,7 @@ impl RemoteServerManager {
             );
             return;
         };
-        log::debug!(
+        log::info!(
             "[Remote codebase indexing] Manager requesting codebase index mutation: \
              operation={operation:?} host={host_id} session={session_id:?} \
              remote_identity_key={remote_identity_key} repo_path={repo_path}"
@@ -1571,7 +1571,7 @@ impl RemoteServerManager {
 
                 match mutation_kind.send(client, repo_path, auth_token).await {
                     Ok(status) => {
-                        log::debug!(
+                        log::info!(
                             "[Remote codebase indexing] Manager received codebase index mutation response: \
                              operation={operation:?} host={host_id} session={session_id:?} \
                              remote_identity_key={remote_identity_key} repo_path={} state={:?}",


### PR DESCRIPTION
## Description
Adds the remote codebase incremental-sync path:
- Introduces the `TriggerCodebaseIncrementalSync` remote-server RPC.
- Wires client/server/manager handling so stale remote indexes can request incremental sync instead of a full resync.
- Preserves pending-files status so stale-but-synced indexes are surfaced correctly.

This PR stacks on the duplicate-status-push cleanup.

## Testing
Added unit tests
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
https://www.loom.com/share/f04143f53c0642cca9c50222a6191ddf

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
