### PR TITLE
Clip terminal view column to prevent split-pane footer overflow

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -26140,7 +26140,7 @@ impl View for TerminalView {
 
                     let stack = Stack::new()
                         .with_constrain_absolute_children()
-                        .with_child(column.finish());
+                        .with_child(Clipped::new(column.finish()).finish());
                     if matches!(input_mode, InputMode::Waterfall) && !is_alt_screen_active {
                         self.render_waterfall_mode_background(&model, stack, app)
                     } else {


### PR DESCRIPTION
## Description

`TerminalView::render`'s main column wraps the output area in `Shrinkable` but adds the input area without any flex/clip. In a Flex column, non-flex children are laid out with an unbounded main-axis constraint and take their natural height, so when a horizontal split shortens the top pane the input box + chip rows + footer can overflow past the column's bottom edge and paint into the pane below.

This PR wraps the column in `Clipped` at the outer `Stack`. The Flex column reports the max-constraint height (because of `MainAxisSize::Max`), so the clip rect matches the pane's available height. Sibling overlays in the same `Stack` (context menus, tooltips, ambient-agent progress, etc.) are added after `column.finish()` and remain outside the clip layer, so they're unaffected. The cloud-mode-v2 composing branch directly above already uses `Expanded` (`FlexFit::Tight`) and shrinks correctly, so it doesn't need this wrapper.

This is the vertical analog of #10724 / #10811 (horizontal overflow on the inline-menu header) and applies the same `Clipped`-at-the-overflow-source pattern.

## Linked Issue

Fixes #10906

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

### Before

https://github.com/user-attachments/assets/ec2608e3-9a20-4e58-85a2-36ddc28a2267

### After

https://github.com/user-attachments/assets/9af80501-d88a-45d7-99ab-0e72e35e9d92


## Testing

- [x] I have manually tested my changes locally with `./script/run`.

Reproduction:
1. Open Warp and enter agent input mode with enough chips/attachments that the input footer has multiple rows.
2. `Cmd+Shift+D` to split the window horizontally.
3. Drag the divider up until the top pane is short.
4. Confirm the footer's bottom row clips at the divider instead of bleeding into the lower pane.

Also spot-checked:
- Normal-height pane: input + output still render as before.
- Output area still expands to fill available space when the pane is tall.
- Context menus, tooltips, and ambient-agent progress (sibling overlays in the outer ``Stack``) are unaffected by the clip.

``cargo check -p warp`` is clean.

No automated test added — the fix is a single ``Clipped`` wrapper and is most cheaply verified by manual repro in a short horizontally-split pane.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed agent input footer bottom row overflowing into the adjacent pane when a horizontal split is shortened.
-->