### PR TITLE
feat(themes): add built-in High Contrast Dark and Light themes

### DIFF
--- a/app/src/themes/default_themes.rs
+++ b/app/src/themes/default_themes.rs
@@ -218,6 +218,51 @@ const ADEBERRY_BRIGHT_COLORS: AnsiColors = AnsiColors::new(
     AnsiColor::from_u32(0xFFFFFFFF),
 );
 
+// Pure-saturated ANSI palette targeting WCAG AAA contrast on a black background.
+// Blue is lifted from pure 0000FF because its luminance is too low to read on black.
+const HIGH_CONTRAST_DARK_NORMAL_COLORS: AnsiColors = AnsiColors::new(
+    AnsiColor::from_u32(0x000000FF),
+    AnsiColor::from_u32(0xFF0000FF),
+    AnsiColor::from_u32(0x00FF00FF),
+    AnsiColor::from_u32(0xFFFF00FF),
+    AnsiColor::from_u32(0x4080FFFF),
+    AnsiColor::from_u32(0xFF00FFFF),
+    AnsiColor::from_u32(0x00FFFFFF),
+    AnsiColor::from_u32(0xFFFFFFFF),
+);
+const HIGH_CONTRAST_DARK_BRIGHT_COLORS: AnsiColors = AnsiColors::new(
+    AnsiColor::from_u32(0x808080FF),
+    AnsiColor::from_u32(0xFF8080FF),
+    AnsiColor::from_u32(0x80FF80FF),
+    AnsiColor::from_u32(0xFFFF80FF),
+    AnsiColor::from_u32(0x80B0FFFF),
+    AnsiColor::from_u32(0xFF80FFFF),
+    AnsiColor::from_u32(0x80FFFFFF),
+    AnsiColor::from_u32(0xFFFFFFFF),
+);
+
+// Deeply saturated ANSI palette targeting WCAG AAA contrast on a white background.
+const HIGH_CONTRAST_LIGHT_NORMAL_COLORS: AnsiColors = AnsiColors::new(
+    AnsiColor::from_u32(0x000000FF),
+    AnsiColor::from_u32(0xC00000FF),
+    AnsiColor::from_u32(0x006000FF),
+    AnsiColor::from_u32(0x806000FF),
+    AnsiColor::from_u32(0x0000C0FF),
+    AnsiColor::from_u32(0x800080FF),
+    AnsiColor::from_u32(0x006060FF),
+    AnsiColor::from_u32(0xC0C0C0FF),
+);
+const HIGH_CONTRAST_LIGHT_BRIGHT_COLORS: AnsiColors = AnsiColors::new(
+    AnsiColor::from_u32(0x404040FF),
+    AnsiColor::from_u32(0x800000FF),
+    AnsiColor::from_u32(0x004000FF),
+    AnsiColor::from_u32(0x604000FF),
+    AnsiColor::from_u32(0x000080FF),
+    AnsiColor::from_u32(0x600060FF),
+    AnsiColor::from_u32(0x004040FF),
+    AnsiColor::from_u32(0xFFFFFFFF),
+);
+
 pub(super) fn light_mode_colors() -> TerminalColors {
     TerminalColors::new(LIGHT_MODE_NORMAL_COLORS, LIGHT_MODE_BRIGHT_COLORS)
 }
@@ -258,6 +303,20 @@ pub(super) fn adeberry_colors() -> TerminalColors {
     TerminalColors::new(ADEBERRY_NORMAL_COLORS, ADEBERRY_BRIGHT_COLORS)
 }
 
+pub(super) fn high_contrast_dark_colors() -> TerminalColors {
+    TerminalColors::new(
+        HIGH_CONTRAST_DARK_NORMAL_COLORS,
+        HIGH_CONTRAST_DARK_BRIGHT_COLORS,
+    )
+}
+
+pub(super) fn high_contrast_light_colors() -> TerminalColors {
+    TerminalColors::new(
+        HIGH_CONTRAST_LIGHT_NORMAL_COLORS,
+        HIGH_CONTRAST_LIGHT_BRIGHT_COLORS,
+    )
+}
+
 /// Default bundled themes
 pub fn dark_theme() -> WarpTheme {
     WarpTheme::new(
@@ -282,6 +341,32 @@ pub fn light_theme() -> WarpTheme {
         light_mode_colors(),
         None,
         Some("Light".to_string()),
+    )
+}
+
+pub(super) fn high_contrast_dark() -> WarpTheme {
+    WarpTheme::new(
+        Fill::Solid(ColorU::from_u32(0x000000FF)),
+        ColorU::from_u32(0xFFFFFFFF),
+        Fill::Solid(ColorU::from_u32(0xFFFF00FF)),
+        None,
+        Some(Details::Darker),
+        high_contrast_dark_colors(),
+        None,
+        Some("High Contrast Dark".to_string()),
+    )
+}
+
+pub(super) fn high_contrast_light() -> WarpTheme {
+    WarpTheme::new(
+        Fill::Solid(ColorU::from_u32(0xFFFFFFFF)),
+        ColorU::from_u32(0x000000FF),
+        Fill::Solid(ColorU::from_u32(0x0000C8FF)),
+        None,
+        Some(Details::Lighter),
+        high_contrast_light_colors(),
+        None,
+        Some("High Contrast Light".to_string()),
     )
 }
 

--- a/app/src/themes/theme.rs
+++ b/app/src/themes/theme.rs
@@ -90,6 +90,10 @@ pub enum ThemeKind {
     PinkCity,
     #[schemars(description = "Marble")]
     Marble,
+    #[schemars(description = "High Contrast Dark")]
+    HighContrastDark,
+    #[schemars(description = "High Contrast Light")]
+    HighContrastLight,
     #[schemars(description = "A user-provided custom theme loaded from a file.")]
     Custom(CustomTheme),
     /// Base16 themes are a special case of custom themes with their own semantics for ANSI colors that override "bright" color variants.
@@ -133,6 +137,8 @@ impl std::fmt::Display for ThemeKind {
             ThemeKind::Phenomenon => "Phenomenon",
             ThemeKind::SolarFlare => "Solar Flare",
             ThemeKind::Adeberry => "Adeberry",
+            ThemeKind::HighContrastDark => "High Contrast Dark",
+            ThemeKind::HighContrastLight => "High Contrast Light",
             ThemeKind::SentReferralReward => "Warp Referral",
             ThemeKind::ReceivedReferralReward => "Referred to Warp",
             ThemeKind::Custom(custom_theme) => custom_theme.name.as_str(),
@@ -321,6 +327,8 @@ impl WarpThemeConfig {
             (ThemeKind::Phenomenon, phenomenon()),
             (ThemeKind::SolarFlare, solar_flare()),
             (ThemeKind::Adeberry, adeberry()),
+            (ThemeKind::HighContrastDark, high_contrast_dark()),
+            (ThemeKind::HighContrastLight, high_contrast_light()),
         ]);
         WarpThemeConfig { theme_map }
     }


### PR DESCRIPTION
## Description

Adds two accessibility-focused built-in themes selectable from the theme chooser:

- **High Contrast Dark** — black background, white foreground, yellow accent
- **High Contrast Light** — white background, black foreground, deep-blue accent

ANSI palettes use fully saturated colors targeting WCAG AAA contrast against the background. The dark theme's blue is lifted from pure `#0000FF` to `#4080FF` because pure blue's luminance is too low to read on black.

The change follows the same pattern as the other 23 bundled themes: color constants and `WarpTheme` constructors in `default_themes.rs`, new `ThemeKind` variants wired through `Display` and `WarpThemeConfig::new()` in `theme.rs`.

## Linked Issue

Fixes #11043.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Screenshots / Videos
<img width="1919" height="980" alt="Screenshot 2026-05-16 at 8 07 43 PM" src="https://github.com/user-attachments/assets/029481d8-2ab0-4453-8b73-a73e332cc969" />
<img width="1920" height="981" alt="Screenshot 2026-05-16 at 8 07 26 PM" src="https://github.com/user-attachments/assets/59dff38f-af09-4c1d-b78b-75c2b6b3f6fb" />
<img width="1918" height="983" alt="Screenshot 2026-05-16 at 8 07 08 PM" src="https://github.com/user-attachments/assets/5a2dfa0c-1a2b-459f-a9e6-a769d2fb9b0e" />


## Testing

- `cargo check -p warp` passes
- Manually verified both themes render in the theme chooser and apply correctly to the terminal (built-in palette + UI chrome)

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Added built-in High Contrast Dark and High Contrast Light themes for improved accessibility.
-->