### PR TITLE
[1/n] Sync GraphQL schema with staging and add cynic types for tiered usage visibility

### DIFF
--- a/crates/ai/src/index/full_source_code_embedding/mod.rs
+++ b/crates/ai/src/index/full_source_code_embedding/mod.rs
@@ -92,6 +92,7 @@ pub enum EmbeddingConfig {
     Voyage3_5_Lite_512,
     #[default]
     Voyage3_5_512,
+    Voyage4_512,
 }
 
 #[derive(Debug, Clone)]
@@ -120,6 +121,9 @@ impl From<EmbeddingConfig> for warp_graphql::full_source_code_embedding::Embeddi
             EmbeddingConfig::Voyage3_5_Lite_512 => {
                 warp_graphql::full_source_code_embedding::EmbeddingConfig::Voyage35Lite512
             }
+            EmbeddingConfig::Voyage4_512 => {
+                warp_graphql::full_source_code_embedding::EmbeddingConfig::Voyage4512
+            }
         }
     }
 }
@@ -142,6 +146,9 @@ impl TryFrom<warp_graphql::full_source_code_embedding::EmbeddingConfig> for Embe
             }
             warp_graphql::full_source_code_embedding::EmbeddingConfig::Voyage35512 => {
                 Ok(Self::Voyage3_5_512)
+            }
+            warp_graphql::full_source_code_embedding::EmbeddingConfig::Voyage4512 => {
+                Ok(Self::Voyage4_512)
             }
         }
     }

--- a/crates/graphql/src/api/billing.rs
+++ b/crates/graphql/src/api/billing.rs
@@ -109,6 +109,7 @@ pub struct Tier {
     pub enterprise_credits_auto_reload_policy: Option<EnterpriseCreditsAutoReloadPolicy>,
     pub multi_admin_policy: Option<MultiAdminPolicy>,
     pub ambient_agents_policy: Option<AmbientAgentsPolicy>,
+    pub usage_visibility_policy: Option<UsageVisibilityPolicy>,
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
@@ -292,6 +293,93 @@ pub enum StripeSubscriptionPlan {
     Build,
     BuildBusiness,
     BuildMax,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct UsageVisibilityPolicy {
+    pub admin_granularity: UsageVisibilityGranularity,
+    pub max_prior_cycles: i32,
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+pub enum UsageVisibilityGranularity {
+    OwnOnly,
+    TeamAggregate,
+    PerUserTotals,
+    FullBreakdown,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct BillingCycleUsageHistory {
+    pub current_period_start: Time,
+    pub current_period_end: Time,
+    pub summaries: Vec<BillingCycleUsageSummary>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct BillingCycleUsageSummary {
+    pub period_start: Time,
+    pub period_end: Time,
+    pub entries: Vec<UsageEntry>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct UsageEntry {
+    pub subject_type: AiCreditsUsageAndCostSubjectType,
+    pub subject_uid: Option<String>,
+    pub subject_display_name: Option<String>,
+    pub cost_type: AiCreditsUsageAndCostType,
+    pub usage_bucket: AiCreditsUsageBucket,
+    pub usage_source: AiCreditsUsageSource,
+    pub credits_used: i32,
+    pub cost_cents: i32,
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageAndCostSubjectType")]
+pub enum AiCreditsUsageAndCostSubjectType {
+    Team,
+    User,
+    ServiceAccount,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageAndCostType")]
+pub enum AiCreditsUsageAndCostType {
+    BaseLimit,
+    BonusGrant,
+    Payg,
+    AmbientBonusGrant,
+    Aggregate,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageBucket")]
+pub enum AiCreditsUsageBucket {
+    Ai,
+    Compute,
+    Platform,
+    SuggestedCodeDiffs,
+    Voice,
+    Aggregate,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageSource")]
+pub enum AiCreditsUsageSource {
+    Local,
+    Cloud,
+    Aggregate,
     #[cynic(fallback)]
     Other(String),
 }

--- a/crates/graphql/src/api/full_source_code_embedding.rs
+++ b/crates/graphql/src/api/full_source_code_embedding.rs
@@ -13,6 +13,8 @@ pub enum EmbeddingConfig {
     Voyage35512,
     #[cynic(rename = "VOYAGE_3_5_LITE_512")]
     Voyage35Lite512,
+    #[cynic(rename = "VOYAGE_4_512")]
+    Voyage4512,
 }
 
 #[derive(cynic::Scalar, Debug, Clone)]

--- a/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
+++ b/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
@@ -64,6 +64,10 @@ query GetWorkspacesMetadataForUser($requestContext: RequestContext!) {
               byoApiKeyPolicy {
                 enabled
               }
+              usageVisibilityPolicy {
+                adminGranularity
+                maxPriorCycles
+              }
               pricing {
                 enablePayAsYouGo
                 autoReloadCreditDenomination
@@ -75,6 +79,24 @@ query GetWorkspacesMetadataForUser($requestContext: RequestContext!) {
               status
               stripeSubscriptionId
               type
+            }
+          }
+          billingCycleUsageHistory {
+            currentPeriodStart
+            currentPeriodEnd
+            summaries {
+              periodStart
+              periodEnd
+              entries {
+                subjectType
+                subjectUid
+                subjectDisplayName
+                costType
+                usageBucket
+                usageSource
+                creditsUsed
+                costCents
+              }
             }
           }
           settings {

--- a/crates/graphql/src/api/workspace.rs
+++ b/crates/graphql/src/api/workspace.rs
@@ -1,6 +1,6 @@
 use crate::schema;
 
-use super::billing::{BillingMetadata, BonusGrantsInfo};
+use super::billing::{BillingCycleUsageHistory, BillingMetadata, BonusGrantsInfo};
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct Workspace {
@@ -11,6 +11,7 @@ pub struct Workspace {
     pub teams: Vec<Team>,
     pub billing_metadata: BillingMetadata,
     pub bonus_grants_info: BonusGrantsInfo,
+    pub billing_cycle_usage_history: Option<BillingCycleUsageHistory>,
     pub settings: WorkspaceSettings,
     pub has_billing_history: bool,
     pub invite_code: Option<String>,

--- a/crates/warp_graphql_schema/api/client-schema.ts
+++ b/crates/warp_graphql_schema/api/client-schema.ts
@@ -83,6 +83,7 @@ const clientQueries = [
   'freeAvailableModels',
   'getRelevantFragments',
   'rerankFragments',
+  'harnessAuthSecrets',
   'listWarpDevImages',
   'pricingInfo',
   'managedSecrets',

--- a/crates/warp_graphql_schema/api/client-schema.ts
+++ b/crates/warp_graphql_schema/api/client-schema.ts
@@ -80,6 +80,7 @@ const clientMutations = [
 const clientQueries = [
   'cloudObject',
   'codebaseContextConfig',
+  'freeAvailableModels',
   'getRelevantFragments',
   'rerankFragments',
   'listWarpDevImages',

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -1745,6 +1745,7 @@ input HarnessInput {
 type HarnessModel {
   displayName: String!
   id: ID!
+  reasoningLevel: String
 }
 
 """

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -23,8 +23,6 @@ directive @goField(forceResolver: Boolean, name: String, omittable: Boolean) on 
 
 directive @isDogfood on FIELD_DEFINITION
 
-directive @isWarpEng on FIELD_DEFINITION
-
 directive @key on INTERFACE | OBJECT
 
 """
@@ -85,6 +83,11 @@ enum AICreditsUsageAndCostSubjectType {
 }
 
 enum AICreditsUsageAndCostType {
+  """
+  Sentinel value used on synthetic UsageEntry rows that aggregate across
+  multiple cost types. Real usage rows never carry this value.
+  """
+  AGGREGATE
   AMBIENT_BONUS_GRANT
   BASE_LIMIT
   BONUS_GRANT
@@ -92,18 +95,35 @@ enum AICreditsUsageAndCostType {
 }
 
 enum AICreditsUsageBucket {
+  """
+  Sentinel value used on synthetic UsageEntry rows that aggregate across
+  multiple usage buckets. Real usage rows never carry this value.
+  """
+  AGGREGATE
   AI
   COMPUTE
+  PLATFORM
   SUGGESTED_CODE_DIFFS
   VOICE
 }
 
 enum AICreditsUsageSource {
+  """
+  Sentinel value used on synthetic UsageEntry rows that aggregate across
+  multiple usage sources. Real usage rows never carry this value.
+  """
+  AGGREGATE
   CLOUD
   LOCAL
 }
 
+type APIKeyAgentInfo {
+  name: String!
+  uid: ID!
+}
+
 type APIKeyProperties {
+  agentInfo: APIKeyAgentInfo
   createdAt: Time!
   expiresAt: Time
   keySuffix: String!
@@ -220,22 +240,9 @@ enum AgentHarness {
   OZ
 }
 
-"""A single model available for a third-party harness."""
-type HarnessModel {
-  displayName: String!
-  id: ID!
-}
-
-"""A harness available to the requesting user."""
-type HarnessInfo {
-  availableModels: [HarnessModel!]!
-  displayName: String!
-  enabled: Boolean!
-  harness: AgentHarness!
-}
-
-type AvailableHarnesses {
-  harnesses: [HarnessInfo!]!
+"""Controls whether a team can configure settings for agent harnesses."""
+type AgentHarnessesPolicy {
+  toggleable: Boolean!
 }
 
 """Controls how many agent identities (service accounts) a team can have."""
@@ -336,6 +343,11 @@ input AgentTaskStatusMessageInput {
   message: String!
 }
 
+enum AgentVisibility {
+  PERSONAL
+  TEAM
+}
+
 type AiAutonomyPolicy {
   enabled: Boolean!
   toggleable: Boolean!
@@ -401,6 +413,7 @@ type AmbientAgentSettings {
   defaultHostSlug: String
   enableWarpAttribution: AdminEnablementSetting!
   instanceShape: InstanceShape
+  localAgentTracking: AgentVisibility!
   warpHostedAgentsEnabled: Boolean!
 }
 
@@ -408,10 +421,12 @@ input AmbientAgentSettingsInput {
   defaultHostSlug: String
   enableWarpAttribution: AdminEnablementSetting
   instanceShape: InstanceShapeInput
+  localAgentTracking: AgentVisibility
   warpHostedAgentsEnabled: Boolean
 }
 
 type AmbientAgentsPolicy {
+  allowedLocalAgentTrackingOptions: [AgentVisibility!]!
   enabled: Boolean!
   instanceShape: InstanceShape
   maxConcurrentAgents: Int!
@@ -462,6 +477,10 @@ type ApplyFileDiffStats {
   linesRemoved: Int!
 }
 
+type AvailableHarnesses {
+  harnesses: [HarnessInfo!]!
+}
+
 type AvailableLlms {
   choices: [LlmInfo!]!
   defaultId: String!
@@ -473,6 +492,8 @@ type AwsProviderConfig {
 }
 
 type BillingCycleUsageHistory {
+  currentPeriodEnd: Time!
+  currentPeriodStart: Time!
   summaries: [BillingCycleUsageSummary!]!
 }
 
@@ -644,6 +665,7 @@ type CloudEnvironmentConfig {
   githubRepos: [GitHubRepo!]!
   name: String!
   providers: ProvidersConfig
+  secrets: [SecretRefOutput!]
   setupCommands: [String!]
 }
 
@@ -739,6 +761,20 @@ inside a folder or at the root of a drive.
 """
 union Container = FolderContainer | Space
 
+"""
+Marker for the client to provide a CRC32C checksum of the upload content.
+
+The checksum should be serialized as a base64-encoded big-endian 4-byte value.
+"""
+type ContentCRC32CFieldValue {
+  _: Boolean
+}
+
+"""Marker for the client to provide the upload content."""
+type ContentDataFieldValue {
+  _: Boolean
+}
+
 scalar ContentHash
 
 """Represents usage data for a single multi-agent conversation."""
@@ -783,7 +819,7 @@ input CreateAgentTaskInput {
   """Optional environment UID to run the task in."""
   environmentUid: ID
 
-  """Optional parent run ID to persist on the created task."""
+  """Optional run ID of the parent that spawned this local task."""
   parentRunId: ID
 
   """The prompt for the agent task."""
@@ -894,6 +930,7 @@ type CreateNotebookOutput implements Response {
 union CreateNotebookResult = CreateNotebookOutput | UserFacingError
 
 input CreateSimpleIntegrationInput {
+  agentUid: ID
   config: SimpleIntegrationConfig!
   enabled: Boolean!
   integrationType: String!
@@ -922,14 +959,6 @@ type CreateTeamOutput implements Response {
 }
 
 union CreateTeamResult = CreateTeamOutput | UserFacingError
-
-type ContentCRC32CFieldValue {
-  _: Boolean
-}
-
-type ContentDataFieldValue {
-  _: Boolean
-}
 
 type CreateUploadTarget {
   fields: [UploadField!]!
@@ -1111,6 +1140,9 @@ enum EmbeddingConfig {
   """Corresponds to the Voyage voyage-3.5-lite model with 512 dimensions."""
   VOYAGE_3_5_LITE_512
 
+  """Corresponds to the Voyage voyage-4 model with 512 dimensions."""
+  VOYAGE_4_512
+
   """Corresponds to the Voyage voyage-code-3 model with 512 dimensions."""
   VOYAGE_CODE_3_512
 }
@@ -1131,19 +1163,31 @@ type EmptyTrashOutput implements Response {
 
 union EmptyTrashResult = EmptyTrashOutput | UserFacingError
 
-type EnterpriseAnalyticsPolicy {
+type EnterpriseAnalyticsDataCollectionSettings {
   enabled: Boolean!
+}
+
+input EnterpriseAnalyticsDataCollectionSettingsInput {
+  enabled: Boolean
+}
+
+type EnterpriseAnalyticsPolicy {
+  default: Boolean!
+  enabled: Boolean!
+  toggleable: Boolean!
 }
 
 type EnterpriseBillingSettings {
   maxMonthlyCloudAgentsSpendCents: Int
   maxMonthlyLocalAgentsSpendCents: Int
+  maxMonthlyPerUserTotalSpendCents: Int
   maxMonthlyTotalSpendCents: Int
 }
 
 input EnterpriseBillingSettingsInput {
   maxMonthlyCloudAgentsSpendCents: Int
   maxMonthlyLocalAgentsSpendCents: Int
+  maxMonthlyPerUserTotalSpendCents: Int
   maxMonthlyTotalSpendCents: Int
 }
 
@@ -1230,9 +1274,9 @@ enum Experiment {
   SESSION_SHARING_CONTROL
   SESSION_SHARING_EXPERIMENT
   SPLIT_CREDIT_COST_CONTROL
+  SPLIT_CREDIT_COST_EXPERIMENT
   SSH_REMOTE_SERVER_CONTROL
   SSH_REMOTE_SERVER_EXPERIMENT
-  SPLIT_CREDIT_COST_EXPERIMENT
   SUGGESTED_CODE_DIFFS_CONTROL
   SUGGESTED_CODE_DIFFS_EXPERIMENT
   TMUX_SSH_WARPIFICATION_CONTROL
@@ -1340,6 +1384,11 @@ type GcpProviderConfig {
 }
 
 input GenerateApiKeyInput {
+  """
+  Optional agent UID to use as the authenticated principal for this key.
+  The team is resolved from the agent automatically. The caller must be a member of that team.
+  The agent must be available on the team's current plan.
+  """
   agentUid: ID
   expiresAt: Time
   name: String!
@@ -1656,6 +1705,66 @@ type GithubRepositoryNotFoundError implements UserFacingErrorInterface {
 
 union GuestSubject = PendingUserGuest | TeamGuest | UserGuest
 
+input HarnessAuthSecretsInput {
+  claudeAuthSecretName: String
+  codexAuthSecretName: String
+}
+
+type HarnessConfig {
+  enabled: Boolean!
+}
+
+input HarnessConfigInput {
+  enabled: Boolean
+}
+
+"""A harness available to the requesting user."""
+type HarnessInfo {
+  """
+  Models the user can pick for this harness. Empty for harnesses without a
+  configured catalog.
+  """
+  availableModels: [HarnessModel!]!
+  displayName: String!
+  enabled: Boolean!
+  harness: AgentHarness!
+}
+
+input HarnessInput {
+  type: String!
+}
+
+"""A single model available for a third-party harness."""
+type HarnessModel {
+  displayName: String!
+  id: ID!
+}
+
+"""
+Per-harness enablement settings for a team. Defaults to enabled for all harnesses.
+Only configurable on enterprise plans.
+"""
+type HarnessSettings {
+  harnessConfigs: [HarnessSettingsEntry!]!
+  optOutOfNewHarnesses: Boolean!
+}
+
+type HarnessSettingsEntry {
+  displayName: String!
+  harness: AgentHarness!
+  settings: HarnessConfig!
+}
+
+input HarnessSettingsEntryInput {
+  harness: AgentHarness!
+  settings: HarnessConfigInput!
+}
+
+input HarnessSettingsInput {
+  harnessConfigs: [HarnessSettingsEntryInput!]
+  optOutOfNewHarnesses: Boolean
+}
+
 enum HostEnablementSetting {
   ENFORCE
   RESPECT_USER_SETTING
@@ -1805,12 +1914,24 @@ type ListWarpDevImagesOutput implements Response {
 
 union ListWarpDevImagesResult = ListWarpDevImagesOutput | UserFacingError
 
+type ListedHarnessAuthSecretsConfig {
+  claudeAuthSecretName: String
+  codexAuthSecretName: String
+}
+
+type ListedHarnessConfig {
+  type: String!
+}
+
 type ListedSimpleIntegrationConfig {
   basePrompt: String!
   computerUseEnabled: Boolean!
   environmentUid: String!
+  harness: ListedHarnessConfig
+  harnessAuthSecrets: ListedHarnessAuthSecretsConfig
   mcpServersJson: String!
   modelId: String!
+  secrets: [SecretRefOutput!]
   workerHost: String
 }
 
@@ -1843,6 +1964,11 @@ type LlmContextWindow {
 type LlmHostSettings {
   enabled: Boolean!
   enablementSetting: HostEnablementSetting
+
+  """
+  IAM role ARN that Oz Cloud Agents assume via the OIDC trust flow to obtain credentials for AWS Bedrock requests.
+  """
+  oidcAssumeRoleArn: String
   optOutOfNewModels: Boolean!
   region: String
 }
@@ -1856,6 +1982,7 @@ type LlmHostSettingsEntry {
 input LlmHostSettingsInput {
   enabled: Boolean
   enablementSetting: HostEnablementSetting
+  oidcAssumeRoleArn: String
   optOutOfNewModels: Boolean
   region: String
 }
@@ -1895,7 +2022,9 @@ enum LlmModelHost {
 }
 
 type LlmModelHostSettings {
+  defaultHostModelRef: String
   enabled: Boolean!
+  hostModelRef: String
 }
 
 type LlmModelHostSettingsEntry {
@@ -1905,6 +2034,7 @@ type LlmModelHostSettingsEntry {
 
 input LlmModelHostSettingsInput {
   enabled: Boolean
+  hostModelRef: String
 }
 
 input LlmModelHostSettingsInputEntry {
@@ -2020,13 +2150,9 @@ type ManagedSecretAnthropicApiKeyValue {
   apiKey: String!
 }
 
-"""A managed secret value representing an Anthropic Bedrock API key."""
-type ManagedSecretAnthropicBedrockApiKeyValue {
-  awsBearerTokenBedrock: String!
-  awsRegion: String!
-}
-
-"""A managed secret value representing Anthropic Bedrock access key credentials."""
+"""
+A managed secret value representing Anthropic Bedrock access key credentials.
+"""
 type ManagedSecretAnthropicBedrockAccessKeyValue {
   awsAccessKeyId: String!
   awsRegion: String!
@@ -2037,6 +2163,12 @@ type ManagedSecretAnthropicBedrockAccessKeyValue {
   (e.g. STS-issued credentials). Persistent IAM access keys do not need one.
   """
   awsSessionToken: String
+}
+
+"""A managed secret value representing an Anthropic Bedrock API key."""
+type ManagedSecretAnthropicBedrockApiKeyValue {
+  awsBearerTokenBedrock: String!
+  awsRegion: String!
 }
 
 """ManagedSecretConfig contains configuration for managed secrets."""
@@ -2052,6 +2184,7 @@ type ManagedSecretConfig {
 """A managed secret value representing an OpenAI API key."""
 type ManagedSecretOpenAiApiKeyValue {
   apiKey: String!
+
   """
   Optional base URL for the OpenAI API. When set, the harness uses this
   instead of the provider default (e.g. for regional endpoints).
@@ -2088,20 +2221,11 @@ type ManagedSecretsOutput implements Response {
 
 union ManagedSecretsResult = ManagedSecretsOutput | UserFacingError
 
-input ListHarnessAuthSecretsInput {
-  """
-  Harness whose auth-credential secrets should be returned. Harnesses that
-  don't use auth secrets (e.g. OZ) always return an empty result.
-  """
-  harness: AgentHarness!
+type MemberSpendLimit {
+  maxMonthlySpendCents: Int!
+  principalType: PrincipalType!
+  principalUid: String!
 }
-
-type HarnessAuthSecretsOutput implements Response {
-  managedSecrets: [ManagedSecret!]!
-  responseContext: ResponseContext!
-}
-
-union HarnessAuthSecretsResult = HarnessAuthSecretsOutput | UserFacingError
 
 enum MembershipRole {
   ADMIN
@@ -2803,12 +2927,6 @@ type RootQuery {
   """
   listWarpDevImages: ListWarpDevImagesResult!
   managedSecrets(input: ManagedSecretsInput!, requestContext: RequestContext!): ManagedSecretsResult!
-
-  """
-  Retrieve managed secrets that serve as authentication credentials for the given harness,
-  scoped to the caller's personal drive and team drives.
-  """
-  harnessAuthSecrets(input: ListHarnessAuthSecretsInput!, requestContext: RequestContext!): HarnessAuthSecretsResult!
   pricingInfo(requestContext: RequestContext!): PricingInfoResult!
   rerankFragments(input: RerankFragmentsInput!, requestContext: RequestContext!): RerankFragmentsResult!
 
@@ -2882,6 +3000,13 @@ type ScreenshotArtifact {
   mimeType: String!
 }
 
+"""
+Error type for when a plan change would put the team over the target tier's seat cap.
+"""
+type SeatCapExceededError implements UserFacingErrorInterface {
+  message: String!
+}
+
 type SecretRedactionRegex {
   name: String
   pattern: String!
@@ -2901,6 +3026,15 @@ type SecretRedactionSettings {
 input SecretRedactionSettingsInput {
   enabled: Boolean
   regexes: [SecretRedactionRegexInput!]
+}
+
+input SecretRefInput {
+  """The managed secret name to include."""
+  name: String!
+}
+
+type SecretRefOutput {
+  name: String!
 }
 
 input SendOnboardingSurveyResponsesInput {
@@ -3064,6 +3198,7 @@ type SharedWorkflowsPolicy {
 }
 
 type SimpleIntegration {
+  agentUid: ID
   connectionLink: String!
   connectionStatus: SimpleIntegrationConnectionStatus!
   createdAt: Time
@@ -3077,9 +3212,12 @@ input SimpleIntegrationConfig {
   basePrompt: String
   computerUseEnabled: Boolean
   environmentUid: String
+  harness: HarnessInput
+  harnessAuthSecrets: HarnessAuthSecretsInput
   mcpServersJson: String
   modelId: String
   removeMcpServerNames: [String!]
+  secrets: [SecretRefInput!]
   workerHost: String
 }
 
@@ -3124,6 +3262,7 @@ enum SpaceType {
   User
 }
 
+"""A literal string value."""
 type StaticUploadFieldValue {
   value: String!
 }
@@ -3231,24 +3370,6 @@ type TaskAttachment {
   mimeType: String!
 }
 
-"""Input for task-related queries."""
-input TaskInput {
-  """The ID of the task."""
-  taskId: ID!
-}
-
-type TaskOutput implements Response {
-  responseContext: ResponseContext!
-  task: Task!
-}
-
-union TaskResult = TaskOutput | UserFacingError
-
-type TaskSecretEntry {
-  name: String!
-  value: ManagedSecretValue!
-}
-
 """A set of git credentials for a single hosting provider."""
 type TaskGitCredential {
   """
@@ -3257,7 +3378,7 @@ type TaskGitCredential {
   """
   email: String
 
-  """The git hosting provider (e.g. \"github.com\")."""
+  """The git hosting provider (e.g. "github.com")."""
   host: String!
 
   """The OAuth or installation access token."""
@@ -3286,6 +3407,24 @@ type TaskGitCredentialsOutput implements Response {
 
 union TaskGitCredentialsResult = TaskGitCredentialsOutput | UserFacingError
 
+"""Input for task-related queries."""
+input TaskInput {
+  """The ID of the task."""
+  taskId: ID!
+}
+
+type TaskOutput implements Response {
+  responseContext: ResponseContext!
+  task: Task!
+}
+
+union TaskResult = TaskOutput | UserFacingError
+
+type TaskSecretEntry {
+  name: String!
+  value: ManagedSecretValue!
+}
+
 """Input for the taskSecrets query."""
 input TaskSecretsInput {
   """The ID of the task."""
@@ -3312,7 +3451,14 @@ type Team {
   creatorId in v1 Team type is deprecated and should not be used. Use adminUid instead.
   """
   adminUid: String! @deprecated(reason: "Use members.role to determine admin status")
+
+  """
+  The email domain associated with the team, if one has been set by Warp staff.
+  Required for features that key off the team's domain (e.g. domain capture, SSO).
+  """
+  domain: String
   managedSecrets: ManagedSecretConfig
+  memberSpendLimits: [MemberSpendLimit!]
   members: [TeamMember!]!
   name: String!
   uid: ID!
@@ -3362,6 +3508,7 @@ input TelemetrySettingsInput {
 }
 
 type Tier {
+  agentHarnessesPolicy: AgentHarnessesPolicy
   agentIdentitiesPolicy: AgentIdentitiesPolicy
   aiAutonomyPolicy: AiAutonomyPolicy
   aiPermissionsPolicy: AiPermissionsPolicy
@@ -3393,6 +3540,7 @@ type Tier {
   telemetryDataCollectionPolicy: TelemetryDataCollectionPolicy
   ugcDataCollectionPolicy: UgcDataCollectionPolicy
   usageBasedPricingPolicy: UsageBasedPricingPolicy
+  usageVisibilityPolicy: UsageVisibilityPolicy
   warpAiPolicy: WarpAiPolicy
   warpBasicPolicy: WarpBasicPolicy
 }
@@ -3727,7 +3875,6 @@ type UpdateOnboardingSurveyStatusOutput implements Response {
 union UpdateOnboardingSurveyStatusResult = UpdateOnboardingSurveyStatusOutput | UserFacingError
 
 input UpdateUserSettingsInput {
-  agentAttributionEnabled: Boolean
   cloudConversationStorageEnabled: Boolean
   crashReportingEnabled: Boolean
   telemetryEnabled: Boolean
@@ -3765,7 +3912,9 @@ input UpdateWorkspaceSettingsInput {
   setCloudConversationStorageSettings: CloudConversationStorageSettingsInput
   setCodebaseContextSettings: CodebaseContextSettingsInput
   setDomainCaptureSettings: DomainCaptureSettingsInput
+  setEnterpriseAnalyticsDataCollectionSettings: EnterpriseAnalyticsDataCollectionSettingsInput
   setEnterpriseBillingSettings: EnterpriseBillingSettingsInput
+  setHarnessSettings: HarnessSettingsInput
   setLinkSharingSettings: LinkSharingSettingsInput
   setLlmSettings: LlmSettingsInput
   setSandboxedAgentSettings: SandboxedAgentSettingsInput
@@ -3832,11 +3981,15 @@ input UpdatedObjectInput {
   uid: ID!
 }
 
+"""
+A single name/value pair for a multipart form field in a presigned POST upload.
+"""
 type UploadField {
   name: String!
   value: UploadFieldValue!
 }
 
+"""The value of a multipart form field in a presigned POST upload target."""
 union UploadFieldValue = ContentCRC32CFieldValue | ContentDataFieldValue | StaticUploadFieldValue
 
 type UsageBasedPricingPolicy {
@@ -3880,11 +4033,28 @@ enum UsagePlanSurveyResponse {
 }
 
 """
+Granularity at which a user can see AI usage across their team. Non-admins
+always collapse to OWN_ONLY regardless of tier.
+"""
+enum UsageVisibilityGranularity {
+  FULL_BREAKDOWN
+  OWN_ONLY
+  PER_USER_TOTALS
+  TEAM_AGGREGATE
+}
+
+type UsageVisibilityPolicy {
+  adminGranularity: UsageVisibilityGranularity!
+  maxPriorCycles: Int!
+}
+
+"""
 The User type is the primary way of interacting with our graph.
 Nearly all data is scoped to the currently logged-in user.
 """
 type User {
   anonymousUserInfo: AnonymousUserInfo
+  availableHarnesses: AvailableHarnesses!
   billingMetadata: BillingMetadata
   blocks: [Block!]!
   bonusGrants: [BonusGrant!]!
@@ -3907,11 +4077,18 @@ type User {
   - `[]` means that the user is not part of any server-side enabled experiments.
   """
   experiments: [Experiment!]
-  globalSkills: [String!]!
   githubInstallations: UserGithubInstallationsOutput!
+
+  """
+  Global skills that are always available to the calling principal.
+  The client will fetch and install these, so they're available in every conversation
+  on every device.
+  
+  This is currently only supported for agents, not individual users.
+  """
+  globalSkills: [String!]!
   isOnWorkDomain: Boolean!
   isOnboarded: Boolean!
-  availableHarnesses: AvailableHarnesses!
   llms: FeatureModelChoice!
   managedSecrets: ManagedSecretConfig
   onboardingSurveyStatus: OnboardingSurveyStatus
@@ -4019,7 +4196,6 @@ Workspace specific settings like telemetry enablement override these user settin
 UserSettings types and mutations are the v2 equivalent of the v1 user_settings.graphqls file.
 """
 type UserSettings {
-  isAgentAttributionEnabled: Boolean!
   isCloudConversationStorageEnabled: Boolean!
   isCrashReportingEnabled: Boolean!
   isTelemetryEnabled: Boolean!
@@ -4110,6 +4286,7 @@ type Workspace {
   inviteCode: String
   inviteLinkDomainRestrictions: [InviteLinkDomainRestriction!]!
   isEligibleForDiscovery: Boolean!
+  memberSpendLimits: [MemberSpendLimit!]
   members: [WorkspaceMember!]!
   name: String!
   pendingEmailInvites: [EmailInvite!]!
@@ -4147,7 +4324,9 @@ type WorkspaceSettings {
   cloudConversationStorageSettings: CloudConversationStorageSettings!
   codebaseContextSettings: CodebaseContextSettings!
   domainCaptureSettings: DomainCaptureSettings!
+  enterpriseAnalyticsDataCollectionSettings: EnterpriseAnalyticsDataCollectionSettings!
   enterpriseBillingSettings: EnterpriseBillingSettings
+  harnessSettings: HarnessSettings
   isDiscoverable: Boolean!
   isInviteLinkEnabled: Boolean!
   linkSharingSettings: LinkSharingSettings!

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -1710,6 +1710,13 @@ input HarnessAuthSecretsInput {
   codexAuthSecretName: String
 }
 
+type HarnessAuthSecretsOutput implements Response {
+  managedSecrets: [ManagedSecret!]!
+  responseContext: ResponseContext!
+}
+
+union HarnessAuthSecretsResult = HarnessAuthSecretsOutput | UserFacingError
+
 type HarnessConfig {
   enabled: Boolean!
 }
@@ -1905,6 +1912,14 @@ type ListAIConversationsOutput implements Response {
 }
 
 union ListAIConversationsResult = ListAIConversationsOutput | UserFacingError
+
+input ListHarnessAuthSecretsInput {
+  """
+  Harness whose auth-credential secrets should be returned. Harnesses that
+  don't use auth secrets (e.g. OZ) always return an empty result.
+  """
+  harness: AgentHarness!
+}
 
 type ListWarpDevImagesOutput implements Response {
   """List of available Warp dev base images from Docker Hub"""
@@ -2919,6 +2934,12 @@ type RootQuery {
   getIntegrationsUsingEnvironment(input: GetIntegrationsUsingEnvironmentInput!, requestContext: RequestContext!): GetIntegrationsUsingEnvironmentResult!
   getOAuthConnectTxStatus(input: GetOAuthConnectTxStatusInput!, requestContext: RequestContext!): GetOAuthConnectTxStatusResult!
   getRelevantFragments(input: GetRelevantFragmentsInput!, requestContext: RequestContext!): GetRelevantFragmentsResult!
+
+  """
+  Retrieve managed secrets that serve as authentication credentials for the given harness,
+  scoped to the caller's personal drive and team drives.
+  """
+  harnessAuthSecrets(input: ListHarnessAuthSecretsInput!, requestContext: RequestContext!): HarnessAuthSecretsResult!
   listAIConversations(input: ListAIConversationsInput!, requestContext: RequestContext!): ListAIConversationsResult!
 
   """


### PR DESCRIPTION
WISOTT

i want to make use of a bunch of the new types for the usage + billing page, so a gql regen was required. There's a couple things here that aren't super clean (looks like we diverged a bit from the staging schema because of whitelist omissions) so i made a separate pr for this.

this pr also adds the cynic code for the additional usage & billing types too + wiring up to the workspace gql query.

## Testing

running with workspace queries don't produce any errors in logs

Branch name is horrible name... i think i meant to name it something diff before making the pr etc...