### PR TITLE
[2/n] Add cynic types for tiered usage visibility

### DIFF
--- a/crates/graphql/src/api/billing.rs
+++ b/crates/graphql/src/api/billing.rs
@@ -109,6 +109,7 @@ pub struct Tier {
     pub enterprise_credits_auto_reload_policy: Option<EnterpriseCreditsAutoReloadPolicy>,
     pub multi_admin_policy: Option<MultiAdminPolicy>,
     pub ambient_agents_policy: Option<AmbientAgentsPolicy>,
+    pub usage_visibility_policy: Option<UsageVisibilityPolicy>,
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
@@ -292,6 +293,93 @@ pub enum StripeSubscriptionPlan {
     Build,
     BuildBusiness,
     BuildMax,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct UsageVisibilityPolicy {
+    pub admin_granularity: UsageVisibilityGranularity,
+    pub max_prior_cycles: i32,
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+pub enum UsageVisibilityGranularity {
+    OwnOnly,
+    TeamAggregate,
+    PerUserTotals,
+    FullBreakdown,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct BillingCycleUsageHistory {
+    pub current_period_start: Time,
+    pub current_period_end: Time,
+    pub summaries: Vec<BillingCycleUsageSummary>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct BillingCycleUsageSummary {
+    pub period_start: Time,
+    pub period_end: Time,
+    pub entries: Vec<UsageEntry>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct UsageEntry {
+    pub subject_type: AiCreditsUsageAndCostSubjectType,
+    pub subject_uid: Option<String>,
+    pub subject_display_name: Option<String>,
+    pub cost_type: AiCreditsUsageAndCostType,
+    pub usage_bucket: AiCreditsUsageBucket,
+    pub usage_source: AiCreditsUsageSource,
+    pub credits_used: i32,
+    pub cost_cents: i32,
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageAndCostSubjectType")]
+pub enum AiCreditsUsageAndCostSubjectType {
+    Team,
+    User,
+    ServiceAccount,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageAndCostType")]
+pub enum AiCreditsUsageAndCostType {
+    BaseLimit,
+    BonusGrant,
+    Payg,
+    AmbientBonusGrant,
+    Aggregate,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageBucket")]
+pub enum AiCreditsUsageBucket {
+    Ai,
+    Compute,
+    Platform,
+    SuggestedCodeDiffs,
+    Voice,
+    Aggregate,
+    #[cynic(fallback)]
+    Other(String),
+}
+
+#[derive(cynic::Enum, Clone, Debug, PartialEq, Eq)]
+#[cynic(graphql_type = "AICreditsUsageSource")]
+pub enum AiCreditsUsageSource {
+    Local,
+    Cloud,
+    Aggregate,
     #[cynic(fallback)]
     Other(String),
 }


### PR DESCRIPTION
Adds cynic types for tiered usage visibility + billing-cycle usage history to `crates/graphql/src/api/billing.rs`. Inert until a follow-up PR queries them.

Stacked on #11109.

Conversation: https://staging.warp.dev/conversation/cc554fe4-8a54-4573-a4c7-c3c9615ac225
Plan: https://staging.warp.dev/drive/notebook/yoCVtAF3BCHp5sjKSxraIu

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
