### PR TITLE
Move some types to the `warp_server_client` crate.

### DIFF
--- a/app/src/cloud_object/mod.rs
+++ b/app/src/cloud_object/mod.rs
@@ -31,10 +31,7 @@ use crate::{
     notebooks::{CloudNotebookModel, NotebookId},
     persistence::ModelEvent,
     server::{
-        ids::{
-            ClientId, HashableId, HashedSqliteId, ObjectUid, ServerId, ServerIdAndType, SyncId,
-            ToServerId,
-        },
+        ids::{ClientId, HashableId, HashedSqliteId, ObjectUid, ServerId, SyncId, ToServerId},
         server_api::object::ObjectClient,
         sync_queue::{QueueItem, SerializedModel},
     },
@@ -1021,22 +1018,6 @@ impl<T> ConflictStatus<T> {
     }
 }
 
-/// Represents a unique key for a generic string object. The server enforces that
-/// no two generic string objects have the same key.
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct GenericStringObjectUniqueKey {
-    /// The unique key.  E.g. for cloud prefs this is the storage_key of the pref
-    pub key: String,
-
-    /// Whether this key is unique for all generic string objects, or unique per user.
-    pub unique_per: UniquePer,
-}
-
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub enum UniquePer {
-    User,
-}
-
 impl From<&dyn CloudObject> for ObjectType {
     fn from(value: &dyn CloudObject) -> Self {
         value.object_type()
@@ -1537,130 +1518,6 @@ pub enum CloudObjectLocation {
     Trash,
 }
 
-/// Result of attempting to update a cloud object.
-#[derive(Debug)]
-pub enum UpdateCloudObjectResult<T> {
-    /// The update was successful and the object now has the specified revision.
-    Success {
-        revision_and_editor: RevisionAndLastEditor,
-    },
-    /// The update was rejected because the update was not sent from the current revision in
-    /// storage. The object and revision in storage are returned.
-    Rejected { object: T },
-}
-
-/// Helper struct that contains all the info needed to create an object
-/// on the server
-pub struct CreateObjectRequest {
-    pub serialized_model: Option<SerializedModel>,
-    pub title: Option<String>,
-    pub owner: Owner,
-    pub client_id: ClientId,
-    pub initial_folder_id: Option<FolderId>,
-    pub entrypoint: CloudObjectEventEntrypoint,
-}
-
-#[derive(PartialEq, Eq, Debug)]
-pub struct BulkCreateGenericStringObjectsRequest {
-    pub id: ClientId,
-    pub format: GenericStringObjectFormat,
-    pub uniqueness_key: Option<GenericStringObjectUniqueKey>,
-    pub serialized_model: SerializedModel,
-    pub initial_folder_id: Option<FolderId>,
-    pub entrypoint: CloudObjectEventEntrypoint,
-}
-
-/// Helper struct that contains all the info needed to fetch changed
-/// objects from the server
-#[derive(Default)]
-pub struct ObjectsToUpdate {
-    pub notebooks: Vec<UpdatedObjectInput>,
-    pub workflows: Vec<UpdatedObjectInput>,
-    pub folders: Vec<UpdatedObjectInput>,
-    pub generic_string_objects: Vec<UpdatedObjectInput>,
-}
-
-impl Clone for ObjectsToUpdate {
-    fn clone(&self) -> Self {
-        Self {
-            notebooks: self
-                .notebooks
-                .iter()
-                .map(copy_updated_object_input)
-                .collect(),
-            workflows: self
-                .workflows
-                .iter()
-                .map(copy_updated_object_input)
-                .collect(),
-            folders: self.folders.iter().map(copy_updated_object_input).collect(),
-            generic_string_objects: self
-                .generic_string_objects
-                .iter()
-                .map(copy_updated_object_input)
-                .collect(),
-        }
-    }
-}
-
-fn copy_updated_object_input(input: &UpdatedObjectInput) -> UpdatedObjectInput {
-    UpdatedObjectInput {
-        uid: input.uid.clone(),
-        actions_ts: input.actions_ts,
-        metadata_ts: input.metadata_ts,
-        permissions_ts: input.permissions_ts,
-        revision_ts: input.revision_ts,
-    }
-}
-
-/// The data returned by the server when an object is created, generic to any object type.
-#[derive(Debug)]
-pub struct CreatedCloudObject {
-    pub client_id: ClientId,
-    pub revision_and_editor: RevisionAndLastEditor,
-    pub metadata_ts: ServerTimestamp,
-    pub server_id_and_type: ServerIdAndType,
-    pub creator_uid: Option<String>,
-    pub permissions: ServerPermissions,
-}
-
-/// Result of attempting to create a cloud object.
-/// Allow large enum variant because success is the most common by far
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-pub enum CreateCloudObjectResult {
-    /// The object creation was successful
-    Success {
-        created_cloud_object: CreatedCloudObject,
-    },
-    /// The object creation denied due to an expected user error
-    UserFacingError(String),
-    /// The object creation was rejected because the generic string object had
-    /// already been created by another client.
-    GenericStringObjectUniqueKeyConflict,
-}
-
-/// Result of attempting to bulk create a cloud object.
-#[derive(Debug)]
-pub enum BulkCreateCloudObjectResult {
-    /// The bulk object creation was successful
-    Success {
-        created_cloud_objects: Vec<CreatedCloudObject>,
-    },
-    /// The bulk object creation was rejected because at least one generic string object had
-    /// already been created by another client.
-    GenericStringObjectUniqueKeyConflict,
-}
-
-/// The creation-specific data returned by the server, which is inserted into CloudModel and persisted
-/// just once.
-#[derive(Debug, PartialEq, Clone)]
-pub struct ServerCreationInfo {
-    pub server_id_and_type: ServerIdAndType,
-    pub creator_uid: Option<String>,
-    pub permissions: ServerPermissions,
-}
-
 impl From<Space> for WorkflowSource {
     fn from(space: Space) -> Self {
         match space {
@@ -1680,10 +1537,4 @@ impl From<Owner> for WorkflowSource {
             Owner::Team { team_uid } => Self::Team { team_uid },
         }
     }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct RevisionAndLastEditor {
-    pub revision: Revision,
-    pub last_editor_uid: Option<String>,
 }

--- a/app/src/cloud_object/model/generic_string_model.rs
+++ b/app/src/cloud_object/model/generic_string_model.rs
@@ -11,14 +11,16 @@ use crate::{
     drive::{items::WarpDriveItem, CloudObjectTypeAndId},
     persistence::ModelEvent,
     server::{
-        ids::{ObjectUid, ServerId, SyncId},
+        ids::{ServerId, SyncId},
         server_api::object::ObjectClient,
         sync_queue::{QueueItem, SerializedModel},
     },
 };
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+
+// Re-exported from warp_server_client.
+pub use warp_server_client::ids::GenericStringObjectId;
 
 /// A trait that generic string-based objects should implement.
 pub trait CloudStringObject: CloudObject + Send + Sync {
@@ -359,22 +361,5 @@ where
 
     pub fn json_model(&self) -> &M {
         &self.string_model
-    }
-}
-
-/// Object id type that is common for all generic string objects.
-#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
-pub struct GenericStringObjectId(ServerId);
-crate::server_id_traits! { GenericStringObjectId, "GenericStringObject" }
-
-impl From<GenericStringObjectId> for SyncId {
-    fn from(id: GenericStringObjectId) -> Self {
-        Self::ServerId(id.into())
-    }
-}
-
-impl GenericStringObjectId {
-    pub fn uid(&self) -> ObjectUid {
-        self.0.uid()
     }
 }

--- a/app/src/drive/mod.rs
+++ b/app/src/drive/mod.rs
@@ -19,14 +19,16 @@ pub use index::DriveIndexVariant;
 pub use panel::{DrivePanel, DrivePanelEvent};
 use serde::{Deserialize, Serialize};
 use warp_core::user_preferences::GetUserPreferences as _;
+pub use warp_server_client::drive::{
+    CloudObjectTypeAndId, OpenWarpDriveObjectArgs, OpenWarpDriveObjectSettings,
+};
 use warpui::AppContext;
 
 use crate::{
     cloud_object::{
         model::view::{CloudViewModel, UpdateTimestamp},
-        CloudObject, GenericStringObjectFormat, ObjectIdType, ObjectType,
+        CloudObject, ObjectType,
     },
-    server::ids::{HashedSqliteId, ObjectUid, ServerId, SyncId},
     ui_components::icons::Icon,
     workflows::CloudWorkflow,
 };
@@ -84,154 +86,6 @@ impl fmt::Display for DriveObjectType {
             DriveObjectType::MCPServer => write!(f, "mcp server"),
             DriveObjectType::MCPServerCollection => write!(f, "mcp server collection"),
         }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
-pub struct OpenWarpDriveObjectSettings {
-    /// The folder that should be focused in the Warp Drive when the object is opened.
-    pub focused_folder_id: Option<ServerId>,
-    /// The email of the user to invite to the object, if the object is being opened via the request access flow.
-    pub invitee_email: Option<String>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct OpenWarpDriveObjectArgs {
-    pub object_type: ObjectType,
-    pub server_id: ServerId,
-    pub settings: OpenWarpDriveObjectSettings,
-}
-
-/// Enum to use to pass down type and id between actions to avoid multiplying actions whenever we
-/// need to pass the object id etc.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum CloudObjectTypeAndId {
-    Notebook(SyncId),
-    Workflow(SyncId),
-    Folder(SyncId),
-    GenericStringObject {
-        object_type: GenericStringObjectFormat,
-        id: SyncId,
-    },
-}
-
-impl CloudObjectTypeAndId {
-    pub fn from_id_and_type(id: SyncId, object_type: ObjectType) -> Self {
-        match object_type {
-            ObjectType::Notebook => Self::Notebook(id),
-            ObjectType::Workflow => Self::Workflow(id),
-            ObjectType::Folder => Self::Folder(id),
-            ObjectType::GenericStringObject(format) => Self::GenericStringObject {
-                object_type: format,
-                id,
-            },
-        }
-    }
-
-    pub fn uid(self) -> ObjectUid {
-        match self {
-            Self::Notebook(id) => id.uid(),
-            Self::Workflow(id) => id.uid(),
-            Self::Folder(id) => id.uid(),
-            Self::GenericStringObject { id, .. } => id.uid(),
-        }
-    }
-
-    pub fn sync_id(self) -> SyncId {
-        match self {
-            Self::Notebook(id)
-            | Self::Workflow(id)
-            | Self::Folder(id)
-            | Self::GenericStringObject { id, .. } => id,
-        }
-    }
-
-    pub fn sqlite_uid_hash(self) -> HashedSqliteId {
-        match self {
-            CloudObjectTypeAndId::Notebook(id) => id.sqlite_uid_hash(ObjectIdType::Notebook),
-            CloudObjectTypeAndId::Workflow(id) => id.sqlite_uid_hash(ObjectIdType::Workflow),
-            CloudObjectTypeAndId::Folder(id) => id.sqlite_uid_hash(ObjectIdType::Folder),
-            CloudObjectTypeAndId::GenericStringObject { object_type: _, id } => {
-                id.sqlite_uid_hash(ObjectIdType::GenericStringObject)
-            }
-        }
-    }
-
-    pub fn object_id_type(&self) -> ObjectIdType {
-        match self {
-            CloudObjectTypeAndId::Notebook(_) => ObjectIdType::Notebook,
-            CloudObjectTypeAndId::Workflow(_) => ObjectIdType::Workflow,
-            CloudObjectTypeAndId::GenericStringObject { .. } => ObjectIdType::GenericStringObject,
-            CloudObjectTypeAndId::Folder(_) => ObjectIdType::Folder,
-        }
-    }
-
-    pub fn object_type(&self) -> ObjectType {
-        match self {
-            CloudObjectTypeAndId::Notebook(_) => ObjectType::Notebook,
-            CloudObjectTypeAndId::Workflow(_) => ObjectType::Workflow,
-            CloudObjectTypeAndId::Folder(_) => ObjectType::Folder,
-            CloudObjectTypeAndId::GenericStringObject { object_type, .. } => {
-                ObjectType::GenericStringObject(*object_type)
-            }
-        }
-    }
-
-    pub fn as_folder_id(self) -> Option<SyncId> {
-        match self {
-            CloudObjectTypeAndId::Notebook(_) => None,
-            CloudObjectTypeAndId::Workflow(_) => None,
-            CloudObjectTypeAndId::GenericStringObject { .. } => None,
-            CloudObjectTypeAndId::Folder(f) => Some(f),
-        }
-    }
-
-    pub fn as_notebook_id(self) -> Option<SyncId> {
-        match self {
-            CloudObjectTypeAndId::Notebook(id) => Some(id),
-            _ => None,
-        }
-    }
-
-    pub fn as_generic_string_object_id(self) -> Option<SyncId> {
-        match self {
-            CloudObjectTypeAndId::GenericStringObject { object_type: _, id } => Some(id),
-            _ => None,
-        }
-    }
-
-    pub fn has_server_id(self) -> bool {
-        matches!(
-            self,
-            CloudObjectTypeAndId::Notebook(SyncId::ServerId(_))
-                | CloudObjectTypeAndId::Workflow(SyncId::ServerId(_))
-                | CloudObjectTypeAndId::Folder(SyncId::ServerId(_))
-                | CloudObjectTypeAndId::GenericStringObject {
-                    id: SyncId::ServerId(_),
-                    ..
-                }
-        )
-    }
-
-    pub fn server_id(self) -> Option<ServerId> {
-        match self {
-            CloudObjectTypeAndId::Notebook(SyncId::ServerId(notebook_id)) => Some(notebook_id),
-            CloudObjectTypeAndId::Workflow(SyncId::ServerId(workflow_id)) => Some(workflow_id),
-            CloudObjectTypeAndId::Folder(SyncId::ServerId(folder_id)) => Some(folder_id),
-            CloudObjectTypeAndId::GenericStringObject {
-                id: SyncId::ServerId(json_object_id),
-                ..
-            } => Some(json_object_id),
-            _ => None,
-        }
-    }
-
-    pub fn drive_row_position_id(self) -> String {
-        format!("WarpDriveRow_{}", self.uid())
-    }
-
-    pub fn from_generic_string_object(object_type: GenericStringObjectFormat, id: SyncId) -> Self {
-        Self::GenericStringObject { object_type, id }
     }
 }
 

--- a/app/src/drive/mod.rs
+++ b/app/src/drive/mod.rs
@@ -19,9 +19,7 @@ pub use index::DriveIndexVariant;
 pub use panel::{DrivePanel, DrivePanelEvent};
 use serde::{Deserialize, Serialize};
 use warp_core::user_preferences::GetUserPreferences as _;
-pub use warp_server_client::drive::{
-    CloudObjectTypeAndId, OpenWarpDriveObjectArgs, OpenWarpDriveObjectSettings,
-};
+pub use warp_server_client::drive::CloudObjectTypeAndId;
 use warpui::AppContext;
 
 use crate::{
@@ -29,11 +27,27 @@ use crate::{
         model::view::{CloudViewModel, UpdateTimestamp},
         CloudObject, ObjectType,
     },
+    server::ids::ServerId,
     ui_components::icons::Icon,
     workflows::CloudWorkflow,
 };
 
 type SortByComparator<'a> = dyn FnMut(&&dyn CloudObject, &&dyn CloudObject) -> Ordering + 'a;
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct OpenWarpDriveObjectSettings {
+    /// The folder that should be focused in the Warp Drive when the object is opened.
+    pub focused_folder_id: Option<ServerId>,
+    /// The email of the user to invite to the object, if the object is being opened via the request access flow.
+    pub invitee_email: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct OpenWarpDriveObjectArgs {
+    pub object_type: ObjectType,
+    pub server_id: ServerId,
+    pub settings: OpenWarpDriveObjectSettings,
+}
 
 #[derive(Copy, Clone, Debug)]
 pub enum DriveObjectType {

--- a/app/src/server/graphql/schema/mod.rs
+++ b/app/src/server/graphql/schema/mod.rs
@@ -27,109 +27,102 @@ use warp_graphql::{
     object::ObjectUpdateSuccess,
 };
 
-impl TryFrom<UpdateGenericStringObjectResult> for UpdateCloudObjectResult<Box<dyn ServerObject>> {
-    type Error = anyhow::Error;
-
-    fn try_from(value: UpdateGenericStringObjectResult) -> std::result::Result<Self, Self::Error> {
-        match value {
-            UpdateGenericStringObjectResult::UpdateGenericStringObjectOutput(output) => {
-                match output.update {
-                    GenericStringObjectUpdate::ObjectUpdateSuccess(success) => {
-                        Ok(UpdateCloudObjectResult::Success {
-                            revision_and_editor: RevisionAndLastEditor {
-                                revision: success.revision_ts.into(),
-                                last_editor_uid: Some(success.last_editor_uid.into_inner()),
-                            },
-                        })
-                    }
-                    GenericStringObjectUpdate::GenericStringObjectUpdateRejected(rejected) => {
-                        let boxed: Box<dyn ServerObject> = match rejected
-                            .conflicting_generic_string_object
-                            .format
-                        {
-                            GenericStringObjectFormat::JsonEnvVarCollection => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudEnvVarCollectionModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
+pub fn update_generic_string_object_result_to_update_result(
+    value: UpdateGenericStringObjectResult,
+) -> Result<UpdateCloudObjectResult<Box<dyn ServerObject>>> {
+    match value {
+        UpdateGenericStringObjectResult::UpdateGenericStringObjectOutput(output) => {
+            match output.update {
+                GenericStringObjectUpdate::ObjectUpdateSuccess(success) => {
+                    Ok(UpdateCloudObjectResult::Success {
+                        revision_and_editor: RevisionAndLastEditor {
+                            revision: success.revision_ts.into(),
+                            last_editor_uid: Some(success.last_editor_uid.into_inner()),
+                        },
+                    })
+                }
+                GenericStringObjectUpdate::GenericStringObjectUpdateRejected(rejected) => {
+                    let boxed: Box<dyn ServerObject> = match rejected
+                        .conflicting_generic_string_object
+                        .format
+                    {
+                        GenericStringObjectFormat::JsonEnvVarCollection => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudEnvVarCollectionModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
                                     rejected
                                         .conflicting_generic_string_object
                                         .metadata
-                                        .try_into()?,
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonPreference => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudPreferenceModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .metadata
-                                        .try_into()?,
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonWorkflowEnum => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudWorkflowEnumModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonPreference => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudPreferenceModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
                                     rejected
                                         .conflicting_generic_string_object
                                         .metadata
-                                        .try_into()?,
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonWorkflowEnum => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudWorkflowEnumModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
                                     rejected
                                         .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonAIFact => {
-                                let gso = GenericServerObject::<
+                                        .metadata
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonAIFact => {
+                            let gso = GenericServerObject::<
                                     GenericStringObjectId,
                                     CloudAIFactModel,
                                 >::try_from_graphql_fields(
@@ -152,171 +145,158 @@ impl TryFrom<UpdateGenericStringObjectResult> for UpdateCloudObjectResult<Box<dy
                                         .permissions
                                         .try_into()?,
                                 )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonAIExecutionProfile => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudAIExecutionProfileModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonAIExecutionProfile => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudAIExecutionProfileModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
                                     rejected
                                         .conflicting_generic_string_object
                                         .metadata
-                                        .try_into()?,
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonMCPServer => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudMCPServerModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .metadata
-                                        .try_into()?,
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonTemplatableMCPServer => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudTemplatableMCPServerModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonMCPServer => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudMCPServerModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
                                     rejected
                                         .conflicting_generic_string_object
                                         .metadata
-                                        .try_into()?,
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonCloudEnvironment => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudAmbientAgentEnvironmentModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .metadata
-                                        .try_into()?,
-                                    rejected
-                                        .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                            GenericStringObjectFormat::JsonScheduledAmbientAgent => {
-                                let gso = GenericServerObject::<
-                                    GenericStringObjectId,
-                                    CloudScheduledAmbientAgentModel,
-                                >::try_from_graphql_fields(
-                                    ServerId::from_string_lossy(
-                                        rejected
-                                            .conflicting_generic_string_object
-                                            .metadata
-                                            .uid
-                                            .inner(),
-                                    ),
-                                    Some(
-                                        rejected.conflicting_generic_string_object.serialized_model,
-                                    ),
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonTemplatableMCPServer => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudTemplatableMCPServerModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
                                     rejected
                                         .conflicting_generic_string_object
                                         .metadata
-                                        .try_into()?,
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonCloudEnvironment => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudAmbientAgentEnvironmentModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
                                     rejected
                                         .conflicting_generic_string_object
-                                        .permissions
-                                        .try_into()?,
-                                )?;
-                                let boxed: Box<dyn ServerObject> = Box::new(gso);
-                                boxed
-                            }
-                        };
-                        Ok(UpdateCloudObjectResult::Rejected { object: boxed })
-                    }
-                    GenericStringObjectUpdate::Unknown => {
-                        bail!("update generic string object response has unknown variant")
-                    }
+                                        .metadata
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                        GenericStringObjectFormat::JsonScheduledAmbientAgent => {
+                            let gso = GenericServerObject::<
+                                GenericStringObjectId,
+                                CloudScheduledAmbientAgentModel,
+                            >::try_from_graphql_fields(
+                                ServerId::from_string_lossy(
+                                    rejected
+                                        .conflicting_generic_string_object
+                                        .metadata
+                                        .uid
+                                        .inner(),
+                                ),
+                                Some(rejected.conflicting_generic_string_object.serialized_model),
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .metadata
+                                    .try_into()?,
+                                rejected
+                                    .conflicting_generic_string_object
+                                    .permissions
+                                    .try_into()?,
+                            )?;
+                            let boxed: Box<dyn ServerObject> = Box::new(gso);
+                            boxed
+                        }
+                    };
+                    Ok(UpdateCloudObjectResult::Rejected { object: boxed })
+                }
+                GenericStringObjectUpdate::Unknown => {
+                    bail!("update generic string object response has unknown variant")
                 }
             }
-            UpdateGenericStringObjectResult::UserFacingError(e) => {
-                bail!(get_user_facing_error_message(e))
-            }
-            UpdateGenericStringObjectResult::Unknown => {
-                bail!("update generic string object response has unknown variant")
-            }
+        }
+        UpdateGenericStringObjectResult::UserFacingError(e) => {
+            bail!(get_user_facing_error_message(e))
+        }
+        UpdateGenericStringObjectResult::Unknown => {
+            bail!("update generic string object response has unknown variant")
         }
     }
 }
 
-impl TryFrom<ObjectUpdateSuccess> for UpdateCloudObjectResult<ServerFolder> {
-    type Error = anyhow::Error;
-
-    fn try_from(value: ObjectUpdateSuccess) -> Result<Self, Self::Error> {
-        Ok(UpdateCloudObjectResult::Success {
-            revision_and_editor: RevisionAndLastEditor {
-                revision: value.revision_ts.into(),
-                last_editor_uid: Some(value.last_editor_uid.into_inner()),
-            },
-        })
-    }
+pub fn object_update_success_to_update_result(
+    value: ObjectUpdateSuccess,
+) -> Result<UpdateCloudObjectResult<ServerFolder>> {
+    Ok(UpdateCloudObjectResult::Success {
+        revision_and_editor: RevisionAndLastEditor {
+            revision: value.revision_ts.into(),
+            last_editor_uid: Some(value.last_editor_uid.into_inner()),
+        },
+    })
 }

--- a/app/src/server/graphql/schema/util.rs
+++ b/app/src/server/graphql/schema/util.rs
@@ -3,29 +3,7 @@ use crate::anyhow;
 use crate::cloud_object::model::actions::ObjectActionHistory;
 use crate::cloud_object::model::actions::ObjectActionType;
 use crate::cloud_object::model::actions::{ObjectAction, ObjectActionSubtype};
-use crate::cloud_object::{GenericStringObjectUniqueKey, UniquePer};
 use crate::server::ids::{HashedSqliteId, ObjectUid, ServerId, SyncId};
-
-impl From<GenericStringObjectUniqueKey>
-    for warp_graphql::generic_string_object::GenericStringObjectUniqueKey
-{
-    fn from(key: GenericStringObjectUniqueKey) -> Self {
-        use warp_graphql::generic_string_object::GenericStringObjectUniqueKey as GraphQLFormat;
-        GraphQLFormat {
-            key: key.key,
-            unique_per: key.unique_per.into(),
-        }
-    }
-}
-
-impl From<UniquePer> for warp_graphql::generic_string_object::UniquePer {
-    fn from(unique_per: UniquePer) -> Self {
-        use warp_graphql::generic_string_object::UniquePer as GraphQLUniquePer;
-        match unique_per {
-            UniquePer::User => GraphQLUniquePer::User,
-        }
-    }
-}
 
 impl From<ObjectActionType> for warp_graphql::object_actions::ActionType {
     fn from(action: ObjectActionType) -> Self {

--- a/app/src/server/ids.rs
+++ b/app/src/server/ids.rs
@@ -1,4 +1,6 @@
 // Re-export types from warp_server_client.
+#[allow(unused_imports)]
+pub use warp_server_client::ids::GenericStringObjectId;
 pub use warp_server_client::ids::{
     parse_sqlite_id_to_uid, ApiKeyUid, ClientId, HashableId, HashedSqliteId, ObjectUid, ServerId,
     ServerIdAndType, SyncId, ToServerId,

--- a/app/src/server/server_api/object.rs
+++ b/app/src/server/server_api/object.rs
@@ -32,7 +32,13 @@ use crate::{
             listener::ObjectUpdateMessage,
             update_manager::{GetCloudObjectResponse, InitialLoadResponse},
         },
-        graphql::{get_request_context, get_user_facing_error_message},
+        graphql::{
+            get_request_context, get_user_facing_error_message,
+            schema::{
+                object_update_success_to_update_result,
+                update_generic_string_object_result_to_update_result,
+            },
+        },
         ids::{ClientId, HashableId, ServerId, ServerIdAndType, SyncId, ToServerId},
         server_api::{auth::AuthClient, ServerApi},
         sync_queue::SerializedModel,
@@ -740,7 +746,9 @@ impl ObjectClient for ServerApi {
         let response = self.send_graphql_request(operation, None).await?;
 
         match response.update_folder {
-            UpdateFolderResult::UpdateFolderOutput(output) => output.update.try_into(),
+            UpdateFolderResult::UpdateFolderOutput(output) => {
+                object_update_success_to_update_result(output.update)
+            }
             UpdateFolderResult::UserFacingError(e) => {
                 Err(anyhow!(get_user_facing_error_message(e)))
             }
@@ -767,7 +775,7 @@ impl ObjectClient for ServerApi {
 
         let operation = UpdateGenericStringObject::build(variables);
         let response = self.send_graphql_request(operation, None).await?;
-        response.update_generic_string_object.try_into()
+        update_generic_string_object_result_to_update_result(response.update_generic_string_object)
     }
 
     async fn grab_notebook_edit_access(&self, notebook_id: NotebookId) -> Result<ServerMetadata> {

--- a/app/src/server/sync_queue.rs
+++ b/app/src/server/sync_queue.rs
@@ -47,6 +47,9 @@ use crate::{
     workflows::{workflow_enum::CloudWorkflowEnumModel, CloudWorkflowModel},
 };
 
+// Re-exported from warp_server_client.
+pub use warp_server_client::cloud_object::SerializedModel;
+
 lazy_static! {
     static ref DEFAULT_RETRY_OPTION: RetryOption =
         RetryOption::exponential(Duration::from_secs(1), 2., 3);
@@ -89,30 +92,6 @@ enum UpdateResponseType {
     /// The update was rejected because the update was not sent from the current revision in
     /// storage. The object and revision in storage are returned.
     Rejected { object: Box<ServerCloudObject> },
-}
-
-// A newtype for a serialized model that wraps a plain string.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SerializedModel(String);
-
-impl SerializedModel {
-    pub fn new(s: String) -> Self {
-        Self(s)
-    }
-
-    pub fn model_as_str(&self) -> &str {
-        &self.0
-    }
-
-    pub fn take(self) -> String {
-        self.0
-    }
-}
-
-impl From<String> for SerializedModel {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -911,7 +890,7 @@ impl SyncQueue {
                 } => {
                     let serialized_model = serialized_model
                         .as_ref()
-                        .map(|data| SerializedModel(data.model_as_str().to_owned()));
+                        .map(|data| SerializedModel::new(data.model_as_str().to_owned()));
 
                     self.create_object(
                         object_type,
@@ -962,7 +941,7 @@ impl SyncQueue {
                                     BulkCreateGenericStringObjectsRequest {
                                         id: data.id,
                                         format: data.format,
-                                        serialized_model: SerializedModel(
+                                        serialized_model: SerializedModel::new(
                                             data.serialized_model
                                                 .as_ref()
                                                 .model_as_str()

--- a/crates/warp_server_client/src/cloud_object/creation.rs
+++ b/crates/warp_server_client/src/cloud_object/creation.rs
@@ -1,0 +1,75 @@
+use warp_graphql::scalars::time::ServerTimestamp;
+
+use crate::ids::{ClientId, FolderId, ServerIdAndType};
+
+use super::{
+    CloudObjectEventEntrypoint, GenericStringObjectFormat, GenericStringObjectUniqueKey, Owner,
+    RevisionAndLastEditor, SerializedModel, ServerPermissions,
+};
+
+/// Helper struct that contains all the info needed to create an object on the server.
+pub struct CreateObjectRequest {
+    pub serialized_model: Option<SerializedModel>,
+    pub title: Option<String>,
+    pub owner: Owner,
+    pub client_id: ClientId,
+    pub initial_folder_id: Option<FolderId>,
+    pub entrypoint: CloudObjectEventEntrypoint,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct BulkCreateGenericStringObjectsRequest {
+    pub id: ClientId,
+    pub format: GenericStringObjectFormat,
+    pub uniqueness_key: Option<GenericStringObjectUniqueKey>,
+    pub serialized_model: SerializedModel,
+    pub initial_folder_id: Option<FolderId>,
+    pub entrypoint: CloudObjectEventEntrypoint,
+}
+
+/// The data returned by the server when an object is created, generic to any object type.
+#[derive(Debug)]
+pub struct CreatedCloudObject {
+    pub client_id: ClientId,
+    pub revision_and_editor: RevisionAndLastEditor,
+    pub metadata_ts: ServerTimestamp,
+    pub server_id_and_type: ServerIdAndType,
+    pub creator_uid: Option<String>,
+    pub permissions: ServerPermissions,
+}
+
+/// Result of attempting to create a cloud object.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum CreateCloudObjectResult {
+    /// The object creation was successful.
+    Success {
+        created_cloud_object: CreatedCloudObject,
+    },
+    /// The object creation was denied due to an expected user error.
+    UserFacingError(String),
+    /// The object creation was rejected because the generic string object had
+    /// already been created by another client.
+    GenericStringObjectUniqueKeyConflict,
+}
+
+/// Result of attempting to bulk create a cloud object.
+#[derive(Debug)]
+pub enum BulkCreateCloudObjectResult {
+    /// The bulk object creation was successful.
+    Success {
+        created_cloud_objects: Vec<CreatedCloudObject>,
+    },
+    /// The bulk object creation was rejected because at least one generic string object had
+    /// already been created by another client.
+    GenericStringObjectUniqueKeyConflict,
+}
+
+/// The creation-specific data returned by the server, which is inserted into CloudModel and persisted
+/// just once.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ServerCreationInfo {
+    pub server_id_and_type: ServerIdAndType,
+    pub creator_uid: Option<String>,
+    pub permissions: ServerPermissions,
+}

--- a/crates/warp_server_client/src/cloud_object/mod.rs
+++ b/crates/warp_server_client/src/cloud_object/mod.rs
@@ -9,10 +9,7 @@ use warp_core::{
     features::FeatureFlag,
     ui::{Icon, appearance::Appearance, theme::Fill},
 };
-use warp_graphql::{
-    object_permissions::AccessLevel, queries::get_updated_cloud_objects::UpdatedObjectInput,
-    scalars::time::ServerTimestamp,
-};
+use warp_graphql::{object_permissions::AccessLevel, scalars::time::ServerTimestamp};
 use warpui_core::{
     Element,
     elements::{
@@ -25,9 +22,14 @@ use warpui_core::{
 use crate::{
     auth::UserUid,
     drive::sharing::{SharingAccessLevel, Subject, TeamKind, UserKind},
-    ids::{ClientId, FolderId, ServerId, ServerIdAndType, SyncId},
+    ids::{FolderId, ServerId, SyncId},
 };
 
+mod creation;
+mod update;
+
+pub use creation::*;
+pub use update::*;
 /// The type of object id each ObjectType corresponds to.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ObjectIdType {
@@ -825,127 +827,6 @@ impl From<String> for SerializedModel {
     fn from(s: String) -> Self {
         Self(s)
     }
-}
-
-/// Result of attempting to update a cloud object.
-#[derive(Debug)]
-pub enum UpdateCloudObjectResult<T> {
-    /// The update was successful and the object now has the specified revision.
-    Success {
-        revision_and_editor: RevisionAndLastEditor,
-    },
-    /// The update was rejected because the update was not sent from the current revision in
-    /// storage. The object and revision in storage are returned.
-    Rejected { object: T },
-}
-
-/// Helper struct that contains all the info needed to create an object on the server.
-pub struct CreateObjectRequest {
-    pub serialized_model: Option<SerializedModel>,
-    pub title: Option<String>,
-    pub owner: Owner,
-    pub client_id: ClientId,
-    pub initial_folder_id: Option<FolderId>,
-    pub entrypoint: CloudObjectEventEntrypoint,
-}
-
-#[derive(PartialEq, Eq, Debug)]
-pub struct BulkCreateGenericStringObjectsRequest {
-    pub id: ClientId,
-    pub format: GenericStringObjectFormat,
-    pub uniqueness_key: Option<GenericStringObjectUniqueKey>,
-    pub serialized_model: SerializedModel,
-    pub initial_folder_id: Option<FolderId>,
-    pub entrypoint: CloudObjectEventEntrypoint,
-}
-
-/// Helper struct that contains all the info needed to fetch changed objects from the server.
-#[derive(Default)]
-pub struct ObjectsToUpdate {
-    pub notebooks: Vec<UpdatedObjectInput>,
-    pub workflows: Vec<UpdatedObjectInput>,
-    pub folders: Vec<UpdatedObjectInput>,
-    pub generic_string_objects: Vec<UpdatedObjectInput>,
-}
-
-impl Clone for ObjectsToUpdate {
-    fn clone(&self) -> Self {
-        Self {
-            notebooks: self
-                .notebooks
-                .iter()
-                .map(copy_updated_object_input)
-                .collect(),
-            workflows: self
-                .workflows
-                .iter()
-                .map(copy_updated_object_input)
-                .collect(),
-            folders: self.folders.iter().map(copy_updated_object_input).collect(),
-            generic_string_objects: self
-                .generic_string_objects
-                .iter()
-                .map(copy_updated_object_input)
-                .collect(),
-        }
-    }
-}
-
-fn copy_updated_object_input(input: &UpdatedObjectInput) -> UpdatedObjectInput {
-    UpdatedObjectInput {
-        uid: input.uid.clone(),
-        actions_ts: input.actions_ts,
-        metadata_ts: input.metadata_ts,
-        permissions_ts: input.permissions_ts,
-        revision_ts: input.revision_ts,
-    }
-}
-
-/// The data returned by the server when an object is created, generic to any object type.
-#[derive(Debug)]
-pub struct CreatedCloudObject {
-    pub client_id: ClientId,
-    pub revision_and_editor: RevisionAndLastEditor,
-    pub metadata_ts: ServerTimestamp,
-    pub server_id_and_type: ServerIdAndType,
-    pub creator_uid: Option<String>,
-    pub permissions: ServerPermissions,
-}
-
-/// Result of attempting to create a cloud object.
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-pub enum CreateCloudObjectResult {
-    /// The object creation was successful.
-    Success {
-        created_cloud_object: CreatedCloudObject,
-    },
-    /// The object creation was denied due to an expected user error.
-    UserFacingError(String),
-    /// The object creation was rejected because the generic string object had
-    /// already been created by another client.
-    GenericStringObjectUniqueKeyConflict,
-}
-
-/// Result of attempting to bulk create a cloud object.
-#[derive(Debug)]
-pub enum BulkCreateCloudObjectResult {
-    /// The bulk object creation was successful.
-    Success {
-        created_cloud_objects: Vec<CreatedCloudObject>,
-    },
-    /// The bulk object creation was rejected because at least one generic string object had
-    /// already been created by another client.
-    GenericStringObjectUniqueKeyConflict,
-}
-
-/// The creation-specific data returned by the server, which is inserted into CloudModel and persisted
-/// just once.
-#[derive(Debug, PartialEq, Clone)]
-pub struct ServerCreationInfo {
-    pub server_id_and_type: ServerIdAndType,
-    pub creator_uid: Option<String>,
-    pub permissions: ServerPermissions,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/warp_server_client/src/cloud_object/mod.rs
+++ b/crates/warp_server_client/src/cloud_object/mod.rs
@@ -9,7 +9,10 @@ use warp_core::{
     features::FeatureFlag,
     ui::{Icon, appearance::Appearance, theme::Fill},
 };
-use warp_graphql::{object_permissions::AccessLevel, scalars::time::ServerTimestamp};
+use warp_graphql::{
+    object_permissions::AccessLevel, queries::get_updated_cloud_objects::UpdatedObjectInput,
+    scalars::time::ServerTimestamp,
+};
 use warpui_core::{
     Element,
     elements::{
@@ -22,7 +25,7 @@ use warpui_core::{
 use crate::{
     auth::UserUid,
     drive::sharing::{SharingAccessLevel, Subject, TeamKind, UserKind},
-    ids::{FolderId, ServerId, SyncId},
+    ids::{ClientId, FolderId, ServerId, ServerIdAndType, SyncId},
 };
 
 /// The type of object id each ObjectType corresponds to.
@@ -132,6 +135,22 @@ pub const JSON_OBJECT_PREFIX: &str = "JSON_";
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum GenericStringObjectFormat {
     Json(JsonObjectType),
+}
+
+/// Represents a unique key for a generic string object. The server enforces that
+/// no two generic string objects have the same key.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct GenericStringObjectUniqueKey {
+    /// The unique key. E.g. for cloud prefs this is the storage key of the pref.
+    pub key: String,
+
+    /// Whether this key is unique for all generic string objects, or unique per user.
+    pub unique_per: UniquePer,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum UniquePer {
+    User,
 }
 
 // Temporarily suppress clippy warnings about the `ToString` impl until we
@@ -784,6 +803,157 @@ pub enum CloudObjectEventEntrypoint {
     Unknown,
 }
 
+// A newtype for a serialized model that wraps a plain string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SerializedModel(String);
+
+impl SerializedModel {
+    pub fn new(s: String) -> Self {
+        Self(s)
+    }
+
+    pub fn model_as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn take(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for SerializedModel {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+/// Result of attempting to update a cloud object.
+#[derive(Debug)]
+pub enum UpdateCloudObjectResult<T> {
+    /// The update was successful and the object now has the specified revision.
+    Success {
+        revision_and_editor: RevisionAndLastEditor,
+    },
+    /// The update was rejected because the update was not sent from the current revision in
+    /// storage. The object and revision in storage are returned.
+    Rejected { object: T },
+}
+
+/// Helper struct that contains all the info needed to create an object on the server.
+pub struct CreateObjectRequest {
+    pub serialized_model: Option<SerializedModel>,
+    pub title: Option<String>,
+    pub owner: Owner,
+    pub client_id: ClientId,
+    pub initial_folder_id: Option<FolderId>,
+    pub entrypoint: CloudObjectEventEntrypoint,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct BulkCreateGenericStringObjectsRequest {
+    pub id: ClientId,
+    pub format: GenericStringObjectFormat,
+    pub uniqueness_key: Option<GenericStringObjectUniqueKey>,
+    pub serialized_model: SerializedModel,
+    pub initial_folder_id: Option<FolderId>,
+    pub entrypoint: CloudObjectEventEntrypoint,
+}
+
+/// Helper struct that contains all the info needed to fetch changed objects from the server.
+#[derive(Default)]
+pub struct ObjectsToUpdate {
+    pub notebooks: Vec<UpdatedObjectInput>,
+    pub workflows: Vec<UpdatedObjectInput>,
+    pub folders: Vec<UpdatedObjectInput>,
+    pub generic_string_objects: Vec<UpdatedObjectInput>,
+}
+
+impl Clone for ObjectsToUpdate {
+    fn clone(&self) -> Self {
+        Self {
+            notebooks: self
+                .notebooks
+                .iter()
+                .map(copy_updated_object_input)
+                .collect(),
+            workflows: self
+                .workflows
+                .iter()
+                .map(copy_updated_object_input)
+                .collect(),
+            folders: self.folders.iter().map(copy_updated_object_input).collect(),
+            generic_string_objects: self
+                .generic_string_objects
+                .iter()
+                .map(copy_updated_object_input)
+                .collect(),
+        }
+    }
+}
+
+fn copy_updated_object_input(input: &UpdatedObjectInput) -> UpdatedObjectInput {
+    UpdatedObjectInput {
+        uid: input.uid.clone(),
+        actions_ts: input.actions_ts,
+        metadata_ts: input.metadata_ts,
+        permissions_ts: input.permissions_ts,
+        revision_ts: input.revision_ts,
+    }
+}
+
+/// The data returned by the server when an object is created, generic to any object type.
+#[derive(Debug)]
+pub struct CreatedCloudObject {
+    pub client_id: ClientId,
+    pub revision_and_editor: RevisionAndLastEditor,
+    pub metadata_ts: ServerTimestamp,
+    pub server_id_and_type: ServerIdAndType,
+    pub creator_uid: Option<String>,
+    pub permissions: ServerPermissions,
+}
+
+/// Result of attempting to create a cloud object.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum CreateCloudObjectResult {
+    /// The object creation was successful.
+    Success {
+        created_cloud_object: CreatedCloudObject,
+    },
+    /// The object creation was denied due to an expected user error.
+    UserFacingError(String),
+    /// The object creation was rejected because the generic string object had
+    /// already been created by another client.
+    GenericStringObjectUniqueKeyConflict,
+}
+
+/// Result of attempting to bulk create a cloud object.
+#[derive(Debug)]
+pub enum BulkCreateCloudObjectResult {
+    /// The bulk object creation was successful.
+    Success {
+        created_cloud_objects: Vec<CreatedCloudObject>,
+    },
+    /// The bulk object creation was rejected because at least one generic string object had
+    /// already been created by another client.
+    GenericStringObjectUniqueKeyConflict,
+}
+
+/// The creation-specific data returned by the server, which is inserted into CloudModel and persisted
+/// just once.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ServerCreationInfo {
+    pub server_id_and_type: ServerIdAndType,
+    pub creator_uid: Option<String>,
+    pub permissions: ServerPermissions,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RevisionAndLastEditor {
+    pub revision: Revision,
+    pub last_editor_uid: Option<String>,
+}
+
 // GraphQL conversion impls.
 
 impl From<GenericStringObjectFormat>
@@ -836,6 +1006,27 @@ impl From<CloudObjectEventEntrypoint> for warp_graphql::object::CloudObjectEvent
             CloudObjectEventEntrypoint::ImportModal => GraphQLEntrypoint::ImportModal,
             CloudObjectEventEntrypoint::Onboarding => GraphQLEntrypoint::Onboarding,
             CloudObjectEventEntrypoint::Unknown => GraphQLEntrypoint::Unknown,
+        }
+    }
+}
+
+impl From<GenericStringObjectUniqueKey>
+    for warp_graphql::generic_string_object::GenericStringObjectUniqueKey
+{
+    fn from(key: GenericStringObjectUniqueKey) -> Self {
+        use warp_graphql::generic_string_object::GenericStringObjectUniqueKey as GraphQLKey;
+        GraphQLKey {
+            key: key.key,
+            unique_per: key.unique_per.into(),
+        }
+    }
+}
+
+impl From<UniquePer> for warp_graphql::generic_string_object::UniquePer {
+    fn from(unique_per: UniquePer) -> Self {
+        use warp_graphql::generic_string_object::UniquePer as GraphQLUniquePer;
+        match unique_per {
+            UniquePer::User => GraphQLUniquePer::User,
         }
     }
 }

--- a/crates/warp_server_client/src/cloud_object/update.rs
+++ b/crates/warp_server_client/src/cloud_object/update.rs
@@ -1,0 +1,57 @@
+use warp_graphql::queries::get_updated_cloud_objects::UpdatedObjectInput;
+
+use super::RevisionAndLastEditor;
+
+/// Result of attempting to update a cloud object.
+#[derive(Debug)]
+pub enum UpdateCloudObjectResult<T> {
+    /// The update was successful and the object now has the specified revision.
+    Success {
+        revision_and_editor: RevisionAndLastEditor,
+    },
+    /// The update was rejected because the update was not sent from the current revision in
+    /// storage. The object and revision in storage are returned.
+    Rejected { object: T },
+}
+
+/// Helper struct that contains all the info needed to fetch changed objects from the server.
+#[derive(Default)]
+pub struct ObjectsToUpdate {
+    pub notebooks: Vec<UpdatedObjectInput>,
+    pub workflows: Vec<UpdatedObjectInput>,
+    pub folders: Vec<UpdatedObjectInput>,
+    pub generic_string_objects: Vec<UpdatedObjectInput>,
+}
+
+impl Clone for ObjectsToUpdate {
+    fn clone(&self) -> Self {
+        Self {
+            notebooks: self
+                .notebooks
+                .iter()
+                .map(copy_updated_object_input)
+                .collect(),
+            workflows: self
+                .workflows
+                .iter()
+                .map(copy_updated_object_input)
+                .collect(),
+            folders: self.folders.iter().map(copy_updated_object_input).collect(),
+            generic_string_objects: self
+                .generic_string_objects
+                .iter()
+                .map(copy_updated_object_input)
+                .collect(),
+        }
+    }
+}
+
+fn copy_updated_object_input(input: &UpdatedObjectInput) -> UpdatedObjectInput {
+    UpdatedObjectInput {
+        uid: input.uid.clone(),
+        actions_ts: input.actions_ts,
+        metadata_ts: input.metadata_ts,
+        permissions_ts: input.permissions_ts,
+        revision_ts: input.revision_ts,
+    }
+}

--- a/crates/warp_server_client/src/drive/mod.rs
+++ b/crates/warp_server_client/src/drive/mod.rs
@@ -5,21 +5,6 @@ use crate::{
     ids::{HashedSqliteId, ObjectUid, ServerId, SyncId},
 };
 
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
-pub struct OpenWarpDriveObjectSettings {
-    /// The folder that should be focused in the Warp Drive when the object is opened.
-    pub focused_folder_id: Option<ServerId>,
-    /// The email of the user to invite to the object, if the object is being opened via the request access flow.
-    pub invitee_email: Option<String>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct OpenWarpDriveObjectArgs {
-    pub object_type: ObjectType,
-    pub server_id: ServerId,
-    pub settings: OpenWarpDriveObjectSettings,
-}
-
 /// Enum to use to pass down type and id between actions to avoid multiplying actions whenever we
 /// need to pass the object id, etc.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]

--- a/crates/warp_server_client/src/drive/mod.rs
+++ b/crates/warp_server_client/src/drive/mod.rs
@@ -1,1 +1,154 @@
 pub mod sharing;
+
+use crate::{
+    cloud_object::{GenericStringObjectFormat, ObjectIdType, ObjectType},
+    ids::{HashedSqliteId, ObjectUid, ServerId, SyncId},
+};
+
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct OpenWarpDriveObjectSettings {
+    /// The folder that should be focused in the Warp Drive when the object is opened.
+    pub focused_folder_id: Option<ServerId>,
+    /// The email of the user to invite to the object, if the object is being opened via the request access flow.
+    pub invitee_email: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct OpenWarpDriveObjectArgs {
+    pub object_type: ObjectType,
+    pub server_id: ServerId,
+    pub settings: OpenWarpDriveObjectSettings,
+}
+
+/// Enum to use to pass down type and id between actions to avoid multiplying actions whenever we
+/// need to pass the object id, etc.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum CloudObjectTypeAndId {
+    Notebook(SyncId),
+    Workflow(SyncId),
+    Folder(SyncId),
+    GenericStringObject {
+        object_type: GenericStringObjectFormat,
+        id: SyncId,
+    },
+}
+
+impl CloudObjectTypeAndId {
+    pub fn from_id_and_type(id: SyncId, object_type: ObjectType) -> Self {
+        match object_type {
+            ObjectType::Notebook => Self::Notebook(id),
+            ObjectType::Workflow => Self::Workflow(id),
+            ObjectType::Folder => Self::Folder(id),
+            ObjectType::GenericStringObject(format) => Self::GenericStringObject {
+                object_type: format,
+                id,
+            },
+        }
+    }
+
+    pub fn uid(self) -> ObjectUid {
+        match self {
+            Self::Notebook(id) => id.uid(),
+            Self::Workflow(id) => id.uid(),
+            Self::Folder(id) => id.uid(),
+            Self::GenericStringObject { id, .. } => id.uid(),
+        }
+    }
+
+    pub fn sync_id(self) -> SyncId {
+        match self {
+            Self::Notebook(id)
+            | Self::Workflow(id)
+            | Self::Folder(id)
+            | Self::GenericStringObject { id, .. } => id,
+        }
+    }
+
+    pub fn sqlite_uid_hash(self) -> HashedSqliteId {
+        match self {
+            CloudObjectTypeAndId::Notebook(id) => id.sqlite_uid_hash(ObjectIdType::Notebook),
+            CloudObjectTypeAndId::Workflow(id) => id.sqlite_uid_hash(ObjectIdType::Workflow),
+            CloudObjectTypeAndId::Folder(id) => id.sqlite_uid_hash(ObjectIdType::Folder),
+            CloudObjectTypeAndId::GenericStringObject { object_type: _, id } => {
+                id.sqlite_uid_hash(ObjectIdType::GenericStringObject)
+            }
+        }
+    }
+
+    pub fn object_id_type(&self) -> ObjectIdType {
+        match self {
+            CloudObjectTypeAndId::Notebook(_) => ObjectIdType::Notebook,
+            CloudObjectTypeAndId::Workflow(_) => ObjectIdType::Workflow,
+            CloudObjectTypeAndId::GenericStringObject { .. } => ObjectIdType::GenericStringObject,
+            CloudObjectTypeAndId::Folder(_) => ObjectIdType::Folder,
+        }
+    }
+
+    pub fn object_type(&self) -> ObjectType {
+        match self {
+            CloudObjectTypeAndId::Notebook(_) => ObjectType::Notebook,
+            CloudObjectTypeAndId::Workflow(_) => ObjectType::Workflow,
+            CloudObjectTypeAndId::Folder(_) => ObjectType::Folder,
+            CloudObjectTypeAndId::GenericStringObject { object_type, .. } => {
+                ObjectType::GenericStringObject(*object_type)
+            }
+        }
+    }
+
+    pub fn as_folder_id(self) -> Option<SyncId> {
+        match self {
+            CloudObjectTypeAndId::Notebook(_) => None,
+            CloudObjectTypeAndId::Workflow(_) => None,
+            CloudObjectTypeAndId::GenericStringObject { .. } => None,
+            CloudObjectTypeAndId::Folder(f) => Some(f),
+        }
+    }
+
+    pub fn as_notebook_id(self) -> Option<SyncId> {
+        match self {
+            CloudObjectTypeAndId::Notebook(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    pub fn as_generic_string_object_id(self) -> Option<SyncId> {
+        match self {
+            CloudObjectTypeAndId::GenericStringObject { object_type: _, id } => Some(id),
+            _ => None,
+        }
+    }
+
+    pub fn has_server_id(self) -> bool {
+        matches!(
+            self,
+            CloudObjectTypeAndId::Notebook(SyncId::ServerId(_))
+                | CloudObjectTypeAndId::Workflow(SyncId::ServerId(_))
+                | CloudObjectTypeAndId::Folder(SyncId::ServerId(_))
+                | CloudObjectTypeAndId::GenericStringObject {
+                    id: SyncId::ServerId(_),
+                    ..
+                }
+        )
+    }
+
+    pub fn server_id(self) -> Option<ServerId> {
+        match self {
+            CloudObjectTypeAndId::Notebook(SyncId::ServerId(notebook_id)) => Some(notebook_id),
+            CloudObjectTypeAndId::Workflow(SyncId::ServerId(workflow_id)) => Some(workflow_id),
+            CloudObjectTypeAndId::Folder(SyncId::ServerId(folder_id)) => Some(folder_id),
+            CloudObjectTypeAndId::GenericStringObject {
+                id: SyncId::ServerId(json_object_id),
+                ..
+            } => Some(json_object_id),
+            _ => None,
+        }
+    }
+
+    pub fn drive_row_position_id(self) -> String {
+        format!("WarpDriveRow_{}", self.uid())
+    }
+
+    pub fn from_generic_string_object(object_type: GenericStringObjectFormat, id: SyncId) -> Self {
+        Self::GenericStringObject { object_type, id }
+    }
+}

--- a/crates/warp_server_client/src/ids.rs
+++ b/crates/warp_server_client/src/ids.rs
@@ -413,3 +413,20 @@ impl From<FolderId> for SyncId {
         Self::ServerId(id.into())
     }
 }
+
+/// Object ID type that is common for all generic string objects.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct GenericStringObjectId(ServerId);
+crate::server_id_traits! { GenericStringObjectId, "GenericStringObject" }
+
+impl From<GenericStringObjectId> for SyncId {
+    fn from(id: GenericStringObjectId) -> Self {
+        Self::ServerId(id.into())
+    }
+}
+
+impl GenericStringObjectId {
+    pub fn uid(&self) -> ObjectUid {
+        self.0.uid()
+    }
+}


### PR DESCRIPTION
## Description
Moves the low-level cloud object, drive, ID, and server request/response types that are shared with server-client code into `warp_server_client`.

This creates a stable boundary for later extracting the generic server/cloud object containers without pulling app-local `CloudModel`, UI, or runtime behavior into the client crate. Existing app import paths continue to work through re-exports where practical.

Key pieces moved or introduced here:
- Cloud object identity and format types such as `ObjectType`, `ObjectIdType`, `GenericStringObjectFormat`, `JsonObjectType`, and generic string uniqueness metadata.
- Sync and server ID support such as `ClientId`, `SyncId`, `ObjectUid`, and sqlite hash helpers.
- Drive object addressing types such as `CloudObjectTypeAndId` and open-object args/settings.
- Portable create/update payload and result types under `warp_server_client::cloud_object`.

## Testing
Validated on the stack tip after Phase 3:

- `cargo fmt --manifest-path /Users/david/src/warp/Cargo.toml --all`
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp_server_client`
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp`
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp --tests`
- `git --no-pager diff --check`

Co-Authored-By: Oz <oz-agent@warp.dev>
