### PR TITLE
Move `GenericCloudObject` to `warp_server_client`.

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -43,6 +43,7 @@ use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::conversation_navigation::ConversationNavigationData;
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::AuthStateProvider;
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind};
 use crate::server::cloud_objects::update_manager::{UpdateManager, UpdateManagerEvent};
 use crate::server::ids::{ServerId, SyncId};

--- a/app/src/ai/agent_sdk/common.rs
+++ b/app/src/ai/agent_sdk/common.rs
@@ -18,7 +18,7 @@ use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::auth::auth_state::AuthStateProvider;
-use crate::cloud_object::{CloudObject, Owner};
+use crate::cloud_object::{CloudObject, CloudObjectLookup as _, Owner};
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ai::AIClient;

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -69,7 +69,7 @@ use crate::ai::skills::{
     SkillWatcher,
 };
 use crate::auth::AuthStateProvider;
-use crate::cloud_object::CloudObject;
+use crate::cloud_object::{CloudObject, CloudObjectLookup as _};
 use crate::send_telemetry_from_app_ctx;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ai::AIClient;

--- a/app/src/ai/agent_sdk/environment.rs
+++ b/app/src/ai/agent_sdk/environment.rs
@@ -26,7 +26,7 @@ use crate::ai::cloud_environments::{
 };
 use crate::auth::UserUid;
 use crate::cloud_object::model::generic_string_model::GenericStringObjectId;
-use crate::cloud_object::CloudObject;
+use crate::cloud_object::{CloudObject, CloudObjectLookup as _};
 use crate::server::cloud_objects::update_manager::{
     ObjectOperation, OperationSuccessType, UpdateManager, UpdateManagerEvent,
 };

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -60,6 +60,7 @@ use crate::ai::skills::{
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::send_telemetry_sync_from_app_ctx;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ai::{AIClient, AgentConfigSnapshot};

--- a/app/src/ai/agent_sdk/schedule.rs
+++ b/app/src/ai/agent_sdk/schedule.rs
@@ -18,7 +18,7 @@ use crate::ai::ambient_agents::scheduled::{
     CloudScheduledAmbientAgent, ScheduledAgentManager, ScheduledAmbientAgent, UpdateScheduleParams,
 };
 use crate::ai::ambient_agents::AgentConfigSnapshot;
-use crate::cloud_object::CloudObject;
+use crate::cloud_object::{CloudObject, CloudObjectLookup as _};
 use crate::server::ids::{ServerId, SyncId};
 use crate::util::time_format::format_approx_duration_from_now_utc;
 

--- a/app/src/ai/ambient_agents/scheduled.rs
+++ b/app/src/ai/ambient_agents/scheduled.rs
@@ -15,8 +15,8 @@ use crate::cloud_object::model::generic_string_model::{
 use crate::cloud_object::model::json_model::{JsonModel, JsonSerializer};
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::{
-    GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey, JsonObjectType,
-    Owner, Revision,
+    CloudObjectLookup as _, GenericCloudObject, GenericStringObjectFormat,
+    GenericStringObjectUniqueKey, JsonObjectType, Owner, Revision,
 };
 use crate::drive::CloudObjectTypeAndId;
 use crate::server::cloud_objects::update_manager::{
@@ -53,23 +53,6 @@ pub type CloudScheduledAmbientAgent =
     GenericCloudObject<GenericStringObjectId, CloudScheduledAmbientAgentModel>;
 pub type CloudScheduledAmbientAgentModel =
     GenericStringModel<ScheduledAmbientAgent, JsonSerializer>;
-
-impl CloudScheduledAmbientAgent {
-    pub fn get_all(app: &AppContext) -> Vec<CloudScheduledAmbientAgent> {
-        CloudModel::as_ref(app)
-            .get_all_objects_of_type::<GenericStringObjectId, CloudScheduledAmbientAgentModel>()
-            .cloned()
-            .collect()
-    }
-
-    pub fn get_by_id<'a>(
-        sync_id: &'a SyncId,
-        app: &'a AppContext,
-    ) -> Option<&'a CloudScheduledAmbientAgent> {
-        CloudModel::as_ref(app)
-            .get_object_of_type::<GenericStringObjectId, CloudScheduledAmbientAgentModel>(sync_id)
-    }
-}
 
 impl ScheduledAmbientAgent {
     pub fn new(name: String, cron_schedule: String, enabled: bool, prompt: String) -> Self {

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/environment_selector.rs
@@ -22,6 +22,7 @@ use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::appearance::Appearance;
 use crate::cloud_object::model::generic_string_model::StringModel;
 use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::context_chips::display_menu::{
     ChipMenuType, DisplayChipMenu, FixedFooter, GenericMenuItem, PromptDisplayMenuEvent,
 };

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -44,6 +44,7 @@ use crate::ai::local_child_harnesses::{
     local_child_harness_disabled_message, local_child_harness_is_enabled,
 };
 use crate::appearance::Appearance;
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::menu::{MenuItem, MenuItemFields};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;

--- a/app/src/ai/cloud_agent_config/mod.rs
+++ b/app/src/ai/cloud_agent_config/mod.rs
@@ -1,18 +1,15 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use warpui::{AppContext, SingletonEntity as _};
 
 use crate::cloud_object::model::generic_string_model::{
     GenericStringModel, GenericStringObjectId, StringModel,
 };
 use crate::cloud_object::model::json_model::{JsonModel, JsonSerializer};
-use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::{
     GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey, JsonObjectType,
     Revision,
 };
-use crate::server::ids::SyncId;
 use crate::server::server_api::ai::AgentConfigSnapshot;
 use crate::server::sync_queue::QueueItem;
 
@@ -55,20 +52,6 @@ impl AgentConfig {
             harness: None,
             harness_auth_secrets: None,
         }
-    }
-}
-
-impl CloudAgentConfig {
-    pub fn get_all(app: &AppContext) -> Vec<CloudAgentConfig> {
-        CloudModel::as_ref(app)
-            .get_all_objects_of_type::<GenericStringObjectId, CloudAgentConfigModel>()
-            .cloned()
-            .collect()
-    }
-
-    pub fn get_by_id<'a>(sync_id: &'a SyncId, app: &'a AppContext) -> Option<&'a CloudAgentConfig> {
-        CloudModel::as_ref(app)
-            .get_object_of_type::<GenericStringObjectId, CloudAgentConfigModel>(sync_id)
     }
 }
 

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -9,12 +9,10 @@ use crate::cloud_object::model::generic_string_model::{
     GenericStringModel, GenericStringObjectId, StringModel,
 };
 use crate::cloud_object::model::json_model::{JsonModel, JsonSerializer};
-use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::{
     GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey, JsonObjectType,
     Revision,
 };
-use crate::server::ids::SyncId;
 use crate::server::sync_queue::QueueItem;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
@@ -109,23 +107,6 @@ pub type CloudAmbientAgentEnvironment =
     GenericCloudObject<GenericStringObjectId, CloudAmbientAgentEnvironmentModel>;
 pub type CloudAmbientAgentEnvironmentModel =
     GenericStringModel<AmbientAgentEnvironment, JsonSerializer>;
-
-impl CloudAmbientAgentEnvironment {
-    pub fn get_all(app: &AppContext) -> Vec<CloudAmbientAgentEnvironment> {
-        CloudModel::as_ref(app)
-            .get_all_objects_of_type::<GenericStringObjectId, CloudAmbientAgentEnvironmentModel>()
-            .cloned()
-            .collect()
-    }
-
-    pub fn get_by_id<'a>(
-        sync_id: &'a SyncId,
-        app: &'a AppContext,
-    ) -> Option<&'a CloudAmbientAgentEnvironment> {
-        CloudModel::as_ref(app)
-            .get_object_of_type::<GenericStringObjectId, CloudAmbientAgentEnvironmentModel>(sync_id)
-    }
-}
 
 impl AmbientAgentEnvironment {
     pub fn new(

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -47,6 +47,7 @@ use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
 use crate::appearance::Appearance;
 use crate::auth::UserUid;
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::notebooks::NotebookId;
 use crate::send_telemetry_from_ctx;
 use crate::server::ids::{ServerId, SyncId};

--- a/app/src/ai/mcp/mod.rs
+++ b/app/src/ai/mcp/mod.rs
@@ -15,10 +15,9 @@ use crate::cloud_object::model::generic_string_model::{
     GenericStringModel, GenericStringObjectId, StringModel,
 };
 use crate::cloud_object::model::json_model::{JsonModel, JsonSerializer};
-use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::{
-    GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey, JsonObjectType,
-    Revision,
+    CloudObjectUuid, GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey,
+    JsonObjectType, Revision,
 };
 use crate::drive::items::mcp_server::WarpDriveMCPServer;
 use crate::drive::items::WarpDriveItem;
@@ -56,7 +55,6 @@ cfg_if::cfg_if! {
 
 pub mod gallery;
 pub use gallery::MCPGalleryManager;
-use warpui::{AppContext, SingletonEntity as _};
 pub mod templatable;
 pub use templatable::{JsonTemplate, TemplatableMCPServer, TemplateVariable};
 pub mod logs;
@@ -162,26 +160,9 @@ pub struct ServerSentEvents {
 pub type CloudMCPServer = GenericCloudObject<GenericStringObjectId, CloudMCPServerModel>;
 pub type CloudMCPServerModel = GenericStringModel<MCPServer, JsonSerializer>;
 
-impl CloudMCPServer {
-    pub fn get_all(app: &AppContext) -> Vec<CloudMCPServer> {
-        CloudModel::as_ref(app)
-            .get_all_objects_of_type::<GenericStringObjectId, CloudMCPServerModel>()
-            .cloned()
-            .collect()
-    }
-
-    pub fn get_by_id<'a>(sync_id: &'a SyncId, app: &'a AppContext) -> Option<&'a CloudMCPServer> {
-        CloudModel::as_ref(app)
-            .get_object_of_type::<GenericStringObjectId, CloudMCPServerModel>(sync_id)
-    }
-
-    pub fn get_by_uuid<'a>(
-        uuid: &'a uuid::Uuid,
-        app: &'a AppContext,
-    ) -> Option<&'a CloudMCPServer> {
-        CloudModel::as_ref(app)
-            .get_all_objects_of_type::<GenericStringObjectId, CloudMCPServerModel>()
-            .find(|server| server.model().string_model.uuid == *uuid)
+impl CloudObjectUuid for MCPServer {
+    fn uuid(&self) -> uuid::Uuid {
+        self.uuid
     }
 }
 

--- a/app/src/ai/mcp/templatable.rs
+++ b/app/src/ai/mcp/templatable.rs
@@ -5,16 +5,14 @@ use handlebars::get_arguments;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use warp_core::ui::appearance::Appearance;
-use warpui::{AppContext, SingletonEntity as _};
 
 use crate::cloud_object::model::generic_string_model::{
     GenericStringModel, GenericStringObjectId, StringModel,
 };
 use crate::cloud_object::model::json_model::{JsonModel, JsonSerializer};
-use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::{
-    GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey, JsonObjectType,
-    Revision, UniquePer,
+    CloudObjectUuid, GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey,
+    JsonObjectType, Revision, UniquePer,
 };
 use crate::drive::items::WarpDriveItem;
 use crate::server::datetime_ext::DateTimeExt;
@@ -205,29 +203,9 @@ pub type CloudTemplatableMCPServer =
     GenericCloudObject<GenericStringObjectId, CloudTemplatableMCPServerModel>;
 pub type CloudTemplatableMCPServerModel = GenericStringModel<TemplatableMCPServer, JsonSerializer>;
 
-impl CloudTemplatableMCPServer {
-    pub fn get_all(app: &AppContext) -> Vec<CloudTemplatableMCPServer> {
-        CloudModel::as_ref(app)
-            .get_all_objects_of_type::<GenericStringObjectId, CloudTemplatableMCPServerModel>()
-            .cloned()
-            .collect()
-    }
-
-    pub fn get_by_id<'a>(
-        sync_id: &'a SyncId,
-        app: &'a AppContext,
-    ) -> Option<&'a CloudTemplatableMCPServer> {
-        CloudModel::as_ref(app)
-            .get_object_of_type::<GenericStringObjectId, CloudTemplatableMCPServerModel>(sync_id)
-    }
-
-    pub fn get_by_uuid<'a>(
-        uuid: &'a uuid::Uuid,
-        app: &'a AppContext,
-    ) -> Option<&'a CloudTemplatableMCPServer> {
-        CloudModel::as_ref(app)
-            .get_all_objects_of_type::<GenericStringObjectId, CloudTemplatableMCPServerModel>()
-            .find(|server| server.model().string_model.uuid == *uuid)
+impl CloudObjectUuid for TemplatableMCPServer {
+    fn uuid(&self) -> uuid::Uuid {
+        self.uuid
     }
 }
 

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -44,8 +44,8 @@ use crate::ai::mcp::{
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::cloud_object::{
-    CloudObject, CloudObjectLocation, CloudObjectMetadataExt, GenericStringObjectFormat,
-    JsonObjectType, Space,
+    CloudObject, CloudObjectLocation, CloudObjectLookup as _, CloudObjectMetadataExt,
+    CloudObjectUuidLookup as _, GenericStringObjectFormat, JsonObjectType, Space,
 };
 use crate::drive::CloudObjectTypeAndId;
 use crate::persistence::{
@@ -1416,8 +1416,6 @@ impl TemplatableMCPServerManager {
         servers_to_restart: HashSet<Uuid>,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Import inline because of circular dependencies
-        use crate::ai::mcp::CloudMCPServer;
         let cloud_legacy_servers = CloudMCPServer::get_all(ctx);
         log::info!(
             "Converting {} legacy MCP servers into templatable MCP servers",

--- a/app/src/cloud_object/mod.rs
+++ b/app/src/cloud_object/mod.rs
@@ -40,9 +40,7 @@ use crate::env_vars::CloudEnvVarCollectionModel;
 use crate::notebooks::{CloudNotebookModel, NotebookId};
 use crate::persistence::ModelEvent;
 use crate::server::cloud_objects::update_manager::InitiatedBy;
-use crate::server::ids::{
-    ClientId, HashableId, HashedSqliteId, ObjectUid, ServerId, SyncId, ToServerId,
-};
+use crate::server::ids::{HashableId, HashedSqliteId, ObjectUid, ServerId, SyncId, ToServerId};
 use crate::server::server_api::object::ObjectClient;
 use crate::server::sync_queue::{QueueItem, SerializedModel};
 use crate::settings::cloud_preferences::CloudPreferenceModel;
@@ -479,10 +477,14 @@ pub trait CloudModelType: Debug + Clone + Send + Sync {
     fn set_display_name(&mut self, _name: &str) {}
 
     /// Returns the upsert event for putting this model into the SQLite database.
-    fn upsert_event(&self, object: &Self::CloudObjectType) -> ModelEvent;
+    fn upsert_event(params: CloudObjectUpsertParams<Self>) -> ModelEvent
+    where
+        Self: Sized;
 
     /// Returns a bulk upsert event for putting a list of this model into the SQLite database.
-    fn bulk_upsert_event(objects: &[Self::CloudObjectType]) -> ModelEvent;
+    fn bulk_upsert_event(objects: Vec<CloudObjectUpsertParams<Self>>) -> ModelEvent
+    where
+        Self: Sized;
 
     /// Returns the sync queue item for creating this model on the server.
     fn create_object_queue_item(
@@ -543,50 +545,59 @@ pub trait CloudModelType: Debug + Clone + Send + Sync {
         false
     }
 }
+/// Provides app-local typed lookup helpers for generic cloud object aliases.
+pub trait CloudObjectLookup: Sized + Clone {
+    fn get_all(app: &AppContext) -> Vec<Self>;
+
+    fn get_by_id<'a>(sync_id: &'a SyncId, app: &'a AppContext) -> Option<&'a Self>;
+}
+
+impl<K, M> CloudObjectLookup for GenericCloudObject<K, M>
+where
+    K: HashableId + ToServerId + Debug + Into<String> + Clone + 'static,
+    M: CloudModelType<IdType = K, CloudObjectType = GenericCloudObject<K, M>> + 'static,
+{
+    fn get_all(app: &AppContext) -> Vec<Self> {
+        CloudModel::as_ref(app)
+            .get_all_objects_of_type::<K, M>()
+            .cloned()
+            .collect()
+    }
+
+    fn get_by_id<'a>(sync_id: &'a SyncId, app: &'a AppContext) -> Option<&'a Self> {
+        CloudModel::as_ref(app).get_object_of_type::<K, M>(sync_id)
+    }
+}
+
+/// Marks string model payloads that can be looked up by UUID.
+pub trait CloudObjectUuid {
+    fn uuid(&self) -> uuid::Uuid;
+}
+
+/// Provides app-local UUID lookups for cloud objects whose payload exposes a UUID.
+pub trait CloudObjectUuidLookup: Sized {
+    fn get_by_uuid<'a>(uuid: &'a uuid::Uuid, app: &'a AppContext) -> Option<&'a Self>;
+}
+
+impl<T, S> CloudObjectUuidLookup
+    for GenericCloudObject<GenericStringObjectId, GenericStringModel<T, S>>
+where
+    T: StringModel<
+            CloudObjectType = GenericCloudObject<GenericStringObjectId, GenericStringModel<T, S>>,
+        > + CloudObjectUuid,
+    S: Serializer<T>,
+{
+    fn get_by_uuid<'a>(uuid: &'a uuid::Uuid, app: &'a AppContext) -> Option<&'a Self> {
+        CloudModel::as_ref(app)
+            .get_all_objects_of_type::<GenericStringObjectId, GenericStringModel<T, S>>()
+            .find(|object| object.model().string_model.uuid() == *uuid)
+    }
+}
 
 lazy_static! {
     static ref SPACE_DETECT_RE: Regex = Regex::new(r"\s+").expect("Expect regex to be valid");
     static ref SAFE_URL_CHAR_RE: Regex =
         Regex::new(r"[^a-zA-Z0-9\s-]").expect("Expect regex to be valid");
-}
-
-/// A generic implementation of cloud objects that can be used for any model and id types.
-///
-/// For instance, rather than directly implementing the CloudObject trait, CloudObjects can
-/// implement GenericCloudObject<K, M> where K is their id type and M is their model type.
-///
-/// For example, CloudNotebook becomes:
-///
-///   pub type CloudNotebook = GenericCloudObject<NotebookId, CloudNotebookModel>
-///
-/// The advantage of using the generic model is you get common implementations
-/// of CloudObject methods like ```versions``` for free.
-///
-/// See the comments for CloudObject to understand the relationship between
-/// this trait, CloudObject and CloudModelType.  They are tightly coupled.
-#[derive(Clone, Debug)]
-pub struct GenericCloudObject<K, M>
-where
-    K: HashableId + ToServerId + Debug + Into<String> + Clone + 'static,
-    M: CloudModelType<IdType = K> + 'static,
-{
-    pub id: SyncId,
-    pub metadata: CloudObjectMetadata,
-    pub permissions: CloudObjectPermissions,
-    /// Tracks whether this object has a conflict with the server version.
-    /// This is runtime state (not persisted) - conflicts are always NoConflicts when loaded from SQLite.
-    pub conflict_status: ConflictStatus<GenericServerObject<K, M>>,
-
-    // Intentionally not public to prevent users of this class from holding
-    // onto references to the model outside of this struct.
-    //
-    // This is an Arc in order to support clone-on-write semantics for the model.
-    // By wrapping the model in an Arc, clones become cheap, and we can avoid
-    // doing deep clones of the model whenever the containing object is cloned.
-    //
-    // Callers who want to update the model need to call set_model to update the
-    // entire model atomically.
-    model: Arc<M>,
 }
 
 impl<K, M> CloudObject for GenericCloudObject<K, M>
@@ -595,7 +606,7 @@ where
     M: CloudModelType<IdType = K, CloudObjectType = GenericCloudObject<K, M>> + 'static,
 {
     fn model_type_name(&self) -> &'static str {
-        self.model.model_type_name()
+        self.model().model_type_name()
     }
 
     fn uid(&self) -> ObjectUid {
@@ -611,11 +622,11 @@ where
     }
 
     fn should_show_activity_toasts(&self) -> bool {
-        self.model.should_show_activity_toasts()
+        self.model().should_show_activity_toasts()
     }
 
     fn warn_if_unsaved_at_quit(&self) -> bool {
-        self.model.warn_if_unsaved_at_quit()
+        self.model().warn_if_unsaved_at_quit()
     }
 
     fn metadata(&self) -> &CloudObjectMetadata {
@@ -635,19 +646,19 @@ where
     }
 
     fn object_type(&self) -> ObjectType {
-        self.model.object_type()
+        self.model().object_type()
     }
 
     fn cloud_object_type_and_id(&self) -> CloudObjectTypeAndId {
-        self.model.cloud_object_type_and_id(self.id)
+        self.model().cloud_object_type_and_id(self.id)
     }
 
     fn should_clear_on_unique_key_conflict(&self) -> bool {
-        self.model.should_clear_on_unique_key_conflict()
+        self.model().should_clear_on_unique_key_conflict()
     }
 
     fn can_move_to_space(&self, space: Space, app: &AppContext) -> bool {
-        self.model.can_move_to_space(self.space(app), space)
+        self.model().can_move_to_space(self.space(app), space)
     }
 
     fn has_conflicting_changes(&self) -> bool {
@@ -672,11 +683,11 @@ where
         self.set_pending_content_changes_status(CloudObjectSyncStatus::NoLocalChanges);
 
         if let ConflictStatus::ConflictingChanges { object } = new_conflict {
-            if self.model.should_update_after_server_conflict() {
+            if self.model().should_update_after_server_conflict() {
                 // Update metadata revision from the server object.
                 self.metadata.update_revision_from_server(&object.metadata);
                 // Update the model from the server.
-                self.model = object.model.clone().into();
+                self.set_model(object.model.clone());
                 // Update conflict status - this may create a new conflict if there are pending changes.
                 if self.metadata.has_pending_content_changes() {
                     self.conflict_status = ConflictStatus::ConflictingChanges { object };
@@ -692,11 +703,11 @@ where
     }
 
     fn object_link(&self) -> Option<String> {
-        if !self.model.supports_linking() {
+        if !self.model().supports_linking() {
             return None;
         }
 
-        let display_name = self.model.display_name();
+        let display_name = self.model().display_name();
         // First remove all the url unsafe chars
         let name_without_unsafe_chars = SAFE_URL_CHAR_RE.replace_all(display_name.trim(), "");
         // Then turn all the spaces into dashes
@@ -734,11 +745,11 @@ where
     }
 
     fn upsert_event(&self) -> ModelEvent {
-        self.model.upsert_event(self)
+        M::upsert_event(self.upsert_params(self.object_type()))
     }
 
     fn display_name(&self) -> String {
-        self.model.display_name()
+        self.model().display_name()
     }
 
     fn versions(&self, app: &AppContext) -> Option<UpdatedObjectInput> {
@@ -764,24 +775,24 @@ where
         entrypoint: CloudObjectEventEntrypoint,
         initiated_by: InitiatedBy,
     ) -> Option<QueueItem> {
-        self.model
+        self.model()
             .create_object_queue_item(self, entrypoint, initiated_by)
     }
 
     fn update_object_queue_item(&self, revision_ts: Option<Revision>) -> QueueItem {
-        self.model.update_object_queue_item(revision_ts, self)
+        self.model().update_object_queue_item(revision_ts, self)
     }
 
     fn renders_in_warp_drive(&self) -> bool {
-        self.model.renders_in_warp_drive()
+        self.model().renders_in_warp_drive()
     }
 
     fn to_warp_drive_item(&self, appearance: &Appearance) -> Option<Box<dyn WarpDriveItem>> {
-        self.model.to_warp_drive_item(self.id, appearance, self)
+        self.model().to_warp_drive_item(self.id, appearance, self)
     }
 
     fn can_export(&self) -> bool {
-        self.model.can_export()
+        self.model().can_export()
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -796,121 +807,6 @@ where
         Box::new(self.clone())
     }
 }
-
-impl<K, M> GenericCloudObject<K, M>
-where
-    K: HashableId + ToServerId + Debug + Into<String> + Clone + 'static,
-    M: CloudModelType<IdType = K, CloudObjectType = GenericCloudObject<K, M>> + 'static,
-{
-    /// Gets a reference to the model held by the object.
-    pub fn model(&self) -> &M {
-        &self.model
-    }
-
-    /// Returns a shared handle to the model.
-    pub fn shared_model(&self) -> Arc<M> {
-        self.model.clone()
-    }
-
-    /// Sets a new version of the model on the object, replacing the old version.
-    pub fn set_model(&mut self, model: M) {
-        self.model = model.into();
-    }
-
-    /// Returns a bulk upsert event for putting a list of this model into the SQLite database.
-    pub fn bulk_upsert_event(objects: &[Self]) -> ModelEvent {
-        M::bulk_upsert_event(objects)
-    }
-
-    /// Constructs a new instance of this model with the given id, model, metadata and permissions.
-    pub fn new(
-        id: SyncId,
-        model: M,
-        metadata: CloudObjectMetadata,
-        permissions: CloudObjectPermissions,
-    ) -> Self {
-        Self {
-            id,
-            model: model.into(),
-            metadata,
-            permissions,
-            conflict_status: ConflictStatus::NoConflicts,
-        }
-    }
-
-    /// Creates a new GenericCloudObject with the given model, owner, and initial folder id.
-    /// This is for the local creation flow, as opposed to creating from a server update.
-    pub fn new_local(
-        model: M,
-        owner: Owner,
-        initial_folder_id: Option<SyncId>,
-        client_id: ClientId,
-    ) -> Self {
-        Self {
-            id: SyncId::ClientId(client_id),
-            model: model.into(),
-            metadata: CloudObjectMetadata {
-                pending_changes_statuses: CloudObjectStatuses {
-                    content_sync_status: CloudObjectSyncStatus::InFlight(NumInFlightRequests(1)),
-                    has_pending_metadata_change: false,
-                    has_pending_permissions_change: false,
-                    pending_untrash: false,
-                    pending_delete: false,
-                },
-                folder_id: initial_folder_id,
-                revision: Default::default(),
-                metadata_last_updated_ts: Default::default(),
-                current_editor_uid: Default::default(),
-                trashed_ts: Default::default(),
-                // Objects created from the client are never welcome objects.
-                is_welcome_object: false,
-                creator_uid: None,
-                last_editor_uid: None,
-                last_task_run_ts: None,
-            },
-            permissions: CloudObjectPermissions {
-                owner,
-                anyone_with_link: None,
-                guests: Default::default(),
-                permissions_last_updated_ts: None,
-            },
-            conflict_status: ConflictStatus::NoConflicts,
-        }
-    }
-
-    /// Creates a new `GenericCloudObject` from a `ServerObject`.
-    pub fn new_from_server(server_object: GenericServerObject<K, M>) -> Self {
-        Self {
-            id: server_object.id,
-            model: server_object.model.into(),
-            metadata: CloudObjectMetadata::new_from_server(server_object.metadata),
-            permissions: CloudObjectPermissions::new_from_server(server_object.permissions),
-            conflict_status: ConflictStatus::NoConflicts,
-        }
-    }
-
-    /// Marks this object as being in conflict with the provided object.
-    pub fn set_conflicting_object(&mut self, object: Arc<GenericServerObject<K, M>>) {
-        self.conflict_status = ConflictStatus::ConflictingChanges { object };
-    }
-
-    fn update_from_server_object(&mut self, server_object: GenericServerObject<K, M>) {
-        // Check if we should create a conflict or apply the update.
-        if self.metadata.has_pending_content_changes() || self.has_conflicting_changes() {
-            // There are pending changes, so this creates a conflict.
-            self.conflict_status = ConflictStatus::ConflictingChanges {
-                object: Arc::new(server_object),
-            };
-        } else {
-            // No pending changes, apply the server update.
-            self.metadata
-                .update_revision_from_server(&server_object.metadata);
-            self.model = server_object.model.clone().into();
-            self.conflict_status = ConflictStatus::NoConflicts;
-        }
-    }
-}
-
 impl<T, S> ServerObjectModel for GenericStringModel<T, S>
 where
     T: StringModel<

--- a/app/src/cloud_object/model/generic_string_model.rs
+++ b/app/src/cloud_object/model/generic_string_model.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use warp_server_client::cloud_object::CloudObjectUpsertParams;
 // Re-exported from warp_server_client.
 pub use warp_server_client::ids::GenericStringObjectId;
 
@@ -155,7 +156,7 @@ where
     }
 
     fn serialized(&self) -> SerializedModel {
-        self.model.serialized()
+        self.model().serialized()
     }
 
     fn clone_box(&self) -> Box<dyn CloudStringObject> {
@@ -203,8 +204,9 @@ where
         self.string_model.set_display_name(name);
     }
 
-    fn upsert_event(&self, object: &GenericCloudObject<GenericStringObjectId, Self>) -> ModelEvent {
-        let object = object as &dyn CloudStringObject;
+    fn upsert_event(params: CloudObjectUpsertParams<Self>) -> ModelEvent {
+        let object = GenericCloudObject::<GenericStringObjectId, Self>::from(params);
+        let object = &object as &dyn CloudStringObject;
         ModelEvent::UpsertGenericStringObject {
             object: CloudStringObject::clone_box(object),
         }
@@ -226,11 +228,16 @@ where
         self.string_model.can_export()
     }
 
-    fn bulk_upsert_event(
-        objects: &[GenericCloudObject<GenericStringObjectId, Self>],
-    ) -> ModelEvent {
+    fn bulk_upsert_event(objects: Vec<CloudObjectUpsertParams<Self>>) -> ModelEvent {
         ModelEvent::UpsertGenericStringObjects(
-            objects.iter().map(CloudStringObject::clone_box).collect(),
+            objects
+                .into_iter()
+                .map(|params| {
+                    Box::new(GenericCloudObject::<GenericStringObjectId, Self>::from(
+                        params,
+                    )) as Box<dyn CloudStringObject>
+                })
+                .collect(),
         )
     }
 
@@ -246,7 +253,7 @@ where
                 owner: object.permissions.owner,
                 id: client_id,
                 title: None,
-                serialized_model: Some(object.model.serialized().into()),
+                serialized_model: Some(object.model().serialized().into()),
                 initial_folder_id: object.metadata.folder_id,
                 entrypoint,
                 initiated_by,

--- a/app/src/cloud_object/model/model_tests.rs
+++ b/app/src/cloud_object/model/model_tests.rs
@@ -1038,18 +1038,18 @@ fn test_collapse_all_in_location() {
             let folder_1 = folder_from_cloud_model(model, folder_1_id);
             let folder_4 = folder_from_cloud_model(model, folder_4_id);
             let folder_5 = folder_from_cloud_model(model, folder_5_id);
-            assert!(!folder_1.model.is_open);
-            assert!(!folder_4.model.is_open);
-            assert!(!folder_5.model.is_open);
+            assert!(!folder_1.model().is_open);
+            assert!(!folder_4.model().is_open);
+            assert!(!folder_5.model().is_open);
             // but the others are still open
             let folder_2 = folder_from_cloud_model(model, folder_2_id);
             let folder_3 = folder_from_cloud_model(model, folder_3_id);
             let folder_6 = folder_from_cloud_model(model, folder_6_id);
             let folder_7 = folder_from_cloud_model(model, folder_7_id);
-            assert!(folder_2.model.is_open);
-            assert!(folder_3.model.is_open);
-            assert!(folder_6.model.is_open);
-            assert!(folder_7.model.is_open);
+            assert!(folder_2.model().is_open);
+            assert!(folder_3.model().is_open);
+            assert!(folder_6.model().is_open);
+            assert!(folder_7.model().is_open);
 
             model.collapse_all_in_location(
                 CloudObjectLocation::Space(Default::default()),
@@ -1064,13 +1064,13 @@ fn test_collapse_all_in_location() {
             let folder_5 = folder_from_cloud_model(model, folder_5_id);
             let folder_6 = folder_from_cloud_model(model, folder_6_id);
             let folder_7 = folder_from_cloud_model(model, folder_7_id);
-            assert!(!folder_1.model.is_open);
-            assert!(!folder_2.model.is_open);
-            assert!(!folder_3.model.is_open);
-            assert!(!folder_4.model.is_open);
-            assert!(!folder_5.model.is_open);
-            assert!(!folder_6.model.is_open);
-            assert!(!folder_7.model.is_open);
+            assert!(!folder_1.model().is_open);
+            assert!(!folder_2.model().is_open);
+            assert!(!folder_3.model().is_open);
+            assert!(!folder_4.model().is_open);
+            assert!(!folder_5.model().is_open);
+            assert!(!folder_6.model().is_open);
+            assert!(!folder_7.model().is_open);
         });
     })
 }
@@ -1135,19 +1135,19 @@ fn test_collapse_all_in_trash() {
             // folders 1, 4 should be collapsed
             let folder_1 = folder_from_cloud_model(model, folder_1_id);
             let folder_4 = folder_from_cloud_model(model, folder_4_id);
-            assert!(!folder_1.model.is_open);
-            assert!(!folder_4.model.is_open);
+            assert!(!folder_1.model().is_open);
+            assert!(!folder_4.model().is_open);
             // but the others, including folder 5, are still open
             let folder_2 = folder_from_cloud_model(model, folder_2_id);
             let folder_3 = folder_from_cloud_model(model, folder_3_id);
             let folder_5 = folder_from_cloud_model(model, folder_5_id);
             let folder_6 = folder_from_cloud_model(model, folder_6_id);
             let folder_7 = folder_from_cloud_model(model, folder_7_id);
-            assert!(folder_2.model.is_open);
-            assert!(folder_3.model.is_open);
-            assert!(folder_5.model.is_open);
-            assert!(folder_6.model.is_open);
-            assert!(folder_7.model.is_open);
+            assert!(folder_2.model().is_open);
+            assert!(folder_3.model().is_open);
+            assert!(folder_5.model().is_open);
+            assert!(folder_6.model().is_open);
+            assert!(folder_7.model().is_open);
 
             model.collapse_all_in_location(
                 CloudObjectLocation::Space(Default::default()),
@@ -1162,13 +1162,13 @@ fn test_collapse_all_in_trash() {
             let folder_5 = folder_from_cloud_model(model, folder_5_id);
             let folder_6 = folder_from_cloud_model(model, folder_6_id);
             let folder_7 = folder_from_cloud_model(model, folder_7_id);
-            assert!(!folder_1.model.is_open);
-            assert!(!folder_2.model.is_open);
-            assert!(!folder_3.model.is_open);
-            assert!(!folder_4.model.is_open);
-            assert!(!folder_5.model.is_open);
-            assert!(!folder_6.model.is_open);
-            assert!(!folder_7.model.is_open);
+            assert!(!folder_1.model().is_open);
+            assert!(!folder_2.model().is_open);
+            assert!(!folder_3.model().is_open);
+            assert!(!folder_4.model().is_open);
+            assert!(!folder_5.model().is_open);
+            assert!(!folder_6.model().is_open);
+            assert!(!folder_7.model().is_open);
         });
     })
 }

--- a/app/src/cloud_object/model/persistence.rs
+++ b/app/src/cloud_object/model/persistence.rs
@@ -544,7 +544,7 @@ impl CloudModel {
         ctx: &mut ModelContext<Self>,
     ) {
         if let Some(folder) = self.get_folder(&server_folder.id) {
-            server_folder.model.is_open = folder.model.is_open;
+            server_folder.model.is_open = folder.model().is_open;
         }
 
         self.upsert_from_server_object(server_folder, ctx);
@@ -890,13 +890,13 @@ impl CloudModel {
             let is_open = match open_state {
                 FolderOpenState::Open => true,
                 FolderOpenState::Closed => false,
-                FolderOpenState::Reversed => !folder.model.is_open,
+                FolderOpenState::Reversed => !folder.model().is_open,
             };
 
             folder.set_model(CloudFolderModel {
                 is_open,
-                is_warp_pack: folder.model.is_warp_pack,
-                name: folder.model.name.clone(),
+                is_warp_pack: folder.model().is_warp_pack,
+                name: folder.model().name.clone(),
             });
 
             let folder_clone = folder.clone();
@@ -1780,7 +1780,10 @@ impl CloudModel {
 
         if let Some(model_event_sender) = &self.model_event_sender {
             if let Err(e) = model_event_sender.send(M::bulk_upsert_event(
-                objects_without_pending_changes.as_slice(),
+                objects_without_pending_changes
+                    .iter()
+                    .map(|object| object.upsert_params(object.object_type()))
+                    .collect(),
             )) {
                 log::error!("Error saving team objects to cache: {e:?}");
             }

--- a/app/src/context_chips/display_menu.rs
+++ b/app/src/context_chips/display_menu.rs
@@ -33,6 +33,7 @@ use warpui::{
 
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::cloud_object::model::generic_string_model::StringModel;
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::editor::{
     EditorOptions, EditorView, Event as EditorEvent, PropagateAndNoOpNavigationKeys, TextOptions,
 };

--- a/app/src/drive/folders/mod.rs
+++ b/app/src/drive/folders/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use warp_server_client::cloud_object::CloudObjectUpsertParams;
 // Re-exported from warp_server_client.
 pub use warp_server_client::ids::FolderId;
 
@@ -65,14 +66,14 @@ impl CloudModelType for CloudFolderModel {
         self.name.clone()
     }
 
-    fn upsert_event(&self, folder: &CloudFolder) -> ModelEvent {
+    fn upsert_event(params: CloudObjectUpsertParams<Self>) -> ModelEvent {
         ModelEvent::UpsertFolder {
-            folder: folder.clone(),
+            folder: CloudFolder::from(params),
         }
     }
 
-    fn bulk_upsert_event(objects: &[CloudFolder]) -> ModelEvent {
-        ModelEvent::UpsertFolders(objects.to_vec())
+    fn bulk_upsert_event(objects: Vec<CloudObjectUpsertParams<Self>>) -> ModelEvent {
+        ModelEvent::UpsertFolders(objects.into_iter().map(CloudFolder::from).collect())
     }
 
     fn create_object_queue_item(

--- a/app/src/env_vars/mod.rs
+++ b/app/src/env_vars/mod.rs
@@ -230,12 +230,6 @@ impl JsonModel for EnvVarCollection {
     }
 }
 
-impl PartialEq<CloudEnvVarCollection> for CloudEnvVarCollection {
-    fn eq(&self, other: &CloudEnvVarCollection) -> bool {
-        self.model().string_model == other.model().string_model && self.id == other.id
-    }
-}
-
 pub fn serialize_variables_for_shell<'s, I: IntoIterator<Item = (&'s str, &'s EnvVarValue)>>(
     pairs: I,
     shell_type: ShellType,

--- a/app/src/notebooks/mod.rs
+++ b/app/src/notebooks/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use warp_server_client::cloud_object::CloudObjectUpsertParams;
 use warpui::AppContext;
 
 use crate::ai::document::ai_document_model::AIDocumentId;
@@ -82,14 +83,14 @@ impl CloudModelType for CloudNotebookModel {
         name.clone_into(&mut self.title);
     }
 
-    fn upsert_event(&self, notebook: &CloudNotebook) -> ModelEvent {
+    fn upsert_event(params: CloudObjectUpsertParams<Self>) -> ModelEvent {
         ModelEvent::UpsertNotebook {
-            notebook: notebook.clone(),
+            notebook: CloudNotebook::from(params),
         }
     }
 
-    fn bulk_upsert_event(objects: &[CloudNotebook]) -> ModelEvent {
-        ModelEvent::UpsertNotebooks(objects.to_vec())
+    fn bulk_upsert_event(objects: Vec<CloudObjectUpsertParams<Self>>) -> ModelEvent {
+        ModelEvent::UpsertNotebooks(objects.into_iter().map(CloudNotebook::from).collect())
     }
 
     fn create_object_queue_item(

--- a/app/src/server/cloud_objects/update_manager.rs
+++ b/app/src/server/cloud_objects/update_manager.rs
@@ -1189,7 +1189,12 @@ impl UpdateManager {
                 )
             });
 
-        GenericCloudObject::<K, M>::bulk_upsert_event(&objects_without_pending_changes)
+        M::bulk_upsert_event(
+            objects_without_pending_changes
+                .iter()
+                .map(|object| object.upsert_params(object.object_type()))
+                .collect(),
+        )
     }
 
     /// Generic handler deleting all objects of a given model type from the server (e.g. all updated/deleted notebooks or workflows).
@@ -3601,7 +3606,10 @@ impl UpdateManager {
 
         // Update sqlite with a single bulk request
         self.save_to_db(vec![GenericStringModel::<T, S>::bulk_upsert_event(
-            &objects,
+            objects
+                .iter()
+                .map(|object| object.upsert_params(object.object_type()))
+                .collect(),
         )]);
 
         // Populate sync queue with a single bulk request

--- a/app/src/server/cloud_objects/update_manager_tests.rs
+++ b/app/src/server/cloud_objects/update_manager_tests.rs
@@ -800,7 +800,9 @@ async fn run_sync_state_after_creation_item_not_in_sync_queue<K, M>(
     // we created an object in the db
     assert_eq!(
         std::mem::discriminant(&events[0]),
-        std::mem::discriminant(&object.model().upsert_event(&object))
+        std::mem::discriminant(&M::upsert_event(
+            object.upsert_params(object.model().object_type())
+        ))
     );
     // when we got the correct response back from the server,
     // we updated the db with the server id

--- a/app/src/settings_view/environments_page.rs
+++ b/app/src/settings_view/environments_page.rs
@@ -43,7 +43,8 @@ use crate::ai::cloud_environments::{self, CloudAmbientAgentEnvironment};
 use crate::appearance::Appearance;
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::cloud_object::{
-    CloudObjectLocation, GenericStringObjectFormat, JsonObjectType, Owner, Space,
+    CloudObjectLocation, CloudObjectLookup as _, GenericStringObjectFormat, JsonObjectType, Owner,
+    Space,
 };
 use crate::drive::CloudObjectTypeAndId;
 use crate::editor::{

--- a/app/src/settings_view/mcp_servers/server_card.rs
+++ b/app/src/settings_view/mcp_servers/server_card.rs
@@ -22,7 +22,7 @@ use warpui::{AppContext, Element, Entity, SingletonEntity, TypedActionView, View
 use crate::ai::mcp::templatable::CloudTemplatableMCPServer;
 use crate::ai::mcp::{MCPServerState, TemplatableMCPServerManager};
 use crate::appearance::Appearance;
-use crate::cloud_object::CloudObject;
+use crate::cloud_object::{CloudObject, CloudObjectUuidLookup as _};
 use crate::settings_view::mcp_servers::{style, ServerCardItemId};
 use crate::ui_components::avatar::{Avatar, AvatarContent, StatusElementTypes};
 use crate::ui_components::blended_colors;

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -199,7 +199,7 @@ use crate::cloud_object::model::actions::ObjectActionType;
 use crate::cloud_object::model::generic_string_model::StringModel;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::cloud_object::model::view::CloudViewModel;
-use crate::cloud_object::{CloudObject, Space};
+use crate::cloud_object::{CloudObject, CloudObjectLookup as _, Space};
 #[cfg(feature = "local_fs")]
 use crate::code::editor_management::CodeSource;
 use crate::code_review::diff_state::DiffMode;
@@ -3805,6 +3805,8 @@ impl Input {
                     .flatten()
             },
             move |_input, touched_repo, ctx| {
+                use crate::cloud_object::CloudObjectLookup as _;
+
                 let Some(touched_repo) = touched_repo else {
                     return;
                 };
@@ -4013,6 +4015,8 @@ impl Input {
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn maybe_launch_cloud_handoff_request(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        use crate::cloud_object::CloudObjectLookup as _;
+
         if !FeatureFlag::OzHandoff.is_enabled()
             || !FeatureFlag::HandoffLocalCloud.is_enabled()
             || !cfg!(all(feature = "local_fs", not(target_family = "wasm")))

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -31,6 +31,7 @@ use crate::ai::execution_profiles::{CloudAgentComputerUseState, ComputerUsePermi
 use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::{ServerId, SyncId};
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]

--- a/app/src/terminal/view/docker_sandbox/mod.rs
+++ b/app/src/terminal/view/docker_sandbox/mod.rs
@@ -232,6 +232,8 @@ impl TerminalView {
                 // Look up the environment by hardcoded ID.
                 let environment = spawner
                     .spawn(|_, ctx| {
+                        use crate::cloud_object::CloudObjectLookup as _;
+
                         let server_id = ServerId::try_from("SVhg783GBFQHk1OfdPfFU9").ok()?;
                         let sync_id = SyncId::ServerId(server_id);
                         CloudAmbientAgentEnvironment::get_by_id(&sync_id, ctx)

--- a/app/src/workflows/mod.rs
+++ b/app/src/workflows/mod.rs
@@ -25,8 +25,9 @@ pub use categories::{CategoriesView, CategoriesViewEvent, WorkflowsViewAction};
 use crate::appearance::Appearance;
 use crate::cloud_object::model::view::CloudViewModel;
 use crate::cloud_object::{
-    CloudModelType, CloudObjectEventEntrypoint, CreateCloudObjectResult, CreateObjectRequest,
-    GenericCloudObject, GenericServerObject, ObjectType, Revision, UpdateCloudObjectResult,
+    CloudModelType, CloudObjectEventEntrypoint, CloudObjectUpsertParams, CreateCloudObjectResult,
+    CreateObjectRequest, GenericCloudObject, GenericServerObject, ObjectType, Revision,
+    UpdateCloudObjectResult,
 };
 use crate::drive::items::workflow::WarpDriveWorkflow;
 use crate::drive::items::WarpDriveItem;
@@ -258,14 +259,14 @@ impl CloudModelType for CloudWorkflowModel {
         self.data.set_name(name);
     }
 
-    fn upsert_event(&self, workflow: &CloudWorkflow) -> ModelEvent {
+    fn upsert_event(params: CloudObjectUpsertParams<Self>) -> ModelEvent {
         ModelEvent::UpsertWorkflow {
-            workflow: workflow.clone(),
+            workflow: CloudWorkflow::from(params),
         }
     }
 
-    fn bulk_upsert_event(objects: &[CloudWorkflow]) -> ModelEvent {
-        ModelEvent::UpsertWorkflows(objects.to_vec())
+    fn bulk_upsert_event(objects: Vec<CloudObjectUpsertParams<Self>>) -> ModelEvent {
+        ModelEvent::UpsertWorkflows(objects.into_iter().map(CloudWorkflow::from).collect())
     }
 
     fn create_object_queue_item(
@@ -352,18 +353,6 @@ impl CloudModelType for CloudWorkflowModel {
 
     fn can_export(&self) -> bool {
         true
-    }
-}
-
-impl PartialEq<Workflow> for CloudWorkflow {
-    fn eq(&self, other: &Workflow) -> bool {
-        self.model().data == *other
-    }
-}
-
-impl PartialEq<CloudWorkflow> for CloudWorkflow {
-    fn eq(&self, other: &CloudWorkflow) -> bool {
-        self.model().data == other.model().data && self.id == other.id
     }
 }
 

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -41,6 +41,7 @@ use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::conversation_status_ui::render_status_element;
 use crate::appearance::Appearance;
 use crate::cloud_object::model::generic_string_model::StringModel;
+use crate::cloud_object::CloudObjectLookup as _;
 use crate::code::editor::{add_color, remove_color};
 use crate::code::icon_from_file_path;
 use crate::context_chips::display_chip::GitLineChanges;

--- a/crates/warp_server_client/src/cloud_object/generic_cloud_object.rs
+++ b/crates/warp_server_client/src/cloud_object/generic_cloud_object.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+
+use crate::ids::{ClientId, SyncId};
+
+use super::{
+    CloudObjectMetadata, CloudObjectPermissions, CloudObjectStatuses, CloudObjectSyncStatus,
+    ConflictStatus, GenericServerObject, NumInFlightRequests, ObjectType, Owner,
+};
+
+/// A portable payload for persisting or otherwise upserting a cloud object without app-local event types.
+#[derive(Clone, Debug)]
+pub struct CloudObjectUpsertParams<M> {
+    pub id: SyncId,
+    pub object_type: ObjectType,
+    pub metadata: CloudObjectMetadata,
+    pub permissions: CloudObjectPermissions,
+    pub model: M,
+}
+
+/// A generic implementation of cloud objects that can be used for any model and id types.
+///
+/// For instance, rather than directly implementing the CloudObject trait, CloudObjects can
+/// implement GenericCloudObject<K, M> where K is their id type and M is their model type.
+///
+/// For example, CloudNotebook becomes:
+///
+///   pub type CloudNotebook = GenericCloudObject<NotebookId, CloudNotebookModel>
+///
+/// The advantage of using the generic model is you get common implementations
+/// of CloudObject methods like ```versions``` for free.
+///
+/// See the comments for CloudObject to understand the relationship between
+/// this trait, CloudObject and CloudModelType.  They are tightly coupled.
+#[derive(Clone, Debug)]
+pub struct GenericCloudObject<K, M> {
+    pub id: SyncId,
+    pub metadata: CloudObjectMetadata,
+    pub permissions: CloudObjectPermissions,
+    /// Tracks whether this object has a conflict with the server version.
+    /// This is runtime state (not persisted) - conflicts are always NoConflicts when loaded from SQLite.
+    pub conflict_status: ConflictStatus<GenericServerObject<K, M>>,
+
+    // Intentionally not public to prevent users of this class from holding
+    // onto references to the model outside of this struct.
+    //
+    // This is an Arc in order to support clone-on-write semantics for the model.
+    // By wrapping the model in an Arc, clones become cheap, and we can avoid
+    // doing deep clones of the model whenever the containing object is cloned.
+    //
+    // Callers who want to update the model need to call set_model to update the
+    // entire model atomically.
+    model: Arc<M>,
+}
+
+impl<K, M> PartialEq for GenericCloudObject<K, M>
+where
+    M: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.model() == other.model()
+    }
+}
+
+impl<K, M> GenericCloudObject<K, M> {
+    /// Gets a reference to the model held by the object.
+    pub fn model(&self) -> &M {
+        &self.model
+    }
+
+    /// Returns a shared handle to the model.
+    pub fn shared_model(&self) -> Arc<M> {
+        self.model.clone()
+    }
+
+    /// Sets a new version of the model on the object, replacing the old version.
+    pub fn set_model(&mut self, model: M) {
+        self.model = model.into();
+    }
+
+    /// Constructs a new instance of this model with the given id, model, metadata and permissions.
+    pub fn new(
+        id: SyncId,
+        model: M,
+        metadata: CloudObjectMetadata,
+        permissions: CloudObjectPermissions,
+    ) -> Self {
+        Self {
+            id,
+            model: model.into(),
+            metadata,
+            permissions,
+            conflict_status: ConflictStatus::NoConflicts,
+        }
+    }
+
+    /// Creates a new GenericCloudObject with the given model, owner, and initial folder id.
+    /// This is for the local creation flow, as opposed to creating from a server update.
+    pub fn new_local(
+        model: M,
+        owner: Owner,
+        initial_folder_id: Option<SyncId>,
+        client_id: ClientId,
+    ) -> Self {
+        Self {
+            id: SyncId::ClientId(client_id),
+            model: model.into(),
+            metadata: CloudObjectMetadata {
+                pending_changes_statuses: CloudObjectStatuses {
+                    content_sync_status: CloudObjectSyncStatus::InFlight(NumInFlightRequests(1)),
+                    has_pending_metadata_change: false,
+                    has_pending_permissions_change: false,
+                    pending_untrash: false,
+                    pending_delete: false,
+                },
+                folder_id: initial_folder_id,
+                revision: Default::default(),
+                metadata_last_updated_ts: Default::default(),
+                current_editor_uid: Default::default(),
+                trashed_ts: Default::default(),
+                // Objects created from the client are never welcome objects.
+                is_welcome_object: false,
+                creator_uid: None,
+                last_editor_uid: None,
+                last_task_run_ts: None,
+            },
+            permissions: CloudObjectPermissions {
+                owner,
+                anyone_with_link: None,
+                guests: Default::default(),
+                permissions_last_updated_ts: None,
+            },
+            conflict_status: ConflictStatus::NoConflicts,
+        }
+    }
+
+    /// Creates a new [`GenericCloudObject`] from a [`GenericServerObject`].
+    pub fn new_from_server(server_object: GenericServerObject<K, M>) -> Self {
+        Self {
+            id: server_object.id,
+            model: server_object.model.into(),
+            metadata: CloudObjectMetadata::new_from_server(server_object.metadata),
+            permissions: CloudObjectPermissions::new_from_server(server_object.permissions),
+            conflict_status: ConflictStatus::NoConflicts,
+        }
+    }
+
+    /// Marks this object as being in conflict with the provided object.
+    pub fn set_conflicting_object(&mut self, object: Arc<GenericServerObject<K, M>>) {
+        self.conflict_status = ConflictStatus::ConflictingChanges { object };
+    }
+
+    pub fn update_from_server_object(&mut self, server_object: GenericServerObject<K, M>) {
+        // Check if we should create a conflict or apply the update.
+        if self.metadata.has_pending_content_changes() || self.conflict_status.has_conflicts() {
+            // There are pending changes, so this creates a conflict.
+            self.conflict_status = ConflictStatus::ConflictingChanges {
+                object: Arc::new(server_object),
+            };
+        } else {
+            // No pending changes, apply the server update.
+            self.metadata
+                .update_revision_from_server(&server_object.metadata);
+            self.model = server_object.model.into();
+            self.conflict_status = ConflictStatus::NoConflicts;
+        }
+    }
+
+    /// Returns portable upsert parameters for this object.
+    pub fn upsert_params(&self, object_type: ObjectType) -> CloudObjectUpsertParams<M>
+    where
+        M: Clone,
+    {
+        CloudObjectUpsertParams {
+            id: self.id,
+            object_type,
+            metadata: self.metadata.clone(),
+            permissions: self.permissions.clone(),
+            model: self.model().clone(),
+        }
+    }
+
+    /// Converts this object into portable upsert parameters.
+    pub fn into_upsert_params(self, object_type: ObjectType) -> CloudObjectUpsertParams<M>
+    where
+        M: Clone,
+    {
+        let Self {
+            id,
+            metadata,
+            permissions,
+            model,
+            conflict_status: _,
+        } = self;
+        let model = Arc::try_unwrap(model).unwrap_or_else(|model| (*model).clone());
+        CloudObjectUpsertParams {
+            id,
+            object_type,
+            metadata,
+            permissions,
+            model,
+        }
+    }
+}
+
+impl<K, M> From<CloudObjectUpsertParams<M>> for GenericCloudObject<K, M> {
+    fn from(params: CloudObjectUpsertParams<M>) -> Self {
+        Self::new(params.id, params.model, params.metadata, params.permissions)
+    }
+}

--- a/crates/warp_server_client/src/cloud_object/mod.rs
+++ b/crates/warp_server_client/src/cloud_object/mod.rs
@@ -25,10 +25,12 @@ use crate::drive::sharing::{SharingAccessLevel, Subject, TeamKind, UserKind};
 use crate::ids::{FolderId, ServerId, SyncId};
 
 mod creation;
+mod generic_cloud_object;
 mod server_object;
 mod update;
 
 pub use creation::*;
+pub use generic_cloud_object::*;
 pub use server_object::*;
 pub use update::*;
 /// The type of object id each ObjectType corresponds to.


### PR DESCRIPTION
## Description
Moves `GenericCloudObject` into `warp_server_client` while keeping app-local cloud object behavior in `warp`.

The upstream type now owns the portable data/container behavior: model accessors, constructors, server update/conflict handling, and portable upsert params. The app crate continues to own `CloudObject`, `CloudModelType`, persistence events, queue behavior, UI/Drive integration, and other runtime-specific logic.

This also adds app-local lookup extension traits so type aliases can keep readable calls like `CloudAmbientAgentEnvironment::get_all(ctx)`, `CloudScheduledAmbientAgent::get_by_id(...)`, and `CloudMCPServer::get_by_uuid(...)` without duplicating helper functions or making the upstream crate depend on `AppContext`/`CloudModel`.

## Testing
Validated on the stack tip after Phase 3:

- `cargo fmt --manifest-path /Users/david/src/warp/Cargo.toml --all`
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp_server_client`
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp`
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp --tests`
- `git --no-pager diff --check`

Co-Authored-By: Oz <oz-agent@warp.dev>
