### PR TITLE
[REMOTE-1688] Add Codex auth secret types to CLI

### DIFF
--- a/app/src/ai/agent_sdk/secret.rs
+++ b/app/src/ai/agent_sdk/secret.rs
@@ -12,8 +12,8 @@ use warp_cli::{
     agent::OutputFormat,
     scope::ObjectScope,
     secret::{
-        AnthropicMethod, CreateProvider, CreateSecretArgs, DeleteSecretArgs, ListSecretsArgs,
-        SecretCommand, SecretType, UpdateSecretArgs, ValueArgs,
+        AnthropicMethod, CodexMethod, CreateProvider, CreateSecretArgs, DeleteSecretArgs,
+        ListSecretsArgs, SecretCommand, SecretType, UpdateSecretArgs, ValueArgs,
     },
     GlobalOptions,
 };
@@ -105,6 +105,11 @@ enum SecretInput {
         session_token: Option<String>,
         region: Option<String>,
     },
+    /// OpenAI API key secret with optional base URL.
+    OpenaiApiKey {
+        value_args: ValueArgs,
+        base_url: Option<String>,
+    },
 }
 
 impl SecretInput {
@@ -137,6 +142,10 @@ impl SecretInput {
                 session_token,
                 region,
             ),
+            SecretInput::OpenaiApiKey {
+                value_args,
+                base_url,
+            } => read_openai_api_key_secret_value(&value_args, base_url),
         }
     }
 }
@@ -171,6 +180,17 @@ fn create_secret(ctx: &mut AppContext, args: CreateSecretArgs) -> Result<()> {
                     secret_access_key: a.secret_access_key,
                     session_token: a.session_token,
                     region: a.region,
+                },
+                a.common.description,
+                a.common.scope,
+            ),
+        },
+        Some(CreateProvider::Codex(codex)) => match codex.method {
+            CodexMethod::ApiKey(a) => (
+                a.common.name,
+                SecretInput::OpenaiApiKey {
+                    value_args: a.value,
+                    base_url: a.base_url,
                 },
                 a.common.description,
                 a.common.scope,
@@ -556,6 +576,11 @@ fn make_simple_secret_value(secret_type: SecretType, raw: &str) -> ManagedSecret
             // Bedrock secrets are multi-field and handled via SecretInput::Bedrock.
             unreachable!("Bedrock secrets should not go through make_simple_secret_value")
         }
+        SecretType::OpenaiApiKey => {
+            // OpenAI API key secrets are handled via SecretInput::OpenaiApiKey so the optional
+            // base URL can be plumbed through alongside the API key.
+            unreachable!("OpenAI API key secrets should not go through make_simple_secret_value")
+        }
     }
 }
 
@@ -585,6 +610,32 @@ fn make_secret_value_from_gql_type(
         }
         ManagedSecretType::OpenaiApiKey => Ok(ManagedSecretValue::openai_api_key(raw, None)),
     }
+}
+
+/// Read an OpenAI API key secret from CLI flags or interactive prompts.
+///
+/// The API key value is read from `--value-file`, stdin, or an interactive prompt (in that
+/// order), matching the behavior of other simple secret types. `base_url` is optional and is
+/// taken verbatim from the `--base-url` flag; we do not prompt for it interactively, since the
+/// vast majority of users use the default endpoint.
+fn read_openai_api_key_secret_value(
+    value_args: &ValueArgs,
+    base_url: Option<String>,
+) -> Result<Option<ManagedSecretValue>> {
+    let api_key = match read_simple_secret_value(value_args)? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    // Treat an empty `--base-url` value as "no base URL" rather than persisting a blank string.
+    let base_url = base_url.and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_owned())
+        }
+    });
+    Ok(Some(ManagedSecretValue::openai_api_key(api_key, base_url)))
 }
 
 /// Read a Bedrock API key secret from dedicated CLI flags or interactive prompts.

--- a/app/src/ai/agent_sdk/secret.rs
+++ b/app/src/ai/agent_sdk/secret.rs
@@ -614,10 +614,14 @@ fn make_secret_value_from_gql_type(
 
 /// Read an OpenAI API key secret from CLI flags or interactive prompts.
 ///
-/// The API key value is read from `--value-file`, stdin, or an interactive prompt (in that
-/// order), matching the behavior of other simple secret types. `base_url` is optional and is
-/// taken verbatim from the `--base-url` flag; we do not prompt for it interactively, since the
-/// vast majority of users use the default endpoint.
+/// The API key value is read from `--value-file`, stdin, or an interactive password prompt (in
+/// that order), matching the behavior of other simple secret types.
+///
+/// `base_url` is optional. When `--base-url` is provided we use it verbatim (an empty value is
+/// treated as "no base URL"). When it is not provided and we are running interactively, we
+/// prompt for it; pressing Enter at the prompt skips the base URL. In non-interactive mode we
+/// silently default to no base URL, since the vast majority of users use the provider's default
+/// endpoint.
 fn read_openai_api_key_secret_value(
     value_args: &ValueArgs,
     base_url: Option<String>,
@@ -626,15 +630,44 @@ fn read_openai_api_key_secret_value(
         Some(v) => v,
         None => return Ok(None),
     };
-    // Treat an empty `--base-url` value as "no base URL" rather than persisting a blank string.
-    let base_url = base_url.and_then(|s| {
-        let trimmed = s.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_owned())
+
+    // The base URL is optional. An empty `--base-url` flag, empty interactive submission, or
+    // omission in non-interactive mode all map to `None` so we never persist a blank string.
+    let base_url: Option<String> = match base_url {
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_owned())
+            }
         }
-    });
+        None => {
+            if !io::stdin().is_terminal() {
+                // Non-interactive: leave the base URL unset rather than prompting or failing.
+                None
+            } else {
+                match inquire::Text::new("OpenAI base URL (optional, press Enter to skip):")
+                    .with_help_message("e.g. https://us.api.openai.com/v1 for a regional endpoint")
+                    .prompt()
+                {
+                    Ok(value) => {
+                        let trimmed = value.trim();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_owned())
+                        }
+                    }
+                    Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                        return Ok(None);
+                    }
+                    Err(err) => return Err(err.into()),
+                }
+            }
+        }
+    };
+
     Ok(Some(ManagedSecretValue::openai_api_key(api_key, base_url)))
 }
 

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -8,6 +8,7 @@ use crate::environment::{EnvironmentCommand, ImageCommand};
 use crate::harness_support::{HarnessSupportCommand, TaskStatus};
 use crate::integration::IntegrationCommand;
 use crate::schedule::ScheduleSubcommand;
+use crate::secret::{CodexMethod, CreateProvider, SecretCommand};
 use crate::task::{MessageCommand, TaskCommand};
 
 fn set_env_var(name: &str, value: &str) -> Option<OsString> {
@@ -1941,6 +1942,98 @@ fn report_shutdown_clean_parses() {
 
     assert!(shutdown_args.error_category.is_none());
     assert!(shutdown_args.error_message.is_none());
+}
+
+#[test]
+fn secret_create_codex_api_key_parses_minimal() {
+    warp_core::features::mark_initialized();
+
+    let args = Args::try_parse_from([
+        "warp",
+        "secret",
+        "create",
+        "codex",
+        "api-key",
+        "my-openai-key",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp secret create codex api-key` command");
+    };
+    let CliCommand::Secret(SecretCommand::Create(create_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp secret create` command");
+    };
+    let Some(CreateProvider::Codex(codex)) = &create_args.provider else {
+        panic!("Expected `codex` provider subcommand");
+    };
+    let CodexMethod::ApiKey(api_key_args) = &codex.method;
+
+    assert_eq!(api_key_args.common.name, "my-openai-key");
+    assert!(api_key_args.common.description.is_none());
+    assert!(api_key_args.value.value_file.is_none());
+    assert!(api_key_args.base_url.is_none());
+}
+
+#[test]
+fn secret_create_codex_api_key_accepts_base_url_and_value_file() {
+    warp_core::features::mark_initialized();
+
+    let args = Args::try_parse_from([
+        "warp",
+        "secret",
+        "create",
+        "codex",
+        "api-key",
+        "my-openai-key",
+        "--value-file",
+        "key.txt",
+        "--base-url",
+        "https://us.api.openai.com/v1",
+        "--description",
+        "OpenAI key for Codex",
+        "--team",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp secret create codex api-key` command");
+    };
+    let CliCommand::Secret(SecretCommand::Create(create_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp secret create` command");
+    };
+    let Some(CreateProvider::Codex(codex)) = &create_args.provider else {
+        panic!("Expected `codex` provider subcommand");
+    };
+    let CodexMethod::ApiKey(api_key_args) = &codex.method;
+
+    assert_eq!(api_key_args.common.name, "my-openai-key");
+    assert_eq!(
+        api_key_args.common.description.as_deref(),
+        Some("OpenAI key for Codex")
+    );
+    assert!(api_key_args.common.scope.team);
+    assert!(!api_key_args.common.scope.personal);
+    assert_eq!(
+        api_key_args
+            .value
+            .value_file
+            .as_ref()
+            .and_then(|p| p.to_str()),
+        Some("key.txt")
+    );
+    assert_eq!(
+        api_key_args.base_url.as_deref(),
+        Some("https://us.api.openai.com/v1")
+    );
+}
+
+#[test]
+fn secret_create_codex_api_key_requires_name() {
+    warp_core::features::mark_initialized();
+
+    let result = Args::try_parse_from(["warp", "secret", "create", "codex", "api-key"]);
+    assert!(result.is_err());
 }
 
 #[test]

--- a/crates/warp_cli/src/secret.rs
+++ b/crates/warp_cli/src/secret.rs
@@ -9,7 +9,7 @@ use crate::scope::ObjectScope;
 pub enum SecretCommand {
     /// Create a new secret.
     ///
-    /// Use `oz secret create anthropic api-key <NAME>` to create a Claude/Anthropic auth secret,
+    /// Use `oz secret create claude api-key <NAME>` to create a Claude/Anthropic auth secret,
     /// or `oz secret create codex api-key <NAME>` to create a Codex/OpenAI auth secret.
     Create(CreateSecretArgs),
     /// Delete a secret.
@@ -52,6 +52,7 @@ pub struct CreateSecretArgs {
 #[derive(Debug, Clone, Subcommand)]
 pub enum CreateProvider {
     /// Create a Claude/Anthropic auth secret.
+    #[command(name = "claude")]
     Anthropic(AnthropicCreateArgs),
     /// Create a Codex/OpenAI auth secret.
     Codex(CodexCreateArgs),

--- a/crates/warp_cli/src/secret.rs
+++ b/crates/warp_cli/src/secret.rs
@@ -140,8 +140,9 @@ pub struct OpenAiApiKeyArgs {
     pub value: ValueArgs,
 
     /// Optional base URL for the OpenAI API (e.g. a regional endpoint like
-    /// `https://us.api.openai.com/v1`). When omitted, the harness uses the
-    /// provider's default endpoint.
+    /// `https://us.api.openai.com/v1`). When omitted in interactive mode the
+    /// CLI prompts for it; pressing Enter at the prompt skips it. When omitted
+    /// in non-interactive mode the harness uses the provider's default endpoint.
     #[arg(long = "base-url")]
     pub base_url: Option<String>,
 }

--- a/crates/warp_cli/src/secret.rs
+++ b/crates/warp_cli/src/secret.rs
@@ -9,7 +9,8 @@ use crate::scope::ObjectScope;
 pub enum SecretCommand {
     /// Create a new secret.
     ///
-    /// Use `oz secret create anthropic api-key <NAME>` to create a Claude/Anthropic auth secret.
+    /// Use `oz secret create anthropic api-key <NAME>` to create a Claude/Anthropic auth secret,
+    /// or `oz secret create codex api-key <NAME>` to create a Codex/OpenAI auth secret.
     Create(CreateSecretArgs),
     /// Delete a secret.
     Delete(DeleteSecretArgs),
@@ -52,6 +53,8 @@ pub struct CreateSecretArgs {
 pub enum CreateProvider {
     /// Create a Claude/Anthropic auth secret.
     Anthropic(AnthropicCreateArgs),
+    /// Create a Codex/OpenAI auth secret.
+    Codex(CodexCreateArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -111,6 +114,36 @@ pub struct BedrockApiKeyArgs {
     /// AWS region for the Bedrock endpoint. If not provided, prompts interactively.
     #[arg(long = "region")]
     pub region: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct CodexCreateArgs {
+    #[command(subcommand)]
+    pub method: CodexMethod,
+}
+
+/// Codex credential type.
+#[derive(Debug, Clone, Subcommand)]
+pub enum CodexMethod {
+    /// Direct OpenAI API key.
+    #[command(name = "api-key")]
+    ApiKey(OpenAiApiKeyArgs),
+}
+
+/// Arguments for creating an OpenAI API key secret used by the Codex harness.
+#[derive(Debug, Clone, Args)]
+pub struct OpenAiApiKeyArgs {
+    #[clap(flatten)]
+    pub common: CommonSecretCreateArgs,
+
+    #[clap(flatten)]
+    pub value: ValueArgs,
+
+    /// Optional base URL for the OpenAI API (e.g. a regional endpoint like
+    /// `https://us.api.openai.com/v1`). When omitted, the harness uses the
+    /// provider's default endpoint.
+    #[arg(long = "base-url")]
+    pub base_url: Option<String>,
 }
 
 /// Arguments for creating an Anthropic Bedrock access key secret.
@@ -190,6 +223,9 @@ pub enum SecretType {
     // Not exposed via the CLI `--type` flag; constructed internally for provider subcommands.
     #[value(skip)]
     AnthropicBedrockApiKey,
+    // Not exposed via the CLI `--type` flag; constructed internally for provider subcommands.
+    #[value(skip)]
+    OpenaiApiKey,
 }
 
 impl fmt::Display for SecretType {
@@ -198,6 +234,7 @@ impl fmt::Display for SecretType {
             SecretType::RawValue => write!(f, "raw-value"),
             SecretType::AnthropicApiKey => write!(f, "anthropic-api-key"),
             SecretType::AnthropicBedrockApiKey => write!(f, "anthropic-bedrock-api-key"),
+            SecretType::OpenaiApiKey => write!(f, "openai-api-key"),
         }
     }
 }


### PR DESCRIPTION
## Description

Adds an `oz secret create codex api-key <NAME>` subcommand that mirrors the existing `oz secret create anthropic ...` provider flow. The Codex harness currently only authenticates via an OpenAI API key (with an optional custom base URL, e.g. for regional endpoints), which matches the single Codex auth secret type the server already supports (`openai_api_key`).

```sh
# Read the API key from a file
oz secret create codex api-key my-key --value-file key.txt

# Pin a regional base URL alongside the key
oz secret create codex api-key my-key \
    --base-url https://us.api.openai.com/v1 \
    --team
```

The API key value is read from `--value-file`, stdin, or an interactive password prompt — same as the existing simple-secret flows. The `--base-url` flag is optional; an empty value is normalized to `None` so we never persist a blank base URL.

Closes [REMOTE-1688](https://linear.app/warpdotdev/issue/REMOTE-1688/add-codex-auth-secret-types-to-cli).

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes). _N/A — CLI-only change._

## Testing

- Added clap parser tests in `crates/warp_cli/src/lib_tests.rs` covering:
  - the minimal `oz secret create codex api-key <NAME>` form,
  - the form with `--value-file`, `--base-url`, `--description`, and `--team` together,
  - and a regression case asserting the secret name is still required.
- All 148 `warp_cli` tests pass under `cargo nextest run -p warp_cli`.
- `cargo fmt --check -p warp_cli -p warp` and `cargo clippy -p warp_cli -p warp --all-targets --tests -- -D warnings` are clean.

- [x] I have manually tested my changes locally with `./script/run`

I tested an API key that doesn't require a us endpoint and one that does (the staging one). Creating, deleting and actually using the secrets works.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-OZ: Added `oz secret create codex api-key <NAME>` for creating OpenAI API key auth secrets used by the Codex harness, with an optional `--base-url` flag.
-->

_Conversation: https://staging.warp.dev/conversation/5d5a73fb-ec89-4c6c-91c0-54d49f9bfc90_
_Run: https://oz.staging.warp.dev/runs/019e3365-8f0e-70d3-8384-e763989d8229_

_This PR was generated with [Oz](https://warp.dev/oz)._
