### PR TITLE
Route Billing & Usage settings by active plan

### DIFF
--- a/app/src/settings_view/about_page.rs
+++ b/app/src/settings_view/about_page.rs
@@ -142,11 +142,11 @@ impl SettingsPageMeta for AboutPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -3480,11 +3480,11 @@ impl SettingsPageMeta for AISettingsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -5170,11 +5170,11 @@ impl SettingsPageMeta for AppearanceSettingsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -74,8 +74,7 @@ use super::{
     },
     settings_page::{
         build_sub_header, render_body_item, render_customer_type_badge, render_info_icon,
-        AdditionalInfo, Category, PageType, SettingsPageMeta, SettingsPageViewHandle,
-        SettingsWidget, HEADER_PADDING,
+        AdditionalInfo, Category, PageType, SettingsPageMeta, SettingsWidget, HEADER_PADDING,
     },
     MatchData, SettingsSection,
 };
@@ -660,6 +659,22 @@ impl BillingAndUsagePageView {
             .collect();
     }
 
+    pub(crate) fn deactivate_subscriptions(&mut self, ctx: &mut ViewContext<Self>) {
+        let user_workspaces = UserWorkspaces::handle(ctx);
+        let auth_manager = AuthManager::handle(ctx);
+        let team_update_manager = TeamUpdateManager::handle(ctx);
+        let request_usage_model = AIRequestUsageModel::handle(ctx);
+        let pricing_info_model = PricingInfoModel::handle(ctx);
+        let usage_history_model = self.usage_history_model.clone();
+
+        ctx.unsubscribe_to_model(&user_workspaces);
+        ctx.unsubscribe_to_model(&auth_manager);
+        ctx.unsubscribe_to_model(&team_update_manager);
+        ctx.unsubscribe_to_model(&request_usage_model);
+        ctx.unsubscribe_to_model(&pricing_info_model);
+        ctx.unsubscribe_to_model(&usage_history_model);
+    }
+
     fn show_addon_credit_modal(&mut self, ctx: &mut ViewContext<Self>) {
         self.addon_credit_modal_state.open();
 
@@ -714,11 +729,11 @@ impl SettingsPageMeta for BillingAndUsagePageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }
@@ -1007,12 +1022,6 @@ impl TypedActionView for BillingAndUsagePageView {
                 });
             }
         }
-    }
-}
-
-impl From<ViewHandle<BillingAndUsagePageView>> for SettingsPageViewHandle {
-    fn from(view_handle: ViewHandle<BillingAndUsagePageView>) -> Self {
-        SettingsPageViewHandle::BillingAndUsage(view_handle)
     }
 }
 

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -70,7 +70,7 @@ use super::{
     billing_and_usage_page::{BillingAndUsagePageAction, BillingUsageTab},
     settings_page::{
         render_customer_type_badge, render_info_icon, render_sub_header, AdditionalInfo, MatchData,
-        SettingsPageMeta, SettingsPageViewHandle, PAGE_PADDING,
+        SettingsPageMeta, PAGE_PADDING,
     },
     SettingsSection,
 };
@@ -87,6 +87,7 @@ const RESTRICTED_BILLING_USAGE_WARNING_STRING: &str =
     "Auto reload is disabled due to recent failed reload. Please update your payment method and try again.";
 
 const HEADER_FONT_SIZE: f32 = 16.;
+const SEARCH_TERMS: &str = "billing usage plan credits buy credits manage billing admin panel usage history cloud agent trial auto reload monthly spend limit add-on credits";
 
 const CARD_BORDER_COLOR: ColorU = ColorU {
     r: 43,
@@ -411,6 +412,22 @@ impl BillingAndUsagePageV2View {
             }
             _ => {}
         }
+    }
+
+    pub(crate) fn deactivate_subscriptions(&mut self, ctx: &mut ViewContext<Self>) {
+        let user_workspaces = UserWorkspaces::handle(ctx);
+        let auth_manager = AuthManager::handle(ctx);
+        let team_update_manager = TeamUpdateManager::handle(ctx);
+        let request_usage_model = AIRequestUsageModel::handle(ctx);
+        let pricing_info_model = PricingInfoModel::handle(ctx);
+        let usage_history_model = self.usage_history.model.clone();
+
+        ctx.unsubscribe_to_model(&user_workspaces);
+        ctx.unsubscribe_to_model(&auth_manager);
+        ctx.unsubscribe_to_model(&team_update_manager);
+        ctx.unsubscribe_to_model(&request_usage_model);
+        ctx.unsubscribe_to_model(&pricing_info_model);
+        ctx.unsubscribe_to_model(&usage_history_model);
     }
 
     fn show_toast(&self, message: &str, flavor: ToastFlavor, ctx: &mut ViewContext<Self>) {
@@ -1606,13 +1623,13 @@ impl SettingsPageMeta for BillingAndUsagePageV2View {
         self.refresh_addon_credits_settings(ctx);
     }
 
-    fn update_filter(&mut self, _query: &str, _ctx: &mut ViewContext<Self>) -> MatchData {
-        MatchData::Uncounted(false)
+    fn update_filter(&mut self, query: &str, _ctx: &mut ViewContext<Self>) -> MatchData {
+        search_terms_match(SEARCH_TERMS, query).into()
     }
 
-    fn scroll_to_widget(&mut self, _widget_id: &'static str) {}
+    fn scroll_to_widget(&mut self, _widget_id: &'static str, _ctx: &mut ViewContext<Self>) {}
 
-    fn clear_highlighted_widget(&mut self) {}
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {}
 }
 
 impl Entity for BillingAndUsagePageV2View {
@@ -1880,6 +1897,17 @@ impl TypedActionView for BillingAndUsagePageV2View {
     }
 }
 
+fn search_terms_match(terms: &str, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+
+    let terms_lower = terms.to_lowercase();
+    query
+        .to_lowercase()
+        .split_whitespace()
+        .all(|word| terms_lower.contains(word))
+}
 fn render_balance_card(
     appearance: &Appearance,
     dot_color: ColorU,
@@ -1964,8 +1992,24 @@ fn render_balance_card(
     .finish()
 }
 
-impl From<warpui::ViewHandle<BillingAndUsagePageV2View>> for SettingsPageViewHandle {
-    fn from(view_handle: warpui::ViewHandle<BillingAndUsagePageV2View>) -> Self {
-        SettingsPageViewHandle::BillingAndUsageV2(view_handle)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_terms_match_empty_query() {
+        assert!(search_terms_match(SEARCH_TERMS, ""));
+    }
+
+    #[test]
+    fn search_terms_match_billing_page_terms() {
+        assert!(search_terms_match(SEARCH_TERMS, "billing"));
+        assert!(search_terms_match(SEARCH_TERMS, "usage history"));
+        assert!(search_terms_match(SEARCH_TERMS, "buy credits"));
+    }
+
+    #[test]
+    fn search_terms_do_not_match_unrelated_terms() {
+        assert!(!search_terms_match(SEARCH_TERMS, "keyboard shortcuts"));
     }
 }

--- a/app/src/settings_view/billing_and_usage_router_page.rs
+++ b/app/src/settings_view/billing_and_usage_router_page.rs
@@ -1,0 +1,315 @@
+use crate::{
+    auth::AuthStateProvider,
+    workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent},
+};
+use warp_core::features::FeatureFlag;
+use warpui::{
+    elements::{ChildView, Empty},
+    AppContext, Element, Entity, SingletonEntity, TypedActionView, UpdateView, View, ViewContext,
+    ViewHandle,
+};
+
+use super::{
+    billing_and_usage_page::{
+        BillingAndUsagePageAction, BillingAndUsagePageEvent, BillingAndUsagePageView,
+    },
+    billing_and_usage_page_v2::BillingAndUsagePageV2View,
+    settings_page::{MatchData, SettingsPageMeta, SettingsPageViewHandle},
+    SettingsSection,
+};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum BillingAndUsageRoute {
+    V1,
+    V2,
+}
+
+impl BillingAndUsageRoute {
+    fn from_state(v2_flag_enabled: bool, is_build_plan: bool) -> Self {
+        if v2_flag_enabled && is_build_plan {
+            Self::V2
+        } else {
+            Self::V1
+        }
+    }
+
+    fn current(ctx: &AppContext) -> Self {
+        Self::from_state(
+            FeatureFlag::BillingAndUsagePageV2.is_enabled(),
+            UserWorkspaces::as_ref(ctx)
+                .current_workspace()
+                .is_some_and(|workspace| workspace.billing_metadata.is_on_build_plan()),
+        )
+    }
+}
+
+enum ActiveBillingAndUsagePage {
+    V1(ViewHandle<BillingAndUsagePageView>),
+    V2(ViewHandle<BillingAndUsagePageV2View>),
+}
+
+impl ActiveBillingAndUsagePage {
+    fn deactivate(self, ctx: &mut ViewContext<BillingAndUsageRouterPageView>) {
+        match self {
+            Self::V1(handle) => {
+                ctx.unsubscribe_to_view(&handle);
+                ctx.update_view(&handle, |view, ctx| {
+                    view.deactivate_subscriptions(ctx);
+                });
+            }
+            Self::V2(handle) => {
+                ctx.unsubscribe_to_view(&handle);
+                ctx.update_view(&handle, |view, ctx| {
+                    view.deactivate_subscriptions(ctx);
+                });
+            }
+        }
+    }
+
+    fn on_page_selected(
+        &self,
+        allow_steal_focus: bool,
+        ctx: &mut ViewContext<BillingAndUsageRouterPageView>,
+    ) {
+        match self {
+            Self::V1(handle) => {
+                ctx.update_view(handle, |view, ctx| {
+                    view.on_page_selected(allow_steal_focus, ctx);
+                });
+            }
+            Self::V2(handle) => {
+                ctx.update_view(handle, |view, ctx| {
+                    view.on_page_selected(allow_steal_focus, ctx);
+                });
+            }
+        }
+    }
+
+    fn update_filter(
+        &self,
+        query: &str,
+        ctx: &mut ViewContext<BillingAndUsageRouterPageView>,
+    ) -> MatchData {
+        match self {
+            Self::V1(handle) => ctx.update_view(handle, |view, ctx| view.update_filter(query, ctx)),
+            Self::V2(handle) => ctx.update_view(handle, |view, ctx| view.update_filter(query, ctx)),
+        }
+    }
+
+    fn scroll_to_widget(
+        &self,
+        widget_id: &'static str,
+        ctx: &mut ViewContext<BillingAndUsageRouterPageView>,
+    ) {
+        match self {
+            Self::V1(handle) => {
+                ctx.update_view(handle, |view, ctx| view.scroll_to_widget(widget_id, ctx));
+            }
+            Self::V2(handle) => {
+                ctx.update_view(handle, |view, ctx| view.scroll_to_widget(widget_id, ctx));
+            }
+        }
+    }
+
+    fn clear_highlighted_widget(&self, ctx: &mut ViewContext<BillingAndUsageRouterPageView>) {
+        match self {
+            Self::V1(handle) => {
+                ctx.update_view(handle, |view, ctx| view.clear_highlighted_widget(ctx));
+            }
+            Self::V2(handle) => {
+                ctx.update_view(handle, |view, ctx| view.clear_highlighted_widget(ctx));
+            }
+        }
+    }
+
+    fn handle_action(
+        &self,
+        action: &BillingAndUsagePageAction,
+        ctx: &mut ViewContext<BillingAndUsageRouterPageView>,
+    ) {
+        match self {
+            Self::V1(handle) => {
+                ctx.update_view(handle, |view, ctx| view.handle_action(action, ctx));
+            }
+            Self::V2(handle) => {
+                ctx.update_view(handle, |view, ctx| view.handle_action(action, ctx));
+            }
+        }
+    }
+
+    fn child_view(&self) -> Box<dyn Element> {
+        match self {
+            Self::V1(handle) => ChildView::new(handle).finish(),
+            Self::V2(handle) => ChildView::new(handle).finish(),
+        }
+    }
+
+    fn get_modal_content(&self, app: &AppContext) -> Option<Box<dyn Element>> {
+        match self {
+            Self::V1(handle) => handle.read(app, |view, _| view.get_modal_content()),
+            Self::V2(handle) => handle.read(app, |view, _| view.get_modal_content()),
+        }
+    }
+}
+
+pub struct BillingAndUsageRouterPageView {
+    active_route: Option<BillingAndUsageRoute>,
+    active_page: Option<ActiveBillingAndUsagePage>,
+}
+
+impl BillingAndUsageRouterPageView {
+    pub fn new(ctx: &mut ViewContext<Self>) -> Self {
+        let mut me = Self {
+            active_route: None,
+            active_page: None,
+        };
+        me.refresh_active_page(ctx);
+        ctx.subscribe_to_model(&UserWorkspaces::handle(ctx), |me, _, event, ctx| {
+            if matches!(event, UserWorkspacesEvent::TeamsChanged) {
+                me.refresh_active_page(ctx);
+            }
+            ctx.notify();
+        });
+        me
+    }
+
+    pub fn get_modal_content(&self, app: &AppContext) -> Option<Box<dyn Element>> {
+        self.active_page
+            .as_ref()
+            .and_then(|page| page.get_modal_content(app))
+    }
+
+    fn refresh_active_page(&mut self, ctx: &mut ViewContext<Self>) {
+        let route = BillingAndUsageRoute::current(ctx);
+        if self.active_route == Some(route) {
+            return;
+        }
+
+        if let Some(active_page) = self.active_page.take() {
+            active_page.deactivate(ctx);
+        }
+
+        self.active_page = Some(match route {
+            BillingAndUsageRoute::V1 => {
+                let handle = ctx.add_typed_action_view(BillingAndUsagePageView::new);
+                ctx.subscribe_to_view(&handle, |_, _, event, ctx| {
+                    ctx.emit(event.clone());
+                });
+                ActiveBillingAndUsagePage::V1(handle)
+            }
+            BillingAndUsageRoute::V2 => {
+                let handle = ctx.add_typed_action_view(BillingAndUsagePageV2View::new);
+                ctx.subscribe_to_view(&handle, |_, _, event, ctx| {
+                    ctx.emit(event.clone());
+                });
+                ActiveBillingAndUsagePage::V2(handle)
+            }
+        });
+        self.active_route = Some(route);
+        ctx.notify();
+    }
+}
+
+impl SettingsPageMeta for BillingAndUsageRouterPageView {
+    fn section() -> SettingsSection {
+        SettingsSection::BillingAndUsage
+    }
+
+    fn should_render(&self, ctx: &AppContext) -> bool {
+        !AuthStateProvider::as_ref(ctx)
+            .get()
+            .is_anonymous_or_logged_out()
+    }
+
+    fn on_page_selected(&mut self, allow_steal_focus: bool, ctx: &mut ViewContext<Self>) {
+        self.refresh_active_page(ctx);
+        if let Some(active_page) = &self.active_page {
+            active_page.on_page_selected(allow_steal_focus, ctx);
+        }
+    }
+
+    fn update_filter(&mut self, query: &str, ctx: &mut ViewContext<Self>) -> MatchData {
+        self.refresh_active_page(ctx);
+        self.active_page
+            .as_ref()
+            .map(|page| page.update_filter(query, ctx))
+            .unwrap_or(MatchData::Uncounted(false))
+    }
+
+    fn scroll_to_widget(&mut self, widget_id: &'static str, ctx: &mut ViewContext<Self>) {
+        self.refresh_active_page(ctx);
+        if let Some(active_page) = &self.active_page {
+            active_page.scroll_to_widget(widget_id, ctx);
+        }
+    }
+
+    fn clear_highlighted_widget(&mut self, ctx: &mut ViewContext<Self>) {
+        self.refresh_active_page(ctx);
+        if let Some(active_page) = &self.active_page {
+            active_page.clear_highlighted_widget(ctx);
+        }
+    }
+}
+
+impl Entity for BillingAndUsageRouterPageView {
+    type Event = BillingAndUsagePageEvent;
+}
+
+impl View for BillingAndUsageRouterPageView {
+    fn ui_name() -> &'static str {
+        "Billing and usage router"
+    }
+
+    fn render(&self, _app: &AppContext) -> Box<dyn Element> {
+        self.active_page
+            .as_ref()
+            .map(ActiveBillingAndUsagePage::child_view)
+            .unwrap_or_else(|| Empty::new().finish())
+    }
+}
+
+impl TypedActionView for BillingAndUsageRouterPageView {
+    type Action = BillingAndUsagePageAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        self.refresh_active_page(ctx);
+        if let Some(active_page) = &self.active_page {
+            active_page.handle_action(action, ctx);
+        }
+    }
+}
+
+impl From<ViewHandle<BillingAndUsageRouterPageView>> for SettingsPageViewHandle {
+    fn from(view_handle: ViewHandle<BillingAndUsageRouterPageView>) -> Self {
+        SettingsPageViewHandle::BillingAndUsageRouter(view_handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routes_to_v1_when_v2_flag_is_disabled() {
+        assert_eq!(
+            BillingAndUsageRoute::from_state(false, true),
+            BillingAndUsageRoute::V1
+        );
+    }
+
+    #[test]
+    fn routes_to_v1_when_v2_flag_is_enabled_for_non_build_plan() {
+        assert_eq!(
+            BillingAndUsageRoute::from_state(true, false),
+            BillingAndUsageRoute::V1
+        );
+    }
+
+    #[test]
+    fn routes_to_v2_when_v2_flag_is_enabled_for_build_plan() {
+        assert_eq!(
+            BillingAndUsageRoute::from_state(true, true),
+            BillingAndUsageRoute::V2
+        );
+    }
+}

--- a/app/src/settings_view/code_page.rs
+++ b/app/src/settings_view/code_page.rs
@@ -2554,11 +2554,11 @@ impl SettingsPageMeta for CodeSettingsPageView {
         );
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/environments_page.rs
+++ b/app/src/settings_view/environments_page.rs
@@ -2033,11 +2033,11 @@ impl SettingsPageMeta for EnvironmentsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -4066,11 +4066,11 @@ impl SettingsPageMeta for FeaturesPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/keybindings.rs
+++ b/app/src/settings_view/keybindings.rs
@@ -831,11 +831,11 @@ impl SettingsPageMeta for KeybindingsView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -1112,11 +1112,11 @@ impl SettingsPageMeta for MainSettingsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/mcp_servers_page.rs
+++ b/app/src/settings_view/mcp_servers_page.rs
@@ -548,11 +548,11 @@ impl SettingsPageMeta for MCPServersSettingsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget()
     }
 }

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -27,8 +27,8 @@ use crate::{
 use about_page::AboutPageView;
 use ai_page::{AISettingsPageAction, AISettingsPageEvent, AISettingsPageView, AISubpage};
 use appearance_page::{AppearancePageAction, AppearanceSettingsPageView};
-use billing_and_usage_page::{BillingAndUsagePageEvent, BillingAndUsagePageView};
-use billing_and_usage_page_v2::BillingAndUsagePageV2View;
+use billing_and_usage_page::BillingAndUsagePageEvent;
+use billing_and_usage_router_page::BillingAndUsageRouterPageView;
 use code_page::CodeSubpage;
 use code_page::{CodeSettingsPageAction, CodeSettingsPageEvent};
 use environments_page::EnvironmentsPageView;
@@ -82,6 +82,7 @@ mod appearance_page;
 mod billing_and_usage;
 mod billing_and_usage_page;
 mod billing_and_usage_page_v2;
+mod billing_and_usage_router_page;
 mod code_page;
 mod custom_inference_modal;
 mod delete_environment_confirmation_dialog;
@@ -1008,8 +1009,9 @@ macro_rules! update_page {
             SettingsPageViewHandle::CloudEnvironments(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::About(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::Code(handle) => $ctx.update_view(handle, $update),
-            SettingsPageViewHandle::BillingAndUsage(handle) => $ctx.update_view(handle, $update),
-            SettingsPageViewHandle::BillingAndUsageV2(handle) => $ctx.update_view(handle, $update),
+            SettingsPageViewHandle::BillingAndUsageRouter(handle) => {
+                $ctx.update_view(handle, $update)
+            }
             SettingsPageViewHandle::MCPServers(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::WarpDrive(handle) => $ctx.update_view(handle, $update),
         }
@@ -1105,20 +1107,12 @@ impl SettingsView {
             me.handle_environments_page_event(event, ctx);
         });
 
-        let should_use_billing_and_usage_v2 = FeatureFlag::BillingAndUsagePageV2.is_enabled();
-        let billing_and_usage_page: SettingsPage = if should_use_billing_and_usage_v2 {
-            let handle = ctx.add_typed_action_view(BillingAndUsagePageV2View::new);
-            ctx.subscribe_to_view(&handle, |me, _, event, ctx| {
-                me.handle_billing_and_usage_page_event(event, ctx);
-            });
-            SettingsPage::new(handle)
-        } else {
-            let handle = ctx.add_typed_action_view(BillingAndUsagePageView::new);
-            ctx.subscribe_to_view(&handle, |me, _, event, ctx| {
-                me.handle_billing_and_usage_page_event(event, ctx);
-            });
-            SettingsPage::new(handle)
-        };
+        let billing_and_usage_page_handle =
+            ctx.add_typed_action_view(BillingAndUsageRouterPageView::new);
+        ctx.subscribe_to_view(&billing_and_usage_page_handle, |me, _, event, ctx| {
+            me.handle_billing_and_usage_page_event(event, ctx);
+        });
+        let billing_and_usage_page = SettingsPage::new(billing_and_usage_page_handle);
 
         // Keybindings page
         let keybindings_handle = ctx.add_typed_action_view(KeybindingsView::new);
@@ -1922,7 +1916,7 @@ impl SettingsView {
             update_page!(
                 &current_page.view_handle,
                 |view, ctx| {
-                    view.clear_highlighted_widget();
+                    view.clear_highlighted_widget(ctx);
                     ctx.notify();
                 },
                 ctx
@@ -2006,8 +2000,7 @@ impl SettingsView {
             SettingsPageViewHandle::Keybindings(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::Features(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::Appearance(v) => v.as_ref(app).should_render(app),
-            SettingsPageViewHandle::BillingAndUsage(v) => v.as_ref(app).should_render(app),
-            SettingsPageViewHandle::BillingAndUsageV2(v) => v.as_ref(app).should_render(app),
+            SettingsPageViewHandle::BillingAndUsageRouter(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::About(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::OzCloudAPIKeys(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::Privacy(v) => v.as_ref(app).should_render(app),
@@ -2186,8 +2179,8 @@ impl SettingsView {
         if let Some(current_page) = self.current_settings_page() {
             update_page!(
                 &current_page.view_handle,
-                |view, _| {
-                    view.scroll_to_widget(widget_id);
+                |view, ctx| {
+                    view.scroll_to_widget(widget_id, ctx);
                 },
                 ctx
             )
@@ -2225,11 +2218,8 @@ impl SettingsView {
         app: &AppContext,
     ) -> Option<Box<dyn Element>> {
         match page_handle {
-            SettingsPageViewHandle::BillingAndUsage(view) => {
-                view.read(app, |view, _| view.get_modal_content())
-            }
-            SettingsPageViewHandle::BillingAndUsageV2(view) => {
-                view.read(app, |view, _| view.get_modal_content())
+            SettingsPageViewHandle::BillingAndUsageRouter(view) => {
+                view.read(app, |view, _| view.get_modal_content(app))
             }
             SettingsPageViewHandle::Privacy(view) => {
                 view.read(app, |view, _| view.get_modal_content())

--- a/app/src/settings_view/platform_page.rs
+++ b/app/src/settings_view/platform_page.rs
@@ -852,11 +852,11 @@ impl SettingsPageMeta for PlatformPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/privacy_page.rs
+++ b/app/src/settings_view/privacy_page.rs
@@ -632,11 +632,11 @@ impl SettingsPageMeta for PrivacyPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/referrals_page.rs
+++ b/app/src/settings_view/referrals_page.rs
@@ -422,11 +422,11 @@ impl SettingsPageMeta for ReferralsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/settings_page.rs
+++ b/app/src/settings_view/settings_page.rs
@@ -9,8 +9,7 @@ use super::{
     about_page::AboutPageView,
     ai_page::{AISettingsPageAction, AISettingsPageView},
     appearance_page::AppearanceSettingsPageView,
-    billing_and_usage_page::BillingAndUsagePageView,
-    billing_and_usage_page_v2::BillingAndUsagePageV2View,
+    billing_and_usage_router_page::BillingAndUsageRouterPageView,
     code_page::CodeSettingsPageView,
     environments_page::EnvironmentsPageView,
     features_page::FeaturesPageView,
@@ -98,9 +97,9 @@ pub trait SettingsPageMeta {
 
     fn update_filter(&mut self, query: &str, ctx: &mut ViewContext<Self>) -> MatchData;
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str);
+    fn scroll_to_widget(&mut self, widget_id: &'static str, ctx: &mut ViewContext<Self>);
 
-    fn clear_highlighted_widget(&mut self);
+    fn clear_highlighted_widget(&mut self, ctx: &mut ViewContext<Self>);
 }
 
 /// Page enum lists all the pages that we want to support.
@@ -121,8 +120,7 @@ pub enum SettingsPageViewHandle {
     Referrals(ViewHandle<ReferralsPageView>),
     AI(ViewHandle<AISettingsPageView>),
     CloudEnvironments(ViewHandle<EnvironmentsPageView>),
-    BillingAndUsage(ViewHandle<BillingAndUsagePageView>),
-    BillingAndUsageV2(ViewHandle<BillingAndUsagePageV2View>),
+    BillingAndUsageRouter(ViewHandle<BillingAndUsageRouterPageView>),
     MCPServers(ViewHandle<MCPServersSettingsPageView>),
     WarpDrive(ViewHandle<WarpDriveSettingsPageView>),
 }
@@ -145,8 +143,7 @@ impl SettingsPageViewHandle {
             Referrals(view_handle) => ChildView::new(view_handle).finish(),
             AI(view_handle) => ChildView::new(view_handle).finish(),
             CloudEnvironments(view_handle) => ChildView::new(view_handle).finish(),
-            BillingAndUsage(view_handle) => ChildView::new(view_handle).finish(),
-            BillingAndUsageV2(view_handle) => ChildView::new(view_handle).finish(),
+            BillingAndUsageRouter(view_handle) => ChildView::new(view_handle).finish(),
             MCPServers(view_handle) => ChildView::new(view_handle).finish(),
             WarpDrive(view_handle) => ChildView::new(view_handle).finish(),
         }

--- a/app/src/settings_view/show_blocks_view.rs
+++ b/app/src/settings_view/show_blocks_view.rs
@@ -629,11 +629,11 @@ impl SettingsPageMeta for ShowBlocksView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -1778,11 +1778,11 @@ impl SettingsPageMeta for TeamsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/warp_drive_page.rs
+++ b/app/src/settings_view/warp_drive_page.rs
@@ -95,11 +95,11 @@ impl SettingsPageMeta for WarpDriveSettingsPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/app/src/settings_view/warpify_page.rs
+++ b/app/src/settings_view/warpify_page.rs
@@ -509,11 +509,11 @@ impl SettingsPageMeta for WarpifyPageView {
         self.page.update_filter(query, ctx)
     }
 
-    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+    fn scroll_to_widget(&mut self, widget_id: &'static str, _ctx: &mut ViewContext<Self>) {
         self.page.scroll_to_widget(widget_id)
     }
 
-    fn clear_highlighted_widget(&mut self) {
+    fn clear_highlighted_widget(&mut self, _ctx: &mut ViewContext<Self>) {
         self.page.clear_highlighted_widget();
     }
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -947,6 +947,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::SoloUserByok,
     FeatureFlag::CustomInferenceEndpoints,
     FeatureFlag::RemoteCodebaseIndexing,
+    FeatureFlag::BillingAndUsagePageV2,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Adds an intermediate Billing & Usage settings router that chooses the active billing page at runtime based on the `BillingAndUsagePageV2` feature flag and whether the current workspace is on Build. This keeps settings wiring stable while allowing the active page to change when workspace billing metadata changes.

Also updates the settings page meta methods to accept context, cleans up subscriptions when the router swaps active billing pages, dogfood-enables the V2 page flag, and keeps the active V2 billing page discoverable in settings search.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] `cargo test -p warp settings_view::billing_and_usage_router_page::tests --lib`
- [x] `cargo test -p warp settings_view::billing_and_usage_page_v2::tests --lib`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; no local manual UI verification was run.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>