### PR TITLE
Expose terminal focus URL env vars

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -115,6 +115,7 @@ use crate::shell_indicator::ShellIndicatorType;
 use crate::terminal::available_shells::{AvailableShell, AvailableShells};
 #[cfg(not(target_family = "wasm"))]
 use crate::terminal::cli_agent_sessions::plugin_manager::PluginModalKind;
+use crate::terminal::focus_env::add_session_focus_env_vars;
 use crate::terminal::general_settings::{GeneralSettings, GeneralSettingsChangedEvent};
 #[cfg(feature = "local_tty")]
 use crate::terminal::local_tty;
@@ -1321,6 +1322,7 @@ impl PaneGroup {
                         // TODO(CORE-3187): On Windows, support WSL directory restoration.
                         Some(cwd).filter(|p| p.exists()),
                         HashMap::new(),
+                        uuid.as_bytes(),
                         IsSharedSessionCreator::No,
                         resources,
                         None,
@@ -1621,6 +1623,7 @@ impl PaneGroup {
                 let (terminal_view, terminal_manager) = PaneGroup::create_session(
                     startup_directory,
                     HashMap::new(),
+                    uuid.0.as_slice(),
                     IsSharedSessionCreator::No,
                     resources,
                     block_list,
@@ -3815,9 +3818,11 @@ impl PaneGroup {
         pane_history: &mut Vec<PaneId>,
         ctx: &mut ViewContext<Self>,
     ) -> (PaneData, InitialFocus) {
+        let uuid = Uuid::new_v4();
         let (view, terminal_manager) = PaneGroup::create_session(
             options.initial_directory,
             options.env_vars,
+            uuid.as_bytes(),
             options.is_shared_session_creator,
             resources,
             None,
@@ -3829,7 +3834,6 @@ impl PaneGroup {
             None,
             ctx,
         );
-        let uuid = Uuid::new_v4();
 
         let pane_data = TerminalPane::new(
             uuid.as_bytes().to_vec(),
@@ -6253,7 +6257,8 @@ impl PaneGroup {
     #[allow(clippy::too_many_arguments, unused_variables)]
     fn create_session(
         startup_directory: Option<PathBuf>,
-        env_vars: HashMap<OsString, OsString>,
+        mut env_vars: HashMap<OsString, OsString>,
+        terminal_session_uuid: &[u8],
         is_shared_session: IsSharedSessionCreator,
         resources: TerminalViewResources,
         restored_blocks: Option<&Vec<SerializedBlockListItem>>,
@@ -6268,6 +6273,8 @@ impl PaneGroup {
         ViewHandle<TerminalView>,
         ModelHandle<Box<dyn TerminalManager>>,
     ) {
+        add_session_focus_env_vars(&mut env_vars, terminal_session_uuid);
+
         cfg_if::cfg_if! {
             if #[cfg(feature = "remote_tty")] {
                 let terminal_manager: ModelHandle<Box<dyn TerminalManager>> = crate::terminal::remote_tty::TerminalManager::create_model(
@@ -6566,6 +6573,7 @@ impl PaneGroup {
         let (view, terminal_manager) = PaneGroup::create_session(
             startup_directory,
             HashMap::new(),
+            uuid.as_bytes(),
             IsSharedSessionCreator::No,
             resources,
             None,
@@ -6682,6 +6690,7 @@ impl PaneGroup {
         let (view, terminal_manager) = PaneGroup::create_session(
             startup_directory,
             env_vars,
+            uuid.as_bytes(),
             is_shared_session_creator,
             resources,
             None,

--- a/app/src/terminal/focus_env.rs
+++ b/app/src/terminal/focus_env.rs
@@ -1,0 +1,32 @@
+use std::{collections::HashMap, ffi::OsString};
+
+use crate::channel::ChannelState;
+
+pub(crate) const FOCUS_URL_ENV: &str = "WARP_FOCUS_URL";
+pub(crate) const TERMINAL_SESSION_UUID_ENV: &str = "WARP_TERMINAL_SESSION_UUID";
+
+pub(crate) fn session_focus_url(session_uuid_hex: &str) -> String {
+    format!(
+        "{}://session/{session_uuid_hex}",
+        ChannelState::url_scheme()
+    )
+}
+
+pub(crate) fn add_session_focus_env_vars(
+    env_vars: &mut HashMap<OsString, OsString>,
+    session_uuid: &[u8],
+) {
+    let session_uuid_hex = hex::encode(session_uuid);
+    env_vars.insert(
+        OsString::from(TERMINAL_SESSION_UUID_ENV),
+        OsString::from(session_uuid_hex.clone()),
+    );
+    env_vars.insert(
+        OsString::from(FOCUS_URL_ENV),
+        OsString::from(session_focus_url(&session_uuid_hex)),
+    );
+}
+
+#[cfg(test)]
+#[path = "focus_env_tests.rs"]
+mod tests;

--- a/app/src/terminal/focus_env_tests.rs
+++ b/app/src/terminal/focus_env_tests.rs
@@ -1,0 +1,29 @@
+use std::{collections::HashMap, ffi::OsString};
+
+use crate::channel::ChannelState;
+
+use super::{add_session_focus_env_vars, FOCUS_URL_ENV, TERMINAL_SESSION_UUID_ENV};
+
+#[test]
+fn focus_env_vars_point_at_session_deeplink() {
+    let uuid = [
+        0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00,
+        0x00,
+    ];
+    let mut env_vars = HashMap::new();
+
+    add_session_focus_env_vars(&mut env_vars, &uuid);
+
+    let expected_hex = "550e8400e29b41d4a716446655440000";
+    assert_eq!(
+        env_vars.get(&OsString::from(TERMINAL_SESSION_UUID_ENV)),
+        Some(&OsString::from(expected_hex))
+    );
+    assert_eq!(
+        env_vars.get(&OsString::from(FOCUS_URL_ENV)),
+        Some(&OsString::from(format!(
+            "{}://session/{expected_hex}",
+            ChannelState::url_scheme()
+        )))
+    );
+}

--- a/app/src/terminal/local_tty/windows/environment.rs
+++ b/app/src/terminal/local_tty/windows/environment.rs
@@ -13,6 +13,7 @@ use winreg::{RegKey, RegValue};
 
 use crate::safe_info;
 use crate::terminal::cli_agent_sessions::event::current_protocol_version;
+use crate::terminal::focus_env::{FOCUS_URL_ENV, TERMINAL_SESSION_UUID_ENV};
 use crate::terminal::local_tty::shell::{extra_path_entries, ssh_socket_dir, ShellStarter};
 use crate::terminal::local_tty::PtyOptions;
 
@@ -198,6 +199,8 @@ fn wsl_env_allowlist(include_initial_working_dir: bool) -> OsString {
         format!("{IS_LOCAL_SESSION_NAME}/u"),
         format!("{SSH_SOCKET_DIR}/u"),
         format!("{CLIENT_VERSION_NAME}/u"),
+        format!("{TERMINAL_SESSION_UUID_ENV}/u"),
+        format!("{FOCUS_URL_ENV}/u"),
     ];
 
     if FeatureFlag::HOANotifications.is_enabled() {
@@ -382,6 +385,8 @@ mod tests {
                 format!("{IS_LOCAL_SESSION_NAME}/u"),
                 format!("{SSH_SOCKET_DIR}/u"),
                 format!("{CLIENT_VERSION_NAME}/u"),
+                format!("{TERMINAL_SESSION_UUID_ENV}/u"),
+                format!("{FOCUS_URL_ENV}/u"),
             ],
         );
     }
@@ -402,6 +407,8 @@ mod tests {
                 format!("{IS_LOCAL_SESSION_NAME}/u"),
                 format!("{SSH_SOCKET_DIR}/u"),
                 format!("{CLIENT_VERSION_NAME}/u"),
+                format!("{TERMINAL_SESSION_UUID_ENV}/u"),
+                format!("{FOCUS_URL_ENV}/u"),
                 format!("{CLI_AGENT_PROTOCOL_VERSION_NAME}/u"),
                 format!("{INITIAL_WORKING_DIR_NAME}/pu"),
             ],

--- a/app/src/terminal/mod.rs
+++ b/app/src/terminal/mod.rs
@@ -39,6 +39,7 @@ pub mod enable_auto_reload_modal;
 pub mod event;
 pub mod event_listener;
 pub mod find;
+pub(crate) mod focus_env;
 pub mod general_settings;
 pub mod grid_renderer;
 pub mod grid_size_util;


### PR DESCRIPTION
## Description

Expose a per-terminal focus handle to processes running inside Warp terminal sessions.

This adds two environment variables to terminal sessions:

- `WARP_TERMINAL_SESSION_UUID`: the terminal session UUID as 32 lowercase hex characters.
- `WARP_FOCUS_URL`: a channel-aware deep link such as `warposs://session/<uuid>` or `warp://session/<uuid>`.

External notifier scripts can use `WARP_FOCUS_URL` as an opaque jump-back target. Opening that URL lets Warp resolve the current window, pane group, and pane internally via the existing session deep-link handler.

The WSL allowlist is also updated so these values can pass through to WSL shells.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Closes #8611

## Testing

- [x] I have manually tested my changes locally with `./script/run`

- `rustfmt --edition 2021 --check app/src/terminal/focus_env.rs app/src/terminal/mod.rs app/src/pane_group/mod.rs app/src/terminal/local_tty/windows/environment.rs`
- `git diff --check -- app/src/pane_group/mod.rs app/src/terminal/local_tty/windows/environment.rs app/src/terminal/mod.rs app/src/terminal/focus_env.rs`
- `cargo test -p warp terminal::focus_env::tests::focus_env_vars_point_at_session_deeplink --lib`
- Manual: launched local `WarpOss`, confirmed `WARP_TERMINAL_SESSION_UUID` and `WARP_FOCUS_URL` are present in terminal panes, and verified `open "$WARP_FOCUS_URL"` focuses the originating pane across multiple panes/windows.

### Screenshots / Videos

Demo video: https://github.com/user-attachments/assets/0aba8e7e-e5d6-4449-a371-296c862f893d

The recording shows `WARP_TERMINAL_SESSION_UUID` and `WARP_FOCUS_URL` in a local `WarpOss` pane, then uses the focus URL from another terminal to return focus to the originating pane.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Expose a Warp focus URL in terminal session environments so external notification tools can return focus to the originating pane.

