### PR TITLE
Make agent run skill flag repeatable

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -31,7 +31,7 @@ use warp_managed_secrets::ManagedSecretValue;
 use warpui::r#async::{FutureExt, TimeoutError};
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, ModelSpawner, SingletonEntity};
 
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::conversation::{AIConversationId, InvokeSkillUserQuery};
 use crate::ai::agent::{
     AIAgentActionResultType, AIAgentExchange, AIAgentInput, AIAgentOutput, CancellationReason,
     RenderableAIError, RequestFileEditsResult,
@@ -365,6 +365,11 @@ struct GlobalSkillResolution {
 pub enum AgentRunPrompt {
     /// Prompt is provided locally (already resolved to a plain string).
     Local(String),
+    /// A local Oz run that invokes a skill using the skill-specific API input.
+    LocalSkill {
+        skill: ParsedSkill,
+        user_query: Option<InvokeSkillUserQuery>,
+    },
     /// Server resolves prompt from the task's stored prompt.
     /// Used when task_id is provided without an explicit prompt.
     ServerSide {
@@ -1858,6 +1863,20 @@ impl AgentDriver {
                     Self::load_global_skills(&foreground, global_skill_specs, global_skill_repos),
                 )
                 .await;
+
+            foreground
+                .spawn(|_, ctx| {
+                    // In all CLI runs, we should include all loaded skills from any source:
+                    // - The `--skill` flag
+                    // - Global skills
+                    // - Skills from cloned repos
+                    // Unlike in the desktop app, there aren't multiple terminal sessions with
+                    // different skill sets that we need to filter out.
+                    SkillManager::handle(ctx).update(ctx, |manager, _| {
+                        manager.set_cloud_environment(true);
+                    });
+                })
+                .await?;
         }
 
         let (task_id_for_refresh, ai_client_for_refresh) = foreground
@@ -2121,6 +2140,13 @@ impl AgentDriver {
             Option<String>,
         ) = match prompt {
             AgentRunPrompt::Local(text) => (Cow::Borrowed(text), None, None, None),
+            AgentRunPrompt::LocalSkill { skill, user_query } => {
+                let prompt = match user_query {
+                    Some(user_query) => format!("{}\n\n{}", skill.content, user_query.query),
+                    None => skill.content.clone(),
+                };
+                (Cow::Owned(prompt), None, None, None)
+            }
             AgentRunPrompt::ServerSide {
                 skill,
                 attachments_dir,
@@ -2754,6 +2780,27 @@ impl AgentDriver {
                             .input()
                             .update(ctx, |input, ctx| input.input_enter(ctx));
                     }
+                }
+                AgentRunPrompt::LocalSkill { skill, user_query } => {
+                    if FeatureFlag::AgentView.is_enabled() {
+                        terminal.enter_agent_view(
+                            None,
+                            restored_conversation_id,
+                            AgentViewEntryOrigin::Cli,
+                            ctx,
+                        );
+                    }
+
+                    terminal.ai_controller().update(ctx, |controller, ctx| {
+                        controller.send_ai_input_with_context(
+                            |context| AIAgentInput::InvokeSkill {
+                                context,
+                                skill: skill.clone(),
+                                user_query: user_query.clone(),
+                            },
+                            ctx,
+                        );
+                    });
                 }
                 AgentRunPrompt::ServerSide {
                     skill,

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -31,10 +31,10 @@ use warp_managed_secrets::ManagedSecretValue;
 use warpui::r#async::{FutureExt, TimeoutError};
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, ModelSpawner, SingletonEntity};
 
-use crate::ai::agent::conversation::{AIConversationId, InvokeSkillUserQuery};
+use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentActionResultType, AIAgentExchange, AIAgentInput, AIAgentOutput, CancellationReason,
-    RenderableAIError, RequestFileEditsResult,
+    InvokeSkillUserQuery, RenderableAIError, RequestFileEditsResult,
 };
 use crate::ai::agent_sdk::driver::harness::{
     harness_model_env_vars, task_env_vars, HarnessCleanupDisposition, HarnessKind, HarnessRunner,

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -43,7 +43,7 @@ use crate::ai::agent::api::convert_conversation::{
     convert_conversation_data_to_ai_conversation, RestorationMode,
 };
 use crate::ai::agent::api::ServerConversationToken;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::{conversation::AIConversationId, InvokeSkillUserQuery};
 use crate::ai::agent_sdk::driver::harness::{harness_kind, HarnessKind};
 use crate::ai::agent_sdk::driver::{AgentDriverOptions, AgentRunPrompt, Task};
 use crate::ai::agent_sdk::mcp_config::build_mcp_servers_from_specs;
@@ -255,7 +255,7 @@ fn run_agent(
                     "unexpected argument '--conversation' found"
                 ));
             }
-            if args.skill.is_some() && !FeatureFlag::OzPlatformSkills.is_enabled() {
+            if !args.skill.is_empty() && !FeatureFlag::OzPlatformSkills.is_enabled() {
                 return Err(anyhow::anyhow!("unexpected argument '--skill' found"));
             }
             if args.harness != Harness::Oz && !FeatureFlag::AgentHarness.is_enabled() {
@@ -415,23 +415,53 @@ fn build_merged_config_and_task(
     // Keep the task config snapshot aligned with the effective model selection.
     merged_config.model_id = model_override.clone().map(|id| id.to_string());
 
-    // Combine base_prompt with user prompt locally.
-    let local_prompt = match (merged_config.base_prompt.as_deref(), prompt) {
-        (Some(base_prompt), Some(Prompt::PlainText(user_prompt))) => {
-            Prompt::PlainText(format!("{base_prompt}\n\n{user_prompt}"))
+    let prompt = if args.harness == Harness::Oz {
+        if let Some(skill) = resolved_skill {
+            let user_query = prompt
+                .as_ref()
+                .map(|prompt| {
+                    resolve_prompt(prompt, ctx).map(|query| InvokeSkillUserQuery {
+                        query,
+                        referenced_attachments: Default::default(),
+                    })
+                })
+                .transpose()?;
+
+            AgentRunPrompt::LocalSkill {
+                skill: skill.parsed_skill.clone(),
+                user_query,
+            }
+        } else {
+            let local_prompt = match (merged_config.base_prompt.as_deref(), prompt) {
+                (Some(base_prompt), Some(Prompt::PlainText(user_prompt))) => {
+                    Prompt::PlainText(format!("{base_prompt}\n\n{user_prompt}"))
+                }
+                (Some(base_prompt), None) => Prompt::PlainText(base_prompt.to_string()),
+                (_, Some(p)) => p.clone(),
+                (None, None) => {
+                    return Err(anyhow::anyhow!(AgentDriverError::InvalidRuntimeState));
+                }
+            };
+            AgentRunPrompt::Local(resolve_prompt(&local_prompt, ctx)?)
         }
-        (Some(base_prompt), None) => {
-            // Skill-only invocation: use skill instructions as the prompt
-            Prompt::PlainText(base_prompt.to_string())
-        }
-        (_, Some(p)) => p.clone(),
-        (None, None) => {
-            return Err(anyhow::anyhow!(AgentDriverError::InvalidRuntimeState));
-        }
+    } else {
+        // Third-party harnesses do not use Warp's InvokeSkill input type, so keep passing
+        // skill instructions as prompt text for harness-native execution.
+        let local_prompt = match (merged_config.base_prompt.as_deref(), prompt) {
+            (Some(base_prompt), Some(Prompt::PlainText(user_prompt))) => {
+                Prompt::PlainText(format!("{base_prompt}\n\n{user_prompt}"))
+            }
+            (Some(base_prompt), None) => Prompt::PlainText(base_prompt.to_string()),
+            (_, Some(p)) => p.clone(),
+            (None, None) => {
+                return Err(anyhow::anyhow!(AgentDriverError::InvalidRuntimeState));
+            }
+        };
+        AgentRunPrompt::Local(resolve_prompt(&local_prompt, ctx)?)
     };
 
     let task = Task {
-        prompt: AgentRunPrompt::Local(resolve_prompt(&local_prompt, ctx)?),
+        prompt,
         model: model_override,
         profile: args.profile.clone(),
         mcp_specs: runtime_mcp_specs,
@@ -816,56 +846,98 @@ impl AgentDriverRunner {
         Ok(())
     }
 
-    /// Resolve the skill spec from args, if one was provided.
+    /// Resolve the skill specs from args, if any were provided.
     ///
-    /// In sandboxed mode with a fully-qualified spec (org + repo), the repo is
-    /// cloned first since it may not exist locally. Otherwise we resolve directly
-    /// against the local filesystem.
-    async fn resolve_skill(
+    /// In sandboxed mode with fully-qualified specs (org + repo), the
+    /// repos are cloned first since they may not exist locally. Otherwise we
+    /// resolve directly against the local filesystem. Every resolved skill is
+    /// also registered with `SkillManager` so the agent can read it later.
+    async fn resolve_skills(
         foreground: &ModelSpawner<Self>,
         args: &RunAgentArgs,
         working_dir: &Path,
         setup_events: &SetupClientEventReporter,
-    ) -> Result<Option<ResolvedSkill>, AgentDriverError> {
+    ) -> Result<Vec<ResolvedSkill>, AgentDriverError> {
         if !FeatureFlag::OzPlatformSkills.is_enabled() {
-            return Ok(None);
+            return Ok(Vec::new());
         }
-        let Some(skill_spec) = args.skill.clone() else {
-            return Ok(None);
-        };
+        if args.skill.is_empty() {
+            return Ok(Vec::new());
+        }
+        let skill_specs = args.skill.clone();
+        let mut repos_to_clone = Vec::new();
+        if args.sandboxed {
+            for skill_spec in &skill_specs {
+                let (Some(org), Some(repo_name)) = (&skill_spec.org, &skill_spec.repo) else {
+                    continue;
+                };
+                repos_to_clone.push((org.clone(), repo_name.clone()));
+            }
+            repos_to_clone.sort();
+            repos_to_clone.dedup();
+        }
 
-        // In sandboxed mode with a fully-qualified spec, clone the repo first.
-        let needs_clone = args.sandboxed && skill_spec.org.is_some() && skill_spec.repo.is_some();
-        if needs_clone {
-            let org = skill_spec.org.as_ref().expect("org checked above");
-            let repo_name = skill_spec.repo.as_ref().expect("repo checked above");
-            log::info!("Cloning {org}/{repo_name} for skill resolution in sandboxed mode");
-            setup_events
-                .record_result(SetupStep::SkillRepoClone, async {
-                    clone_repo_for_skill(org, repo_name, working_dir)
+        if !repos_to_clone.is_empty() {
+            let repos_for_log = repos_to_clone
+                .iter()
+                .map(|(org, repo_name)| format!("{org}/{repo_name}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            safe_info!(
+                safe: (
+                    "Cloning {} repo(s) for skill resolution in sandboxed mode",
+                    repos_to_clone.len()
+                ),
+                full: ("Cloning repos for skill resolution in sandboxed mode: {repos_for_log}")
+            );
+
+            let clone_futures = repos_to_clone
+                .into_iter()
+                .map(|(org, repo_name)| async move {
+                    clone_repo_for_skill(&org, &repo_name, working_dir)
                         .await
                         .map_err(|err| {
                             AgentDriverError::SkillResolutionFailed(format_skill_resolution_error(
                                 err,
                             ))
                         })
+                });
+            setup_events.record_result(SetupStep::SkillRepoClone, async {
+                try_join_all(clone_futures).await
+            });
+        }
+
+        let mut resolved_skills = Vec::with_capacity(skill_specs.len());
+        for skill_spec in skill_specs {
+            let working_dir_buf = working_dir.to_path_buf();
+            let skill = foreground
+                .spawn(move |_, ctx| resolve_skill_spec(&skill_spec, &working_dir_buf, ctx))
+                .await?
+                .map_err(|err| {
+                    AgentDriverError::SkillResolutionFailed(format_skill_resolution_error(err))
+                })?;
+            log::debug!(
+                "Resolved skill '{}' from {}",
+                skill.name,
+                skill.skill_path.display()
+            );
+            resolved_skills.push(skill);
+        }
+        if !resolved_skills.is_empty() {
+            let skills = resolved_skills
+                .iter()
+                .map(|skill| skill.parsed_skill.clone())
+                .collect::<Vec<_>>();
+            foreground
+                .spawn(move |_, ctx| {
+                    SkillManager::handle(ctx).update(ctx, |manager, _| {
+                        manager.handle_skills_added(skills);
+                    });
                 })
                 .await?;
         }
 
-        let working_dir_buf = working_dir.to_path_buf();
-        let skill = foreground
-            .spawn(move |_, ctx| resolve_skill_spec(&skill_spec, &working_dir_buf, ctx))
-            .await?
-            .map_err(|err| {
-                AgentDriverError::SkillResolutionFailed(format_skill_resolution_error(err))
-            })?;
-        log::debug!(
-            "Resolved skill '{}' from {}",
-            skill.name,
-            skill.skill_path.display()
-        );
-        Ok(Some(skill))
+        Ok(resolved_skills)
     }
 
     /// Build the AgentDriverOptions and Task, handling task creation or existing task setup.
@@ -888,21 +960,22 @@ impl AgentDriverRunner {
         }
         .map_err(AgentDriverError::ConfigBuildFailed)?;
 
-        // Resolve the skill, if we have one
-        let resolved_skill =
-            Self::resolve_skill(foreground, &args, &working_dir, setup_events).await?;
+        // Resolve and register any explicitly requested skills. Only the first is invoked.
+        let resolved_skills =
+            Self::resolve_skills(foreground, &args, &working_dir, setup_events).await?;
+        let invoked_skill = resolved_skills.first().cloned();
 
         // Extract variables we want to use later before moving args into the closure
         let task_id_str = args.task_id.clone();
         let prompt = args.prompt_arg.to_prompt();
-        let skill = args.skill.clone();
+        let skill = args.invoked_skill().cloned();
 
         // Build the AgentConfigSnapshot, Task, and AgentDriverOptions
         let prompt_clone = prompt.clone();
         let (merged_config, mut task, mut driver_options) = foreground
             .spawn(move |_, ctx| -> anyhow::Result<_> {
                 let (merged_config, task) =
-                    build_merged_config_and_task(&args, &resolved_skill, &prompt_clone, ctx)?;
+                    build_merged_config_and_task(&args, &invoked_skill, &prompt_clone, ctx)?;
 
                 let task_id = args.task_id.as_ref().and_then(|s| s.parse().ok());
                 let should_share = (args.share.is_shared() || args.task_id.is_some())

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -12,6 +12,7 @@ use anyhow::Context;
 pub(crate) use driver::harness::{task_env_vars, validate_cli_installed, ClaudeHarness};
 pub use driver::AgentDriver;
 use driver::AgentDriverError;
+use futures::future::try_join_all;
 use telemetry::CliTelemetryEvent;
 use warp_cli::agent::{
     AgentCommand, AgentProfileCommand, Harness, OutputFormat, Prompt, RunAgentArgs,
@@ -31,6 +32,7 @@ use warp_cli::share::ShareRequest;
 use warp_cli::task::{MessageCommand, TaskCommand};
 use warp_cli::{CliCommand, GlobalOptions, OZ_HARNESS_ENV};
 use warp_core::features::FeatureFlag;
+use warp_core::safe_info;
 use warp_graphql::object_permissions::OwnerType;
 use warp_isolation_platform::IsolationPlatformError;
 #[cfg(not(target_family = "wasm"))]
@@ -43,7 +45,8 @@ use crate::ai::agent::api::convert_conversation::{
     convert_conversation_data_to_ai_conversation, RestorationMode,
 };
 use crate::ai::agent::api::ServerConversationToken;
-use crate::ai::agent::{conversation::AIConversationId, InvokeSkillUserQuery};
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::InvokeSkillUserQuery;
 use crate::ai::agent_sdk::driver::harness::{harness_kind, HarnessKind};
 use crate::ai::agent_sdk::driver::{AgentDriverOptions, AgentRunPrompt, Task};
 use crate::ai::agent_sdk::mcp_config::build_mcp_servers_from_specs;
@@ -58,7 +61,7 @@ use crate::ai::aws_credentials::refresh_aws_credentials;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::llms::LLMId;
 use crate::ai::skills::{
-    clone_repo_for_skill, resolve_skill_spec, ResolveSkillError, ResolvedSkill,
+    clone_repo_for_skill, resolve_skill_spec, ResolveSkillError, ResolvedSkill, SkillManager,
 };
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::AuthStateProvider;
@@ -902,9 +905,11 @@ impl AgentDriverRunner {
                             ))
                         })
                 });
-            setup_events.record_result(SetupStep::SkillRepoClone, async {
-                try_join_all(clone_futures).await
-            });
+            setup_events
+                .record_result(SetupStep::SkillRepoClone, async {
+                    try_join_all(clone_futures).await
+                })
+                .await?;
         }
 
         let mut resolved_skills = Vec::with_capacity(skill_specs.len());

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -23,6 +23,7 @@
 //! that aren't relevant to the handler's correctness).
 
 use std::collections::HashMap;
+
 use warp_core::ui::appearance::Appearance;
 use warpui::platform::WindowStyle;
 use warpui::App;

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -1,12 +1,9 @@
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 use ai::skills::{
     home_skills_path, read_skills, ParsedSkill, SkillProvider, SKILL_PROVIDER_DEFINITIONS,
 };
 use anyhow::Error;
-use regex::Regex;
 use repo_metadata::local_model::GetContentsArgs;
 use repo_metadata::{RepoContent, RepoMetadataModel};
 use warpui::AppContext;
@@ -68,52 +65,45 @@ pub fn is_skill_file(path: &Path) -> bool {
     extract_skill_parent_directory(path).is_ok()
 }
 
-static SKILL_PROVIDER_PATHS: LazyLock<HashSet<String>> = LazyLock::new(|| {
-    // Collect the skill provider paths from the definitions
-    SKILL_PROVIDER_DEFINITIONS
-        .iter()
-        .map(|p| p.skills_path.to_string_lossy().to_string())
-        .collect()
-});
-
-// Pattern: {prefix}/{provider_path}/{skill-name}/SKILL.md
-// where provider_path is 2 parts (e.g., ".agents/skills") and skill-name is 1 part
-#[cfg(not(target_os = "windows"))]
-static SKILL_FILE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(.+)/([^/]+/[^/]+)/[^/]+/SKILL\.md$")
-        .expect("Failed to compile skill file pattern")
-});
-
-// On windows, the path separator is \
-#[cfg(target_os = "windows")]
-static SKILL_FILE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(.+)\\([^\\]+\\[^\\]+)\\[^\\]+\\SKILL\.md$")
-        .expect("Failed to compile skill file pattern")
-});
-
 pub fn extract_skill_parent_directory(path: &Path) -> Result<PathBuf, Error> {
-    let is_warp_home_skill = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name == "SKILL.md")
-        && path
-            .parent()
-            .and_then(Path::parent)
-            .is_some_and(|parent| warp_managed_skill_dirs().iter().any(|dir| parent == dir));
-    if is_warp_home_skill {
+    if path.file_name().and_then(|name| name.to_str()) != Some("SKILL.md") {
+        return Err(anyhow::anyhow!("Not a skill path: {}", path.display()));
+    }
+
+    // Find the provider-specific skills directory. For example, if `path` is
+    // `path/to/project/.claude/skills/my-skill/SKILL.md`, `provider_skills_dir`
+    // is `path/to/project/.claude/skills`.
+    let Some(provider_skills_dir) = path.parent().and_then(Path::parent) else {
+        return Err(anyhow::anyhow!("Not a skill path: {}", path.display()));
+    };
+
+    if warp_managed_skill_dirs()
+        .iter()
+        .any(|dir| provider_skills_dir == dir)
+    {
         return dirs::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Home directory not available for {}", path.display()));
     }
-    let path_str = path.to_string_lossy();
 
-    if let Some(captures) = SKILL_FILE_PATTERN.captures(&path_str) {
-        if let Some(provider_path) = captures.get(2) {
-            if SKILL_PROVIDER_PATHS.contains(provider_path.as_str()) {
-                if let Some(parent_directory) = captures.get(1) {
-                    return Ok(PathBuf::from(parent_directory.as_str()));
-                }
+    for provider in SKILL_PROVIDER_DEFINITIONS.iter() {
+        if !provider_skills_dir.ends_with(&provider.skills_path) {
+            continue;
+        }
+
+        let mut parent_directory = provider_skills_dir;
+        for _ in provider.skills_path.components() {
+            if let Some(parent) = parent_directory.parent() {
+                parent_directory = parent;
+            } else {
+                return Err(anyhow::anyhow!("Not a skill path: {}", path.display()));
             }
         }
+
+        if parent_directory.as_os_str().is_empty() {
+            return Err(anyhow::anyhow!("Not a skill path: {}", path.display()));
+        }
+
+        return Ok(parent_directory.to_path_buf());
     }
 
     Err(anyhow::anyhow!("Not a skill path: {}", path.display()))

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -212,6 +212,15 @@ fn extract_skill_parent_directory_different_providers() {
     }
 }
 
+#[cfg(target_os = "windows")]
+#[test]
+fn extract_skill_parent_directory_handles_mixed_windows_separators() {
+    let parent_directory = std::path::PathBuf::from(r"C:\repo");
+    let skill_path = std::path::PathBuf::from(r"C:\repo\.agents/skills/my-skill/SKILL.md");
+    let result = extract_skill_parent_directory(&skill_path);
+    assert_eq!(result.ok(), Some(parent_directory));
+}
+
 #[test]
 fn extract_skill_parent_directory_returns_none_for_non_skill() {
     let Some(home_dir) = dirs::home_dir() else {

--- a/app/src/ai/skills/resolve_skill_spec.rs
+++ b/app/src/ai/skills/resolve_skill_spec.rs
@@ -19,6 +19,7 @@ use ai::skills::{
 use command::blocking::Command;
 use command::r#async::Command as AsyncCommand;
 use warp_cli::skill::SkillSpec;
+use warp_core::{safe_debug, safe_info};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, SingletonEntity as _};
 
@@ -153,9 +154,12 @@ pub async fn clone_repo_for_skill(
     // Check if target already exists.
     if target_dir.exists() {
         if target_dir.join(".git").is_dir() {
-            log::info!(
-                "Target directory {} already exists and appears to be a git repo, skipping clone",
-                target_dir.display()
+            safe_info!(
+                safe: ("Target repo for skill resolution already exists, skipping clone"),
+                full: (
+                    "Target directory {} already exists and appears to be a git repo, skipping clone",
+                    target_dir.display()
+                )
             );
             return Ok(());
         }
@@ -170,11 +174,19 @@ pub async fn clone_repo_for_skill(
         });
     }
 
-    log::info!("Cloning {} into {}", repo_url, target_dir.display());
-    log::debug!(
-        "[GIT OPERATION] resolve_skill_spec.rs clone_repo_for_skill git clone {} {}",
-        repo_url,
-        target_dir.display()
+    safe_info!(
+        safe: ("Cloning repo for skill resolution"),
+        full: ("Cloning {} into {}", repo_url, target_dir.display())
+    );
+    safe_debug!(
+        safe: (
+            "[GIT OPERATION] resolve_skill_spec.rs clone_repo_for_skill git clone <repo-url> <target-dir>"
+        ),
+        full: (
+            "[GIT OPERATION] resolve_skill_spec.rs clone_repo_for_skill git clone {} {}",
+            repo_url,
+            target_dir.display()
+        )
     );
 
     let output = AsyncCommand::new("git")
@@ -199,7 +211,10 @@ pub async fn clone_repo_for_skill(
         });
     }
 
-    log::info!("Successfully cloned {org}/{repo}");
+    safe_info!(
+        safe: ("Successfully cloned repo for skill resolution"),
+        full: ("Successfully cloned {org}/{repo}")
+    );
     Ok(())
 }
 

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -17,6 +17,63 @@ use crate::settings::AISettings;
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
 
 // ============================================================================
+// Tests for explicit skill registration
+// ============================================================================
+
+#[test]
+fn handle_skills_added_registers_multiple_explicit_skills() {
+    let temp = TempDir::new().unwrap();
+    let repo = dunce::canonicalize(temp.path()).unwrap().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+
+    let primary_path = repo.join(".agents/skills/primary/SKILL.md");
+    let helper_path = repo.join(".agents/skills/helper/SKILL.md");
+    let skills = vec![
+        ParsedSkill {
+            name: "primary".to_string(),
+            description: "Primary skill".to_string(),
+            path: primary_path.clone(),
+            content: "# Primary".to_string(),
+            line_range: None,
+            provider: SkillProvider::Agents,
+            scope: SkillScope::Project,
+        },
+        ParsedSkill {
+            name: "helper".to_string(),
+            description: "Helper skill".to_string(),
+            path: helper_path.clone(),
+            content: "# Helper".to_string(),
+            line_range: None,
+            provider: SkillProvider::Agents,
+            scope: SkillScope::Project,
+        },
+    ];
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
+        app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        let skill_manager_handle = app.add_singleton_model(SkillManager::new);
+
+        skill_manager_handle.update(&mut app, |manager, _ctx| {
+            manager.handle_skills_added(skills);
+        });
+
+        let registered_paths = skill_manager_handle.read(&app, |manager, _ctx| {
+            (
+                manager.skill_paths_by_name("primary"),
+                manager.skill_paths_by_name("helper"),
+            )
+        });
+
+        assert_eq!(registered_paths.0, vec![primary_path]);
+        assert_eq!(registered_paths.1, vec![helper_path]);
+    });
+}
+
+// ============================================================================
 // Tests for get_skills_for_working_directory subdirectory scoping
 // ============================================================================
 

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 
+use crate::SortOrderArg;
 use crate::config_file::ConfigFileArgs;
 use crate::environment::EnvironmentCreateArgs;
 use crate::json_filter::JsonOutput;
@@ -12,7 +13,6 @@ use crate::model::ModelArgs;
 use crate::scope::ObjectScope;
 use crate::share::ShareArgs;
 use crate::skill::SkillSpec;
-use crate::SortOrderArg;
 
 /// Output format for agent results.
 #[derive(Debug, Copy, Clone, ValueEnum, Eq, PartialEq, Default)]

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 
-use crate::SortOrderArg;
 use crate::config_file::ConfigFileArgs;
 use crate::environment::EnvironmentCreateArgs;
 use crate::json_filter::JsonOutput;
@@ -13,6 +12,7 @@ use crate::model::ModelArgs;
 use crate::scope::ObjectScope;
 use crate::share::ShareArgs;
 use crate::skill::SkillSpec;
+use crate::SortOrderArg;
 
 /// Output format for agent results.
 #[derive(Debug, Copy, Clone, ValueEnum, Eq, PartialEq, Default)]
@@ -283,11 +283,12 @@ pub struct RunAgentArgs {
     /// If a repo is specified, searches only that repo. If org is also specified,
     /// validates the repo's git remote matches the expected org.
     ///
-    /// When used with --prompt, the skill provides the base context and the prompt is the task.
+    /// When used with --prompt, the first skill provides the base context and the prompt is the task.
+    /// Repeat this flag to make additional skills available to the agent.
     ///
     /// To automate a skill on a schedule, use `oz schedule create --skill <SKILL>`.
     #[arg(long = "skill", value_name = "SKILL")]
-    pub skill: Option<SkillSpec>,
+    pub skill: Vec<SkillSpec>,
 
     /// Name for this agent task.
     #[arg(long = "name", short = 'n')]
@@ -388,6 +389,11 @@ impl RunAgentArgs {
         let mut specs = self.mcp_specs.clone();
         specs.extend(self.mcp_servers.iter().cloned().map(MCPSpec::Uuid));
         specs
+    }
+
+    /// Return the first `--skill` value, which is the skill invoked for this run.
+    pub fn invoked_skill(&self) -> Option<&SkillSpec> {
+        self.skill.first()
     }
 }
 

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -446,7 +446,7 @@ fn agent_run_accepts_prompt_only() {
 
     assert_eq!(run_args.prompt_arg.prompt.as_deref(), Some("hello"));
     assert!(run_args.prompt_arg.saved_prompt.is_none());
-    assert!(run_args.skill.is_none());
+    assert!(run_args.skill.is_empty());
     assert!(run_args.task_id.is_none());
 }
 
@@ -463,7 +463,7 @@ fn agent_run_accepts_saved_prompt_only() {
 
     assert!(run_args.prompt_arg.prompt.is_none());
     assert_eq!(run_args.prompt_arg.saved_prompt.as_deref(), Some("sp-123"));
-    assert!(run_args.skill.is_none());
+    assert!(run_args.skill.is_empty());
     assert!(run_args.task_id.is_none());
 }
 
@@ -479,8 +479,44 @@ fn agent_run_accepts_skill_only() {
     };
 
     assert!(run_args.prompt_arg.prompt.is_none());
-    assert!(run_args.skill.is_some());
+    assert_eq!(run_args.skill.len(), 1);
+    assert_eq!(
+        run_args.invoked_skill().unwrap().skill_identifier,
+        "my-skill"
+    );
     assert!(run_args.task_id.is_none());
+}
+
+#[test]
+fn agent_run_accepts_multiple_skills() {
+    let args = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run",
+        "--skill",
+        "primary",
+        "--skill",
+        "repo:helper",
+        "--prompt",
+        "do stuff",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp agent run` command");
+    };
+    let CliCommand::Agent(AgentCommand::Run(run_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp agent run` command");
+    };
+
+    assert_eq!(run_args.skill.len(), 2);
+    assert_eq!(run_args.skill[0].skill_identifier, "primary");
+    assert_eq!(run_args.skill[1].repo.as_deref(), Some("repo"));
+    assert_eq!(run_args.skill[1].skill_identifier, "helper");
+    assert_eq!(
+        run_args.invoked_skill().unwrap().skill_identifier,
+        "primary"
+    );
 }
 
 #[test]
@@ -495,7 +531,7 @@ fn agent_run_accepts_task_id_only() {
     };
 
     assert!(run_args.prompt_arg.prompt.is_none());
-    assert!(run_args.skill.is_none());
+    assert!(run_args.skill.is_empty());
     assert_eq!(run_args.task_id.as_deref(), Some("tid-456"));
 }
 
@@ -514,7 +550,7 @@ fn agent_run_accepts_prompt_and_skill() {
     };
 
     assert_eq!(run_args.prompt_arg.prompt.as_deref(), Some("do stuff"));
-    assert!(run_args.skill.is_some());
+    assert_eq!(run_args.skill.len(), 1);
 }
 
 #[test]
@@ -538,7 +574,7 @@ fn agent_run_accepts_saved_prompt_and_skill() {
     };
 
     assert_eq!(run_args.prompt_arg.saved_prompt.as_deref(), Some("sp-1"));
-    assert!(run_args.skill.is_some());
+    assert_eq!(run_args.skill.len(), 1);
 }
 
 #[test]
@@ -590,7 +626,7 @@ fn agent_run_accepts_skill_and_task_id() {
     };
 
     assert!(run_args.prompt_arg.prompt.is_none());
-    assert!(run_args.skill.is_some());
+    assert_eq!(run_args.skill.len(), 1);
     assert_eq!(run_args.task_id.as_deref(), Some("tid-1"));
 }
 

--- a/specs/repeatable-oz-agent-run-skill/PRODUCT.md
+++ b/specs/repeatable-oz-agent-run-skill/PRODUCT.md
@@ -1,0 +1,45 @@
+# Repeatable `oz agent run --skill` Product Spec
+## Summary
+`oz agent run --skill <SPEC>` should accept the flag multiple times. Each provided skill should be resolved with the same behavior as the existing single-skill flag, and every resolved skill should be available to the running Oz agent through the normal skill system. Only the first skill should be treated as the invoked skill for the run.
+## Problem
+Today, users can provide one `--skill` to set the initial skill instructions for an Oz agent run. Some workflows need one primary invoked skill plus additional skills available for the agent to read later. Users currently cannot express that directly in a single command without relying on environment-wide skill discovery or modifying prompts manually.
+## Goals
+- Allow multiple `--skill <SPEC>` flags on `oz agent run`.
+- Resolve every provided skill using the same lookup, qualification, cloning, and error behavior that the single flag already uses.
+- Make every resolved skill available in the run's `SkillsManager`.
+- Submit only the first resolved skill as the invoked skill.
+- Preserve existing behavior for commands that provide zero or one `--skill`.
+## Non-goals
+- Changing `oz agent run-cloud --skill` behavior.
+- Changing skill resolution precedence or accepted skill spec formats.
+- Combining multiple skill instruction bodies into the initial prompt.
+- Changing the skill file format or the displayed skill-invoked output.
+## Figma / design references
+Figma: none provided.
+## User Experience
+1. A user can run `oz agent run --skill primary --skill helper --prompt "Do the task"`.
+2. The command parser accepts repeated `--skill` flags and preserves their order.
+3. The first skill in the command is the invoked skill. Its instructions are used exactly where the previous single `--skill` instructions were used:
+   - as the base prompt for a local prompt run,
+   - as the skill-only prompt for a skill-only run,
+   - as the server-side attached skill for a `--task-id` run.
+4. Additional skills are not treated as invoked skills. They do not replace the run name, base prompt, task creation prompt, server-side attached skill, or skill-invoked output.
+5. Every provided skill spec is resolved before the run starts. If any skill fails to resolve, the command fails with the same style of error the single-skill path already reports.
+6. Each resolved skill is registered with the run's `SkillsManager` so it is available through the agent's normal skill-listing and read-skill behavior.
+7. Skill resolution order is deterministic and follows the CLI order. The first successfully resolved skill remains the invoked skill even when later skills have different names, providers, or qualified repo specs.
+8. Existing commands with a single `--skill` keep their current behavior and output.
+9. Existing commands without `--skill` keep their current prompt validation behavior.
+## Success Criteria
+1. `oz agent run --skill a --skill b --prompt "..."` parses successfully.
+2. All provided skill specs are resolved using the existing resolver.
+3. All resolved skills are inserted into `SkillsManager`.
+4. Only the first resolved skill is passed into the existing invoked-skill path.
+5. Single-skill and no-skill command behavior remains unchanged.
+6. Tests cover parser order, multi-skill resolution, `SkillsManager` population, and first-skill-only invoked behavior.
+## Validation
+- Add CLI parsing coverage for repeated `--skill` preserving order.
+- Add Rust unit coverage around resolving multiple skills from disk and registering all of them with `SkillsManager`.
+- Add or update task/config tests so only the first skill contributes invoked-skill configuration.
+- Run targeted Rust tests for `warp_cli` and the touched agent SDK modules.
+## Open questions
+- None.

--- a/specs/repeatable-oz-agent-run-skill/TECH.md
+++ b/specs/repeatable-oz-agent-run-skill/TECH.md
@@ -1,0 +1,56 @@
+# Repeatable `oz agent run --skill` Technical Spec
+## Problem
+`RunAgentArgs` currently stores `--skill` as `Option<SkillSpec>`, and the local agent setup resolves at most one skill before building the task. The implementation must preserve that first skill as the invoked skill while still resolving and registering every repeated skill so the Oz harness sees them in the normal `SkillsManager` context.
+## Relevant code
+- `crates/warp_cli/src/agent.rs:260` - `RunAgentArgs.skill` defines the local `oz agent run --skill` CLI field.
+- `crates/warp_cli/src/lib_tests.rs:397` - parser tests lock in accepted prompt/skill combinations.
+- `app/src/ai/agent_sdk/mod.rs:230` - feature-gate handling rejects `--skill` when Oz platform skills are disabled.
+- `app/src/ai/agent_sdk/mod.rs:329` - `build_merged_config_and_task` consumes the resolved invoked skill.
+- `app/src/ai/agent_sdk/mod.rs:741` - `AgentDriverRunner::resolve_skill` resolves the single CLI skill.
+- `app/src/ai/agent_sdk/mod.rs:811` - `build_driver_options_and_task` resolves skill before task/config construction.
+- `app/src/ai/skills/resolve_skill_spec.rs:132` - existing resolver implements skill spec lookup behavior.
+- `app/src/ai/skills/skill_manager.rs:372` - `SkillManager::handle_skills_added` registers parsed skills by path and name.
+- `app/src/ai/agent_sdk/driver_tests.rs:580` - existing skill-loading tests verify `SkillsManager` contents.
+## Current state
+The parser accepts only one local `--skill` because `RunAgentArgs.skill` is an `Option<SkillSpec>`. Agent setup clones sandboxed fully qualified skill repos only for that one spec, resolves it with `resolve_skill_spec`, and passes the resulting `Option<ResolvedSkill>` into config/task construction. Environment and global skills are loaded later in `AgentDriver::run_internal`, but the explicitly invoked skill is not explicitly added to `SkillsManager` by the setup path.
+## Proposed changes
+1. Change only local `RunAgentArgs.skill` to `Vec<SkillSpec>` with append semantics. Leave `RunCloudArgs.skill` as `Option<SkillSpec>` because repeatable behavior is scoped to `oz agent run`.
+2. Update local prompt-group, feature-gate, and prompt-source checks from `is_some()` to `!is_empty()`.
+3. Add a helper on `RunAgentArgs` such as `invoked_skill(&self) -> Option<&SkillSpec>` to centralize first-skill selection. Use it anywhere the code needs the historical single-skill behavior, including task creation prompt text.
+4. Replace `AgentDriverRunner::resolve_skill` with a multi-skill resolver that:
+   - returns `Vec<ResolvedSkill>`,
+   - iterates `args.skill` in CLI order,
+   - applies the same sandboxed `org/repo` clone rule before resolving each skill,
+   - calls `resolve_skill_spec` for each spec with the same working directory and error formatting.
+5. Add all resolved skills to `SkillsManager` after resolution and before task construction. This should call `SkillManager::handle_skills_added` with the resolved skills' `parsed_skill` values. The manager's path/name maps already deduplicate by path, so repeated registration is safe.
+6. Continue passing only `resolved_skills.first().cloned()` into `build_merged_config_and_task` and `build_server_side_task`. Those functions should not concatenate multiple skill instruction bodies.
+7. Update CLI tests and add focused app-unit coverage. Prefer small helper tests over end-to-end UI tests where possible.
+## End-to-end flow
+1. Clap parses repeated `--skill` values into `RunAgentArgs.skill` in command-line order.
+2. Local agent setup canonicalizes the working directory.
+3. Setup resolves each skill spec in order, cloning qualified sandboxed repos when needed.
+4. Setup registers every resolved parsed skill with `SkillsManager`.
+5. Setup selects the first resolved skill as `invoked_skill`.
+6. Existing config/task construction uses `invoked_skill` exactly like the old single resolved skill.
+7. `AgentDriver::run_internal` starts the Oz harness with the invoked skill prompt and a `SkillsManager` that also includes any additional resolved skills.
+## Risks and mitigations
+- Risk: secondary skills accidentally change the prompt or run name.
+  - Mitigation: keep existing config/task functions single-skill and pass only the first resolved skill.
+- Risk: feature-gate checks accidentally allow hidden `--skill` usage.
+  - Mitigation: update all local checks to use `!args.skill.is_empty()`.
+- Risk: resolving the same repo-qualified skill multiple times clones redundantly.
+  - Mitigation: existing `clone_repo_for_skill` skips targets that already exist as git repos; no new clone cache is needed.
+- Risk: third-party harness behavior changes unexpectedly.
+  - Mitigation: this change only impacts local `RunAgentArgs`; `run-cloud` remains unchanged, and existing Oz-only skill loading gates stay in place.
+## Testing and validation
+- `crates/warp_cli/src/lib_tests.rs`: assert repeated `--skill` parses in order.
+- `app/src/ai/agent_sdk/mod.rs` or adjacent tests: verify helper behavior selects only the first skill for invoked-skill code paths.
+- `app/src/ai/agent_sdk/driver_tests.rs`: verify registering resolved CLI skills inserts all parsed skills into `SkillsManager`.
+- Run:
+  - `cargo nextest run -p warp_cli agent_run_accepts_multiple_skills`
+  - `cargo nextest run -p warp <targeted skill/agent SDK tests>`
+  - `cargo fmt`
+## Follow-ups
+- Consider whether `oz agent run-cloud --skill` should become repeatable separately if cloud task creation needs the same primary-plus-supporting-skill behavior.
+## Parallelization
+Parallel sub-agents are not proposed. The parser, resolver, config, and tests are tightly coupled and fit in a small local change; splitting the work would add merge overhead without reducing meaningful wall-clock time.


### PR DESCRIPTION
## Summary

This makes the `--skill` flag on `oz agent run` repeatable. We'll use this to fully support multiple run-attached skills. All requested skills are resolved and registered with `SkillsManager`. However, only the _first_ skill is treated as the invoked skill.

In combination with warpdotdev/warp-server#11252, we'll correctly prioritize all attached skills for a given run.

While testing this, I fixed local handling of skill invocation with a prompt. We'll now use an `InvokeSkill` message, instead concatenating the skill and prompt client-side.

## Testing

- Ran `cargo fmt --manifest-path /Users/ben/src/warp/Cargo.toml --all`.
- Ran focused tests:
  - `cargo nextest run --manifest-path /Users/ben/src/warp/Cargo.toml -p warp handle_skills_added_registers_multiple_explicit_skills cloud_environment_skills_always_included`
  - Result: 2 passed.
- Ran targeted clippy:
  - `cargo clippy --manifest-path /Users/ben/src/warp/Cargo.toml -p warp --lib -- -D warnings`
  - Result: passed.
- Manually tested repeatable `--skill` with `./script/run` using real sandboxed skills.
  - Confirmed same-repo skills only clone once.
  - Confirmed cross-repo skills clone both repos.
  - Confirmed that the agent reports both skills in context.

Example output from a test run:

```sh
$ ./script/run -- agent run --cwd work --skill warpdotdev/common-skills:resolve-merge-conflicts --skill warpdotdev/oz-for-oss:bootstrap-issue-config --skill warpdotdev/oz-for-oss:verify-pr --prompt "Please confirm that you have access to verify-pr, bootstrap-issue-config, and resolve-merge-conflicts skills" --sandboxed
...
Run ID: 019e418c-759e-7b29-b0d4-99e91fba4cad
Open in Oz: https://oz.staging.warp.dev/runs/019e418c-759e-7b29-b0d4-99e91fba4cad

New conversation started with debug ID: e79169fe-8a9b-4577-8fb2-6905e1c8b70d

I can confirm that I have access to all three skills you mentioned:

1. **resolve-merge-conflicts** - Available at multiple paths including `/Users/ben/src/warp-internal/.agents/skills/resolve-merge-conflicts/SKILL.md`, `/Users/ben/src/warp/work/common-skills/.agents/skills/resolve-merge-conflicts/SKILL.md`, and `/Users/ben/.agents/skills/resolve-merge-conflicts/SKILL.md`

2. **bootstrap-issue-config** - Available at `/Users/ben/src/warp/work/oz-for-oss/.agents/skills/bootstrap-issue-config/SKILL.md`

3. **verify-pr** - Available at `/Users/ben/src/warp/work/oz-for-oss/.agents/skills/verify-pr/SKILL.md`

All three skills are in the curated skills list and ready to use. How would you like me to proceed with these skills?
```

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/859faac9-88c6-4cd1-b33e-a37f3efe44fd_
_Run: https://oz.staging.warp.dev/runs/019e34e0-eae3-7f3a-b66c-ca1e13e3c6f5_
_This PR was generated with [Oz](https://warp.dev/oz)._
