### PR TITLE
fix: keep cloud handoff details panel closed

### DIFF
--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -200,6 +200,11 @@ impl TerminalView {
                     event,
                     AmbientAgentViewModelEvent::ExecutionSessionReady { .. }
                 ) {
+                    if self.pending_cloud_followup_task_id.is_some()
+                        && !self.is_conversation_details_panel_open
+                    {
+                        self.suppress_initial_conversation_details_panel_auto_open();
+                    }
                     self.pending_cloud_followup_task_id = None;
                     self.remove_conversation_ended_tombstone(ctx);
                 }

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -185,9 +185,6 @@ impl TerminalView {
         task_id: AmbientAgentTaskId,
         ctx: &mut ViewContext<Self>,
     ) {
-        if !self.is_conversation_details_panel_open {
-            self.suppress_initial_conversation_details_panel_auto_open();
-        }
         self.pending_cloud_followup_task_id = Some(task_id);
         self.input.update(ctx, |input, ctx| {
             input.reset_after_cloud_followup_submission(ctx);

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -185,6 +185,9 @@ impl TerminalView {
         task_id: AmbientAgentTaskId,
         ctx: &mut ViewContext<Self>,
     ) {
+        if !self.is_conversation_details_panel_open {
+            self.suppress_initial_conversation_details_panel_auto_open();
+        }
         self.pending_cloud_followup_task_id = Some(task_id);
         self.input.update(ctx, |input, ctx| {
             input.reset_after_cloud_followup_submission(ctx);

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -887,6 +887,70 @@ fn test_cloud_cloud_handoff_session_join_keeps_closed_details_panel_hidden() {
         });
     });
 }
+
+#[test]
+fn test_cloud_cloud_handoff_session_join_respects_details_panel_closed_after_followup_input() {
+    let _cloud_mode_flag = FeatureFlag::CloudMode.override_enabled(true);
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+        let firebase_uid = UserUid::new("mock_firebase_uid");
+
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+
+            view.is_conversation_details_panel_open = true;
+            view.fetch_and_update_conversation_details_panel(ctx);
+            assert!(view.is_conversation_details_panel_open);
+
+            view.enable_cloud_followup_input(task_id, ctx);
+            view.handle_action(&TerminalAction::ToggleConversationDetailsPanel, ctx);
+            assert!(!view.is_conversation_details_panel_open);
+            assert!(!view.has_auto_opened_conversation_details_panel);
+
+            view.handle_ambient_agent_event(
+                &crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent::ExecutionSessionReady {
+                    session_id: SessionId::new(),
+                },
+                ctx,
+            );
+
+            view.model
+                .lock()
+                .set_shared_session_status(SharedSessionStatus::ViewPending);
+            view.on_session_share_joined(
+                ParticipantId::new(),
+                firebase_uid,
+                ReplicaId::random(),
+                Box::new(ParticipantList::default()),
+                SessionId::new(),
+                SessionSourceType::AmbientAgent {
+                    task_id: Some(task_id.to_string()),
+                },
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(!view.is_conversation_details_panel_open);
+            assert!(view.has_auto_opened_conversation_details_panel);
+        });
+    });
+}
 #[test]
 fn test_restored_ambient_view_resolves_cta_from_view_model_task_id() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -830,6 +830,64 @@ fn test_local_to_cloud_handoff_session_join_keeps_details_panel_hidden() {
 }
 
 #[test]
+fn test_cloud_cloud_handoff_session_join_keeps_closed_details_panel_hidden() {
+    let _cloud_mode_flag = FeatureFlag::CloudMode.override_enabled(true);
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+        let firebase_uid = UserUid::new("mock_firebase_uid");
+
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+
+            assert!(!view.is_conversation_details_panel_open);
+            assert!(!view.has_auto_opened_conversation_details_panel);
+
+            view.enable_cloud_followup_input(task_id, ctx);
+            view.handle_ambient_agent_event(
+                &crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent::ExecutionSessionReady {
+                    session_id: SessionId::new(),
+                },
+                ctx,
+            );
+
+            view.model
+                .lock()
+                .set_shared_session_status(SharedSessionStatus::ViewPending);
+            view.on_session_share_joined(
+                ParticipantId::new(),
+                firebase_uid,
+                ReplicaId::random(),
+                Box::new(ParticipantList::default()),
+                SessionId::new(),
+                SessionSourceType::AmbientAgent {
+                    task_id: Some(task_id.to_string()),
+                },
+                ctx,
+            );
+        });
+
+        terminal.read(&app, |view, _| {
+            assert!(!view.is_conversation_details_panel_open);
+            assert!(view.has_auto_opened_conversation_details_panel);
+        });
+    });
+}
+#[test]
 fn test_restored_ambient_view_resolves_cta_from_view_model_task_id() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);


### PR DESCRIPTION
## Summary
- Suppress the one-shot conversation details auto-open when starting a cloud-cloud follow-up from a closed panel
- Add a regression test covering `ExecutionSessionReady` followed by the ambient shared-session join
- Leave the local-to-cloud review-comment path unchanged

## Testing
- `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp -E 'test(test_cloud_cloud_handoff_session_join_keeps_closed_details_panel_hidden) | test(test_ambient_session_join_auto_opens_details_panel) | test(test_local_to_cloud_handoff_session_join_keeps_details_panel_hidden)' -j 1`
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all -- --check`

## Demo

https://www.loom.com/share/405ec6f6cdfc4512973a98e3673aaa6c

_Conversation: https://staging.warp.dev/conversation/9ab9bdaa-5438-4d6f-a3a4-37884c27f7cf_
_Run: https://oz.staging.warp.dev/runs/019e3691-7fb5-7e0d-824f-9ccc5dfc55ef_
_Plans_:
- _[Prevent details sidepanel auto-open during handoff transitions](https://staging.warp.dev/drive/notebook/syIaC03HSlGqKyVLahh6Tq)_
_This PR was generated with [Oz](https://warp.dev/oz)._
