### PR TITLE
Fix Mermaid SVG text rendering on WASM

### DIFF
--- a/crates/warpui_core/src/image_cache.rs
+++ b/crates/warpui_core/src/image_cache.rs
@@ -32,8 +32,16 @@ const MIN_REFRESH_DELAY_MS: u32 = 50;
 static SVG_FONT_DB: LazyLock<Arc<usvg::fontdb::Database>> = LazyLock::new(|| {
     let mut fontdb = usvg::fontdb::Database::new();
     fontdb.load_system_fonts();
+    load_svg_fallback_fonts(&mut fontdb);
     Arc::new(fontdb)
 });
+
+fn load_svg_fallback_fonts(fontdb: &mut usvg::fontdb::Database) {
+    fontdb.load_font_data(
+        include_bytes!("../../../app/assets/bundled/fonts/roboto/Roboto-Regular.ttf").to_vec(),
+    );
+    fontdb.set_sans_serif_family("Roboto");
+}
 
 pub fn prewarm_svg_font_db() {
     LazyLock::force(&SVG_FONT_DB);

--- a/crates/warpui_core/src/image_cache_tests.rs
+++ b/crates/warpui_core/src/image_cache_tests.rs
@@ -401,6 +401,43 @@ fn test_svg_text_rasterizes_with_loaded_system_fonts() {
 }
 
 #[test]
+fn test_svg_text_rasterizes_with_bundled_sans_serif_fallback() {
+    let image_type = ImageType::try_from_bytes(
+        br##"<svg width="160" height="40" viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg">
+  <text x="10" y="24" font-family="sans-serif" font-size="20" fill="#000000">Warp</text>
+</svg>
+"##,
+    )
+    .expect("SVG should parse");
+    let ImageType::Svg { svg } = &image_type else {
+        panic!("Expected SVG image type");
+    };
+
+    assert!(svg.fontdb().faces().any(|face| {
+        face.families
+            .iter()
+            .any(|(family, _)| family.as_str() == "Roboto")
+    }));
+
+    let image = image_type
+        .to_image(
+            Vector2I::new(160, 40),
+            FitType::Contain,
+            true,
+            AnimatedImageBehavior::FullAnimation,
+        )
+        .expect("SVG should rasterize");
+    let Image::Static(image) = image else {
+        panic!("Expected static image");
+    };
+
+    assert!(image
+        .rgba_bytes()
+        .chunks_exact(4)
+        .any(|pixel| pixel[3] != 0));
+}
+
+#[test]
 fn test_evict_image_drops_arc_for_resized_bysize() {
     let asset_cache = new_asset_cache();
     let image_cache = ImageCache::new();


### PR DESCRIPTION
## Description
Fix Mermaid SVG text rendering in Warp on Web by loading Warp's bundled Roboto font into the SVG rasterizer font database and using it as the generic `sans-serif` fallback. This makes SVG `<text>` nodes render even when the WASM environment has no system fonts available to `resvg`/`usvg`.

This also adds a regression test that verifies SVG text using `font-family="sans-serif"` rasterizes with the bundled fallback font.

Conversation: https://staging.warp.dev/conversation/dec72e18-18e8-437d-ae6b-fbe19337bfc2
Plan: https://staging.warp.dev/drive/notebook/7fwDiOj3BG8HN1xpuHBH0M

<img width="1372" height="859" alt="Screenshot 2026-05-17 at 10 58 42 AM" src="https://github.com/user-attachments/assets/ad563679-4749-4b1c-ba3f-d656dfa40d1e" />

<img width="992" height="815" alt="Screenshot 2026-05-17 at 11 25 23 AM" src="https://github.com/user-attachments/assets/01ba05f1-0063-493e-9552-5ee23493ea04" />

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] `cargo nextest run --no-fail-fast --workspace test_svg_text_rasterizes_with_bundled_sans_serif_fallback`
- [x] `./script/wasm/bundle --debug --check-only`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Mermaid diagram text not rendering in Warp on Web.

Co-Authored-By: Oz <oz-agent@warp.dev>
