### PR TITLE
fix: enable cloud continuation from WASM tombstones

### DIFF
--- a/app/src/ai/agent_management/telemetry.rs
+++ b/app/src/ai/agent_management/telemetry.rs
@@ -109,7 +109,6 @@ pub enum AgentManagementTelemetryEvent {
     #[cfg(not(target_family = "wasm"))]
     TombstoneContinueLocally,
     /// User clicked "Continue" in the tombstone to start a cloud follow-up.
-    #[cfg(not(target_family = "wasm"))]
     TombstoneContinueInCloud { task_id: String },
     /// User clicked "Continue locally" in the details panel
     #[cfg(not(target_family = "wasm"))]
@@ -196,7 +195,6 @@ impl TelemetryEvent for AgentManagementTelemetryEvent {
             }
             #[cfg(not(target_family = "wasm"))]
             AgentManagementTelemetryEvent::TombstoneContinueLocally => None,
-            #[cfg(not(target_family = "wasm"))]
             AgentManagementTelemetryEvent::TombstoneContinueInCloud { task_id } => Some(json!({
                 "task_id": task_id,
             })),
@@ -254,7 +252,6 @@ impl TelemetryEventDesc for AgentManagementTelemetryEventDiscriminants {
             Self::TombstoneArtifactClicked => "AgentManagement.TombstoneArtifactClicked",
             #[cfg(not(target_family = "wasm"))]
             Self::TombstoneContinueLocally => "AgentManagement.TombstoneContinueLocally",
-            #[cfg(not(target_family = "wasm"))]
             Self::TombstoneContinueInCloud => "AgentManagement.TombstoneContinueInCloud",
             #[cfg(not(target_family = "wasm"))]
             Self::DetailsPanelContinueLocally => "AgentManagement.DetailsPanelContinueLocally",
@@ -290,7 +287,6 @@ impl TelemetryEventDesc for AgentManagementTelemetryEventDiscriminants {
             Self::TombstoneArtifactClicked => "User clicked an artifact in the tombstone view",
             #[cfg(not(target_family = "wasm"))]
             Self::TombstoneContinueLocally => "User clicked Continue locally in the tombstone",
-            #[cfg(not(target_family = "wasm"))]
             Self::TombstoneContinueInCloud => {
                 "User clicked Continue in the tombstone to start a cloud follow-up"
             }

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -5654,6 +5654,16 @@ impl PaneGroup {
         task_id: AmbientAgentTaskId,
         ctx: &mut ViewContext<Self>,
     ) {
+        // URL-loaded conversation transcripts (e.g. Warp-on-Web deep links)
+        // restore from conversation data before the ambient task cache is
+        // guaranteed to contain this task. Native continuation usually reaches
+        // this path after task-backed navigation, but the restored cloud-mode
+        // pane still needs task ownership/harness data to resolve the correct
+        // inline follow-up or tombstone CTA. Request the task and let
+        // TerminalView's TasksUpdated subscription re-resolve once it arrives.
+        AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+            model.get_or_async_fetch_task_data(&task_id, ctx);
+        });
         let mut conversation_id = None;
         terminal_view.update(ctx, |view, ctx| {
             // The cloud-mode terminal model starts with

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7207,20 +7207,33 @@ impl TerminalView {
         &mut self,
         ctx: &mut ViewContext<Self>,
     ) {
-        if !FeatureFlag::CloudModeSetupV2.is_enabled()
-            || self.conversation_ended_tombstone_view_id.is_some()
-        {
+        if !FeatureFlag::CloudModeSetupV2.is_enabled() {
             return;
         }
 
-        let task_id = {
+        let (task_id, is_active_shared_session, is_finished_viewer) = {
             let model = self.model.lock();
-            if !model.is_shared_ambient_agent_session()
-                || model.is_receiving_agent_conversation_replay()
-            {
+            if model.is_receiving_agent_conversation_replay() {
                 return;
             }
-            model.ambient_agent_task_id()
+
+            let status = model.shared_session_status();
+            // This method also handles restored cloud-mode panes that rendered
+            // a conservative tombstone before task data arrived. When the task
+            // cache updates, either the existing tombstone or FinishedViewer
+            // status tells us to re-resolve the CTA/input state.
+            let should_update = model.is_shared_ambient_agent_session()
+                || self.conversation_ended_tombstone_view_id.is_some()
+                || status.is_finished_viewer();
+            if !should_update {
+                return;
+            }
+
+            (
+                self.ambient_agent_task_id_for_details_panel_from_model(&model, ctx),
+                status.is_active_viewer() || status.is_active_sharer(),
+                status.is_finished_viewer(),
+            )
         };
 
         let Some(task_id) = task_id else {
@@ -7230,16 +7243,12 @@ impl TerminalView {
             return;
         };
 
-        if !task.is_no_longer_running() || self.pending_cloud_followup_task_id == Some(task_id) {
+        if !task.is_no_longer_running() || self.pending_cloud_followup_task_id.is_some() {
             return;
         }
 
         if FeatureFlag::HandoffCloudCloud.is_enabled() {
-            let has_live_shared_session = {
-                let status = self.model.lock().shared_session_status().clone();
-                status.is_active_viewer() || status.is_active_sharer()
-            };
-            if has_live_shared_session {
+            if is_active_shared_session {
                 return;
             }
             let Some(state) = self.cloud_conversation_continuation_ui_state(ctx) else {
@@ -7250,7 +7259,11 @@ impl TerminalView {
                     self.insert_conversation_ended_tombstone_with_cta(cta, ctx);
                 }
                 CloudConversationContinuationUiState::FollowupInput => {
-                    self.enable_cloud_followup_input(task_id, ctx);
+                    if self.conversation_ended_tombstone_view_id.is_some() || is_finished_viewer {
+                        self.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
+                    } else {
+                        self.enable_cloud_followup_input(task_id, ctx);
+                    }
                 }
             }
         } else {

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -54,7 +54,6 @@ struct TombstoneDisplayData {
 
 #[derive(Debug, Clone)]
 pub enum ConversationEndedTombstoneEvent {
-    #[cfg(not(target_family = "wasm"))]
     ContinueInCloud { task_id: AmbientAgentTaskId },
 }
 
@@ -157,7 +156,6 @@ impl TombstoneDisplayData {
 pub struct ConversationEndedTombstoneView {
     display_data: TombstoneDisplayData,
     artifact_buttons_view: ViewHandle<ArtifactButtonsRow>,
-    #[cfg(not(target_family = "wasm"))]
     continue_in_cloud_button: Option<ViewHandle<ActionButton>>,
     #[cfg(not(target_family = "wasm"))]
     continue_locally_button: Option<ViewHandle<ActionButton>>,
@@ -196,7 +194,6 @@ impl ConversationEndedTombstoneView {
 
         let artifact_buttons_view =
             ctx.add_typed_action_view(|ctx| ArtifactButtonsRow::new(&display_data.artifacts, ctx));
-        #[cfg(not(target_family = "wasm"))]
         let continue_in_cloud_button = match tombstone_cta {
             Some(TombstoneCta::ContinueInCloud { task_id }) => {
                 Some(ctx.add_typed_action_view(move |_| {
@@ -231,22 +228,26 @@ impl ConversationEndedTombstoneView {
         // In wasm, continuing locally is impossible so we instead
         // offer to open the conversation in warp (where you can continue locally).
         #[cfg(target_family = "wasm")]
-        let open_in_warp_button = conversation_id.map(|conv_id| {
-            ctx.add_typed_action_view(move |_| {
-                ActionButton::new("Open in Warp", PrimaryTheme)
-                    .with_tooltip("Open this conversation in the Warp desktop app")
-                    .on_click(move |ctx| {
-                        ctx.dispatch_typed_action(ConversationEndedTombstoneAction::OpenInWarp(
-                            conv_id,
-                        ));
+        let open_in_warp_button =
+            if matches!(tombstone_cta, Some(TombstoneCta::ContinueInCloud { .. })) {
+                None
+            } else {
+                conversation_id.map(|conv_id| {
+                    ctx.add_typed_action_view(move |_| {
+                        ActionButton::new("Open in Warp", PrimaryTheme)
+                            .with_tooltip("Open this conversation in the Warp desktop app")
+                            .on_click(move |ctx| {
+                                ctx.dispatch_typed_action(
+                                    ConversationEndedTombstoneAction::OpenInWarp(conv_id),
+                                );
+                            })
                     })
-            })
-        });
+                })
+            };
 
         let view = Self {
             display_data,
             artifact_buttons_view,
-            #[cfg(not(target_family = "wasm"))]
             continue_in_cloud_button,
             #[cfg(not(target_family = "wasm"))]
             continue_locally_button,
@@ -486,14 +487,14 @@ impl ConversationEndedTombstoneView {
 
         let mut has_button = false;
 
-        #[cfg(not(target_family = "wasm"))]
-        {
-            let is_any_ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
-            if is_any_ai_enabled {
-                if let Some(continue_in_cloud_button) = &self.continue_in_cloud_button {
-                    row.add_child(ChildView::new(continue_in_cloud_button).finish());
-                    has_button = true;
-                }
+        let is_any_ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
+        if is_any_ai_enabled {
+            if let Some(continue_in_cloud_button) = &self.continue_in_cloud_button {
+                row.add_child(ChildView::new(continue_in_cloud_button).finish());
+                has_button = true;
+            }
+            #[cfg(not(target_family = "wasm"))]
+            {
                 if let Some(continue_locally_button) = &self.continue_locally_button {
                     row.add_child(ChildView::new(continue_locally_button).finish());
                     has_button = true;
@@ -538,15 +539,15 @@ impl ConversationEndedTombstoneView {
         self.continue_locally_button.is_some()
     }
 
-    #[cfg(not(target_family = "wasm"))]
     pub(in crate::terminal::view) fn has_continue_in_cloud_button_for_test(&self) -> bool {
         self.continue_in_cloud_button.is_some()
     }
 }
 #[derive(Debug, Clone)]
 pub enum ConversationEndedTombstoneAction {
-    #[cfg(not(target_family = "wasm"))]
-    ContinueInCloud { task_id: AmbientAgentTaskId },
+    ContinueInCloud {
+        task_id: AmbientAgentTaskId,
+    },
     #[cfg(not(target_family = "wasm"))]
     ContinueLocally(AIConversationId),
     #[cfg(target_family = "wasm")]
@@ -630,7 +631,6 @@ impl TypedActionView for ConversationEndedTombstoneView {
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
-            #[cfg(not(target_family = "wasm"))]
             ConversationEndedTombstoneAction::ContinueInCloud { task_id } => {
                 send_telemetry_from_ctx!(
                     AgentManagementTelemetryEvent::TombstoneContinueInCloud {

--- a/app/src/terminal/view/shared_session/mod.rs
+++ b/app/src/terminal/view/shared_session/mod.rs
@@ -9,7 +9,6 @@ pub mod test_utils;
 mod view_impl;
 mod viewer;
 
-#[cfg(not(target_family = "wasm"))]
 pub(in crate::terminal::view) use conversation_ended_tombstone_view::ConversationEndedTombstoneEvent;
 pub(in crate::terminal::view) use conversation_ended_tombstone_view::ConversationEndedTombstoneView;
 pub(in crate::terminal::view) use {adapter::Adapter as SharedSessionAdapter, viewer::Viewer};

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -76,7 +76,6 @@ use super::cloud_conversation_continuation::{
 use super::sharer::inactivity_modal::InactivityModalEvent;
 use super::sharer::Sharer;
 use super::viewer::Viewer;
-#[cfg(not(target_family = "wasm"))]
 use super::ConversationEndedTombstoneEvent;
 use super::ConversationEndedTombstoneView;
 
@@ -909,7 +908,6 @@ impl TerminalView {
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
     fn start_cloud_followup_from_tombstone(
         &mut self,
         task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
@@ -1745,7 +1743,6 @@ impl TerminalView {
         let tombstone_view_handle = ctx.add_typed_action_view(|ctx| {
             ConversationEndedTombstoneView::new(ctx, terminal_view_id, task_id, tombstone_cta)
         });
-        #[cfg(not(target_family = "wasm"))]
         ctx.subscribe_to_view(&tombstone_view_handle, |me, _, event, ctx| match event {
             ConversationEndedTombstoneEvent::ContinueInCloud { task_id } => {
                 me.start_cloud_followup_from_tombstone(*task_id, ctx);

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -9,7 +9,9 @@ use warp_multi_agent_api::{self as api, client_action as api_client_action};
 
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent::AIAgentInput;
-use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentRunDisplayStatus};
+use crate::ai::agent_conversations_model::{
+    AgentConversationsModel, AgentConversationsModelEvent, AgentRunDisplayStatus,
+};
 use crate::ai::ambient_agents::task::{TaskPrincipalInfo, TaskStatusErrorCode, TaskStatusMessage};
 use crate::ai::ambient_agents::{
     AgentSource, AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState,
@@ -1350,6 +1352,82 @@ fn test_restored_owned_tombstone_hides_input_until_continue() {
             assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
             {
                 let model = view.model.lock();
+                assert!(view.is_input_box_visible(&model, ctx));
+            }
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Editable
+            );
+        });
+    });
+}
+
+#[test]
+fn test_deep_linked_ambient_continuation_refreshes_when_task_data_arrives() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        let task_id = task.task_id;
+
+        terminal.update(&mut app, |view, ctx| {
+            // Mirrors opening a cloud conversation directly (for example, a
+            // Warp-on-Web deep link) before AgentConversationsModel has loaded
+            // the ambient task. The restored pane only has the task id from
+            // conversation metadata, so it first renders the conservative
+            // ended-session UI.
+            let mut model = view.model.lock();
+            model.set_shared_session_source_type(SessionSourceType::AmbientAgent {
+                task_id: Some(task_id.to_string()),
+            });
+            model.set_shared_session_status(SharedSessionStatus::FinishedViewer);
+            drop(model);
+
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+
+            view.insert_conversation_ended_tombstone_with_resolved_cta(ctx);
+
+            assert!(view.conversation_ended_tombstone_view_id.is_some());
+            assert_eq!(view.pending_cloud_followup_task_id, None);
+            {
+                let model = view.model.lock();
+                assert!(matches!(
+                    model.shared_session_status(),
+                    SharedSessionStatus::FinishedViewer
+                ));
+                assert!(!view.is_input_box_visible(&model, ctx));
+            }
+        });
+
+        AgentConversationsModel::handle(&app).update(&mut app, |model, ctx| {
+            // Once the task fetch or initial task sync finishes, the terminal
+            // subscription should re-resolve the continuation state and replace
+            // the conservative tombstone with owned follow-up input.
+            model.insert_task_for_test(task);
+            ctx.emit(AgentConversationsModelEvent::TasksUpdated);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, Some(task_id));
+            {
+                let model = view.model.lock();
+                assert!(matches!(
+                    model.shared_session_status(),
+                    SharedSessionStatus::NotShared
+                ));
                 assert!(view.is_input_box_visible(&model, ctx));
             }
             assert_eq!(


### PR DESCRIPTION
## Description
Fixes APP-4505 by enabling Warp-on-Web conversation tombstones to continue supported cloud agent conversations instead of only offering the native-client fallback.

Changes are split across three atomic commits:
- render Continue in cloud tombstone actions/events in WASM builds
- hydrate restored cloud-mode task data so direct/deep-linked transcripts can re-resolve the right CTA or inline follow-up input
- add focused restored/deep-linked continuation test coverage

## Linked Issue
- https://linear.app/warpdotdev/issue/APP-4505/cannot-continue-cloud-agent-conversation-from-wasm-build

## Testing
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] `cargo test -p warp cloud_conversation_continuation`
- [x] `cargo test -p warp test_deep_linked_ambient_continuation_refreshes_when_task_data_arrives`
- [x] `cargo test -p warp test_restored_owned_tombstone_hides_input_until_continue`
- [x] `WITH_LOCAL_SERVER=1 ./script/wasm/run` built and served the WASM bundle locally; stopped with Ctrl-C after manual verification

### Screenshots / Videos
- Loom demo: https://www.loom.com/share/5d4496956a934b5c85f640d0bb5c5048

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent Artifacts
- Conversation: https://staging.warp.dev/conversation/b765b384-c4d2-4714-87aa-e1f1934466e4
- Plan: https://staging.warp.dev/drive/notebook/OMxHI3XGpBR2HphoP1zjF4

CHANGELOG-BUG-FIX: Fixed continuing cloud agent conversations from Warp-on-Web tombstones.

Co-Authored-By: Oz <oz-agent@warp.dev>
