### PR TITLE
Add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+## Cursor Cloud specific instructions
+
+### Overview
+
+Warp is a Rust-based terminal emulator (65+ crate workspace). The OSS binary (`warp-oss`) builds and runs without any external backend services. See `WARP.md` for architecture details and `CONTRIBUTING.md` for the development workflow.
+
+### Building and Running
+
+- **Build**: `cargo build --bin warp-oss --features gui`
+- **Run**: `WARP_SKIP_COMMON_SKILLS_INSTALL=1 cargo run --bin warp-oss --features gui` (the skip flag avoids interactive prompts from common-skills installation)
+- **Run via script**: `WARP_SKIP_COMMON_SKILLS_INSTALL=1 ./script/run` (also works, auto-detects OSS channel)
+- The `gui` feature flag is required for the graphical application.
+
+### Linting
+
+- `cargo fmt -- --check`
+- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
+- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` (separate run with default features)
+- See `./script/presubmit` for the full presubmit suite.
+
+### Testing
+
+- `cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2`
+- Integration tests (`crates/integration/`) require a display server (X11/Xvfb). In headless Cloud Agent VMs, most integration tests will fail with X11 auth errors — this is expected.
+- To run integration tests headlessly, start Xvfb: `Xvfb :99 -screen 0 1280x1024x24 &` and set `DISPLAY=:99`.
+- `command-signatures-v2` is excluded from the default test run; it requires Node.js with corepack enabled and yarn 4.
+
+### Environment Gotchas
+
+- **corepack / yarn 4**: The `command-signatures-v2` crate build script requires `corepack enable` and yarn >= 4.0.1. Without this, `cargo clippy`/`cargo build` will fail on that crate.
+- **libstdc++.so symlink**: On Ubuntu 24.04, the linker may fail to find `-lstdc++` because `libstdc++.so` is only in `/usr/lib/gcc/x86_64-linux-gnu/13/`. Create a symlink: `sudo ln -sf /usr/lib/gcc/x86_64-linux-gnu/13/libstdc++.so /usr/lib/x86_64-linux-gnu/libstdc++.so`
+- **protoc**: Must be >= 3.15 for proto3 `optional` fields. The `script/linux/install_build_deps` installs v25.1 from GitHub releases.
+- **`WARP_SKIP_COMMON_SKILLS_INSTALL=1`**: Set this when running `./script/run` to avoid interactive prompts about common-skills installation.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `AGENTS.md` with Cloud Agent-specific development environment instructions, documenting non-obvious gotchas discovered during setup:

- Build/run/lint/test command reference for the OSS binary
- corepack/yarn 4 requirement for `command-signatures-v2` crate
- `libstdc++.so` symlink issue on Ubuntu 24.04
- protoc version requirements
- How to skip interactive common-skills prompts in automated environments
- Integration test display server requirements

## Linked Issue

N/A — this is development infrastructure for Cursor Cloud Agents.

- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

Environment was fully set up and validated:

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Warp terminal launching and executing `echo "Hello from Warp"`:

<a href="https://cursor.com/agents/bc-05bc27ec-8c81-4e5b-9f10-8e6a66ffdbb8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwarp-terminal-hello-world-demo.mp4"><img src="https://cursor.com/artifacts/c/art-8a7b85bb-030e-4366-a5cd-560a26683d70" alt="warp-terminal-hello-world-demo.mp4" /></a>

![Warp welcome screen](https://cursor.com/artifacts/c/art-f112a5b5-c177-4471-b360-5f5e1d2368df)
![Hello from Warp output](https://cursor.com/artifacts/c/art-8b53388b-5d1a-4ab7-9e1f-296a47cba54c)

CHANGELOG-NONE
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05bc27ec-8c81-4e5b-9f10-8e6a66ffdbb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05bc27ec-8c81-4e5b-9f10-8e6a66ffdbb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

