### PR TITLE
Disable handoff for orchestrated agents

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -2075,7 +2075,10 @@ impl AgentInputFooter {
                 .is_enabled()
                 .then(|| ChildView::new(&self.fast_forward_button).finish()),
             AgentToolbarItemKind::HandoffToCloud => {
-                if !AISettings::as_ref(app).is_cloud_handoff_enabled(app) || is_cloud_context {
+                if !AISettings::as_ref(app)
+                    .is_cloud_handoff_enabled_for_terminal_view(self.terminal_view_id, app)
+                    || is_cloud_context
+                {
                     return None;
                 }
 

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -580,9 +580,13 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
 
         let is_cloud_agent =
             is_in_cloud_context(agent_view_controller.agent_view_state(), terminal_model);
+        let ai_settings = AISettings::as_ref(app);
 
         // Handoff to cloud only available for local agents.
-        if !is_cloud_agent && AISettings::as_ref(app).is_ampersand_handoff_enabled(app) {
+        if !is_cloud_agent
+            && ai_settings
+                .is_ampersand_handoff_enabled_for_conversation(Some(active_conversation), app)
+        {
             items.push(
                 MessageItem::clickable(
                     vec![
@@ -635,7 +639,8 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
         // Code review only works locally.
         #[cfg(not(target_family = "wasm"))]
         if !is_cloud_agent
-            && !AISettings::as_ref(app).is_cloud_handoff_enabled(app)
+            && !ai_settings
+                .is_cloud_handoff_enabled_for_conversation(Some(active_conversation), app)
             && *TabSettings::as_ref(app).show_code_review_button
         {
             let code_review_keystroke = if OperatingSystem::get().is_mac() {

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -8,7 +8,10 @@ use std::path::PathBuf;
 
 use indexmap::IndexMap;
 
-use crate::ai::request_usage_model::RequestLimitInfo;
+use crate::ai::{
+    agent::conversation::AIConversation, blocklist::BlocklistAIHistoryModel,
+    request_usage_model::RequestLimitInfo,
+};
 use crate::auth::AuthStateProvider;
 use crate::report_if_error;
 use crate::settings::PrivacySettings;
@@ -20,7 +23,8 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use warpui::platform::OperatingSystem;
 use warpui::{
-    platform::keyboard::KeyCode, AppContext, Entity, ModelContext, SingletonEntity, UpdateModel,
+    platform::keyboard::KeyCode, AppContext, Entity, EntityId, ModelContext, SingletonEntity,
+    UpdateModel,
 };
 
 use settings::{
@@ -1695,9 +1699,45 @@ impl AISettings {
             crate::workspaces::workspace::AdminEnablementSetting::Disable
         )
     }
+    pub fn is_cloud_handoff_enabled_for_conversation(
+        &self,
+        conversation: Option<&AIConversation>,
+        app: &warpui::AppContext,
+    ) -> bool {
+        self.is_cloud_handoff_enabled(app)
+            && !conversation
+                .is_some_and(|conversation| is_orchestration_conversation(conversation, app))
+    }
+
+    pub fn is_cloud_handoff_enabled_for_terminal_view(
+        &self,
+        terminal_view_id: EntityId,
+        app: &warpui::AppContext,
+    ) -> bool {
+        let active_conversation =
+            BlocklistAIHistoryModel::as_ref(app).active_conversation(terminal_view_id);
+        self.is_cloud_handoff_enabled_for_conversation(active_conversation, app)
+    }
 
     pub fn is_ampersand_handoff_enabled(&self, app: &warpui::AppContext) -> bool {
         self.is_cloud_handoff_enabled(app) && !*self.should_force_disable_ampersand_handoff
+    }
+    pub fn is_ampersand_handoff_enabled_for_conversation(
+        &self,
+        conversation: Option<&AIConversation>,
+        app: &warpui::AppContext,
+    ) -> bool {
+        self.is_cloud_handoff_enabled_for_conversation(conversation, app)
+            && !*self.should_force_disable_ampersand_handoff
+    }
+
+    pub fn is_ampersand_handoff_enabled_for_terminal_view(
+        &self,
+        terminal_view_id: EntityId,
+        app: &warpui::AppContext,
+    ) -> bool {
+        self.is_cloud_handoff_enabled_for_terminal_view(terminal_view_id, app)
+            && !*self.should_force_disable_ampersand_handoff
     }
 
     /// Determines whether a quota reset banner should be displayed to the user.
@@ -1982,6 +2022,12 @@ impl AISettings {
     }
 }
 
+fn is_orchestration_conversation(conversation: &AIConversation, app: &AppContext) -> bool {
+    conversation.has_parent_agent()
+        || !BlocklistAIHistoryModel::as_ref(app)
+            .child_conversation_ids_of(&conversation.id())
+            .is_empty()
+}
 /// Singleton model that caches compiled regexes for the `cli_agent_footer_enabled_commands`
 /// setting. Each entry pairs a compiled regex with the CLI agent it maps to.
 pub struct CompiledCommandsForCodingAgentToolbar {

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3869,7 +3869,8 @@ impl Input {
             )
         };
         *edit_origin == EditOrigin::UserTyped
-            && AISettings::as_ref(ctx).is_ampersand_handoff_enabled(ctx)
+            && AISettings::as_ref(ctx)
+                .is_ampersand_handoff_enabled_for_terminal_view(self.terminal_view_id, ctx)
             && !is_powershell_with_nld_enabled
             && FeatureFlag::AgentView.is_enabled()
             && self.agent_view_controller.as_ref(ctx).is_fullscreen()

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -319,7 +319,8 @@ impl SlashCommandDataSource {
         ActiveCommandsContext {
             session_context,
             is_orchestration_enabled: ai_settings.is_orchestration_enabled(ctx),
-            is_cloud_handoff_enabled: ai_settings.is_cloud_handoff_enabled(ctx),
+            is_cloud_handoff_enabled: ai_settings
+                .is_cloud_handoff_enabled_for_terminal_view(self.terminal_view_id, ctx),
             is_feedback_skill_available: crate::workspace::is_feedback_skill_available(ctx),
             #[cfg(not(target_family = "wasm"))]
             active_conversation_is_cloud_oz: self.active_conversation_is_cloud_oz(ctx),

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -898,7 +898,9 @@ impl Input {
             }
             #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
             move_to_cloud if command.name == commands::MOVE_TO_CLOUD.name => {
-                if !AISettings::as_ref(ctx).is_cloud_handoff_enabled(ctx) {
+                if !AISettings::as_ref(ctx)
+                    .is_cloud_handoff_enabled_for_terminal_view(self.terminal_view_id, ctx)
+                {
                     return false;
                 }
                 let prompt = argument

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13607,6 +13607,23 @@ impl Workspace {
             .as_ref(ctx)
             .active_conversation(terminal_view_id)
             .cloned();
+        if !AISettings::as_ref(ctx)
+            .is_cloud_handoff_enabled_for_conversation(source_conversation.as_ref(), ctx)
+        {
+            Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
+            let window_id = ctx.window_id();
+            WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                toast_stack.add_ephemeral_toast(
+                    DismissibleToast::error(
+                        "Cloud handoff isn't available for orchestrated agent conversations."
+                            .to_owned(),
+                    ),
+                    window_id,
+                    ctx,
+                );
+            });
+            return;
+        }
 
         let has_existing_conversation = source_conversation.as_ref().is_some_and(|c| !c.is_empty());
 


### PR DESCRIPTION
## Description

Disables local-to-cloud handoff for orchestrated agent conversations, including both orchestrating parent conversations and orchestrated child conversations.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
https://www.loom.com/share/ecf8c613802346549f61357fe1c56df4

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/11aa0f2d-d55a-4c38-b52a-0e86b1868eaf_
_Run: https://oz.staging.warp.dev/runs/019e3742-69ca-7bf4-8acd-eda6ea5edcaa_
_This PR was generated with [Oz](https://warp.dev/oz)._
