### PR TITLE
Package Swift runtime dylibs with macOS CLI

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -463,8 +463,29 @@ jobs:
 
       - name: Package CLI binary
         run: |
-          mv ${{ steps.bundle_cli.outputs.binary_path }} oz-${{ steps.get-config.outputs.channel }}
-          tar czf oz-${{ steps.get-config.outputs.channel }}-macos-${{ matrix.arch }}.tar.gz oz-${{ steps.get-config.outputs.channel }} -C "$(dirname "${{ steps.bundle_cli.outputs.bundled_resources_dir }}")" resources
+          bundle_dir="$(dirname "${{ steps.bundle_cli.outputs.bundled_resources_dir }}")"
+          mv "${{ steps.bundle_cli.outputs.binary_path }}" oz-${{ steps.get-config.outputs.channel }}
+          tar_args=(oz-${{ steps.get-config.outputs.channel }} -C "$bundle_dir" resources)
+          if [[ -d "$bundle_dir/lib" ]]; then
+            tar_args+=(-C "$bundle_dir" lib)
+          fi
+          tar czf oz-${{ steps.get-config.outputs.channel }}-macos-${{ matrix.arch }}.tar.gz "${tar_args[@]}"
+        shell: bash
+
+      - name: Validate CLI tarball launch layout
+        run: |
+          tarball="oz-${{ steps.get-config.outputs.channel }}-macos-${{ matrix.arch }}.tar.gz"
+          tar tzf "$tarball"
+
+          if otool -L oz-${{ steps.get-config.outputs.channel }} | grep -q '@rpath/libswift'; then
+            otool -l oz-${{ steps.get-config.outputs.channel }} | grep -A2 LC_RPATH
+            tar tzf "$tarball" | grep -E '^lib/libswift.*\.dylib$'
+          fi
+
+          verify_dir="$(mktemp -d)"
+          tar xzf "$tarball" -C "$verify_dir"
+          "$verify_dir/oz-${{ steps.get-config.outputs.channel }}" --version
+        shell: bash
 
       - name: Add CLI to GitHub release assets
         if: ${{ needs.prepare_release.outputs.should_publish == 'true' }}

--- a/crates/remote_server/src/install_remote_server.sh
+++ b/crates/remote_server/src/install_remote_server.sh
@@ -82,4 +82,10 @@ tar -xzf "$tmpdir/oz.tar.gz" -C "$tmpdir"
 bin=$(find "$tmpdir" -type f -name 'oz*' ! -name '*.tar.gz' | head -n1)
 if [ -z "$bin" ]; then echo "no binary found in tarball" >&2; exit 1; fi
 chmod +x "$bin"
+if [ -d "$tmpdir/lib" ]; then
+  rm -rf "$install_dir/lib.tmp"
+  cp -R "$tmpdir/lib" "$install_dir/lib.tmp"
+  rm -rf "$install_dir/lib"
+  mv "$install_dir/lib.tmp" "$install_dir/lib"
+fi
 mv "$bin" "$install_dir/{binary_name}{version_suffix}"

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -366,6 +366,80 @@ fn install_script_avoids_pattern_substitution_for_tilde_expansion() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn install_script_installs_packaged_lib_directory() {
+    use command::blocking::Command;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Stdio;
+
+    fn replace_home(path: &str, home: &Path) -> PathBuf {
+        PathBuf::from(path.replacen('~', home.to_str().unwrap(), 1))
+    }
+
+    let root = std::env::temp_dir().join(format!(
+        "warp-install-script-lib-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let home = root.join("home");
+    let payload = root.join("payload");
+    fs::create_dir_all(payload.join("lib")).unwrap();
+    fs::create_dir_all(&home).unwrap();
+    fs::write(payload.join("oz-fixture"), "#!/bin/sh\nprintf 'fixture'\n").unwrap();
+    fs::write(payload.join("lib/libswiftCore.dylib"), "swift core fixture").unwrap();
+
+    let tarball = root.join("oz.tar.gz");
+    let tar_output = Command::new("tar")
+        .arg("-czf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(&payload)
+        .arg(".")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to create test tarball");
+    assert!(
+        tar_output.status.success(),
+        "tar exited with {:?}: stderr={}",
+        tar_output.status,
+        String::from_utf8_lossy(&tar_output.stderr),
+    );
+
+    let bash = if Path::new("/bin/bash").exists() {
+        "/bin/bash"
+    } else {
+        "bash"
+    };
+    let script = install_script(Some(tarball.to_str().unwrap()));
+    let output = Command::new(bash)
+        .arg("-c")
+        .arg(script)
+        .env("HOME", &home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run install script");
+    assert!(
+        output.status.success(),
+        "install script exited with {:?}: stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let installed_binary = replace_home(&remote_server_binary(), &home);
+    let installed_dir = replace_home(&remote_server_dir(), &home);
+    assert!(installed_binary.is_file());
+    assert_eq!(
+        fs::read_to_string(installed_dir.join("lib/libswiftCore.dylib")).unwrap(),
+        "swift core fixture",
+    );
+    assert!(!installed_dir.join("lib.tmp").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[test]
 fn version_hash_is_deterministic() {
     // version_hash uses the compile-time GIT_RELEASE_TAG which is typically

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -92,6 +92,106 @@ function relpath() {
   python -c "import os,sys;print(os.path.relpath(*(sys.argv[1:])))" "$@";
 }
 
+function cli_binary_has_rpath() {
+  local binary_path="$1"
+  local rpath="$2"
+
+  otool -l "$binary_path" | grep -A2 "LC_RPATH" | grep -q "path $rpath "
+}
+
+function add_cli_distribution_rpath() {
+  local binary_path="$1"
+  local rpath="@executable_path/lib"
+
+  if cli_binary_has_rpath "$binary_path" "$rpath"; then
+    echo "$binary_path already has LC_RPATH $rpath"
+  else
+    echo "Adding LC_RPATH $rpath to $binary_path"
+    install_name_tool -add_rpath "$rpath" "$binary_path"
+  fi
+}
+
+function copy_cli_swift_runtime_libraries() {
+  local binary_path="$1"
+  local lib_dir="$2"
+  local tmp_lib_dir="$lib_dir.tmp"
+  local swift_toolchain
+  local swift_stdlib_args
+
+  echo "Copying required Swift runtime dylibs for $binary_path"
+  rm -rf "$lib_dir" "$tmp_lib_dir"
+  mkdir -p "$tmp_lib_dir"
+  swift_stdlib_args=(
+    --copy
+    --scan-executable "$binary_path"
+    --destination "$tmp_lib_dir"
+    --platform macosx
+  )
+
+  swift_toolchain="$(xcrun --find swiftc)"
+  if [[ "$swift_toolchain" == */Toolchains/*.xctoolchain/usr/bin/swiftc ]]; then
+    swift_toolchain="${swift_toolchain%/usr/bin/swiftc}"
+    swift_stdlib_args+=(--toolchain "$swift_toolchain")
+  fi
+
+  xcrun swift-stdlib-tool "${swift_stdlib_args[@]}"
+
+  if find "$tmp_lib_dir" -type f -name 'libswift*.dylib' | grep -q .; then
+    mv "$tmp_lib_dir" "$lib_dir"
+    echo "Copied Swift runtime dylibs into $lib_dir"
+  else
+    echo "No Swift runtime dylibs are required for $binary_path"
+    rm -rf "$tmp_lib_dir"
+  fi
+}
+
+function validate_cli_distribution_linkage() {
+  local binary_path="$1"
+  local lib_dir="$2"
+
+  echo "Validating CLI binary linkage for $binary_path"
+  otool -L "$binary_path"
+  otool -l "$binary_path" | awk '
+    /LC_RPATH/ { in_rpath = 1 }
+    in_rpath && /path / { print; in_rpath = 0 }
+  '
+
+  if otool -L "$binary_path" | grep -q '@rpath/libswift'; then
+    if ! cli_binary_has_rpath "$binary_path" "@executable_path/lib"; then
+      echo "error: CLI binary references @rpath/libswift* but is missing LC_RPATH @executable_path/lib." >&2
+      exit 1
+    fi
+    if [[ ! -d "$lib_dir" ]] || ! find "$lib_dir" -type f -name 'libswift*.dylib' | grep -q .; then
+      echo "error: CLI binary references @rpath/libswift* but no Swift runtime dylibs were copied into $lib_dir." >&2
+      exit 1
+    fi
+  fi
+
+  if otool -L "$binary_path" | grep -E -q '/(Applications/Xcode|Library/Developer/CommandLineTools|Toolchains)/.*libswift'; then
+    echo "error: CLI binary references absolute Xcode/toolchain Swift library paths." >&2
+    exit 1
+  fi
+}
+
+function codesign_cli_libs() {
+  local lib_dir="$1"
+  local signing_cert="$2"
+  local timestamp_arg="${3:-}"
+
+  if [[ ! -d "$lib_dir" ]]; then
+    return
+  fi
+
+  find "$lib_dir" -type f -name '*.dylib' -print0 | while IFS= read -r -d '' dylib; do
+    echo "Codesigning $dylib..."
+    if [[ -n "$timestamp_arg" ]]; then
+      codesign -f -o runtime --timestamp -s "$signing_cert" "$dylib"
+    else
+      codesign --force --options runtime --sign "$signing_cert" "$dylib"
+    fi
+  done
+}
+
 # Defaults for command-line flags.
 UNIVERSAL_BINARY=true
 BUILD_BINARY=true
@@ -587,6 +687,11 @@ elif [[ "$ARTIFACT" == "cli" ]]; then
 
   echo "Copying binary into $OUT_DIR/$WARP_BIN"
   cp "target/$DEFAULT_TARGET/$TARGET_PROFILE_DIR/$WARP_BIN" "$OUT_DIR/$WARP_BIN"
+  add_cli_distribution_rpath "$OUT_DIR/$WARP_BIN"
+
+  CLI_LIB_DIR="$OUT_DIR/lib"
+  copy_cli_swift_runtime_libraries "$OUT_DIR/$WARP_BIN" "$CLI_LIB_DIR"
+  validate_cli_distribution_linkage "$OUT_DIR/$WARP_BIN" "$CLI_LIB_DIR"
 
   if [[ -n "$TARGET_ARCH" && -e "target/$DEFAULT_TARGET/$TARGET_PROFILE_DIR/$WARP_BIN.dSYM" ]]; then
     echo "Copying .dSYM into $OUT_DIR/$WARP_BIN.dSYM"
@@ -667,6 +772,7 @@ if [[ $SELFSIGN = true ]]; then
     echo "Self-signing $BUNDLE_DIR/$WARP_APP_NAME.app with ${SIGNING_CERT}..."
     codesign --force --deep --options runtime --sign "$SIGNING_CERT" "$BUNDLE_DIR/$WARP_APP_NAME.app" --entitlements script/Debug-Entitlements.plist
   elif [[ "$ARTIFACT" == cli ]]; then
+    codesign_cli_libs "$OUT_DIR/lib" "$SIGNING_CERT"
     echo "Self-signing $OUT_DIR/$WARP_BIN with ${SIGNING_CERT}..."
     codesign --force --options runtime --sign "$SIGNING_CERT" "$OUT_DIR/$WARP_BIN" --entitlements script/Debug-Entitlements.plist
   fi
@@ -676,19 +782,34 @@ elif [[ $CODESIGN = true ]]; then
     # Use --deep so we sign bundled frameworks as well
     codesign --deep -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$BUNDLE_DIR/$WARP_APP_NAME.app" --entitlements script/Entitlements.plist
   elif [[ "$ARTIFACT" == cli ]]; then
+    codesign_cli_libs "$OUT_DIR/lib" "$APPLE_TEAM_ID" "--timestamp"
     echo "Codesigning $OUT_DIR/$WARP_BIN..."
     codesign -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$OUT_DIR/$WARP_BIN" --entitlements script/Entitlements.plist
-
     # Create the .zip for notarization in a separate location - otherwise, Apple's codesigning
     # tools decide that it's a sealed resource that belongs to the binary and needs to also be signed.
+    # Notarize the complete standalone CLI distribution layout, including the adjacent Swift
+    # runtime dylibs and resources, so Apple validates the same layout we ship in the tarball.
+    NOTARIZATION_STAGING_DIR="$BUNDLE_DIR/${WARP_BIN}_notarize"
     NOTARIZATION_ARTIFACT="$BUNDLE_DIR/${WARP_BIN}_notarize.zip"
+    if [[ -e "$NOTARIZATION_STAGING_DIR" ]]; then
+      echo "Removing old notarization staging directory..."
+      rm -rf "$NOTARIZATION_STAGING_DIR"
+    fi
     if [[ -e "$NOTARIZATION_ARTIFACT" ]]; then
       echo "Removing old notarization artifact..."
       rm "$NOTARIZATION_ARTIFACT"
     fi
+    mkdir -p "$NOTARIZATION_STAGING_DIR"
+    cp "$OUT_DIR/$WARP_BIN" "$NOTARIZATION_STAGING_DIR/"
+    if [[ -d "$OUT_DIR/lib" ]]; then
+      cp -R "$OUT_DIR/lib" "$NOTARIZATION_STAGING_DIR/"
+    fi
+    if [[ -d "$OUT_DIR/resources" ]]; then
+      cp -R "$OUT_DIR/resources" "$NOTARIZATION_STAGING_DIR/"
+    fi
 
     # Create a .zip archive to notarize.
-    ditto -c -k "$OUT_DIR/$WARP_BIN" "$NOTARIZATION_ARTIFACT"
+    ditto -c -k --keepParent "$NOTARIZATION_STAGING_DIR" "$NOTARIZATION_ARTIFACT"
     
     # It's not possible to staple notarization tickets to standalone binaries:
     # https://developer.apple.com/documentation/security/customizing-the-notarization-workflow?language=objc#Staple-the-ticket-to-your-distribution
@@ -839,6 +960,10 @@ if [ "${GITHUB_ACTIONS}" == "true" ]; then
 
   if [[ -n "$BUNDLED_RESOURCES_DIR" ]]; then
     echo "bundled_resources_dir=$BUNDLED_RESOURCES_DIR" >> "$GITHUB_OUTPUT"
+  fi
+
+  if [[ -n "$CLI_LIB_DIR" && -d "$CLI_LIB_DIR" ]]; then
+    echo "cli_lib_dir=$CLI_LIB_DIR" >> "$GITHUB_OUTPUT"
   fi
   
   echo "::echo::off"


### PR DESCRIPTION
## Summary
- Package required Swift runtime dylibs beside the standalone macOS CLI in `target/.../bundle/osx/lib` using `xcrun swift-stdlib-tool`.
- Add `LC_RPATH @executable_path/lib` to the standalone CLI before signing so `@rpath/libswift*.dylib` resolves from the adjacent `lib/` directory.
- Sign copied dylibs before signing the CLI executable and notarize a complete CLI distribution staging folder containing the binary, `lib/`, and `resources/`.
- Include `lib/` in macOS CLI release tarballs when present and validate the tarball launch layout in the macOS release workflow.
- Install extracted `lib/` directories to `$install_dir/lib` via `lib.tmp` without changing the remote-server binary path.
- Add a focused installer test that runs the real install script against a tarball containing `lib/libswiftCore.dylib`.

## Diff summary
```text
.github/workflows/create_release.yml              |  25 ++++-
crates/remote_server/src/install_remote_server.sh |   6 +
crates/remote_server/src/setup_tests.rs           |  74 +++++++++++++
script/macos/bundle                               | 129 +++++++++++++++++++++-
4 files changed, 230 insertions(+), 4 deletions(-)
```

## Base branch note
The requested cloud base `origin/aloke/remote_code_errors_new` was not available (`fatal: couldn't find remote ref aloke/remote_code_errors_new` / GitHub branch lookup returned 404), so this PR targets `master` per fallback instructions.

## Validation
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all` ✅
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p remote_server install_script_` ✅
  - `install_script_avoids_pattern_substitution_for_tilde_expansion`
  - `install_script_tilde_expansion_resolves_correctly`
  - `install_script_installs_packaged_lib_directory`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p remote_server --tests` ✅
  - Passed with pre-existing warnings in `warpui_core` / `warpui`; no error after changing the new test to use `command::blocking::Command`.
- `bash -n script/macos/bundle` ✅
- `bash -n crates/remote_server/src/install_remote_server.sh` ✅
- `git --no-pager diff --check` ✅

## Artifact / computer-use proof
This cloud worker is Linux, so macOS-only commands (`otool`, `install_name_tool`, `xcrun swift-stdlib-tool`, `codesign`, `notarytool`) and macOS x86_64 dyld launch cannot execute here. I attached the closest reproducible proof artifacts to the Oz run:
- `validation.txt` (`019e3751-8e89-7944-be3c-80c927b2e02c`): validation transcript, Linux limitation note, and synthetic top-level tar layout listing.
- `oz-dev-macos-x86_64.synthetic.tar.gz` (`019e3751-a3f9-7e99-9c10-c54f34b2fb5c`): synthetic tarball showing the intended top-level `oz-dev`, `resources/`, and `lib/libswiftCore.dylib` layout.

The release workflow now performs the host-specific verification on macOS by listing the tarball, checking `otool -L` for Swift deps, checking `LC_RPATH`, asserting `lib/libswift*.dylib` is in the tarball when Swift deps are present, extracting the tarball, and running `oz-<channel> --version` from the extracted layout.

## macOS follow-up commands
Run on a macOS x86_64-capable host or the `release_macos_cli` workflow:
```bash
script/bundle --read-passwords-from-env --channel dev --arch x86_64 --artifact cli
otool -L target/release-cli-debug_assertions/bundle/osx/dev | grep 'libswift\|@rpath'
otool -l target/release-cli-debug_assertions/bundle/osx/dev | grep -A2 LC_RPATH
find target/release-cli-debug_assertions/bundle/osx/lib -name 'libswift*.dylib' -maxdepth 1
# After packaging in CI:
tar tzf oz-dev-macos-x86_64.tar.gz | grep -E '^(oz-dev|resources/|lib/libswift.*\.dylib)'
verify_dir=$(mktemp -d)
tar xzf oz-dev-macos-x86_64.tar.gz -C "$verify_dir"
"$verify_dir/oz-dev" --version
```

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/e30bebc5-db94-43cf-ae36-cf57f23fdc7a_
_Run: https://oz.staging.warp.dev/runs/019e3748-d963-7283-b3b4-144d9a132143_
_This PR was generated with [Oz](https://warp.dev/oz)._
