### PR TITLE
Fix typos in comments

### DIFF
--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -8270,7 +8270,7 @@ fn move_single_word(text: &str) -> CharOffset {
 /// The anchor for showing command x-ray information
 #[derive(Debug)]
 pub enum CommandXRayAnchor {
-    /// Show x-ray info based on the cursor positon
+    /// Show x-ray info based on the cursor position
     Cursor,
 
     /// Show x-ray info based on a hover at the given display point

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -78,7 +78,7 @@ pub struct SubMenu<A: Action + Clone = ()> {
 /// Menu contains the menu items and defines the logic for managing the actions and rendering of the
 /// items. It has two variants (scrollable and fixed) which slightly change the way it's laid out.
 /// TODO: In the future, if we keep bumping into more rendering changes here, it may make sense to
-/// abstract the Menu functionality into a trait and have separte implementations for dropdown and
+/// abstract the Menu functionality into a trait and have separate implementations for dropdown and
 /// context menu.
 pub struct Menu<A: Action + Clone = ()> {
     /// Whether or not the element should make the rest of the window unresponsive. All mouse events

--- a/app/src/terminal/event.rs
+++ b/app/src/terminal/event.rs
@@ -193,8 +193,8 @@ pub struct InitShellEvent {
 pub struct BootstrappedEvent {
     /// The command which spawned the shell.
     pub spawning_command: String,
-    // This is wrapped in an `Box` to surpress clippy's large-enum-variant warning, not because it
-    // functionally needs to be wrapped in an `Box`.
+    // This is wrapped in a `Box` to suppress clippy's large-enum-variant warning, not because it
+    // functionally needs to be wrapped in a `Box`.
     pub session_info: Box<SessionInfo>,
     pub restored_block_commands: Vec<HistoryEntry>,
     /// The time we spent sourcing the user's rcfiles, in seconds.  This may be
@@ -296,11 +296,11 @@ pub struct UserBlockCompleted {
     pub command_with_obfuscated_secrets: String,
 
     /// The output lines for a block without any escape sequences.
-    /// They are truncated to the number of lines specificed by the caller.
+    /// They are truncated to the number of lines specified by the caller.
     pub output_truncated: String,
 
     /// The output lines for a block without any escape sequences.
-    /// They are truncated to the number of lines specificed by the caller.
+    /// They are truncated to the number of lines specified by the caller.
     /// Forced secrets to be obfuscated as well.
     pub output_truncated_with_obfuscated_secrets: String,
 

--- a/app/src/terminal/input/inline_menu/positioning.rs
+++ b/app/src/terminal/input/inline_menu/positioning.rs
@@ -154,16 +154,16 @@ impl InlineMenuPositioner {
     /// This inset application is done in one of two ways in waterfall mode:
     /// * If there is no gap, we subtract the 'inset', equivalent to the inline menu
     ///   height from the max height constraint of the blocklist element
-    /// * If there _is_ a gap, we subtract the inset from painted visible blocklist element originj
+    /// * If there _is_ a gap, we subtract the inset from painted visible blocklist element origin
     ///   at paint time.
     ///
     /// When there is no gap, that's pretty much all we need to do.
     ///
     /// When there is a gap, there is further accounting to be done: this blocklist translation is
     /// applied at paint-time to reduce the surface area of logic that needs to be aware of the
-    /// inline menu visiblity/height (for example, the sumtree doesn't need to be aware of this at
+    /// inline menu visibility/height (for example, the sumtree doesn't need to be aware of this at
     /// all). This means, however, we do need to account for inset value in logic that translates
-    /// artifacts of rendering (layout/paint) back to the data model -- main in places where the
+    /// artifacts of rendering (layout/paint) back to the data model -- mainly in places where the
     /// sumtree heights are dependent on the laid out input size (the inline menu is part of the
     /// input element subtree). The main areas considered are:
     ///

--- a/app/src/terminal/mod.rs
+++ b/app/src/terminal/mod.rs
@@ -188,7 +188,7 @@ pub enum SizeUpdateReason {
     /// Updated because of some general refresh (e.g. a font-size change)
     Refresh,
 
-    /// Updated after the temrinal has been laid out, so some of the element
+    /// Updated after the terminal has been laid out, so some of the element
     /// sizes that drive terminal size may have changed.
     AfterLayout,
 
@@ -306,8 +306,8 @@ pub struct SizeInfo {
     ///
     /// Note that *rows* is always determined as a function of pane size, not
     /// the content element size, which is somewhat counterintuitive.  The reason
-    /// is that the content element size changes frequenetly as the input size
-    /// changes or the input dissapears for long running commands, but many
+    /// is that the content element size changes frequently as the input size
+    /// changes or the input disappears for long running commands, but many
     /// programs do not handle size changes while they are running very well.  To
     /// get around this we make them think that rows always comes from the pane size.
     rows: usize,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Fixes a small set of obvious typos in Rust comments/doc comments.

## Linked Issue
None.

## Testing
- `git diff --check HEAD~1..HEAD`
- `/home/ubuntu/.local/bin/codespell app/src/terminal/event.rs app/src/terminal/mod.rs app/src/editor/view/mod.rs app/src/terminal/input/inline_menu/positioning.rs app/src/menu.rs`
- `rg "\\b(surpress|specificed|temrinal|frequenetly|dissapears|positon|originj|visiblity|separte)\\b"` on the changed files

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not relevant for comment-only changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-672ec3b4-7952-48b6-89c7-b519f79e96a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-672ec3b4-7952-48b6-89c7-b519f79e96a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

