### PR TITLE
Clarify SSH extension timeout copy

### DIFF
--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -146,36 +146,6 @@ impl Error {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn timed_out_error_copy_leads_with_timeout() {
-        let error = Error::TimedOut.user_facing_error(SetupStage::Launch);
-
-        assert_eq!(error.body, "Timed out while trying to start SSH extension");
-        assert_eq!(
-            error.detail.as_deref(),
-            Some(
-                "Warp stopped waiting for the SSH extension to respond. Your SSH session is \
-                 still running, but advanced features are unavailable for now."
-            )
-        );
-    }
-
-    #[test]
-    fn non_timeout_error_copy_still_leads_with_failure() {
-        let error = Error::UnsupportedOs {
-            os: "plan9".to_string(),
-        }
-        .user_facing_error(SetupStage::CheckBinary);
-
-        assert_eq!(error.body, "Failed to verify SSH extension");
-        assert_eq!(error.detail.as_deref(), Some("Unsupported OS: plan9"));
-    }
-}
-
 /// A successful return from [`RemoteTransport::connect`].
 ///
 /// Bundles the live [`RemoteServerClient`] and its [`ClientEvent`]
@@ -318,3 +288,7 @@ pub trait RemoteTransport: Send + Sync + std::fmt::Debug {
     /// the reconnect loop entirely.
     fn is_reconnectable(&self, exit_status: Option<&RemoteServerExitStatus>) -> bool;
 }
+
+#[cfg(test)]
+#[path = "transport_tests.rs"]
+mod tests;

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -111,11 +111,20 @@ impl Error {
     /// SSH remote-server failed banner, using `stage` to provide
     /// context-appropriate copy.
     pub fn user_facing_error(&self, stage: SetupStage) -> UserFacingError {
+        if matches!(self, Self::TimedOut) {
+            return UserFacingError {
+                body: format!("Timed out while trying to {}", stage.action_description()),
+                detail: Some(
+                    "Warp stopped waiting for the SSH extension to respond. Your SSH session is \
+                    still running, but advanced features are unavailable for now."
+                        .into(),
+                ),
+            };
+        }
+
         let body = format!("Failed to {}", stage.action_description());
         let detail = match self {
-            Self::TimedOut => {
-                Some("The operation timed out — check your network connection".into())
-            }
+            Self::TimedOut => unreachable!("handled above"),
             Self::UnsupportedOs { os } => Some(format!("Unsupported OS: {os}")),
             Self::UnsupportedArch { arch } => Some(format!("Unsupported architecture: {arch}")),
             Self::ScriptFailed { exit_code, stderr } => {
@@ -134,6 +143,36 @@ impl Error {
             Self::Other(_) => None,
         };
         UserFacingError { body, detail }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timed_out_error_copy_leads_with_timeout() {
+        let error = Error::TimedOut.user_facing_error(SetupStage::Launch);
+
+        assert_eq!(error.body, "Timed out while trying to start SSH extension");
+        assert_eq!(
+            error.detail.as_deref(),
+            Some(
+                "Warp stopped waiting for the SSH extension to respond. Your SSH session is \
+                 still running, but advanced features are unavailable for now."
+            )
+        );
+    }
+
+    #[test]
+    fn non_timeout_error_copy_still_leads_with_failure() {
+        let error = Error::UnsupportedOs {
+            os: "plan9".to_string(),
+        }
+        .user_facing_error(SetupStage::CheckBinary);
+
+        assert_eq!(error.body, "Failed to verify SSH extension");
+        assert_eq!(error.detail.as_deref(), Some("Unsupported OS: plan9"));
     }
 }
 

--- a/crates/remote_server/src/transport_tests.rs
+++ b/crates/remote_server/src/transport_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn timed_out_error_copy_leads_with_timeout() {
+    let error = Error::TimedOut.user_facing_error(SetupStage::Launch);
+
+    assert_eq!(error.body, "Timed out while trying to start SSH extension");
+    assert_eq!(
+        error.detail.as_deref(),
+        Some(
+            "Warp stopped waiting for the SSH extension to respond. Your SSH session is \
+             still running, but advanced features are unavailable for now."
+        )
+    );
+}
+
+#[test]
+fn non_timeout_error_copy_still_leads_with_failure() {
+    let error = Error::UnsupportedOs {
+        os: "plan9".to_string(),
+    }
+    .user_facing_error(SetupStage::CheckBinary);
+
+    assert_eq!(error.body, "Failed to verify SSH extension");
+    assert_eq!(error.detail.as_deref(), Some("Unsupported OS: plan9"));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Update SSH remote server timeout copy so timeout failures lead with "Timed out" and clarify that the user's SSH session can continue while advanced features are unavailable.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo test -p remote_server transport::tests:: -- --nocapture`
- `cargo test -p remote_server`
- `cargo clippy -p remote_server --all-targets -- -D warnings`
- Manually demoed the real banner by connecting Warp to a local SSH server whose SSH rc sleeps longer than the extension check timeout.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
[ssh_extension_timeout_banner_demo.mp4](https://cursor.com/agents/bc-056c7091-e101-43b8-a044-53d6c48f6920/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fssh_extension_timeout_banner_demo.mp4)
[SSH extension timeout banner](https://cursor.com/agents/bc-056c7091-e101-43b8-a044-53d6c48f6920/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fssh_extension_timeout_banner.webp)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Clarified that SSH extension setup timeout errors are timeouts and do not stop the SSH session.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-056c7091-e101-43b8-a044-53d6c48f6920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-056c7091-e101-43b8-a044-53d6c48f6920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

