### PR TITLE
Update the auth FTUX with more info.

### DIFF
--- a/app/src/ai/auth_secret_types.rs
+++ b/app/src/ai/auth_secret_types.rs
@@ -16,7 +16,6 @@ pub struct AuthSecretTypeInfo {
     pub display_name: &'static str,
     pub secret_type: ManagedSecretType,
     pub fields: &'static [AuthSecretTypeField],
-    pub header_text: &'static str,
     pub learn_more_url: &'static str,
 }
 
@@ -102,7 +101,6 @@ pub fn build_managed_secret_value(
 static CODEX_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 1] = [AuthSecretTypeInfo {
     display_name: "OpenAI API Key",
     secret_type: ManagedSecretType::OpenaiApiKey,
-    header_text: "Please paste in an OpenAI API Key.",
     learn_more_url: CODEX_LEARN_MORE_URL,
     fields: &[
         AuthSecretTypeField {
@@ -124,7 +122,6 @@ static CLAUDE_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 3] = [
     AuthSecretTypeInfo {
         display_name: "Anthropic API Key",
         secret_type: ManagedSecretType::AnthropicApiKey,
-        header_text: "Please paste in an Anthropic API Key.",
         learn_more_url: CLAUDE_LEARN_MORE_URL,
         fields: &[AuthSecretTypeField {
             label: "ANTHROPIC_API_KEY",
@@ -136,7 +133,6 @@ static CLAUDE_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 3] = [
     AuthSecretTypeInfo {
         display_name: "Bedrock API Key",
         secret_type: ManagedSecretType::AnthropicBedrockApiKey,
-        header_text: "Please paste in a Bedrock token.",
         learn_more_url: CLAUDE_LEARN_MORE_URL,
         fields: &[
             AuthSecretTypeField {
@@ -156,7 +152,6 @@ static CLAUDE_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 3] = [
     AuthSecretTypeInfo {
         display_name: "Bedrock Access Key",
         secret_type: ManagedSecretType::AnthropicBedrockAccessKey,
-        header_text: "Please paste in a Bedrock Access Key.",
         learn_more_url: CLAUDE_LEARN_MORE_URL,
         fields: &[
             AuthSecretTypeField {

--- a/app/src/ai/auth_secret_types.rs
+++ b/app/src/ai/auth_secret_types.rs
@@ -16,6 +16,8 @@ pub struct AuthSecretTypeInfo {
     pub display_name: &'static str,
     pub secret_type: ManagedSecretType,
     pub fields: &'static [AuthSecretTypeField],
+    pub header_text: &'static str,
+    pub learn_more_url: &'static str,
 }
 
 pub fn auth_secret_types_for_harness(harness: Harness) -> &'static [AuthSecretTypeInfo] {
@@ -25,6 +27,21 @@ pub fn auth_secret_types_for_harness(harness: Harness) -> &'static [AuthSecretTy
         _ => &[],
     }
 }
+
+pub fn learn_more_url_for_harness(harness: Harness) -> &'static str {
+    match harness {
+        Harness::Claude => CLAUDE_LEARN_MORE_URL,
+        Harness::Codex => CODEX_LEARN_MORE_URL,
+        _ => DEFAULT_LEARN_MORE_URL,
+    }
+}
+
+const DEFAULT_LEARN_MORE_URL: &str =
+    "https://docs.warp.dev/agent-platform/cloud-agents/harnesses/authentication/";
+const CODEX_LEARN_MORE_URL: &str =
+    "https://docs.warp.dev/agent-platform/cloud-agents/harnesses/authentication/#connecting-codex-credentials";
+const CLAUDE_LEARN_MORE_URL: &str =
+    "https://docs.warp.dev/agent-platform/cloud-agents/harnesses/authentication/#connecting-claude-code-credentials";
 
 pub fn build_managed_secret_value(
     info: &AuthSecretTypeInfo,
@@ -85,16 +102,18 @@ pub fn build_managed_secret_value(
 static CODEX_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 1] = [AuthSecretTypeInfo {
     display_name: "OpenAI API Key",
     secret_type: ManagedSecretType::OpenaiApiKey,
+    header_text: "Please paste in an OpenAI API Key.",
+    learn_more_url: CODEX_LEARN_MORE_URL,
     fields: &[
         AuthSecretTypeField {
             label: "OPENAI_API_KEY",
-            placeholder: None,
+            placeholder: Some("sk-..."),
             optional: false,
             sensitive: true,
         },
         AuthSecretTypeField {
             label: "BASE_URL",
-            placeholder: Some("BASE_URL (e.g. https://us.api.openai.com/v1)"),
+            placeholder: Some("https://us.api.openai.com/v1"),
             optional: true,
             sensitive: false,
         },
@@ -105,9 +124,11 @@ static CLAUDE_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 3] = [
     AuthSecretTypeInfo {
         display_name: "Anthropic API Key",
         secret_type: ManagedSecretType::AnthropicApiKey,
+        header_text: "Please paste in an Anthropic API Key.",
+        learn_more_url: CLAUDE_LEARN_MORE_URL,
         fields: &[AuthSecretTypeField {
             label: "ANTHROPIC_API_KEY",
-            placeholder: None,
+            placeholder: Some("sk-ant-..."),
             optional: false,
             sensitive: true,
         }],
@@ -115,16 +136,18 @@ static CLAUDE_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 3] = [
     AuthSecretTypeInfo {
         display_name: "Bedrock API Key",
         secret_type: ManagedSecretType::AnthropicBedrockApiKey,
+        header_text: "Please paste in a Bedrock token.",
+        learn_more_url: CLAUDE_LEARN_MORE_URL,
         fields: &[
             AuthSecretTypeField {
                 label: "AWS_BEARER_TOKEN_BEDROCK",
-                placeholder: None,
+                placeholder: Some("Bearer token"),
                 optional: false,
                 sensitive: true,
             },
             AuthSecretTypeField {
                 label: "AWS_REGION",
-                placeholder: None,
+                placeholder: Some("us-east-1"),
                 optional: false,
                 sensitive: false,
             },
@@ -133,28 +156,30 @@ static CLAUDE_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 3] = [
     AuthSecretTypeInfo {
         display_name: "Bedrock Access Key",
         secret_type: ManagedSecretType::AnthropicBedrockAccessKey,
+        header_text: "Please paste in a Bedrock Access Key.",
+        learn_more_url: CLAUDE_LEARN_MORE_URL,
         fields: &[
             AuthSecretTypeField {
                 label: "AWS_ACCESS_KEY_ID",
-                placeholder: None,
+                placeholder: Some("AKIA..."),
                 optional: false,
                 sensitive: true,
             },
             AuthSecretTypeField {
                 label: "AWS_SECRET_ACCESS_KEY",
-                placeholder: None,
+                placeholder: Some("Secret access key"),
                 optional: false,
                 sensitive: true,
             },
             AuthSecretTypeField {
                 label: "AWS_SESSION_TOKEN",
-                placeholder: None,
+                placeholder: Some("Session token (temporary credentials only)"),
                 optional: true,
                 sensitive: true,
             },
             AuthSecretTypeField {
                 label: "AWS_REGION",
-                placeholder: None,
+                placeholder: Some("us-east-1"),
                 optional: false,
                 sensitive: false,
             },

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -64,7 +64,7 @@ const DEFAULT_MODEL_LABEL: &str = "Default model";
 
 /// Label shown in the auth secret picker when no secret is selected
 /// (the child agent will inherit credentials from its environment).
-const AUTH_SECRET_INHERIT_LABEL: &str = "Inherit key from environment";
+const AUTH_SECRET_INHERIT_LABEL: &str = "Skip (advanced)";
 /// Label for the auth secret column.
 pub const AUTH_SECRET_COLUMN_LABEL: &str = "API key";
 

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -218,13 +218,11 @@ impl HarnessAvailabilityModel {
         harness: Harness,
         name: String,
         value: ManagedSecretValue,
+        owner: SecretOwner,
         ctx: &mut ModelContext<Self>,
     ) {
         let manager = ManagedSecretManager::handle(ctx);
-        let create_future =
-            manager
-                .as_ref(ctx)
-                .create_secret(SecretOwner::CurrentUser, name, value, None);
+        let create_future = manager.as_ref(ctx).create_secret(owner, name, value, None);
         ctx.spawn(create_future, move |me, result, ctx| match result {
             Ok(secret) => {
                 let entry = AuthSecretEntry {

--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
@@ -367,8 +367,8 @@ impl AuthSecretFtuxDropdown {
 
         items.push(MenuItem::Item(
             MenuItemFields::new_with_label(
-                "Skip setting an API key",
-                "Choose this if authentication is set up in the environment",
+                "Skip (advanced)",
+                "Only if your key is already set in the environment (e.g. baked into the Docker image)",
             )
             .with_font_size_override(FONT_SIZE)
             .with_padding_override(MENU_ITEM_VERTICAL_PADDING, MENU_HORIZONTAL_PADDING)

--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
@@ -1,14 +1,18 @@
 use crate::view_components::DismissibleToast;
 use crate::workspace::ToastStack;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 use warp_cli::agent::Harness;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::Fill;
+use warp_managed_secrets::client::SecretOwner;
 use warpui::elements::{
     Border, ChildView, Clipped, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
-    Expanded, Flex, Hoverable, MainAxisSize, MouseStateHandle, ParentElement as _, Radius, Text,
+    Expanded, Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle,
+    ParentElement as _, Radius, Text, Wrap,
 };
 use warpui::fonts::{Properties, Weight};
+use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle,
@@ -17,7 +21,8 @@ use warpui::{
 use settings::Setting as _;
 
 use crate::ai::auth_secret_types::{
-    auth_secret_types_for_harness, build_managed_secret_value, AuthSecretTypeInfo,
+    auth_secret_types_for_harness, build_managed_secret_value, learn_more_url_for_harness,
+    AuthSecretTypeInfo,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::harness_availability::{HarnessAvailabilityEvent, HarnessAvailabilityModel};
@@ -40,8 +45,6 @@ const BUTTON_FONT_SIZE: f32 = 14.;
 
 const EDITOR_FONT_SIZE: f32 = 14.;
 
-const ROW_SPACING: f32 = 24.;
-
 const CONTENT_SECTION_SPACING: f32 = 12.;
 
 const FORM_FIELD_SPACING: f32 = 8.;
@@ -54,11 +57,18 @@ const CORNER_RADIUS: f32 = 4.;
 
 const FIELD_EDITOR_MIN_HEIGHT: f32 = 32.;
 
+const TYPE_DESCRIPTION_FONT_SIZE: f32 = 12.;
+
+const CHECKBOX_SIZE: f32 = 14.;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum AuthSecretFtuxAction {
     Skip,
     Cancel,
     Continue,
+    Back,
+    LearnMore(&'static str),
+    ToggleTeamScope,
 }
 
 struct SecretCreationState {
@@ -73,8 +83,11 @@ pub struct AuthSecretFtuxView {
     name_editor: ViewHandle<EditorView>,
     field_editors: Vec<ViewHandle<EditorView>>,
     creation_state: Option<SecretCreationState>,
-    cancel_mouse_state: MouseStateHandle,
+    back_button_mouse_state: MouseStateHandle,
+    share_with_team: bool,
     continue_mouse_state: MouseStateHandle,
+    learn_more_mouse_state: MouseStateHandle,
+    team_checkbox_mouse_state: MouseStateHandle,
 }
 
 impl AuthSecretFtuxView {
@@ -82,7 +95,7 @@ impl AuthSecretFtuxView {
         ambient_agent_model: ModelHandle<AmbientAgentViewModel>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let name_editor = make_single_line_editor(Some("NICKNAME"), false, ctx);
+        let name_editor = make_single_line_editor(Some("e.g. My API Key"), false, ctx);
 
         ctx.subscribe_to_view(&name_editor, |me, _, event, ctx| {
             me.handle_form_editor_nav(0, event, ctx);
@@ -180,8 +193,11 @@ impl AuthSecretFtuxView {
             name_editor,
             field_editors: Vec::new(),
             creation_state: None,
-            cancel_mouse_state: MouseStateHandle::default(),
+            back_button_mouse_state: MouseStateHandle::default(),
+            share_with_team: false,
             continue_mouse_state: MouseStateHandle::default(),
+            learn_more_mouse_state: MouseStateHandle::default(),
+            team_checkbox_mouse_state: MouseStateHandle::default(),
         }
     }
 
@@ -273,6 +289,7 @@ impl AuthSecretFtuxView {
             editors.push(editor);
         }
         self.field_editors = editors;
+        self.share_with_team = false;
         self.creation_state = Some(SecretCreationState {
             harness,
             secret_type_index: type_index,
@@ -358,14 +375,27 @@ impl AuthSecretFtuxView {
         }
         ctx.notify();
 
+        let owner = self.resolve_secret_owner(ctx);
         HarnessAvailabilityModel::handle(ctx).update(ctx, |model, ctx| {
-            model.create_auth_secret(harness, name, value, ctx);
+            model.create_auth_secret(harness, name, value, owner, ctx);
         });
+    }
+
+    fn resolve_secret_owner(&self, ctx: &ViewContext<Self>) -> SecretOwner {
+        if self.share_with_team {
+            if let Some(team) = UserWorkspaces::as_ref(ctx).current_team() {
+                return SecretOwner::Team {
+                    team_uid: team.uid.uid(),
+                };
+            }
+        }
+        SecretOwner::CurrentUser
     }
 
     fn clear_creation_state(&mut self, ctx: &mut ViewContext<Self>) {
         if self.creation_state.is_some() {
             self.creation_state = None;
+            self.share_with_team = false;
             self.clear_all_editor_buffers(ctx);
             self.field_editors.clear();
             self.ftux_dropdown.update(ctx, |dropdown, ctx| {
@@ -414,20 +444,80 @@ impl AuthSecretFtuxView {
     fn render_description(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
-        let harness = self.ambient_agent_model.as_ref(app).selected_harness();
-        let display_name = harness_display::display_name(harness);
-        let description = format!(
-            "Please select an API key or create a new one to use \
-             {display_name} as a cloud agent."
-        );
-        Text::new_inline(
-            description,
-            appearance.ui_font_family(),
-            DESCRIPTION_FONT_SIZE,
+        let font_family = appearance.ui_font_family();
+        let sub_color = internal_colors::text_sub(theme, theme.surface_1());
+        let accent_color = theme.accent().into_solid();
+
+        let main_text = if let Some(info) = self.current_type_info() {
+            Text::new_inline(
+                info.header_text.to_string(),
+                font_family,
+                DESCRIPTION_FONT_SIZE,
+            )
+            .with_color(theme.foreground().into())
+            .finish()
+        } else {
+            let harness = self.ambient_agent_model.as_ref(app).selected_harness();
+            let display_name = harness_display::display_name(harness);
+            let description =
+                format!("Please select an API key to use {display_name} in the cloud with Oz.");
+            Text::new_inline(description, font_family, DESCRIPTION_FONT_SIZE)
+                .with_color(theme.foreground().into())
+                .soft_wrap(true)
+                .finish()
+        };
+
+        let privacy_text = Text::new_inline(
+            "Your credentials are encrypted end-to-end. ".to_string(),
+            font_family,
+            TYPE_DESCRIPTION_FONT_SIZE,
         )
-        .with_color(theme.foreground().into())
+        .with_color(sub_color)
         .soft_wrap(true)
-        .finish()
+        .finish();
+
+        let harness = self.ambient_agent_model.as_ref(app).selected_harness();
+        let harness_name = harness_display::display_name(harness);
+        let learn_more_url = self
+            .current_type_info()
+            .map(|info| info.learn_more_url)
+            .unwrap_or_else(|| learn_more_url_for_harness(harness));
+        let learn_more_label =
+            format!("Learn more about authentication for {harness_name} in Warp.");
+        let learn_more = Hoverable::new(self.learn_more_mouse_state.clone(), move |state| {
+            let color = if state.is_hovered() {
+                accent_color
+            } else {
+                sub_color
+            };
+            Text::new_inline(
+                learn_more_label.clone(),
+                font_family,
+                TYPE_DESCRIPTION_FONT_SIZE,
+            )
+            .with_color(color)
+            .with_style(Properties::default().weight(Weight::Semibold))
+            .soft_wrap(true)
+            .finish()
+        })
+        .with_cursor(warpui::platform::Cursor::PointingHand)
+        .on_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(AuthSecretFtuxAction::LearnMore(learn_more_url));
+        })
+        .finish();
+
+        let privacy_row = Wrap::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(privacy_text)
+            .with_child(learn_more)
+            .finish();
+
+        Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_spacing(4.)
+            .with_child(main_text)
+            .with_child(privacy_row)
+            .finish()
     }
 
     fn render_field_label(&self, label: &str, app: &AppContext) -> Box<dyn Element> {
@@ -474,6 +564,49 @@ impl AuthSecretFtuxView {
         .finish()
     }
 
+    fn render_scope_checkbox(&self, app: &AppContext) -> Box<dyn Element> {
+        let has_team = UserWorkspaces::as_ref(app).current_team().is_some();
+        if !has_team {
+            return Empty::new().finish();
+        }
+
+        let appearance = Appearance::as_ref(app);
+        let zero = Coords::uniform(0.);
+        let checkbox = appearance
+            .ui_builder()
+            .checkbox(self.team_checkbox_mouse_state.clone(), Some(CHECKBOX_SIZE))
+            .with_style(UiComponentStyles {
+                margin: Some(zero),
+                ..Default::default()
+            })
+            .check(self.share_with_team)
+            .build()
+            .on_click(|ctx, _, _| {
+                ctx.dispatch_typed_action(AuthSecretFtuxAction::ToggleTeamScope);
+            })
+            .with_cursor(warpui::platform::Cursor::PointingHand)
+            .finish();
+
+        let theme = appearance.theme();
+        let label_color = internal_colors::text_sub(theme, theme.surface_1());
+        let label = Text::new_inline(
+            "Share with team".to_string(),
+            appearance.ui_font_family(),
+            TYPE_DESCRIPTION_FONT_SIZE,
+        )
+        .with_color(label_color)
+        .finish();
+
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::End)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(6.)
+            .with_child(checkbox)
+            .with_child(label)
+            .finish()
+    }
+
     fn render_creation_form(&self, app: &AppContext) -> Box<dyn Element> {
         let Some(info) = self.current_type_info() else {
             return Empty::new().finish();
@@ -483,7 +616,11 @@ impl AuthSecretFtuxView {
             .with_main_axis_size(MainAxisSize::Min)
             .with_spacing(FORM_FIELD_SPACING);
 
-        column.add_child(self.render_field_label("NICKNAME", app));
+        column.add_child(
+            Container::new(self.render_field_label("NAME", app))
+                .with_padding_top(CONTENT_SECTION_SPACING)
+                .finish(),
+        );
         column.add_child(self.render_editor_container(&self.name_editor, app));
 
         for (idx, field) in info.fields.iter().enumerate() {
@@ -497,6 +634,9 @@ impl AuthSecretFtuxView {
                 column.add_child(self.render_editor_container(editor, app));
             }
         }
+
+        column.add_child(self.render_scope_checkbox(app));
+
         column.finish()
     }
 
@@ -543,11 +683,16 @@ impl AuthSecretFtuxView {
         let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
         row.add_child(Expanded::new(1., Empty::new().finish()).finish());
 
+        let (label, action) = if self.creation_state.is_some() {
+            ("Back", AuthSecretFtuxAction::Back)
+        } else {
+            ("Cancel", AuthSecretFtuxAction::Cancel)
+        };
         row.add_child(self.render_button(
-            "Cancel",
-            self.cancel_mouse_state.clone(),
+            label,
+            self.back_button_mouse_state.clone(),
             None,
-            AuthSecretFtuxAction::Cancel,
+            action,
             app,
         ));
 
@@ -604,6 +749,14 @@ impl TypedActionView for AuthSecretFtuxView {
             AuthSecretFtuxAction::Skip => self.handle_skip(ctx),
             AuthSecretFtuxAction::Cancel => self.handle_cancel(ctx),
             AuthSecretFtuxAction::Continue => self.handle_continue(ctx),
+            AuthSecretFtuxAction::Back => self.clear_creation_state(ctx),
+            AuthSecretFtuxAction::LearnMore(url) => {
+                ctx.open_url(url);
+            }
+            AuthSecretFtuxAction::ToggleTeamScope => {
+                self.share_with_team = !self.share_with_team;
+                ctx.notify();
+            }
         }
     }
 }
@@ -616,22 +769,27 @@ impl View for AuthSecretFtuxView {
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let mut column = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_main_axis_size(MainAxisSize::Min)
-            .with_spacing(ROW_SPACING);
+            .with_main_axis_size(MainAxisSize::Min);
 
         let mut content_section = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_main_axis_size(MainAxisSize::Min)
             .with_spacing(CONTENT_SECTION_SPACING);
         content_section.add_child(self.render_description(app));
-        content_section.add_child(ChildView::new(&self.ftux_dropdown).finish());
+        if self.creation_state.is_none() {
+            content_section.add_child(ChildView::new(&self.ftux_dropdown).finish());
+        }
         column.add_child(content_section.finish());
 
         if self.creation_state.is_some() {
             column.add_child(self.render_creation_form(app));
         }
 
-        column.add_child(self.render_bottom_row(app));
+        column.add_child(
+            Container::new(self.render_bottom_row(app))
+                .with_padding_top(CONTENT_SECTION_SPACING)
+                .finish(),
+        );
 
         column.finish()
     }

--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
@@ -448,19 +448,14 @@ impl AuthSecretFtuxView {
         let sub_color = internal_colors::text_sub(theme, theme.surface_1());
         let accent_color = theme.accent().into_solid();
 
-        let main_text = if let Some(info) = self.current_type_info() {
-            Text::new_inline(
-                info.header_text.to_string(),
-                font_family,
-                DESCRIPTION_FONT_SIZE,
-            )
-            .with_color(theme.foreground().into())
-            .finish()
-        } else {
-            let harness = self.ambient_agent_model.as_ref(app).selected_harness();
-            let display_name = harness_display::display_name(harness);
-            let description =
-                format!("Please select an API key to use {display_name} in the cloud with Oz.");
+        let main_text = {
+            let description = if self.current_type_info().is_some() {
+                "Enter your credentials below.".to_string()
+            } else {
+                let harness = self.ambient_agent_model.as_ref(app).selected_harness();
+                let display_name = harness_display::display_name(harness);
+                format!("Select an API key type to use {display_name} in the cloud with Oz.")
+            };
             Text::new_inline(description, font_family, DESCRIPTION_FONT_SIZE)
                 .with_color(theme.foreground().into())
                 .soft_wrap(true)


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR updates the auth FTUX to have more specific information to help guide users through setup.

Notable changes:
- Added a "Learn more about ..." button that links to docs to help with setup
- Updated the "skip" text in the dropdown to contain a specific example about what it means for credentials to be inherited from the environment, and to say "advanced"
- Added a "share with team" button so we can create team-scoped keys
- We no longer show the dropdown selector and the input fields at the same time (they're two separate stages)—I think this makes it easier for the user to focus on the fields and makes it feel less busy
- Added more specific placeholder text

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
https://www.loom.com/share/67b1cff03cee40c48b8560226e903a54

Some copy has changed since filming but the Loom is still a faithful representation.


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

