### PR TITLE
Move cloud object models to separate crate.

### DIFF
--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -1,131 +1,24 @@
-use std::fmt;
-
-use serde::{Deserialize, Serialize};
-use warp_server_client::cloud_object::Owner;
+pub use warp_server_client::cloud_object::models::{
+    AmbientAgentEnvironment, AwsProviderConfig, BaseImage, GcpProviderConfig, GithubRepo,
+    ProvidersConfig,
+};
+use warp_server_client::cloud_object::{
+    GenericCloudObject, GenericStringModel, GenericStringObjectFormat,
+    GenericStringObjectUniqueKey, JsonObjectType, Owner, Revision,
+};
+use warp_server_client::ids::GenericStringObjectId;
 use warpui::{AppContext, SingletonEntity as _};
 
 use crate::auth::AuthStateProvider;
-use crate::cloud_object::model::generic_string_model::{
-    GenericStringModel, GenericStringObjectId, StringModel,
-};
+use crate::cloud_object::model::generic_string_model::StringModel;
 use crate::cloud_object::model::json_model::{JsonModel, JsonSerializer};
-use crate::cloud_object::{
-    GenericCloudObject, GenericStringObjectFormat, GenericStringObjectUniqueKey, JsonObjectType,
-    Revision,
-};
 use crate::server::sync_queue::QueueItem;
 use crate::workspaces::user_workspaces::UserWorkspaces;
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct GithubRepo {
-    /// Repository owner (e.g. "warpdotdev")
-    pub owner: String,
-    /// Repository name (e.g. "warp-internal")
-    pub repo: String,
-}
-
-impl GithubRepo {
-    pub fn new(owner: String, repo: String) -> Self {
-        Self { owner, repo }
-    }
-}
-
-impl fmt::Display for GithubRepo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/{}", self.owner, self.repo)
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum BaseImage {
-    DockerImage(String),
-}
-
-impl fmt::Display for BaseImage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BaseImage::DockerImage(s) => s.fmt(f),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct GcpProviderConfig {
-    pub project_number: String,
-    pub workload_identity_federation_pool_id: String,
-    pub workload_identity_federation_provider_id: String,
-    /// Service account email for impersonation. When set, the federated token
-    /// is exchanged for a service account access token.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub service_account_email: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct AwsProviderConfig {
-    pub role_arn: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
-pub struct ProvidersConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gcp: Option<GcpProviderConfig>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aws: Option<AwsProviderConfig>,
-}
-
-impl ProvidersConfig {
-    pub fn is_empty(&self) -> bool {
-        self.gcp.is_none() && self.aws.is_none()
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-/// An AmbientAgentEnvironment represents an environment that we would run a Warp agent in.
-pub struct AmbientAgentEnvironment {
-    /// Environment name
-    #[serde(default)]
-    pub name: String,
-    /// Optional description of the environment (max 240 characters)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// List of GitHub repositories
-    #[serde(default)]
-    pub github_repos: Vec<GithubRepo>,
-    /// Base image specification
-    #[serde(flatten)]
-    pub base_image: BaseImage,
-    /// List of setup commands to run after cloning
-    #[serde(default)]
-    pub setup_commands: Vec<String>,
-    /// Optional cloud provider configurations for automatic auth.
-    #[serde(default, skip_serializing_if = "ProvidersConfig::is_empty")]
-    pub providers: ProvidersConfig,
-}
 
 pub type CloudAmbientAgentEnvironment =
     GenericCloudObject<GenericStringObjectId, CloudAmbientAgentEnvironmentModel>;
 pub type CloudAmbientAgentEnvironmentModel =
     GenericStringModel<AmbientAgentEnvironment, JsonSerializer>;
-
-impl AmbientAgentEnvironment {
-    pub fn new(
-        name: String,
-        description: Option<String>,
-        github_repos: Vec<GithubRepo>,
-        docker_image: String,
-        setup_commands: Vec<String>,
-    ) -> Self {
-        Self {
-            name,
-            description,
-            github_repos,
-            base_image: BaseImage::DockerImage(docker_image),
-            setup_commands,
-            providers: ProvidersConfig::default(),
-        }
-    }
-}
 
 impl StringModel for AmbientAgentEnvironment {
     type CloudObjectType = CloudAmbientAgentEnvironment;

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -1,3 +1,6 @@
+// Some of these re-exported types aren't used in the wasm build, so we suppress this
+// warning.
+#[cfg_attr(target_family = "wasm", expect(unused_imports))]
 pub use warp_server_client::cloud_object::models::{
     AmbientAgentEnvironment, AwsProviderConfig, BaseImage, GcpProviderConfig, GithubRepo,
     ProvidersConfig,

--- a/app/src/workflows/workflow_enum.rs
+++ b/app/src/workflows/workflow_enum.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+pub use warp_server_client::cloud_object::models::{EnumVariants, WorkflowEnum};
 
 use crate::cloud_object::model::generic_string_model::{
     GenericStringModel, GenericStringObjectId, StringModel,
@@ -9,27 +9,6 @@ use crate::cloud_object::{
     Revision,
 };
 use crate::server::sync_queue::QueueItem;
-
-/// Data model for a workflow enum, one type of argument that can be inserted into a workflow
-/// A workflow enum can either be static or dynamic, as determined by the type of `EnumVariants` it uses
-///
-/// A `Static` enum contains a finite set of user-specified string values
-/// A `Dynamic` enum contains a single shell command, which is executed to determine suggested variants for that argument
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash, PartialOrd)]
-pub struct WorkflowEnum {
-    /// Enum name
-    pub name: String,
-    /// Whether or not the variable should be visible to other workflows
-    pub is_shared: bool,
-    /// The variants for this enum
-    pub variants: EnumVariants,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash, PartialOrd)]
-pub enum EnumVariants {
-    Static(Vec<String>), // contains the explicit variants for a static enum
-    Dynamic(String),     // contains the value of the shell command associated with the dynamic enum
-}
 
 pub type CloudWorkflowEnum = GenericCloudObject<GenericStringObjectId, CloudWorkflowEnumModel>;
 pub type CloudWorkflowEnumModel = GenericStringModel<WorkflowEnum, JsonSerializer>;

--- a/crates/warp_server_client/src/cloud_object/mod.rs
+++ b/crates/warp_server_client/src/cloud_object/mod.rs
@@ -27,6 +27,7 @@ use crate::ids::{FolderId, ServerId, SyncId};
 mod creation;
 mod generic_cloud_object;
 mod generic_string_model;
+pub mod models;
 mod server_object;
 mod update;
 

--- a/crates/warp_server_client/src/cloud_object/models/cloud_environment.rs
+++ b/crates/warp_server_client/src/cloud_object/models/cloud_environment.rs
@@ -1,0 +1,109 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GithubRepo {
+    /// Repository owner (e.g. "warpdotdev")
+    pub owner: String,
+    /// Repository name (e.g. "warp-internal")
+    pub repo: String,
+}
+
+impl GithubRepo {
+    pub fn new(owner: String, repo: String) -> Self {
+        Self { owner, repo }
+    }
+}
+
+impl fmt::Display for GithubRepo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.owner, self.repo)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum BaseImage {
+    DockerImage(String),
+}
+
+impl fmt::Display for BaseImage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BaseImage::DockerImage(s) => s.fmt(f),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct GcpProviderConfig {
+    pub project_number: String,
+    pub workload_identity_federation_pool_id: String,
+    pub workload_identity_federation_provider_id: String,
+    /// Service account email for impersonation. When set, the federated token
+    /// is exchanged for a service account access token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_account_email: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct AwsProviderConfig {
+    pub role_arn: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
+pub struct ProvidersConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gcp: Option<GcpProviderConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aws: Option<AwsProviderConfig>,
+}
+
+impl ProvidersConfig {
+    pub fn is_empty(&self) -> bool {
+        self.gcp.is_none() && self.aws.is_none()
+    }
+}
+
+/// An AmbientAgentEnvironment represents an environment that we would run a Warp agent in.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct AmbientAgentEnvironment {
+    /// Environment name
+    #[serde(default)]
+    pub name: String,
+    /// Optional description of the environment (max 240 characters)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// List of GitHub repositories
+    #[serde(default)]
+    pub github_repos: Vec<GithubRepo>,
+    /// Base image specification
+    #[serde(flatten)]
+    pub base_image: BaseImage,
+    /// List of setup commands to run after cloning
+    #[serde(default)]
+    pub setup_commands: Vec<String>,
+    /// Optional cloud provider configurations for automatic auth.
+    #[serde(default, skip_serializing_if = "ProvidersConfig::is_empty")]
+    pub providers: ProvidersConfig,
+}
+
+impl AmbientAgentEnvironment {
+    pub fn new(
+        name: String,
+        description: Option<String>,
+        github_repos: Vec<GithubRepo>,
+        docker_image: String,
+        setup_commands: Vec<String>,
+    ) -> Self {
+        Self {
+            name,
+            description,
+            github_repos,
+            base_image: BaseImage::DockerImage(docker_image),
+            setup_commands,
+            providers: ProvidersConfig::default(),
+        }
+    }
+}

--- a/crates/warp_server_client/src/cloud_object/models/mod.rs
+++ b/crates/warp_server_client/src/cloud_object/models/mod.rs
@@ -1,0 +1,5 @@
+mod cloud_environment;
+mod workflow_enum;
+
+pub use cloud_environment::*;
+pub use workflow_enum::*;

--- a/crates/warp_server_client/src/cloud_object/models/workflow_enum.rs
+++ b/crates/warp_server_client/src/cloud_object/models/workflow_enum.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+/// Data model for a workflow enum, one type of argument that can be inserted into a workflow
+/// A workflow enum can either be static or dynamic, as determined by the type of `EnumVariants` it uses
+///
+/// A `Static` enum contains a finite set of user-specified string values
+/// A `Dynamic` enum contains a single shell command, which is executed to determine suggested variants for that argument
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash, PartialOrd)]
+pub struct WorkflowEnum {
+    /// Enum name
+    pub name: String,
+    /// Whether or not the variable should be visible to other workflows
+    pub is_shared: bool,
+    /// The variants for this enum
+    pub variants: EnumVariants,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash, PartialOrd)]
+pub enum EnumVariants {
+    Static(Vec<String>), // contains the explicit variants for a static enum
+    Dynamic(String),     // contains the value of the shell command associated with the dynamic enum
+}


### PR DESCRIPTION
## Description
Moves the remaining low-level cloud object model definitions out of the app crate so they can be reused outside `warp` without pulling in app-specific code.

This PR moves the workflow enum and cloud environment model surfaces into the server/client cloud object layer while keeping compatibility re-exports for existing app call sites. This is a preparatory step toward extracting the shared cloud object substrate and model crates in the follow-up PRs.

> [!NOTE]
> note from dstern: this honestly should probably just have been merged into a higher PR in the stack (which pulls these back _out_ of `cloud_objects` and into a `cloud_object_models` crate with all of the other models), but it's here, so cest la vie 

## Linked Issue
None.

## Testing
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp --tests`

No manual app testing; this is a crate-boundary refactor with no intended product behavior changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
