### PR TITLE
feat: add handoff funnel telemetry

### DIFF
--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -520,6 +520,7 @@ impl AmbientAgentRunner {
                                     println!("To increase your concurrent agent limit, upgrade your plan: {}", url);
                                 }
                             }
+                            AmbientAgentEvent::FollowupAccepted => {}
                             AmbientAgentEvent::StateChanged {
                                 state,
                                 status_message,

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -111,7 +111,7 @@ mod snapshot;
 pub(crate) mod terminal;
 
 use environment::PrepareEnvironmentError;
-pub(crate) use snapshot::upload_snapshot_for_handoff;
+pub(crate) use snapshot::{upload_snapshot_for_handoff, HandoffSnapshotUploadOutcome};
 use terminal::TerminalDriverEvent;
 
 const MCP_SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(20);

--- a/app/src/ai/agent_sdk/driver/snapshot.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot.rs
@@ -643,6 +643,17 @@ struct SnapshotOutcome {
     manifest_uploaded: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HandoffSnapshotUploadOutcome {
+    SkippedEmptyWorkspace,
+    Uploaded {
+        initial_snapshot_token: InitialSnapshotToken,
+        partial_blob_upload: bool,
+    },
+    ManifestUploadFailed,
+    FailedBeforeManifest,
+}
+
 // --- Manifest schema ---
 
 #[derive(serde::Serialize)]
@@ -730,26 +741,17 @@ async fn upload_snapshot_from_declarations_file(
 /// contents, allocate an initial snapshot token plus presigned upload URLs via
 /// `AIClient::upload_local_handoff_snapshot`, and upload the artifacts.
 ///
-/// Returns:
-/// - `Ok(Some(initial_snapshot_token))` when a token was minted **and the manifest landed in GCS**.
-///   Individual blob uploads may still have failed; the manifest catalogues their status so the
-///   cloud agent rehydrates against whatever did land, matching the cloud→cloud best-effort
-///   posture.
-/// - `Ok(None)` when the workspace was empty (no repos, no orphan files) **or** when the
-///   manifest itself failed to upload. Without the manifest the snapshot is unusable, so
-///   callers should spawn the cloud agent without an initial snapshot token instead of pointing
-///   it at an incomplete prefix. Manifest-upload failures are also routed through
-///   `report_error!` so on-call alerting catches the silent regression.
-/// - `Err(_)` only for hard failures of `upload_local_handoff_snapshot` itself (auth, etc.).
+/// Returns a structured outcome so the caller can distinguish empty workspaces,
+/// manifest failures, partial blob uploads, and hard token-allocation failures.
 pub(crate) async fn upload_snapshot_for_handoff(
     repo_paths: Vec<PathBuf>,
     orphan_file_paths: Vec<PathBuf>,
     client: Arc<dyn AIClient>,
     http: &http_client::Client,
-) -> Result<Option<InitialSnapshotToken>> {
+) -> Result<HandoffSnapshotUploadOutcome> {
     if repo_paths.is_empty() && orphan_file_paths.is_empty() {
         log::info!("Handoff snapshot has no declarations; skipping upload");
-        return Ok(None);
+        return Ok(HandoffSnapshotUploadOutcome::SkippedEmptyWorkspace);
     }
 
     let declarations: Vec<DeclarationEntry> = repo_paths
@@ -841,7 +843,7 @@ pub(crate) async fn upload_snapshot_for_handoff(
     else {
         // Manifest serialization failed (already reported via `report_error!` inside
         // the helper). Without a manifest the snapshot is unusable, so refuse the token.
-        return Ok(None);
+        return Ok(HandoffSnapshotUploadOutcome::FailedBeforeManifest);
     };
 
     let summary = SnapshotSummary::from_entries(&outcome.entries, outcome.manifest_uploaded);
@@ -855,10 +857,13 @@ pub(crate) async fn upload_snapshot_for_handoff(
             summary.uploaded,
             summary.total,
         ));
-        return Ok(None);
+        return Ok(HandoffSnapshotUploadOutcome::ManifestUploadFailed);
     }
 
-    Ok(Some(initial_snapshot_token))
+    Ok(HandoffSnapshotUploadOutcome::Uploaded {
+        initial_snapshot_token,
+        partial_blob_upload: !summary.all_uploaded(),
+    })
 }
 
 /// Core upload pipeline.

--- a/app/src/ai/ambient_agents/spawn.rs
+++ b/app/src/ai/ambient_agents/spawn.rs
@@ -75,6 +75,8 @@ pub enum AmbientAgentEvent {
     },
     /// Session started and join information became available.
     SessionStarted { session_join_info: SessionJoinInfo },
+    /// Follow-up request was accepted by the API and polling has started.
+    FollowupAccepted,
     /// Timed out waiting for the agent session to be ready.
     TimedOut,
     /// Cloud agent capacity limit has been reached. This does not block
@@ -147,6 +149,7 @@ pub fn submit_run_followup(
             yield Err(err);
             return;
         }
+        yield Ok(AmbientAgentEvent::FollowupAccepted);
 
         let mut stream = Box::pin(poll_run_until_joinable_session(
             run_id,

--- a/app/src/ai/ambient_agents/spawn_tests.rs
+++ b/app/src/ai/ambient_agents/spawn_tests.rs
@@ -46,6 +46,20 @@ fn task_with(
     }
 }
 
+async fn expect_followup_accepted<S>(stream: &mut S)
+where
+    S: futures::Stream<Item = Result<AmbientAgentEvent, anyhow::Error>> + Unpin,
+{
+    use futures::StreamExt;
+
+    let event = stream
+        .next()
+        .await
+        .expect("expected follow-up accepted")
+        .expect("expected ok");
+    assert!(matches!(event, AmbientAgentEvent::FollowupAccepted));
+}
+
 #[tokio::test]
 async fn followup_submits_before_polling_and_ignores_previous_session_id() {
     use futures::StreamExt;
@@ -101,6 +115,8 @@ async fn followup_submits_before_polling_and_ignores_previous_session_id() {
         ai_client,
         None,
     ));
+
+    expect_followup_accepted(&mut stream).await;
 
     let event = stream
         .next()
@@ -194,6 +210,8 @@ async fn followup_terminal_failure_surfaces_status_message() {
         None,
     ));
 
+    expect_followup_accepted(&mut stream).await;
+
     let event = stream
         .next()
         .await
@@ -259,6 +277,8 @@ async fn followup_without_previous_session_id_accepts_joinable_session() {
         None,
     ));
 
+    expect_followup_accepted(&mut stream).await;
+
     let event = stream
         .next()
         .await
@@ -321,6 +341,8 @@ async fn followup_without_previous_session_id_errors_if_run_finishes_before_sess
         ai_client,
         None,
     ));
+
+    expect_followup_accepted(&mut stream).await;
 
     let event = stream
         .next()
@@ -407,6 +429,8 @@ async fn followup_skips_prior_terminal_state_until_working_then_attaches() {
         ai_client,
         None,
     ));
+
+    expect_followup_accepted(&mut stream).await;
 
     // First emitted event must be `Pending` — the prior `Blocked` was suppressed.
     let event = stream
@@ -497,6 +521,8 @@ async fn followup_skips_prior_terminal_then_surfaces_real_failure() {
         None,
     ));
 
+    expect_followup_accepted(&mut stream).await;
+
     let event = stream
         .next()
         .await
@@ -563,6 +589,8 @@ async fn followup_cancelled_state_breaks_skip_loop() {
         None,
     ));
 
+    expect_followup_accepted(&mut stream).await;
+
     let event = stream
         .next()
         .await
@@ -615,6 +643,8 @@ async fn followup_bounded_skip_for_server_stall() {
         ai_client,
         None,
     ));
+
+    expect_followup_accepted(&mut stream).await;
 
     // After exhausting the bounded skips, the next poll falls through to the terminal
     // branch, emitting a StateChanged for the stale state and a synthetic timeout error.

--- a/app/src/ai/ambient_agents/telemetry.rs
+++ b/app/src/ai/ambient_agents/telemetry.rs
@@ -32,6 +32,56 @@ pub enum HandoffEntryPoint {
     FooterChip,
 }
 
+/// Funnel stages for local-to-cloud handoff.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HandoffLocalCloudStage {
+    ForkConversation,
+    PaneOpened,
+    AutoSubmitQueued,
+    AutoSubmitStarted,
+    CloudRunDispatched,
+    ApiAccepted,
+    ApiFailed,
+    SessionReady,
+}
+
+/// Funnel stages for cloud-to-cloud follow-up handoff.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HandoffCloudCloudStage {
+    FollowupSubmitted,
+    ApiAccepted,
+    ApiFailed,
+    PollTimeout,
+    SessionReady,
+    HotswapAttached,
+}
+
+/// Low-cardinality outcome values for handoff funnel events.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HandoffFunnelOutcome {
+    Started,
+    Succeeded,
+    Failed,
+    Queued,
+}
+
+/// Snapshot outcomes for local-to-cloud handoff.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HandoffSnapshotOutcome {
+    Started,
+    SkippedEmptyWorkspace,
+    TokenAllocationFailed,
+    Uploaded,
+    UploadedWithPartialBlobs,
+    ManifestUploadFailed,
+    Failed,
+    SpawnedWithoutSnapshot,
+}
+
 /// Telemetry events for client interactions with cloud agents.
 #[derive(Debug, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumIter))]
@@ -90,6 +140,27 @@ pub enum CloudAgentTelemetryEvent {
         /// Whether the handoff forked an existing conversation.
         forked_existing_conversation: bool,
     },
+    /// Local-to-cloud handoff funnel stage outcome.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    HandoffLocalCloudFunnel {
+        stage: HandoffLocalCloudStage,
+        outcome: HandoffFunnelOutcome,
+        reason: Option<String>,
+        forked_existing_conversation: Option<bool>,
+    },
+    /// Local-to-cloud handoff snapshot pipeline outcome.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    HandoffSnapshot {
+        outcome: HandoffSnapshotOutcome,
+        reason: Option<String>,
+    },
+    /// Cloud-to-cloud handoff follow-up funnel stage outcome.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    HandoffCloudCloudFunnel {
+        stage: HandoffCloudCloudStage,
+        outcome: HandoffFunnelOutcome,
+        reason: Option<String>,
+    },
 }
 
 impl TelemetryEvent for CloudAgentTelemetryEvent {
@@ -136,6 +207,30 @@ impl TelemetryEvent for CloudAgentTelemetryEvent {
                 "entry_point": entry_point,
                 "forked_existing_conversation": forked_existing_conversation,
             })),
+            CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                stage,
+                outcome,
+                reason,
+                forked_existing_conversation,
+            } => Some(json!({
+                "stage": stage,
+                "outcome": outcome,
+                "reason": reason,
+                "forked_existing_conversation": forked_existing_conversation,
+            })),
+            CloudAgentTelemetryEvent::HandoffSnapshot { outcome, reason } => Some(json!({
+                "outcome": outcome,
+                "reason": reason,
+            })),
+            CloudAgentTelemetryEvent::HandoffCloudCloudFunnel {
+                stage,
+                outcome,
+                reason,
+            } => Some(json!({
+                "stage": stage,
+                "outcome": outcome,
+                "reason": reason,
+            })),
         }
     }
 
@@ -178,6 +273,9 @@ impl TelemetryEventDesc for CloudAgentTelemetryEventDiscriminants {
             }
             Self::DispatchFailed => "AmbientAgent.DispatchFailed",
             Self::HandoffInitiated => "AmbientAgent.Handoff.Initiated",
+            Self::HandoffLocalCloudFunnel => "AmbientAgent.Handoff.LocalCloud.Funnel",
+            Self::HandoffSnapshot => "AmbientAgent.Handoff.Snapshot",
+            Self::HandoffCloudCloudFunnel => "AmbientAgent.Handoff.CloudCloud.Funnel",
         }
     }
 
@@ -200,6 +298,9 @@ impl TelemetryEventDesc for CloudAgentTelemetryEventDiscriminants {
             }
             Self::DispatchFailed => "Ambient agent failed to dispatch or encountered an error",
             Self::HandoffInitiated => "User initiated a local-to-cloud handoff",
+            Self::HandoffLocalCloudFunnel => "Local-to-cloud handoff funnel stage outcome",
+            Self::HandoffSnapshot => "Local-to-cloud handoff snapshot outcome",
+            Self::HandoffCloudCloudFunnel => "Cloud-to-cloud handoff funnel stage outcome",
         }
     }
 
@@ -209,3 +310,66 @@ impl TelemetryEventDesc for CloudAgentTelemetryEventDiscriminants {
 }
 
 warp_core::register_telemetry_event!(CloudAgentTelemetryEvent);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use warp_core::telemetry::TelemetryEvent;
+
+    #[test]
+    fn local_cloud_funnel_event_has_expected_name_and_payload() {
+        let event = CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+            stage: HandoffLocalCloudStage::PaneOpened,
+            outcome: HandoffFunnelOutcome::Succeeded,
+            reason: None,
+            forked_existing_conversation: Some(true),
+        };
+
+        assert_eq!(event.name(), "AmbientAgent.Handoff.LocalCloud.Funnel");
+        assert_eq!(
+            event.payload(),
+            Some(json!({
+                "stage": "pane_opened",
+                "outcome": "succeeded",
+                "reason": null,
+                "forked_existing_conversation": true,
+            }))
+        );
+    }
+
+    #[test]
+    fn snapshot_event_serializes_manifest_failure_reason() {
+        let event = CloudAgentTelemetryEvent::HandoffSnapshot {
+            outcome: HandoffSnapshotOutcome::ManifestUploadFailed,
+            reason: Some("manifest_upload_failed".to_string()),
+        };
+
+        assert_eq!(event.name(), "AmbientAgent.Handoff.Snapshot");
+        assert_eq!(
+            event.payload(),
+            Some(json!({
+                "outcome": "manifest_upload_failed",
+                "reason": "manifest_upload_failed",
+            }))
+        );
+    }
+
+    #[test]
+    fn cloud_cloud_funnel_event_serializes_hotswap_stage() {
+        let event = CloudAgentTelemetryEvent::HandoffCloudCloudFunnel {
+            stage: HandoffCloudCloudStage::HotswapAttached,
+            outcome: HandoffFunnelOutcome::Succeeded,
+            reason: None,
+        };
+
+        assert_eq!(event.name(), "AmbientAgent.Handoff.CloudCloud.Funnel");
+        assert_eq!(
+            event.payload(),
+            Some(json!({
+                "stage": "hotswap_attached",
+                "outcome": "succeeded",
+                "reason": null,
+            }))
+        );
+    }
+}

--- a/app/src/ai/ambient_agents/telemetry.rs
+++ b/app/src/ai/ambient_agents/telemetry.rs
@@ -40,9 +40,6 @@ pub enum HandoffLocalCloudStage {
     PaneOpened,
     AutoSubmitQueued,
     AutoSubmitStarted,
-    CloudRunDispatched,
-    ApiAccepted,
-    ApiFailed,
     SessionReady,
 }
 
@@ -51,8 +48,6 @@ pub enum HandoffLocalCloudStage {
 #[serde(rename_all = "snake_case")]
 pub enum HandoffCloudCloudStage {
     FollowupSubmitted,
-    ApiAccepted,
-    ApiFailed,
     PollTimeout,
     SessionReady,
     HotswapAttached,

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -39,7 +39,11 @@ pub use progress::{render_progress, ProgressProps, ProgressStep, ProgressStepSta
 pub use progress_ui_state::AmbientAgentProgressUIState;
 pub use tips::{get_cloud_mode_tips, CloudModeTip};
 
+use crate::ai::ambient_agents::telemetry::{
+    CloudAgentTelemetryEvent, HandoffCloudCloudStage, HandoffFunnelOutcome,
+};
 use warp_core::features::FeatureFlag;
+use warp_core::send_telemetry_from_ctx;
 use warpui::geometry::vector::Vector2F;
 use warpui::{AppContext, ModelHandle, ViewHandle, WindowId};
 
@@ -111,6 +115,14 @@ pub fn create_cloud_mode_view(
                 }
                 AmbientAgentViewModelEvent::ExecutionSessionReady { session_id } => {
                     manager.attach_execution_session(*session_id, ctx);
+                    send_telemetry_from_ctx!(
+                        CloudAgentTelemetryEvent::HandoffCloudCloudFunnel {
+                            stage: HandoffCloudCloudStage::HotswapAttached,
+                            outcome: HandoffFunnelOutcome::Succeeded,
+                            reason: None,
+                        },
+                        ctx
+                    );
                 }
                 AmbientAgentViewModelEvent::EnteredSetupState
                 | AmbientAgentViewModelEvent::EnteredComposingState

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -15,7 +15,10 @@ use crate::ai::ambient_agents::github_auth_notifier::{GitHubAuthEvent, GitHubAut
 use crate::ai::ambient_agents::github_auth_url;
 use crate::ai::ambient_agents::spawn::{spawn_task, submit_run_followup, AmbientAgentEvent};
 use crate::ai::ambient_agents::task::{HarnessAuthSecretsConfig, HarnessConfig};
-use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
+use crate::ai::ambient_agents::telemetry::{
+    CloudAgentTelemetryEvent, HandoffCloudCloudStage, HandoffFunnelOutcome, HandoffLocalCloudStage,
+    HandoffSnapshotOutcome,
+};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::ambient_agents::{
     OUT_OF_CREDITS_TASK_FAILURE_MESSAGE, SERVER_OVERLOADED_TASK_FAILURE_MESSAGE,
@@ -527,6 +530,56 @@ impl AmbientAgentViewModel {
         }
     }
 
+    fn record_local_handoff_funnel(
+        &self,
+        stage: HandoffLocalCloudStage,
+        outcome: HandoffFunnelOutcome,
+        reason: Option<&str>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if !self.is_local_to_cloud_handoff() {
+            return;
+        }
+        send_telemetry_from_ctx!(
+            CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                stage,
+                outcome,
+                reason: reason.map(ToOwned::to_owned),
+                forked_existing_conversation: self.local_handoff_forked_existing_conversation(),
+            },
+            ctx
+        );
+    }
+
+    fn record_cloud_followup_funnel(
+        stage: HandoffCloudCloudStage,
+        outcome: HandoffFunnelOutcome,
+        reason: Option<&str>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        send_telemetry_from_ctx!(
+            CloudAgentTelemetryEvent::HandoffCloudCloudFunnel {
+                stage,
+                outcome,
+                reason: reason.map(ToOwned::to_owned),
+            },
+            ctx
+        );
+    }
+
+    fn local_handoff_forked_existing_conversation(&self) -> Option<bool> {
+        #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+        {
+            self.pending_handoff
+                .as_ref()
+                .map(|handoff| handoff.forked_conversation_id.is_some())
+        }
+        #[cfg(not(all(feature = "local_fs", not(target_family = "wasm"))))]
+        {
+            None
+        }
+    }
+
     /// True when this pane is a handoff pane and the touched-workspace derivation +
     /// snapshot upload have both settled and no submission is in flight. Used by the
     /// input layer to gate clearing the editor buffer on submit.
@@ -667,6 +720,12 @@ impl AmbientAgentViewModel {
             progress: AgentProgress::new(),
             kind: SessionStartupKind::InitialRun,
         };
+        self.record_local_handoff_funnel(
+            HandoffLocalCloudStage::AutoSubmitQueued,
+            HandoffFunnelOutcome::Queued,
+            None,
+            ctx,
+        );
         self.start_progress_timer(ctx);
         ctx.emit(AmbientAgentViewModelEvent::PendingHandoffChanged);
         ctx.emit(AmbientAgentViewModelEvent::DispatchedAgent);
@@ -689,6 +748,12 @@ impl AmbientAgentViewModel {
             return None;
         }
         let launch = handoff.auto_submit.take()?;
+        self.record_local_handoff_funnel(
+            HandoffLocalCloudStage::AutoSubmitStarted,
+            HandoffFunnelOutcome::Started,
+            None,
+            ctx,
+        );
         ctx.emit(AmbientAgentViewModelEvent::PendingHandoffChanged);
         Some(launch)
     }
@@ -948,6 +1013,12 @@ impl AmbientAgentViewModel {
             previous_session_id,
             ai_client,
             None,
+        );
+        Self::record_cloud_followup_funnel(
+            HandoffCloudCloudStage::FollowupSubmitted,
+            HandoffFunnelOutcome::Started,
+            None,
+            ctx,
         );
 
         self.pending_followup_prompt = Some(prompt);
@@ -1215,6 +1286,18 @@ impl AmbientAgentViewModel {
                 ActiveAgentViewsModel::handle(ctx).update(ctx, |model, ctx| {
                     model.register_ambient_session(self.terminal_view_id, task_id, ctx);
                 });
+                self.record_local_handoff_funnel(
+                    HandoffLocalCloudStage::CloudRunDispatched,
+                    HandoffFunnelOutcome::Succeeded,
+                    None,
+                    ctx,
+                );
+                self.record_local_handoff_funnel(
+                    HandoffLocalCloudStage::ApiAccepted,
+                    HandoffFunnelOutcome::Succeeded,
+                    None,
+                    ctx,
+                );
 
                 ctx.emit(AmbientAgentViewModelEvent::ProgressUpdated);
             }
@@ -1225,8 +1308,10 @@ impl AmbientAgentViewModel {
                 if ignore_events {
                     return;
                 }
-
-                if let Status::WaitingForSession { progress, .. } = &mut self.status {
+                let is_local_handoff = self.is_local_to_cloud_handoff();
+                let local_handoff_forked_existing_conversation =
+                    self.local_handoff_forked_existing_conversation();
+                if let Status::WaitingForSession { progress, kind } = &mut self.status {
                     match state {
                         AmbientAgentTaskState::Cancelled => {
                             self.handle_cancellation(ctx);
@@ -1257,6 +1342,27 @@ impl AmbientAgentViewModel {
                             let error = status_message
                                 .map(|msg| msg.message)
                                 .unwrap_or_else(|| "Cloud agent failed".to_string());
+                            match kind {
+                                SessionStartupKind::InitialRun if is_local_handoff => {
+                                    send_telemetry_from_ctx!(
+                                        CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                                            stage: HandoffLocalCloudStage::ApiFailed,
+                                            outcome: HandoffFunnelOutcome::Failed,
+                                            reason: Some("task_failed".to_string()),
+                                            forked_existing_conversation:
+                                                local_handoff_forked_existing_conversation,
+                                        },
+                                        ctx
+                                    );
+                                }
+                                SessionStartupKind::InitialRun => {}
+                                SessionStartupKind::Followup => Self::record_cloud_followup_funnel(
+                                    HandoffCloudCloudStage::ApiFailed,
+                                    HandoffFunnelOutcome::Failed,
+                                    Some("task_failed"),
+                                    ctx,
+                                ),
+                            }
                             self.handle_spawn_error(error, ctx);
                         }
                     }
@@ -1274,14 +1380,28 @@ impl AmbientAgentViewModel {
                         Status::WaitingForSession {
                             kind: SessionStartupKind::InitialRun,
                             ..
-                        } => AmbientAgentViewModelEvent::SessionReady {
-                            session_id: event_session_id,
-                        },
+                        } => {
+                            self.record_local_handoff_funnel(
+                                HandoffLocalCloudStage::SessionReady,
+                                HandoffFunnelOutcome::Succeeded,
+                                None,
+                                ctx,
+                            );
+                            AmbientAgentViewModelEvent::SessionReady {
+                                session_id: event_session_id,
+                            }
+                        }
                         Status::WaitingForSession {
                             kind: SessionStartupKind::Followup,
                             ..
                         }
                         | Status::AgentRunning => {
+                            Self::record_cloud_followup_funnel(
+                                HandoffCloudCloudStage::SessionReady,
+                                HandoffFunnelOutcome::Succeeded,
+                                None,
+                                ctx,
+                            );
                             AmbientAgentViewModelEvent::ExecutionSessionReady {
                                 session_id: event_session_id,
                             }
@@ -1308,7 +1428,38 @@ impl AmbientAgentViewModel {
                     ctx.emit(AmbientAgentViewModelEvent::ShowCloudAgentCapacityModal);
                 }
             }
-            AmbientAgentEvent::TimedOut => {}
+            AmbientAgentEvent::FollowupAccepted => {
+                if ignore_events {
+                    return;
+                }
+                Self::record_cloud_followup_funnel(
+                    HandoffCloudCloudStage::ApiAccepted,
+                    HandoffFunnelOutcome::Succeeded,
+                    None,
+                    ctx,
+                );
+            }
+            AmbientAgentEvent::TimedOut => match &self.status {
+                Status::WaitingForSession {
+                    kind: SessionStartupKind::InitialRun,
+                    ..
+                } => self.record_local_handoff_funnel(
+                    HandoffLocalCloudStage::SessionReady,
+                    HandoffFunnelOutcome::Failed,
+                    Some("poll_timeout"),
+                    ctx,
+                ),
+                Status::WaitingForSession {
+                    kind: SessionStartupKind::Followup,
+                    ..
+                } => Self::record_cloud_followup_funnel(
+                    HandoffCloudCloudStage::PollTimeout,
+                    HandoffFunnelOutcome::Failed,
+                    Some("poll_timeout"),
+                    ctx,
+                ),
+                _ => {}
+            },
         }
     }
 
@@ -1318,6 +1469,27 @@ impl AmbientAgentViewModel {
         ctx: &mut ModelContext<Self>,
     ) {
         let error_message = err.to_string();
+        match &self.status {
+            Status::WaitingForSession {
+                kind: SessionStartupKind::InitialRun,
+                ..
+            } => self.record_local_handoff_funnel(
+                HandoffLocalCloudStage::ApiFailed,
+                HandoffFunnelOutcome::Failed,
+                Some("stream_error"),
+                ctx,
+            ),
+            Status::WaitingForSession {
+                kind: SessionStartupKind::Followup,
+                ..
+            } => Self::record_cloud_followup_funnel(
+                HandoffCloudCloudStage::ApiFailed,
+                HandoffFunnelOutcome::Failed,
+                Some("stream_error"),
+                ctx,
+            ),
+            _ => {}
+        }
         send_telemetry_from_ctx!(
             CloudAgentTelemetryEvent::DispatchFailed {
                 error: error_message.clone()
@@ -1541,15 +1713,39 @@ impl AmbientAgentViewModel {
             return;
         }
         let initial_snapshot_token = handoff.snapshot_upload.initial_snapshot_token();
+        let no_snapshot_reason =
+            initial_snapshot_token
+                .is_none()
+                .then(|| match &handoff.snapshot_upload {
+                    SnapshotUploadStatus::SkippedEmptyWorkspace => "empty_workspace",
+                    SnapshotUploadStatus::Failed(_) => "snapshot_upload_failed",
+                    SnapshotUploadStatus::Pending => "snapshot_pending",
+                    SnapshotUploadStatus::Uploaded(_) => "uploaded",
+                });
         let forked_conversation_id = handoff.forked_conversation_id.clone();
         handoff.submission_state = HandoffSubmissionState::Starting;
         ctx.emit(AmbientAgentViewModelEvent::PendingHandoffChanged);
+        if let Some(reason) = no_snapshot_reason {
+            send_telemetry_from_ctx!(
+                CloudAgentTelemetryEvent::HandoffSnapshot {
+                    outcome: HandoffSnapshotOutcome::SpawnedWithoutSnapshot,
+                    reason: Some(reason.to_string()),
+                },
+                ctx
+            );
+        }
 
         let request = self.build_handoff_spawn_request(
             prompt,
             attachments,
             forked_conversation_id,
             initial_snapshot_token,
+            ctx,
+        );
+        self.record_local_handoff_funnel(
+            HandoffLocalCloudStage::CloudRunDispatched,
+            HandoffFunnelOutcome::Started,
+            None,
             ctx,
         );
         self.spawn_agent_with_request(request, ctx);

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -1286,18 +1286,6 @@ impl AmbientAgentViewModel {
                 ActiveAgentViewsModel::handle(ctx).update(ctx, |model, ctx| {
                     model.register_ambient_session(self.terminal_view_id, task_id, ctx);
                 });
-                self.record_local_handoff_funnel(
-                    HandoffLocalCloudStage::CloudRunDispatched,
-                    HandoffFunnelOutcome::Succeeded,
-                    None,
-                    ctx,
-                );
-                self.record_local_handoff_funnel(
-                    HandoffLocalCloudStage::ApiAccepted,
-                    HandoffFunnelOutcome::Succeeded,
-                    None,
-                    ctx,
-                );
 
                 ctx.emit(AmbientAgentViewModelEvent::ProgressUpdated);
             }
@@ -1308,10 +1296,7 @@ impl AmbientAgentViewModel {
                 if ignore_events {
                     return;
                 }
-                let is_local_handoff = self.is_local_to_cloud_handoff();
-                let local_handoff_forked_existing_conversation =
-                    self.local_handoff_forked_existing_conversation();
-                if let Status::WaitingForSession { progress, kind } = &mut self.status {
+                if let Status::WaitingForSession { progress, .. } = &mut self.status {
                     match state {
                         AmbientAgentTaskState::Cancelled => {
                             self.handle_cancellation(ctx);
@@ -1342,27 +1327,6 @@ impl AmbientAgentViewModel {
                             let error = status_message
                                 .map(|msg| msg.message)
                                 .unwrap_or_else(|| "Cloud agent failed".to_string());
-                            match kind {
-                                SessionStartupKind::InitialRun if is_local_handoff => {
-                                    send_telemetry_from_ctx!(
-                                        CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
-                                            stage: HandoffLocalCloudStage::ApiFailed,
-                                            outcome: HandoffFunnelOutcome::Failed,
-                                            reason: Some("task_failed".to_string()),
-                                            forked_existing_conversation:
-                                                local_handoff_forked_existing_conversation,
-                                        },
-                                        ctx
-                                    );
-                                }
-                                SessionStartupKind::InitialRun => {}
-                                SessionStartupKind::Followup => Self::record_cloud_followup_funnel(
-                                    HandoffCloudCloudStage::ApiFailed,
-                                    HandoffFunnelOutcome::Failed,
-                                    Some("task_failed"),
-                                    ctx,
-                                ),
-                            }
                             self.handle_spawn_error(error, ctx);
                         }
                     }
@@ -1428,17 +1392,7 @@ impl AmbientAgentViewModel {
                     ctx.emit(AmbientAgentViewModelEvent::ShowCloudAgentCapacityModal);
                 }
             }
-            AmbientAgentEvent::FollowupAccepted => {
-                if ignore_events {
-                    return;
-                }
-                Self::record_cloud_followup_funnel(
-                    HandoffCloudCloudStage::ApiAccepted,
-                    HandoffFunnelOutcome::Succeeded,
-                    None,
-                    ctx,
-                );
-            }
+            AmbientAgentEvent::FollowupAccepted => {}
             AmbientAgentEvent::TimedOut => match &self.status {
                 Status::WaitingForSession {
                     kind: SessionStartupKind::InitialRun,
@@ -1469,27 +1423,6 @@ impl AmbientAgentViewModel {
         ctx: &mut ModelContext<Self>,
     ) {
         let error_message = err.to_string();
-        match &self.status {
-            Status::WaitingForSession {
-                kind: SessionStartupKind::InitialRun,
-                ..
-            } => self.record_local_handoff_funnel(
-                HandoffLocalCloudStage::ApiFailed,
-                HandoffFunnelOutcome::Failed,
-                Some("stream_error"),
-                ctx,
-            ),
-            Status::WaitingForSession {
-                kind: SessionStartupKind::Followup,
-                ..
-            } => Self::record_cloud_followup_funnel(
-                HandoffCloudCloudStage::ApiFailed,
-                HandoffFunnelOutcome::Failed,
-                Some("stream_error"),
-                ctx,
-            ),
-            _ => {}
-        }
         send_telemetry_from_ctx!(
             CloudAgentTelemetryEvent::DispatchFailed {
                 error: error_message.clone()
@@ -1740,12 +1673,6 @@ impl AmbientAgentViewModel {
             attachments,
             forked_conversation_id,
             initial_snapshot_token,
-            ctx,
-        );
-        self.record_local_handoff_funnel(
-            HandoffLocalCloudStage::CloudRunDispatched,
-            HandoffFunnelOutcome::Started,
-            None,
             ctx,
         );
         self.spawn_agent_with_request(request, ctx);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -46,10 +46,12 @@ use crate::ai::agent_management::telemetry::AgentManagementTelemetryEvent;
 use crate::ai::agent_management::view::{AgentManagementView, AgentManagementViewEvent};
 use crate::ai::agent_management::AgentManagementEvent;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::agent_sdk::driver::upload_snapshot_for_handoff;
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::ambient_agents::telemetry::HandoffEntryPoint;
+use crate::ai::agent_sdk::driver::{upload_snapshot_for_handoff, HandoffSnapshotUploadOutcome};
 use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::ambient_agents::telemetry::{
+    HandoffEntryPoint, HandoffFunnelOutcome, HandoffLocalCloudStage, HandoffSnapshotOutcome,
+};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::agent_input_footer::editor::AgentToolbarEditorMode;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
@@ -13386,6 +13388,13 @@ impl Workspace {
         model_handle: ModelHandle<AmbientAgentViewModel>,
         ctx: &mut ViewContext<Self>,
     ) {
+        send_telemetry_from_ctx!(
+            CloudAgentTelemetryEvent::HandoffSnapshot {
+                outcome: HandoffSnapshotOutcome::Started,
+                reason: None,
+            },
+            ctx
+        );
         let server_api_provider = ServerApiProvider::as_ref(ctx);
         let ai_client = server_api_provider.get_ai_client();
         let http = server_api_provider.get_http_client();
@@ -13410,20 +13419,75 @@ impl Workspace {
                     }
                     model.set_pending_handoff_workspace(derived_workspace, model_ctx);
                     match upload_result {
-                        Ok(Some(initial_snapshot_token)) => {
+                        Ok(HandoffSnapshotUploadOutcome::Uploaded {
+                            initial_snapshot_token,
+                            partial_blob_upload,
+                        }) => {
+                            send_telemetry_from_ctx!(
+                                CloudAgentTelemetryEvent::HandoffSnapshot {
+                                    outcome: if partial_blob_upload {
+                                        HandoffSnapshotOutcome::UploadedWithPartialBlobs
+                                    } else {
+                                        HandoffSnapshotOutcome::Uploaded
+                                    },
+                                    reason: partial_blob_upload
+                                        .then(|| "partial_blob_upload".to_string()),
+                                },
+                                model_ctx
+                            );
                             model.set_pending_handoff_snapshot_upload(
                                 SnapshotUploadStatus::Uploaded(initial_snapshot_token),
                                 model_ctx,
                             );
                         }
-                        Ok(None) => {
+                        Ok(HandoffSnapshotUploadOutcome::SkippedEmptyWorkspace) => {
+                            send_telemetry_from_ctx!(
+                                CloudAgentTelemetryEvent::HandoffSnapshot {
+                                    outcome: HandoffSnapshotOutcome::SkippedEmptyWorkspace,
+                                    reason: Some("empty_workspace".to_string()),
+                                },
+                                model_ctx
+                            );
                             model.set_pending_handoff_snapshot_upload(
                                 SnapshotUploadStatus::SkippedEmptyWorkspace,
                                 model_ctx,
                             );
                         }
+                        Ok(HandoffSnapshotUploadOutcome::ManifestUploadFailed) => {
+                            send_telemetry_from_ctx!(
+                                CloudAgentTelemetryEvent::HandoffSnapshot {
+                                    outcome: HandoffSnapshotOutcome::ManifestUploadFailed,
+                                    reason: Some("manifest_upload_failed".to_string()),
+                                },
+                                model_ctx
+                            );
+                            model.record_handoff_snapshot_upload_failed(
+                                "manifest upload failed".to_string(),
+                                model_ctx,
+                            );
+                        }
+                        Ok(HandoffSnapshotUploadOutcome::FailedBeforeManifest) => {
+                            send_telemetry_from_ctx!(
+                                CloudAgentTelemetryEvent::HandoffSnapshot {
+                                    outcome: HandoffSnapshotOutcome::Failed,
+                                    reason: Some("failed_before_manifest".to_string()),
+                                },
+                                model_ctx
+                            );
+                            model.record_handoff_snapshot_upload_failed(
+                                "snapshot preparation failed".to_string(),
+                                model_ctx,
+                            );
+                        }
                         Err(err) => {
                             log::warn!("Handoff snapshot upload failed: {err:#}");
+                            send_telemetry_from_ctx!(
+                                CloudAgentTelemetryEvent::HandoffSnapshot {
+                                    outcome: HandoffSnapshotOutcome::TokenAllocationFailed,
+                                    reason: Some("token_allocation_failed".to_string()),
+                                },
+                                model_ctx
+                            );
                             model
                                 .record_handoff_snapshot_upload_failed(format!("{err}"), model_ctx);
                         }
@@ -13518,6 +13582,15 @@ impl Workspace {
             log::warn!(
                 "start_local_to_cloud_handoff: failed to push fresh cloud-mode pane over the active session"
             );
+            send_telemetry_from_ctx!(
+                CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                    stage: HandoffLocalCloudStage::PaneOpened,
+                    outcome: HandoffFunnelOutcome::Failed,
+                    reason: Some("pane_open_failed".to_string()),
+                    forked_existing_conversation: Some(false),
+                },
+                ctx
+            );
             Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
             let window_id = ctx.window_id();
             WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
@@ -13532,6 +13605,15 @@ impl Workspace {
             });
             return;
         };
+        send_telemetry_from_ctx!(
+            CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                stage: HandoffLocalCloudStage::PaneOpened,
+                outcome: HandoffFunnelOutcome::Succeeded,
+                reason: None,
+                forked_existing_conversation: Some(false),
+            },
+            ctx
+        );
 
         if let Some(environment_id) = environment_id {
             model_handle.update(ctx, |model, ctx| {
@@ -13708,6 +13790,15 @@ impl Workspace {
             },
             move |me, result, ctx| match result {
                 Ok(response) => {
+                    send_telemetry_from_ctx!(
+                        CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                            stage: HandoffLocalCloudStage::ForkConversation,
+                            outcome: HandoffFunnelOutcome::Succeeded,
+                            reason: None,
+                            forked_existing_conversation: Some(true),
+                        },
+                        ctx
+                    );
                     me.complete_local_to_cloud_handoff_open(
                         source_view,
                         source_conversation,
@@ -13720,6 +13811,15 @@ impl Workspace {
                 Err(err) => {
                     log::warn!(
                         "start_local_to_cloud_handoff: fork_conversation RPC failed: {err:#}"
+                    );
+                    send_telemetry_from_ctx!(
+                        CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                            stage: HandoffLocalCloudStage::ForkConversation,
+                            outcome: HandoffFunnelOutcome::Failed,
+                            reason: Some("fork_rpc_failed".to_string()),
+                            forked_existing_conversation: Some(true),
+                        },
+                        ctx
                     );
                     Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
                     let window_id = ctx.window_id();
@@ -13793,6 +13893,15 @@ impl Workspace {
             log::warn!(
                 "complete_local_to_cloud_handoff_open: failed to push cloud-mode pane after forking conversation"
             );
+            send_telemetry_from_ctx!(
+                CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                    stage: HandoffLocalCloudStage::PaneOpened,
+                    outcome: HandoffFunnelOutcome::Failed,
+                    reason: Some("pane_open_failed".to_string()),
+                    forked_existing_conversation: Some(true),
+                },
+                ctx
+            );
             let window_id = ctx.window_id();
             WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                 toast_stack.add_ephemeral_toast(
@@ -13806,6 +13915,15 @@ impl Workspace {
             });
             return;
         };
+        send_telemetry_from_ctx!(
+            CloudAgentTelemetryEvent::HandoffLocalCloudFunnel {
+                stage: HandoffLocalCloudStage::PaneOpened,
+                outcome: HandoffFunnelOutcome::Succeeded,
+                reason: None,
+                forked_existing_conversation: Some(true),
+            },
+            ctx
+        );
         // Restore the forked conversation into the newly-created pane.
         new_pane_view.update(ctx, |terminal_view, view_ctx| {
             terminal_view.restore_conversation_after_view_creation(


### PR DESCRIPTION
## Summary
- Add client telemetry events for local-cloud and cloud-cloud handoff funnel stages, snapshot outcomes, spawned-without-snapshot, API/session outcomes, and hotswap attachment.
- Return structured local handoff snapshot upload outcomes so manifest failures, partial blob uploads, empty workspace skips, and token allocation failures are distinguishable.
- Update follow-up stream tests for the API-accepted event and add telemetry serialization coverage.

## Validation
- `cargo +1.92.0 test --manifest-path /workspace/warp/Cargo.toml -p warp --lib ai::ambient_agents::telemetry::tests::` passed (3 tests).
- `cargo +1.92.0 test --manifest-path /workspace/warp/Cargo.toml -p warp --lib ai::ambient_agents::spawn::tests::followup` passed (9 tests).
- `rustfmt +1.92.0 --config-path /workspace/warp/.rustfmt.toml ...` ran on touched Rust files.
- `git -C /workspace/warp --no-pager diff --check` passed.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/bb5694d2-c4a9-4171-a5d4-9006c6a4308f_
_Run: https://oz.staging.warp.dev/runs/019e389e-7f5c-7d01-85af-a449c008e618_
_This PR was generated with [Oz](https://warp.dev/oz)._
