### PR TITLE
Persist killed child agents and rename Kill→Delete after terminal state

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -429,16 +429,17 @@ impl OrchestrationPillBar {
                 ),
             ]
         };
-        // Stop is shown only while in progress; Kill becomes Delete once
-        // the agent has reached a terminal state. Blocked is treated as
-        // non-terminal (still mid-flight, waiting on user input).
+        // Stop is shown only while the agent is in progress; Kill becomes
+        // Delete once the agent's run has finished (Success / Error /
+        // Cancelled). Blocked is treated as not-yet-finished (the agent
+        // is still mid-flight, waiting on user input).
         let conversation_status = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
             .map(|conversation| conversation.status().clone());
         let is_in_progress = conversation_status
             .as_ref()
             .is_some_and(|status| status.is_in_progress());
-        let is_terminal = conversation_status
+        let is_in_finished_state = conversation_status
             .as_ref()
             .is_some_and(|status| status.is_done());
         items.push(MenuItem::Separator);
@@ -449,7 +450,7 @@ impl OrchestrationPillBar {
                 OrchestrationPillBarAction::Stop(conversation_id),
             ));
         }
-        let (kill_label, kill_icon) = if is_terminal {
+        let (kill_label, kill_icon) = if is_in_finished_state {
             ("Delete agent", Icon::Trash)
         } else {
             ("Kill agent", Icon::X)

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -429,9 +429,18 @@ impl OrchestrationPillBar {
                 ),
             ]
         };
-        let is_in_progress = BlocklistAIHistoryModel::as_ref(ctx)
+        // Stop is shown only while in progress; Kill becomes Delete once
+        // the agent has reached a terminal state. Blocked is treated as
+        // non-terminal (still mid-flight, waiting on user input).
+        let conversation_status = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
-            .is_some_and(|conversation| conversation.status().is_in_progress());
+            .map(|conversation| conversation.status().clone());
+        let is_in_progress = conversation_status
+            .as_ref()
+            .is_some_and(|status| status.is_in_progress());
+        let is_terminal = conversation_status
+            .as_ref()
+            .is_some_and(|status| status.is_done());
         items.push(MenuItem::Separator);
         if is_in_progress {
             items.push(destructive_item(
@@ -440,9 +449,14 @@ impl OrchestrationPillBar {
                 OrchestrationPillBarAction::Stop(conversation_id),
             ));
         }
+        let (kill_label, kill_icon) = if is_terminal {
+            ("Delete agent", Icon::Trash)
+        } else {
+            ("Kill agent", Icon::X)
+        };
         items.push(destructive_item(
-            "Kill agent",
-            Icon::X,
+            kill_label,
+            kill_icon,
             OrchestrationPillBarAction::Kill(conversation_id),
         ));
 

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -975,13 +975,14 @@ fn kill_agent_conversation(
         log::warn!("KillAgentConversation: no child pane found for {conversation_id:?}");
     }
 
-    let Some(terminal_view_id) = owner_terminal_view_id else {
+    if owner_terminal_view_id.is_none() {
         log::warn!(
             "KillAgentConversation: no terminal view found for conversation {conversation_id:?}"
         );
-        return;
-    };
-    conversation_utils::remove_conversation(conversation_id, terminal_view_id, false, ctx);
+    }
+    // Delete (not remove): drop the conversation from sqlite + cloud so a
+    // killed child does not resurrect on restart.
+    conversation_utils::delete_conversation(conversation_id, owner_terminal_view_id, ctx);
 }
 
 /// Attaches a terminal view to the pane group by subscribing to its events


### PR DESCRIPTION
Loom: https://www.loom.com/share/45edb8dbfdad48409c63e1dd4396916c
Fixes https://linear.app/warpdotdev/issue/QUALITY-669/ensure-killing-persist-across-app-restarts

## Description

Two small fixes to the orchestration pill bar's child-agent menu.

**1. Killing a child agent is now durable across app restarts.**

**2. "Kill agent" → "Delete agent" once the agent has reached a
terminal state.**

Stop is unchanged. Orchestrator pills are unaffected.

### Heads-up on widened semantics

- **Cloud delete is now unconditional for Kill.** This should match semantic intent + we don't want this in cloud convos.
  - Archive is a different action, we can follow up on adding this later (the current semantics map to removal/deletion only)

## Testing

- [x] I have manually tested my changes locally with `./script/run`
- `cargo fmt` clean.
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` clean.
