### PR TITLE
Center child pill avatar within status overlay box

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -15,7 +15,7 @@ use warp_core::ui::theme::Fill;
 use warp_core::ui::{appearance::Appearance, theme::WarpTheme};
 use warpui::elements::new_scrollable::{NewScrollable, ScrollableAppearance, SingleAxisConfig};
 use warpui::elements::{
-    AnchorPair, ChildAnchor, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container,
+    Align, AnchorPair, ChildAnchor, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container,
     CornerRadius, CrossAxisAlignment, Element, Empty, Fill as ElementFill, Flex, Hoverable,
     MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning, OffsetType, ParentAnchor,
     ParentElement, ParentOffsetBounds, PositionedElementOffsetBounds, PositioningAxis, Radius,
@@ -1819,14 +1819,17 @@ fn render_avatar_with_status_overlay(
     theme: &WarpTheme,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
-    // Disc sized to match the helper's brand-circle slot.
-    let avatar = render_avatar_disc(
+    // `Align` centers the disc in the helper's `total_size` box; without it
+    // the disc anchors top-left and sits ~2.5px higher than the orchestrator
+    // pill's plain avatar.
+    let avatar = Align::new(render_avatar_disc(
         avatar_color,
         glyph,
         icon_with_status::circle_size(AVATAR_WITH_STATUS_TOTAL_SIZE),
         theme,
         appearance,
-    );
+    ))
+    .finish();
     render_icon_with_status(
         IconWithStatusVariant::CustomAvatar {
             avatar,


### PR DESCRIPTION
Fixes https://linear.app/warpdotdev/issue/QUALITY-688/avatar-icon-gets-too-close-to-top-when-pill-is-active 


Before:
<img width="486" height="102" alt="image" src="https://github.com/user-attachments/assets/bb171353-f4b3-4ddc-b5b6-b1fdc4ac06b6" />


After:
<img width="315" height="71" alt="image" src="https://github.com/user-attachments/assets/4e736d07-583b-42ce-84b5-4e6d415cb631" />


## Description

Fixes a small alignment bug in the orchestration pill bar: child agent avatars sit ~2.5px higher than the orchestrator avatar.

**Root cause:** the orchestrator pill renders a plain 16x16 disc (`render_avatar_disc(AVATAR_SIZE)`) which `CrossAxisAlignment::Center` centers naturally in the 22px pill row. Child pills with a status overlay go through `render_icon_with_status` which wraps the 16px disc in a ~21x21 bounding box and anchors the disc at the box's **top-left** corner. Net effect: child disc top sits at ~0.5px from pill top, vs orchestrator's 3px.

**Fix:** wrap the disc passed to `render_icon_with_status` in `Align` (defaults to center) so it sits in the middle of the 21x21 box. Badge stays anchored at box BR, disc now centers — both pill kinds visually align.

## Testing
- [x] I have manually tested my changes locally with \`./script/run\`

Verified that child pill avatars (e.g. \`H/haiku-1\`, \`H/haiku-2\`) now align vertically with the Orchestrator's Oz avatar in the pill bar.
