### PR TITLE
Fix stale dependency definitions causing unnecessary rebuilds.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "warp_cli",
  "win32job",
 ]
 
@@ -5918,9 +5917,6 @@ dependencies = [
 [[package]]
 name = "handlebars"
 version = "0.0.0"
-dependencies = [
- "warpui",
-]
 
 [[package]]
 name = "hash32"

--- a/crates/app-installation-detection/Cargo.toml
+++ b/crates/app-installation-detection/Cargo.toml
@@ -16,7 +16,6 @@ tower.workspace = true
 tower-http = { workspace = true, features = ["trace", "cors"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-warp_cli.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 win32job = "2.0.1"

--- a/crates/handlebars/Cargo.toml
+++ b/crates/handlebars/Cargo.toml
@@ -4,6 +4,3 @@ edition = "2024"
 authors.workspace = true
 publish.workspace = true
 license.workspace = true
-
-[dependencies]
-warpui.workspace = true

--- a/crates/handlebars/src/parser_tests.rs
+++ b/crates/handlebars/src/parser_tests.rs
@@ -1,133 +1,127 @@
-use warpui::App;
-
 use crate::parser::{ParsedArgument, ParsedArgumentResult, ParsedArgumentsIterator};
 
 #[test]
 fn test_parsed_arguments_iterator() {
-    App::test((), |_app| async move {
-        let mut args_iterator = ParsedArgumentsIterator::new(
-            "one two{{three}} {{four}}{{ab東早}} \ne{{восибing}}}".chars(),
-        );
+    let mut args_iterator = ParsedArgumentsIterator::new(
+        "one two{{three}} {{four}}{{ab東早}} \ne{{восибing}}}".chars(),
+    );
 
-        let arg_three = args_iterator.next();
-        assert_eq!(
-            arg_three,
-            Some(ParsedArgument {
-                chars_range: 9..14,
-                result: ParsedArgumentResult::Valid {
-                    current_word_index: 2
-                },
-            })
-        );
-        let arg_four = args_iterator.next();
-        assert_eq!(
-            arg_four,
-            Some(ParsedArgument {
-                chars_range: 19..23,
-                result: ParsedArgumentResult::Valid {
-                    current_word_index: 3
-                },
-            })
-        );
-        let arg_ab = args_iterator.next();
-        assert_eq!(
-            arg_ab,
-            Some(ParsedArgument {
-                chars_range: 27..31,
-                result: ParsedArgumentResult::Valid {
-                    current_word_index: 5
-                },
-            })
-        );
-        let arg_vosibing = args_iterator.next();
-        assert_eq!(
-            arg_vosibing,
-            Some(ParsedArgument {
-                chars_range: 38..46,
-                result: ParsedArgumentResult::Valid {
-                    current_word_index: 7
-                },
-            })
-        );
+    let arg_three = args_iterator.next();
+    assert_eq!(
+        arg_three,
+        Some(ParsedArgument {
+            chars_range: 9..14,
+            result: ParsedArgumentResult::Valid {
+                current_word_index: 2
+            },
+        })
+    );
+    let arg_four = args_iterator.next();
+    assert_eq!(
+        arg_four,
+        Some(ParsedArgument {
+            chars_range: 19..23,
+            result: ParsedArgumentResult::Valid {
+                current_word_index: 3
+            },
+        })
+    );
+    let arg_ab = args_iterator.next();
+    assert_eq!(
+        arg_ab,
+        Some(ParsedArgument {
+            chars_range: 27..31,
+            result: ParsedArgumentResult::Valid {
+                current_word_index: 5
+            },
+        })
+    );
+    let arg_vosibing = args_iterator.next();
+    assert_eq!(
+        arg_vosibing,
+        Some(ParsedArgument {
+            chars_range: 38..46,
+            result: ParsedArgumentResult::Valid {
+                current_word_index: 7
+            },
+        })
+    );
 
-        let mut invalid_ranges_iter = ParsedArgumentsIterator::new(
-            "one {{two}} {{inv\nal東旪!}} \n{{1malformed}} {{overlap{{bad }}".chars(),
-        );
+    let mut invalid_ranges_iter = ParsedArgumentsIterator::new(
+        "one {{two}} {{inv\nal東旪!}} \n{{1malformed}} {{overlap{{bad }}".chars(),
+    );
 
-        let arg_two = invalid_ranges_iter.next();
-        assert_eq!(
-            arg_two,
-            Some(ParsedArgument {
-                chars_range: 6..9,
-                result: ParsedArgumentResult::Valid {
-                    current_word_index: 1
-                },
-            })
-        );
+    let arg_two = invalid_ranges_iter.next();
+    assert_eq!(
+        arg_two,
+        Some(ParsedArgument {
+            chars_range: 6..9,
+            result: ParsedArgumentResult::Valid {
+                current_word_index: 1
+            },
+        })
+    );
 
-        let arg_invalid = invalid_ranges_iter.next();
-        assert_eq!(
-            arg_invalid,
-            Some(ParsedArgument {
-                chars_range: 14..23,
-                result: ParsedArgumentResult::Invalid,
-            })
-        );
-        let arg_malformed = invalid_ranges_iter.next();
-        assert_eq!(
-            arg_malformed,
-            Some(ParsedArgument {
-                chars_range: 29..39,
-                result: ParsedArgumentResult::Invalid,
-            })
-        );
-        let arg_bad = invalid_ranges_iter.next();
-        assert_eq!(
-            arg_bad,
-            Some(ParsedArgument {
-                chars_range: 53..57,
-                result: ParsedArgumentResult::Invalid,
-            })
-        );
-    })
+    let arg_invalid = invalid_ranges_iter.next();
+    assert_eq!(
+        arg_invalid,
+        Some(ParsedArgument {
+            chars_range: 14..23,
+            result: ParsedArgumentResult::Invalid,
+        })
+    );
+    let arg_malformed = invalid_ranges_iter.next();
+    assert_eq!(
+        arg_malformed,
+        Some(ParsedArgument {
+            chars_range: 29..39,
+            result: ParsedArgumentResult::Invalid,
+        })
+    );
+    let arg_bad = invalid_ranges_iter.next();
+    assert_eq!(
+        arg_bad,
+        Some(ParsedArgument {
+            chars_range: 53..57,
+            result: ParsedArgumentResult::Invalid,
+        })
+    );
 }
 
 #[test]
 fn test_parsed_arguments_iterator_with_escaped_args() {
-    App::test((), |_app| async move {
-        let mut escaped_ranges_iter = ParsedArgumentsIterator::new(
-            "one {{TWO}} {{{.ID!}}} {{{{{not_3 an arg?}}} {{real_arg}} {{.invalid}}".chars(),
-        );
+    let mut escaped_ranges_iter = ParsedArgumentsIterator::new(
+        "one {{TWO}} {{{.ID!}}} {{{{{not_3 an arg?}}} {{real_arg}} {{.invalid}}".chars(),
+    );
 
-        let arg_two = escaped_ranges_iter.next();
-        assert_eq!(
-            arg_two,
-            Some(ParsedArgument {
-                chars_range: 6..9,
-                result: ParsedArgumentResult::Valid {
-                    current_word_index: 1
-                }
-            })
-        );
+    let arg_two = escaped_ranges_iter.next();
+    assert_eq!(
+        arg_two,
+        Some(ParsedArgument {
+            chars_range: 6..9,
+            result: ParsedArgumentResult::Valid {
+                current_word_index: 1
+            }
+        })
+    );
 
-        let arg_real = escaped_ranges_iter.next();
-        assert_eq!(
-            arg_real,
-            Some(ParsedArgument {
-                chars_range: 47..55,
-                result: ParsedArgumentResult::Valid {
-                    current_word_index: 4
-                }
-            })
-        );
+    let arg_real = escaped_ranges_iter.next();
+    assert_eq!(
+        arg_real,
+        Some(ParsedArgument {
+            chars_range: 47..55,
+            result: ParsedArgumentResult::Valid {
+                current_word_index: 4
+            }
+        })
+    );
 
-        let arg_invalid = escaped_ranges_iter.next();
-        assert_eq!(
-            arg_invalid,
-            Some(ParsedArgument {
-                chars_range: 60..68,
-                result: ParsedArgumentResult::Invalid
-            })
-        )
-    })
+    let arg_invalid = escaped_ranges_iter.next();
+    assert_eq!(
+        arg_invalid,
+        Some(ParsedArgument {
+            chars_range: 60..68,
+            result: ParsedArgumentResult::Invalid
+        })
+    )
 }


### PR DESCRIPTION
## Description

Noticed that `cargo check -p warp` wasn't taking advantage of the cache for all crates, even when I hadn't modified any files.

Asked agent mode, and it found two stale dependencies between crates in our workspace.  I cleaned these up, and it fixed the issue.  (One of them was a test-only dependency, but we didn't even really need the dependency at all, so I cleaned it up.)