### PR TITLE
Plumb --bedrock-role-region into the Bedrock OIDC STS client

### DIFF
--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -611,6 +611,7 @@ impl AgentDriverRunner {
             // Pull relevant variables out of args before moving it into the closure.
             let share_requests = args.share.share.clone();
             let bedrock_inference_role = args.bedrock_inference_role.clone();
+            let bedrock_role_region = args.bedrock_role_region.clone();
             let has_task_id = args.task_id.is_some();
             let args_harness = args.harness;
             // `--conversation` path (user-invoked local resume): validate before any task side
@@ -652,6 +653,16 @@ impl AgentDriverRunner {
 
             #[cfg(not(target_family = "wasm"))]
             if let Some(role_arn) = bedrock_inference_role {
+                // clap's `requires` constraint enforces this at parse time, so a missing
+                // region here means a caller is constructing `RunAgentArgs` directly
+                // without the flag. Fail loudly so callers don't silently fall back to a
+                // hard-coded STS region.
+                let role_region = bedrock_role_region.ok_or_else(|| {
+                    AgentDriverError::AwsBedrockCredentialsFailed(
+                        "--bedrock-role-region is required when --bedrock-inference-role is set"
+                            .to_string(),
+                    )
+                })?;
                 // Set the OIDC strategy on the UI thread and kick off the refresh; the
                 // returned future resolves when credentials are committed to the model.
                 let refresh_future = foreground
@@ -662,6 +673,7 @@ impl AgentDriverRunner {
                                 AwsCredentialsRefreshStrategy::OidcManaged {
                                     task_id: bedrock_task_id,
                                     role_arn,
+                                    region: role_region,
                                 },
                             );
                             refresh_aws_credentials(manager, ctx)

--- a/app/src/ai/aws_credentials.rs
+++ b/app/src/ai/aws_credentials.rs
@@ -11,6 +11,7 @@ use aws_credential_types::provider::error::CredentialsError;
 use aws_credential_types::provider::ProvideCredentials;
 use futures::channel::oneshot::channel;
 use futures::future::BoxFuture;
+use tokio::sync::Mutex;
 use vec1::vec1;
 use warp_managed_secrets::{client::IdentityTokenOptions, ManagedSecretManager};
 use warpui::{ModelContext, ModelHandle, SingletonEntity};
@@ -88,18 +89,35 @@ pub(crate) fn aws_role_session_name(run_id: &str) -> String {
     format!("Oz_Run_{run_id}")
 }
 
-/// Builds an STS client targeting `region`. `AssumeRoleWithWebIdentity` is
+/// Last-region STS client cache. A single device almost always uses one
+/// Bedrock region (the org's configured region), so a one-entry cache keyed
+/// by region is enough to preserve the HTTPS connection pool across credential
+/// refreshes. We use a `Mutex` (rather than `tokio::sync::OnceCell`) because
+/// the cache must be able to replace its contents if the region ever changes.
+static STS_CLIENT_CACHE: Mutex<Option<(String, aws_sdk_sts::Client)>> = Mutex::const_new(None);
+
+/// Returns an STS client targeting `region`, reusing a cached client when the
+/// region matches the previous call. `AssumeRoleWithWebIdentity` is
 /// unauthenticated (the web identity token is the credential), so we skip the
 /// default credentials chain via `no_credentials()`. The region is supplied by
 /// the caller (typically driven by the run's `--bedrock-role-region` flag) so
 /// that the STS endpoint matches the Bedrock region the org has configured.
 async fn sts_client(region: &str) -> aws_sdk_sts::Client {
+    let mut cache = STS_CLIENT_CACHE.lock().await;
+    if let Some((cached_region, client)) = cache.as_ref() {
+        if cached_region == region {
+            return client.clone();
+        }
+    }
+
     let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .no_credentials()
         .region(aws_config::Region::new(region.to_string()))
         .load()
         .await;
-    aws_sdk_sts::Client::new(&config)
+    let client = aws_sdk_sts::Client::new(&config);
+    *cache = Some((region.to_string(), client.clone()));
+    client
 }
 
 fn aws_credentials_state_for_error(err: LoadAwsCredentialsError) -> AwsCredentialsState {

--- a/app/src/ai/aws_credentials.rs
+++ b/app/src/ai/aws_credentials.rs
@@ -285,9 +285,6 @@ fn refresh_aws_credentials_local_chain(
 }
 
 /// Refreshes credentials via OIDC identity token + STS AssumeRoleWithWebIdentity.
-/// `region` is the STS endpoint region; it is plumbed in alongside the role ARN
-/// so the STS call lands in the same regional endpoint the org has configured
-/// for Bedrock.
 fn refresh_aws_credentials_oidc(
     task_id: Option<String>,
     role_arn: String,

--- a/app/src/ai/aws_credentials.rs
+++ b/app/src/ai/aws_credentials.rs
@@ -89,19 +89,14 @@ pub(crate) fn aws_role_session_name(run_id: &str) -> String {
     format!("Oz_Run_{run_id}")
 }
 
-/// Last-region STS client cache. A single device almost always uses one
-/// Bedrock region (the org's configured region), so a one-entry cache keyed
-/// by region is enough to preserve the HTTPS connection pool across credential
-/// refreshes. We use a `Mutex` (rather than `tokio::sync::OnceCell`) because
-/// the cache must be able to replace its contents if the region ever changes.
+/// Cached STS client for OIDC credential refreshes -- cached on the last region used.
+/// (in practice, there should only ever be 1 region used per warp app lifetime)
+///
+/// `AssumeRoleWithWebIdentity` is unauthenticated (the web identity token is the
+/// credential), so we skip the default credentials chain via `no_credentials()`
+/// and reuse a single client across refreshes.
 static STS_CLIENT_CACHE: Mutex<Option<(String, aws_sdk_sts::Client)>> = Mutex::const_new(None);
 
-/// Returns an STS client targeting `region`, reusing a cached client when the
-/// region matches the previous call. `AssumeRoleWithWebIdentity` is
-/// unauthenticated (the web identity token is the credential), so we skip the
-/// default credentials chain via `no_credentials()`. The region is supplied by
-/// the caller (typically driven by the run's `--bedrock-role-region` flag) so
-/// that the STS endpoint matches the Bedrock region the org has configured.
 async fn sts_client(region: &str) -> aws_sdk_sts::Client {
     let mut cache = STS_CLIENT_CACHE.lock().await;
     if let Some((cached_region, client)) = cache.as_ref() {

--- a/app/src/ai/aws_credentials.rs
+++ b/app/src/ai/aws_credentials.rs
@@ -11,7 +11,6 @@ use aws_credential_types::provider::error::CredentialsError;
 use aws_credential_types::provider::ProvideCredentials;
 use futures::channel::oneshot::channel;
 use futures::future::BoxFuture;
-use tokio::sync::OnceCell;
 use vec1::vec1;
 use warp_managed_secrets::{client::IdentityTokenOptions, ManagedSecretManager};
 use warpui::{ModelContext, ModelHandle, SingletonEntity};
@@ -89,23 +88,18 @@ pub(crate) fn aws_role_session_name(run_id: &str) -> String {
     format!("Oz_Run_{run_id}")
 }
 
-/// Cached STS client for OIDC credential refreshes.
-///
-/// `AssumeRoleWithWebIdentity` is unauthenticated (the web identity token is the
-/// credential), so we skip the default credentials chain via `no_credentials()`
-/// and reuse a single client across refreshes.
-static STS_CLIENT: OnceCell<aws_sdk_sts::Client> = OnceCell::const_new();
-
-async fn sts_client() -> &'static aws_sdk_sts::Client {
-    STS_CLIENT
-        .get_or_init(|| async {
-            let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-                .no_credentials()
-                .load()
-                .await;
-            aws_sdk_sts::Client::new(&config)
-        })
-        .await
+/// Builds an STS client targeting `region`. `AssumeRoleWithWebIdentity` is
+/// unauthenticated (the web identity token is the credential), so we skip the
+/// default credentials chain via `no_credentials()`. The region is supplied by
+/// the caller (typically driven by the run's `--bedrock-role-region` flag) so
+/// that the STS endpoint matches the Bedrock region the org has configured.
+async fn sts_client(region: &str) -> aws_sdk_sts::Client {
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .no_credentials()
+        .region(aws_config::Region::new(region.to_string()))
+        .load()
+        .await;
+    aws_sdk_sts::Client::new(&config)
 }
 
 fn aws_credentials_state_for_error(err: LoadAwsCredentialsError) -> AwsCredentialsState {
@@ -237,9 +231,11 @@ pub(crate) fn refresh_aws_credentials(
         AwsCredentialsRefreshStrategy::LocalChain => {
             refresh_aws_credentials_local_chain(manager, ctx)
         }
-        AwsCredentialsRefreshStrategy::OidcManaged { task_id, role_arn } => {
-            refresh_aws_credentials_oidc(task_id, role_arn, manager, ctx)
-        }
+        AwsCredentialsRefreshStrategy::OidcManaged {
+            task_id,
+            role_arn,
+            region,
+        } => refresh_aws_credentials_oidc(task_id, role_arn, region, manager, ctx),
     }
 }
 
@@ -289,9 +285,13 @@ fn refresh_aws_credentials_local_chain(
 }
 
 /// Refreshes credentials via OIDC identity token + STS AssumeRoleWithWebIdentity.
+/// `region` is the STS endpoint region; it is plumbed in alongside the role ARN
+/// so the STS call lands in the same regional endpoint the org has configured
+/// for Bedrock.
 fn refresh_aws_credentials_oidc(
     task_id: Option<String>,
     role_arn: String,
+    region: String,
     manager: &mut ApiKeyManager,
     ctx: &mut ModelContext<ApiKeyManager>,
 ) -> BoxFuture<'static, Result<(), String>> {
@@ -337,7 +337,7 @@ fn refresh_aws_credentials_oidc(
                 .await
                 .context("Failed to mint AWS Bedrock task identity token")?;
 
-            let client = sts_client().await;
+            let client = sts_client(&region).await;
             let session_name = aws_role_session_name(&task_id);
             let credentials = client
                 .assume_role_with_web_identity()

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -84,7 +84,7 @@ pub enum AwsCredentialsRefreshStrategy {
     LocalChain,
     /// Credentials are managed externally via OIDC/STS.
     /// The task ID is used to scope the STS AssumeRoleWithWebIdentity session.
-    /// The role ARN + region are the IAM role info used to assume via STS.
+    /// The role ARN + region are the info used to assume the IAM role via STS.
     OidcManaged {
         task_id: Option<String>,
         role_arn: String,

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -84,10 +84,7 @@ pub enum AwsCredentialsRefreshStrategy {
     LocalChain,
     /// Credentials are managed externally via OIDC/STS.
     /// The task ID is used to scope the STS AssumeRoleWithWebIdentity session.
-    /// The role ARN is the IAM role to assume via STS.
-    /// The region pins the STS endpoint so the AssumeRoleWithWebIdentity call
-    /// targets the same regional endpoint as the downstream Bedrock service
-    /// (typically the org's configured Bedrock region).
+    /// The role ARN + region are the IAM role info used to assume via STS.
     OidcManaged {
         task_id: Option<String>,
         role_arn: String,

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -85,9 +85,13 @@ pub enum AwsCredentialsRefreshStrategy {
     /// Credentials are managed externally via OIDC/STS.
     /// The task ID is used to scope the STS AssumeRoleWithWebIdentity session.
     /// The role ARN is the IAM role to assume via STS.
+    /// The region pins the STS endpoint so the AssumeRoleWithWebIdentity call
+    /// targets the same regional endpoint as the downstream Bedrock service
+    /// (typically the org's configured Bedrock region).
     OidcManaged {
         task_id: Option<String>,
         role_arn: String,
+        region: String,
     },
 }
 

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -328,8 +328,27 @@ pub struct RunAgentArgs {
     #[arg(long = "sandboxed", hide = true)]
     pub sandboxed: bool,
     /// IAM role ARN to use for federated AWS Bedrock credentials for this run.
-    #[arg(long = "bedrock-inference-role", value_name = "ROLE_ARN", hide = true)]
+    ///
+    /// When set, `--bedrock-role-region` must also be provided so the STS
+    /// `AssumeRoleWithWebIdentity` call targets the right regional endpoint.
+    #[arg(
+        long = "bedrock-inference-role",
+        value_name = "ROLE_ARN",
+        requires = "bedrock_role_region",
+        hide = true
+    )]
     pub bedrock_inference_role: Option<String>,
+
+    /// AWS region to use for the STS `AssumeRoleWithWebIdentity` call that
+    /// mints federated Bedrock credentials. Required together with
+    /// `--bedrock-inference-role`.
+    #[arg(
+        long = "bedrock-role-region",
+        value_name = "REGION",
+        requires = "bedrock_inference_role",
+        hide = true
+    )]
+    pub bedrock_role_region: Option<String>,
 
     #[command(flatten)]
     pub computer_use: HiddenComputerUseArgs,

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -328,9 +328,6 @@ pub struct RunAgentArgs {
     #[arg(long = "sandboxed", hide = true)]
     pub sandboxed: bool,
     /// IAM role ARN to use for federated AWS Bedrock credentials for this run.
-    ///
-    /// When set, `--bedrock-role-region` must also be provided so the STS
-    /// `AssumeRoleWithWebIdentity` call targets the right regional endpoint.
     #[arg(
         long = "bedrock-inference-role",
         value_name = "ROLE_ARN",

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -57,6 +57,8 @@ fn agent_run_accepts_hidden_bedrock_inference_role_flag() {
         "hello",
         "--bedrock-inference-role",
         "arn:aws:iam::123456789012:role/test",
+        "--bedrock-role-region",
+        "us-east-1",
     ])
     .unwrap();
 
@@ -70,6 +72,43 @@ fn agent_run_accepts_hidden_bedrock_inference_role_flag() {
     assert_eq!(
         run_args.bedrock_inference_role.as_deref(),
         Some("arn:aws:iam::123456789012:role/test")
+    );
+    assert_eq!(run_args.bedrock_role_region.as_deref(), Some("us-east-1"));
+}
+
+#[test]
+fn agent_run_rejects_bedrock_inference_role_without_region() {
+    let err = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run",
+        "--prompt",
+        "hello",
+        "--bedrock-inference-role",
+        "arn:aws:iam::123456789012:role/test",
+    ])
+    .expect_err("--bedrock-inference-role must require --bedrock-role-region");
+    assert!(
+        err.to_string().contains("--bedrock-role-region"),
+        "expected error to reference --bedrock-role-region, got: {err}"
+    );
+}
+
+#[test]
+fn agent_run_rejects_bedrock_role_region_without_role() {
+    let err = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run",
+        "--prompt",
+        "hello",
+        "--bedrock-role-region",
+        "us-east-1",
+    ])
+    .expect_err("--bedrock-role-region must require --bedrock-inference-role");
+    assert!(
+        err.to_string().contains("--bedrock-inference-role"),
+        "expected error to reference --bedrock-inference-role, got: {err}"
     );
 }
 


### PR DESCRIPTION
pr 2/2 that addresses convo here: https://github.com/warpdotdev/warp-server/pull/11178#discussion_r3251382454

## Description

Adds a hidden `--bedrock-role-region` flag that pairs with the existing `--bedrock-inference-role` on `warp agent run`, and threads the region through the Bedrock OIDC credential refresh so the STS `AssumeRoleWithWebIdentity` call lands on the same regional endpoint the org has configured for Bedrock.

Previously the worker set `AWS_REGION` on the task container, which leaked the region into every sub-process inside the run. The companion warp-server and oz-agent-worker PRs now snapshot the region alongside the role ARN and emit it as a CLI flag instead.
