### PR TITLE
Fix asset-loading errors on WASM

### DIFF
--- a/crates/asset_cache/src/lib.rs
+++ b/crates/asset_cache/src/lib.rs
@@ -3,9 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_fs::{OpenOptions, create_dir_all};
 use bytes::Bytes;
-use futures::AsyncWriteExt;
 use reqwest::Url;
 use warpui_core::assets::asset_cache::{
     Asset, AssetCache, AssetSource, AssetState, AsyncAssetId, AsyncAssetType,
@@ -89,7 +87,7 @@ async fn fetch_file_to_memory(url: Url) -> Result<Bytes, anyhow::Error> {
             let response = async_compat::Compat::new(async move { reqwest::get(url).await }).await?;
         }
     }
-    let content = response.bytes().await?;
+    let content = response.error_for_status()?.bytes().await?;
     Ok(content)
 }
 
@@ -109,7 +107,11 @@ fn get_file_path_for_asset(url: &Url, cache_dir: &Path) -> PathBuf {
     cache_dir.join(filename)
 }
 
+#[cfg(not(target_family = "wasm"))]
 async fn persist_bytes(bytes: &Bytes, file: &Path) {
+    use async_fs::{OpenOptions, create_dir_all};
+    use futures::AsyncWriteExt;
+
     let Some(parent_folder) = file.parent() else {
         log::error!("attempted to write cache file in filesystem root");
         return;
@@ -140,6 +142,11 @@ async fn persist_bytes(bytes: &Bytes, file: &Path) {
     if let Err(e) = file.flush().await {
         log::error!("Error flushing file: {e:#}");
     };
+}
+
+#[cfg(target_family = "wasm")]
+async fn persist_bytes(_bytes: &Bytes, file: &Path) {
+    log::debug!("Cannot persist asset to {} on the web", file.display());
 }
 
 async fn fetch_file_and_persist_bytes(url: Url, file: Option<PathBuf>) -> Result<Bytes> {


### PR DESCRIPTION
## Description

This fixes two bugs in our asset cache, which I noticed while debugging Warp-on-Web errors:
1. Caching asset data to disk was not correctly gated. This meant that loading the settings page on the web would panic, since we cache the user's profile picture. This may have been dev-only, since I couldn't reproduce on stable.
2. We didn't check the HTTP status code when fetching assets by URL. Instead, we'd try to parse whatever the error response was. For example, I got a 429 error back from Google, and we tried to parse it as an SVG.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

Tested by running the WASM app and server together, and opening the settings page.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
