### PR TITLE
Add error pattern telemetry for third party harnesses.

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -53,8 +53,10 @@ use crate::ai::{
     agent_sdk::driver::harness::{
         harness_model_env_vars, task_env_vars, HarnessCleanupDisposition, HarnessKind,
         HarnessRunner, ResumePayload, SavePoint, ThirdPartyHarness,
+        ThirdPartyHarnessTelemetryEvent,
     },
 };
+use crate::send_telemetry_from_app_ctx;
 use crate::terminal::cli_agent_sessions::plugin_manager::{
     plugin_manager_for, CliAgentPluginManager,
 };
@@ -2206,6 +2208,19 @@ impl AgentDriver {
                             error.pattern,
                             error.excerpt,
                         );
+                        let telemetry_harness = harness_name.clone();
+                        let telemetry_pattern = error.pattern.clone();
+                        let _ = foreground
+                            .spawn(move |_, ctx| {
+                                use warp_core::telemetry::TelemetryEvent as _;
+                                let event =
+                                    ThirdPartyHarnessTelemetryEvent::RuntimeErrorDetected {
+                                        harness: telemetry_harness,
+                                        pattern: telemetry_pattern,
+                                    };
+                                send_telemetry_from_app_ctx!(event, ctx);
+                            })
+                            .await;
                         let session_status = foreground
                             .spawn(|me, ctx| {
                                 let view_id =

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -41,11 +41,13 @@ mod codex;
 pub(crate) mod codex_transcript;
 mod gemini;
 mod json_utils;
+mod telemetry;
 pub(crate) use claude_code::ClaudeHarness;
 use claude_transcript::ClaudeResumeInfo;
 use codex::CodexHarness;
 use codex_transcript::CodexResumeInfo;
 use gemini::GeminiHarness;
+pub(crate) use telemetry::ThirdPartyHarnessTelemetryEvent;
 
 /// Harness-agnostic payload describing how to resume an existing conversation.
 ///

--- a/app/src/ai/agent_sdk/driver/harness/telemetry.rs
+++ b/app/src/ai/agent_sdk/driver/harness/telemetry.rs
@@ -1,0 +1,84 @@
+use serde_json::{json, Value};
+use strum_macros::{EnumDiscriminants, EnumIter};
+use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
+
+/// Telemetry events emitted by the third-party harness runtime layer.
+#[derive(Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(EnumIter))]
+pub(crate) enum ThirdPartyHarnessTelemetryEvent {
+    /// The runtime output scanner observed one of the harness's known
+    /// failure substrings. Fires once per detection, before any suppression
+    /// logic, so dashboards can compare raw trigger volume vs. detections
+    /// that actually fail the run.
+    RuntimeErrorDetected {
+        /// CLI command prefix for the harness whose block was scanned
+        /// (e.g. `"claude"`, `"codex"`).
+        harness: String,
+        /// The originating needle from `runtime_error_patterns` that hit.
+        pattern: String,
+    },
+}
+
+impl TelemetryEvent for ThirdPartyHarnessTelemetryEvent {
+    fn name(&self) -> &'static str {
+        ThirdPartyHarnessTelemetryEventDiscriminants::from(self).name()
+    }
+
+    fn payload(&self) -> Option<Value> {
+        match self {
+            ThirdPartyHarnessTelemetryEvent::RuntimeErrorDetected { harness, pattern } => {
+                Some(json!({
+                    "harness": harness,
+                    "pattern": pattern,
+                }))
+            }
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        ThirdPartyHarnessTelemetryEventDiscriminants::from(self).description()
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        ThirdPartyHarnessTelemetryEventDiscriminants::from(self).enablement_state()
+    }
+
+    fn contains_ugc(&self) -> bool {
+        match self {
+            ThirdPartyHarnessTelemetryEvent::RuntimeErrorDetected { .. } => false,
+        }
+    }
+
+    fn event_descs() -> impl Iterator<Item = Box<dyn TelemetryEventDesc>> {
+        warp_core::telemetry::enum_events::<Self>()
+    }
+}
+
+impl TelemetryEventDesc for ThirdPartyHarnessTelemetryEventDiscriminants {
+    fn name(&self) -> &'static str {
+        match self {
+            ThirdPartyHarnessTelemetryEventDiscriminants::RuntimeErrorDetected => {
+                "ThirdPartyHarness.RuntimeError.Detected"
+            }
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            ThirdPartyHarnessTelemetryEventDiscriminants::RuntimeErrorDetected => {
+                "Runtime output scanner detected a known failure substring in a third-party \
+                 harness block."
+            }
+        }
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        match self {
+            ThirdPartyHarnessTelemetryEventDiscriminants::RuntimeErrorDetected => {
+                EnablementState::Always
+            }
+        }
+    }
+}
+
+warp_core::register_telemetry_event!(ThirdPartyHarnessTelemetryEvent);

--- a/app/src/ai/agent_sdk/driver/harness/telemetry.rs
+++ b/app/src/ai/agent_sdk/driver/harness/telemetry.rs
@@ -58,7 +58,7 @@ impl TelemetryEventDesc for ThirdPartyHarnessTelemetryEventDiscriminants {
     fn name(&self) -> &'static str {
         match self {
             ThirdPartyHarnessTelemetryEventDiscriminants::RuntimeErrorDetected => {
-                "ThirdPartyHarness.RuntimeError.Detected"
+                "AmbientAgents.ThirdPartyHarness.RuntimeError.Detected"
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

WISOTT! A follow up from https://github.com/warpdotdev/warp/pull/11148.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

Tested with `oz-local` and I see this in the oz local logs:

```
2026-05-18T14:50:09Z [WARN] [warp::ai::agent_sdk::driver] Runtime failure detected for claude: pattern=Invalid API key, excerpt=⎿  Invalid API key · Fix external API key
2026-05-18T14:50:09Z [INFO] [warpui_core::telemetry::event_store] Recorded telemetry event: Event {
    payload: NamedEvent {
        user_id: Some(
            "6K0M7hjt9wWgaPWJex41aMpD29a2",
        ),
        anonymous_id: "65a3f077-55c8-4f4e-a55a-16e2bf1dcc94",
        name: "ThirdPartyHarness.RuntimeError.Detected",
        value: Some(
            Object {
                "harness": String("claude"),
                "pattern": String("Invalid API key"),
            },
        ),
    },
    session_created_at: 2026-05-18T14:49:27.914804Z,
    timestamp: 2026-05-18T14:50:09.923527Z,
    contains_ugc: false,
}
```

No CLI telemetry seems to appear in the Rudderstack sandbox source for some reason. But checking with Ben N, I'm not super worried that we're missing all CLI telemetry events and we flush all events on shutdown.

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

