### PR TITLE
fix(terminal-input): tolerate localized PowerShell executable output (#9182)

### DIFF
--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -621,7 +621,10 @@ impl ShellType {
                 // this will print one item per line. However, when it is converted to a string,
                 // it will join the entries together with a space. So to make sure we get one item
                 // per line, we explicitly join the results with a newline.
-                "Get-Command -CommandType Application | Select-Object -ExpandProperty Name"
+                //
+                // We write the joined text to stdout as explicit UTF-8 bytes so localized
+                // executable names do not depend on the machine's active Windows code page.
+                r#"$names = Get-Command -CommandType Application | Select-Object -ExpandProperty Name; $text = [string]::Join([Environment]::NewLine, $names); $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($text); [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)"#
             }
         }
     }
@@ -636,8 +639,9 @@ impl ShellType {
     ) -> Vec<SmolStr> {
         match output {
             Ok(command_output) if command_output.status == CommandExitStatus::Success => {
-                // Be tolerant of Windows-localized command output that may not be UTF-8.
-                let output_string = String::from_utf8_lossy(&command_output.stdout).into_owned();
+                let Ok(output_string) = command_output.to_string() else {
+                    return Vec::new();
+                };
                 match self {
                     ShellType::Bash | ShellType::Zsh => {
                         // For bash and zsh, we wrote the command such that the output is just

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -324,10 +324,12 @@ impl ShellType {
             }
             #[cfg(windows)]
             ShellType::PowerShell => {
-                vec![base_config_dir()
-                    .join("Microsoft/Windows/PowerShell/PSReadLine/ConsoleHost_history.txt")
-                    .display()
-                    .to_string()]
+                vec![
+                    base_config_dir()
+                        .join("Microsoft/Windows/PowerShell/PSReadLine/ConsoleHost_history.txt")
+                        .display()
+                        .to_string(),
+                ]
             }
         }
     }
@@ -634,9 +636,8 @@ impl ShellType {
     ) -> Vec<SmolStr> {
         match output {
             Ok(command_output) if command_output.status == CommandExitStatus::Success => {
-                let Ok(output_string) = command_output.to_string() else {
-                    return Vec::new();
-                };
+                // Be tolerant of Windows-localized command output that may not be UTF-8.
+                let output_string = String::from_utf8_lossy(&command_output.stdout).into_owned();
                 match self {
                     ShellType::Bash | ShellType::Zsh => {
                         // For bash and zsh, we wrote the command such that the output is just

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -324,12 +324,10 @@ impl ShellType {
             }
             #[cfg(windows)]
             ShellType::PowerShell => {
-                vec![
-                    base_config_dir()
-                        .join("Microsoft/Windows/PowerShell/PSReadLine/ConsoleHost_history.txt")
-                        .display()
-                        .to_string(),
-                ]
+                vec![base_config_dir()
+                    .join("Microsoft/Windows/PowerShell/PSReadLine/ConsoleHost_history.txt")
+                    .display()
+                    .to_string()]
             }
         }
     }

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -271,14 +271,18 @@ fn test_should_add_command_to_history() {
     }
 }
 
-/// Ensures one localized non-UTF-8 PowerShell entry does not drop later ASCII executables.
+/// Ensures UTF-8 PowerShell executable output preserves localized and ASCII entries together.
 #[test]
-fn test_powershell_executables_from_gbk_output() {
-    let expected_lossy = String::from_utf8_lossy(b"\xb2\xe2\xca\xd4.exe").into_owned();
-    let gbk_entry = b"\xb2\xe2\xca\xd4.exe";
+fn test_powershell_executables_from_utf8_output() {
+    let localized_entry = "测试.exe";
     let ascii_entry = b"git.exe";
     let output = CommandOutput {
-        stdout: [gbk_entry.as_slice(), b"\n", ascii_entry.as_slice()].concat(),
+        stdout: [
+            localized_entry.as_bytes(),
+            b"\n".as_slice(),
+            ascii_entry.as_slice(),
+        ]
+        .concat(),
         stderr: Vec::new(),
         status: CommandExitStatus::Success,
         exit_code: Some(0.into()),
@@ -288,10 +292,8 @@ fn test_powershell_executables_from_gbk_output() {
         ShellType::PowerShell.executables_from_shell_command_output(Ok(output), false);
 
     assert!(
-        executables
-            .iter()
-            .any(|name| name == expected_lossy.as_str()),
-        "expected lossy-decoded executable name to be preserved"
+        executables.iter().any(|name| name == localized_entry),
+        "expected localized executable name to be preserved"
     );
 
     assert!(
@@ -300,9 +302,8 @@ fn test_powershell_executables_from_gbk_output() {
     );
 
     if cfg!(windows) {
-        let expected_trimmed = expected_lossy.trim_end_matches(".exe");
         assert!(
-            executables.iter().any(|name| name == expected_trimmed),
+            executables.iter().any(|name| name == "测试"),
             "expected Windows executable suffix trimming to remain intact"
         );
         assert!(
@@ -310,4 +311,19 @@ fn test_powershell_executables_from_gbk_output() {
             "expected Windows suffix trimming to preserve later ASCII executables"
         );
     }
+}
+
+/// Ensures the PowerShell executable discovery script writes UTF-8 bytes to stdout.
+#[test]
+fn test_powershell_shell_command_to_get_executables_writes_utf8() {
+    let command = ShellType::PowerShell.shell_command_to_get_executables();
+
+    assert!(
+        command.contains("System.Text.UTF8Encoding"),
+        "expected PowerShell executable discovery to encode stdout as UTF-8"
+    );
+    assert!(
+        command.contains("OpenStandardOutput().Write"),
+        "expected PowerShell executable discovery to write bytes directly to stdout"
+    );
 }

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -271,12 +271,14 @@ fn test_should_add_command_to_history() {
     }
 }
 
-/// Ensures localized PowerShell executable output does not get dropped on non-UTF-8 Windows code pages.
+/// Ensures one localized non-UTF-8 PowerShell entry does not drop later ASCII executables.
 #[test]
 fn test_powershell_executables_from_gbk_output() {
     let expected_lossy = String::from_utf8_lossy(b"\xb2\xe2\xca\xd4.exe").into_owned();
+    let gbk_entry = b"\xb2\xe2\xca\xd4.exe";
+    let ascii_entry = b"git.exe";
     let output = CommandOutput {
-        stdout: b"\xb2\xe2\xca\xd4.exe".to_vec(),
+        stdout: [gbk_entry.as_slice(), b"\n", ascii_entry.as_slice()].concat(),
         stderr: Vec::new(),
         status: CommandExitStatus::Success,
         exit_code: Some(0.into()),
@@ -292,11 +294,20 @@ fn test_powershell_executables_from_gbk_output() {
         "expected lossy-decoded executable name to be preserved"
     );
 
+    assert!(
+        executables.iter().any(|name| name == "git.exe"),
+        "expected ASCII executable entries after localized output to survive"
+    );
+
     if cfg!(windows) {
         let expected_trimmed = expected_lossy.trim_end_matches(".exe");
         assert!(
             executables.iter().any(|name| name == expected_trimmed),
             "expected Windows executable suffix trimming to remain intact"
+        );
+        assert!(
+            executables.iter().any(|name| name == "git"),
+            "expected Windows suffix trimming to preserve later ASCII executables"
         );
     }
 }

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -270,3 +270,33 @@ fn test_should_add_command_to_history() {
         assert!(fish_shell.should_add_command_to_history(" asdf"));
     }
 }
+
+/// Ensures localized PowerShell executable output does not get dropped on non-UTF-8 Windows code pages.
+#[test]
+fn test_powershell_executables_from_gbk_output() {
+    let expected_lossy = String::from_utf8_lossy(b"\xb2\xe2\xca\xd4.exe").into_owned();
+    let output = CommandOutput {
+        stdout: b"\xb2\xe2\xca\xd4.exe".to_vec(),
+        stderr: Vec::new(),
+        status: CommandExitStatus::Success,
+        exit_code: Some(0.into()),
+    };
+
+    let executables =
+        ShellType::PowerShell.executables_from_shell_command_output(Ok(output), false);
+
+    assert!(
+        executables
+            .iter()
+            .any(|name| name == expected_lossy.as_str()),
+        "expected lossy-decoded executable name to be preserved"
+    );
+
+    if cfg!(windows) {
+        let expected_trimmed = expected_lossy.trim_end_matches(".exe");
+        assert!(
+            executables.iter().any(|name| name == expected_trimmed),
+            "expected Windows executable suffix trimming to remain intact"
+        );
+    }
+}

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -270,18 +270,3 @@ fn test_should_add_command_to_history() {
         assert!(fish_shell.should_add_command_to_history(" asdf"));
     }
 }
-
-/// Ensures the PowerShell executable discovery script writes UTF-8 bytes to stdout.
-#[test]
-fn test_powershell_shell_command_to_get_executables_writes_utf8() {
-    let command = ShellType::PowerShell.shell_command_to_get_executables();
-
-    assert!(
-        command.contains("System.Text.UTF8Encoding"),
-        "expected PowerShell executable discovery to encode stdout as UTF-8"
-    );
-    assert!(
-        command.contains("OpenStandardOutput().Write"),
-        "expected PowerShell executable discovery to write bytes directly to stdout"
-    );
-}

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -271,48 +271,6 @@ fn test_should_add_command_to_history() {
     }
 }
 
-/// Ensures UTF-8 PowerShell executable output preserves localized and ASCII entries together.
-#[test]
-fn test_powershell_executables_from_utf8_output() {
-    let localized_entry = "测试.exe";
-    let ascii_entry = b"git.exe";
-    let output = CommandOutput {
-        stdout: [
-            localized_entry.as_bytes(),
-            b"\n".as_slice(),
-            ascii_entry.as_slice(),
-        ]
-        .concat(),
-        stderr: Vec::new(),
-        status: CommandExitStatus::Success,
-        exit_code: Some(0.into()),
-    };
-
-    let executables =
-        ShellType::PowerShell.executables_from_shell_command_output(Ok(output), false);
-
-    assert!(
-        executables.iter().any(|name| name == localized_entry),
-        "expected localized executable name to be preserved"
-    );
-
-    assert!(
-        executables.iter().any(|name| name == "git.exe"),
-        "expected ASCII executable entries after localized output to survive"
-    );
-
-    if cfg!(windows) {
-        assert!(
-            executables.iter().any(|name| name == "测试"),
-            "expected Windows executable suffix trimming to remain intact"
-        );
-        assert!(
-            executables.iter().any(|name| name == "git"),
-            "expected Windows suffix trimming to preserve later ASCII executables"
-        );
-    }
-}
-
 /// Ensures the PowerShell executable discovery script writes UTF-8 bytes to stdout.
 #[test]
 fn test_powershell_shell_command_to_get_executables_writes_utf8() {


### PR DESCRIPTION
## Description
Fixes the persistent Windows PowerShell repro behind #9182 by making executable discovery tolerant of localized, non-UTF-8 command output.

This PR supersedes #11202, which I accidentally opened from the wrong base branch. This branch is created from `upstream/master` and contains only the fix for this issue.

The issue's existing open PR focuses on suppressing error underlining until the external-commands list finishes loading. That approach can reduce transient false positives, but it does not address the deeper Windows-specific failure mode I reproduced locally: when PowerShell returns executable names using the active system code page (for example GBK with Chinese executable names), `executables_from_shell_command_output()` drops the entire list because `CommandOutput::to_string()` expects strict UTF-8. Once the executable list is empty, valid commands can continue to look unknown long after loading has finished.

This change fixes the decoding failure at the point where Warp turns PowerShell generator output into executable names:

- decode successful PowerShell executable output with `String::from_utf8_lossy(...)` instead of discarding the list on UTF-8 failure
- keep the existing Windows `.exe` suffix trimming behavior intact
- add a regression test that feeds GBK-encoded PowerShell output and verifies the executable name is still preserved

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Fixes #9182

## Testing
- [ ] I have manually tested my changes locally with `./script/run`
- Ran `cargo test -p warp_terminal shell:: -- --nocapture`
- Added `test_powershell_executables_from_gbk_output` to cover localized non-UTF-8 PowerShell output
- I did not add a manual recording because this change is not UI-specific and I validated it with a focused regression test instead

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix Windows PowerShell command discovery when localized executable names are emitted in a non-UTF-8 code page.
