### PR TITLE
Update auth FTUX skip secret text.

### DIFF
--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_dropdown.rs
@@ -405,7 +405,7 @@ impl AuthSecretFtuxDropdown {
         items.push(MenuItem::Item(
             MenuItemFields::new_with_label(
                 "Skip (advanced)",
-                "Only if your key is already set in the environment (e.g. baked into the Docker image)",
+                "Only if your key is already set in the environment (e.g. injected as a Kubernetes secret)",
             )
             .with_font_size_override(FONT_SIZE)
             .with_padding_override(MENU_ITEM_VERTICAL_PADDING, MENU_HORIZONTAL_PADDING)


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
The PR updates the auth FTUX secret text so that we recommend an actually secure way of injecting harness credentials into your environment that isn't baking them into the Docker image. 

Since all Docker images we use are public, we don't want to tell people to inject their API keys in there!

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->
<img width="885" height="419" alt="image" src="https://github.com/user-attachments/assets/c9b821b0-33ca-49c0-81e2-947e2ae23ae3" />

- [x] I have manually tested my changes locally with `./script/run`


