### PR TITLE
Connect with setup branches RPC

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -93,7 +93,7 @@ use crate::terminal::cli_agent::{
 };
 #[cfg(feature = "local_fs")]
 use crate::util::file::external_editor::EditorSettings;
-use crate::util::git::{get_all_branches, BranchEntry};
+use crate::util::git::BranchEntry;
 #[cfg(feature = "local_fs")]
 use crate::util::openable_file_type::resolve_file_target_with_editor_choice;
 #[cfg(feature = "local_fs")]
@@ -734,8 +734,7 @@ impl CodeReviewView {
         self.is_open = true;
 
         ctx.subscribe_to_model(&self.diff_state_model, Self::handle_diff_state_model_event);
-        if self.repo_path().is_some_and(LocalOrRemotePath::is_local) {
-            // TODO: add support for remote repositories
+        if self.repo_path().is_some() {
             self.fetch_branches_and_setup_dropdown(ctx);
         }
         ctx.notify();
@@ -1323,7 +1322,6 @@ impl CodeReviewView {
         });
 
         let has_repo = repo_path.is_some();
-        let has_local_repo = repo_path.as_ref().is_some_and(LocalOrRemotePath::is_local);
         let active_repo = repo_path.clone().map(RepositoryState::new);
 
         let mut view = Self {
@@ -1371,7 +1369,7 @@ impl CodeReviewView {
             git_dialog: None,
         };
         view.set_active_repo_comment_model(comment_batch_model, ctx);
-        if has_local_repo {
+        if has_repo {
             view.fetch_branches_and_setup_dropdown(ctx);
         }
         if has_repo {
@@ -1484,64 +1482,9 @@ impl CodeReviewView {
     }
 
     fn fetch_branches_and_setup_dropdown(&mut self, ctx: &mut ViewContext<Self>) {
-        // TODO: add support for remote repositories
-        let Some(repo_path) = self
-            .repo_path()
-            .and_then(LocalOrRemotePath::to_local_path)
-            .map(Path::to_path_buf)
-        else {
-            return;
-        };
-        let fetched_repo_path = repo_path.clone();
-        ctx.spawn(
-            async move {
-                get_all_branches(&repo_path, None, false /* include_remotes */)
-                    .await
-            },
-            move |me, branches_result, ctx| {
-                // If the active repo changed while branches were being fetched,
-                // discard the stale result.
-                if me.repo_path().and_then(LocalOrRemotePath::to_local_path)
-                    != Some(fetched_repo_path.as_path())
-                {
-                    return;
-                }
-                match branches_result {
-                    Ok(branches) => {
-                        if let Some(repo) = me.active_repo.as_mut() {
-                            let branch_count = branches.len();
-                            let repo_path = &repo.repo_path;
-                            safe_info!(
-                                safe: ("Code Review: Set available_branches with {} branches", branch_count),
-                                full: (
-                                    "Code Review: Set available_branches for repo {:?} with {} branches",
-                                    repo_path,
-                                    branch_count
-                                )
-                            );
-                            repo.available_branches = branches;
-                        }
-                        me.update_diff_selector_selection(ctx);
-                    }
-                    Err(err) => {
-                        log::warn!("Failed to fetch branches: {err}");
-                        // Fallback to default dropdown with just uncommitted changes and main branch
-                        if let Some(repo) = me.active_repo.as_mut() {
-                            let repo_path = &repo.repo_path;
-                            safe_info!(
-                                safe: ("Code Review: Set available_branches to empty (fallback after error)"),
-                                full: (
-                                    "Code Review: Set available_branches to empty for repo {:?} (fallback after error)",
-                                    repo_path
-                                )
-                            );
-                            repo.available_branches = vec![];
-                        }
-                        me.update_diff_selector_selection(ctx);
-                    }
-                }
-            },
-        );
+        self.diff_state_model.update(ctx, |model, ctx| {
+            model.fetch_branches(ctx);
+        });
     }
 
     pub(crate) fn build_diff_targets(&self, ctx: &ViewContext<Self>) -> Vec<DiffTarget> {
@@ -2406,6 +2349,21 @@ impl CodeReviewView {
                 // Don't clear loaded state — keep stale diffs visible
                 // so the user can still see what they were looking at.
                 ctx.notify();
+            }
+            DiffStateModelEvent::BranchesReceived(branches) => {
+                if let Some(repo) = self.active_repo.as_mut() {
+                    let branch_count = branches.len();
+                    safe_info!(
+                        safe: ("Code Review: Set available_branches with {} branches", branch_count),
+                        full: (
+                            "Code Review: Set available_branches for repo {:?} with {} branches",
+                            &repo.repo_path,
+                            branch_count
+                        )
+                    );
+                    repo.available_branches = branches.clone();
+                }
+                self.update_diff_selector_selection(ctx);
             }
         }
     }

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -773,9 +773,17 @@ impl CodeReviewView {
             }
         }
 
+        // If the view is freshly created (state is None/loading) but the model
+        // already holds computed diffs (DiffState::Loaded), a non-forced load
+        // will no-op because the model thinks it's done. Force a reload so
+        // the model re-emits NewDiffsComputed and the view gets populated.
+        let view_needs_diffs = matches!(self.state(), CodeReviewViewState::None);
+        let model_already_loaded = matches!(self.diff_state(ctx), DiffState::Loaded);
+        let force = view_needs_diffs && model_already_loaded;
+
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(true, ctx);
-            model.load_diffs_for_current_repo(false, ctx);
+            model.load_diffs_for_current_repo(force, ctx);
         });
     }
 

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -31,6 +31,8 @@ use crate::util::git::{
     detect_current_branch, detect_main_branch, get_unpushed_commits, parse_unified_diff_header,
     Commit, PrInfo,
 };
+#[cfg(feature = "local_fs")]
+use crate::util::git::get_all_branches;
 use warp_util::git::run_git_command;
 
 use crate::code_review::diff_size_limits::compute_diff_size;
@@ -461,6 +463,35 @@ impl LocalDiffStateModel {
     fn queue_full_invalidation(&mut self) {
         self.file_invalidation.cancel_all();
         self.file_invalidation.invalidate_all_pending = true;
+    }
+
+    /// Fetches branches for the active repository and emits
+    /// `DiffStateModelEvent::BranchesReceived` on completion.
+    #[cfg(feature = "local_fs")]
+    pub fn fetch_branches(&self, ctx: &mut ModelContext<Self>) {
+        let Some(repo_path) = self.active_repository_path(ctx) else {
+            return;
+        };
+        ctx.spawn(
+            async move {
+                get_all_branches(&repo_path, None, false /* include_remotes */).await
+            },
+            |_me, branches_result, ctx| {
+                let branches = match branches_result {
+                    Ok(branches) => branches,
+                    Err(err) => {
+                        log::warn!("LocalDiffStateModel: failed to fetch branches: {err}");
+                        vec![]
+                    }
+                };
+                ctx.emit(DiffStateModelEvent::BranchesReceived(branches));
+            },
+        );
+    }
+
+    #[cfg(not(feature = "local_fs"))]
+    pub fn fetch_branches(&self, _ctx: &mut ModelContext<Self>) {
+        // Noop on WASM builds.
     }
 
     pub fn set_diff_mode(

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -26,13 +26,13 @@ use warpui::{r#async::SpawnedFutureHandle, ModelContext};
 use crate::code_review::diff_size_limits::DiffSize;
 use crate::features::FeatureFlag;
 #[cfg(feature = "local_fs")]
+use crate::util::git::get_all_branches;
+#[cfg(feature = "local_fs")]
 use crate::util::git::get_pr_for_branch;
 use crate::util::git::{
     detect_current_branch, detect_main_branch, get_unpushed_commits, parse_unified_diff_header,
     Commit, PrInfo,
 };
-#[cfg(feature = "local_fs")]
-use crate::util::git::get_all_branches;
 use warp_util::git::run_git_command;
 
 use crate::code_review::diff_size_limits::compute_diff_size;

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -5,7 +5,7 @@
 //! operations to whichever is active.
 //! All consumers should use `DiffStateModel` rather than accessing sub-models directly.
 
-use crate::util::git::{Commit, PrInfo};
+use crate::util::git::{BranchEntry, Commit, PrInfo};
 use warp_core::SessionId;
 use warp_util::remote_path::RemotePath;
 use warpui::{AppContext, ModelContext, ModelHandle};
@@ -318,6 +318,8 @@ pub enum DiffStateModelEvent {
     /// The remote connection was lost. Stale diffs should be preserved while
     /// the model waits for a new subscription.
     ConnectionLost,
+    /// Branch list received from the backend (local git or remote server).
+    BranchesReceived(Vec<BranchEntry>),
 }
 
 // ── Unified model ────────────────────────────────────────────────────────
@@ -383,6 +385,9 @@ impl DiffStateModel {
             }
             DiffStateModelEvent::ConnectionLost => {
                 ctx.emit(DiffStateModelEvent::ConnectionLost);
+            }
+            DiffStateModelEvent::BranchesReceived(branches) => {
+                ctx.emit(DiffStateModelEvent::BranchesReceived(branches.clone()));
             }
         }
     }
@@ -548,6 +553,21 @@ impl DiffStateModel {
                 });
             }
             Self::Remote(_) => {}
+        }
+    }
+
+    pub(crate) fn fetch_branches(&self, ctx: &mut ModelContext<Self>) {
+        match self {
+            Self::Local(local) => {
+                local.update(ctx, |local, ctx| {
+                    local.fetch_branches(ctx);
+                });
+            }
+            Self::Remote(model) => {
+                model.update(ctx, |model, ctx| {
+                    model.fetch_branches(ctx);
+                });
+            }
         }
     }
 

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -255,6 +255,7 @@ impl DiffMode {
 
 /// User-visible representation of the diffs we've loaded,
 /// which only includes changes against the specific base the user has selected.
+#[derive(Debug)]
 pub enum DiffState {
     NotInRepository,
     Loading,
@@ -526,18 +527,20 @@ impl DiffStateModel {
         }
     }
 
-    pub(crate) fn load_diffs_for_current_repo(
-        &self,
-        should_fetch_base: bool,
-        ctx: &mut ModelContext<Self>,
-    ) {
+    pub(crate) fn load_diffs_for_current_repo(&self, force: bool, ctx: &mut ModelContext<Self>) {
         match self {
             Self::Local(local) => {
                 local.update(ctx, |local, ctx| {
-                    local.load_diffs_for_current_repo(should_fetch_base, ctx);
+                    local.load_diffs_for_current_repo(force, ctx);
                 });
             }
-            Self::Remote(_) => {}
+            Self::Remote(remote) => {
+                if force {
+                    remote.update(ctx, |remote, ctx| {
+                        remote.replay_latest_diffs(ctx);
+                    });
+                }
+            }
         }
     }
 

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -141,9 +141,7 @@ impl RemoteDiffStateModel {
                 self.handle_file_delta_received(delta, ctx);
             }
             RemoteServerManagerEvent::GetBranchesResponse {
-                repo_path,
-                result,
-                ..
+                repo_path, result, ..
             } if repo_path == &self.remote_path.path => {
                 let branches = match result {
                     Ok(branch_infos) => branch_infos
@@ -154,9 +152,7 @@ impl RemoteDiffStateModel {
                         })
                         .collect(),
                     Err(err) => {
-                        log::warn!(
-                            "RemoteDiffStateModel: GetBranches failed: {err}"
-                        );
+                        log::warn!("RemoteDiffStateModel: GetBranches failed: {err}");
                         vec![]
                     }
                 };
@@ -258,6 +254,28 @@ impl RemoteDiffStateModel {
     }
 
     // ── Apply methods ──────────────────────────────────────────────────────
+
+    /// Re-emits `NewDiffsComputed` with the currently loaded diff data.
+    /// Called when a view subscribes after the initial snapshot was already processed.
+    pub(crate) fn replay_latest_diffs(&self, ctx: &mut ModelContext<Self>) {
+        match &self.state {
+            InternalRemoteDiffState::Loaded(diffs) => {
+                let base_content = GitDiffWithBaseContent::from(diffs);
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed(Some(Arc::new(
+                    base_content,
+                ))));
+            }
+            InternalRemoteDiffState::NotInRepository => {
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+            }
+            InternalRemoteDiffState::Error(_) => {
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+            }
+            InternalRemoteDiffState::Loading | InternalRemoteDiffState::Disconnected => {
+                // Nothing to replay yet.
+            }
+        }
+    }
 
     fn apply_snapshot(
         &mut self,

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use crate::remote_server::diff_state_proto::{try_decode_file_delta, try_decode_snapshot};
 use crate::remote_server::proto;
-use crate::util::git::{Commit, PrInfo};
+use crate::util::git::{BranchEntry, Commit, PrInfo};
 use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
 use warp_core::{HostId, SessionId};
 use warp_util::remote_path::RemotePath;
@@ -139,6 +139,28 @@ impl RemoteDiffStateModel {
                     return;
                 }
                 self.handle_file_delta_received(delta, ctx);
+            }
+            RemoteServerManagerEvent::GetBranchesResponse {
+                repo_path,
+                result,
+                ..
+            } if repo_path == &self.remote_path.path => {
+                let branches = match result {
+                    Ok(branch_infos) => branch_infos
+                        .iter()
+                        .map(|info| BranchEntry {
+                            name: info.name.clone(),
+                            is_main: info.is_main,
+                        })
+                        .collect(),
+                    Err(err) => {
+                        log::warn!(
+                            "RemoteDiffStateModel: GetBranches failed: {err}"
+                        );
+                        vec![]
+                    }
+                };
+                ctx.emit(DiffStateModelEvent::BranchesReceived(branches));
             }
             RemoteServerManagerEvent::HostDisconnected { host_id }
                 if host_id == &self.remote_path.host_id =>
@@ -456,6 +478,17 @@ impl RemoteDiffStateModel {
         self.unsubscribe(ctx);
         self.mode = mode;
         self.resubscribe(ctx);
+    }
+
+    /// Fetches branches for the remote repository via the `GetBranches` RPC.
+    /// The response is handled in `handle_manager_event` which emits
+    /// `DiffStateModelEvent::BranchesReceived`.
+    pub fn fetch_branches(&self, ctx: &mut ModelContext<Self>) {
+        let session_id = self.session_id;
+        let remote_path = self.remote_path.clone();
+        RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+            mgr.get_branches(session_id, remote_path, None, false, ctx);
+        });
     }
 
     /// Sends a `DiscardFiles` request to the remote server.

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -299,29 +299,28 @@ impl WorkingDirectoriesModel {
 
     /// DiffStateModels are shared across tabs. When you delete repos from one tab,
     /// we should check if its still in use in any tab. If not, stop its watcher and delete it.
+    /// Drops diff state models and cached views for repos that are no longer
+    /// active in any pane group. Called from `refresh_working_directories`
+    /// when a repo leaves the computed set.
+    ///
+    /// The model is dropped unconditionally for the repos passed in — the
+    /// caller has already verified they are not in the new repo set. We do
+    /// NOT re-check `repository_roots` here because a racing side-channel
+    /// (e.g. `register_remote_repo`) may have re-added the repo, which
+    /// would prevent the stale model from being cleaned up.
     fn drop_unused_diff_state_models(
         &mut self,
         removed_repos: impl Iterator<Item = LocalOrRemotePath>,
         ctx: &mut ModelContext<Self>,
     ) {
         for repo_key in removed_repos {
-            if self
-                .repository_roots
-                .values()
-                .all(|tab| !tab.contains(&repo_key))
-            {
-                if let Some(model) = self.diff_state_models.remove(&repo_key) {
-                    model.update(ctx, |model, ctx| {
-                        model.stop_active_watcher(ctx);
-                    });
-                }
-                // Remove the cached CodeReviewView so the panel re-creates
-                // one with the correct terminal_view when the user navigates
-                // back. The DiffStateModel is still alive (for remote) so
-                // `get_or_create_diff_state_model` will reuse it.
-                for views in self.code_review_views.values_mut() {
-                    views.remove(&repo_key);
-                }
+            if let Some(model) = self.diff_state_models.remove(&repo_key) {
+                model.update(ctx, |model, ctx| {
+                    model.stop_active_watcher(ctx);
+                });
+            }
+            for views in self.code_review_views.values_mut() {
+                views.remove(&repo_key);
             }
         }
     }

--- a/app/src/remote_server/diff_state_tracker.rs
+++ b/app/src/remote_server/diff_state_tracker.rs
@@ -374,6 +374,10 @@ impl RemoteDiffStateManager {
                 // Client-only event — should not occur on the server side.
                 log::warn!("Unexpected ConnectionLost event on server-side model key={key:?}");
             }
+            DiffStateModelEvent::BranchesReceived(_) => {
+                // Client-only event — the server model fetches branches
+                // directly via handle_get_branches, not through this tracker.
+            }
         }
     }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -14452,10 +14452,11 @@ impl Workspace {
             }
             pane_group::Event::RepoChanged => {
                 self.refresh_working_directories_for_pane_group(&pane_group, ctx);
-                #[cfg(feature = "local_fs")]
-                if self.active_tab_pane_group().as_ref(ctx).right_panel_open {
-                    self.setup_code_review_panel(None, ctx);
-                }
+                // Code review panel setup is handled by the RepositoriesChanged
+                // event emitted from refresh_working_directories, which triggers
+                // ensure_code_review_view_exists on the right panel. Calling
+                // setup_code_review_panel here would race with refresh and
+                // re-create models that were just dropped.
 
                 if FeatureFlag::DirectoryTabColors.is_enabled() {
                     if let Some(tab) = self
@@ -14484,19 +14485,11 @@ impl Workspace {
                     });
                 }
 
-                // Register the remote repo in WorkingDirectoriesModel so it
-                // appears in the code review dropdown via RepositoriesChanged.
-                // Also map the repo to the terminal that navigated there so
-                // `find_review_terminal` can resolve the preferred terminal.
-                let repo_key = LocalOrRemotePath::Remote(remote_path.clone());
-                let terminal_view_id =
-                    pane_group.read(ctx, |pg, ctx| pg.active_session_view(ctx).map(|tv| tv.id()));
-                self.working_directories_model.update(ctx, |model, ctx| {
-                    model.register_remote_repo(pane_group_id, repo_key.clone(), ctx);
-                    if let Some(terminal_id) = terminal_view_id {
-                        model.register_terminal_for_repo(pane_group_id, repo_key, terminal_id);
-                    }
-                });
+                // Remote repos now enter repository_roots through
+                // refresh_working_directories_for_pane_group (via
+                // pwd_as_local_or_remote). No need to register here —
+                // doing so would race with refresh and prevent stale
+                // DiffStateModels from being dropped.
             }
             #[cfg(not(feature = "local_fs"))]
             pane_group::Event::RemoteRepoNavigated { .. } => {}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8113,24 +8113,6 @@ impl Workspace {
         context: Option<&CodeReviewPaneContext>,
         ctx: &mut ViewContext<Self>,
     ) {
-        // When no explicit context is provided (i.e. we're being called from a
-        // focus-change or session-change handler rather than from an explicit
-        // panel-open action), skip the setup if the right panel already has a
-        // selected code review view. The `RepositoriesChanged` →
-        // `ensure_code_review_view_exists` path manages the view lifecycle
-        // during directory changes. Re-deriving the repo from the terminal's
-        // stale `current_repo_path()` here would race with refresh and
-        // re-create models that were just dropped.
-        if context.is_none()
-            && self
-                .right_panel_view
-                .as_ref(ctx)
-                .selected_repo_path()
-                .is_some()
-        {
-            return;
-        }
-
         // If context is provided, use it directly. Otherwise, derive from active pane group.
         let context_data: Option<(
             Option<LocalOrRemotePath>,
@@ -14353,10 +14335,6 @@ impl Workspace {
                     .as_ref(ctx)
                     .active_session_view(ctx)
                 {
-                    #[cfg(feature = "local_fs")]
-                    if self.active_tab_pane_group().as_ref(ctx).right_panel_open {
-                        self.setup_code_review_panel(None, ctx);
-                    }
                     // Get the ID of the workflow that's active in the pane, if there is one.
                     let active_workflow_id = terminal_view
                         .read(ctx, |terminal_view, _| terminal_view.input().clone())

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8113,6 +8113,24 @@ impl Workspace {
         context: Option<&CodeReviewPaneContext>,
         ctx: &mut ViewContext<Self>,
     ) {
+        // When no explicit context is provided (i.e. we're being called from a
+        // focus-change or session-change handler rather than from an explicit
+        // panel-open action), skip the setup if the right panel already has a
+        // selected code review view. The `RepositoriesChanged` →
+        // `ensure_code_review_view_exists` path manages the view lifecycle
+        // during directory changes. Re-deriving the repo from the terminal's
+        // stale `current_repo_path()` here would race with refresh and
+        // re-create models that were just dropped.
+        if context.is_none()
+            && self
+                .right_panel_view
+                .as_ref(ctx)
+                .selected_repo_path()
+                .is_some()
+        {
+            return;
+        }
+
         // If context is provided, use it directly. Otherwise, derive from active pane group.
         let context_data: Option<(
             Option<LocalOrRemotePath>,
@@ -15439,9 +15457,10 @@ impl Workspace {
                     right_panel.update_session_env(is_remote, is_wsl_session, ctx);
                 });
 
-                if self.active_tab_pane_group().as_ref(ctx).right_panel_open {
-                    self.setup_code_review_panel(None, ctx);
-                }
+                // Code review panel setup is handled by the RepositoriesChanged
+                // event emitted from refresh_working_directories earlier in this
+                // function. Calling setup_code_review_panel here would race
+                // with that path and re-create models that were just dropped.
             }
         } else {
             let enablement = CodingPanelEnablementState::from_session_env(


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
