### PR TITLE
Support diff stats chip for remote sessions

### DIFF
--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -19,6 +19,7 @@ use crate::settings::{AISettings, AISettingsChangedEvent, InputSettings};
 use crate::settings_view::keybindings::{KeybindingChangedEvent, KeybindingChangedNotifier};
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::input::{MenuPositioning, MenuPositioningProvider};
+use crate::terminal::model::session::SessionType;
 use crate::terminal::model_events::ModelEventDispatcher;
 use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 use crate::ui_components::blended_colors;
@@ -1213,44 +1214,65 @@ impl DisplayChip {
             appearance,
         );
 
-        // Get the keybinding for the tooltip
-        let code_review_keybinding = self.code_review_keybinding.clone().unwrap_or_default();
+        // Code review is only supported on local sessions and
+        // on remote sessions with a connected host ID.
+        let supports_code_review = self
+            .session_context
+            .as_ref()
+            .map(|ctx| match ctx.session.session_type() {
+                SessionType::Local => true,
+                SessionType::WarpifiedRemote { host_id: Some(_) } => {
+                    FeatureFlag::RemoteCodeReview.is_enabled()
+                }
+                SessionType::WarpifiedRemote { host_id: None } => false,
+            })
+            .unwrap_or(false);
 
-        let diff_stats_display = Hoverable::new(self.diff_stats_mouse_state.clone(), |state| {
-            let base_container = Container::new(git_diff_stats_content)
+        let diff_stats_display = if supports_code_review {
+            // Get the keybinding for the tooltip
+            let code_review_keybinding = self.code_review_keybinding.clone().unwrap_or_default();
+
+            Hoverable::new(self.diff_stats_mouse_state.clone(), |state| {
+                let base_container = Container::new(git_diff_stats_content)
+                    .with_vertical_padding(2.)
+                    .with_horizontal_padding(4.);
+
+                let base_container = if state.is_hovered() {
+                    base_container
+                        .with_background(appearance.theme().surface_2())
+                        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(
+                            CHIP_INNER_CORNER_RADIUS,
+                        )))
+                        .finish()
+                } else {
+                    base_container.finish()
+                };
+
+                let mut stack = Stack::new().with_child(base_container);
+                if state.is_hovered() {
+                    let tool_tip = appearance
+                        .ui_builder()
+                        .tool_tip_with_sublabel(
+                            CODE_REVIEW_TOOLTIP_TEXT.to_string(),
+                            code_review_keybinding.clone(),
+                        )
+                        .build()
+                        .finish();
+                    stack.add_positioned_overlay_child(tool_tip, udi_tooltip_positioning());
+                }
+                stack.finish()
+            })
+            .on_click(|ctx, _app, _position| {
+                ctx.dispatch_typed_action(DisplayChipAction::ToggleCodeReview);
+            })
+            .with_cursor(Cursor::PointingHand)
+            .finish()
+        } else {
+            Container::new(git_diff_stats_content)
                 .with_vertical_padding(2.)
-                .with_horizontal_padding(4.);
-
-            let base_container = if state.is_hovered() {
-                base_container
-                    .with_background(appearance.theme().surface_2())
-                    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(
-                        CHIP_INNER_CORNER_RADIUS,
-                    )))
-                    .finish()
-            } else {
-                base_container.finish()
-            };
-
-            let mut stack = Stack::new().with_child(base_container);
-            if state.is_hovered() {
-                let tool_tip = appearance
-                    .ui_builder()
-                    .tool_tip_with_sublabel(
-                        CODE_REVIEW_TOOLTIP_TEXT.to_string(),
-                        code_review_keybinding.clone(),
-                    )
-                    .build()
-                    .finish();
-                stack.add_positioned_overlay_child(tool_tip, udi_tooltip_positioning());
-            }
-            stack.finish()
-        })
-        .on_click(|ctx, _app, _position| {
-            ctx.dispatch_typed_action(DisplayChipAction::ToggleCodeReview);
-        })
-        .with_cursor(Cursor::PointingHand)
-        .finish();
+                .with_horizontal_padding(4.)
+                .finish()
+        };
 
         let content = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -1213,58 +1213,44 @@ impl DisplayChip {
             appearance,
         );
 
-        let is_local_session = self
-            .session_context
-            .as_ref()
-            .map(|ctx| ctx.session.is_local())
-            .unwrap_or(true);
+        // Get the keybinding for the tooltip
+        let code_review_keybinding = self.code_review_keybinding.clone().unwrap_or_default();
 
-        let diff_stats_display = if is_local_session {
-            // Get the keybinding for the tooltip
-            let code_review_keybinding = self.code_review_keybinding.clone().unwrap_or_default();
-
-            Hoverable::new(self.diff_stats_mouse_state.clone(), |state| {
-                let base_container = Container::new(git_diff_stats_content)
-                    .with_vertical_padding(2.)
-                    .with_horizontal_padding(4.);
-
-                let base_container = if state.is_hovered() {
-                    base_container
-                        .with_background(appearance.theme().surface_2())
-                        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(
-                            CHIP_INNER_CORNER_RADIUS,
-                        )))
-                        .finish()
-                } else {
-                    base_container.finish()
-                };
-
-                let mut stack = Stack::new().with_child(base_container);
-                if state.is_hovered() {
-                    let tool_tip = appearance
-                        .ui_builder()
-                        .tool_tip_with_sublabel(
-                            CODE_REVIEW_TOOLTIP_TEXT.to_string(),
-                            code_review_keybinding.clone(),
-                        )
-                        .build()
-                        .finish();
-                    stack.add_positioned_overlay_child(tool_tip, udi_tooltip_positioning());
-                }
-                stack.finish()
-            })
-            .on_click(|ctx, _app, _position| {
-                ctx.dispatch_typed_action(DisplayChipAction::ToggleCodeReview);
-            })
-            .with_cursor(Cursor::PointingHand)
-            .finish()
-        } else {
-            // Remote session: chip is non-interactive (no tooltip, no click handler)
-            Container::new(git_diff_stats_content)
+        let diff_stats_display = Hoverable::new(self.diff_stats_mouse_state.clone(), |state| {
+            let base_container = Container::new(git_diff_stats_content)
                 .with_vertical_padding(2.)
-                .with_horizontal_padding(4.)
-                .finish()
-        };
+                .with_horizontal_padding(4.);
+
+            let base_container = if state.is_hovered() {
+                base_container
+                    .with_background(appearance.theme().surface_2())
+                    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(
+                        CHIP_INNER_CORNER_RADIUS,
+                    )))
+                    .finish()
+            } else {
+                base_container.finish()
+            };
+
+            let mut stack = Stack::new().with_child(base_container);
+            if state.is_hovered() {
+                let tool_tip = appearance
+                    .ui_builder()
+                    .tool_tip_with_sublabel(
+                        CODE_REVIEW_TOOLTIP_TEXT.to_string(),
+                        code_review_keybinding.clone(),
+                    )
+                    .build()
+                    .finish();
+                stack.add_positioned_overlay_child(tool_tip, udi_tooltip_positioning());
+            }
+            stack.finish()
+        })
+        .on_click(|ctx, _app, _position| {
+            ctx.dispatch_typed_action(DisplayChipAction::ToggleCodeReview);
+        })
+        .with_cursor(Cursor::PointingHand)
+        .finish();
 
         let content = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)


### PR DESCRIPTION
## Description
- WISOTT 
- Built on https://github.com/warpdotdev/warp/pull/11026 and https://github.com/warpdotdev/warp/pull/11208
- Removes the local gate such that remote repos are also able to open the code review view on git diff stats chip click 

## Linked Issue
[APP-4527](https://linear.app/warpdotdev/issue/APP-4527/ensure-diff-changes-chip-opens-code-review-view-for-remote-repo)

## Testing
https://www.loom.com/share/a87e011f46c5417eb5918a49711bcaeb
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode