### PR TITLE
Preserve focused match identity in async find across streaming updates

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -4126,19 +4126,9 @@ impl AIBlock {
     /// Handles find match focus changes by auto-expanding collapsed reasoning blocks
     /// that contain the focused match.
     fn handle_find_match_focus_change(&mut self, ctx: &mut ViewContext<Self>) {
-        // Get the currently focused match ID from the terminal's find model
-        let focused_match_id = self
-            .find_model
-            .as_ref(ctx)
-            .block_list_find_run()
-            .and_then(|run| match run.focused_match() {
-                Some(crate::terminal::find::BlockListMatch::RichContent { match_id, .. }) => {
-                    Some(*match_id)
-                }
-                _ => None,
-            });
-
-        let Some(match_id) = focused_match_id else {
+        // Get the currently focused match ID from the terminal's find model.
+        // The helper handles both the sync and async find paths.
+        let Some(match_id) = self.find_model.as_ref(ctx).focused_rich_content_match_id() else {
             return;
         };
 

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -46,7 +46,6 @@ use warpui::{
 
 use super::{add_highlights_to_rich_text, add_highlights_to_text, output::LinkActionConstructors};
 use crate::ai::agent::MessageId;
-use crate::terminal::find::BlockListMatch;
 use crate::terminal::grid_renderer::{FOCUSED_MATCH_COLOR, MATCH_COLOR};
 use crate::{
     ai::{
@@ -2872,12 +2871,8 @@ pub fn get_highlight_ranges_for_find_matches(
 ) -> impl Iterator<Item = HighlightedRange> {
     let find_match_locations = find_state.matches_for_location(location);
     let focused_match_location = find_model
-        .block_list_find_run()
-        .and_then(|run| match run.focused_match() {
-            Some(BlockListMatch::RichContent { match_id, .. }) => Some(match_id),
-            _ => None,
-        })
-        .and_then(|match_id| find_state.location_for_match(*match_id));
+        .focused_rich_content_match_id()
+        .and_then(|match_id| find_state.location_for_match(match_id));
     let mut highlighted_ranges = vec![];
     for find_match_location in find_match_locations {
         let is_focused_match =

--- a/app/src/terminal/find/model.rs
+++ b/app/src/terminal/find/model.rs
@@ -303,27 +303,61 @@ impl TerminalFindModel {
         }
 
         if let Some(controller) = &self.async_find_controller {
-            // Async path: convert AbsoluteMatch to Point range.
-            let async_match = controller.focused_terminal_match()?;
-            let block = model.block_list().block_at(async_match.block_index)?;
-            let grid = match async_match.grid_type {
-                GridType::PromptAndCommand => block.prompt_and_command_grid().grid_handler(),
-                GridType::Output => block.output_grid().grid_handler(),
-                _ => return None,
-            };
-            let range = async_match.range.to_range(grid)?;
-            Some(BlockListMatch::CommandBlock(BlockGridMatch {
-                block_index: async_match.block_index,
-                grid_type: async_match.grid_type,
-                range,
-                is_filtered: false,
-            }))
+            // Async path: the focused match is either a terminal match or an
+            // AI match (or neither). Try each in turn and synthesize the
+            // corresponding `BlockListMatch` variant so consumers don't need
+            // to know which path produced the focus.
+            if let Some(async_match) = controller.focused_terminal_match() {
+                let block = model.block_list().block_at(async_match.block_index)?;
+                let grid = match async_match.grid_type {
+                    GridType::PromptAndCommand => block.prompt_and_command_grid().grid_handler(),
+                    GridType::Output => block.output_grid().grid_handler(),
+                    _ => return None,
+                };
+                let range = async_match.range.to_range(grid)?;
+                return Some(BlockListMatch::CommandBlock(BlockGridMatch {
+                    block_index: async_match.block_index,
+                    grid_type: async_match.grid_type,
+                    range,
+                    is_filtered: false,
+                }));
+            }
+            if let Some(ai_match) = controller.focused_ai_match() {
+                return Some(BlockListMatch::RichContent {
+                    match_id: ai_match.match_id,
+                    view_id: ai_match.view_id,
+                    index: ai_match.total_index,
+                });
+            }
+            None
         } else {
             // Sync path: get from block_list_find_run.
             self.block_list_find_run
                 .as_ref()
                 .and_then(|run| run.focused_match())
                 .cloned()
+        }
+    }
+
+    /// Returns the focused rich content (AI) match id, if any.
+    ///
+    /// This works for both sync and async find paths and is used by AI block
+    /// rendering to apply the focused-match highlight color.
+    pub(crate) fn focused_rich_content_match_id(&self) -> Option<RichContentMatchId> {
+        if self.terminal_model.lock().is_alt_screen_active() {
+            return None;
+        }
+
+        if let Some(controller) = &self.async_find_controller {
+            controller.focused_ai_match().map(|m| m.match_id)
+        } else {
+            self.block_list_find_run
+                .as_ref()
+                .and_then(|run| run.focused_match())
+                .and_then(|m| match m {
+                    BlockListMatch::RichContent { match_id, .. } => Some(*match_id),
+                    _ => None,
+                })
         }
     }
 

--- a/app/src/terminal/find/model/async_find.rs
+++ b/app/src/terminal/find/model/async_find.rs
@@ -204,6 +204,27 @@ pub struct AsyncBlockGridMatch {
     pub block_index: BlockIndex,
 }
 
+/// A focused match in a rich content (AI) block.
+///
+/// Mirrors the data carried by `BlockListMatch::RichContent` in the sync path,
+/// so callers can synthesize a `BlockListMatch` from either path.
+#[derive(Debug, Clone)]
+pub struct AsyncFocusedAiMatch {
+    /// The view id of the rich content block.
+    pub view_id: EntityId,
+    /// The id of the focused match within the rich content block.
+    pub match_id: RichContentMatchId,
+    /// The total index of the rich content block in the blocklist sumtree.
+    pub total_index: TotalIndex,
+}
+
+/// Resolution of the global focused match index to either a terminal or an AI match.
+#[derive(Debug, Clone)]
+enum FocusedMatchResolution {
+    Terminal(AsyncBlockGridMatch),
+    Ai(AsyncFocusedAiMatch),
+}
+
 /// Per-block find results, keyed by block index.
 #[derive(Debug, Default)]
 pub(crate) struct BlockFindResults {
@@ -373,9 +394,10 @@ pub struct AsyncFindController {
     /// The FindOptions for the current find run, stored for `active_find_options()` access.
     current_find_options: Option<FindOptions>,
 
-    /// Cached result of `focused_terminal_match()`, updated when focus or matches change.
-    /// Avoids re-sorting HashMap keys and iterating on every call.
-    cached_focused_match: Option<AsyncBlockGridMatch>,
+    /// Cached resolution of `focused_match_index` to either a terminal match,
+    /// an AI match, or `None` (out of range). Updated when focus or matches
+    /// change
+    cached_focused_match: Option<FocusedMatchResolution>,
 
     /// Monotonically increasing generation counter, bumped each time new streams
     /// are spawned. The result stream callback captures the generation at spawn
@@ -484,26 +506,46 @@ impl AsyncFindController {
         self.update_cached_focused_match();
     }
 
-    /// Returns the focused match as an AsyncBlockGridMatch if it's a terminal match.
+    /// Returns the focused match as an `AsyncBlockGridMatch` if it's a terminal match.
     ///
     /// Returns a cached value that is updated when focus or matches change,
-    /// avoiding the cost of sorting and iterating on every call.
+    /// avoiding the cost of sorting and iterating on every call. Returns
+    /// `None` if focus is on an AI match or out of range.
     pub fn focused_terminal_match(&self) -> Option<AsyncBlockGridMatch> {
-        self.cached_focused_match.clone()
+        match &self.cached_focused_match {
+            Some(FocusedMatchResolution::Terminal(m)) => Some(m.clone()),
+            _ => None,
+        }
+    }
+
+    /// Returns the focused match as an `AsyncFocusedAiMatch` if it's an AI match.
+    ///
+    /// Returns a cached value that is updated when focus or matches change,
+    /// avoiding the cost of sorting and iterating on every call. Returns
+    /// `None` if focus is on a terminal match or out of range.
+    pub fn focused_ai_match(&self) -> Option<AsyncFocusedAiMatch> {
+        match &self.cached_focused_match {
+            Some(FocusedMatchResolution::Ai(m)) => Some(m.clone()),
+            _ => None,
+        }
     }
 
     /// Recomputes the cached focused match from the current matches and focus index.
+    ///
+    /// Resolves the global `focused_match_index` to either a terminal match or
+    /// an AI match (or `None`, if out of range) and stores it in the unified
+    /// cache.
     fn update_cached_focused_match(&mut self) {
-        self.cached_focused_match = self.compute_focused_terminal_match();
+        self.cached_focused_match = self.compute_focused_match();
     }
 
-    /// Computes the focused terminal match by iterating through all matches
+    /// Computes the focused match by iterating through all matches
     /// (terminal and AI) in visual display order, derived from the TotalIndex
     /// maps stored in the block results.
     ///
-    /// Returns `Some` if the focused index lands on a terminal match, `None`
-    /// if it lands on an AI match or is out of range.
-    fn compute_focused_terminal_match(&self) -> Option<AsyncBlockGridMatch> {
+    /// Returns the matched item (terminal or AI) at the focused index, or
+    /// `None` if the index is out of range.
+    fn compute_focused_match(&self) -> Option<FocusedMatchResolution> {
         let focused_idx = self.focused_match_index?;
         let mut current_idx = 0;
 
@@ -538,13 +580,14 @@ impl AsyncFindController {
         // of the blocklist (newest blocks, near the prompt) come first.
         ordered_blocks.sort_by(|a, b| b.0.cmp(&a.0));
 
+        let reverse_within_block = matches!(
+            self.block_sort_direction,
+            BlockSortDirection::MostRecentLast
+        );
+
         for (_, block_info) in &ordered_blocks {
             match block_info {
                 BlockInfo::Terminal { block_index, .. } => {
-                    let reverse_within_grid = matches!(
-                        self.block_sort_direction,
-                        BlockSortDirection::MostRecentLast
-                    );
                     for &grid_type in &grid_types {
                         if let Some(matches) = self
                             .block_results
@@ -554,29 +597,52 @@ impl AsyncFindController {
                             // For MostRecentLast, sync focus traversal
                             // iterates from the bottom of each grid first.
                             let iter: Box<dyn Iterator<Item = &AbsoluteMatch>> =
-                                if reverse_within_grid {
+                                if reverse_within_block {
                                     Box::new(matches.iter().rev())
                                 } else {
                                     Box::new(matches.iter())
                                 };
                             for match_range in iter {
                                 if current_idx == focused_idx {
-                                    return Some(AsyncBlockGridMatch {
-                                        block_index: *block_index,
-                                        grid_type,
-                                        range: match_range.clone(),
-                                    });
+                                    return Some(FocusedMatchResolution::Terminal(
+                                        AsyncBlockGridMatch {
+                                            block_index: *block_index,
+                                            grid_type,
+                                            range: match_range.clone(),
+                                        },
+                                    ));
                                 }
                                 current_idx += 1;
                             }
                         }
                     }
                 }
-                BlockInfo::RichContent { view_id, .. } => {
-                    // Count AI matches so the index arithmetic stays correct,
-                    // but don't return them as terminal matches.
+                BlockInfo::RichContent {
+                    view_id,
+                    total_index,
+                } => {
                     if let Some(ai_matches) = self.block_results.ai_matches.get(view_id) {
-                        current_idx += ai_matches.len();
+                        // Mirror sync find's per-AI-block traversal order. Sync
+                        // reverses rich-content match ids for MostRecentLast so
+                        // that matches inside one AI block are walked from
+                        // bottom to top; we apply the same reversal at iteration
+                        // time to keep stored order canonical.
+                        let iter: Box<dyn Iterator<Item = &RichContentMatchId>> =
+                            if reverse_within_block {
+                                Box::new(ai_matches.iter().rev())
+                            } else {
+                                Box::new(ai_matches.iter())
+                            };
+                        for &match_id in iter {
+                            if current_idx == focused_idx {
+                                return Some(FocusedMatchResolution::Ai(AsyncFocusedAiMatch {
+                                    view_id: *view_id,
+                                    match_id,
+                                    total_index: *total_index,
+                                }));
+                            }
+                            current_idx += 1;
+                        }
                     }
                 }
             }

--- a/app/src/terminal/find/model/async_find.rs
+++ b/app/src/terminal/find/model/async_find.rs
@@ -194,7 +194,7 @@ impl Ord for AbsoluteMatch {
 ///
 /// Similar to `BlockGridMatch` but uses `AbsoluteMatch` for the range, allowing
 /// the caller to convert to relative coordinates when needed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AsyncBlockGridMatch {
     /// The type of grid in which the match was found.
     pub grid_type: GridType,
@@ -208,7 +208,7 @@ pub struct AsyncBlockGridMatch {
 ///
 /// Mirrors the data carried by `BlockListMatch::RichContent` in the sync path,
 /// so callers can synthesize a `BlockListMatch` from either path.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AsyncFocusedAiMatch {
     /// The view id of the rich content block.
     pub view_id: EntityId,
@@ -219,7 +219,7 @@ pub struct AsyncFocusedAiMatch {
 }
 
 /// Resolution of the global focused match index to either a terminal or an AI match.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum FocusedMatchResolution {
     Terminal(AsyncBlockGridMatch),
     Ai(AsyncFocusedAiMatch),
@@ -399,6 +399,18 @@ pub struct AsyncFindController {
     /// change
     cached_focused_match: Option<FocusedMatchResolution>,
 
+    /// Identity of a previously focused match that could not be re-located
+    /// during the most recent mutation of `block_results` (e.g. because the
+    /// match was removed by `remove_block` and the rescan has not yet
+    /// repopulated it).
+    ///
+    /// While this is `Some`, the `BlockGridMatches` auto-select shortcut is
+    /// suppressed so that a freshly arriving result chunk gets a chance to
+    /// re-locate this identity before we silently "settle" on match 0.
+    /// Cleared either when the identity is re-located or when the queue
+    /// drains (`FindTaskMessage::Done`).
+    pending_focus_identity: Option<FocusedMatchResolution>,
+
     /// Monotonically increasing generation counter, bumped each time new streams
     /// are spawned. The result stream callback captures the generation at spawn
     /// time and skips messages that arrive after a newer generation has started,
@@ -423,6 +435,7 @@ impl AsyncFindController {
             focused_match_index: None,
             current_find_options: None,
             cached_focused_match: None,
+            pending_focus_identity: None,
             generation: 0,
         }
     }
@@ -547,8 +560,49 @@ impl AsyncFindController {
     /// `None` if the index is out of range.
     fn compute_focused_match(&self) -> Option<FocusedMatchResolution> {
         let focused_idx = self.focused_match_index?;
-        let mut current_idx = 0;
+        let mut result = None;
+        self.walk_matches(|idx, resolution| {
+            if idx == focused_idx {
+                result = Some(resolution);
+                true
+            } else {
+                false
+            }
+        });
+        result
+    }
 
+    /// Finds the global match index of a previously captured match identity
+    /// in the *current* state of `block_results`.
+    ///
+    /// Uses the same traversal order as `compute_focused_match`, so the
+    /// returned index is directly assignable to `focused_match_index`.
+    /// Returns `None` if no equal `FocusedMatchResolution` exists in the
+    /// current results (e.g. the underlying block was removed or the
+    /// terminal range was deleted by a `DirtyRangeMatches` update).
+    fn relocate_focused_match(&self, captured: &FocusedMatchResolution) -> Option<usize> {
+        let mut found = None;
+        self.walk_matches(|idx, resolution| {
+            if &resolution == captured {
+                found = Some(idx);
+                true
+            } else {
+                false
+            }
+        });
+        found
+    }
+
+    /// Walks every match in current visual order, invoking `f(global_index,
+    /// resolution)` for each. Stops as soon as `f` returns `true`.
+    ///
+    /// This is the shared traversal that both `compute_focused_match` and
+    /// `relocate_focused_match` are built on; keeping a single implementation
+    /// here ensures the two stay in sync.
+    fn walk_matches<F>(&self, mut f: F)
+    where
+        F: FnMut(usize, FocusedMatchResolution) -> bool,
+    {
         // Determine grid iteration order within each terminal block.
         let grid_types: [GridType; 2] = match self.block_sort_direction {
             BlockSortDirection::MostRecentFirst => [GridType::PromptAndCommand, GridType::Output],
@@ -585,6 +639,7 @@ impl AsyncFindController {
             BlockSortDirection::MostRecentLast
         );
 
+        let mut current_idx = 0;
         for (_, block_info) in &ordered_blocks {
             match block_info {
                 BlockInfo::Terminal { block_index, .. } => {
@@ -603,14 +658,14 @@ impl AsyncFindController {
                                     Box::new(matches.iter())
                                 };
                             for match_range in iter {
-                                if current_idx == focused_idx {
-                                    return Some(FocusedMatchResolution::Terminal(
-                                        AsyncBlockGridMatch {
-                                            block_index: *block_index,
-                                            grid_type,
-                                            range: match_range.clone(),
-                                        },
-                                    ));
+                                let resolution =
+                                    FocusedMatchResolution::Terminal(AsyncBlockGridMatch {
+                                        block_index: *block_index,
+                                        grid_type,
+                                        range: match_range.clone(),
+                                    });
+                                if f(current_idx, resolution) {
+                                    return;
                                 }
                                 current_idx += 1;
                             }
@@ -634,12 +689,13 @@ impl AsyncFindController {
                                 Box::new(ai_matches.iter())
                             };
                         for &match_id in iter {
-                            if current_idx == focused_idx {
-                                return Some(FocusedMatchResolution::Ai(AsyncFocusedAiMatch {
-                                    view_id: *view_id,
-                                    match_id,
-                                    total_index: *total_index,
-                                }));
+                            let resolution = FocusedMatchResolution::Ai(AsyncFocusedAiMatch {
+                                view_id: *view_id,
+                                match_id,
+                                total_index: *total_index,
+                            });
+                            if f(current_idx, resolution) {
+                                return;
                             }
                             current_idx += 1;
                         }
@@ -647,8 +703,70 @@ impl AsyncFindController {
                 }
             }
         }
+    }
 
-        None
+    /// Runs `mutation` against `self` while preserving the *identity* of the
+    /// previously focused match across the mutation.
+    ///
+    /// On entry, captures the identity of the current focused match (or, if
+    /// there is no current focus but a prior mutation could not find its
+    /// match, the `pending_focus_identity`). After `mutation` runs:
+    ///
+    /// 1. If we captured an identity, try to relocate it in the new state.
+    ///    On success the focused index is updated to that location and any
+    ///    stale `pending_focus_identity` is cleared.
+    /// 2. If the identity cannot be re-located (e.g. the match was removed),
+    ///    the identity is stashed in `pending_focus_identity` so a
+    ///    subsequent mutation gets another chance to find it, and the
+    ///    current `focused_match_index` is clamped into range.
+    /// 3. If no identity was captured, the focused index is simply clamped.
+    ///
+    /// `cached_focused_match` is recomputed once at the end.
+    fn with_focus_preservation<F>(&mut self, mutation: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        // Prefer the live cache; fall back to a stashed identity from an
+        // earlier mutation that could not relocate. This handles the
+        // full-block-invalidation + chunked-rescan handoff: `remove_block`
+        // stashes to pending, and the subsequent `BlockGridMatches` arrival
+        // resumes from pending.
+        let captured = self
+            .cached_focused_match
+            .clone()
+            .or_else(|| self.pending_focus_identity.clone());
+
+        mutation(self);
+
+        match captured {
+            Some(identity) => match self.relocate_focused_match(&identity) {
+                Some(new_idx) => {
+                    self.focused_match_index = Some(new_idx);
+                    self.pending_focus_identity = None;
+                }
+                None => {
+                    self.pending_focus_identity = Some(identity);
+                    self.clamp_focused_match_index_no_cache();
+                }
+            },
+            None => {
+                self.clamp_focused_match_index_no_cache();
+            }
+        }
+        self.update_cached_focused_match();
+    }
+
+    /// Clamp variant that does NOT recompute `cached_focused_match`.
+    ///
+    /// Used by `with_focus_preservation`, which recomputes the cache once at
+    /// the end after all of its own bookkeeping has run.
+    fn clamp_focused_match_index_no_cache(&mut self) {
+        let total = self.match_count();
+        if total == 0 {
+            self.focused_match_index = None;
+        } else {
+            self.focused_match_index = self.focused_match_index.map(|i| i.min(total - 1));
+        }
     }
 
     /// Registers a rich content view for AI block searching.
@@ -706,6 +824,7 @@ impl AsyncFindController {
         self.block_results.clear();
         self.focused_match_index = None;
         self.cached_focused_match = None;
+        self.pending_focus_identity = None;
         self.current_find_options = Some(options.clone());
         self.status = AsyncFindStatus::Scanning;
 
@@ -783,34 +902,45 @@ impl AsyncFindController {
                 matches,
             } => {
                 if !matches.is_empty() {
-                    // Store TotalIndex for this block if not already known
-                    // (e.g. the block was added after the initial scan).
-                    if !self
-                        .block_results
-                        .terminal_total_indices
-                        .contains_key(&block_index)
-                    {
-                        let total_index = {
-                            let model = self.terminal_model.lock();
-                            total_index_for_block(block_index, model.block_list())
-                        };
-                        self.block_results
+                    self.with_focus_preservation(|me| {
+                        // Store TotalIndex for this block if not already known
+                        // (e.g. the block was added after the initial scan).
+                        // Done inside the mutation so that any pending identity
+                        // pointing at this block can be relocated by the
+                        // post-mutation walk, which uses these indices.
+                        if !me
+                            .block_results
                             .terminal_total_indices
-                            .insert(block_index, total_index);
-                    }
+                            .contains_key(&block_index)
+                        {
+                            let total_index = {
+                                let model = me.terminal_model.lock();
+                                total_index_for_block(block_index, model.block_list())
+                            };
+                            me.block_results
+                                .terminal_total_indices
+                                .insert(block_index, total_index);
+                        }
 
-                    self.block_results
-                        .terminal_matches
-                        .entry((block_index, grid_type))
-                        .or_default()
-                        .extend(matches);
+                        me.block_results
+                            .terminal_matches
+                            .entry((block_index, grid_type))
+                            .or_default()
+                            .extend(matches);
+                    });
 
-                    // Auto-select the first match when results first arrive.
-                    if self.focused_match_index.is_none() {
+                    // Auto-select the first match when results first arrive,
+                    // but only if (a) we have no prior focus and (b) we are
+                    // not still waiting to relocate a previously focused
+                    // match. The pending check is what keeps focus from
+                    // silently snapping back to match 0 mid-rescan.
+                    if self.focused_match_index.is_none()
+                        && self.pending_focus_identity.is_none()
+                        && self.match_count() > 0
+                    {
                         self.focused_match_index = Some(0);
+                        self.update_cached_focused_match();
                     }
-
-                    self.clamp_focused_match_index();
                 }
             }
             FindTaskMessage::DirtyRangeMatches {
@@ -819,51 +949,45 @@ impl AsyncFindController {
                 dirty_range,
                 matches,
             } => {
-                self.block_results.update_dirty_matches(
-                    block_index,
-                    grid_type,
-                    dirty_range,
-                    matches,
-                );
-                // Prune matches that have been truncated from scrollback.
-                // Dirty range messages arrive when the active block receives
-                // new output, which is exactly when truncation can occur.
-                self.prune_truncated_matches(block_index, grid_type);
-                self.clamp_focused_match_index();
+                self.with_focus_preservation(|me| {
+                    me.block_results.update_dirty_matches(
+                        block_index,
+                        grid_type,
+                        dirty_range,
+                        matches,
+                    );
+                    // Prune matches that have been truncated from scrollback.
+                    // Dirty range messages arrive when the active block
+                    // receives new output, which is exactly when truncation
+                    // can occur.
+                    me.prune_truncated_matches(block_index, grid_type);
+                });
             }
             FindTaskMessage::ScanAIBlock {
                 view_id,
                 total_index,
             } => {
                 // Scan AI block on main thread.
-                if let Some(view) = self.rich_content_views.get(&view_id) {
-                    if let Some(config) = &self.current_config {
-                        let options = FindOptions {
-                            query: Some(config.query.clone()),
-                            is_case_sensitive: config.is_case_sensitive,
-                            is_regex_enabled: config.is_regex_enabled,
-                            blocks_to_include_in_results: None,
-                        };
-                        let start = instant::Instant::now();
-                        let match_ids = view.run_find(&options, ctx);
-                        let elapsed = start.elapsed();
-                        log::trace!(
-                            "[async_find] AI block scan took {}ms for view_id={:?}",
-                            elapsed.as_millis(),
-                            view_id
-                        );
-                        if !match_ids.is_empty() {
-                            self.block_results.ai_matches.insert(view_id, match_ids);
-                            self.block_results
+                let match_ids = self.run_ai_scan(view_id, ctx);
+                if let Some(match_ids) = match_ids {
+                    if !match_ids.is_empty() {
+                        self.with_focus_preservation(|me| {
+                            me.block_results.ai_matches.insert(view_id, match_ids);
+                            me.block_results
                                 .ai_total_indices
                                 .insert(view_id, total_index);
-                            self.clamp_focused_match_index();
-                        }
+                        });
                     }
                 }
             }
             FindTaskMessage::Done => {
                 self.status = AsyncFindStatus::Complete;
+                // The queue has drained; we will not get any more chunks for
+                // this scan, so any unresolved pending identity is gone for
+                // good. Clearing here lets a subsequent `BlockGridMatches`
+                // arrival (e.g. from a future `invalidate_block`) auto-select
+                // normally.
+                self.pending_focus_identity = None;
             }
         }
 
@@ -871,6 +995,33 @@ impl AsyncFindController {
         if let Some(tx) = &self.throttle_tx {
             let _ = tx.try_send(());
         }
+    }
+
+    /// Runs the AI block scan for `view_id` against the currently registered
+    /// rich content view, returning the resulting match ids (or `None` if
+    /// either the view or the current find config is unavailable).
+    fn run_ai_scan(
+        &self,
+        view_id: EntityId,
+        ctx: &mut ModelContext<TerminalFindModel>,
+    ) -> Option<Vec<RichContentMatchId>> {
+        let view = self.rich_content_views.get(&view_id)?;
+        let config = self.current_config.as_ref()?;
+        let options = FindOptions {
+            query: Some(config.query.clone()),
+            is_case_sensitive: config.is_case_sensitive,
+            is_regex_enabled: config.is_regex_enabled,
+            blocks_to_include_in_results: None,
+        };
+        let start = instant::Instant::now();
+        let match_ids = view.run_find(&options, ctx);
+        let elapsed = start.elapsed();
+        log::trace!(
+            "[async_find] AI block scan took {}ms for view_id={:?}",
+            elapsed.as_millis(),
+            view_id
+        );
+        Some(match_ids)
     }
 
     /// Cancels the current find operation, if any.
@@ -902,6 +1053,7 @@ impl AsyncFindController {
         self.block_results.clear();
         self.focused_match_index = None;
         self.cached_focused_match = None;
+        self.pending_focus_identity = None;
         self.status = AsyncFindStatus::Idle;
         self.current_find_options = None;
 
@@ -936,10 +1088,15 @@ impl AsyncFindController {
         };
 
         // For a full block rescan (no dirty range), clear existing results now
-        // so stale matches are not shown while the rescan is pending.
+        // so stale matches are not shown while the rescan is pending. Wrap in
+        // `with_focus_preservation` so the identity of the previously focused
+        // match is captured BEFORE `remove_block` wipes it; the subsequent
+        // chunked `BlockGridMatches` arrivals from the rescan will then be
+        // able to relocate it via `pending_focus_identity`.
         if dirty_info.is_none() {
-            self.block_results.remove_block(block_index);
-            self.clamp_focused_match_index();
+            self.with_focus_preservation(|me| {
+                me.block_results.remove_block(block_index);
+            });
         }
 
         log::trace!(
@@ -1047,6 +1204,7 @@ impl AsyncFindController {
         self.block_results.clear();
         self.focused_match_index = None;
         self.cached_focused_match = None;
+        self.pending_focus_identity = None;
         self.current_find_options = Some(options.clone());
         self.status = AsyncFindStatus::Scanning;
 

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -4,16 +4,18 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::FairMutex;
-use warpui::App;
+use warpui::{App, EntityId};
 
 use crate::terminal::block_list_element::GridType;
 use crate::terminal::find::model::block_list::run_find_on_block_list;
 use crate::terminal::find::model::{FindOptions, TerminalFindModel};
-use crate::terminal::find::BlockListMatch;
+use crate::terminal::find::{BlockListMatch, RichContentMatchId};
+use crate::terminal::model::blocks::TotalIndex;
 use crate::terminal::model::grid::grid_handler::AbsolutePoint;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::terminal_model::{BlockIndex, BlockSortDirection};
 use crate::terminal::model::TerminalModel;
+use crate::view_components::find::FindDirection;
 
 use super::{
     is_query_refinement, AbsoluteMatch, AsyncFindConfig, AsyncFindController, AsyncFindStatus,
@@ -354,8 +356,6 @@ fn test_block_invalidation_with_dirty_range() {
 
 #[test]
 fn test_focus_next_match_wraps_around() {
-    use crate::view_components::find::FindDirection;
-
     let mock_terminal_model = TerminalModel::mock(None, None);
     let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
     let mut controller = AsyncFindController::new(terminal_model);
@@ -797,4 +797,144 @@ fn test_async_focused_order_matches_sync_most_recent_last() {
 #[test]
 fn test_async_focused_order_matches_sync_most_recent_first() {
     assert_async_focused_order_matches_sync(BlockSortDirection::MostRecentFirst);
+}
+
+#[test]
+fn test_focused_ai_match_resolves_only_ai_block() {
+    let mock_terminal_model = TerminalModel::mock(None, None);
+    let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+    let mut controller = AsyncFindController::new(terminal_model);
+
+    // Seed a single AI block with two matches. Default block sort direction is
+    // MostRecentLast, which reverses per-AI-block traversal at iteration time.
+    let view_id = EntityId::from_usize(42);
+    let ai_match_a = RichContentMatchId::default();
+    let ai_match_b = RichContentMatchId::default();
+    {
+        let results = controller.block_results_mut();
+        results
+            .ai_matches
+            .insert(view_id, vec![ai_match_a, ai_match_b]);
+        results.ai_total_indices.insert(view_id, TotalIndex(7));
+    }
+
+    assert_eq!(controller.match_count(), 2);
+    assert!(
+        controller.focused_terminal_match().is_none(),
+        "There are no terminal matches; focused_terminal_match should be None."
+    );
+
+    // MostRecentLast reverses per-AI-block iteration, so index 0 resolves to
+    // the last stored match (ai_match_b) and index 1 to the first.
+    controller.focused_match_index = Some(0);
+    controller.update_cached_focused_match();
+    let focused = controller
+        .focused_ai_match()
+        .expect("AI match should be focused at index 0.");
+    assert_eq!(focused.view_id, view_id);
+    assert_eq!(focused.match_id, ai_match_b);
+    assert_eq!(focused.total_index, TotalIndex(7));
+    assert!(
+        controller.focused_terminal_match().is_none(),
+        "Terminal cache must be cleared when focus lands on an AI match."
+    );
+
+    controller.focused_match_index = Some(1);
+    controller.update_cached_focused_match();
+    let focused = controller
+        .focused_ai_match()
+        .expect("AI match should be focused at index 1.");
+    assert_eq!(focused.match_id, ai_match_a);
+}
+
+#[test]
+fn test_focused_ai_match_most_recent_first_preserves_storage_order() {
+    let mock_terminal_model = TerminalModel::mock(None, None);
+    let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+    let mut controller = AsyncFindController::new(terminal_model);
+
+    // Override the default MostRecentLast so we exercise the un-reversed
+    // per-AI-block iteration path.
+    controller.block_sort_direction = BlockSortDirection::MostRecentFirst;
+
+    let view_id = EntityId::from_usize(99);
+    let ai_match_a = RichContentMatchId::default();
+    let ai_match_b = RichContentMatchId::default();
+    {
+        let results = controller.block_results_mut();
+        results
+            .ai_matches
+            .insert(view_id, vec![ai_match_a, ai_match_b]);
+        results.ai_total_indices.insert(view_id, TotalIndex(3));
+    }
+
+    // MostRecentFirst iterates storage order: index 0 -> first, index 1 -> last.
+    controller.focused_match_index = Some(0);
+    controller.update_cached_focused_match();
+    let focused = controller
+        .focused_ai_match()
+        .expect("AI match should be focused at index 0.");
+    assert_eq!(focused.match_id, ai_match_a);
+
+    controller.focused_match_index = Some(1);
+    controller.update_cached_focused_match();
+    let focused = controller
+        .focused_ai_match()
+        .expect("AI match should be focused at index 1.");
+    assert_eq!(focused.match_id, ai_match_b);
+}
+
+#[test]
+fn test_focused_match_index_walks_across_terminal_and_ai_blocks() {
+    let mock_terminal_model = TerminalModel::mock(None, None);
+    let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+    let mut controller = AsyncFindController::new(terminal_model);
+
+    // Two blocks at different TotalIndex positions:
+    //  - AI block (TotalIndex 5, newer) with one match.
+    //  - Terminal block at BlockIndex(0) (TotalIndex 1, older) with one
+    //    Output match. The AI block is sorted first because its TotalIndex
+    //    is higher.
+    let ai_view_id = EntityId::from_usize(11);
+    let ai_match = RichContentMatchId::default();
+    let terminal_match = make_match(0);
+    {
+        let results = controller.block_results_mut();
+        results.ai_matches.insert(ai_view_id, vec![ai_match]);
+        results.ai_total_indices.insert(ai_view_id, TotalIndex(5));
+        results
+            .terminal_matches
+            .insert((BlockIndex(0), GridType::Output), vec![terminal_match]);
+        results
+            .terminal_total_indices
+            .insert(BlockIndex(0), TotalIndex(1));
+    }
+
+    assert_eq!(controller.match_count(), 2);
+
+    // Index 0 -> AI match (newest block, AI block in this fixture).
+    controller.focused_match_index = Some(0);
+    controller.update_cached_focused_match();
+    let focused_ai = controller
+        .focused_ai_match()
+        .expect("Index 0 should resolve to AI match.");
+    assert_eq!(focused_ai.view_id, ai_view_id);
+    assert_eq!(focused_ai.match_id, ai_match);
+    assert!(
+        controller.focused_terminal_match().is_none(),
+        "Terminal cache must be empty when focus is on AI block."
+    );
+
+    // Index 1 -> terminal match (older block).
+    controller.focused_match_index = Some(1);
+    controller.update_cached_focused_match();
+    assert!(
+        controller.focused_ai_match().is_none(),
+        "AI cache must be empty when focus is on terminal block."
+    );
+    let focused_terminal = controller
+        .focused_terminal_match()
+        .expect("Index 1 should resolve to terminal match.");
+    assert_eq!(focused_terminal.block_index, BlockIndex(0));
+    assert_eq!(focused_terminal.grid_type, GridType::Output);
 }

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -938,3 +938,313 @@ fn test_focused_match_index_walks_across_terminal_and_ai_blocks() {
     assert_eq!(focused_terminal.block_index, BlockIndex(0));
     assert_eq!(focused_terminal.grid_type, GridType::Output);
 }
+
+/// Seeds a controller with a single terminal block containing `matches` at
+/// the given rows, registers its TotalIndex, and returns the controller.
+fn make_controller_with_block(block_index: BlockIndex, rows: &[u64]) -> AsyncFindController {
+    let mock_terminal_model = TerminalModel::mock(None, None);
+    let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+    let mut controller = AsyncFindController::new(terminal_model);
+    {
+        let results = controller.block_results_mut();
+        results.terminal_matches.insert(
+            (block_index, GridType::Output),
+            rows.iter().copied().map(make_match).collect(),
+        );
+        results
+            .terminal_total_indices
+            .insert(block_index, TotalIndex(1));
+    }
+    controller
+}
+
+#[test]
+fn test_with_focus_preservation_preserves_identity_when_inserting_before() {
+    // Block has matches at rows 10, 20, 30; focus on row 20 (global index 1
+    // for MostRecentLast with iter().rev() => 30, 20, 10 ordering).
+    let block_index = BlockIndex(0);
+    let mut controller = make_controller_with_block(block_index, &[10, 20, 30]);
+
+    // Focus index 1 -> row 20 in reverse iteration.
+    controller.focused_match_index = Some(1);
+    controller.update_cached_focused_match();
+    let focused_before = controller
+        .focused_terminal_match()
+        .expect("Initial focus should resolve.");
+    assert_eq!(focused_before.range.start_row(), 20);
+
+    // Simulate streaming a new match in via DirtyRangeMatches that inserts
+    // a row BEFORE the focused row 20 (e.g. row 5 in a non-overlapping dirty
+    // range). After the mutation: rows 5, 10, 20, 30. The identity of the
+    // focused match (row 20) must be preserved; the global index shifts.
+    controller.with_focus_preservation(|me| {
+        me.block_results.update_dirty_matches(
+            block_index,
+            GridType::Output,
+            0..=6,
+            vec![make_match(5)],
+        );
+    });
+
+    let focused_after = controller
+        .focused_terminal_match()
+        .expect("Focus identity should be preserved.");
+    assert_eq!(
+        focused_after.range.start_row(),
+        20,
+        "Focused row identity must be preserved across insertion."
+    );
+    assert!(
+        controller.pending_focus_identity.is_none(),
+        "Successful relocation must clear pending_focus_identity."
+    );
+    // With MostRecentLast and reverse iteration, rows reversed are
+    // [30, 20, 10, 5]. Row 20 is at global index 1 unchanged.
+    assert_eq!(controller.focused_match_index, Some(1));
+}
+
+#[test]
+fn test_with_focus_preservation_stashes_pending_when_match_is_replaced() {
+    // Block has matches at rows 10, 20, 30; focus on row 20.
+    let block_index = BlockIndex(0);
+    let mut controller = make_controller_with_block(block_index, &[10, 20, 30]);
+
+    controller.focused_match_index = Some(1);
+    controller.update_cached_focused_match();
+    assert_eq!(
+        controller
+            .focused_terminal_match()
+            .map(|m| m.range.start_row()),
+        Some(20)
+    );
+
+    // Dirty range 18..=22 replaces the focused row 20. New matches: just row
+    // 19. After mutation: 10, 19, 30. Row 20's identity cannot be relocated.
+    controller.with_focus_preservation(|me| {
+        me.block_results.update_dirty_matches(
+            block_index,
+            GridType::Output,
+            18..=22,
+            vec![make_match(19)],
+        );
+    });
+
+    assert!(
+        controller.pending_focus_identity.is_some(),
+        "Identity must be stashed when the focused match disappears."
+    );
+    // Focused index is clamped into range (3 matches remain, max idx 2).
+    let idx = controller
+        .focused_match_index
+        .expect("Clamp should leave a valid index.");
+    assert!(idx < 3, "Clamped focus index must be in range.");
+}
+
+#[test]
+fn test_with_focus_preservation_resolves_pending_when_match_reappears() {
+    let block_index = BlockIndex(0);
+    let mut controller = make_controller_with_block(block_index, &[10, 20, 30]);
+
+    controller.focused_match_index = Some(1);
+    controller.update_cached_focused_match();
+
+    // First mutation: drop everything in the block (mirrors `remove_block`
+    // during a full invalidate). Pending is stashed.
+    controller.with_focus_preservation(|me| {
+        me.block_results.remove_block(block_index);
+    });
+    assert!(controller.pending_focus_identity.is_some());
+    assert_eq!(controller.match_count(), 0);
+    assert!(controller.focused_match_index.is_none());
+
+    // Second mutation: rescan delivers the same matches back, including
+    // row 20. The pending identity should resolve and clear.
+    controller.with_focus_preservation(|me| {
+        me.block_results
+            .terminal_total_indices
+            .insert(block_index, TotalIndex(1));
+        me.block_results.terminal_matches.insert(
+            (block_index, GridType::Output),
+            vec![make_match(10), make_match(20), make_match(30)],
+        );
+    });
+
+    assert!(
+        controller.pending_focus_identity.is_none(),
+        "Pending identity must clear on successful relocation."
+    );
+    let focused = controller
+        .focused_terminal_match()
+        .expect("Focus must be relocated to the same row.");
+    assert_eq!(focused.range.start_row(), 20);
+    assert_eq!(controller.focused_match_index, Some(1));
+}
+
+#[test]
+fn test_block_grid_matches_auto_select_skipped_when_pending_identity_set() {
+    App::test((), |mut app| async move {
+        let mock_terminal_model = TerminalModel::mock(None, None);
+        let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+
+        // Construct a controller pre-seeded with a focused match, then
+        // synthesize a pending identity via a remove_block-style mutation.
+        let test_model = app.add_model(|_| {
+            let mut model = TerminalFindModel::new(terminal_model.clone());
+            let mut controller = AsyncFindController::new(terminal_model.clone());
+            controller.set_test_status(AsyncFindStatus::Scanning);
+
+            // Seed: block 0 with one match, focused.
+            {
+                let results = controller.block_results_mut();
+                results
+                    .terminal_matches
+                    .insert((BlockIndex(0), GridType::Output), vec![make_match(10)]);
+                results
+                    .terminal_total_indices
+                    .insert(BlockIndex(0), TotalIndex(1));
+            }
+            controller.focused_match_index = Some(0);
+            controller.update_cached_focused_match();
+
+            // Wipe the block via with_focus_preservation, which stashes the
+            // identity into pending_focus_identity.
+            controller.with_focus_preservation(|me| {
+                me.block_results.remove_block(BlockIndex(0));
+            });
+            assert!(controller.pending_focus_identity.is_some());
+
+            model.async_find_controller = Some(controller);
+            model
+        });
+
+        // Now deliver BlockGridMatches for an UNRELATED row (e.g. row 99)
+        // that does NOT match the pending identity. Auto-select MUST NOT
+        // fire while pending is set.
+        test_model.update(&mut app, |model, ctx| {
+            model
+                .async_find_controller
+                .as_mut()
+                .unwrap()
+                .process_message(
+                    FindTaskMessage::BlockGridMatches {
+                        block_index: BlockIndex(0),
+                        grid_type: GridType::Output,
+                        matches: vec![make_match(99)],
+                    },
+                    ctx,
+                );
+        });
+
+        let (focused, pending_set, count) = test_model.update(&mut app, |model, _ctx| {
+            let c = model.async_find_controller.as_ref().unwrap();
+            (
+                c.focused_match_index(),
+                c.pending_focus_identity.is_some(),
+                c.match_count(),
+            )
+        });
+        assert_eq!(count, 1, "New match should be stored.");
+        assert!(
+            pending_set,
+            "Pending identity should still be set; row 99 != row 10."
+        );
+        assert!(
+            focused.is_none(),
+            "Auto-select must be suppressed while pending_focus_identity is set."
+        );
+    });
+}
+
+#[test]
+fn test_block_grid_matches_auto_select_fires_without_pending() {
+    App::test((), |mut app| async move {
+        let mock_terminal_model = TerminalModel::mock(None, None);
+        let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+
+        let test_model = app.add_model(|_| {
+            let mut model = TerminalFindModel::new(terminal_model.clone());
+            let mut controller = AsyncFindController::new(terminal_model.clone());
+            controller.set_test_status(AsyncFindStatus::Scanning);
+            model.async_find_controller = Some(controller);
+            model
+        });
+
+        // No prior focus, no pending. First BlockGridMatches arrival should
+        // auto-select index 0 (regression check).
+        test_model.update(&mut app, |model, ctx| {
+            model
+                .async_find_controller
+                .as_mut()
+                .unwrap()
+                .process_message(
+                    FindTaskMessage::BlockGridMatches {
+                        block_index: BlockIndex(0),
+                        grid_type: GridType::Output,
+                        matches: vec![make_match(5), make_match(10)],
+                    },
+                    ctx,
+                );
+        });
+
+        let focused = test_model.update(&mut app, |model, _ctx| {
+            model
+                .async_find_controller
+                .as_ref()
+                .unwrap()
+                .focused_match_index()
+        });
+        assert_eq!(focused, Some(0), "Auto-select should fire on first chunk.");
+    });
+}
+
+#[test]
+fn test_ai_focus_preserved_across_terminal_dirty_range_update() {
+    // Two blocks:
+    //  - AI block (TotalIndex 5, newest) with one match.
+    //  - Terminal block at BlockIndex(0) (TotalIndex 1, older) with one
+    //    Output match.
+    // Focus is on the AI match (global index 0). A DirtyRangeMatches that
+    // changes the terminal block must not move focus off the AI match.
+    let mock_terminal_model = TerminalModel::mock(None, None);
+    let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+    let mut controller = AsyncFindController::new(terminal_model);
+
+    let ai_view_id = EntityId::from_usize(123);
+    let ai_match = RichContentMatchId::default();
+    {
+        let results = controller.block_results_mut();
+        results.ai_matches.insert(ai_view_id, vec![ai_match]);
+        results.ai_total_indices.insert(ai_view_id, TotalIndex(5));
+        results
+            .terminal_matches
+            .insert((BlockIndex(0), GridType::Output), vec![make_match(10)]);
+        results
+            .terminal_total_indices
+            .insert(BlockIndex(0), TotalIndex(1));
+    }
+    controller.focused_match_index = Some(0);
+    controller.update_cached_focused_match();
+    let focused_ai_before = controller
+        .focused_ai_match()
+        .expect("Initial focus should resolve to AI match.");
+    assert_eq!(focused_ai_before.match_id, ai_match);
+
+    // Add a terminal match BEFORE the existing one. With MostRecentLast +
+    // reverse iter, this shifts the AI match's global index. Identity
+    // preservation must follow.
+    controller.with_focus_preservation(|me| {
+        me.block_results.update_dirty_matches(
+            BlockIndex(0),
+            GridType::Output,
+            0..=6,
+            vec![make_match(5)],
+        );
+    });
+
+    let focused_after = controller
+        .focused_ai_match()
+        .expect("AI match identity must be preserved across terminal updates.");
+    assert_eq!(focused_after.match_id, ai_match);
+    assert_eq!(focused_after.view_id, ai_view_id);
+    assert!(controller.pending_focus_identity.is_none());
+}


### PR DESCRIPTION
## Description

Fixes a focus-drift bug in async find: when the user focuses a match and new results stream into the active block, the focused match silently drifts to "the most recent match" instead of staying anchored to the row they selected.

### Repro
1. Run `./script/run`, search `info` once output starts streaming.
2. Focus the second match from the bottom of the blocklist.
3. As new output streams in, the highlighted/focused match jumps off the chosen row and lands on the newest match.

### Root cause
Every mutation of `block_results` previously called `clamp_focused_match_index`, which kept the *numeric* `focused_match_index` in range but did not preserve the *identity* of the match the user was looking at. As new matches were inserted before the focused row (or as the block was rescanned), the global index that previously pointed at "row N in block 5" silently pointed somewhere else.

### Fix — identity-based preservation
- Derive `PartialEq, Eq` on `AsyncBlockGridMatch`, `AsyncFocusedAiMatch`, `FocusedMatchResolution`.
- Factor the focus traversal into a shared `walk_matches` callback used by both `compute_focused_match` ("what is at global index N") and the new `relocate_focused_match` ("where is identity X").
- Add `with_focus_preservation(mutation)`: captures the cached identity, runs the mutation, then either relocates it and updates `focused_match_index`, or stashes it in a new `pending_focus_identity` field and clamps.
- Wrap every `block_results` mutator in this helper.

### When does async find re-run, and how is each case handled?

Async find mutates `block_results` from four distinct sites; each is now wrapped in `with_focus_preservation`.

1. **`FindTaskMessage::BlockGridMatches`** — initial scan or a chunk of a rescan. Background task sends one of these per `ROWS_PER_CHUNK`-row chunk per grid per block. Each arrival appends matches; identity preservation keeps the focused row anchored even as earlier/newer chunks land.
2. **`FindTaskMessage::DirtyRangeMatches`** — incremental update for the active block as new output streams in (the original repro). `update_dirty_matches` splices new matches in over the dirty range, which can shift global indices. The wrapper relocates the focused identity to its new global position.
3. **`FindTaskMessage::ScanAIBlock`** — main-thread AI block scan. Replaces all matches for a view id. The wrapper keeps a focused match in a *different* block stable across this swap.
4. **`invalidate_block(block, None)`** — full-block rescan (e.g. after a command completes via `notify_block_completed`). `remove_block` wipes the focused match's block entirely; the wrapper stashes the captured identity into `pending_focus_identity` because relocation fails.

### Why `pending_focus_identity` is essential

`pending_focus_identity` exists for case **4** above, and is the main motivation for this whole field.

- `invalidate_block(block, None)` removes every match in the focused block. `cached_focused_match` becomes `None` (nothing to point at) and a naive clamp would just drop the focus.
- The background task then streams the rescan back as **multiple** `BlockGridMatches` chunks — not one message. If the focused row is in, say, the third chunk, the first two chunks would otherwise trigger the auto-select shortcut (`focused_match_index = Some(0)`) and silently snap focus to the newest match before the original ever returns. This is exactly the buggy behavior in the original report.
- The fix: when `with_focus_preservation` cannot relocate the identity, it stashes it into `pending_focus_identity`. Subsequent `BlockGridMatches` arrivals fall back to the pending identity via `cached_focused_match.or_else(|| pending.clone())` and keep trying to relocate it as new chunks land. The `BlockGridMatches` auto-select is gated on `pending_focus_identity.is_none()` so it cannot fire until either the identity is resolved or the queue drains.
- Pending is cleared on successful relocation, on `FindTaskMessage::Done` (queue drained, no more chunks coming), and on every reset path (`new`, `start_find`, `clear_results`, `filter_results_for_refinement`).

For cases 1–3, capture-and-relocate alone is enough; the identity is still present in `cached_focused_match` going into the mutation, and `pending_focus_identity` stays dormant.

## Linked Issue
- [x] N/A — small follow-up to the async find work.

## Testing

Added 6 new unit tests in `async_find_tests.rs`:

- `test_with_focus_preservation_preserves_identity_when_inserting_before` — `DirtyRangeMatches` inserts a row before the focused one; identity is preserved, index shifts.
- `test_with_focus_preservation_stashes_pending_when_match_is_replaced` — focused row is wiped by a dirty range; pending is set; index is clamped.
- `test_with_focus_preservation_resolves_pending_when_match_reappears` — simulates the `remove_block` → chunked rescan flow end-to-end; pending resolves and is cleared.
- `test_block_grid_matches_auto_select_skipped_when_pending_identity_set` — guards the auto-select gate.
- `test_block_grid_matches_auto_select_fires_without_pending` — regression check that the original auto-select still works when there is no prior focus.
- `test_ai_focus_preserved_across_terminal_dirty_range_update` — AI focus survives a terminal-side mutation that shifts global indices.

All 27 `async_find` tests pass under `cargo nextest run -p warp --lib async_find`. `cargo fmt` and `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` are clean.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — non-visual bug fix.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed async find drift where the focused match would jump to the most recent match as new output streamed in.
-->

CHANGELOG-BUG-FIX: Fixed async find drift where the focused match would jump to the most recent match as new output streamed in.

---
_Conversation: https://staging.warp.dev/conversation/3316a9a5-f74f-42e3-a321-8ab7616d2d5d_
_Run: https://oz.staging.warp.dev/runs/019e3c03-35d2-7e93-b240-e086cd161368_
_Plans_:
- _[Async find: focus & highlight AI block matches](https://staging.warp.dev/drive/notebook/uNSJQVN7Qndu0xTUjtHc4m)_
- _[Async find: preserve focused match identity across streaming updates](https://staging.warp.dev/drive/notebook/YIEGaYJ6xAOR0HDRTwngp5)_

_This PR was generated with [Oz](https://warp.dev/oz)._
