### PR TITLE
fix(tmux): break out of ReadingCommandOutput on OpenSSH disconnect (#9900)

### DIFF
--- a/app/src/terminal/model/tmux/parser.rs
+++ b/app/src/terminal/model/tmux/parser.rs
@@ -295,6 +295,25 @@ impl TmuxControlModeParser {
                             output_lines: Err(std::mem::take(lines)),
                         });
                         self.state = ParserState::BeginningOfLine;
+                    } else if looks_like_ssh_disconnect_diagnostic(current_line) {
+                        // Issue #9900: if the SSH transport dies after `%begin`
+                        // but before `%end` arrives, this state would otherwise
+                        // swallow every subsequent byte (local zsh's prompt,
+                        // queued wrapper fragments, etc.) as command-output
+                        // content forever. OpenSSH's standard disconnect
+                        // diagnostics are highly recognizable, so seeing one of
+                        // them inside a `%begin/%end` block is a strong
+                        // signal that the multiplexed transport is gone and
+                        // the rest of this stream is local shell bytes, not
+                        // tmux output. Treat as a parse error so the existing
+                        // recovery path tears down control mode and
+                        // re-renders to the user.
+                        report_parse_error(
+                            handler,
+                            "SSH transport disconnect detected inside %begin/%end",
+                            b'\n',
+                        );
+                        self.state = ParserState::Error;
                     } else {
                         // Command output still ongoing -- append to list of lines.
                         lines.push(std::mem::take(current_line));
@@ -458,6 +477,41 @@ impl Default for TmuxControlModeParser {
 
 fn report_parse_error(handler: &mut impl TmuxControlModeHandler, message: &'static str, byte: u8) {
     handler.tmux_control_mode_message(TmuxMessage::ParseError { message, byte })
+}
+
+/// Returns `true` if `line` looks like one of OpenSSH's standard disconnect
+/// diagnostics. Used inside `ReadingCommandOutput` to detect that the
+/// multiplexed SSH transport has died mid-command, so we can break out of
+/// the begin/end block instead of buffering every subsequent byte forever.
+///
+/// We deliberately stick to needles that are emitted by OpenSSH itself (not
+/// translatable, present across versions):
+/// - `client_loop: send disconnect`     -- OpenSSH client's `client_loop`
+/// - `packet_write_wait`                -- OpenSSH stderr on write-side EPIPE
+/// - `ssh_exchange_identification`      -- handshake failed at version-string exchange
+/// - `kex_exchange_identification`      -- modern variant of the above for key exchange
+/// - `Read from remote host`            -- OpenSSH stderr on read error
+/// - `Connection to ` ... ` closed`     -- OpenSSH's final "Connection to <host> closed." line (both substrings must appear on the same line)
+///
+/// Plain `Broken pipe` is intentionally NOT included because that text is
+/// produced by many unrelated tools and would risk false positives. The
+/// needles above are specific enough that they should not occur in a
+/// legitimate tmux command response.
+fn looks_like_ssh_disconnect_diagnostic(line: &[u8]) -> bool {
+    const NEEDLES: &[&[u8]] = &[
+        b"client_loop: send disconnect",
+        b"packet_write_wait",
+        b"ssh_exchange_identification",
+        b"kex_exchange_identification",
+        b"Read from remote host",
+    ];
+    for needle in NEEDLES {
+        if memchr::memmem::find(line, needle).is_some() {
+            return true;
+        }
+    }
+    memchr::memmem::find(line, b"Connection to ").is_some()
+        && memchr::memmem::find(line, b" closed").is_some()
 }
 
 #[cfg(test)]

--- a/app/src/terminal/model/tmux/parser_tests.rs
+++ b/app/src/terminal/model/tmux/parser_tests.rs
@@ -257,6 +257,213 @@ fn test_begin_without_end() {
     assert_eq!(handler.messages.len(), 0);
 }
 
+// Regression test for issue #9900. Previously the parser was permanently
+// stuck inside `ReadingCommandOutput` if `%end`/`%error` never arrived: the
+// SSH client's disconnect diagnostics, the local zsh re-prompt, and Warp's
+// still-queued wrapper command bytes all got swallowed as "command output
+// content." Now, an OpenSSH disconnect line breaks the begin/end block via
+// ParseError so the existing recovery path tears down control mode.
+#[test]
+fn ssh_disconnect_inside_begin_end_emits_parse_error() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    // 1. tmux had started responding to a wrapper command.
+    let begin = b"%begin 1622462330 1 0\n";
+    // 2. SSH transport dies. Local OpenSSH prints its disconnect diagnostics
+    //    to the PTY. None of this is tmux protocol, but it arrives between
+    //    `%begin` and an `%end` that will never come.
+    let ssh_garbage: &[u8] = b"Read from remote host 10.0.0.1: Operation timed out\n";
+
+    for &byte in begin.iter().chain(ssh_garbage.iter()) {
+        parser.advance(&mut handler, byte);
+    }
+
+    // The OpenSSH-specific phrase is detected inside the begin/end block,
+    // so we emit a ParseError. The performer (in ansi/mod.rs) translates
+    // that into `exited = true` plus a full control-mode state reset.
+    assert_eq!(handler.messages.len(), 1);
+    assert!(
+        matches!(handler.messages[0], TmuxMessage::ParseError { .. }),
+        "expected ParseError on OpenSSH disconnect inside %begin/%end, got {:?}",
+        handler.messages[0]
+    );
+}
+
+#[test]
+fn ssh_disconnect_client_loop_send_disconnect_pattern_triggers_parse_error() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input = b"%begin 1 1 0\nclient_loop: send disconnect: Broken pipe\n";
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    assert_eq!(handler.messages.len(), 1);
+    assert!(matches!(
+        handler.messages[0],
+        TmuxMessage::ParseError { .. }
+    ));
+}
+
+#[test]
+fn ssh_disconnect_connection_to_host_closed_pattern_triggers_parse_error() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input = b"%begin 1 1 0\nConnection to 192.0.2.1 closed.\n";
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    assert_eq!(handler.messages.len(), 1);
+    assert!(matches!(
+        handler.messages[0],
+        TmuxMessage::ParseError { .. }
+    ));
+}
+
+// `Broken pipe` alone is too generic — many unrelated tools print it. We
+// must NOT escape the begin/end block on this string alone, otherwise a
+// remote command whose stderr happens to mention `Broken pipe` would
+// incorrectly tear down control mode mid-flight.
+#[test]
+fn lone_broken_pipe_does_not_trigger_ssh_disconnect_detection() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input = b"%begin 1 1 0\nsome remote tool said: Broken pipe\nfurther output\n%end\n";
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    // The whole begin/end block completes normally with both output lines
+    // captured. No spurious ParseError.
+    assert_eq!(handler.messages.len(), 1);
+    match &handler.messages[0] {
+        TmuxMessage::CommandOutput {
+            output_lines: Ok(lines),
+        } => {
+            assert_eq!(lines.len(), 2);
+        }
+        other => panic!("expected CommandOutput Ok with 2 lines, got {other:?}"),
+    }
+}
+
+// `Connection to ` and ` closed` must both appear on the SAME line to count.
+// A remote command that prints them on separate lines (or with other words
+// between them on separate lines) should not trigger detection.
+#[test]
+fn connection_to_and_closed_on_different_lines_does_not_trigger() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input = b"%begin 1 1 0\nConnection to remote\nthe port was closed\n%end\n";
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    assert_eq!(handler.messages.len(), 1);
+    assert!(matches!(
+        handler.messages[0],
+        TmuxMessage::CommandOutput {
+            output_lines: Ok(_)
+        }
+    ));
+}
+
+#[test]
+fn ssh_disconnect_packet_write_wait_pattern_triggers_parse_error() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input = b"%begin 1 1 0\npacket_write_wait: Connection to 10.0.0.1 port 22: Broken pipe\n";
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    assert_eq!(handler.messages.len(), 1);
+    assert!(matches!(
+        handler.messages[0],
+        TmuxMessage::ParseError { .. }
+    ));
+}
+
+#[test]
+fn ssh_disconnect_ssh_exchange_identification_pattern_triggers_parse_error() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input = b"%begin 1 1 0\nssh_exchange_identification: read: Connection reset by peer\n";
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    assert_eq!(handler.messages.len(), 1);
+    assert!(matches!(
+        handler.messages[0],
+        TmuxMessage::ParseError { .. }
+    ));
+}
+
+#[test]
+fn ssh_disconnect_kex_exchange_identification_pattern_triggers_parse_error() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input = b"%begin 1 1 0\nkex_exchange_identification: Connection closed by remote host\n";
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    assert_eq!(handler.messages.len(), 1);
+    assert!(matches!(
+        handler.messages[0],
+        TmuxMessage::ParseError { .. }
+    ));
+}
+
+// End-to-end byte stream from issue #9900: tmux had just sent `%begin`, then
+// the wrapper command's own echo (from the `(builtin echo -n "^^^..."; ...)`
+// payload) starts arriving, the SSH transport dies, the local OpenSSH client
+// prints its disconnect diagnostics, and the local zsh's prompt would come
+// next. We must escape the begin/end block at the disconnect line so the
+// trailing local-shell bytes do not get silently absorbed.
+#[test]
+fn issue_9900_repro_wrapper_echo_then_ssh_death_emits_parse_error() {
+    let mut parser = TmuxControlModeParser::new();
+    let mut handler = TestHandler::new();
+
+    let input: &[u8] = b"%begin 1622462330 1 0\n\
+        ^^^1777710953501548|||\n\
+        Read from remote host 10.0.0.1: Operation timed out\n\
+        Connection to 10.0.0.1 closed.\n\
+        client_loop: send disconnect: Broken pipe\n";
+
+    for &byte in input {
+        parser.advance(&mut handler, byte);
+    }
+
+    // The wrapper echo line `^^^...|||` was absorbed as content (expected -- it
+    // is not a disconnect signal). On the very next line we hit
+    // `Read from remote host`, which fires ParseError. Subsequent OpenSSH
+    // diagnostic lines may also fire ParseError because the test loop feeds
+    // every byte; in production, the outer `ansi/mod.rs` byte loop breaks on
+    // the first `exited = true` so only one fires. Either way, the FIRST
+    // message must be ParseError -- that is what tears down control mode
+    // before any further bytes can leak.
+    assert!(
+        !handler.messages.is_empty(),
+        "expected at least one ParseError, got no messages"
+    );
+    assert!(
+        matches!(handler.messages[0], TmuxMessage::ParseError { .. }),
+        "expected first message to be ParseError, got {:?}",
+        handler.messages[0]
+    );
+}
+
 #[test]
 fn test_example_output() {
     let mut parser = TmuxControlModeParser::new();


### PR DESCRIPTION
## Summary
Fixes #9900 — after an SSH session times out, Warp keeps injecting tmux `new-window -d '(builtin echo …)|cat; sleep 1'` wrapper bytes into the now-local zsh prompt, producing repeated `zsh: command not found: new-window` plus mangled `ltin echo` fragments.

## Root cause
At the tmux parser layer. After `%begin`, `ParserState::ReadingCommandOutput` accepts ANY byte as command-output content and only escapes when it sees `%end` / `%error`. If the multiplexed SSH transport dies first, the parser stays stuck in that state forever:

- The local OpenSSH client's disconnect diagnostics
- The local zsh re-prompt
- Warp's still-queued wrapper bytes

…are all silently swallowed as "more command output." `tmux_performer.exited` is never set, `ControlModeEvent::Exited` never fires, and `tmux_control_mode_context` is never cleared. Each new completion request keeps queueing more wrapper commands.

Empirical proof in `app/src/terminal/model/tmux/parser_tests.rs` (`test_begin_without_end` was the existing assertion that 0 messages are emitted in this scenario — that's exactly the latent bug).

## Fix
Inside `ReadingCommandOutput`, after each completed content line, sniff for non-localized OpenSSH disconnect diagnostics:

- `client_loop: send disconnect`
- `packet_write_wait`
- `ssh_exchange_identification`
- `kex_exchange_identification`
- `Read from remote host`
- `Connection to ` … ` closed` (both substrings on the same line)

When matched, emit `TmuxMessage::ParseError`. The existing parse-error recovery path (`ansi/mod.rs:471-481`) already (a) sets `tmux_performer.exited = true`, (b) emits `ControlModeEvent::Exited` upstream, and (c) resets the ansi state machine back to default. That reuse keeps the diff small.

Plain `Broken pipe` is deliberately NOT a needle (too generic; many tools print it). The 6 needles above are emitted directly by OpenSSH and unlikely to occur in legitimate tmux command responses.

Uses `memchr::memmem::find` (already a workspace dep).

## Tests
9 new parser tests, all pass (24 total in `parser_tests.rs`):
- Regression test mirroring the byte stream from the issue body
- 1 positive test per supported needle (6 tests)
- 2 negative tests:
  - lone `Broken pipe` does NOT trigger (deliberate exclusion)
  - `Connection to` / `closed` on different lines does NOT trigger

`cargo fmt` + `cargo clippy -p warp --lib --no-deps --tests` clean.

## Scope
`ParserState::ReadingPaneOutput` has the same structural escape hatch problem, but pane output is byte-escaped (`\NNN` octal for bytes < 32), so raw SSH disconnect text from the local PTY is unlikely to land there. Left for a follow-up to keep this PR focused.

## Follow-up worth flagging
Pattern-matching OpenSSH stderr is a band-aid. A timeout-based escape from `ReadingCommandOutput` (or tracking SSH process state) would catch all transport failures, not just OpenSSH's. The current approach was chosen for minimal blast radius; happy to follow up with the more general fix in a separate PR if maintainers want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)