### PR TITLE
Add run_agents profile permission

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -287,6 +287,9 @@ impl RequestParams {
             != crate::ai::execution_profiles::AskUserQuestionPermission::Never;
 
         let orchestration_enabled = ai_settings.is_orchestration_enabled(app)
+            && BlocklistAIPermissions::as_ref(app)
+                .get_run_agents_setting(app, terminal_view_id)
+                .is_enabled()
             && session_context
                 .session_type()
                 .as_ref()

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -19,6 +19,27 @@ pub async fn generate_multi_agent_output(
         .take()
         .unwrap_or_else(|| get_supported_tools(&params));
     let supported_cli_agent_tools = get_supported_cli_agent_tools(&params);
+    let request = build_request(params, supported_tools, supported_cli_agent_tools)?;
+
+    let response_stream = server_api.generate_multi_agent_output(&request).await;
+    match response_stream {
+        Ok(stream) => {
+            let output_stream = stream.take_until(cancellation_rx);
+            Ok(Box::pin(output_stream))
+        }
+        Err(e) => {
+            let (tx, rx) = async_channel::unbounded();
+            let _ = tx.send(Err(e)).await;
+            Ok(Box::pin(rx))
+        }
+    }
+}
+
+fn build_request(
+    mut params: RequestParams,
+    supported_tools: Vec<api::ToolType>,
+    supported_cli_agent_tools: Vec<api::ToolType>,
+) -> Result<api::Request, ConvertToAPITypeError> {
     let mut logging_metadata = HashMap::new();
     if let Some(metadata) = params.metadata {
         logging_metadata.insert(
@@ -55,8 +76,7 @@ pub async fn generate_multi_agent_output(
         params.api_keys,
         params.allow_use_of_warp_credits,
     );
-
-    let request = api::Request {
+    Ok(api::Request {
         task_context: Some(api::request::TaskContext {
             tasks: params.tasks,
         }),
@@ -104,7 +124,8 @@ pub async fn generate_multi_agent_output(
                 FeatureFlag::SummarizationViaMessageReplacement.is_enabled(),
             supports_bundled_skills: FeatureFlag::BundledSkills.is_enabled(),
             supports_research_agent: params.research_agent_enabled,
-            supports_orchestration_v2: FeatureFlag::OrchestrationV2.is_enabled(),
+            supports_orchestration_v2: params.orchestration_enabled
+                && FeatureFlag::OrchestrationV2.is_enabled(),
             custom_model_providers: params.custom_model_providers,
         }),
         metadata: Some(api::request::Metadata {
@@ -135,20 +156,7 @@ pub async fn generate_multi_agent_output(
             .existing_suggestions
             .map(|suggestions| suggestions.into()),
         mcp_context: params.mcp_context.map(Into::into),
-    };
-
-    let response_stream = server_api.generate_multi_agent_output(&request).await;
-    match response_stream {
-        Ok(stream) => {
-            let output_stream = stream.take_until(cancellation_rx);
-            Ok(Box::pin(output_stream))
-        }
-        Err(e) => {
-            let (tx, rx) = async_channel::unbounded();
-            let _ = tx.send(Err(e)).await;
-            Ok(Box::pin(rx))
-        }
-    }
+    })
 }
 
 fn api_keys_with_warp_credit_fallback_setting(

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -19,27 +19,6 @@ pub async fn generate_multi_agent_output(
         .take()
         .unwrap_or_else(|| get_supported_tools(&params));
     let supported_cli_agent_tools = get_supported_cli_agent_tools(&params);
-    let request = build_request(params, supported_tools, supported_cli_agent_tools)?;
-
-    let response_stream = server_api.generate_multi_agent_output(&request).await;
-    match response_stream {
-        Ok(stream) => {
-            let output_stream = stream.take_until(cancellation_rx);
-            Ok(Box::pin(output_stream))
-        }
-        Err(e) => {
-            let (tx, rx) = async_channel::unbounded();
-            let _ = tx.send(Err(e)).await;
-            Ok(Box::pin(rx))
-        }
-    }
-}
-
-fn build_request(
-    mut params: RequestParams,
-    supported_tools: Vec<api::ToolType>,
-    supported_cli_agent_tools: Vec<api::ToolType>,
-) -> Result<api::Request, ConvertToAPITypeError> {
     let mut logging_metadata = HashMap::new();
     if let Some(metadata) = params.metadata {
         logging_metadata.insert(
@@ -76,7 +55,8 @@ fn build_request(
         params.api_keys,
         params.allow_use_of_warp_credits,
     );
-    Ok(api::Request {
+
+    let request = api::Request {
         task_context: Some(api::request::TaskContext {
             tasks: params.tasks,
         }),
@@ -156,7 +136,20 @@ fn build_request(
             .existing_suggestions
             .map(|suggestions| suggestions.into()),
         mcp_context: params.mcp_context.map(Into::into),
-    })
+    };
+
+    let response_stream = server_api.generate_multi_agent_output(&request).await;
+    match response_stream {
+        Ok(stream) => {
+            let output_stream = stream.take_until(cancellation_rx);
+            Ok(Box::pin(output_stream))
+        }
+        Err(e) => {
+            let (tx, rx) = async_channel::unbounded();
+            let _ = tx.send(Err(e)).await;
+            Ok(Box::pin(rx))
+        }
+    }
 }
 
 fn api_keys_with_warp_credit_fallback_setting(

--- a/app/src/ai/agent/api/impl_tests.rs
+++ b/app/src/ai/agent/api/impl_tests.rs
@@ -1,19 +1,34 @@
 use super::{
-    api_keys_with_warp_credit_fallback_setting, get_supported_cli_agent_tools, get_supported_tools,
+    api_keys_with_warp_credit_fallback_setting, build_request, get_supported_cli_agent_tools,
+    get_supported_tools,
 };
 use crate::ai::agent::api::RequestParams;
+use crate::ai::agent::{AIAgentContext, AIAgentInput, UserQueryMode};
 use crate::ai::blocklist::SessionContext;
 use crate::ai::llms::LLMId;
 use crate::terminal::model::session::SessionType;
+use std::collections::HashMap;
+use std::sync::Arc;
 use warp_core::features::FeatureFlag;
 use warp_core::HostId;
 use warp_multi_agent_api as api;
+fn test_user_query() -> AIAgentInput {
+    AIAgentInput::UserQuery {
+        query: "test query".to_string(),
+        context: Arc::<[AIAgentContext]>::from([]),
+        static_query_type: None,
+        referenced_attachments: HashMap::new(),
+        user_query_mode: UserQueryMode::Normal,
+        running_command: None,
+        intended_agent: None,
+    }
+}
 
 fn request_params_with_ask_user_question_enabled(ask_user_question_enabled: bool) -> RequestParams {
     let model = LLMId::from("test-model");
 
     RequestParams {
-        input: vec![],
+        input: vec![test_user_query()],
         conversation_token: None,
         forked_from_conversation_token: None,
         ambient_agent_task_id: None,
@@ -112,6 +127,53 @@ fn supported_tools_includes_ask_user_question_when_enabled_and_feature_flag_is_e
     let supported_tools = get_supported_tools(&params);
 
     assert!(supported_tools.contains(&api::ToolType::AskUserQuestion));
+}
+
+#[test]
+fn supported_tools_omit_orchestration_tools_when_orchestration_is_disabled() {
+    let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
+    let _run_agents_tool = FeatureFlag::RunAgentsTool.override_enabled(true);
+    let mut params = request_params_with_ask_user_question_enabled(false);
+    params.orchestration_enabled = false;
+
+    let supported_tools = get_supported_tools(&params);
+
+    assert!(!supported_tools.contains(&api::ToolType::StartAgent));
+    assert!(!supported_tools.contains(&api::ToolType::StartAgentV2));
+    assert!(!supported_tools.contains(&api::ToolType::RunAgents));
+    assert!(!supported_tools.contains(&api::ToolType::SendMessageToAgent));
+}
+
+#[test]
+fn request_disables_orchestration_v2_when_orchestration_is_disabled() {
+    let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
+    let mut params = request_params_with_ask_user_question_enabled(false);
+    params.orchestration_enabled = false;
+
+    let request = build_request(params, vec![], vec![]).expect("request should build");
+
+    assert!(
+        !request
+            .settings
+            .expect("request should have settings")
+            .supports_orchestration_v2
+    );
+}
+
+#[test]
+fn request_enables_orchestration_v2_when_orchestration_is_enabled() {
+    let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
+    let mut params = request_params_with_ask_user_question_enabled(false);
+    params.orchestration_enabled = true;
+
+    let request = build_request(params, vec![], vec![]).expect("request should build");
+
+    assert!(
+        request
+            .settings
+            .expect("request should have settings")
+            .supports_orchestration_v2
+    );
 }
 
 #[test]

--- a/app/src/ai/agent/api/impl_tests.rs
+++ b/app/src/ai/agent/api/impl_tests.rs
@@ -1,34 +1,19 @@
 use super::{
-    api_keys_with_warp_credit_fallback_setting, build_request, get_supported_cli_agent_tools,
-    get_supported_tools,
+    api_keys_with_warp_credit_fallback_setting, get_supported_cli_agent_tools, get_supported_tools,
 };
 use crate::ai::agent::api::RequestParams;
-use crate::ai::agent::{AIAgentContext, AIAgentInput, UserQueryMode};
 use crate::ai::blocklist::SessionContext;
 use crate::ai::llms::LLMId;
 use crate::terminal::model::session::SessionType;
-use std::collections::HashMap;
-use std::sync::Arc;
 use warp_core::features::FeatureFlag;
 use warp_core::HostId;
 use warp_multi_agent_api as api;
-fn test_user_query() -> AIAgentInput {
-    AIAgentInput::UserQuery {
-        query: "test query".to_string(),
-        context: Arc::<[AIAgentContext]>::from([]),
-        static_query_type: None,
-        referenced_attachments: HashMap::new(),
-        user_query_mode: UserQueryMode::Normal,
-        running_command: None,
-        intended_agent: None,
-    }
-}
 
 fn request_params_with_ask_user_question_enabled(ask_user_question_enabled: bool) -> RequestParams {
     let model = LLMId::from("test-model");
 
     RequestParams {
-        input: vec![test_user_query()],
+        input: vec![],
         conversation_token: None,
         forked_from_conversation_token: None,
         ambient_agent_task_id: None,
@@ -127,53 +112,6 @@ fn supported_tools_includes_ask_user_question_when_enabled_and_feature_flag_is_e
     let supported_tools = get_supported_tools(&params);
 
     assert!(supported_tools.contains(&api::ToolType::AskUserQuestion));
-}
-
-#[test]
-fn supported_tools_omit_orchestration_tools_when_orchestration_is_disabled() {
-    let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
-    let _run_agents_tool = FeatureFlag::RunAgentsTool.override_enabled(true);
-    let mut params = request_params_with_ask_user_question_enabled(false);
-    params.orchestration_enabled = false;
-
-    let supported_tools = get_supported_tools(&params);
-
-    assert!(!supported_tools.contains(&api::ToolType::StartAgent));
-    assert!(!supported_tools.contains(&api::ToolType::StartAgentV2));
-    assert!(!supported_tools.contains(&api::ToolType::RunAgents));
-    assert!(!supported_tools.contains(&api::ToolType::SendMessageToAgent));
-}
-
-#[test]
-fn request_disables_orchestration_v2_when_orchestration_is_disabled() {
-    let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
-    let mut params = request_params_with_ask_user_question_enabled(false);
-    params.orchestration_enabled = false;
-
-    let request = build_request(params, vec![], vec![]).expect("request should build");
-
-    assert!(
-        !request
-            .settings
-            .expect("request should have settings")
-            .supports_orchestration_v2
-    );
-}
-
-#[test]
-fn request_enables_orchestration_v2_when_orchestration_is_enabled() {
-    let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
-    let mut params = request_params_with_ask_user_question_enabled(false);
-    params.orchestration_enabled = true;
-
-    let request = build_request(params, vec![], vec![]).expect("request should build");
-
-    assert!(
-        request
-            .settings
-            .expect("request should have settings")
-            .supports_orchestration_v2
-    );
 }
 
 #[test]

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -691,12 +691,10 @@ impl BlocklistAIActionModel {
         request: ai::agent::action::RunAgentsRequest,
         ctx: &mut ModelContext<Self>,
     ) {
-        let mut found: Option<(AIConversationId, AIAgentAction)> = None;
+        let mut found = None;
         for (conv_id, queue) in self.pending_actions.iter_mut() {
-            if let Some(idx) = queue.iter().position(|a| &a.id == action_id) {
-                if let Some(action) = queue.remove(idx) {
-                    found = Some((*conv_id, action));
-                }
+            if let Some(action) = queue.iter_mut().find(|action| &action.id == action_id) {
+                found = Some((*conv_id, action));
                 break;
             }
         }
@@ -708,33 +706,12 @@ impl BlocklistAIActionModel {
         };
         if !matches!(action.action, AIAgentActionType::RunAgents(_)) {
             log::warn!(
-                "BlocklistAIActionModel::execute_run_agents: pending action {action_id:?} is not RunAgents; re-queueing"
+                "BlocklistAIActionModel::execute_run_agents: pending action {action_id:?} is not RunAgents"
             );
-            self.pending_actions
-                .entry(conversation_id)
-                .or_default()
-                .push_front(action);
             return;
         }
-        let task_id = action.task_id.clone();
-        let action_id_clone = action_id.clone();
-
-        self.executor.update(ctx, |executor, exec_ctx| {
-            executor.execute_run_agents(
-                action_id_clone,
-                request,
-                conversation_id,
-                task_id,
-                exec_ctx,
-            );
-        });
-
-        self.update_conversation_in_progress_status(conversation_id, ctx);
-        self.add_running_action(
-            conversation_id,
-            action_id.clone(),
-            RunningActionPhase::Serial,
-        );
+        action.action = AIAgentActionType::RunAgents(request);
+        self.execute_action(action_id, conversation_id, ctx);
     }
 
     /// Removes a pending `RunAgents` action and records a `Denied`

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -331,8 +331,8 @@ impl BlocklistAIActionExecutor {
         let read_skill_executor = ctx.add_model(|_| ReadSkillExecutor::new());
         let fetch_conversation_executor = ctx.add_model(|_| FetchConversationExecutor::new());
         let start_agent_executor = ctx.add_model(StartAgentExecutor::new);
-        let run_agents_executor =
-            ctx.add_model(|_| RunAgentsExecutor::new(start_agent_executor.clone()));
+        let run_agents_executor = ctx
+            .add_model(|_| RunAgentsExecutor::new(start_agent_executor.clone(), terminal_view_id));
         let send_message_executor = ctx.add_model(|_| SendMessageToAgentExecutor::new());
         let ask_user_question_executor =
             ctx.add_model(|_| AskUserQuestionExecutor::new(terminal_view_id));

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -89,10 +89,9 @@ use crate::ai::{agent::AnyFileContent, paths::host_native_absolute_path};
 use crate::{
     ai::{
         agent::{
-            conversation::AIConversationId, task::TaskId, AIAgentAction, AIAgentActionId,
-            AIAgentActionResult, AIAgentActionResultType, AIAgentActionType,
-            AIAgentActionTypeDiscriminants, CancellationReason, FileContext, FileLocations,
-            ServerOutputId,
+            conversation::AIConversationId, AIAgentAction, AIAgentActionId, AIAgentActionResult,
+            AIAgentActionResultType, AIAgentActionType, AIAgentActionTypeDiscriminants,
+            CancellationReason, FileContext, FileLocations, ServerOutputId,
         },
         ambient_agents::AmbientAgentTaskId,
         get_relevant_files::controller::GetRelevantFilesController,
@@ -720,8 +719,6 @@ impl BlocklistAIActionExecutor {
                 .ask_user_question_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
                 .into(),
-            // Standard executor path (un-edited request). The card
-            // view's Accept uses `execute_run_agents` instead.
             AIAgentActionType::RunAgents(_) => self
                 .run_agents_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
@@ -858,78 +855,6 @@ impl BlocklistAIActionExecutor {
         for action_id in action_ids {
             self.cancel_running_async_action(&action_id, reason, ctx);
         }
-    }
-
-    /// Dispatches a `RunAgents` action with a user-edited request
-    /// (from the confirmation card's Accept handler).
-    pub fn execute_run_agents(
-        &mut self,
-        action_id: AIAgentActionId,
-        request: ai::agent::action::RunAgentsRequest,
-        conversation_id: AIConversationId,
-        task_id: TaskId,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        if self.is_shared_session_viewer() {
-            log::warn!("RunAgents dispatch attempted in shared-session-viewer mode; ignoring");
-            return;
-        }
-        if self.async_executing_actions.contains_key(&action_id) {
-            log::warn!("RunAgents dispatch reentered for {action_id:?}; ignoring");
-            return;
-        }
-
-        let receiver = self.run_agents_executor.update(ctx, |executor, exec_ctx| {
-            executor.dispatch_run_agents(
-                action_id.clone(),
-                request.clone(),
-                conversation_id,
-                exec_ctx,
-            )
-        });
-
-        // Synthesize an AIAgentAction for cancellation and task_id
-        // plumbing.
-        let action = AIAgentAction {
-            id: action_id.clone(),
-            task_id,
-            action: AIAgentActionType::RunAgents(request),
-            requires_result: true,
-        };
-        self.async_executing_actions.insert(
-            action_id.clone(),
-            AsyncExecutingAction {
-                action,
-                conversation_id,
-            },
-        );
-        ctx.emit(BlocklistAIActionExecutorEvent::ExecutingAction {
-            action_id: action_id.clone(),
-        });
-
-        ctx.spawn(
-            async move { receiver.recv().await },
-            move |me, result, ctx| {
-                let Some(running) = me.async_executing_actions.remove(&action_id) else {
-                    return;
-                };
-                let result_type = match result {
-                    Ok(r) => AIAgentActionResultType::RunAgents(r),
-                    Err(_) => AIAgentActionResultType::RunAgents(
-                        ai::agent::action_result::RunAgentsResult::Cancelled,
-                    ),
-                };
-                ctx.emit(BlocklistAIActionExecutorEvent::FinishedAction {
-                    result: Arc::new(AIAgentActionResult {
-                        id: action_id,
-                        task_id: running.action.task_id,
-                        result: result_type,
-                    }),
-                    conversation_id: running.conversation_id,
-                    cancellation_reason: None,
-                });
-            },
-        );
     }
 
     fn should_autoexecute(&self, input: ExecuteActionInput, ctx: &mut ModelContext<Self>) -> bool {

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -17,7 +17,7 @@ use crate::ai::blocklist::inline_action::orchestration_controls::OrchestrationEd
 use futures::{future::BoxFuture, FutureExt};
 use warp_cli::agent::Harness;
 use warp_core::execution_mode::AppExecutionMode;
-use warpui::{Entity, ModelContext, ModelHandle};
+use warpui::{Entity, EntityId, ModelContext, ModelHandle};
 
 use super::start_agent::{StartAgentExecutor, StartAgentOutcome};
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
@@ -26,7 +26,8 @@ use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
     StartAgentExecutionMode,
 };
-use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
+use crate::ai::execution_profiles::RunAgentsPermission;
 use crate::ai::local_child_harnesses::local_child_harness_disabled_message;
 use warpui::SingletonEntity;
 
@@ -48,6 +49,7 @@ struct PendingRunAgents;
 pub struct RunAgentsExecutor {
     pending: HashMap<AIAgentActionId, PendingRunAgents>,
     start_agent_executor: ModelHandle<StartAgentExecutor>,
+    terminal_view_id: EntityId,
 }
 
 /// Lifecycle events for in-flight dispatches.
@@ -66,10 +68,14 @@ impl Entity for RunAgentsExecutor {
 }
 
 impl RunAgentsExecutor {
-    pub fn new(start_agent_executor: ModelHandle<StartAgentExecutor>) -> Self {
+    pub fn new(
+        start_agent_executor: ModelHandle<StartAgentExecutor>,
+        terminal_view_id: EntityId,
+    ) -> Self {
         Self {
             pending: HashMap::new(),
             start_agent_executor,
+            terminal_view_id,
         }
     }
 
@@ -88,6 +94,16 @@ impl RunAgentsExecutor {
         ctx: &mut ModelContext<Self>,
     ) -> async_channel::Receiver<RunAgentsResult> {
         let (sender, receiver) = async_channel::bounded(1);
+        if BlocklistAIPermissions::as_ref(ctx)
+            .get_run_agents_setting(ctx, Some(self.terminal_view_id))
+            .is_never_allow()
+        {
+            let _ = sender.try_send(RunAgentsResult::Denied {
+                reason: "Running child agents is disabled by the active execution profile."
+                    .to_string(),
+            });
+            return receiver;
+        }
 
         if self.pending.contains_key(&action_id) {
             log::warn!("RunAgentsExecutor: dispatch reentered for {action_id:?}; rejecting");
@@ -264,6 +280,17 @@ impl RunAgentsExecutor {
         let mut request = request.clone();
         let action_id = id.clone();
         let parent_conversation_id = input.conversation_id;
+        let permission = BlocklistAIPermissions::as_ref(ctx)
+            .get_run_agents_setting(ctx, Some(self.terminal_view_id));
+
+        if permission.is_never_allow() {
+            return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
+                RunAgentsResult::Denied {
+                    reason: "Running child agents is disabled by the active execution profile."
+                        .to_string(),
+                },
+            ));
+        }
 
         // When auto-executing (autonomous/CLI-driver mode), the confirmation
         // card is bypassed. Replicate its policy/normalization here:
@@ -303,12 +330,23 @@ impl RunAgentsExecutor {
 
     pub(super) fn should_autoexecute(
         &self,
-        _input: ExecuteActionInput,
+        input: ExecuteActionInput,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
+        let AIAgentActionType::RunAgents(_) = &input.action.action else {
+            return false;
+        };
         // Non-interactive (CLI driver) agents cannot present a
         // confirmation card, so they must auto-execute.
-        AppExecutionMode::as_ref(ctx).is_autonomous()
+        if AppExecutionMode::as_ref(ctx).is_autonomous() {
+            return true;
+        }
+
+        matches!(
+            BlocklistAIPermissions::as_ref(ctx)
+                .get_run_agents_setting(ctx, Some(self.terminal_view_id)),
+            RunAgentsPermission::AlwaysAllow
+        )
     }
 
     pub(super) fn preprocess_action(

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -15,6 +15,7 @@ use ai::skills::SkillReference;
 
 use crate::ai::blocklist::inline_action::orchestration_controls::OrchestrationEditState;
 use futures::{future::BoxFuture, FutureExt};
+use settings::Setting;
 use warp_cli::agent::Harness;
 use warp_core::execution_mode::AppExecutionMode;
 use warpui::{Entity, EntityId, ModelContext, ModelHandle};
@@ -26,7 +27,9 @@ use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
     StartAgentExecutionMode,
 };
+use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
+use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::execution_profiles::RunAgentsPermission;
 use crate::ai::local_child_harnesses::local_child_harness_disabled_message;
 use warpui::SingletonEntity;
@@ -297,25 +300,17 @@ impl RunAgentsExecutor {
         // 1. Deny if the orchestration config is explicitly disapproved.
         // 2. Override model/harness/execution_mode from the approved config.
         if AppExecutionMode::as_ref(ctx).is_autonomous() {
-            if let Some(conversation) =
-                BlocklistAIHistoryModel::as_ref(ctx).conversation(&parent_conversation_id)
+            if resolve_autonomous_request_from_config(&mut request, parent_conversation_id, ctx)
+                .is_some_and(|status| status.is_disapproved())
             {
-                if let Some((config, status)) =
-                    conversation.orchestration_config_for_plan(&request.plan_id)
-                {
-                    if status.is_disapproved() {
-                        return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
-                            RunAgentsResult::Denied {
-                                reason: "Orchestration config was disapproved".to_string(),
-                            },
-                        ));
-                    }
-                    if status.is_approved() {
-                        resolve_request_from_config(&mut request, config);
-                    }
-                }
+                return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
+                    RunAgentsResult::Denied {
+                        reason: "Orchestration config was disapproved".to_string(),
+                    },
+                ));
             }
         }
+        populate_default_auth_secret_for_autoexecute(&mut request, ctx);
 
         let receiver = self.dispatch_run_agents(action_id, request, parent_conversation_id, ctx);
 
@@ -333,9 +328,26 @@ impl RunAgentsExecutor {
         input: ExecuteActionInput,
         ctx: &mut ModelContext<Self>,
     ) -> bool {
-        let AIAgentActionType::RunAgents(_) = &input.action.action else {
+        let AIAgentActionType::RunAgents(request) = &input.action.action else {
             return false;
         };
+        let mut request = request.clone();
+        if AppExecutionMode::as_ref(ctx).is_autonomous() {
+            if resolve_autonomous_request_from_config(&mut request, input.conversation_id, ctx)
+                .is_some_and(|status| status.is_disapproved())
+            {
+                return false;
+            }
+        }
+        if requires_default_auth_secret_for_autoexecute(&request)
+            && request
+                .harness_auth_secret_name
+                .as_deref()
+                .is_none_or(|name| name.trim().is_empty())
+            && default_auth_secret_name_for_harness(&request.harness_type, ctx).is_none()
+        {
+            return false;
+        }
         // Non-interactive (CLI driver) agents cannot present a
         // confirmation card, so they must auto-execute.
         if AppExecutionMode::as_ref(ctx).is_autonomous() {
@@ -358,9 +370,69 @@ impl RunAgentsExecutor {
     }
 }
 
+#[cfg(test)]
+#[path = "run_agents_tests.rs"]
+mod tests;
+
 enum ChildSlot {
     Failed(String),
     Pending(async_channel::Receiver<StartAgentOutcome>),
+}
+
+fn resolve_autonomous_request_from_config(
+    request: &mut RunAgentsRequest,
+    parent_conversation_id: AIConversationId,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) -> Option<ai::agent::orchestration_config::OrchestrationConfigStatus> {
+    let conversation =
+        BlocklistAIHistoryModel::as_ref(ctx).conversation(&parent_conversation_id)?;
+    let (config, status) = conversation.orchestration_config_for_plan(&request.plan_id)?;
+    if status.is_approved() {
+        resolve_request_from_config(request, config);
+    }
+    Some(status)
+}
+
+fn requires_default_auth_secret_for_autoexecute(request: &RunAgentsRequest) -> bool {
+    if !request.execution_mode.is_remote() {
+        return false;
+    }
+    let Some(harness) = Harness::parse_orchestration_harness(&request.harness_type) else {
+        return false;
+    };
+    harness != Harness::Oz && !auth_secret_types_for_harness(harness).is_empty()
+}
+
+fn default_auth_secret_name_for_harness(
+    harness_type: &str,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) -> Option<String> {
+    let harness = Harness::parse_orchestration_harness(harness_type)?;
+    if harness == Harness::Oz {
+        return None;
+    }
+    CloudAgentSettings::as_ref(ctx)
+        .last_selected_auth_secret
+        .value()
+        .get(harness.config_name())
+        .cloned()
+        .filter(|name| !name.trim().is_empty())
+}
+
+fn populate_default_auth_secret_for_autoexecute(
+    request: &mut RunAgentsRequest,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) {
+    if !requires_default_auth_secret_for_autoexecute(request)
+        || request
+            .harness_auth_secret_name
+            .as_deref()
+            .is_some_and(|name| !name.trim().is_empty())
+    {
+        return;
+    }
+    request.harness_auth_secret_name =
+        default_auth_secret_name_for_harness(&request.harness_type, ctx);
 }
 
 /// Unconditionally overrides run-wide fields on a `RunAgentsRequest`

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -308,7 +308,7 @@ impl RunAgentsExecutor {
         if AppExecutionMode::as_ref(ctx).is_autonomous() {
             return true;
         }
-        has_approved_orchestration_config(request, input.conversation_id, ctx)
+        approved_orchestration_config_can_autoexecute(request, input.conversation_id, ctx)
             || BlocklistAIPermissions::as_ref(ctx)
                 .get_run_agents_setting(ctx, Some(self.terminal_view_id))
                 .is_always_allow()
@@ -332,24 +332,15 @@ enum ChildSlot {
     Pending(async_channel::Receiver<StartAgentOutcome>),
 }
 
-fn orchestration_config_status_for_request(
-    request: &RunAgentsRequest,
-    parent_conversation_id: AIConversationId,
-    ctx: &ModelContext<RunAgentsExecutor>,
-) -> Option<ai::agent::orchestration_config::OrchestrationConfigStatus> {
-    BlocklistAIHistoryModel::as_ref(ctx)
-        .conversation(&parent_conversation_id)?
-        .orchestration_config_for_plan(&request.plan_id)
-        .map(|(_, status)| status)
-}
-
-fn has_approved_orchestration_config(
+fn approved_orchestration_config_can_autoexecute(
     request: &RunAgentsRequest,
     parent_conversation_id: AIConversationId,
     ctx: &ModelContext<RunAgentsExecutor>,
 ) -> bool {
-    orchestration_config_status_for_request(request, parent_conversation_id, ctx)
+    let mut resolved_request = request.clone();
+    resolve_request_from_approved_config(&mut resolved_request, parent_conversation_id, ctx)
         .is_some_and(|status| status.is_approved())
+        && can_execute_with_auth_secret(&resolved_request, ctx)
 }
 
 fn resolve_request_from_approved_config(

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -30,7 +30,6 @@ use crate::ai::agent::{
 use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
-use crate::ai::execution_profiles::RunAgentsPermission;
 use crate::ai::local_child_harnesses::local_child_harness_disabled_message;
 use warpui::SingletonEntity;
 
@@ -86,10 +85,10 @@ impl RunAgentsExecutor {
         self.pending.contains_key(action_id)
     }
 
-    /// Fans out per-child dispatches and returns a receiver for the
-    /// aggregate `RunAgentsResult`. Validation failures short-circuit
-    /// synchronously.
-    pub fn dispatch_run_agents(
+    /// Fans out a prepared request into per-child dispatches and returns a
+    /// receiver for the aggregate `RunAgentsResult`. Validation failures
+    /// short-circuit synchronously.
+    fn dispatch_prepared_run_agents(
         &mut self,
         action_id: AIAgentActionId,
         request: RunAgentsRequest,
@@ -97,16 +96,6 @@ impl RunAgentsExecutor {
         ctx: &mut ModelContext<Self>,
     ) -> async_channel::Receiver<RunAgentsResult> {
         let (sender, receiver) = async_channel::bounded(1);
-        if BlocklistAIPermissions::as_ref(ctx)
-            .get_run_agents_setting(ctx, Some(self.terminal_view_id))
-            .is_never_allow()
-        {
-            let _ = sender.try_send(RunAgentsResult::Denied {
-                reason: "Running child agents is disabled by the active execution profile."
-                    .to_string(),
-            });
-            return receiver;
-        }
 
         if self.pending.contains_key(&action_id) {
             log::warn!("RunAgentsExecutor: dispatch reentered for {action_id:?}; rejecting");
@@ -283,40 +272,21 @@ impl RunAgentsExecutor {
         let mut request = request.clone();
         let action_id = id.clone();
         let parent_conversation_id = input.conversation_id;
-        let permission = BlocklistAIPermissions::as_ref(ctx)
-            .get_run_agents_setting(ctx, Some(self.terminal_view_id));
-
-        if permission.is_never_allow() {
+        if let Some(reason) = prepare_request_for_execution(
+            &mut request,
+            parent_conversation_id,
+            self.terminal_view_id,
+            ctx,
+        ) {
             return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
                 RunAgentsResult::Denied {
-                    reason: "Running child agents is disabled by the active execution profile."
-                        .to_string(),
+                    reason: reason.to_string(),
                 },
             ));
         }
 
-        // When auto-executing (autonomous/CLI-driver mode), the confirmation
-        // card is bypassed. Replicate its policy/normalization here:
-        // 1. Deny if the orchestration config is explicitly disapproved.
-        // 2. Override model/harness/execution_mode from the approved config.
-        if AppExecutionMode::as_ref(ctx).is_autonomous() {
-            if apply_autonomous_config_and_check_disapproval(
-                &mut request,
-                parent_conversation_id,
-                ctx,
-            )
-            .is_disapproved()
-            {
-                return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
-                    RunAgentsResult::Denied {
-                        reason: "Orchestration config was disapproved".to_string(),
-                    },
-                ));
-            }
-        }
-        populate_default_auth_secret_for_autoexecute(&mut request, ctx);
-
-        let receiver = self.dispatch_run_agents(action_id, request, parent_conversation_id, ctx);
+        let receiver =
+            self.dispatch_prepared_run_agents(action_id, request, parent_conversation_id, ctx);
 
         ActionExecution::new_async(
             async move { receiver.recv().await },
@@ -335,34 +305,13 @@ impl RunAgentsExecutor {
         let AIAgentActionType::RunAgents(request) = &input.action.action else {
             return false;
         };
-        let mut request = request.clone();
-        let is_autonomous = AppExecutionMode::as_ref(ctx).is_autonomous();
-        if is_autonomous
-            // Approved orchestration configs override run-wide request fields.
-            // Resolve them before auth gating so we inspect the effective harness/mode.
-            && apply_autonomous_config_and_check_disapproval(
-                &mut request,
-                input.conversation_id,
-                ctx,
-            )
-                .is_disapproved()
-        {
-            return false;
-        }
-        if !can_autoexecute_with_auth_secret(&request, ctx) {
-            return false;
-        }
-        // Non-interactive (CLI driver) agents cannot present a
-        // confirmation card, so they must auto-execute.
-        if is_autonomous {
+        if AppExecutionMode::as_ref(ctx).is_autonomous() {
             return true;
         }
-
-        matches!(
-            BlocklistAIPermissions::as_ref(ctx)
-                .get_run_agents_setting(ctx, Some(self.terminal_view_id)),
-            RunAgentsPermission::AlwaysAllow
-        )
+        has_approved_orchestration_config(request, input.conversation_id, ctx)
+            || BlocklistAIPermissions::as_ref(ctx)
+                .get_run_agents_setting(ctx, Some(self.terminal_view_id))
+                .is_always_allow()
     }
 
     pub(super) fn preprocess_action(
@@ -383,7 +332,27 @@ enum ChildSlot {
     Pending(async_channel::Receiver<StartAgentOutcome>),
 }
 
-fn resolve_autonomous_request_from_config(
+fn orchestration_config_status_for_request(
+    request: &RunAgentsRequest,
+    parent_conversation_id: AIConversationId,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) -> Option<ai::agent::orchestration_config::OrchestrationConfigStatus> {
+    BlocklistAIHistoryModel::as_ref(ctx)
+        .conversation(&parent_conversation_id)?
+        .orchestration_config_for_plan(&request.plan_id)
+        .map(|(_, status)| status)
+}
+
+fn has_approved_orchestration_config(
+    request: &RunAgentsRequest,
+    parent_conversation_id: AIConversationId,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) -> bool {
+    orchestration_config_status_for_request(request, parent_conversation_id, ctx)
+        .is_some_and(|status| status.is_approved())
+}
+
+fn resolve_request_from_approved_config(
     request: &mut RunAgentsRequest,
     parent_conversation_id: AIConversationId,
     ctx: &ModelContext<RunAgentsExecutor>,
@@ -397,35 +366,45 @@ fn resolve_autonomous_request_from_config(
     Some(status)
 }
 
-enum AutonomousRequestPreparation {
-    Ready,
-    Disapproved,
-}
-
-impl AutonomousRequestPreparation {
-    fn is_disapproved(&self) -> bool {
-        matches!(self, Self::Disapproved)
-    }
-}
-
-/// Applies any approved orchestration config directly to the request so
-/// downstream autoexecute checks and dispatch use the same resolved fields.
-/// Returns `Disapproved` when the stored config explicitly blocks launch.
-fn apply_autonomous_config_and_check_disapproval(
+/// Normalizes the request and returns a denial reason when launch is blocked.
+///
+/// Autonomous agents always run: their calls may still inherit approved plan
+/// config fields and default auth secrets, but they bypass interactive policy
+/// denials because they cannot present a confirmation card.
+fn prepare_request_for_execution(
     request: &mut RunAgentsRequest,
     parent_conversation_id: AIConversationId,
+    terminal_view_id: EntityId,
     ctx: &ModelContext<RunAgentsExecutor>,
-) -> AutonomousRequestPreparation {
-    if resolve_autonomous_request_from_config(request, parent_conversation_id, ctx)
-        .is_some_and(|status| status.is_disapproved())
-    {
-        AutonomousRequestPreparation::Disapproved
-    } else {
-        AutonomousRequestPreparation::Ready
+) -> Option<&'static str> {
+    let status = resolve_request_from_approved_config(request, parent_conversation_id, ctx);
+    populate_default_auth_secret_for_execution(request, ctx);
+
+    if AppExecutionMode::as_ref(ctx).is_autonomous() {
+        return None;
     }
+
+    if status.is_some_and(|status| status.is_disapproved()) {
+        return Some("Orchestration config was disapproved");
+    }
+
+    if BlocklistAIPermissions::as_ref(ctx)
+        .get_run_agents_setting(ctx, Some(terminal_view_id))
+        .is_never_allow()
+    {
+        return Some("Running child agents is disabled by the active execution profile.");
+    }
+
+    if !can_execute_with_auth_secret(request, ctx) {
+        return Some(
+            "Cloud child agents using this harness require an API key before they can run.",
+        );
+    }
+
+    None
 }
 
-fn requires_default_auth_secret_for_autoexecute(request: &RunAgentsRequest) -> bool {
+fn requires_default_auth_secret_for_execution(request: &RunAgentsRequest) -> bool {
     if !request.execution_mode.is_remote() {
         return false;
     }
@@ -435,11 +414,11 @@ fn requires_default_auth_secret_for_autoexecute(request: &RunAgentsRequest) -> b
     harness != Harness::Oz && !auth_secret_types_for_harness(harness).is_empty()
 }
 
-fn can_autoexecute_with_auth_secret(
+fn can_execute_with_auth_secret(
     request: &RunAgentsRequest,
     ctx: &ModelContext<RunAgentsExecutor>,
 ) -> bool {
-    if !requires_default_auth_secret_for_autoexecute(request) {
+    if !requires_default_auth_secret_for_execution(request) {
         return true;
     }
     if request
@@ -468,11 +447,11 @@ fn default_auth_secret_name_for_harness(
         .filter(|name| !name.trim().is_empty())
 }
 
-fn populate_default_auth_secret_for_autoexecute(
+fn populate_default_auth_secret_for_execution(
     request: &mut RunAgentsRequest,
     ctx: &ModelContext<RunAgentsExecutor>,
 ) {
-    if !requires_default_auth_secret_for_autoexecute(request)
+    if !requires_default_auth_secret_for_execution(request)
         || request
             .harness_auth_secret_name
             .as_deref()

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -300,8 +300,12 @@ impl RunAgentsExecutor {
         // 1. Deny if the orchestration config is explicitly disapproved.
         // 2. Override model/harness/execution_mode from the approved config.
         if AppExecutionMode::as_ref(ctx).is_autonomous() {
-            if resolve_autonomous_request_from_config(&mut request, parent_conversation_id, ctx)
-                .is_some_and(|status| status.is_disapproved())
+            if apply_autonomous_config_and_check_disapproval(
+                &mut request,
+                parent_conversation_id,
+                ctx,
+            )
+            .is_disapproved()
             {
                 return ActionExecution::Sync(AIAgentActionResultType::RunAgents(
                     RunAgentsResult::Denied {
@@ -332,25 +336,25 @@ impl RunAgentsExecutor {
             return false;
         };
         let mut request = request.clone();
-        if AppExecutionMode::as_ref(ctx).is_autonomous() {
-            if resolve_autonomous_request_from_config(&mut request, input.conversation_id, ctx)
-                .is_some_and(|status| status.is_disapproved())
-            {
-                return false;
-            }
-        }
-        if requires_default_auth_secret_for_autoexecute(&request)
-            && request
-                .harness_auth_secret_name
-                .as_deref()
-                .is_none_or(|name| name.trim().is_empty())
-            && default_auth_secret_name_for_harness(&request.harness_type, ctx).is_none()
+        let is_autonomous = AppExecutionMode::as_ref(ctx).is_autonomous();
+        if is_autonomous
+            // Approved orchestration configs override run-wide request fields.
+            // Resolve them before auth gating so we inspect the effective harness/mode.
+            && apply_autonomous_config_and_check_disapproval(
+                &mut request,
+                input.conversation_id,
+                ctx,
+            )
+                .is_disapproved()
         {
+            return false;
+        }
+        if !can_autoexecute_with_auth_secret(&request, ctx) {
             return false;
         }
         // Non-interactive (CLI driver) agents cannot present a
         // confirmation card, so they must auto-execute.
-        if AppExecutionMode::as_ref(ctx).is_autonomous() {
+        if is_autonomous {
             return true;
         }
 
@@ -393,6 +397,34 @@ fn resolve_autonomous_request_from_config(
     Some(status)
 }
 
+enum AutonomousRequestPreparation {
+    Ready,
+    Disapproved,
+}
+
+impl AutonomousRequestPreparation {
+    fn is_disapproved(&self) -> bool {
+        matches!(self, Self::Disapproved)
+    }
+}
+
+/// Applies any approved orchestration config directly to the request so
+/// downstream autoexecute checks and dispatch use the same resolved fields.
+/// Returns `Disapproved` when the stored config explicitly blocks launch.
+fn apply_autonomous_config_and_check_disapproval(
+    request: &mut RunAgentsRequest,
+    parent_conversation_id: AIConversationId,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) -> AutonomousRequestPreparation {
+    if resolve_autonomous_request_from_config(request, parent_conversation_id, ctx)
+        .is_some_and(|status| status.is_disapproved())
+    {
+        AutonomousRequestPreparation::Disapproved
+    } else {
+        AutonomousRequestPreparation::Ready
+    }
+}
+
 fn requires_default_auth_secret_for_autoexecute(request: &RunAgentsRequest) -> bool {
     if !request.execution_mode.is_remote() {
         return false;
@@ -401,6 +433,23 @@ fn requires_default_auth_secret_for_autoexecute(request: &RunAgentsRequest) -> b
         return false;
     };
     harness != Harness::Oz && !auth_secret_types_for_harness(harness).is_empty()
+}
+
+fn can_autoexecute_with_auth_secret(
+    request: &RunAgentsRequest,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) -> bool {
+    if !requires_default_auth_secret_for_autoexecute(request) {
+        return true;
+    }
+    if request
+        .harness_auth_secret_name
+        .as_deref()
+        .is_some_and(|name| !name.trim().is_empty())
+    {
+        return true;
+    }
+    default_auth_secret_name_for_harness(&request.harness_type, ctx).is_some()
 }
 
 fn default_auth_secret_name_for_harness(
@@ -439,6 +488,8 @@ fn populate_default_auth_secret_for_autoexecute(
 /// from the approved orchestration config, delegating to
 /// `OrchestrationEditState::override_from_approved_config`.
 fn resolve_request_from_config(request: &mut RunAgentsRequest, config: &OrchestrationConfig) {
+    // The approved plan config is the source of truth for these run-wide fields,
+    // so callers pass a mutable request and continue with the normalized value.
     let mut edit_state = OrchestrationEditState::from_run_agents_fields(
         &request.model_id,
         &request.harness_type,

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+
+use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
+use settings::Setting;
+use warp_core::execution_mode::ExecutionMode;
+use warpui::{App, EntityId, ModelHandle};
+
+use super::*;
+use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
+use crate::ai::agent::task::TaskId;
+use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
+use crate::ai::cloud_agent_settings::CloudAgentSettings;
+use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
+use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
+use crate::{
+    auth::AuthStateProvider,
+    cloud_object::model::persistence::CloudModel,
+    network::NetworkStatus,
+    server::{cloud_objects::update_manager::UpdateManager, sync_queue::SyncQueue},
+    settings::PrivacySettings,
+    test_util::settings::initialize_settings_for_tests_with_mode,
+    workspaces::{team_tester::TeamTesterStatus, user_workspaces::UserWorkspaces},
+    AgentNotificationsModel, GlobalResourceHandles, GlobalResourceHandlesProvider, LaunchMode,
+};
+
+struct RunAgentsTestState {
+    conversation_id: AIConversationId,
+    executor: ModelHandle<RunAgentsExecutor>,
+}
+
+fn initialize_run_agents_test(app: &mut App, mode: ExecutionMode) -> RunAgentsTestState {
+    initialize_settings_for_tests_with_mode(app, mode, false);
+    let global_resource_handles = GlobalResourceHandles::mock(app);
+    app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+    let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+    app.add_singleton_model(|_| CLIAgentSessionsModel::new());
+    app.add_singleton_model(|_| ActiveAgentViewsModel::new());
+    app.add_singleton_model(AgentNotificationsModel::new);
+    app.add_singleton_model(BlocklistAIPermissions::new);
+    let terminal_view_id = EntityId::new();
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(SyncQueue::mock);
+    app.add_singleton_model(|_| NetworkStatus::new());
+    app.add_singleton_model(TeamTesterStatus::mock);
+    app.add_singleton_model(UpdateManager::mock);
+    app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+    app.add_singleton_model(|ctx| {
+        AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+    });
+    app.add_singleton_model(PrivacySettings::mock);
+    app.add_singleton_model(UserWorkspaces::default_mock);
+    let conversation_id = history.update(app, |history_model, ctx| {
+        history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+    });
+    let start_agent_executor = app.add_model(StartAgentExecutor::new);
+    let executor =
+        app.add_model(|_| RunAgentsExecutor::new(start_agent_executor, terminal_view_id));
+
+    RunAgentsTestState {
+        conversation_id,
+        executor,
+    }
+}
+
+fn remote_run_agents_action(harness_type: &str) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from("run-agents-action".to_string()),
+        task_id: TaskId::new("run-agents-task".to_string()),
+        requires_result: true,
+        action: AIAgentActionType::RunAgents(RunAgentsRequest {
+            summary: "Run child agent".to_string(),
+            base_prompt: "Help".to_string(),
+            skills: vec![],
+            model_id: String::new(),
+            harness_type: harness_type.to_string(),
+            execution_mode: RunAgentsExecutionMode::Remote {
+                environment_id: "env-1".to_string(),
+                worker_host: "warp".to_string(),
+                computer_use_enabled: false,
+            },
+            agent_run_configs: vec![RunAgentsAgentRunConfig {
+                name: "child".to_string(),
+                prompt: "Help".to_string(),
+                title: String::new(),
+            }],
+            plan_id: String::new(),
+            harness_auth_secret_name: None,
+        }),
+    }
+}
+
+fn persist_default_auth_secret(app: &mut App, harness_config_name: &str, secret_name: &str) {
+    CloudAgentSettings::handle(app).update(app, |settings, ctx| {
+        let mut secrets = settings.last_selected_auth_secret.value().clone();
+        secrets.insert(harness_config_name.to_string(), secret_name.to_string());
+        settings
+            .last_selected_auth_secret
+            .set_value(secrets, ctx)
+            .unwrap();
+        settings
+            .inherit_auth_secret_harnesses
+            .set_value(HashMap::new(), ctx)
+            .unwrap();
+    });
+}
+
+#[test]
+fn should_not_autoexecute_remote_non_warp_harness_without_default_auth_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        let action = remote_run_agents_action("codex");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(!should_autoexecute);
+    });
+}
+
+#[test]
+fn should_autoexecute_remote_non_warp_harness_with_default_auth_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        persist_default_auth_secret(&mut app, "codex", "default-openai-key");
+        let action = remote_run_agents_action("codex");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(should_autoexecute);
+    });
+}
+
+#[test]
+fn should_autoexecute_remote_warp_harness_without_default_auth_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        let action = remote_run_agents_action("oz");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(should_autoexecute);
+    });
+}
+
+#[test]
+fn populate_default_auth_secret_for_autoexecute_uses_persisted_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        persist_default_auth_secret(&mut app, "claude", "default-anthropic-key");
+        let AIAgentActionType::RunAgents(mut request) = remote_run_agents_action("claude").action
+        else {
+            panic!("expected run_agents action");
+        };
+
+        state.executor.update(&mut app, |_, ctx| {
+            populate_default_auth_secret_for_autoexecute(&mut request, ctx);
+        });
+
+        assert_eq!(
+            request.harness_auth_secret_name.as_deref(),
+            Some("default-anthropic-key")
+        );
+    });
+}

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -46,6 +46,16 @@ fn persist_plan_config(
     plan_id: &str,
     status: OrchestrationConfigStatus,
 ) {
+    persist_plan_config_with_harness(app, conversation_id, plan_id, "oz", status);
+}
+
+fn persist_plan_config_with_harness(
+    app: &mut App,
+    conversation_id: AIConversationId,
+    plan_id: &str,
+    harness_type: &str,
+    status: OrchestrationConfigStatus,
+) {
     BlocklistAIHistoryModel::handle(app).update(app, |history, _ctx| {
         history
             .conversation_mut(&conversation_id)
@@ -54,7 +64,7 @@ fn persist_plan_config(
                 plan_id.to_string(),
                 OrchestrationConfig {
                     model_id: "auto".to_string(),
-                    harness_type: "oz".to_string(),
+                    harness_type: harness_type.to_string(),
                     execution_mode: OrchestrationExecutionMode::Remote {
                         environment_id: "env-1".to_string(),
                         worker_host: "warp".to_string(),
@@ -165,6 +175,33 @@ fn should_autoexecute_when_plan_has_approved_orchestration_config() {
         });
 
         assert!(should_autoexecute);
+    });
+}
+
+#[test]
+fn should_not_autoexecute_approved_remote_non_warp_plan_without_default_auth_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        persist_plan_config_with_harness(
+            &mut app,
+            state.conversation_id,
+            "plan-1",
+            "codex",
+            OrchestrationConfigStatus::Approved,
+        );
+        let action = with_plan_id(remote_run_agents_action("oz"), "plan-1");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(!should_autoexecute);
     });
 }
 

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
 use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode, RunAgentsRequest};
+use ai::agent::orchestration_config::{
+    OrchestrationConfig, OrchestrationConfigStatus, OrchestrationExecutionMode,
+};
 use settings::Setting;
 use warp_core::execution_mode::ExecutionMode;
 use warpui::{App, EntityId, ModelHandle};
@@ -11,6 +14,7 @@ use crate::ai::agent::task::TaskId;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::execution_profiles::RunAgentsPermission;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::{
@@ -27,6 +31,38 @@ use crate::{
 struct RunAgentsTestState {
     conversation_id: AIConversationId,
     executor: ModelHandle<RunAgentsExecutor>,
+}
+fn with_plan_id(mut action: AIAgentAction, plan_id: &str) -> AIAgentAction {
+    let AIAgentActionType::RunAgents(request) = &mut action.action else {
+        panic!("expected run_agents action");
+    };
+    request.plan_id = plan_id.to_string();
+    action
+}
+
+fn persist_plan_config(
+    app: &mut App,
+    conversation_id: AIConversationId,
+    plan_id: &str,
+    status: OrchestrationConfigStatus,
+) {
+    BlocklistAIHistoryModel::handle(app).update(app, |history, _ctx| {
+        history
+            .conversation_mut(&conversation_id)
+            .expect("conversation should exist")
+            .set_orchestration_config_for_plan(
+                plan_id.to_string(),
+                OrchestrationConfig {
+                    model_id: "auto".to_string(),
+                    harness_type: "oz".to_string(),
+                    execution_mode: OrchestrationExecutionMode::Remote {
+                        environment_id: "env-1".to_string(),
+                        worker_host: "warp".to_string(),
+                    },
+                },
+                status,
+            );
+    });
 }
 
 fn initialize_run_agents_test(app: &mut App, mode: ExecutionMode) -> RunAgentsTestState {
@@ -107,10 +143,142 @@ fn persist_default_auth_secret(app: &mut App, harness_config_name: &str, secret_
 }
 
 #[test]
-fn should_not_autoexecute_remote_non_warp_harness_without_default_auth_secret() {
+fn should_autoexecute_when_plan_has_approved_orchestration_config() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        persist_plan_config(
+            &mut app,
+            state.conversation_id,
+            "plan-1",
+            OrchestrationConfigStatus::Approved,
+        );
+        let action = with_plan_id(remote_run_agents_action("oz"), "plan-1");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(should_autoexecute);
+    });
+}
+
+#[test]
+fn execute_denies_disapproved_plan_config() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        persist_plan_config(
+            &mut app,
+            state.conversation_id,
+            "plan-1",
+            OrchestrationConfigStatus::Disapproved,
+        );
+        let action = with_plan_id(remote_run_agents_action("oz"), "plan-1");
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: state.conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+
+        let AnyActionExecution::Sync(AIAgentActionResultType::RunAgents(RunAgentsResult::Denied {
+            reason,
+        })) = execution
+        else {
+            panic!("expected synchronous run_agents denial");
+        };
+        assert_eq!(reason, "Orchestration config was disapproved");
+    });
+}
+
+#[test]
+fn execute_denies_never_allow_profile_setting() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        set_run_agents_permission(&mut app, RunAgentsPermission::NeverAllow);
+        let action = remote_run_agents_action("oz");
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: state.conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+
+        let AnyActionExecution::Sync(AIAgentActionResultType::RunAgents(RunAgentsResult::Denied {
+            reason,
+        })) = execution
+        else {
+            panic!("expected synchronous run_agents denial");
+        };
+        assert_eq!(
+            reason,
+            "Running child agents is disabled by the active execution profile."
+        );
+    });
+}
+
+#[test]
+fn autonomous_mode_autoexecutes_and_does_not_deny_missing_api_key() {
     App::test((), |mut app| async move {
         let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        set_run_agents_permission(&mut app, RunAgentsPermission::NeverAllow);
         let action = remote_run_agents_action("codex");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+        assert!(should_autoexecute);
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: state.conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+        assert!(matches!(execution, AnyActionExecution::Async { .. }));
+    });
+}
+
+fn set_run_agents_permission(app: &mut App, permission: RunAgentsPermission) {
+    AIExecutionProfilesModel::handle(app).update(app, |profiles, ctx| {
+        let profile_id = *profiles.active_profile(None, ctx).id();
+        profiles.set_run_agents(profile_id, permission, ctx);
+    });
+}
+
+#[test]
+fn should_not_autoexecute_without_approved_plan_or_always_allow_profile() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        let action = remote_run_agents_action("oz");
 
         let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
             executor.should_autoexecute(
@@ -127,9 +295,62 @@ fn should_not_autoexecute_remote_non_warp_harness_without_default_auth_secret() 
 }
 
 #[test]
+fn execute_denies_remote_non_warp_harness_without_default_auth_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        let action = remote_run_agents_action("codex");
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: state.conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+
+        let AnyActionExecution::Sync(AIAgentActionResultType::RunAgents(RunAgentsResult::Denied {
+            reason,
+        })) = execution
+        else {
+            panic!("expected synchronous run_agents denial");
+        };
+        assert_eq!(
+            reason,
+            "Cloud child agents using this harness require an API key before they can run."
+        );
+    });
+}
+
+#[test]
+fn should_autoexecute_remote_non_warp_harness_with_always_allow_even_without_default_auth_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        set_run_agents_permission(&mut app, RunAgentsPermission::AlwaysAllow);
+        let action = remote_run_agents_action("codex");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(should_autoexecute);
+    });
+}
+
+#[test]
 fn should_autoexecute_remote_non_warp_harness_with_default_auth_secret() {
     App::test((), |mut app| async move {
-        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        set_run_agents_permission(&mut app, RunAgentsPermission::AlwaysAllow);
         persist_default_auth_secret(&mut app, "codex", "default-openai-key");
         let action = remote_run_agents_action("codex");
 
@@ -150,7 +371,8 @@ fn should_autoexecute_remote_non_warp_harness_with_default_auth_secret() {
 #[test]
 fn should_autoexecute_remote_warp_harness_without_default_auth_secret() {
     App::test((), |mut app| async move {
-        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        set_run_agents_permission(&mut app, RunAgentsPermission::AlwaysAllow);
         let action = remote_run_agents_action("oz");
 
         let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
@@ -170,7 +392,7 @@ fn should_autoexecute_remote_warp_harness_without_default_auth_secret() {
 #[test]
 fn populate_default_auth_secret_for_autoexecute_uses_persisted_secret() {
     App::test((), |mut app| async move {
-        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
         persist_default_auth_secret(&mut app, "claude", "default-anthropic-key");
         let AIAgentActionType::RunAgents(mut request) = remote_run_agents_action("claude").action
         else {
@@ -178,7 +400,7 @@ fn populate_default_auth_secret_for_autoexecute_uses_persisted_secret() {
         };
 
         state.executor.update(&mut app, |_, ctx| {
-            populate_default_auth_secret_for_autoexecute(&mut request, ctx);
+            populate_default_auth_secret_for_execution(&mut request, ctx);
         });
 
         assert_eq!(

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -2466,16 +2466,6 @@ impl AIBlock {
             }
         }
 
-        // Now that streaming is complete and all RunAgents requests are
-        // fully populated, re-evaluate auto-launch for any card that
-        // was created during streaming with an empty agent_run_configs.
-        let conversation_id_for_auto_launch = self.client_ids.conversation_id;
-        for view in self.run_agents_card_views.values() {
-            view.update(ctx, |card, ctx| {
-                card.try_auto_launch_on_stream_complete(conversation_id_for_auto_launch, ctx);
-            });
-        }
-
         // Collect UI state handles for code snippets, tables, and image
         // tooltips in a single pass. Each handle type is collected in the
         // order its section type appears, matching the indices used during

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -16,7 +16,6 @@ use crate::ai::blocklist::telemetry::{
     OrchestrationExecutionModeKind, OrchestrationHarnessKind, RunAgentsCardDecision,
     RunAgentsCardDecisionEvent,
 };
-use crate::BlocklistAIHistoryModel;
 use ai::skills::SkillReference;
 use pathfinder_geometry::vector::vec2f;
 use std::rc::Rc;
@@ -211,15 +210,8 @@ pub struct RunAgentsCardView {
     state: RunAgentsEditState,
     handles: RunAgentsCardHandles,
     spawning: Option<RunAgentsSpawningSnapshot>,
-    /// Set when an approved plan config triggered immediate dispatch
-    /// without user confirmation.
-    auto_launched: bool,
-    /// Set when the action has a `RunAgentsResult::Denied` result in
-    /// history (e.g. orchestration was disabled at dispatch time).
-    is_denied: bool,
-    /// Retained from construction so `update_request()` can re-evaluate
-    /// the auto-launch condition when `agent_run_configs` arrives via
-    /// streaming after the initial empty chunk.
+    /// Retained for interactive defaults and telemetry about plan-sourced
+    /// orchestration state.
     active_config: Option<(OrchestrationConfig, OrchestrationConfigStatus)>,
 
     // Split-button accept menu state
@@ -243,20 +235,6 @@ pub struct RunAgentsCardView {
     /// One-shot guard: cancelling the auto-popped modal must not re-pop.
     /// Reset on harness / execution-mode change.
     has_auto_opened_create_modal: bool,
-}
-/// Computes the `is_denied` flag at construction time.
-///
-/// The card is denied when either the action already has a `Denied`
-/// result in history *or* the active config is explicitly disapproved.
-pub(crate) fn compute_is_denied(
-    has_denied_result: bool,
-    active_config: &Option<(OrchestrationConfig, OrchestrationConfigStatus)>,
-) -> bool {
-    has_denied_result
-        || matches!(
-            active_config,
-            Some((_, status)) if status.is_disapproved()
-        )
 }
 
 /// Resolves UI-only interactive defaults on edit state that has
@@ -315,28 +293,7 @@ impl RunAgentsCardView {
         block_model: Rc<dyn AIBlockModel<View = AIBlock>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        // Detect an existing Denied result from history (e.g. restored
-        // conversation where orchestration was disabled).
-        let is_denied = if let Some(AIActionStatus::Finished(result)) =
-            action_model.as_ref(ctx).get_action_status(&action_id)
-        {
-            matches!(
-                &result.result,
-                AIAgentActionResultType::RunAgents(RunAgentsResult::Denied { .. })
-            )
-        } else {
-            false
-        };
-
-        // Treat the action as denied when the config is explicitly
-        // disapproved — the card will auto-deny via the subscription
-        // once the action becomes blocked.
-        let is_denied = compute_is_denied(is_denied, &active_config);
-
-        // Auto-launch is deferred to try_auto_launch_on_stream_complete
-        // (called after streaming finishes and agent_run_configs is populated).
         let state = RunAgentsEditState::from_request(request);
-        let auto_launched = false;
         // Snapshot the raw incoming request so we can diff against the
         // edited state at Accept time.
         let original_tool_call_request = request.clone();
@@ -403,11 +360,6 @@ impl RunAgentsCardView {
         });
 
         // Re-render when this action finishes or becomes blocked.
-        // When `auto_launched` is true and the action becomes blocked,
-        // dispatch `execute_run_agents` — the deferred auto-launch
-        // only sets the flag and shows the spawning UI; the actual
-        // execution must wait until the action model has queued the
-        // action.
         let action_id_for_action_events = action_id.clone();
         ctx.subscribe_to_model(&action_model, move |me, _, event, ctx| match event {
             BlocklistAIActionEvent::FinishedAction { action_id, .. }
@@ -416,29 +368,19 @@ impl RunAgentsCardView {
                 ctx.notify();
             }
             BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(action_id)
-                if action_id == &action_id_for_action_events && me.is_denied =>
-            {
-                let action_id = me.action_id.clone();
-                me.action_model.update(ctx, |action_model, action_ctx| {
-                    action_model.deny_run_agents(&action_id, String::new(), action_ctx);
-                });
-            }
-            BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(action_id)
-                if action_id == &action_id_for_action_events && me.auto_launched =>
-            {
-                let request = me.state.to_request();
-                let action_id = me.action_id.clone();
-                me.action_model.update(ctx, |action_model, action_ctx| {
-                    action_model.execute_run_agents(&action_id, request, action_ctx);
-                });
-            }
-            BlocklistAIActionEvent::ActionBlockedOnUserConfirmation(action_id)
                 if action_id == &action_id_for_action_events =>
             {
                 // Normal case: streaming is complete and the action is
                 // ready for user confirmation. Re-render so the card
                 // transitions from the "Configuring agents..." placeholder
                 // to the full confirmation UI.
+                resolve_interactive_defaults(&mut me.state, &*me.block_model, ctx);
+                oc::repopulate_all_pickers(&mut me.state.orch, &me.handles.pickers, ctx);
+                me.refresh_accept_button_state(ctx);
+                me.maybe_auto_open_create_modal(ctx);
+                if let Some(conversation_id) = me.block_model.conversation_id(ctx) {
+                    me.emit_orchestration_entered_once(conversation_id, ctx);
+                }
                 ctx.notify();
             }
             _ => {}
@@ -503,8 +445,6 @@ impl RunAgentsCardView {
                 ..Default::default()
             },
             spawning: None,
-            auto_launched,
-            is_denied,
             active_config,
             is_accept_menu_open: false,
             accept_menu,
@@ -529,7 +469,7 @@ impl RunAgentsCardView {
 
     /// Re-sync edit state from the latest streaming request.
     pub fn update_request(&mut self, request: &RunAgentsRequest, ctx: &mut ViewContext<Self>) {
-        if self.spawning.is_some() || self.auto_launched || self.is_denied {
+        if self.spawning.is_some() {
             return;
         }
         // Keep the raw-tool-call snapshot in sync with the latest
@@ -576,77 +516,6 @@ impl RunAgentsCardView {
             self.maybe_auto_open_create_modal(ctx);
             ctx.notify();
         }
-    }
-
-    /// Re-evaluate auto-launch after the output stream has finished and
-    /// the request is fully populated. Avoids acting on partial streaming
-    /// chunks with an empty `agent_run_configs`.
-    pub fn try_auto_launch_on_stream_complete(
-        &mut self,
-        conversation_id: AIConversationId,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        // Refresh active_config: plan_id may have been empty at
-        // construction, and approval may have toggled mid-stream.
-        if !self.state.plan_id.is_empty() {
-            self.active_config = BlocklistAIHistoryModel::as_ref(ctx)
-                .conversation(&conversation_id)
-                .and_then(|conv| {
-                    conv.orchestration_config_for_plan(&self.state.plan_id)
-                        .map(|(c, s)| (c.clone(), s))
-                });
-            // Re-evaluate denied status with the refreshed config.
-            self.is_denied = compute_is_denied(self.is_denied, &self.active_config);
-        }
-        // If there's an approved config for this plan, the user has
-        // already approved these settings — auto-launch without
-        // needing to match individual fields.
-        if let Some((config, status)) = &self.active_config {
-            if status.is_approved()
-                && !self.auto_launched
-                && !self.is_denied
-                && self.spawning.is_none()
-                && !self.state.agent_run_configs.is_empty()
-            {
-                self.state.orch.override_from_approved_config(config);
-
-                // Re-resolve auth from settings keyed by the approved
-                // harness. Unconditional: a streaming-time selection may
-                // belong to a different harness and must not carry over.
-                // Honors an explicit `Inherit` choice persisted for this
-                // harness so auto-launch doesn't override it with a stale
-                // named fallback.
-                self.state.orch.auth_secret_selection =
-                    oc::resolve_auth_secret_selection_for_harness(
-                        &self.state.orch.harness_type,
-                        ctx,
-                    );
-                if oc::accept_disabled_reason_with_auth(&self.state.orch, ctx).is_none() {
-                    self.auto_launched = true;
-                    ctx.notify();
-                    return;
-                }
-            }
-        }
-
-        // No auto-launchable approved config — the confirmation card
-        // will be shown. Resolve from config (if any) then apply
-        // interactive defaults so the pickers display sensible values.
-        if let Some((config, status)) = &self.active_config {
-            if status.is_approved() {
-                self.state.orch.resolve_from_config(config);
-            }
-        }
-        resolve_interactive_defaults(&mut self.state, &*self.block_model, ctx);
-        oc::repopulate_all_pickers(&mut self.state.orch, &self.handles.pickers, ctx);
-        self.refresh_accept_button_state(ctx);
-        // First-chance fallback; don't reset the one-shot or we'd re-pop
-        // after the user cancelled.
-        self.maybe_auto_open_create_modal(ctx);
-
-        // The card is about to be shown — log it as an orchestration
-        // entry point.
-        self.emit_orchestration_entered_once(conversation_id, ctx);
     }
 
     /// Validates and dispatches the resolved request.
@@ -752,7 +621,7 @@ impl RunAgentsCardView {
         }
         // Skip non-interactive card states (render short-circuits to a
         // status-only card; the user can't act on a popped modal).
-        if self.is_denied || self.auto_launched || self.spawning.is_some() {
+        if self.spawning.is_some() {
             return;
         }
         if self.block_model.is_restored() {
@@ -1013,32 +882,12 @@ impl View for RunAgentsCardView {
             return Empty::new().finish();
         }
 
-        // Denied at construction — render static disabled card.
-        if self.is_denied {
-            return render_status_only_card(
-                "Orchestration is currently disabled. Re-enable on the plan card to launch."
-                    .to_string(),
-                appearance,
-                StatusKind::Cancelled,
-                app,
-            );
-        }
-
         // In-flight dispatch: check both spawning snapshot and action
         // status because the event arrives one tick after the status.
         if let Some(snapshot) = &self.spawning {
             return render_spawning_card(snapshot, appearance, app);
         }
         if matches!(status, Some(AIActionStatus::RunningAsync)) {
-            let snapshot = RunAgentsSpawningSnapshot {
-                agent_count: self.state.agent_run_configs.len(),
-            };
-            return render_spawning_card(&snapshot, appearance, app);
-        }
-
-        // Auto-launched: show spawning card while dispatch is in
-        // flight (before the executor fires the SpawningStarted event).
-        if self.auto_launched {
             let snapshot = RunAgentsSpawningSnapshot {
                 agent_count: self.state.agent_run_configs.len(),
             };

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -507,69 +507,6 @@ mod override_from_approved_config_tests {
     }
 }
 
-mod compute_is_denied_tests {
-    use super::super::compute_is_denied;
-    use ai::agent::orchestration_config::{
-        OrchestrationConfig, OrchestrationConfigStatus, OrchestrationExecutionMode,
-    };
-
-    fn some_config(
-        status: OrchestrationConfigStatus,
-    ) -> Option<(OrchestrationConfig, OrchestrationConfigStatus)> {
-        Some((
-            OrchestrationConfig {
-                model_id: "auto".to_string(),
-                harness_type: "oz".to_string(),
-                execution_mode: OrchestrationExecutionMode::Local,
-            },
-            status,
-        ))
-    }
-
-    #[test]
-    fn false_when_no_denied_result_and_no_config() {
-        assert!(!compute_is_denied(false, &None));
-    }
-
-    #[test]
-    fn true_when_has_denied_result_from_history() {
-        assert!(compute_is_denied(true, &None));
-    }
-
-    #[test]
-    fn true_when_config_is_disapproved() {
-        let config = some_config(OrchestrationConfigStatus::Disapproved);
-        assert!(compute_is_denied(false, &config));
-    }
-
-    #[test]
-    fn true_when_both_denied_and_disapproved() {
-        let config = some_config(OrchestrationConfigStatus::Disapproved);
-        assert!(compute_is_denied(true, &config));
-    }
-
-    #[test]
-    fn false_when_config_is_approved() {
-        let config = some_config(OrchestrationConfigStatus::Approved);
-        assert!(!compute_is_denied(false, &config));
-    }
-
-    #[test]
-    fn false_when_config_status_is_none() {
-        let config = some_config(OrchestrationConfigStatus::None);
-        assert!(!compute_is_denied(false, &config));
-    }
-
-    #[test]
-    fn denied_result_overrides_approved_config() {
-        let config = some_config(OrchestrationConfigStatus::Approved);
-        assert!(
-            compute_is_denied(true, &config),
-            "History denied result should take precedence over approved config"
-        );
-    }
-}
-
 #[test]
 fn local_to_cloud_idempotent_when_already_remote() {
     let mut state = RunAgentsEditState::from_request(&make_request(

--- a/app/src/ai/blocklist/permissions.rs
+++ b/app/src/ai/blocklist/permissions.rs
@@ -198,6 +198,7 @@ impl BlocklistAIPermissions {
             mcp_denylist: self.get_mcp_denylist_for_profile(ctx, profile_id),
             computer_use: self.get_computer_use_setting_for_profile(ctx, profile_id),
             ask_user_question: self.get_ask_user_question_setting_for_profile(ctx, profile_id),
+            run_agents: self.get_run_agents_setting_for_profile(ctx, profile_id),
 
             // Some fields are read directly from the profile.
             name: profile_data.name.clone(),
@@ -634,6 +635,29 @@ impl BlocklistAIPermissions {
         let active_profile =
             AIExecutionProfilesModel::as_ref(ctx).active_profile(terminal_view_id, ctx);
         self.get_ask_user_question_setting_for_profile(ctx, *active_profile.id())
+    }
+
+    pub fn get_run_agents_setting_for_profile(
+        &self,
+        ctx: &AppContext,
+        profile_id: ClientProfileId,
+    ) -> crate::ai::execution_profiles::RunAgentsPermission {
+        let profiles_model = AIExecutionProfilesModel::as_ref(ctx);
+        profiles_model
+            .get_profile_by_id(profile_id, ctx)
+            .unwrap_or_else(|| profiles_model.default_profile(ctx))
+            .data()
+            .run_agents
+    }
+
+    pub fn get_run_agents_setting(
+        &self,
+        ctx: &AppContext,
+        terminal_view_id: Option<EntityId>,
+    ) -> crate::ai::execution_profiles::RunAgentsPermission {
+        let active_profile =
+            AIExecutionProfilesModel::as_ref(ctx).active_profile(terminal_view_id, ctx);
+        self.get_run_agents_setting_for_profile(ctx, *active_profile.id())
     }
 
     /// Returns whether or not Agent Mode can auto-read the given files.

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -2,7 +2,7 @@ use crate::ai::blocklist::BlocklistAIPermissions;
 use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
 use crate::ai::execution_profiles::{
     profiles::{AIExecutionProfilesModel, AIExecutionProfilesModelEvent, ClientProfileId},
-    AIExecutionProfile, ActionPermission, WriteToPtyPermission,
+    AIExecutionProfile, ActionPermission, RunAgentsPermission, WriteToPtyPermission,
 };
 use crate::ai::llms::{
     DisableReason, LLMContextWindow, LLMId, LLMInfo, LLMPreferences, LLMPreferencesEvent,
@@ -123,6 +123,7 @@ struct TooltipMouseStateHandles {
     write_to_pty_tooltip_mouse_state: MouseStateHandle,
     computer_use_tooltip_mouse_state: MouseStateHandle,
     ask_user_question_tooltip_mouse_state: MouseStateHandle,
+    run_agents_tooltip_mouse_state: MouseStateHandle,
     call_mcp_servers_tooltip_mouse_state: MouseStateHandle,
     // Separate mouse state handles for text input editors (for workspace override tooltips)
     command_allowlist_editor_tooltip_mouse_state: MouseStateHandle,
@@ -189,6 +190,9 @@ pub enum ExecutionProfileEditorViewAction {
     SetAskUserQuestion {
         permission: super::AskUserQuestionPermission,
     },
+    SetRunAgents {
+        permission: RunAgentsPermission,
+    },
     AddToCommandAllowlist {
         predicate: AgentModeCommandExecutionPredicate,
     },
@@ -248,6 +252,7 @@ pub struct ExecutionProfileEditorView {
     call_mcp_servers_dropdown: ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
     computer_use_dropdown: ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
     ask_user_question_dropdown: ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
+    run_agents_dropdown: ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
     command_allowlist_editor: ViewHandle<SubmittableTextInput>,
     command_denylist_editor: ViewHandle<SubmittableTextInput>,
     directory_allowlist_editor: ViewHandle<SubmittableTextInput>,
@@ -467,6 +472,33 @@ impl ExecutionProfileEditorView {
             dropdown
         });
 
+        let run_agents_dropdown = ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_items(
+                vec![
+                    DropdownItem::new(
+                        "Never",
+                        ExecutionProfileEditorViewAction::SetRunAgents {
+                            permission: RunAgentsPermission::NeverAllow,
+                        },
+                    ),
+                    DropdownItem::new(
+                        "Always allow",
+                        ExecutionProfileEditorViewAction::SetRunAgents {
+                            permission: RunAgentsPermission::AlwaysAllow,
+                        },
+                    ),
+                    DropdownItem::new(
+                        "Always ask",
+                        ExecutionProfileEditorViewAction::SetRunAgents {
+                            permission: RunAgentsPermission::AlwaysAsk,
+                        },
+                    ),
+                ],
+                ctx,
+            );
+            dropdown
+        });
         let mcp_allowlist_dropdown = ctx.add_typed_action_view(|ctx| {
             let mut dropdown = FilterableDropdown::new(ctx);
             dropdown.set_menu_header_to_static("Select MCP servers");
@@ -624,6 +656,7 @@ impl ExecutionProfileEditorView {
             call_mcp_servers_dropdown,
             computer_use_dropdown,
             ask_user_question_dropdown,
+            run_agents_dropdown,
             command_allowlist_editor,
             command_denylist_editor,
             directory_allowlist_editor,
@@ -889,6 +922,7 @@ impl ExecutionProfileEditorView {
         let computer_use_disabled = !ai_settings.is_computer_use_permissions_editable(ctx);
         let ask_user_question_disabled =
             !ai_settings.is_ask_user_question_permissions_editable(ctx);
+        let run_agents_disabled = !ai_settings.is_run_agents_permissions_editable(ctx);
         let mcp_disabled = !ai_settings.is_mcp_permission_editable(ctx);
 
         Self::refresh_filterable_model_dropdown(
@@ -964,6 +998,12 @@ impl ExecutionProfileEditorView {
             &self.ask_user_question_dropdown,
             current_permissions.ask_user_question,
             ask_user_question_disabled,
+            ctx,
+        );
+        Self::refresh_run_agents_dropdown_menu(
+            &self.run_agents_dropdown,
+            current_permissions.run_agents,
+            run_agents_disabled,
             ctx,
         );
         Self::refresh_mcp_dropdown(
@@ -1078,6 +1118,31 @@ impl ExecutionProfileEditorView {
                 super::AskUserQuestionPermission::AskExceptInAutoApprove
                 | super::AskUserQuestionPermission::Unknown => 1,
                 super::AskUserQuestionPermission::AlwaysAsk => 2,
+            };
+
+            menu.set_selected_by_index(active, ctx);
+            ctx.notify();
+        });
+        ctx.notify();
+    }
+
+    fn refresh_run_agents_dropdown_menu(
+        menu: &ViewHandle<Dropdown<ExecutionProfileEditorViewAction>>,
+        current_permission: RunAgentsPermission,
+        disabled: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        menu.update(ctx, |menu, ctx| {
+            if !disabled {
+                menu.set_enabled(ctx);
+            } else {
+                menu.set_disabled(ctx);
+            }
+
+            let active = match current_permission {
+                RunAgentsPermission::NeverAllow | RunAgentsPermission::Unknown => 0,
+                RunAgentsPermission::AlwaysAllow => 1,
+                RunAgentsPermission::AlwaysAsk => 2,
             };
 
             menu.set_selected_by_index(active, ctx);
@@ -1587,6 +1652,12 @@ impl TypedActionView for ExecutionProfileEditorView {
             ExecutionProfileEditorViewAction::SetAskUserQuestion { permission } => {
                 AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles_model, ctx| {
                     profiles_model.set_ask_user_question(self.profile_id, *permission, ctx);
+                });
+                ctx.notify();
+            }
+            ExecutionProfileEditorViewAction::SetRunAgents { permission } => {
+                AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles_model, ctx| {
+                    profiles_model.set_run_agents(self.profile_id, *permission, ctx);
                 });
                 ctx.notify();
             }

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -499,7 +499,7 @@ impl ExecutionProfileEditorView {
             );
             dropdown
         });
-        
+
         let mcp_allowlist_dropdown = ctx.add_typed_action_view(|ctx| {
             let mut dropdown = FilterableDropdown::new(ctx);
             dropdown.set_menu_header_to_static("Select MCP servers");

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -499,6 +499,7 @@ impl ExecutionProfileEditorView {
             );
             dropdown
         });
+        
         let mcp_allowlist_dropdown = ctx.add_typed_action_view(|ctx| {
             let mut dropdown = FilterableDropdown::new(ctx);
             dropdown.set_menu_header_to_static("Select MCP servers");

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -552,6 +552,17 @@ pub fn render_permissions_section(
             .ask_user_question_tooltip_mouse_state
             .clone(),
     ));
+    column.add_child(render_permission_row(
+        appearance,
+        Icon::Workflow,
+        "Run agents",
+        &view.run_agents_dropdown,
+        profile_data.run_agents.description(),
+        !ai_settings.is_run_agents_permissions_editable(app),
+        view.tooltip_mouse_state_handles
+            .run_agents_tooltip_mouse_state
+            .clone(),
+    ));
 
     column.add_child(render_permission_row(
         appearance,

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -554,8 +554,8 @@ pub fn render_permissions_section(
     ));
     column.add_child(render_permission_row(
         appearance,
-        Icon::Workflow,
-        "Run agents",
+        Icon::Atom,
+        "Run orchestrated agents",
         &view.run_agents_dropdown,
         profile_data.run_agents.description(),
         !ai_settings.is_run_agents_permissions_editable(app),

--- a/app/src/ai/execution_profiles/mod.rs
+++ b/app/src/ai/execution_profiles/mod.rs
@@ -179,6 +179,46 @@ impl ComputerUsePermission {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RunAgentsPermission {
+    NeverAllow,
+    AlwaysAllow,
+    #[default]
+    AlwaysAsk,
+
+    // This is intended to catch deserialization errors whenever we add new variants to this enum.
+    #[serde(other)]
+    Unknown,
+}
+
+impl RunAgentsPermission {
+    pub fn description(&self) -> &'static str {
+        match self {
+            RunAgentsPermission::NeverAllow => {
+                "The Agent cannot run child agents and the run_agents tool will not be available."
+            }
+            RunAgentsPermission::AlwaysAllow => {
+                "Give the Agent full autonomy to run child agents without approval."
+            }
+            RunAgentsPermission::AlwaysAsk => {
+                "Require explicit approval before the Agent runs child agents."
+            }
+            RunAgentsPermission::Unknown => "Unknown setting.",
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, Self::AlwaysAllow | Self::AlwaysAsk)
+    }
+
+    pub fn is_always_allow(&self) -> bool {
+        matches!(self, Self::AlwaysAllow)
+    }
+
+    pub fn is_never_allow(&self) -> bool {
+        matches!(self, Self::NeverAllow | Self::Unknown)
+    }
+}
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AskUserQuestionPermission {
     /// Never pause; skip questions and continue with best judgment.
     Never,
@@ -238,6 +278,7 @@ pub struct AIExecutionProfile {
     pub write_to_pty: WriteToPtyPermission,
     pub mcp_permissions: ActionPermission,
     pub ask_user_question: AskUserQuestionPermission,
+    pub run_agents: RunAgentsPermission,
 
     /// Always ask for permission for these commands
     pub command_denylist: Vec<AgentModeCommandExecutionPredicate>,
@@ -278,6 +319,7 @@ impl Default for AIExecutionProfile {
             write_to_pty: WriteToPtyPermission::AlwaysAsk,
             mcp_permissions: ActionPermission::AgentDecides,
             ask_user_question: AskUserQuestionPermission::AlwaysAsk,
+            run_agents: RunAgentsPermission::AlwaysAsk,
             command_denylist: DEFAULT_COMMAND_EXECUTION_DENYLIST.clone(),
             command_allowlist: Vec::new(),
             directory_allowlist: Vec::new(),
@@ -330,6 +372,7 @@ impl AIExecutionProfile {
             write_to_pty: WriteToPtyPermission::AlwaysAllow,
             mcp_permissions: ActionPermission::AlwaysAllow,
             ask_user_question: AskUserQuestionPermission::Never,
+            run_agents: RunAgentsPermission::AlwaysAllow,
             command_denylist: Vec::new(),
             command_allowlist: Vec::new(),
             directory_allowlist: Vec::new(),
@@ -385,6 +428,7 @@ impl AIExecutionProfile {
             mcp_permissions: ActionPermission::AlwaysAllow,
             write_to_pty: WriteToPtyPermission::AlwaysAllow,
             ask_user_question: AskUserQuestionPermission::Never,
+            run_agents: RunAgentsPermission::AlwaysAllow,
             command_denylist,
             command_allowlist: DEFAULT_COMMAND_EXECUTION_ALLOWLIST.to_vec(),
             directory_allowlist: Vec::new(),

--- a/app/src/ai/execution_profiles/mod.rs
+++ b/app/src/ai/execution_profiles/mod.rs
@@ -218,6 +218,7 @@ impl RunAgentsPermission {
         matches!(self, Self::NeverAllow | Self::Unknown)
     }
 }
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AskUserQuestionPermission {
     /// Never pause; skip questions and continue with best judgment.

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -840,6 +840,39 @@ impl AIExecutionProfilesModel {
         }
     }
 
+    pub fn set_run_agents(
+        &mut self,
+        profile_id: ClientProfileId,
+        permission: super::RunAgentsPermission,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let current_value = self
+            .get_profile_by_id(profile_id, ctx)
+            .map(|p| p.data().run_agents);
+
+        self.edit_profile_internal(
+            profile_id,
+            |profile| {
+                if profile.run_agents != permission {
+                    profile.run_agents = permission;
+                    return true;
+                }
+                false
+            },
+            ctx,
+        );
+
+        if current_value != Some(permission) {
+            send_telemetry_from_ctx!(
+                TelemetryEvent::AIExecutionProfileSettingUpdated {
+                    setting_type: "run_agents".to_string(),
+                    setting_value: format!("{permission:?}"),
+                },
+                ctx
+            );
+        }
+    }
+
     pub fn set_web_search_enabled(
         &mut self,
         profile_id: ClientProfileId,

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1892,6 +1892,10 @@ impl AISettings {
         self.is_any_ai_enabled(app)
     }
 
+    pub fn is_run_agents_permissions_editable(&self, app: &AppContext) -> bool {
+        self.is_orchestration_enabled(app)
+    }
+
     pub fn show_code_suggestion_speedbump(&self, app: &AppContext) -> bool {
         self.is_any_ai_enabled(app) && *self.show_code_suggestion_speedbump
     }

--- a/app/src/settings_view/execution_profile_view.rs
+++ b/app/src/settings_view/execution_profile_view.rs
@@ -3,7 +3,7 @@ use crate::ai::execution_profiles::profiles::{
     AIExecutionProfilesModel, AIExecutionProfilesModelEvent, ClientProfileId,
 };
 use crate::ai::execution_profiles::{
-    ActionPermission, AskUserQuestionPermission, WriteToPtyPermission,
+    ActionPermission, AskUserQuestionPermission, RunAgentsPermission, WriteToPtyPermission,
 };
 use crate::ai::llms::LLMPreferences;
 use crate::appearance::Appearance;
@@ -300,6 +300,15 @@ impl View for ExecutionProfileView {
                                 Icon::MessageText,
                                 "Ask questions:",
                                 &profile.ask_user_question,
+                                appearance,
+                                is_any_ai_enabled,
+                            ),
+                        ));
+                        permissions_column.add_child(with_standard_vertical_margin(
+                            render_run_agents_permission_line_with_icon(
+                                Icon::Workflow,
+                                "Run agents:",
+                                &profile.run_agents,
                                 appearance,
                                 is_any_ai_enabled,
                             ),
@@ -743,6 +752,20 @@ fn render_ask_user_question_permission_line_with_icon(
     render_permission_line_with_icon(icon, label, permission_text, appearance, is_ai_enabled)
 }
 
+fn render_run_agents_permission_line_with_icon(
+    icon: Icon,
+    label: impl Into<String>,
+    permission: &RunAgentsPermission,
+    appearance: &Appearance,
+    is_ai_enabled: bool,
+) -> Box<dyn Element> {
+    let permission_text = match permission {
+        RunAgentsPermission::NeverAllow | RunAgentsPermission::Unknown => "Never",
+        RunAgentsPermission::AlwaysAllow => "Always allow",
+        RunAgentsPermission::AlwaysAsk => "Always ask",
+    };
+    render_permission_line_with_icon(icon, label, permission_text, appearance, is_ai_enabled)
+}
 fn render_bool_permission_line_with_icon(
     icon: Icon,
     label: impl Into<String>,

--- a/app/src/settings_view/execution_profile_view.rs
+++ b/app/src/settings_view/execution_profile_view.rs
@@ -766,6 +766,7 @@ fn render_run_agents_permission_line_with_icon(
     };
     render_permission_line_with_icon(icon, label, permission_text, appearance, is_ai_enabled)
 }
+
 fn render_bool_permission_line_with_icon(
     icon: Icon,
     label: impl Into<String>,

--- a/app/src/workspace/view/orchestration_launch_modal/view.rs
+++ b/app/src/workspace/view/orchestration_launch_modal/view.rs
@@ -71,7 +71,7 @@ const FEATURE_ITEMS: &[FeatureItem] = &[
         badge: None,
     },
     FeatureItem {
-        icon: Icon::Atom02,
+        icon: Icon::Atom,
         title: "Multi-agent orchestration",
         description: "Warp Agents will now orchestrate swarms of subagents, allowing you to parallelize tasks.",
         badge: None,

--- a/crates/warp_core/src/ui/icons.rs
+++ b/crates/warp_core/src/ui/icons.rs
@@ -312,7 +312,7 @@ pub enum Icon {
     MessageChatSquare,
     Pin,
     PinFilled,
-    Atom02,
+    Atom,
     Cognition,
     Dataflow04,
     // Language-specific icons for the code block dropdown
@@ -635,7 +635,7 @@ impl From<Icon> for &'static str {
             Icon::ClockPlus => "bundled/svg/clock-plus.svg",
             Icon::HeartHand => "bundled/svg/heart-hand.svg",
             Icon::MessageChatSquare => "bundled/svg/message-chat-square.svg",
-            Icon::Atom02 => "bundled/svg/atom-02.svg",
+            Icon::Atom => "bundled/svg/atom-02.svg",
             Icon::Cognition => "bundled/svg/cognition.svg",
             Icon::Dataflow04 => "bundled/svg/dataflow-04.svg",
             Icon::MermaidLang => "bundled/svg/file_type/mermaid.svg",


### PR DESCRIPTION
## Description
Adds an execution profile permission for the `run_agents` tool call with three options:
- Never allow
- Always allow
- Always ask

This wires the setting through profile persistence, the profile editor, profile summaries, API tool advertisement, and executor enforcement so disabled profiles do not expose or run the tool.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

No linked issue.

## Testing
- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo test -p warp supported_tools_ --lib`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; not manually tested in the app UI.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Added an execution profile permission for controlling whether agents can use `run_agents`.

Co-Authored-By: Oz <oz-agent@warp.dev>
