### PR TITLE
Softwrap helper text below the Repo field in the create environment form

### DIFF
--- a/app/src/settings_view/update_environment_form.rs
+++ b/app/src/settings_view/update_environment_form.rs
@@ -1,9 +1,10 @@
 use super::{
     editor_text_colors,
-    settings_page::{render_input_list, InputListItem},
+    settings_page::{InputListItem, render_input_list},
 };
 use crate::server::server_api::ServerApiProvider;
 use crate::{
+    ChannelState,
     ai::ambient_agents::{
         github_auth_url::{self, AuthSource, GithubAuthRedirectTarget},
         telemetry::CloudAgentTelemetryEvent,
@@ -21,12 +22,11 @@ use crate::{
     server::ids::SyncId,
     ui_components::{buttons::icon_button, icons::Icon},
     view_components::{
+        SubmittableTextInput, SubmittableTextInputEvent, WarningBoxButtonConfig, WarningBoxConfig,
         action_button::{ActionButton, DangerSecondaryTheme, PrimaryTheme},
-        render_warning_box, SubmittableTextInput, SubmittableTextInputEvent,
-        WarningBoxButtonConfig, WarningBoxConfig,
+        render_warning_box,
     },
     workspaces::user_workspaces::UserWorkspaces,
-    ChannelState,
 };
 use instant::{Duration, Instant};
 use log::debug;
@@ -37,6 +37,8 @@ use warp_core::send_telemetry_from_ctx;
 use warp_editor::editor::NavigationKey;
 use warp_graphql::queries::user_github_info::UserGithubInfoResult;
 use warpui::{
+    AppContext, Entity, FocusContext, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
     elements::{
         Border, ChildAnchor, ChildView, Clipped, ClippedScrollStateHandle, ClippedScrollable,
         ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Dismiss, Element, Empty,
@@ -52,8 +54,6 @@ use warpui::{
     platform::Cursor,
     prelude::Coords,
     ui_components::components::{UiComponent, UiComponentStyles},
-    AppContext, Entity, FocusContext, SingletonEntity, TypedActionView, View, ViewContext,
-    ViewHandle,
 };
 
 const SUBMIT_BUTTON_FOCUSED: &str = "SubmitButtonFocused";
@@ -2335,14 +2335,13 @@ impl UpdateEnvironmentForm {
             // "Missing a repo? Configure access on GitHub" text with link
             let install_link = app_install_link.clone();
 
-            // Build as a row with plain text + link
-            let mut text_row = Flex::row()
+            // Build the "Missing a repo? [link]" row
+            let mut missing_repo_row = Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_spacing(4.);
 
-            text_row.add_child(helper);
             // Plain text part
-            text_row.add_child(
+            missing_repo_row.add_child(
                 Text::new(
                     "Missing a repo?",
                     appearance.ui_font_family(),
@@ -2377,9 +2376,15 @@ impl UpdateEnvironmentForm {
             })
             .finish();
 
-            text_row.add_child(link);
+            missing_repo_row.add_child(link);
 
-            text_row.finish()
+            // Stack helper text and the missing-repo row in a column so that the helper text
+            // can softwrap across the full field width instead of overflowing on a single line.
+            Flex::column()
+                .with_spacing(2.)
+                .with_child(helper)
+                .with_child(missing_repo_row.finish())
+                .finish()
         }
 
         #[cfg(target_family = "wasm")]


### PR DESCRIPTION
## Description
Softwrap the helper text below the Repo(s) field in the create/edit environment form.

Previously all three text spans ("Type owner/repo and press Enter to add…", "Missing a repo?", and "Configure access on GitHub") were siblings in a single `Flex::row()`. Because `Flex::row()` never constrains a child's width, the text never wrapped — it just overflowed and got clipped.

**Fix:** restructure `render_repo_helper_text_row` to use `Flex::column()`:
- Row 1: hint text — now gets the full field width and wraps as needed.
- Row 2: "Missing a repo? [Configure access on GitHub]" — compact row, unchanged visually.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://app.warp.dev/conversation/1a8ef08e-3d39-4add-910b-5cd47fef9a99_
_Run: https://oz.warp.dev/runs/019e3cb9-fa5a-75c8-b02d-1980ea4dfab9_
_This PR was generated with [Oz](https://warp.dev/oz)._
