### PR TITLE
Softwrap helper text below repo field in create environment form

### DIFF
--- a/app/src/settings_view/update_environment_form.rs
+++ b/app/src/settings_view/update_environment_form.rs
@@ -2322,6 +2322,7 @@ impl UpdateEnvironmentForm {
             appearance.ui_font_family(),
             appearance.ui_font_size() * 0.85,
         )
+        .soft_wrap(true)
         .with_color(theme.nonactive_ui_text_color().into())
         .finish();
 
@@ -2335,14 +2336,13 @@ impl UpdateEnvironmentForm {
             // "Missing a repo? Configure access on GitHub" text with link
             let install_link = app_install_link.clone();
 
-            // Build as a row with plain text + link
-            let mut text_row = Flex::row()
+            // Build "Missing a repo?" + link as an inner row
+            let mut missing_repo_row = Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_spacing(4.);
 
-            text_row.add_child(helper);
             // Plain text part
-            text_row.add_child(
+            missing_repo_row.add_child(
                 Text::new(
                     "Missing a repo?",
                     appearance.ui_font_family(),
@@ -2377,9 +2377,16 @@ impl UpdateEnvironmentForm {
             })
             .finish();
 
-            text_row.add_child(link);
+            missing_repo_row.add_child(link);
 
-            text_row.finish()
+            // Stack helper text and "Missing a repo?" row in a column so the
+            // helper text can softwrap without truncating the link.
+            Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .with_spacing(2.)
+                .with_child(helper)
+                .with_child(missing_repo_row.finish())
+                .finish()
         }
 
         #[cfg(target_family = "wasm")]


### PR DESCRIPTION
## Description
Softwrap the helper text below the Repo(s) field in the create/edit environment form.

Previously `render_repo_helper_text_row` placed all three elements—the instruction text, "Missing a repo?", and the "Configure access on GitHub" link—in a single `Flex::row()`. This caused the text to overflow and get clipped instead of wrapping.

**Changes:**
- Add `.soft_wrap(true)` to the "Type owner/repo and press Enter..." `Text` element.
- Restructure the layout from a single flat `Flex::row()` to a `Flex::column()` with:
  - Row 1: the instruction text (softwraps as needed)
  - Row 2: "Missing a repo? [Configure access on GitHub]" inner row

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://app.warp.dev/conversation/4c4a2d66-2788-4c7a-b206-a010ef46988c_
_Run: https://oz.warp.dev/runs/019e3cbb-8ddb-75e4-ad5f-4a0092d5c9dd_

_This PR was generated with [Oz](https://warp.dev/oz)._
