### PR TITLE
Show environment pane close icon without hover

### DIFF
--- a/app/src/settings_view/environments_page.rs
+++ b/app/src/settings_view/environments_page.rs
@@ -577,6 +577,23 @@ impl EnvironmentsPageView {
     pub fn pane_configuration(&self) -> ModelHandle<crate::pane_group::pane::PaneConfiguration> {
         self.pane_configuration.clone()
     }
+
+    fn render_pane_header_content() -> HeaderContent {
+        HeaderContent::Standard(StandardHeader {
+            title: "Environments".to_string(),
+            title_secondary: None,
+            title_style: None,
+            title_clip_config: warpui::text_layout::ClipConfig::start(),
+            title_max_width: None,
+            left_of_title: None,
+            right_of_title: None,
+            left_of_overflow: None,
+            options: StandardHeaderOptions {
+                always_show_icons: true,
+                ..Default::default()
+            },
+        })
+    }
     pub fn set_github_auth_redirect_target(
         &mut self,
         target: GithubAuthRedirectTarget,
@@ -2045,7 +2062,7 @@ impl SettingsPageMeta for EnvironmentsPageView {
 use crate::pane_group::{
     focus_state::PaneFocusHandle,
     pane::{
-        view::{HeaderContent, HeaderRenderContext},
+        view::{HeaderContent, HeaderRenderContext, StandardHeader, StandardHeaderOptions},
         BackingView,
     },
 };
@@ -2078,7 +2095,7 @@ impl BackingView for EnvironmentsPageView {
         _ctx: &HeaderRenderContext<'_>,
         _app: &AppContext,
     ) -> HeaderContent {
-        HeaderContent::simple("Environments")
+        Self::render_pane_header_content()
     }
 
     fn set_focus_handle(&mut self, focus_handle: PaneFocusHandle, _ctx: &mut ViewContext<Self>) {

--- a/app/src/settings_view/environments_page_tests.rs
+++ b/app/src/settings_view/environments_page_tests.rs
@@ -840,6 +840,18 @@ fn test_set_github_auth_redirect_target_updates_form() {
 }
 
 #[test]
+fn test_environment_pane_header_always_shows_icons() {
+    let HeaderContent::Standard(header) = EnvironmentsPageView::render_pane_header_content() else {
+        panic!("Environment pane should use a standard header");
+    };
+
+    assert!(
+        header.options.always_show_icons,
+        "environment pane header icons should remain visible without hover"
+    );
+}
+
+#[test]
 fn test_render_empty_state_shows_github_remote_and_local_rows() {
     // Empty-state UI should include GitHub-remote (suggested) and agent-assisted local repos paths.
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description
- Keep the Environment Management pane header controls visible without requiring hover, so the close icon is always available like other always-visible pane headers.
- Extract the environment pane header construction into a helper and add a focused unit test for the `always_show_icons` behavior.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt -- --check`
- [x] `cargo test -p warp test_environment_pane_header_always_shows_icons --lib`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Screenshot validation was delegated to a subagent. The sandbox cannot run live app screenshot capture because there is no `DISPLAY`/`WAYLAND_DISPLAY` and no available `xvfb-run`/`Xvfb`/`weston`, so the attached artifact is a labeled fallback visual, not a live Warp screenshot.

- Fallback visual artifact: `environment_pane_close_icon_fallback.png` (Oz conversation artifact `019e3cd6-7792-700b-90dc-e49240d9dce4`)
- Original local artifact path from validation: `/tmp/environment-pane-close-icon-screenshots/environment_pane_close_icon_fallback.png`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the Environment Management pane header so its close icon remains visible without hover.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/e8dc1eac-4971-4da6-8617-4f86ee8be27c_
_Run: https://oz.warp.dev/runs/019e3cba-7ffe-736a-8c67-2d41313809fa_
_This PR was generated with [Oz](https://warp.dev/oz)._
