### PR TITLE
Throttle ambient agent task fetch based on RTC invalidation message.

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -53,6 +53,7 @@ use warpui::{
 };
 
 const POLLING_INTERVAL: Duration = Duration::from_secs(30);
+const RTC_TASK_REFRESH_THROTTLE: Duration = Duration::from_secs(5);
 const INITIAL_TASK_AMOUNT: i32 = 100;
 
 /// How long to skip refetching a task that just failed with a transient error
@@ -85,6 +86,34 @@ enum TaskFetchState {
     /// can back off for [`TRANSIENT_FETCH_FAILURE_COOLDOWN`] before retrying.
     /// The `String` carries a human-readable description of the failure for display in the UI.
     TransientlyFailed { at: Instant, message: String },
+}
+
+/// Tracks the cooldown window for RTC-triggered task-list refreshes. Pending events keep
+/// the earliest timestamp in the burst because `updated_after` is a lower bound; using the
+/// latest timestamp could skip tasks that changed earlier in the same window.
+#[derive(Default)]
+enum RtcTaskRefreshThrottleState {
+    #[default]
+    Idle,
+    CoolingDown {
+        pending_timestamp: Option<DateTime<Utc>>,
+        timer_abort_handle: AbortHandle,
+    },
+}
+
+fn record_earliest_rtc_task_refresh_timestamp(
+    pending_timestamp: &mut Option<DateTime<Utc>>,
+    timestamp: DateTime<Utc>,
+) {
+    match pending_timestamp {
+        Some(existing_timestamp) if timestamp < *existing_timestamp => {
+            *existing_timestamp = timestamp;
+        }
+        None => {
+            *pending_timestamp = Some(timestamp);
+        }
+        Some(_) => {}
+    }
 }
 
 /// Protected eviction: we'll always keep at least 200 personal tasks in the model.
@@ -495,6 +524,7 @@ pub struct AgentConversationsModel {
     /// the meaning of each variant. Tasks that have been successfully fetched live in `tasks`
     /// and are absent from this map.
     task_fetch_state: HashMap<AmbientAgentTaskId, TaskFetchState>,
+    rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState,
 }
 
 pub enum AgentConversationsModelEvent {
@@ -541,6 +571,7 @@ impl AgentConversationsModel {
                 active_data_consumers_per_window: HashMap::new(),
                 has_finished_initial_load: true,
                 task_fetch_state: HashMap::new(),
+                rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
             };
         }
 
@@ -578,6 +609,7 @@ impl AgentConversationsModel {
             active_data_consumers_per_window: HashMap::new(),
             has_finished_initial_load: false,
             task_fetch_state: HashMap::new(),
+            rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
         };
 
         // Only sync local conversations if we're not in CLI mode. Server-side data
@@ -644,7 +676,58 @@ impl AgentConversationsModel {
         ctx: &mut ModelContext<Self>,
     ) {
         if let UpdateManagerEvent::AmbientTaskUpdated { timestamp } = event {
-            self.fetch_tasks_updated_after(*timestamp, ctx);
+            match std::mem::take(&mut self.rtc_task_refresh_throttle_state) {
+                RtcTaskRefreshThrottleState::Idle => {
+                    self.fetch_tasks_updated_after(*timestamp, ctx);
+                    self.start_rtc_task_refresh_throttle_timer(ctx);
+                }
+                RtcTaskRefreshThrottleState::CoolingDown {
+                    mut pending_timestamp,
+                    timer_abort_handle,
+                } => {
+                    record_earliest_rtc_task_refresh_timestamp(&mut pending_timestamp, *timestamp);
+                    self.rtc_task_refresh_throttle_state =
+                        RtcTaskRefreshThrottleState::CoolingDown {
+                            pending_timestamp,
+                            timer_abort_handle,
+                        };
+                }
+            }
+        }
+    }
+
+    fn start_rtc_task_refresh_throttle_timer(&mut self, ctx: &mut ModelContext<Self>) {
+        let future_handle = ctx.spawn(
+            async move {
+                Timer::after(RTC_TASK_REFRESH_THROTTLE).await;
+            },
+            |model, _, ctx| {
+                let pending_timestamp =
+                    match std::mem::take(&mut model.rtc_task_refresh_throttle_state) {
+                        RtcTaskRefreshThrottleState::Idle => None,
+                        RtcTaskRefreshThrottleState::CoolingDown {
+                            pending_timestamp, ..
+                        } => pending_timestamp,
+                    };
+
+                if let Some(timestamp) = pending_timestamp {
+                    model.fetch_tasks_updated_after(timestamp, ctx);
+                    model.start_rtc_task_refresh_throttle_timer(ctx);
+                }
+            },
+        );
+        self.rtc_task_refresh_throttle_state = RtcTaskRefreshThrottleState::CoolingDown {
+            pending_timestamp: None,
+            timer_abort_handle: future_handle.abort_handle(),
+        };
+    }
+
+    fn abort_rtc_task_refresh_throttle(&mut self) {
+        if let RtcTaskRefreshThrottleState::CoolingDown {
+            timer_abort_handle, ..
+        } = std::mem::take(&mut self.rtc_task_refresh_throttle_state)
+        {
+            timer_abort_handle.abort();
         }
     }
 
@@ -1741,6 +1824,7 @@ impl AgentConversationsModel {
         self.tasks.clear();
         self.conversations.clear();
         self.abort_existing_poll();
+        self.abort_rtc_task_refresh_throttle();
         self.active_data_consumers_per_window.clear();
         self.task_fetch_state.clear();
         // Reset the initial load flag so that we can retry the initial sync with the new logged in user

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -36,10 +36,10 @@ use super::entry::{
     AgentConversationEntryId, AgentConversationNavigationSubject, AgentConversationProvenance,
 };
 use super::{
-    AgentConversationsModel, AgentConversationsModelEvent, AgentManagementFilters,
-    AgentRunDisplayStatus, ArtifactFilter, ConversationMetadata, ConversationUpdateKind,
-    EnvironmentFilter, HarnessFilter, OwnerFilter, StatusFilter, TaskFetchState,
-    MAX_PERSONAL_TASKS, MAX_TEAM_TASKS,
+    record_earliest_rtc_task_refresh_timestamp, AgentConversationsModel,
+    AgentConversationsModelEvent, AgentManagementFilters, AgentRunDisplayStatus, ArtifactFilter,
+    ConversationMetadata, ConversationUpdateKind, EnvironmentFilter, HarnessFilter, OwnerFilter,
+    RtcTaskRefreshThrottleState, StatusFilter, TaskFetchState, MAX_PERSONAL_TASKS, MAX_TEAM_TASKS,
 };
 use crate::ai::ambient_agents::task::HarnessConfig;
 use crate::workspace::WorkspaceAction;
@@ -580,7 +580,40 @@ fn create_test_model() -> AgentConversationsModel {
         active_data_consumers_per_window: HashMap::new(),
         has_finished_initial_load: false,
         task_fetch_state: Default::default(),
+        rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
     }
+}
+
+#[test]
+fn rtc_task_refresh_pending_timestamp_records_first_timestamp() {
+    let timestamp = Utc::now();
+    let mut pending_timestamp = None;
+
+    record_earliest_rtc_task_refresh_timestamp(&mut pending_timestamp, timestamp);
+
+    assert_eq!(pending_timestamp, Some(timestamp));
+}
+
+#[test]
+fn rtc_task_refresh_pending_timestamp_keeps_earliest_timestamp() {
+    let earliest_timestamp = Utc::now();
+    let later_timestamp = earliest_timestamp + Duration::seconds(3);
+    let mut pending_timestamp = Some(earliest_timestamp);
+
+    record_earliest_rtc_task_refresh_timestamp(&mut pending_timestamp, later_timestamp);
+
+    assert_eq!(pending_timestamp, Some(earliest_timestamp));
+}
+
+#[test]
+fn rtc_task_refresh_pending_timestamp_replaces_later_timestamp() {
+    let earliest_timestamp = Utc::now();
+    let later_timestamp = earliest_timestamp + Duration::seconds(3);
+    let mut pending_timestamp = Some(later_timestamp);
+
+    record_earliest_rtc_task_refresh_timestamp(&mut pending_timestamp, earliest_timestamp);
+
+    assert_eq!(pending_timestamp, Some(earliest_timestamp));
 }
 
 fn create_test_conversation_metadata(

--- a/specs/ambient-agent-rtc-refresh-throttle/TECH.md
+++ b/specs/ambient-agent-rtc-refresh-throttle/TECH.md
@@ -1,0 +1,37 @@
+# Ambient agent RTC refresh throttling — Tech Spec
+## Context
+Ambient agent task updates arrive through the Warp Drive RTC subscription. `WarpDriveUpdate::AmbientTaskUpdated` is converted into `ObjectUpdateMessage::AmbientTaskUpdated` in `app/src/workspaces/gql_convert.rs:1124`, then forwarded through `Listener::get_warp_drive_updates` in `app/src/server/cloud_objects/listener.rs:351`. `UpdateManager::received_message_from_server` gates the event on `FeatureFlag::AmbientAgentsRTC` in `app/src/server/cloud_objects/update_manager.rs:1278` and emits `UpdateManagerEvent::AmbientTaskUpdated { timestamp }` from `handle_ambient_task_changed` in `app/src/server/cloud_objects/update_manager.rs:1119`.
+`AgentConversationsModel::new` subscribes to `UpdateManager` when `AmbientAgentsRTC` is enabled in `app/src/ai/agent_conversations_model.rs:568`. Today `AgentConversationsModel::handle_update_manager_event` immediately calls `fetch_tasks_updated_after` for every task update event in `app/src/ai/agent_conversations_model.rs:641`. That method calls `AIClient::list_ambient_agent_tasks` with `TaskListFilter { updated_after: Some(timestamp - 1 second) }`, which maps to `GET /api/v1/agent/runs` in `app/src/server/server_api/ai.rs:1726`.
+This creates request volume proportional to team-wide ambient task update volume. For users in large Warp teams, many unrelated cloud agent task updates can trigger many list-run requests from every client. The non-RTC periodic polling path in `AgentConversationsModel::poll_for_tasks` uses a 30 second interval and is disabled while `AmbientAgentsRTC` is enabled in `should_be_polling` at `app/src/ai/agent_conversations_model.rs:893`. The orchestration viewer has a 5 second polling cadence in `app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs`, but it is not an event-stream throttle and should not be reused directly.
+## Proposed changes
+Add an RTC-only leading/trailing throttle inside `AgentConversationsModel`. Keep `Listener` and `UpdateManager` as generic event plumbing; the request-volume policy belongs at the single consumer that owns `list_ambient_agent_tasks`.
+Add a module-local constant:
+- `RTC_TASK_REFRESH_THROTTLE: Duration = Duration::from_secs(5)`
+Add an internal throttle state to `AgentConversationsModel`:
+- `Idle` when no throttle window is active.
+- `CoolingDown { pending_timestamp, timer_abort_handle }` after a refresh has fired and the 5 second cooldown timer is active.
+When `handle_update_manager_event` receives `UpdateManagerEvent::AmbientTaskUpdated`:
+- If state is `Idle`, call `fetch_tasks_updated_after(timestamp, ctx)` immediately and start a 5 second cooldown timer.
+- If state is `CoolingDown`, merge the event into `pending_timestamp` without issuing a request.
+When the cooldown timer expires:
+- If `pending_timestamp` is present, call `fetch_tasks_updated_after(pending_timestamp, ctx)` and start a new cooldown timer.
+- If there is no pending timestamp, return to `Idle`.
+The pending timestamp must be the earliest timestamp observed during the cooldown window. The server filter is `updated_after`, so latest-timestamp coalescing could skip runs updated earlier in the window after the leading request began. Earliest-timestamp coalescing may over-fetch a small window, but it preserves correctness and still caps request volume.
+Leave `fetch_tasks_updated_after` as the raw fetch method so initial sync, manual filter fetches, and future direct callers do not inherit RTC throttling accidentally. Keep the existing 1 second subtraction buffer because the server filter is strict and server/client clocks can differ.
+On `reset`, abort any active RTC throttle timer and clear pending state to avoid a trailing fetch after logout. Keep the existing `spawn_with_retry_on_error` behavior for each logical fetch; this change caps logical fetch starts, and retry policy can be revisited separately if backend attempt volume remains too high.
+## Testing and validation
+Add focused unit coverage for the throttle's timestamp coalescing helper:
+- no pending timestamp records the first timestamp;
+- later timestamps do not replace the earliest pending timestamp;
+- earlier timestamps replace the pending timestamp.
+If a future patch adds an injectable `AIClient` seam or fake clock for `AgentConversationsModel`, add model-level tests for:
+- a burst of RTC events causes one immediate fetch and one trailing fetch;
+- the trailing fetch uses the earliest pending timestamp;
+- `reset` cancels any pending trailing refresh;
+- RTC disabled keeps the existing periodic polling behavior unchanged.
+Run targeted validation:
+- `cargo nextest run -E 'test(rtc_task_refresh)'`
+- `cargo check -p warp`
+Before opening or updating a PR, run the repository-required format and clippy checks. Do not use `cargo fmt --all` or file-specific `cargo fmt`.
+## Parallelization
+Do not split implementation across sub-agents. The change is small and tightly coupled: the spec, throttle state, event handling, reset cleanup, and tests all live around `AgentConversationsModel`. Parallel edits would touch the same files and add merge overhead without meaningful wall-clock savings.


### PR DESCRIPTION
## Description

Throttles task re-fetching triggered by RTC invalidation messages to maximum of 1 fetch every 5 seconds. Prevents spammy task list fetching in common scenarios where members of a team have access to all other teammate's agent runs, an update to each of which triggers an RTC invalidation message

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->