### PR TITLE
Clip requested action text in narrow panes

### DIFF
--- a/app/src/ai/blocklist/inline_action/requested_action.rs
+++ b/app/src/ai/blocklist/inline_action/requested_action.rs
@@ -454,9 +454,15 @@ fn render_requested_action_row_for_element(
     // in Align, because Align always reports the full constraint width, which would
     // inflate the text row and force the button to a new line unconditionally.
     if has_action_button {
-        text_row.add_child(Shrinkable::new(1., element).finish());
+        text_row.add_child(Shrinkable::new(1., Clipped::new(element).finish()).finish());
     } else {
-        text_row.add_child(Shrinkable::new(1., Align::new(element).left().finish()).finish());
+        text_row.add_child(
+            Shrinkable::new(
+                1.,
+                Clipped::new(Align::new(element).left().finish()).finish(),
+            )
+            .finish(),
+        );
     }
 
     let content = if let Some(action_button) = action_button {


### PR DESCRIPTION
## Description
Clips requested action row body content to the same shrinkable bounds as the rounded row background. This prevents long action text (for example file paths like `skills-lock.json:6`) from painting past the row background when the pane is narrow.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Slack feedback: https://warp-core.slack.com/archives/C08KTPNQN65/p1779141317356059

## Testing
- [x] `cargo fmt -p warp --check --manifest-path /workspace/warp/Cargo.toml`
- [x] `cargo check -p warp --manifest-path /workspace/warp/Cargo.toml`
- [ ] `cargo clippy -p warp --all-targets --manifest-path /workspace/warp/Cargo.toml -- -D warnings` (blocked by unrelated existing clippy errors in `warpui_core`/`warpui`; the first failures are `clippy::collapsible_match`, `clippy::unnecessary_unwrap`, and `clippy::unnecessary_sort_by` outside this change)
- [ ] I have manually tested my changes locally with `./script/run` (not run in this headless sandbox)

### Screenshots / Videos
Original Slack screenshot showed action text overflowing past the rounded row background at narrow pane widths. I was not able to capture a local UI screenshot in this headless sandbox.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed AI inline action row text overflowing past its rounded background in narrow panes.

_Conversation: https://staging.warp.dev/conversation/d4528770-a5bc-4402-a923-0b994ca20545_
_Run: https://oz.staging.warp.dev/runs/019e3d16-30b6-76af-a06f-bbc828128c77_
_This PR was generated with [Oz](https://warp.dev/oz)._
