### PR TITLE
Fix compact reject hover affordance

### DIFF
--- a/app/src/ai/blocklist/inline_action/inline_action_header.rs
+++ b/app/src/ai/blocklist/inline_action/inline_action_header.rs
@@ -96,6 +96,78 @@ impl RightClickConfig {
     }
 }
 
+fn render_compact_action_button_row_with_header_icon(
+    buttons: Vec<&dyn RenderCompactibleActionButton>,
+    header_icon: Option<warpui::elements::Icon>,
+    appearance: &Appearance,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let mut row = Flex::row()
+        .with_main_axis_alignment(MainAxisAlignment::End)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_main_axis_size(MainAxisSize::Min);
+
+    for (index, button) in buttons.into_iter().enumerate() {
+        let element = if index == 0 {
+            if let (Some(icon), Some(mouse_state)) = (
+                header_icon.clone(),
+                button.compact_button_mouse_state_handle(app),
+            ) {
+                render_compact_button_with_header_icon(button, icon, mouse_state, appearance, app)
+            } else {
+                button.render_compact_button()
+            }
+        } else {
+            button.render_compact_button()
+        };
+
+        let mut container = Container::new(element);
+        if index != 0 {
+            container = container.with_margin_left(8.);
+        }
+        row.add_child(container.finish());
+    }
+
+    row.finish()
+}
+
+fn render_compact_button_with_header_icon(
+    button: &dyn RenderCompactibleActionButton,
+    header_icon: warpui::elements::Icon,
+    mouse_state: MouseStateHandle,
+    appearance: &Appearance,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    Hoverable::new(mouse_state, move |mouse_state| {
+        let icon_size = icon_size(app);
+        let icon = Container::new(
+            ConstrainedBox::new(header_icon.clone().finish())
+                .with_width(icon_size)
+                .with_height(icon_size)
+                .finish(),
+        )
+        .with_margin_left(8.)
+        .finish();
+
+        let row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_child(icon)
+            .with_child(button.render_compact_button())
+            .finish();
+
+        let mut container =
+            Container::new(row).with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
+        if mouse_state.is_hovered() {
+            container = container.with_background(internal_colors::fg_overlay_2(theme));
+        }
+        container.finish()
+    })
+    .with_defer_events_to_children()
+    .finish()
+}
+
 #[derive(Clone)]
 pub enum InteractionMode {
     /// Renders action buttons.
@@ -191,6 +263,15 @@ impl HeaderConfig {
         app: &AppContext,
         interaction_mode_content: Option<Box<dyn Element>>,
     ) -> Box<dyn Element> {
+        self.render_header_with_options(app, interaction_mode_content, true)
+    }
+
+    fn render_header_with_options(
+        self,
+        app: &AppContext,
+        interaction_mode_content: Option<Box<dyn Element>>,
+        show_icon: bool,
+    ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let header_background = theme.surface_2();
@@ -204,7 +285,7 @@ impl HeaderConfig {
             .with_main_axis_alignment(MainAxisAlignment::Start)
             .with_cross_axis_alignment(CrossAxisAlignment::Center);
 
-        if let Some(icon) = self.icon {
+        if let (true, Some(icon)) = (show_icon, self.icon) {
             left_content_container.add_child(
                 Container::new(
                     ConstrainedBox::new(icon.finish())
@@ -367,11 +448,20 @@ impl HeaderConfig {
                     let button_refs: Vec<&dyn RenderCompactibleActionButton> =
                         action_buttons.iter().map(|b| b.as_ref()).collect();
 
-                    let (regular_row, compact_row) =
+                    let (regular_row, _) =
                         render_compact_and_regular_button_rows(button_refs, None, appearance, app);
+                    let compact_button_refs: Vec<&dyn RenderCompactibleActionButton> =
+                        action_buttons.iter().map(|b| b.as_ref()).collect();
+                    let compact_row = render_compact_action_button_row_with_header_icon(
+                        compact_button_refs,
+                        self.icon.clone(),
+                        appearance,
+                        app,
+                    );
 
                     let regular_header = self.clone().render_header(app, Some(regular_row));
-                    let compact_header = self.render_header(app, Some(compact_row));
+                    let compact_header =
+                        self.render_header_with_options(app, Some(compact_row), false);
 
                     let size_switch_threshold =
                         size_switch_threshold * appearance.monospace_ui_scalar();

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -414,6 +414,10 @@ impl ActionButton {
         self.disabled
     }
 
+    pub fn mouse_state_handle(&self) -> MouseStateHandle {
+        self.mouse_state_handle.clone()
+    }
+
     /// Returns the height of the button.
     pub fn height(&self, app: &AppContext) -> f32 {
         let appearance = Appearance::as_ref(app);

--- a/app/src/view_components/compactible_action_button.rs
+++ b/app/src/view_components/compactible_action_button.rs
@@ -11,7 +11,7 @@ use warp_core::ui::appearance::Appearance;
 use warpui::{
     elements::{
         ChildView, ConstrainedBox, Container, CrossAxisAlignment, Flex, MainAxisAlignment,
-        MainAxisSize, ParentElement,
+        MainAxisSize, MouseStateHandle, ParentElement,
     },
     Action, AppContext, Element, TypedActionView, View, ViewContext, ViewHandle,
 };
@@ -34,6 +34,10 @@ pub struct CompactibleActionButton {
 pub trait RenderCompactibleActionButton {
     fn render_expanded_button(&self) -> Box<dyn Element>;
     fn render_compact_button(&self) -> Box<dyn Element>;
+
+    fn compact_button_mouse_state_handle(&self, _app: &AppContext) -> Option<MouseStateHandle> {
+        None
+    }
 }
 
 impl CompactibleActionButton {
@@ -166,6 +170,10 @@ impl RenderCompactibleActionButton for CompactibleActionButton {
     }
     fn render_compact_button(&self) -> Box<dyn Element> {
         ChildView::new(self.compact_button()).finish()
+    }
+
+    fn compact_button_mouse_state_handle(&self, app: &AppContext) -> Option<MouseStateHandle> {
+        Some(self.compact_button().as_ref(app).mouse_state_handle())
     }
 }
 

--- a/app/src/view_components/compactible_split_action_button.rs
+++ b/app/src/view_components/compactible_split_action_button.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use warpui::elements::{ChildView, Flex, ParentElement, SavePosition};
-use warpui::{Action, Element, TypedActionView, View, ViewContext, ViewHandle};
+use warpui::{Action, AppContext, Element, TypedActionView, View, ViewContext, ViewHandle};
 
 use crate::view_components::action_button::AdjoinedSide;
 use crate::view_components::compactible_action_button::RenderCompactibleActionButton;
@@ -128,5 +128,12 @@ impl RenderCompactibleActionButton for CompactibleSplitActionButton {
     }
     fn render_compact_button(&self) -> Box<dyn Element> {
         self.render_button(false)
+    }
+
+    fn compact_button_mouse_state_handle(
+        &self,
+        app: &AppContext,
+    ) -> Option<warpui::elements::MouseStateHandle> {
+        self.primary_button.compact_button_mouse_state_handle(app)
     }
 }


### PR DESCRIPTION
## Description
Fixes compact inline action headers so the reject affordance hover background includes both the status icon (yellow square) and the `X` icon.

In compact mode, the header status icon is now rendered as part of the first compact action button group and shares that button's mouse state. The regular/full-width header layout is unchanged.

## Linked Issue
Slack feedback: "the hover of this reject button should always include both the yellow square and the x"

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- [ ] I have manually tested my changes locally with `./script/run`

`rustfmt` was not available in the sandbox toolchain (`rustfmt` component missing), so file-level formatting could not be run here.

### Screenshots / Videos
Not captured in this sandbox.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the compact reject affordance hover state so it includes both the yellow status square and the X icon.

_Conversation: https://staging.warp.dev/conversation/95ed4c30-6aaf-43eb-8ab0-37c2ba9c3123_
_Run: https://oz.staging.warp.dev/runs/019e3d16-6e71-7db7-9e62-a74f85887545_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
