### PR TITLE
Custom model TOS hyperlink coloring

### DIFF
--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -53,6 +53,7 @@ use strum::IntoEnumIterator;
 use warp_core::channel::ChannelState;
 use warp_core::context_flag::ContextFlag;
 use warp_core::features::FeatureFlag;
+use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::color::internal_colors;
 use warpui::elements::{
     Border, ChildAnchor, ChildView, ConstrainedBox, CornerRadius, CrossAxisAlignment, Dismiss,
@@ -7106,7 +7107,13 @@ impl ApiKeysWidget {
                                 appearance.theme().background().into_solid(),
                                 self.custom_inference_terms_index.clone(),
                             )
-                            .with_hyperlink_font_color(appearance.theme().accent().into_solid())
+                            .with_hyperlink_font_color(
+                                appearance
+                                    .theme()
+                                    .accent()
+                                    .blend(&warp_core::ui::theme::Fill::black().with_opacity(50))
+                                    .into_solid(),
+                            )
                             .register_default_click_handlers(|url, ctx, _| {
                                 ctx.dispatch_typed_action(AISettingsPageAction::HyperlinkClick(
                                     url,

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -53,8 +53,10 @@ use strum::IntoEnumIterator;
 use warp_core::channel::ChannelState;
 use warp_core::context_flag::ContextFlag;
 use warp_core::features::FeatureFlag;
-use warp_core::ui::color::blend::Blend;
+use warp_core::ui::color::contrast::MinimumAllowedContrast;
+use warp_core::ui::color::ContrastingColor;
 use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::Fill as ThemeFill;
 use warpui::elements::{
     Border, ChildAnchor, ChildView, ConstrainedBox, CornerRadius, CrossAxisAlignment, Dismiss,
     Empty, Expanded, Fill, Hoverable, HyperlinkLens, MainAxisAlignment, MainAxisSize,
@@ -7092,6 +7094,7 @@ impl ApiKeysWidget {
                 ". BYOK and custom endpoints are intended for individual use and small teams. Companies or organizations with more than 10 employees should use Warp Business or Enterprise.",
             ),
         ])]);
+        let tooltip_background = appearance.theme().tooltip_background();
 
         let info_button =
             Hoverable::new(self.custom_inference_info_tooltip.clone(), move |state| {
@@ -7111,8 +7114,11 @@ impl ApiKeysWidget {
                                 appearance
                                     .theme()
                                     .accent()
-                                    .blend(&warp_core::ui::theme::Fill::black().with_opacity(50))
-                                    .into_solid(),
+                                    .on_background(
+                                        ThemeFill::Solid(tooltip_background),
+                                        MinimumAllowedContrast::Text,
+                                    )
+                                    .into(),
                             )
                             .register_default_click_handlers(|url, ctx, _| {
                                 ctx.dispatch_typed_action(AISettingsPageAction::HyperlinkClick(
@@ -7121,7 +7127,7 @@ impl ApiKeysWidget {
                             })
                             .finish(),
                         )
-                        .with_background_color(appearance.theme().tooltip_background())
+                        .with_background_color(tooltip_background)
                         .with_vertical_padding(4.)
                         .with_horizontal_padding(8.)
                         .with_border(Border::all(1.).with_border_fill(appearance.theme().outline()))


### PR DESCRIPTION
### Issue
The warp terms of service hyperlink on custom inference settings was not readable because of coloring

### Before

<img width="512" height="193" alt="Screenshot 2026-05-18 at 6 27 11 PM" src="https://github.com/user-attachments/assets/431111ad-0e84-454d-ad53-8337eee60618" />

<img width="424" height="175" alt="Screenshot 2026-05-18 at 6 27 39 PM" src="https://github.com/user-attachments/assets/d3b5151c-33b4-4386-89b2-9c36925ae127" />

### After

<img width="452" height="146" alt="Screenshot 2026-05-18 at 6 27 59 PM" src="https://github.com/user-attachments/assets/2837a611-fc1a-480d-a8c0-e859466d8ab5" />

<img width="445" height="210" alt="Screenshot 2026-05-18 at 6 28 47 PM" src="https://github.com/user-attachments/assets/243fede8-ec11-4478-9a35-ffd1a88078aa" />
