### PR TITLE
Fix stale git diff chip and code review button

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -773,6 +773,16 @@ impl CurrentPrompt {
                             output: value.as_ref(),
                             timed_out,
                         });
+                        // GitDiffStats has two value sources that can race when entering a repo:
+                        // this shell fallback (`git diff --shortstat HEAD`, tracked changes only)
+                        // and a repo-status watcher that also counts untracked files. If the
+                        // watcher attached while this fallback was in flight, drop the fallback's
+                        // result
+                        if matches!(chip_kind, ContextChipKind::GitDiffStats)
+                            && me.is_updated_externally(&chip_kind)
+                        {
+                            return;
+                        }
 
                         if timed_out {
                             if suppress_on_failure
@@ -1429,6 +1439,16 @@ impl CurrentPrompt {
             if let Some(old_strong) = old_weak.upgrade(ctx) {
                 ctx.unsubscribe_from_model(&old_strong);
             }
+        }
+
+        // Repo detached, clear GitDiffStats.
+        if handle.is_none() {
+            if let Some(state) = self.states.get_mut(&ContextChipKind::GitDiffStats) {
+                state.clear_abort_handlers();
+                state.clear_cache();
+            }
+            let _ = self.update_tx.try_send(());
+            return;
         }
 
         if let Some(weak) = handle {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4813,6 +4813,10 @@ impl TerminalView {
         self.input.update(ctx, |input, ctx| {
             input.update_repo_path(None, ctx);
         });
+        // Redraw on repo exit so the code review button drops its diff annotation immediately.
+        self.refresh_pane_header(ctx);
+        ctx.emit(Event::TerminalViewStateChanged);
+        ctx.notify();
     }
 
     /// Helper to read metadata from the per-repo sub-model.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4813,10 +4813,6 @@ impl TerminalView {
         self.input.update(ctx, |input, ctx| {
             input.update_repo_path(None, ctx);
         });
-        // Redraw on repo exit so the code review button drops its diff annotation immediately.
-        self.refresh_pane_header(ctx);
-        ctx.emit(Event::TerminalViewStateChanged);
-        ctx.notify();
     }
 
     /// Helper to read metadata from the per-repo sub-model.


### PR DESCRIPTION
## Description

Resolves #11016 

The `GitDiffStats` prompt chip and code review button could show stale state when entering or leaving a git repository.

Problem 1 — Flicker on entering a repo: The chip has two value sources: a shell fallback (git diff --shortstat HEAD, tracked changes only) and a repo-status watcher that also counts untracked files. On cd into a repo there is a race that can cause untracked files to not appear in the diff chip.

Problem 2 — Stale state on leaving a repo: When cd'ing out of a repository, the chip's last value and the code review button's diff annotation are not immediately cleared.

This PR resolves both of these issues

## Changes
- `fetch_chip_value_once()`: If the repo-status watcher attached while a GitDiffStats shell-fallback command was in flight, discard the fallback's result so it can't overwrite the watcher's accurate value.
- `set_git_repo_status()`: On repo detach, immediately abort in-flight handlers and clear the cached GitDiffStats value, then signal a re-render.
-  `clear_git_repo_status()` : On repo exit, refresh the pane header and emit TerminalViewStateChanged so the code review button drops its diff annotation immediately.


## Linked Issue

https://linear.app/warpdotdev/issue/REMOTE-1699/git-diff-chip-not-updating-until-terminal-command-is-run

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

[Demo of issue](https://www.loom.com/share/42e8748176f04510a530727cb7fe7f61) (Note that the code review button also shows stale diffs upon leaving a directory)
[Demo of fix ](https://www.loom.com/share/c1b06e3c8804498ab3d958570f6d0c71) (Untracked file changes now appear right away in the diff chip. Diff chip and code review button are both cleared upon exiting a repo)



## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed the git diff prompt chip flickering on entering a repository, and stale git diff state on the prompt chip and code review button when leaving a repository.
