### PR TITLE
Fix scrollable dropdown menu background

### DIFF
--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -2114,7 +2114,7 @@ impl<A: Action + Clone> SubMenu<A> {
                         ScrollbarWidth::Auto,
                         appearance.theme().nonactive_ui_detail().into(),
                         appearance.theme().active_ui_detail().into(),
-                        warpui::elements::Fill::None,
+                        menu_background_color.into(),
                     )
                     .with_overlayed_scrollbar()
                     .finish(),


### PR DESCRIPTION
## Description
Use the menu surface fill for scrollable menu content instead of `Fill::None`, so dropdowns render an opaque themed background and do not allow controls underneath to bleed through.

This fixes the New API key modal dropdown path and applies consistently to shared scrollable menus.

## Linked Issue
Slack thread: "New API key dropdown needs a background."

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --all --manifest-path /workspace/warp/Cargo.toml --check`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --bin warp-oss`
- `cargo build --manifest-path /workspace/warp/Cargo.toml -p warp --bin warp-oss`
- `cargo build --manifest-path /workspace/warp/Cargo.toml -p warp --bin dev --features skip_login`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp menu --lib` — 165 passed
- Attempted `cargo clippy --manifest-path /workspace/warp/Cargo.toml --workspace --all-targets --all-features --tests -- -D warnings`; it is currently blocked by existing warnings-as-errors in `warpui_core` before reaching this change.
- Computer use: launched the native dev client with `skip_login`, opened Settings → Cloud platform → Oz Cloud API Keys → New API key. The test account had no agents, so the Agent selector rendered its empty state; the Expiration dropdown, which uses the same shared scrollable menu path, rendered with an opaque background and no bleed-through.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not attached; verified with computer use in the sandbox.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed scrollable dropdown menus, including the New API key modal dropdown, rendering without an opaque background.

_Conversation: https://staging.warp.dev/conversation/74ab9246-dfad-4521-8cf2-9b7cb01a1bd6_
_Run: https://oz.staging.warp.dev/runs/019e3d33-f739-7a3c-bd7d-3e78fc503c34_
_This PR was generated with [Oz](https://warp.dev/oz)._
