### PR TITLE
[QUALITY-662] Fix orchestration pill hover contrast to match Figma

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -9,6 +9,7 @@ use std::hash::{Hash, Hasher};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use warp_cli::agent::Harness;
+use warp_core::ui::color::blend::Blend;
 use warp_core::ui::color::coloru_with_opacity;
 use warp_core::ui::theme::Fill;
 use warp_core::ui::{appearance::Appearance, theme::WarpTheme};
@@ -42,7 +43,9 @@ use crate::ai::blocklist::agent_view::orchestration_conversation_links::{
 use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::{
     OrchestrationPillBarEvent, OrchestrationPillBarModel,
 };
-use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
+use crate::ai::blocklist::agent_view::{
+    agent_view_bg_color, AgentViewController, AgentViewControllerEvent,
+};
 use crate::ai::blocklist::orchestration_topology::descendant_conversation_ids_in_spawn_order;
 use crate::ai::blocklist::telemetry::{
     BlocklistOrchestrationTelemetryEvent, PillBarActionKind, PillBarInteractionEvent,
@@ -1681,6 +1684,17 @@ fn render_pill(
     let status = spec.status;
     let is_remote_child = spec.is_remote_child;
 
+    // Per Figma: fg_overlay_2 at rest, fg_overlay_3 on hover, composed over
+    // the agent-view surface. Pre-blend to a solid so the avatar cutout ring
+    // matches the painted pill exactly.
+    let pill_rest_bg = Fill::from(agent_view_bg_color(app))
+        .blend(&internal_colors::fg_overlay_2(theme))
+        .into_solid();
+    let pill_hover_bg = Fill::from(agent_view_bg_color(app))
+        .blend(&internal_colors::fg_overlay_3(theme))
+        .into_solid();
+    let pill_text_color = internal_colors::text_main(theme, theme.background());
+
     // `Hoverable::new`'s build closure is `FnOnce` (see
     // `crates/warpui_core/src/elements/hoverable.rs`). We can therefore move
     // `label` into the closure by value rather than cloning it on every
@@ -1697,15 +1711,9 @@ fn render_pill(
                 theme.background().into_solid(),
             )
         } else if hover_state.is_hovered() || hover_state.is_clicked() || menu_is_open_for_this {
-            (
-                warp_core::ui::theme::color::internal_colors::neutral_3(theme),
-                warp_core::ui::theme::color::internal_colors::text_main(theme, theme.background()),
-            )
+            (pill_hover_bg, pill_text_color)
         } else {
-            (
-                warp_core::ui::theme::color::internal_colors::neutral_2(theme),
-                warp_core::ui::theme::color::internal_colors::text_main(theme, theme.background()),
-            )
+            (pill_rest_bg, pill_text_color)
         };
 
         let show_dots = show_overflow_button && (hover_state.is_hovered() || menu_is_open_for_this);


### PR DESCRIPTION
Before:
<img width="297" height="66" alt="image" src="https://github.com/user-attachments/assets/3d08ecf2-a19c-4582-92eb-b754a64c5b8e" />

<img width="276" height="79" alt="image" src="https://github.com/user-attachments/assets/83f48b36-972f-4c87-b937-926c5826479d" />

After:
<img width="293" height="75" alt="image" src="https://github.com/user-attachments/assets/f3fcc7c7-3b10-40a1-8f20-cf44fec915f4" />

<img width="288" height="72" alt="image" src="https://github.com/user-attachments/assets/b96611ca-619d-4cda-9975-b919f5b100ab" />


## Description
Fixes [QUALITY-662](https://linear.app/warp/issue/QUALITY-662): the orchestration pill bar's child pills were not visibly responding to hover, and the rest colors looked darker than the Figma spec.

The pills were using `neutral_2`/`neutral_3`, which pre-blend the overlay against pure `theme.background()`. But the pill bar sits on the agent-view surface (`surface_overlay_1`), so the painted color came out darker than spec and the rest→hover contrast bump barely read.

Switched to composing `fg_overlay_2` (rest) and `fg_overlay_3` (hover) over `agent_view_bg_color`, then resolving to a solid so the avatar cutout ring still matches the painted pill exactly. Matches the [Figma spec](https://www.figma.com/design/AsF5uAM6L5tUmc11vm9YSi/Agent-orchestration?node-id=4061-21568).

Selected and selected-hover paths are unchanged (already use `theme.foreground()` per spec).

Fixes https://linear.app/warpdotdev/issue/QUALITY-662/improve-hover-contrast-on-pill-buttons

Co-Authored-By: Oz <oz-agent@warp.dev>
