### PR TITLE
fix(tab-configs): let a focused picker own Space (#11138)

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1614,6 +1614,8 @@ pub(crate) fn initialize_app(
     billing::shared_objects_creation_denied_modal::init(ctx);
     tab_configs::new_worktree_modal::init(ctx);
     tab_configs::params_modal::init(ctx);
+    tab_configs::repo_picker::init(ctx);
+    tab_configs::branch_picker::init(ctx);
     ai::blocklist::init(ctx);
     ai::blocklist::block::status_bar::init(ctx);
     drive::index::init(ctx);

--- a/app/src/tab_configs/branch_picker.rs
+++ b/app/src/tab_configs/branch_picker.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
 use warpui::{
-    elements::ChildView, ui_components::components::UiComponentStyles, AppContext, Element, Entity,
-    TypedActionView, View, ViewContext, ViewHandle,
+    elements::ChildView,
+    keymap::{macros::*, FixedBinding},
+    ui_components::components::UiComponentStyles,
+    AppContext, Element, Entity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
 use crate::{
@@ -18,6 +20,43 @@ const DEFAULT_DROPDOWN_WIDTH: f32 = 380.;
 /// Placeholder text shown in the dropdown top bar while branches are loading.
 const LOADING_PLACEHOLDER: &str = "Fetching branches\u{2026}";
 
+/// Keymap-context flag advertised by [`BranchPicker`] only while its dropdown
+/// is collapsed. See [`crate::tab_configs::repo_picker`] for why the Space
+/// binding is gated on a collapsed-only flag rather than an ancestor-level
+/// `!id!("EditorView")` guard (issue #11138).
+const BRANCH_PICKER_COLLAPSED: &str = "BranchPickerCollapsed";
+
+/// Registers [`BranchPicker`]'s Space-to-toggle fixed binding: a focused,
+/// collapsed picker opens on Space; an expanded one leaves Space to its
+/// filter editor.
+pub fn init(app: &mut AppContext) {
+    app.register_fixed_bindings(vec![FixedBinding::new(
+        "space",
+        BranchPickerAction::ToggleDropdown,
+        id!(BRANCH_PICKER_COLLAPSED),
+    )]);
+}
+
+/// Builds [`BranchPicker`]'s keymap context. A pure function so the
+/// collapsed-flag gating is unit-testable without a UI harness.
+fn build_keymap_context(is_expanded: bool) -> warpui::keymap::Context {
+    let mut context = <BranchPicker as View>::default_keymap_context();
+    if !is_expanded {
+        context.set.insert(BRANCH_PICKER_COLLAPSED);
+    }
+    context
+}
+
+/// Actions dispatched within a [`BranchPicker`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum BranchPickerAction {
+    /// Commits a branch selection by name.
+    Select(String),
+    /// Toggles the dropdown open/closed. Dispatched by the Space fixed
+    /// binding while the collapsed picker holds focus.
+    ToggleDropdown,
+}
+
 /// A filterable dropdown that lists local git branches for the given repo path.
 ///
 /// Created with an optional `cwd` — if `None`, the picker starts with the
@@ -26,7 +65,7 @@ const LOADING_PLACEHOLDER: &str = "Fetching branches\u{2026}";
 ///
 /// Emits the selected branch name (a `String`) as its event.
 pub struct BranchPicker {
-    dropdown: ViewHandle<FilterableDropdown<String>>,
+    dropdown: ViewHandle<FilterableDropdown<BranchPickerAction>>,
     /// Pre-selected default value from the TOML `default =` field, used to
     /// restore a selection after the async branch list arrives.
     default_value: Option<String>,
@@ -94,7 +133,10 @@ impl BranchPicker {
             let default = default.clone();
             picker.dropdown.update(ctx, |dropdown, ctx| {
                 dropdown.set_items(
-                    vec![DropdownItem::new(default.clone(), default.clone())],
+                    vec![DropdownItem::new(
+                        default.clone(),
+                        BranchPickerAction::Select(default.clone()),
+                    )],
                     ctx,
                 );
                 dropdown.set_selected_by_name(default.as_str(), ctx);
@@ -126,7 +168,10 @@ impl BranchPicker {
             dropdown.set_disabled(ctx);
             // Show loading text in the dropdown top bar so the modal
             // doesn't shift layout while the fetch is in-flight.
-            let placeholder = DropdownItem::new(LOADING_PLACEHOLDER.to_string(), String::new());
+            let placeholder = DropdownItem::new(
+                LOADING_PLACEHOLDER.to_string(),
+                BranchPickerAction::Select(String::new()),
+            );
             dropdown.set_items(vec![placeholder], ctx);
             dropdown.set_selected_by_name(LOADING_PLACEHOLDER, ctx);
         });
@@ -194,15 +239,27 @@ impl BranchPicker {
                 }
 
                 // Main branches first, then the rest in recency order.
-                let mut items: Vec<DropdownItem<String>> = sort_branches_main_first(&branches)
-                    .map(|entry| DropdownItem::new(entry.name.clone(), entry.name.clone()))
-                    .collect();
+                let mut items: Vec<DropdownItem<BranchPickerAction>> =
+                    sort_branches_main_first(&branches)
+                        .map(|entry| {
+                            DropdownItem::new(
+                                entry.name.clone(),
+                                BranchPickerAction::Select(entry.name.clone()),
+                            )
+                        })
+                        .collect();
 
                 // Add the default as the first item if it isn't already in the list
                 // (e.g. the user typed a branch name that doesn't exist locally yet).
                 if let Some(ref default) = me.default_value {
                     if !branches.iter().any(|entry| entry.name == *default) {
-                        items.insert(0, DropdownItem::new(default.clone(), default.clone()));
+                        items.insert(
+                            0,
+                            DropdownItem::new(
+                                default.clone(),
+                                BranchPickerAction::Select(default.clone()),
+                            ),
+                        );
                     }
                 }
 
@@ -285,15 +342,30 @@ impl View for BranchPicker {
         "BranchPicker"
     }
 
+    /// Advertises [`BRANCH_PICKER_COLLAPSED`] while the dropdown is closed so
+    /// the Space fixed binding only toggles a focused, collapsed picker.
+    fn keymap_context(&self, app: &AppContext) -> warpui::keymap::Context {
+        build_keymap_context(self.dropdown.as_ref(app).is_expanded())
+    }
+
     fn render(&self, _app: &AppContext) -> Box<dyn Element> {
         ChildView::new(&self.dropdown).finish()
     }
 }
 
 impl TypedActionView for BranchPicker {
-    type Action = String;
+    type Action = BranchPickerAction;
 
-    fn handle_action(&mut self, action: &String, ctx: &mut ViewContext<Self>) {
-        ctx.emit(action.clone());
+    fn handle_action(&mut self, action: &BranchPickerAction, ctx: &mut ViewContext<Self>) {
+        match action {
+            BranchPickerAction::Select(name) => ctx.emit(name.clone()),
+            BranchPickerAction::ToggleDropdown => {
+                self.toggle_dropdown(ctx);
+            }
+        }
     }
 }
+
+#[cfg(test)]
+#[path = "branch_picker_tests.rs"]
+mod tests;

--- a/app/src/tab_configs/branch_picker_tests.rs
+++ b/app/src/tab_configs/branch_picker_tests.rs
@@ -1,0 +1,43 @@
+use warpui::keymap::macros::*;
+
+use super::{build_keymap_context, BRANCH_PICKER_COLLAPSED};
+
+#[test]
+fn keymap_context_advertises_collapsed_flag_when_closed() {
+    // A closed, focused picker must expose the flag so its Space binding
+    // fires and opens the dropdown (issue #11138).
+    let context = build_keymap_context(false);
+    assert!(
+        context.set.contains(BRANCH_PICKER_COLLAPSED),
+        "collapsed picker must expose {BRANCH_PICKER_COLLAPSED}; got {:?}",
+        context.set,
+    );
+}
+
+#[test]
+fn keymap_context_omits_collapsed_flag_when_expanded() {
+    // While expanded, the dropdown's filter editor is focused; the picker
+    // must NOT expose the flag, or Space would be stolen from the editor
+    // instead of typing a literal space into the filter query.
+    let context = build_keymap_context(true);
+    assert!(
+        !context.set.contains(BRANCH_PICKER_COLLAPSED),
+        "expanded picker must not expose {BRANCH_PICKER_COLLAPSED}; got {:?}",
+        context.set,
+    );
+}
+
+#[test]
+fn space_binding_predicate_matches_only_collapsed_picker() {
+    // The Space fixed binding is scoped to id!(BRANCH_PICKER_COLLAPSED): it
+    // must match a collapsed picker's context and miss an expanded one.
+    let predicate = id!(BRANCH_PICKER_COLLAPSED);
+    assert!(
+        predicate.eval(&build_keymap_context(false)),
+        "Space must toggle a focused, collapsed picker",
+    );
+    assert!(
+        !predicate.eval(&build_keymap_context(true)),
+        "Space must not fire while the picker's filter editor is focused",
+    );
+}

--- a/app/src/tab_configs/params_modal.rs
+++ b/app/src/tab_configs/params_modal.rs
@@ -42,18 +42,19 @@ pub fn init(app: &mut AppContext) {
             TabConfigParamsModalAction::Escape,
             id!("TabConfigParamsModal"),
         ),
-        // Enter and Space only fire when no EditorView descendant is focused.
-        // When a text field or picker filter editor has focus, the editor
-        // consumes these keys and the modal handles them via event
-        // subscriptions instead (see handle_editor_event).
+        // Enter submits. The `!id!("EditorView")` clause is a no-op on the
+        // modal layer (predicate evaluation is per-view, not chain-wide), but
+        // a focused text/filter editor still wins: it carries its own Enter
+        // binding, which short-circuits ahead of this ancestor binding in
+        // leaf-first keystroke dispatch.
+        //
+        // Space is intentionally NOT bound here (issue #11138). A focused
+        // picker owns Space via its own binding (see `repo_picker::init` /
+        // `branch_picker::init`); a focused text editor receives Space as a
+        // literal character because no ancestor binding can steal it.
         FixedBinding::new(
             "enter",
             TabConfigParamsModalAction::Submit,
-            id!("TabConfigParamsModal") & !id!("EditorView"),
-        ),
-        FixedBinding::new(
-            "space",
-            TabConfigParamsModalAction::ToggleDropdown,
             id!("TabConfigParamsModal") & !id!("EditorView"),
         ),
     ]);
@@ -149,7 +150,6 @@ pub enum TabConfigParamsModalAction {
     Cancel,
     Submit,
     Escape,
-    ToggleDropdown,
 }
 
 impl TabConfigParamsModal {
@@ -324,15 +324,12 @@ impl TabConfigParamsModal {
 
         self.pending_config = Some(config);
 
-        // When the only fields are dropdowns, focus the modal itself so
-        // Enter (submit) and Space (toggle dropdown) fixed bindings fire.
-        // When there are text fields, focus the first one so the user can
-        // start typing immediately.
-        if self.has_text_fields() {
-            self.focus_field(0, ctx);
-        } else {
-            ctx.focus_self();
-        }
+        // Focus the first param field. A focused picker owns Space — it
+        // toggles its own dropdown — while a focused text editor receives
+        // Space as a literal character. Enter still reaches the modal's
+        // submit binding via the ancestor chain regardless of which field
+        // holds focus.
+        self.reclaim_focus(ctx);
         ctx.notify();
     }
 
@@ -388,50 +385,17 @@ impl TabConfigParamsModal {
         ctx.notify();
     }
 
-    /// Restores focus to the modal itself (dropdown-only) or the first text
-    /// field after a picker interaction closes its dropdown.
+    /// Routes focus to the first param field — on open and after a picker
+    /// interaction closes its dropdown — so keyboard control lands on a real
+    /// field rather than resting on the modal. Falls back to self-focus only
+    /// when the config declares no params at all.
     fn reclaim_focus(&self, ctx: &mut ViewContext<Self>) {
-        if self.has_text_fields() {
-            self.focus_field(0, ctx);
-        } else {
+        if self.param_fields.is_empty() {
             ctx.focus_self();
+        } else {
+            self.focus_field(0, ctx);
         }
         ctx.notify();
-    }
-
-    fn has_text_fields(&self) -> bool {
-        self.param_fields
-            .iter()
-            .any(|(_, _, field)| matches!(field, ParamField::Text(_)))
-    }
-
-    fn dropdown_count(&self) -> usize {
-        self.param_fields
-            .iter()
-            .filter(|(_, _, field)| !matches!(field, ParamField::Text(_)))
-            .count()
-    }
-
-    fn toggle_single_dropdown(&mut self, ctx: &mut ViewContext<Self>) {
-        let mut opened = false;
-        for (_, _, field) in &self.param_fields {
-            match field {
-                ParamField::Branch { picker, .. } => {
-                    opened = picker.update(ctx, |p, ctx| p.toggle_dropdown(ctx));
-                    break;
-                }
-                ParamField::Repo { picker, .. } => {
-                    opened = picker.update(ctx, |p, ctx| p.toggle_dropdown(ctx));
-                    break;
-                }
-                ParamField::Text(_) => {}
-            }
-        }
-        // When the dropdown just closed, reclaim focus so Enter/Space
-        // fixed bindings continue to work.
-        if !opened && !self.has_text_fields() {
-            ctx.focus_self();
-        }
     }
 
     fn focus_field(&self, index: usize, ctx: &mut ViewContext<Self>) {
@@ -504,13 +468,12 @@ impl View for TabConfigParamsModal {
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
-        // When focus arrives directly at this view (not at a child), keep
-        // self-focus so the Enter/Space fixed bindings fire. This happens
-        // on initial open (via focus_self in on_open) and when the Modal
-        // wrapper re-focuses the body after a child (like a dropdown)
-        // releases focus.
-        if focus_ctx.is_self_focused() && !self.has_text_fields() {
-            ctx.focus_self();
+        // When focus arrives directly at this view — e.g. the Modal wrapper
+        // re-focuses the body after a dropdown releases focus — route it on
+        // to the first param field instead of letting it rest on the modal,
+        // so a focused picker keeps owning Space (issue #11138).
+        if focus_ctx.is_self_focused() {
+            self.reclaim_focus(ctx);
         }
     }
 
@@ -729,11 +692,6 @@ impl TypedActionView for TabConfigParamsModal {
                 ctx.emit(TabConfigParamsModalEvent::Close);
             }
             TabConfigParamsModalAction::Submit => self.try_submit(ctx),
-            TabConfigParamsModalAction::ToggleDropdown => {
-                if self.dropdown_count() <= 1 {
-                    self.toggle_single_dropdown(ctx);
-                }
-            }
         }
     }
 }

--- a/app/src/tab_configs/repo_picker.rs
+++ b/app/src/tab_configs/repo_picker.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use warp_util::path::user_friendly_path;
 use warpui::{
     elements::{Border, ChildView, Container, Hoverable, MouseStateHandle, Text},
+    keymap::{macros::*, FixedBinding},
     platform::Cursor,
     text_layout::ClipConfig,
     ui_components::components::UiComponentStyles,
@@ -20,6 +21,41 @@ const DEFAULT_DROPDOWN_WIDTH: f32 = 380.;
 
 /// Label for the sticky "Add new repo..." footer at the bottom of the picker.
 const ADD_NEW_REPO_LABEL: &str = "+ Add new repo...";
+
+/// Keymap-context flag advertised by [`RepoPicker`] only while its dropdown
+/// is collapsed. The Space-to-open binding is scoped to this flag so it fires
+/// solely when the closed picker itself holds focus — never while the
+/// expanded dropdown's filter editor is focused, where Space must reach that
+/// editor as a literal character.
+///
+/// `ContextPredicate` evaluation is per-view, so an ancestor-level guard like
+/// `!id!("EditorView")` cannot observe a descendant editor's focus. Gating on
+/// a flag the picker advertises only while collapsed is what keeps the
+/// binding focus-correct (see issue #11138).
+const REPO_PICKER_COLLAPSED: &str = "RepoPickerCollapsed";
+
+/// Registers [`RepoPicker`]'s Space-to-toggle fixed binding.
+///
+/// Embodies "if the dropdown is focused, the dropdown owns Space": a focused,
+/// collapsed picker opens on Space; an expanded one leaves Space to its
+/// filter editor. Every embedder of a `RepoPicker` inherits this.
+pub fn init(app: &mut AppContext) {
+    app.register_fixed_bindings(vec![FixedBinding::new(
+        "space",
+        RepoPickerAction::ToggleDropdown,
+        id!(REPO_PICKER_COLLAPSED),
+    )]);
+}
+
+/// Builds [`RepoPicker`]'s keymap context. Split out as a pure function so
+/// the collapsed-flag gating is unit-testable without a UI harness.
+fn build_keymap_context(is_expanded: bool) -> warpui::keymap::Context {
+    let mut context = <RepoPicker as View>::default_keymap_context();
+    if !is_expanded {
+        context.set.insert(REPO_PICKER_COLLAPSED);
+    }
+    context
+}
 
 /// A filterable dropdown listing known repos (from `PersistedWorkspace`), with a
 /// sticky "+ Add new repo..." footer that is always visible even when scrolling.
@@ -39,6 +75,9 @@ pub struct RepoPicker {
 pub enum RepoPickerAction {
     Select(String),
     AddNewRepo,
+    /// Toggles the dropdown open/closed. Dispatched by the Space fixed
+    /// binding while the collapsed picker holds focus.
+    ToggleDropdown,
 }
 
 pub enum RepoPickerEvent {
@@ -222,6 +261,12 @@ impl View for RepoPicker {
         "RepoPicker"
     }
 
+    /// Advertises [`REPO_PICKER_COLLAPSED`] while the dropdown is closed so
+    /// the Space fixed binding only toggles a focused, collapsed picker.
+    fn keymap_context(&self, app: &AppContext) -> warpui::keymap::Context {
+        build_keymap_context(self.dropdown.as_ref(app).is_expanded())
+    }
+
     fn render(&self, _app: &AppContext) -> Box<dyn Element> {
         ChildView::new(&self.dropdown).finish()
     }
@@ -244,6 +289,13 @@ impl TypedActionView for RepoPicker {
                 });
                 ctx.emit(RepoPickerEvent::RequestAddRepo);
             }
+            RepoPickerAction::ToggleDropdown => {
+                self.toggle_dropdown(ctx);
+            }
         }
     }
 }
+
+#[cfg(test)]
+#[path = "repo_picker_tests.rs"]
+mod tests;

--- a/app/src/tab_configs/repo_picker_tests.rs
+++ b/app/src/tab_configs/repo_picker_tests.rs
@@ -1,0 +1,43 @@
+use warpui::keymap::macros::*;
+
+use super::{build_keymap_context, REPO_PICKER_COLLAPSED};
+
+#[test]
+fn keymap_context_advertises_collapsed_flag_when_closed() {
+    // A closed, focused picker must expose the flag so its Space binding
+    // fires and opens the dropdown (issue #11138).
+    let context = build_keymap_context(false);
+    assert!(
+        context.set.contains(REPO_PICKER_COLLAPSED),
+        "collapsed picker must expose {REPO_PICKER_COLLAPSED}; got {:?}",
+        context.set,
+    );
+}
+
+#[test]
+fn keymap_context_omits_collapsed_flag_when_expanded() {
+    // While expanded, the dropdown's filter editor is focused; the picker
+    // must NOT expose the flag, or Space would be stolen from the editor
+    // instead of typing a literal space into the filter query.
+    let context = build_keymap_context(true);
+    assert!(
+        !context.set.contains(REPO_PICKER_COLLAPSED),
+        "expanded picker must not expose {REPO_PICKER_COLLAPSED}; got {:?}",
+        context.set,
+    );
+}
+
+#[test]
+fn space_binding_predicate_matches_only_collapsed_picker() {
+    // The Space fixed binding is scoped to id!(REPO_PICKER_COLLAPSED): it
+    // must match a collapsed picker's context and miss an expanded one.
+    let predicate = id!(REPO_PICKER_COLLAPSED);
+    assert!(
+        predicate.eval(&build_keymap_context(false)),
+        "Space must toggle a focused, collapsed picker",
+    );
+    assert!(
+        !predicate.eval(&build_keymap_context(true)),
+        "Space must not fire while the picker's filter editor is focused",
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #11138. In a tab config that mixes a `repo` param with a `text` param, pressing **Space** while the text field was focused opened the repo dropdown instead of inserting a literal space, making multi-word text params impossible to enter.

**This revises the original fix per @moirahuang's review.** Space handling has been moved out of the params modal and into the dropdown pickers — *"if the dropdown is focused, the dropdown owns Space."*

## Visual evidence

End-to-end recording with a tab config that mixes a `repo` dropdown and a `text` param (same TOML in both runs):

https://github.com/user-attachments/assets/3cf18e72-e5d5-4c83-b7b8-342cb00b682b

- **Before (red label) — stable** (`v0.2026.05.18.05.32.stable_02`): clicking into the `tab_name` text field and pressing **Space** pops the `repo` dropdown open instead of inserting a space.
- **After (green label) — this PR**: pressing **Space** in `tab_name` inserts a literal space (`my tab` → `my tab ` → `my tab  `); the dropdown stays closed.

> The recording predates this revision, but the observable text-param behaviour is identical. The revised approach **additionally** makes Space toggle a *focused picker* in mixed configs (tab to the dropdown → Space opens it) — something the original modal-gated fix could not do.

Tab config used in both runs:

```toml
name = "PR 11247 repro"

[[panes]]
id = "main"
type = "terminal"
directory = "{{repo}}"
commands = []

[params.repo]
type = "repo"
description = "Repository to open"

[params.tab_name]
type = "text"
description = "Tab name"
default = "my tab"
```

## Root cause

`app/src/tab_configs/params_modal.rs` registered the modal-level Space binding with the scope predicate `id!("TabConfigParamsModal") & !id!("EditorView")`, on the assumption that the `!id!("EditorView")` clause would suppress the binding while a descendant text editor is focused.

But keystroke dispatch (`crates/warpui_core/src/core/app.rs:1998-2034`) evaluates each layer's `ContextPredicate` against **that layer's own** `keymap_context` only — it never merges ancestors with descendants. When the focused view is `EditorView`:

1. At the `EditorView` layer the context contains `"EditorView"` but **not** `"TabConfigParamsModal"`, so the predicate is false. The editor has no Space `FixedBinding`, so dispatch continues up the chain.
2. At the `TabConfigParamsModal` layer the context contains `"TabConfigParamsModal"` but **never** `"EditorView"` (the modal isn't an editor), so `!id!("EditorView")` is always true. The predicate matches, `ToggleDropdown` fires, the editor never sees the space.

Oz's triage flagged this exact concern: "whether fixed-binding scope matching is not recognizing the focused text input as an `EditorView` descendant." It isn't — by design.

## Fix (revised per review)

Per @moirahuang, Space handling now lives in the pickers rather than the modal:

- **`RepoPicker` / `BranchPicker`** each register their own `Space → ToggleDropdown` fixed binding (`repo_picker::init` / `branch_picker::init`), scoped to a keymap-context flag (`RepoPickerCollapsed` / `BranchPickerCollapsed`) that the picker advertises **only while its dropdown is collapsed**. A focused, collapsed picker opens on Space; once expanded the flag is gone, so Space reaches the dropdown's own filter editor as a literal character.
- **The modal no longer binds Space at all.** A focused text editor therefore receives Space as a literal character — no ancestor binding can steal it.
- **The modal focuses its first param field on open** (and on focus reclaim) rather than focusing itself, so the picker actually holds focus and its binding can fire. This is the *"we're focused on that item"* part of the review note, and it also lets Space toggle a focused dropdown in mixed text+dropdown configs.

`BranchPicker`'s action type changes from `String` to a `BranchPickerAction` enum to carry the new `ToggleDropdown` variant; the emitted event stays `String`, so subscribers (e.g. `new_worktree_modal`) are unaffected.

Why a "collapsed-only" flag rather than a plain `!id!("EditorView")` guard on the picker binding: predicate evaluation is per-view, so an ancestor-level negative guard still cannot observe a descendant editor's focus (the same trap as the original bug). A flag the picker advertises *only while collapsed* is what keeps the binding focus-correct — when the dropdown is expanded its filter editor is focused, the flag is absent, and Space falls through to that editor.

## Tests

6 new unit tests — 3 each in `repo_picker_tests.rs` / `branch_picker_tests.rs` — covering the collapsed-flag gating: the flag is present iff the dropdown is collapsed, and the `Space` binding predicate matches a collapsed picker's context but misses an expanded one. The 4 modal-level tests from the original approach are removed (they exercised the now-deleted `DROPDOWN_ONLY_FLAG`).

`cargo check`, `cargo clippy -p warp --lib --tests`, and `cargo fmt` are clean; `cargo test -p warp --lib tab_configs::` passes.

## Scope

Deliberately **not** changed:

- **Enter binding** keeps its `!id!("EditorView")` scope. The guard is dead (same per-layer reason) but Enter is not reported as broken: leaf-first dispatch hits the editor's own Enter binding, which short-circuits before the modal-layer binding ever runs. Touching it here would expand the surface for non-reported behaviour.
- The picker Space bindings are global, so they also apply when a `RepoPicker` / `BranchPicker` is embedded in `new_worktree_modal` — a focused dropdown there now toggles on Space too, which is consistent and desirable. `new_worktree_modal` has no Space binding of its own, so there is no conflict.

## Incidental improvement

The original approach left a pre-existing oddity: in dropdown-only modals the picker's filter `EditorView` could not accept a literal Space, because the modal-layer Space binding swallowed it. With the modal-level binding gone and the picker binding gated on *collapsed*, an expanded dropdown's filter editor now receives Space normally. That oddity is fixed as a side effect.
