### PR TITLE
fix(mermaid): strip Mermaid frontmatter before rendering (#10676)

### DIFF
--- a/app/src/notebooks/editor/model.rs
+++ b/app/src/notebooks/editor/model.rs
@@ -36,7 +36,10 @@ use string_offset::CharOffset;
 use warp_core::features::FeatureFlag;
 use warp_core::semantic_selection::SemanticSelection;
 use warp_editor::{
-    content::{buffer::ShouldAutoscroll, selection_model::BufferSelectionModel},
+    content::{
+        buffer::ShouldAutoscroll, mermaid_diagram::strip_mermaid_frontmatter,
+        selection_model::BufferSelectionModel,
+    },
     model::BufferUpdateWrapper,
     render::model::{BlockItem, StyleUpdateAction},
 };
@@ -154,7 +157,8 @@ fn mermaid_image_html(svg: &[u8]) -> String {
 }
 
 fn render_mermaid_clipboard_html(source: &str) -> Option<String> {
-    let svg = mermaid_to_svg::render_mermaid_to_svg(source, Some(&MermaidTheme::light()))
+    let source = strip_mermaid_frontmatter(source);
+    let svg = mermaid_to_svg::render_mermaid_to_svg(source.as_ref(), Some(&MermaidTheme::light()))
         .ok()?
         .into_bytes();
     Some(mermaid_image_html(&svg))

--- a/crates/editor/src/content/mermaid_diagram.rs
+++ b/crates/editor/src/content/mermaid_diagram.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     hash::{DefaultHasher, Hash, Hasher},
     sync::Arc,
 };
@@ -24,8 +25,56 @@ struct MermaidDiagramAsset;
 
 impl AsyncAssetType for MermaidDiagramAsset {}
 
+/// Strip a leading Mermaid YAML frontmatter block (delimited by `---` lines
+/// on their own) from `source`, leaving the diagram body untouched when no
+/// frontmatter is present.
+///
+/// Mermaid 11 supports a `---\nconfig:\n  ...\n---` block at the top of a
+/// diagram for per-diagram configuration. The pinned `mermaid_to_svg`
+/// renderer's diagram-type detection treats the first non-empty,
+/// non-`%%`-prefixed line as the diagram token; with frontmatter that token
+/// becomes `---` instead of the actual diagram type (e.g. `xychart-beta`),
+/// and the renderer fails to dispatch to the right parser. Warp passes a
+/// hardcoded [`MermaidTheme::light`] anyway and does not honor any of the
+/// frontmatter config keys, so stripping is lossless. See
+/// warpdotdev/warp#10676.
+pub fn strip_mermaid_frontmatter(source: &str) -> Cow<'_, str> {
+    fn next_line_end(s: &str, start: usize) -> usize {
+        s[start..]
+            .find('\n')
+            .map(|p| start + p + 1)
+            .unwrap_or(s.len())
+    }
+
+    let mut cursor = 0;
+    while cursor < source.len() {
+        let end = next_line_end(source, cursor);
+        let line = source[cursor..end].trim();
+        if line.is_empty() {
+            cursor = end;
+            continue;
+        }
+        if line != "---" {
+            return Cow::Borrowed(source);
+        }
+        let mut scan = end;
+        while scan < source.len() {
+            let scan_end = next_line_end(source, scan);
+            if source[scan..scan_end].trim() == "---" {
+                return Cow::Owned(source[scan_end..].to_string());
+            }
+            scan = scan_end;
+        }
+        // Unterminated frontmatter — leave the source so the renderer's own
+        // error surfaces rather than silently dropping content.
+        return Cow::Borrowed(source);
+    }
+
+    Cow::Borrowed(source)
+}
+
 pub fn mermaid_asset_source(source: &str) -> AssetSource {
-    let source = source.to_string();
+    let source = strip_mermaid_frontmatter(source).into_owned();
     let mut hasher = DefaultHasher::new();
     source.hash(&mut hasher);
     let id = format!("light:{:x}", hasher.finish());

--- a/crates/editor/src/content/mermaid_diagram.rs
+++ b/crates/editor/src/content/mermaid_diagram.rs
@@ -34,10 +34,15 @@ impl AsyncAssetType for MermaidDiagramAsset {}
 /// renderer's diagram-type detection treats the first non-empty,
 /// non-`%%`-prefixed line as the diagram token; with frontmatter that token
 /// becomes `---` instead of the actual diagram type (e.g. `xychart-beta`),
-/// and the renderer fails to dispatch to the right parser. Warp passes a
-/// hardcoded [`MermaidTheme::light`] anyway and does not honor any of the
-/// frontmatter config keys, so stripping is lossless. See
-/// warpdotdev/warp#10676.
+/// and the renderer fails to dispatch to the right parser.
+///
+/// This helper intentionally preserves Warp's existing renderer behavior:
+/// Warp passes a hardcoded [`MermaidTheme::light`] and currently ignores all
+/// Mermaid frontmatter metadata and config entries (for example `title`,
+/// `config.theme`, `config.themeVariables`, `config.look`, and
+/// diagram-specific `config` sections). A renderer-level frontmatter parser in
+/// `mermaid_to_svg` would be the more general long-term fix if those config
+/// values should affect output. See warpdotdev/warp#10676.
 pub fn strip_mermaid_frontmatter(source: &str) -> Cow<'_, str> {
     fn next_line_end(s: &str, start: usize) -> usize {
         s[start..]

--- a/crates/editor/src/content/mermaid_diagram_tests.rs
+++ b/crates/editor/src/content/mermaid_diagram_tests.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::*;
 use crate::render::{layout::TextLayout, model::test_utils::TEST_STYLES};
 use warpui::{
@@ -35,6 +37,136 @@ fn loading_mermaid_layout_uses_default_height() {
             assert!((config.height.as_f32() - expected_height.as_f32()).abs() < 0.5);
         });
     })
+}
+
+#[test]
+fn strip_frontmatter_removes_leading_config_block() {
+    // The exact sample from issue #10676.
+    let source = "---\nconfig:\n  theme: default\n---\nxychart-beta\n  title \"x\"\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, "xychart-beta\n  title \"x\"\n");
+    assert!(matches!(stripped, Cow::Owned(_)));
+}
+
+#[test]
+fn strip_frontmatter_preserves_source_without_frontmatter() {
+    let source = "graph TD\nA --> B\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, source);
+    assert!(
+        matches!(stripped, Cow::Borrowed(_)),
+        "no-op stripping should return Borrowed to avoid allocation",
+    );
+}
+
+#[test]
+fn strip_frontmatter_skips_leading_blank_lines_before_open_delimiter() {
+    let source = "\n\n   \n---\nconfig:\n  theme: dark\n---\npie\n  \"a\" : 1\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, "pie\n  \"a\" : 1\n");
+}
+
+#[test]
+fn strip_frontmatter_handles_crlf_line_endings() {
+    let source = "---\r\nconfig:\r\n  theme: default\r\n---\r\nflowchart TD\r\nA --> B\r\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, "flowchart TD\r\nA --> B\r\n");
+}
+
+#[test]
+fn strip_frontmatter_leaves_text_starting_with_three_dashes_then_content() {
+    // `--- something` (with content after the dashes) is not a frontmatter
+    // delimiter — the trimmed line is `--- something`, not `---`.
+    let source = "--- some weird title\nflowchart TD\nA --> B\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, source);
+    assert!(matches!(stripped, Cow::Borrowed(_)));
+}
+
+#[test]
+fn strip_frontmatter_leaves_unterminated_block_for_renderer_to_surface() {
+    // No closing `---`: leave intact so mermaid_to_svg can surface its own
+    // error instead of silently dropping the body.
+    let source = "---\nconfig:\n  theme: default\nflowchart TD\nA --> B\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, source);
+    assert!(matches!(stripped, Cow::Borrowed(_)));
+}
+
+#[test]
+fn strip_frontmatter_handles_empty_input() {
+    assert_eq!(strip_mermaid_frontmatter(""), "");
+}
+
+#[test]
+fn strip_frontmatter_handles_only_frontmatter_no_body() {
+    let source = "---\nconfig: {}\n---\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, "");
+}
+
+#[test]
+fn strip_frontmatter_handles_frontmatter_without_trailing_newline() {
+    // Closing `---` on the final line (no newline after).
+    let source = "---\nfoo: bar\n---";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, "");
+}
+
+#[test]
+fn strip_frontmatter_handles_open_delimiter_only_with_newline() {
+    // `---\n` and nothing else: treated as unterminated, leave intact.
+    let source = "---\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, source);
+    assert!(matches!(stripped, Cow::Borrowed(_)));
+}
+
+#[test]
+fn strip_frontmatter_handles_open_delimiter_only_without_newline() {
+    // Single line `---` with no newline at all: must not panic / loop forever;
+    // returned as-is for the renderer to surface.
+    let source = "---";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, source);
+    assert!(matches!(stripped, Cow::Borrowed(_)));
+}
+
+#[test]
+fn strip_frontmatter_treats_indented_dashes_as_delimiter() {
+    // Documents the intentional choice: a leading-whitespace `---` line is
+    // trimmed before comparison and treated as a frontmatter delimiter. This
+    // mirrors the renderer's own `first_diagram_type_token`, which trims each
+    // line before matching the diagram token — being stricter here would
+    // diverge from the renderer and leave a class of broken sources broken.
+    let source = "\t---\n  config: x\n  ---\nflowchart TD\nA --> B\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, "flowchart TD\nA --> B\n");
+}
+
+#[test]
+fn strip_frontmatter_does_not_treat_inner_dashes_line_as_delimiter() {
+    // The `---` between `title` and `body` here is NOT a frontmatter open
+    // because the first content line is `flowchart TD`, not `---`.
+    let source = "flowchart TD\n---\nA --> B\n";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, source);
+}
+
+#[test]
+fn mermaid_asset_source_hashes_post_strip_for_cache_key_stability() {
+    // The asset cache key must be derived from the post-strip source so that
+    // the same logical diagram with and without frontmatter doesn't churn
+    // the cache (and so the bug-fix actually changes what gets rendered).
+    let with_frontmatter = "---\nconfig:\n  theme: default\n---\nflowchart TD\nA --> B\n";
+    let without_frontmatter = "flowchart TD\nA --> B\n";
+    let with = mermaid_asset_source(with_frontmatter);
+    let without = mermaid_asset_source(without_frontmatter);
+    let (with_id, without_id) = match (&with, &without) {
+        (AssetSource::Async { id: a, .. }, AssetSource::Async { id: b, .. }) => (a, b),
+        _ => panic!("expected Async asset sources"),
+    };
+    assert_eq!(with_id, without_id);
 }
 
 #[test]

--- a/crates/editor/src/content/mermaid_diagram_tests.rs
+++ b/crates/editor/src/content/mermaid_diagram_tests.rs
@@ -49,6 +49,26 @@ fn strip_frontmatter_removes_leading_config_block() {
 }
 
 #[test]
+fn strip_frontmatter_removes_metadata_and_config_keys_warp_does_not_consume() {
+    let source = "\
+---
+title: Ignored title
+config:
+  theme: dark
+  look: handDrawn
+  themeVariables:
+    primaryColor: '#ff0000'
+  flowchart:
+    curve: basis
+---
+flowchart TD
+A --> B
+";
+    let stripped = strip_mermaid_frontmatter(source);
+    assert_eq!(stripped, "flowchart TD\nA --> B\n");
+}
+
+#[test]
 fn strip_frontmatter_preserves_source_without_frontmatter() {
     let source = "graph TD\nA --> B\n";
     let stripped = strip_mermaid_frontmatter(source);


### PR DESCRIPTION
## Summary

Fixes #10676. Mermaid diagrams that start with a YAML frontmatter / `config` block (a `---` ... `---` block at the very top, supported by Mermaid 11+) never render in Warp — the UI stays on "Rendering Mermaid diagram" indefinitely on older builds, and shows the generic failure callout on newer ones. Issue's exact sample:

```mermaid
---
config:
  theme: default
---
xychart-beta
  title "Évolution des prix des appartements à Versailles"
  ...
```

## Visual evidence

Built `WarpOss` from this branch, opened a Personal Notebook, and pasted the issue's mermaid-with-frontmatter source. Same notebook, same markdown — just toggling the Mermaid block's view mode.

<img width="1804" height="1615" alt="warp-pr11249-ui-comparison" src="https://github.com/user-attachments/assets/e6ab2259-3b59-4f18-ae8c-1ccae8fb174f" />

- **Raw view (left)** — `---\nconfig:\n  theme: default\n---` frontmatter is preserved in the source (this is what was breaking master).
- **Diagram view (right)** — `strip_mermaid_frontmatter` strips the leading block before `mermaid_to_svg`, the flowchart renders.

Pipeline-level proof using the same `mermaid_to_svg` rev pinned in this repo:

<img width="1400" height="1158" alt="warp-pr11249-pipeline-proof" src="https://github.com/user-attachments/assets/beef7ea7-471d-44df-b7f5-362ff64a0d74" />

- **Before** — raw source with frontmatter → `Parse error at line 1: Expected 'graph' or 'flowchart' declaration`.
- **After** — stripped source → SVG rendered.

## Root cause

The pinned `mermaid_to_svg` renderer's `first_diagram_type_token` treats the first non-empty, non-`%%`-prefixed line as the diagram token. With frontmatter present that token is `---` rather than `xychart-beta` / `flowchart` / etc., so the renderer fails to dispatch to the right parser and never produces a usable SVG.

Both call sites — `crates/editor/src/content/mermaid_diagram.rs:39` (`mermaid_asset_source`, used by markdown notebook layout) and `app/src/notebooks/editor/model.rs:157` (`render_mermaid_clipboard_html`, the clipboard SVG embed) — pass the raw source through unmodified.

## Fix

Introduce `strip_mermaid_frontmatter` in `crates/editor/src/content/mermaid_diagram.rs` (returns `Cow<'_, str>` — `Borrowed` when no frontmatter, `Owned` otherwise) and apply it at both call sites. The asset cache key is derived from the post-strip source, so the same logical diagram with and without frontmatter shares a cache entry.

Strip is lossless: Warp passes a hardcoded `MermaidTheme::light()` to `render_mermaid_to_svg` and does not consult any of the frontmatter config keys, so nothing about today's rendered output changes when the leading `---` block is removed.

Line trimming before delimiter comparison intentionally mirrors `mermaid_to_svg`'s own `first_diagram_type_token` behavior — being stricter (e.g. requiring `---` at column 0) would leave a class of broken sources still broken on the renderer side.

## Tests

13 new unit tests in `crates/editor/src/content/mermaid_diagram_tests.rs`:

- `strip_frontmatter_removes_leading_config_block` — the issue's exact xychart sample.
- `strip_frontmatter_preserves_source_without_frontmatter` — no-op path returns `Cow::Borrowed` (no spurious allocation).
- `strip_frontmatter_skips_leading_blank_lines_before_open_delimiter` — blanks/whitespace before `---` are not load-bearing.
- `strip_frontmatter_handles_crlf_line_endings` — Windows line endings.
- `strip_frontmatter_leaves_text_starting_with_three_dashes_then_content` — `--- title-like` lines are not delimiters.
- `strip_frontmatter_leaves_unterminated_block_for_renderer_to_surface` — missing close `---` → leave intact so the renderer's own error surfaces.
- `strip_frontmatter_handles_empty_input` — empty string.
- `strip_frontmatter_handles_only_frontmatter_no_body` — frontmatter with no body.
- `strip_frontmatter_handles_frontmatter_without_trailing_newline` — closing `---` on final line.
- `strip_frontmatter_handles_open_delimiter_only_with_newline` — `---\n` alone.
- `strip_frontmatter_handles_open_delimiter_only_without_newline` — `---` alone (no trailing newline).
- `strip_frontmatter_treats_indented_dashes_as_delimiter` — documented intentional choice that mirrors the renderer's line-trim behavior.
- `strip_frontmatter_does_not_treat_inner_dashes_line_as_delimiter` — `---` lines mid-diagram are not delimiters.
- `mermaid_asset_source_hashes_post_strip_for_cache_key_stability` — same cache key with/without frontmatter.

All 16 module tests pass locally (`cargo test -p warp_editor --lib content::mermaid_diagram::`). `cargo fmt --check`, `cargo clippy -p warp_editor --lib`, `cargo clippy -p warp --lib` are clean.

## Scope

Deliberately **not** changed:

- **`mermaid_to_svg` (the warpdotdev fork) is not patched.** Fixing the renderer to recognize frontmatter would be more general but requires a separate PR to that repo plus a dep bump. The Warp-side strip is a single PR that fully solves the user-visible bug with minimal blast radius.
- **Frontmatter `theme` / `config.*` keys remain ignored.** Honoring them would mean parsing YAML and overriding the hardcoded light theme — a feature, not a fix. The current behavior matches what shipped before frontmatter was attempted at all.

## Follow-up

- Patch the `mermaid_to_svg` fork to recognize `---` frontmatter natively, then remove this Warp-side helper. Would also fix the bug for any other consumer of that crate.
- Honor frontmatter `theme: dark` / `theme: forest` etc. by parsing the YAML and passing the appropriate `MermaidTheme` instead of hardcoded `light()`.
- The `MermaidTheme::light()` hardcode itself is worth revisiting — it doesn't honor Warp's app theme.
