### PR TITLE
Remove default waterfall mode feature flag

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -484,7 +484,6 @@ default = [
     "warp_packs",
     "ai_rules",
     "suggested_rules",
-    "default_waterfall_mode",
     "am_workflows",
     "autoupdate_ui_revamp",
     "render_agent_mode_output_markdown",
@@ -657,7 +656,6 @@ embedded_code_review_comments = []
 agent_management_view = []
 agent_management_details_view = []
 interactive_conversation_management_view = []
-default_waterfall_mode = []
 enforce_revisions_to_cloud_objects = []
 suggested_agent_mode_workflows = []
 ssh_tmux_wrapper = []

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2586,8 +2586,6 @@ pub fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::ResizeFix,
         #[cfg(feature = "richtext_multiselect")]
         FeatureFlag::RichTextMultiselect,
-        #[cfg(feature = "default_waterfall_mode")]
-        FeatureFlag::DefaultWaterfallMode,
         #[cfg(feature = "settings_file")]
         FeatureFlag::SettingsFile,
         #[cfg(feature = "rect_selection")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -105,9 +105,6 @@ pub enum FeatureFlag {
     /// Enable multiselect in Notebooks and Warp Text.
     RichTextMultiselect,
 
-    /// If enabled, the default input mode is set to waterfall for new users.
-    DefaultWaterfallMode,
-
     /// Makes the input editor's prompt selectable.
     SelectablePrompt,
 


### PR DESCRIPTION
## Description

Removes the stale `default_waterfall_mode` feature flag now that it is enabled by default and no longer gates any behavior.

## Changes

- Removed `default_waterfall_mode` from the default Cargo feature set.
- Removed the empty Cargo feature definition.
- Removed the `DefaultWaterfallMode` runtime flag variant and app initialization mapping.

## Validation

- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp_features`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp_features -- -D warnings`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --lib -- -D warnings` failed on existing `warpui_core` clippy lints unrelated to this change.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/04ec1fc3-139f-4397-b96d-e185797fdcc8_
_Run: https://oz.staging.warp.dev/runs/019e3da3-c3fe-7991-8b96-b8a3c7c6bfa0_
_This PR was generated with [Oz](https://warp.dev/oz)._
