### PR TITLE
fix: update broken 'Read more' link after upgrade to changelog

### DIFF
--- a/app/src/workspace/view/orchestration_launch_modal/view.rs
+++ b/app/src/workspace/view/orchestration_launch_modal/view.rs
@@ -20,7 +20,7 @@ use crate::view_components::action_button::{ActionButton, ActionButtonTheme, But
 const MODAL_WIDTH: f32 = 420.;
 const HERO_HEIGHT: f32 = 92.;
 const HERO_IMAGE_PATH: &str = "async/png/onboarding/orchestration_launch_banner.png";
-const LEARN_MORE_URL: &str = "https://www.warp.dev/blog/multi-harness-cloud-agent-orchestration";
+const LEARN_MORE_URL: &str = "https://docs.warp.dev/changelog";
 fn modal_background(appearance: &Appearance) -> Fill {
     appearance.theme().surface_3()
 }


### PR DESCRIPTION
## Fix

Fixes #11269

The upgrade 'What's new' popup's 'Read more' button linked to
a 404 blog post (https://www.warp.dev/blog/multi-harness-cloud-agent-orchestration).
Changed to https://docs.warp.dev/changelog.

## Change

- `app/src/workspace/view/orchestration_launch_modal/view.rs`: Updated `LEARN_MORE_URL` constant