### PR TITLE
CLI commands for CRUD on agents

### DIFF
--- a/app/src/ai/agent_sdk/agent_config.rs
+++ b/app/src/ai/agent_sdk/agent_config.rs
@@ -8,7 +8,7 @@ use warpui::{AppContext, ModelContext, SingletonEntity};
 
 use crate::ai::agent_sdk::oauth_flow::poll_oauth_until_terminal;
 use crate::ai::cloud_environments::GithubRepo;
-use crate::server::server_api::ai::AgentListItem;
+use crate::server::server_api::ai::AgentSkillItem;
 use crate::server::server_api::ServerApiProvider;
 
 const MAX_LINE_WIDTH: usize = 90;
@@ -17,8 +17,8 @@ const MAX_AUTH_ATTEMPTS: u32 = 8;
 /// Singleton model that runs async work for agent CLI commands.
 struct AgentConfigRunner;
 
-/// List all available agents.
-pub fn list_agents(ctx: &mut AppContext, args: ListAgentConfigsArgs) -> anyhow::Result<()> {
+/// List all available agent skills.
+pub fn list_skills(ctx: &mut AppContext, args: ListAgentSkillsArgs) -> anyhow::Result<()> {
     let runner = ctx.add_singleton_model(|_ctx| AgentConfigRunner);
     runner.update(ctx, |runner, ctx| runner.list(args.repo.clone(), ctx))
 }
@@ -222,7 +222,7 @@ impl AgentConfigRunner {
             println!("Fetching agent skills from your Warp environments...");
         }
 
-        let list_future = async move { ai_client.list_agents(repo).await };
+        let list_future = async move { ai_client.list_skills(repo).await };
 
         ctx.spawn(list_future, |_, result, ctx| match result {
             Ok(agents) => {
@@ -236,7 +236,7 @@ impl AgentConfigRunner {
     }
 
     /// Print a list of agents in a card-style format.
-    fn print_agents_table(agents: &[AgentListItem]) {
+    fn print_agents_table(agents: &[AgentSkillItem]) {
         if agents.is_empty() {
             println!("No agents found.");
             return;

--- a/app/src/ai/agent_sdk/agent_config.rs
+++ b/app/src/ai/agent_sdk/agent_config.rs
@@ -1,6 +1,6 @@
 //! Commands to interact with available agents via the public API.
 
-use warp_cli::agent::ListAgentConfigsArgs;
+use warp_cli::agent::ListAgentSkillsArgs;
 use warp_graphql::queries::get_oauth_connect_tx_status::OauthConnectTxStatus;
 use warp_graphql::queries::user_repo_auth_status::UserRepoAuthStatusEnum;
 use warpui::platform::TerminationMode;
@@ -238,7 +238,7 @@ impl AgentConfigRunner {
     /// Print a list of agents in a card-style format.
     fn print_agents_table(agents: &[AgentSkillItem]) {
         if agents.is_empty() {
-            println!("No agents found.");
+            println!("No skills found.");
             return;
         }
 

--- a/app/src/ai/agent_sdk/agent_management.rs
+++ b/app/src/ai/agent_sdk/agent_management.rs
@@ -1,0 +1,488 @@
+//! Commands to manage named agents via the public API.
+
+use std::cmp::Ordering;
+use std::io::Write as _;
+
+use anyhow::anyhow;
+use comfy_table::Cell;
+use serde::Serialize;
+use warp_cli::agent::{
+    AgentCreateArgs, AgentDeleteArgs, AgentGetArgs, AgentListArgs, AgentSortByArg,
+    AgentSortOrderArg, AgentUpdateArgs, OutputFormat,
+};
+use warp_cli::json_filter::JsonOutput;
+use warpui::{platform::TerminationMode, AppContext, ModelContext, SingletonEntity};
+
+use crate::server::server_api::ai::{
+    AgentResponse, CreateAgentRequest, SecretRef, UpdateAgentRequest,
+};
+use crate::server::server_api::ServerApiProvider;
+
+use super::output::TableFormat;
+
+/// Singleton model that runs async work for named-agent CLI commands.
+struct AgentManagementRunner;
+
+pub fn list_agents(
+    ctx: &mut AppContext,
+    output_format: OutputFormat,
+    args: AgentListArgs,
+) -> anyhow::Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| AgentManagementRunner);
+    runner.update(ctx, |runner, ctx| runner.list(args, output_format, ctx))
+}
+
+pub fn get_agent(
+    ctx: &mut AppContext,
+    output_format: OutputFormat,
+    args: AgentGetArgs,
+) -> anyhow::Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| AgentManagementRunner);
+    runner.update(ctx, |runner, ctx| runner.get(args, output_format, ctx))
+}
+
+pub fn create_agent(
+    ctx: &mut AppContext,
+    output_format: OutputFormat,
+    args: AgentCreateArgs,
+) -> anyhow::Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| AgentManagementRunner);
+    runner.update(ctx, |runner, ctx| runner.create(args, output_format, ctx))
+}
+
+pub fn update_agent(
+    ctx: &mut AppContext,
+    output_format: OutputFormat,
+    args: AgentUpdateArgs,
+) -> anyhow::Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| AgentManagementRunner);
+    runner.update(ctx, |runner, ctx| runner.update(args, output_format, ctx))
+}
+
+pub fn delete_agent(
+    ctx: &mut AppContext,
+    output_format: OutputFormat,
+    args: AgentDeleteArgs,
+) -> anyhow::Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| AgentManagementRunner);
+    runner.update(ctx, |runner, ctx| runner.delete(args, output_format, ctx))
+}
+impl AgentManagementRunner {
+    fn spawn_command(
+        &self,
+        future: impl warpui::r#async::Spawnable<Output = anyhow::Result<()>>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.spawn(future, |_, result, ctx| match result {
+            Ok(()) => {
+                ctx.terminate_app(TerminationMode::ForceTerminate, None);
+            }
+            Err(err) => {
+                super::report_fatal_error(err, ctx);
+            }
+        });
+    }
+
+    fn list(
+        &self,
+        args: AgentListArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let future = async move {
+            ensure_json_sort_is_not_requested(output_format, &args.json_output, &args)?;
+
+            if matches!(output_format, OutputFormat::Json) || args.json_output.force_json_output() {
+                let response = ai_client.list_agents_raw().await?;
+                super::output::print_raw_json(response, &args.json_output)?;
+            } else {
+                let mut agents = ai_client.list_agents().await?;
+                sort_agents(&mut agents, args.sort_by, args.sort_order);
+                print_agents(&agents, output_format)?;
+            }
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn get(
+        &self,
+        args: AgentGetArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let future = async move {
+            if matches!(output_format, OutputFormat::Json) || args.json_output.force_json_output() {
+                let response = ai_client.get_agent_raw(&args.uid).await?;
+                super::output::print_raw_json(response, &args.json_output)?;
+            } else {
+                let agent = ai_client.get_agent(&args.uid).await?;
+                print_single_agent(&agent, output_format)?;
+            }
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn create(
+        &self,
+        args: AgentCreateArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let future = async move {
+            let json_output = args.json_output.clone();
+            let request = CreateAgentRequest {
+                name: args.name,
+                description: args.description,
+                secrets: secret_refs(args.secrets),
+                skills: args.skills,
+                base_model: args.base_model,
+                environment_id: args.environment,
+            };
+            if matches!(output_format, OutputFormat::Json) || json_output.force_json_output() {
+                let response = ai_client.create_agent_raw(request).await?;
+                super::output::print_raw_json(response, &json_output)?;
+            } else {
+                let agent = ai_client.create_agent(request).await?;
+                print_single_agent(&agent, output_format)?;
+            }
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn update(
+        &self,
+        args: AgentUpdateArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let future = async move {
+            let uid = args.uid.clone();
+            let json_output = args.json_output.clone();
+            let current_agent = if args.add_secrets.is_empty()
+                && args.remove_secrets.is_empty()
+                && args.add_skills.is_empty()
+                && args.remove_skills.is_empty()
+            {
+                None
+            } else {
+                Some(ai_client.get_agent(&uid).await?)
+            };
+            let request = UpdateAgentRequest {
+                name: args.name,
+                description: if args.remove_description {
+                    Some(String::new())
+                } else {
+                    args.description
+                },
+                secrets: if args.remove_all_secrets {
+                    Some(vec![])
+                } else if args.add_secrets.is_empty() && args.remove_secrets.is_empty() {
+                    None
+                } else {
+                    let current_agent = current_agent
+                        .as_ref()
+                        .expect("current agent is fetched when applying secret deltas");
+                    Some(apply_secret_deltas(
+                        &current_agent.secrets,
+                        args.add_secrets,
+                        args.remove_secrets,
+                    ))
+                },
+                skills: if args.remove_all_skills {
+                    Some(vec![])
+                } else if args.add_skills.is_empty() && args.remove_skills.is_empty() {
+                    None
+                } else {
+                    let current_agent = current_agent
+                        .as_ref()
+                        .expect("current agent is fetched when applying skill deltas");
+                    Some(apply_string_deltas(
+                        &current_agent.skills,
+                        args.add_skills,
+                        args.remove_skills,
+                    ))
+                },
+                base_model: if args.remove_base_model {
+                    Some(String::new())
+                } else {
+                    args.base_model
+                },
+                environment_id: if args.remove_environment {
+                    Some(String::new())
+                } else {
+                    args.environment
+                },
+            };
+            if request_is_empty(&request) {
+                return Err(anyhow!("No updates requested"));
+            }
+
+            if matches!(output_format, OutputFormat::Json) || json_output.force_json_output() {
+                let response = ai_client.update_agent_raw(&uid, request).await?;
+                super::output::print_raw_json(response, &json_output)?;
+            } else {
+                let agent = ai_client.update_agent(&uid, request).await?;
+                print_single_agent(&agent, output_format)?;
+            }
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn delete(
+        &self,
+        args: AgentDeleteArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let future = async move {
+            ai_client.delete_agent(&args.uid).await?;
+            print_delete_result(&args.uid, output_format)?;
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+}
+
+fn secret_refs(secrets: Vec<String>) -> Vec<SecretRef> {
+    secrets.into_iter().map(|name| SecretRef { name }).collect()
+}
+fn apply_secret_deltas(
+    current: &[SecretRef],
+    add_secrets: Vec<String>,
+    remove_secrets: Vec<String>,
+) -> Vec<SecretRef> {
+    let names = apply_string_deltas(
+        &current
+            .iter()
+            .map(|secret| secret.name.clone())
+            .collect::<Vec<_>>(),
+        add_secrets,
+        remove_secrets,
+    );
+    secret_refs(names)
+}
+
+fn apply_string_deltas(
+    current: &[String],
+    add_values: Vec<String>,
+    remove_values: Vec<String>,
+) -> Vec<String> {
+    let mut values = current
+        .iter()
+        .filter(|value| !remove_values.contains(value))
+        .cloned()
+        .collect::<Vec<_>>();
+    for value in add_values {
+        if !values.contains(&value) {
+            values.push(value);
+        }
+    }
+    values
+}
+
+fn request_is_empty(request: &UpdateAgentRequest) -> bool {
+    request.name.is_none()
+        && request.description.is_none()
+        && request.secrets.is_none()
+        && request.skills.is_none()
+        && request.base_model.is_none()
+        && request.environment_id.is_none()
+}
+
+fn ensure_json_sort_is_not_requested(
+    output_format: OutputFormat,
+    json_output: &JsonOutput,
+    args: &AgentListArgs,
+) -> anyhow::Result<()> {
+    if (matches!(output_format, OutputFormat::Json) || json_output.force_json_output())
+        && (args.sort_by.is_some() || args.sort_order.is_some())
+    {
+        return Err(anyhow!(
+            "--sort-by and --sort-order are not supported with JSON output"
+        ));
+    }
+
+    Ok(())
+}
+
+fn sort_agents(
+    agents: &mut [AgentResponse],
+    sort_by: Option<AgentSortByArg>,
+    sort_order: Option<AgentSortOrderArg>,
+) {
+    let sort_by = sort_by.unwrap_or(AgentSortByArg::Name);
+    let default_order = match sort_by {
+        AgentSortByArg::Name => AgentSortOrderArg::Asc,
+        AgentSortByArg::CreatedAt => AgentSortOrderArg::Desc,
+    };
+    let sort_order = sort_order.unwrap_or(default_order);
+
+    agents.sort_by(|left, right| {
+        let ordering = match sort_by {
+            AgentSortByArg::Name => left
+                .name
+                .to_lowercase()
+                .cmp(&right.name.to_lowercase())
+                .then_with(|| left.uid.cmp(&right.uid)),
+            AgentSortByArg::CreatedAt => left
+                .created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.uid.cmp(&right.uid)),
+        };
+
+        match sort_order {
+            AgentSortOrderArg::Asc => ordering,
+            AgentSortOrderArg::Desc => match ordering {
+                Ordering::Less => Ordering::Greater,
+                Ordering::Equal => Ordering::Equal,
+                Ordering::Greater => Ordering::Less,
+            },
+        }
+    });
+}
+
+impl TableFormat for AgentResponse {
+    fn header() -> Vec<Cell> {
+        vec![
+            Cell::new("UID"),
+            Cell::new("Name"),
+            Cell::new("Available"),
+            Cell::new("Created"),
+            Cell::new("Description"),
+            Cell::new("Secrets"),
+            Cell::new("Skills"),
+            Cell::new("Base model"),
+            Cell::new("Environment"),
+        ]
+    }
+
+    fn row(&self) -> Vec<Cell> {
+        vec![
+            Cell::new(&self.uid),
+            Cell::new(&self.name),
+            Cell::new(self.available.to_string()),
+            Cell::new(self.created_at.to_rfc3339()),
+            Cell::new(display_optional(self.description.as_deref())),
+            Cell::new(display_list(
+                self.secrets.iter().map(|secret| secret.name.as_str()),
+            )),
+            Cell::new(display_list(self.skills.iter().map(String::as_str))),
+            Cell::new(display_optional(self.base_model.as_deref())),
+            Cell::new(display_optional(self.environment_id.as_deref())),
+        ]
+    }
+}
+
+fn print_agents(agents: &[AgentResponse], output_format: OutputFormat) -> anyhow::Result<()> {
+    match output_format {
+        OutputFormat::Pretty if agents.is_empty() => {
+            println!("No agents found.");
+            print_skills_hint();
+        }
+        OutputFormat::Pretty => {
+            super::output::write_list(agents.to_vec(), output_format, std::io::stdout())?;
+            print_skills_hint();
+        }
+        OutputFormat::Text => {
+            super::output::write_list(agents.to_vec(), output_format, std::io::stdout())?;
+        }
+        OutputFormat::Ndjson => {
+            for agent in agents {
+                super::output::write_json_line(agent, std::io::stdout())?;
+            }
+        }
+        OutputFormat::Json => unreachable!("JSON output is handled by the raw API path"),
+    }
+    Ok(())
+}
+
+fn print_single_agent(agent: &AgentResponse, output_format: OutputFormat) -> anyhow::Result<()> {
+    match output_format {
+        OutputFormat::Pretty | OutputFormat::Text => {
+            super::output::write_list([agent.clone()], output_format, std::io::stdout())?;
+        }
+        OutputFormat::Ndjson => {
+            super::output::write_json_line(agent, std::io::stdout())?;
+        }
+        OutputFormat::Json => unreachable!("JSON output is handled by the raw API path"),
+    }
+    Ok(())
+}
+
+fn print_skills_hint() {
+    let binary_name = warp_cli::binary_name().unwrap_or_else(|| "warp".to_string());
+    println!("Looking for agent skills? Use {binary_name} agent skills instead.");
+}
+
+#[derive(Serialize)]
+struct DeleteAgentResult<'a> {
+    uid: &'a str,
+    deleted: bool,
+}
+
+fn print_delete_result(uid: &str, output_format: OutputFormat) -> anyhow::Result<()> {
+    match output_format {
+        OutputFormat::Pretty => {
+            println!("Deleted agent {uid}.");
+        }
+        OutputFormat::Text => {
+            let mut stdout = std::io::stdout();
+            writeln!(stdout, "{uid}")?;
+        }
+        OutputFormat::Ndjson => {
+            super::output::write_json_line(
+                &DeleteAgentResult { uid, deleted: true },
+                std::io::stdout(),
+            )?;
+        }
+        OutputFormat::Json => {
+            super::output::write_json(
+                &DeleteAgentResult { uid, deleted: true },
+                std::io::stdout(),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn display_optional(value: Option<&str>) -> String {
+    value
+        .filter(|value| !value.is_empty())
+        .unwrap_or("-")
+        .to_string()
+}
+
+fn display_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
+    let values = values
+        .into_iter()
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        "-".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+impl warpui::Entity for AgentManagementRunner {
+    type Event = ();
+}
+impl SingletonEntity for AgentManagementRunner {}
+
+#[cfg(test)]
+#[path = "agent_management_tests.rs"]
+mod tests;

--- a/app/src/ai/agent_sdk/agent_management.rs
+++ b/app/src/ai/agent_sdk/agent_management.rs
@@ -7,18 +7,19 @@ use anyhow::anyhow;
 use comfy_table::Cell;
 use serde::Serialize;
 use warp_cli::agent::{
-    AgentCreateArgs, AgentDeleteArgs, AgentGetArgs, AgentListArgs, AgentSortByArg,
-    AgentSortOrderArg, AgentUpdateArgs, OutputFormat,
+    AgentCreateArgs, AgentDeleteArgs, AgentGetArgs, AgentListArgs, AgentSortByArg, AgentUpdateArgs,
+    OutputFormat,
 };
 use warp_cli::json_filter::JsonOutput;
-use warpui::{platform::TerminationMode, AppContext, ModelContext, SingletonEntity};
+use warp_cli::SortOrderArg;
+use warpui::platform::TerminationMode;
+use warpui::{AppContext, ModelContext, SingletonEntity};
 
+use super::output::TableFormat;
 use crate::server::server_api::ai::{
     AgentResponse, CreateAgentRequest, SecretRef, UpdateAgentRequest,
 };
 use crate::server::server_api::ServerApiProvider;
-
-use super::output::TableFormat;
 
 /// Singleton model that runs async work for named-agent CLI commands.
 struct AgentManagementRunner;
@@ -260,6 +261,8 @@ impl AgentManagementRunner {
 fn secret_refs(secrets: Vec<String>) -> Vec<SecretRef> {
     secrets.into_iter().map(|name| SecretRef { name }).collect()
 }
+
+/// Add and remove the requested secrets, starting with `current` as a baseline.
 fn apply_secret_deltas(
     current: &[SecretRef],
     add_secrets: Vec<String>,
@@ -276,6 +279,7 @@ fn apply_secret_deltas(
     secret_refs(names)
 }
 
+/// Add and remove the requested values, starting with `current` as a baseline.
 fn apply_string_deltas(
     current: &[String],
     add_values: Vec<String>,
@@ -322,12 +326,12 @@ fn ensure_json_sort_is_not_requested(
 fn sort_agents(
     agents: &mut [AgentResponse],
     sort_by: Option<AgentSortByArg>,
-    sort_order: Option<AgentSortOrderArg>,
+    sort_order: Option<SortOrderArg>,
 ) {
     let sort_by = sort_by.unwrap_or(AgentSortByArg::Name);
     let default_order = match sort_by {
-        AgentSortByArg::Name => AgentSortOrderArg::Asc,
-        AgentSortByArg::CreatedAt => AgentSortOrderArg::Desc,
+        AgentSortByArg::Name => SortOrderArg::Asc,
+        AgentSortByArg::CreatedAt => SortOrderArg::Desc,
     };
     let sort_order = sort_order.unwrap_or(default_order);
 
@@ -345,8 +349,8 @@ fn sort_agents(
         };
 
         match sort_order {
-            AgentSortOrderArg::Asc => ordering,
-            AgentSortOrderArg::Desc => match ordering {
+            SortOrderArg::Asc => ordering,
+            SortOrderArg::Desc => match ordering {
                 Ordering::Less => Ordering::Greater,
                 Ordering::Equal => Ordering::Equal,
                 Ordering::Greater => Ordering::Less,
@@ -360,7 +364,6 @@ impl TableFormat for AgentResponse {
         vec![
             Cell::new("UID"),
             Cell::new("Name"),
-            Cell::new("Available"),
             Cell::new("Created"),
             Cell::new("Description"),
             Cell::new("Secrets"),
@@ -374,7 +377,6 @@ impl TableFormat for AgentResponse {
         vec![
             Cell::new(&self.uid),
             Cell::new(&self.name),
-            Cell::new(self.available.to_string()),
             Cell::new(self.created_at.to_rfc3339()),
             Cell::new(display_optional(self.description.as_deref())),
             Cell::new(display_list(
@@ -389,16 +391,25 @@ impl TableFormat for AgentResponse {
 
 fn print_agents(agents: &[AgentResponse], output_format: OutputFormat) -> anyhow::Result<()> {
     match output_format {
-        OutputFormat::Pretty if agents.is_empty() => {
-            println!("No agents found.");
-            print_skills_hint();
-        }
-        OutputFormat::Pretty => {
-            super::output::write_list(agents.to_vec(), output_format, std::io::stdout())?;
-            print_skills_hint();
-        }
-        OutputFormat::Text => {
-            super::output::write_list(agents.to_vec(), output_format, std::io::stdout())?;
+        OutputFormat::Pretty | OutputFormat::Text => {
+            let (visible_agents, hidden_count) = visible_agents_and_hidden_count(agents);
+            match output_format {
+                OutputFormat::Pretty if visible_agents.is_empty() => {
+                    println!("No agents found.");
+                    print_skills_hint();
+                }
+                OutputFormat::Pretty => {
+                    super::output::write_list(visible_agents, output_format, std::io::stdout())?;
+                    print_skills_hint();
+                }
+                OutputFormat::Text => {
+                    super::output::write_list(visible_agents, output_format, std::io::stdout())?;
+                }
+                OutputFormat::Json | OutputFormat::Ndjson => {
+                    unreachable!("handled by outer match")
+                }
+            }
+            print_disabled_agents_hidden_notice(hidden_count);
         }
         OutputFormat::Ndjson => {
             for agent in agents {
@@ -410,6 +421,21 @@ fn print_agents(agents: &[AgentResponse], output_format: OutputFormat) -> anyhow
     Ok(())
 }
 
+fn visible_agents_and_hidden_count(agents: &[AgentResponse]) -> (Vec<AgentResponse>, usize) {
+    let visible_agents = agents
+        .iter()
+        .filter(|agent| agent.available)
+        .cloned()
+        .collect::<Vec<_>>();
+    let hidden_count = agents.len() - visible_agents.len();
+    (visible_agents, hidden_count)
+}
+
+fn print_disabled_agents_hidden_notice(hidden_count: usize) {
+    if hidden_count > 0 {
+        eprintln!("{hidden_count} disabled agents hidden");
+    }
+}
 fn print_single_agent(agent: &AgentResponse, output_format: OutputFormat) -> anyhow::Result<()> {
     match output_format {
         OutputFormat::Pretty | OutputFormat::Text => {
@@ -425,7 +451,7 @@ fn print_single_agent(agent: &AgentResponse, output_format: OutputFormat) -> any
 
 fn print_skills_hint() {
     let binary_name = warp_cli::binary_name().unwrap_or_else(|| "warp".to_string());
-    println!("Looking for agent skills? Use {binary_name} agent skills instead.");
+    println!("\n\nLooking for your agent skills? Use `{binary_name} agent skills` instead.");
 }
 
 #[derive(Serialize)]
@@ -481,6 +507,7 @@ fn display_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
 impl warpui::Entity for AgentManagementRunner {
     type Event = ();
 }
+
 impl SingletonEntity for AgentManagementRunner {}
 
 #[cfg(test)]

--- a/app/src/ai/agent_sdk/agent_management_tests.rs
+++ b/app/src/ai/agent_sdk/agent_management_tests.rs
@@ -1,0 +1,124 @@
+use chrono::{TimeZone as _, Utc};
+
+use super::*;
+
+fn agent(uid: &str, name: &str, created_at_seconds: i64) -> AgentResponse {
+    AgentResponse {
+        uid: uid.to_string(),
+        name: name.to_string(),
+        description: None,
+        available: true,
+        created_at: Utc
+            .timestamp_opt(created_at_seconds, 0)
+            .single()
+            .expect("valid timestamp"),
+        secrets: vec![],
+        skills: vec![],
+        base_model: None,
+        environment_id: None,
+    }
+}
+
+#[test]
+fn sort_agents_defaults_to_name_ascending() {
+    let mut agents = vec![agent("2", "zeta", 2), agent("1", "alpha", 1)];
+
+    sort_agents(&mut agents, None, None);
+
+    assert_eq!(agents[0].name, "alpha");
+    assert_eq!(agents[1].name, "zeta");
+}
+
+#[test]
+fn sort_agents_defaults_created_at_to_descending() {
+    let mut agents = vec![agent("1", "old", 1), agent("2", "new", 2)];
+
+    sort_agents(&mut agents, Some(AgentSortByArg::CreatedAt), None);
+
+    assert_eq!(agents[0].name, "new");
+    assert_eq!(agents[1].name, "old");
+}
+
+#[test]
+fn sort_agents_respects_explicit_sort_order_without_sort_field() {
+    let mut agents = vec![agent("1", "alpha", 1), agent("2", "zeta", 2)];
+
+    sort_agents(&mut agents, None, Some(AgentSortOrderArg::Desc));
+
+    assert_eq!(agents[0].name, "zeta");
+    assert_eq!(agents[1].name, "alpha");
+}
+
+#[test]
+fn update_request_omits_unset_fields_and_serializes_clears() {
+    let request = UpdateAgentRequest {
+        description: Some(String::new()),
+        secrets: Some(vec![]),
+        base_model: Some(String::new()),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_value(request).expect("request serializes");
+
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "description": "",
+            "secrets": [],
+            "base_model": "",
+        })
+    );
+}
+
+#[test]
+fn rejects_sort_for_json_output() {
+    let args = AgentListArgs {
+        sort_by: Some(AgentSortByArg::Name),
+        sort_order: None,
+        json_output: JsonOutput { filter: None },
+    };
+
+    let err = ensure_json_sort_is_not_requested(OutputFormat::Json, &args.json_output, &args)
+        .unwrap_err();
+
+    assert!(err.to_string().contains("not supported with JSON output"));
+}
+
+#[test]
+fn apply_string_deltas_removes_and_appends_without_duplicates() {
+    let values = apply_string_deltas(
+        &["old".to_string(), "keep".to_string()],
+        vec!["new".to_string(), "keep".to_string()],
+        vec!["old".to_string()],
+    );
+
+    assert_eq!(values, ["keep", "new"]);
+}
+
+#[test]
+fn apply_secret_deltas_uses_secret_names() {
+    let values = apply_secret_deltas(
+        &[
+            SecretRef {
+                name: "OLD_TOKEN".to_string(),
+            },
+            SecretRef {
+                name: "KEEP_TOKEN".to_string(),
+            },
+        ],
+        vec!["NEW_TOKEN".to_string()],
+        vec!["OLD_TOKEN".to_string()],
+    );
+
+    assert_eq!(
+        values,
+        [
+            SecretRef {
+                name: "KEEP_TOKEN".to_string()
+            },
+            SecretRef {
+                name: "NEW_TOKEN".to_string()
+            },
+        ]
+    );
+}

--- a/app/src/ai/agent_sdk/agent_management_tests.rs
+++ b/app/src/ai/agent_sdk/agent_management_tests.rs
@@ -3,11 +3,20 @@ use chrono::{TimeZone as _, Utc};
 use super::*;
 
 fn agent(uid: &str, name: &str, created_at_seconds: i64) -> AgentResponse {
+    agent_with_available(uid, name, created_at_seconds, true)
+}
+
+fn agent_with_available(
+    uid: &str,
+    name: &str,
+    created_at_seconds: i64,
+    available: bool,
+) -> AgentResponse {
     AgentResponse {
         uid: uid.to_string(),
         name: name.to_string(),
         description: None,
-        available: true,
+        available,
         created_at: Utc
             .timestamp_opt(created_at_seconds, 0)
             .single()
@@ -19,6 +28,43 @@ fn agent(uid: &str, name: &str, created_at_seconds: i64) -> AgentResponse {
     }
 }
 
+#[test]
+fn table_format_does_not_include_available_column() {
+    let header = AgentResponse::header()
+        .into_iter()
+        .map(|cell| cell.content().to_string())
+        .collect::<Vec<_>>();
+    let row = agent("1", "agent", 1).row();
+
+    assert_eq!(
+        header,
+        [
+            "UID",
+            "Name",
+            "Created",
+            "Description",
+            "Secrets",
+            "Skills",
+            "Base model",
+            "Environment",
+        ]
+    );
+    assert_eq!(row.len(), header.len());
+}
+
+#[test]
+fn visible_agents_and_hidden_count_filters_disabled_agents() {
+    let agents = vec![
+        agent_with_available("1", "enabled", 1, true),
+        agent_with_available("2", "disabled", 2, false),
+    ];
+
+    let (visible_agents, hidden_count) = visible_agents_and_hidden_count(&agents);
+
+    assert_eq!(visible_agents.len(), 1);
+    assert_eq!(visible_agents[0].name, "enabled");
+    assert_eq!(hidden_count, 1);
+}
 #[test]
 fn sort_agents_defaults_to_name_ascending() {
     let mut agents = vec![agent("2", "zeta", 2), agent("1", "alpha", 1)];
@@ -43,7 +89,7 @@ fn sort_agents_defaults_created_at_to_descending() {
 fn sort_agents_respects_explicit_sort_order_without_sort_field() {
     let mut agents = vec![agent("1", "alpha", 1), agent("2", "zeta", 2)];
 
-    sort_agents(&mut agents, None, Some(AgentSortOrderArg::Desc));
+    sort_agents(&mut agents, None, Some(SortOrderArg::Desc));
 
     assert_eq!(agents[0].name, "zeta");
     assert_eq!(agents[1].name, "alpha");

--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -12,9 +12,9 @@ use warp_cli::json_filter::JsonOutput;
 use warp_cli::task::{
     ArtifactTypeArg, ExecutionLocationArg, ListTasksArgs, MessageCommand, MessageDeliveredArgs,
     MessageListArgs, MessageReadArgs, MessageSendArgs, MessageWatchArgs, RunSortByArg,
-    RunSortOrderArg, RunSourceArg, RunStateArg, TaskGetArgs,
+    RunSourceArg, RunStateArg, TaskGetArgs,
 };
-use warp_cli::GlobalOptions;
+use warp_cli::{GlobalOptions, SortOrderArg};
 use warp_core::channel::ChannelState;
 use warp_core::features::FeatureFlag;
 use warpui::platform::TerminationMode;
@@ -181,10 +181,10 @@ fn sort_by_from_arg(arg: RunSortByArg) -> RunSortBy {
     }
 }
 
-fn sort_order_from_arg(arg: RunSortOrderArg) -> RunSortOrder {
+fn sort_order_from_arg(arg: SortOrderArg) -> RunSortOrder {
     match arg {
-        RunSortOrderArg::Asc => RunSortOrder::Asc,
-        RunSortOrderArg::Desc => RunSortOrder::Desc,
+        SortOrderArg::Asc => RunSortOrder::Asc,
+        SortOrderArg::Desc => RunSortOrder::Desc,
     }
 }
 

--- a/app/src/ai/agent_sdk/ambient_tests.rs
+++ b/app/src/ai/agent_sdk/ambient_tests.rs
@@ -2,9 +2,9 @@
 use chrono::{TimeZone, Utc};
 use warp_cli::json_filter::JsonOutput;
 use warp_cli::task::{
-    ArtifactTypeArg, ExecutionLocationArg, ListTasksArgs, RunSortByArg, RunSortOrderArg,
-    RunSourceArg, RunStateArg,
+    ArtifactTypeArg, ExecutionLocationArg, ListTasksArgs, RunSortByArg, RunSourceArg, RunStateArg,
 };
+use warp_cli::SortOrderArg;
 
 use super::*;
 use crate::server::server_api::ai::{ArtifactType, ExecutionLocation, RunSortBy, RunSortOrder};
@@ -138,7 +138,7 @@ fn every_field_maps_through() {
         updated_after: Some(updated_after),
         query: Some("oz run".to_string()),
         sort_by: Some(RunSortByArg::CreatedAt),
-        sort_order: Some(RunSortOrderArg::Asc),
+        sort_order: Some(SortOrderArg::Asc),
         cursor: Some("abcd==".to_string()),
         json_output: JsonOutput::default(),
     };

--- a/app/src/ai/agent_sdk/api_key.rs
+++ b/app/src/ai/agent_sdk/api_key.rs
@@ -9,10 +9,10 @@ use inquire::{Confirm, InquireError, Select};
 use serde::Serialize;
 use warp_cli::agent::OutputFormat;
 use warp_cli::api_key::{
-    ApiKeyCommand, ApiKeyExpirationArgs, ApiKeySortByArg, ApiKeySortOrderArg, CreateApiKeyArgs,
-    ExpireApiKeyArgs, ListApiKeysArgs,
+    ApiKeyCommand, ApiKeyExpirationArgs, ApiKeySortByArg, CreateApiKeyArgs, ExpireApiKeyArgs,
+    ListApiKeysArgs,
 };
-use warp_cli::GlobalOptions;
+use warp_cli::{GlobalOptions, SortOrderArg};
 use warp_graphql::mutations::expire_api_key::ExpireApiKeyResult;
 use warp_graphql::mutations::generate_api_key::GenerateApiKeyResult;
 use warp_graphql::queries::api_keys::ApiKeyProperties;
@@ -363,12 +363,12 @@ struct ExpiredApiKeyInfo {
 fn sort_api_keys(
     keys: &mut [ApiKeyInfo],
     sort_by: Option<ApiKeySortByArg>,
-    sort_order: Option<ApiKeySortOrderArg>,
+    sort_order: Option<SortOrderArg>,
 ) {
     let Some(sort_by) = sort_by else {
         return;
     };
-    let descending = matches!(sort_order, Some(ApiKeySortOrderArg::Desc));
+    let descending = matches!(sort_order, Some(SortOrderArg::Desc));
     match sort_by {
         ApiKeySortByArg::Name => {
             if descending {

--- a/app/src/ai/agent_sdk/api_key_tests.rs
+++ b/app/src/ai/agent_sdk/api_key_tests.rs
@@ -27,7 +27,7 @@ fn sort_api_keys_sorts_by_name_ascending() {
     sort_api_keys(
         &mut keys,
         Some(ApiKeySortByArg::Name),
-        Some(ApiKeySortOrderArg::Asc),
+        Some(SortOrderArg::Asc),
     );
 
     assert_eq!(keys[0].name, "alpha");
@@ -43,7 +43,7 @@ fn sort_api_keys_sorts_by_created_at_descending() {
     sort_api_keys(
         &mut keys,
         Some(ApiKeySortByArg::CreatedAt),
-        Some(ApiKeySortOrderArg::Desc),
+        Some(SortOrderArg::Desc),
     );
 
     assert_eq!(keys[0].name, "newer");

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -367,6 +367,7 @@ fn build_merged_config_and_task(
     let harness_override = (args.harness != Harness::Oz).then_some(HarnessConfig {
         harness_type: args.harness,
         model_id: harness_model_id,
+        reasoning_level: None,
     });
 
     let oz_model = if args.harness == Harness::Oz {
@@ -467,6 +468,7 @@ fn build_server_side_task(
     let harness_override = (args.harness != Harness::Oz).then_some(HarnessConfig {
         harness_type: args.harness,
         model_id: harness_model_id,
+        reasoning_level: None,
     });
 
     let skill_name = resolved_skill.as_ref().map(|s| s.name.clone());
@@ -854,10 +856,10 @@ impl AgentDriverRunner {
                 let should_share = (args.share.is_shared() || args.task_id.is_some())
                     && FeatureFlag::AgentSharedSessions.is_enabled();
 
-                let third_party_harness_model_id = merged_config
+                let third_party_harness_model_config = merged_config
                     .harness
                     .as_ref()
-                    .and_then(|h| h.model_id.clone());
+                    .and_then(|h| h.model_config());
                 let driver_options = driver::AgentDriverOptions {
                     working_dir: working_dir.clone(),
                     task_id,
@@ -869,7 +871,7 @@ impl AgentDriverRunner {
                     cloud_providers: Vec::new(),
                     environment: None,
                     selected_harness: args.harness,
-                    third_party_harness_model_id,
+                    third_party_harness_model_config,
                     snapshot_disabled: args.snapshot.no_snapshot.then_some(true),
                     snapshot_upload_timeout: args
                         .snapshot
@@ -1154,7 +1156,7 @@ impl AgentDriverRunner {
                 }
             }
         };
-        let (parent_run_id, task_conversation_id, task_harness, task_harness_model_id) =
+        let (parent_run_id, task_conversation_id, task_harness, task_harness_model_config) =
             match task_metadata_result {
                 Ok(Some(task_metadata)) => {
                     // The task's harness is stored on the snapshot; if absent, it's the default Oz.
@@ -1165,13 +1167,13 @@ impl AgentDriverRunner {
                     let task_harness = task_harness_config
                         .map(|h| h.harness_type)
                         .unwrap_or(Harness::Oz);
-                    let task_harness_model_id =
-                        task_harness_config.and_then(|h| h.model_id.clone());
+                    let task_harness_model_config =
+                        task_harness_config.and_then(|h| h.model_config());
                     (
                         task_metadata.parent_run_id,
                         task_metadata.conversation_id,
                         Some(task_harness),
-                        task_harness_model_id,
+                        task_harness_model_config,
                     )
                 }
                 Ok(None) => (None, None, None, None),
@@ -1207,8 +1209,8 @@ impl AgentDriverRunner {
         driver_options.parent_run_id = parent_run_id;
         driver_options.secrets = secrets;
         // CLI flags continue to take precedence so users can still override per-invocation.
-        if driver_options.third_party_harness_model_id.is_none() {
-            driver_options.third_party_harness_model_id = task_harness_model_id;
+        if driver_options.third_party_harness_model_config.is_none() {
+            driver_options.third_party_harness_model_config = task_harness_model_config;
         }
 
         // Update the task prompt to include the downloaded attachments dir

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -69,6 +69,7 @@ use crate::workflows::workflow::Workflow;
 
 mod admin;
 mod agent_config;
+mod agent_management;
 mod ambient;
 mod api_key;
 mod artifact;
@@ -307,7 +308,22 @@ fn run_agent(
             ambient::run_ambient_agent(ctx, args)
         }
         AgentCommand::Profile(sub) => profiles::run(ctx, global_options, sub),
-        AgentCommand::List(args) => agent_config::list_agents(ctx, args),
+        AgentCommand::List(args) => {
+            agent_management::list_agents(ctx, global_options.output_format, args)
+        }
+        AgentCommand::Get(args) => {
+            agent_management::get_agent(ctx, global_options.output_format, args)
+        }
+        AgentCommand::Create(args) => {
+            agent_management::create_agent(ctx, global_options.output_format, args)
+        }
+        AgentCommand::Update(args) => {
+            agent_management::update_agent(ctx, global_options.output_format, args)
+        }
+        AgentCommand::Delete(args) => {
+            agent_management::delete_agent(ctx, global_options.output_format, args)
+        }
+        AgentCommand::Skills(args) => agent_config::list_skills(ctx, args),
     }
 }
 
@@ -351,7 +367,6 @@ fn build_merged_config_and_task(
     let harness_override = (args.harness != Harness::Oz).then_some(HarnessConfig {
         harness_type: args.harness,
         model_id: harness_model_id,
-        reasoning_level: None,
     });
 
     let oz_model = if args.harness == Harness::Oz {
@@ -452,7 +467,6 @@ fn build_server_side_task(
     let harness_override = (args.harness != Harness::Oz).then_some(HarnessConfig {
         harness_type: args.harness,
         model_id: harness_model_id,
-        reasoning_level: None,
     });
 
     let skill_name = resolved_skill.as_ref().map(|s| s.name.clone());
@@ -840,10 +854,10 @@ impl AgentDriverRunner {
                 let should_share = (args.share.is_shared() || args.task_id.is_some())
                     && FeatureFlag::AgentSharedSessions.is_enabled();
 
-                let third_party_harness_model_config = merged_config
+                let third_party_harness_model_id = merged_config
                     .harness
                     .as_ref()
-                    .and_then(|h| h.model_config());
+                    .and_then(|h| h.model_id.clone());
                 let driver_options = driver::AgentDriverOptions {
                     working_dir: working_dir.clone(),
                     task_id,
@@ -855,7 +869,7 @@ impl AgentDriverRunner {
                     cloud_providers: Vec::new(),
                     environment: None,
                     selected_harness: args.harness,
-                    third_party_harness_model_config,
+                    third_party_harness_model_id,
                     snapshot_disabled: args.snapshot.no_snapshot.then_some(true),
                     snapshot_upload_timeout: args
                         .snapshot
@@ -1140,7 +1154,7 @@ impl AgentDriverRunner {
                 }
             }
         };
-        let (parent_run_id, task_conversation_id, task_harness, task_harness_model_config) =
+        let (parent_run_id, task_conversation_id, task_harness, task_harness_model_id) =
             match task_metadata_result {
                 Ok(Some(task_metadata)) => {
                     // The task's harness is stored on the snapshot; if absent, it's the default Oz.
@@ -1151,13 +1165,13 @@ impl AgentDriverRunner {
                     let task_harness = task_harness_config
                         .map(|h| h.harness_type)
                         .unwrap_or(Harness::Oz);
-                    let task_harness_model_config =
-                        task_harness_config.and_then(|h| h.model_config());
+                    let task_harness_model_id =
+                        task_harness_config.and_then(|h| h.model_id.clone());
                     (
                         task_metadata.parent_run_id,
                         task_metadata.conversation_id,
                         Some(task_harness),
-                        task_harness_model_config,
+                        task_harness_model_id,
                     )
                 }
                 Ok(None) => (None, None, None, None),
@@ -1193,8 +1207,8 @@ impl AgentDriverRunner {
         driver_options.parent_run_id = parent_run_id;
         driver_options.secrets = secrets;
         // CLI flags continue to take precedence so users can still override per-invocation.
-        if driver_options.third_party_harness_model_config.is_none() {
-            driver_options.third_party_harness_model_config = task_harness_model_config;
+        if driver_options.third_party_harness_model_id.is_none() {
+            driver_options.third_party_harness_model_id = task_harness_model_id;
         }
 
         // Update the task prompt to include the downloaded attachments dir
@@ -1369,6 +1383,11 @@ fn command_requires_auth(command: &CliCommand) -> bool {
                 AgentProfileCommand::List => true,
             },
             AgentCommand::List(_) => true,
+            AgentCommand::Get(_) => true,
+            AgentCommand::Create(_) => true,
+            AgentCommand::Update(_) => true,
+            AgentCommand::Delete(_) => true,
+            AgentCommand::Skills(_) => true,
         },
         CliCommand::Environment(environment_cmd) => match environment_cmd {
             EnvironmentCommand::List => true,
@@ -1528,6 +1547,11 @@ fn command_to_telemetry_event(command: &CliCommand) -> CliTelemetryEvent {
             AgentProfileCommand::List => CliTelemetryEvent::AgentProfileList,
         },
         CliCommand::Agent(AgentCommand::List(_)) => CliTelemetryEvent::AgentList,
+        CliCommand::Agent(AgentCommand::Get(_)) => CliTelemetryEvent::AgentGet,
+        CliCommand::Agent(AgentCommand::Create(_)) => CliTelemetryEvent::AgentCreate,
+        CliCommand::Agent(AgentCommand::Update(_)) => CliTelemetryEvent::AgentUpdate,
+        CliCommand::Agent(AgentCommand::Delete(_)) => CliTelemetryEvent::AgentDelete,
+        CliCommand::Agent(AgentCommand::Skills(_)) => CliTelemetryEvent::AgentSkills,
         CliCommand::Environment(EnvironmentCommand::List) => CliTelemetryEvent::EnvironmentList,
         CliCommand::Environment(EnvironmentCommand::Create { .. }) => {
             CliTelemetryEvent::EnvironmentCreate

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -23,6 +23,16 @@ pub(super) enum CliTelemetryEvent {
     AgentProfileList,
     /// Executing `warp agent list`
     AgentList,
+    /// Executing `warp agent get`
+    AgentGet,
+    /// Executing `warp agent create`
+    AgentCreate,
+    /// Executing `warp agent update`
+    AgentUpdate,
+    /// Executing `warp agent delete`
+    AgentDelete,
+    /// Executing `warp agent skills`
+    AgentSkills,
     /// Executing `warp environment list`
     EnvironmentList,
     /// Executing `warp environment create`
@@ -146,6 +156,11 @@ impl TelemetryEvent for CliTelemetryEvent {
             CliTelemetryEvent::AgentRunAmbient => None,
             CliTelemetryEvent::AgentProfileList => None,
             CliTelemetryEvent::AgentList => None,
+            CliTelemetryEvent::AgentGet => None,
+            CliTelemetryEvent::AgentCreate => None,
+            CliTelemetryEvent::AgentUpdate => None,
+            CliTelemetryEvent::AgentDelete => None,
+            CliTelemetryEvent::AgentSkills => None,
             CliTelemetryEvent::EnvironmentList => None,
             CliTelemetryEvent::EnvironmentCreate => None,
             CliTelemetryEvent::EnvironmentDelete => None,
@@ -228,6 +243,11 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::AgentRunAmbient => "CLI.Execute.Agent.RunAmbient",
             CliTelemetryEventDiscriminants::AgentProfileList => "CLI.Execute.Agent.Profile.List",
             CliTelemetryEventDiscriminants::AgentList => "CLI.Execute.Agent.List",
+            CliTelemetryEventDiscriminants::AgentGet => "CLI.Execute.Agent.Get",
+            CliTelemetryEventDiscriminants::AgentCreate => "CLI.Execute.Agent.Create",
+            CliTelemetryEventDiscriminants::AgentUpdate => "CLI.Execute.Agent.Update",
+            CliTelemetryEventDiscriminants::AgentDelete => "CLI.Execute.Agent.Delete",
+            CliTelemetryEventDiscriminants::AgentSkills => "CLI.Execute.Agent.Skills",
             CliTelemetryEventDiscriminants::EnvironmentList => "CLI.Execute.Environment.List",
             CliTelemetryEventDiscriminants::EnvironmentCreate => "CLI.Execute.Environment.Create",
             CliTelemetryEventDiscriminants::EnvironmentDelete => "CLI.Execute.Environment.Delete",
@@ -306,6 +326,11 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
                 "Listed agent profiles from the Warp CLI"
             }
             CliTelemetryEventDiscriminants::AgentList => "Listed agents from the Warp CLI",
+            CliTelemetryEventDiscriminants::AgentGet => "Got agent details from the Warp CLI",
+            CliTelemetryEventDiscriminants::AgentCreate => "Created an agent from the Warp CLI",
+            CliTelemetryEventDiscriminants::AgentUpdate => "Updated an agent from the Warp CLI",
+            CliTelemetryEventDiscriminants::AgentDelete => "Deleted an agent from the Warp CLI",
+            CliTelemetryEventDiscriminants::AgentSkills => "Listed agent skills from the Warp CLI",
             CliTelemetryEventDiscriminants::EnvironmentList => {
                 "Listed cloud environments from the Warp CLI"
             }

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -5,14 +5,13 @@ use futures::channel::oneshot;
 use parking_lot::FairMutex;
 use warpui::{App, EntityId};
 
+use super::{BlockSelector, ShellCommandExecutor};
 use crate::terminal::event::{BlockMetadataReceivedEvent, BlockWorkingDirectoryUpdatedEvent};
 use crate::terminal::model::block::{BlockId, BlockMetadata};
 use crate::terminal::model::session::active_session::ActiveSession;
 use crate::terminal::model::session::Sessions;
 use crate::terminal::model::terminal_model::{BlockIndex, TerminalModel};
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
-
-use super::{BlockSelector, ShellCommandExecutor};
 
 /// Locks in the contract that `ShellCommandExecutor`'s requested-command finish
 /// detector reacts only to `BlockMetadataReceived` (precmd) and not to

--- a/app/src/ai/blocklist/block/view_impl/query.rs
+++ b/app/src/ai/blocklist/block/view_impl/query.rs
@@ -16,8 +16,7 @@ use warpui::{AppContext, Element, SingletonEntity};
 
 use super::common::{render_query_text, render_user_avatar, FindContext};
 use crate::ai::blocklist::block::view_impl::common::UserQueryProps;
-use crate::ai::blocklist::block::AIBlockAction;
-use crate::ai::blocklist::block::{DetectedLinksState, SecretRedactionState};
+use crate::ai::blocklist::block::{AIBlockAction, DetectedLinksState, SecretRedactionState};
 use crate::ai::blocklist::AttachmentType;
 use crate::appearance::Appearance;
 use crate::ui_components::blended_colors;

--- a/app/src/ai/blocklist/local_shared_session_link_model.rs
+++ b/app/src/ai/blocklist/local_shared_session_link_model.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
+use session_sharing_protocol::common::SessionId;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
 use super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::server::server_api::ai::AIClient;
 use crate::server::server_api::ServerApiProvider;
-use session_sharing_protocol::common::SessionId;
-use std::sync::Arc;
-use warpui::{Entity, ModelContext, SingletonEntity};
 
 /// Ensures that session ID for locally owned shared conversations is linked
 /// to their `ai_tasks` row in the DB. This enables viewers to reconstruct

--- a/app/src/ai/blocklist/local_shared_session_link_model_tests.rs
+++ b/app/src/ai/blocklist/local_shared_session_link_model_tests.rs
@@ -1,12 +1,14 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use session_sharing_protocol::common::SessionId;
+use warpui::App;
+
 use super::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel, LocalSharedSessionLinkModel};
 use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::server::server_api::ai::{AIClient, MockAIClient};
-use session_sharing_protocol::common::SessionId;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
-use warpui::App;
 
 /// Parses a fixed UUID into an `AmbientAgentTaskId`. Using a constant uuid
 /// makes test failures easier to read than `Uuid::new_v4()`.

--- a/app/src/server/cloud_objects/update_manager.rs
+++ b/app/src/server/cloud_objects/update_manager.rs
@@ -1,14 +1,15 @@
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::sync::mpsc::SyncSender;
+use std::sync::Arc;
+use std::time::Duration;
+
 use chrono::{DateTime, Utc};
 use futures::channel::oneshot::{self, Receiver};
 use futures::stream::AbortHandle;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::collections::{HashMap, HashSet};
-use std::future::Future;
-use std::sync::mpsc::SyncSender;
-use std::sync::Arc;
-use std::time::Duration;
 use warp_core::features::FeatureFlag;
 use warp_core::report_error;
 use warp_graphql::mcp_gallery_template::MCPGalleryTemplate;

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -148,10 +148,18 @@ pub enum DeserializationError {
     Transport(reqwest::Error),
 }
 
+#[derive(Deserialize, Debug)]
+struct OutOfCreditsResponse {
+    #[serde(default, rename = "userDisplayMessage")]
+    user_display_message: Option<String>,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum AIApiError {
     #[error("Request failed due to lack of AI quota.")]
-    QuotaLimit,
+    QuotaLimit {
+        user_display_message: Option<String>,
+    },
 
     #[error("Warp is currently overloaded. Please try again later.")]
     ServerOverloaded,
@@ -181,7 +189,12 @@ pub enum AIApiError {
 
 impl From<http_client::ResponseError> for AIApiError {
     fn from(err: http_client::ResponseError) -> Self {
-        Self::from_response_error(err.source, &err.headers)
+        let http_client::ResponseError {
+            source,
+            headers,
+            body,
+        } = err;
+        Self::from_response_error(source, &headers, body)
     }
 }
 
@@ -200,11 +213,15 @@ impl From<serde_json::Error> for AIApiError {
 impl AIApiError {
     /// Converts a reqwest error to an AIApiError, using response headers to distinguish
     /// between different types of 429 errors.
-    fn from_response_error(err: reqwest::Error, headers: &::http::HeaderMap) -> Self {
+    fn from_response_error(
+        err: reqwest::Error,
+        headers: &::http::HeaderMap,
+        body: Option<String>,
+    ) -> Self {
         // For HTTP 429 errors, check the X-Warp-Error-Code header to distinguish
         // between out-of-credits and server-overload.
         if err.status() == Some(http::StatusCode::TOO_MANY_REQUESTS) {
-            return Self::error_for_429(headers);
+            return Self::error_for_429(headers, body);
         }
 
         Self::from_transport_error(err)
@@ -240,13 +257,18 @@ impl AIApiError {
     }
 
     /// Returns the appropriate error for a 429 response by checking the X-Warp-Error-Code header.
-    fn error_for_429(headers: &::http::HeaderMap) -> Self {
+    fn error_for_429(headers: &::http::HeaderMap, body: Option<String>) -> Self {
         if headers
             .get(WARP_ERROR_CODE_HEADER)
             .and_then(|v| v.to_str().ok())
             == Some(WARP_ERROR_CODE_OUT_OF_CREDITS)
         {
-            AIApiError::QuotaLimit
+            let user_display_message = body
+                .and_then(|body| serde_json::from_str::<OutOfCreditsResponse>(&body).ok())
+                .and_then(|r| r.user_display_message);
+            AIApiError::QuotaLimit {
+                user_display_message,
+            }
         } else {
             AIApiError::ServerOverloaded
         }
@@ -258,8 +280,12 @@ impl AIApiError {
         match err {
             reqwest_eventsource::Error::InvalidStatusCode(
                 http::StatusCode::TOO_MANY_REQUESTS,
-                ref res,
-            ) => Self::error_for_429(res.headers()),
+                res,
+            ) => {
+                let headers = res.headers().clone();
+                let body = res.text().await.ok();
+                Self::error_for_429(&headers, body)
+            }
             reqwest_eventsource::Error::InvalidStatusCode(status, res) => Self::ErrorStatus(
                 status,
                 res.text()
@@ -310,9 +336,9 @@ impl ErrorExt for AIApiError {
             AIApiError::Other(error) => error.is_actionable(),
             AIApiError::Stream { source, .. } => source.is_actionable(),
             AIApiError::ErrorStatus(_, _) => self.is_retryable(),
-            AIApiError::QuotaLimit | AIApiError::ServerOverloaded | AIApiError::NoContextFound => {
-                false
-            }
+            AIApiError::QuotaLimit { .. }
+            | AIApiError::ServerOverloaded
+            | AIApiError::NoContextFound => false,
         }
     }
 }
@@ -866,7 +892,13 @@ impl ServerApi {
             }
         }
         if status == StatusCode::TOO_MANY_REQUESTS && is_out_of_credits {
-            return AIApiError::QuotaLimit.into();
+            let user_display_message = serde_json::from_str::<OutOfCreditsResponse>(&response_text)
+                .ok()
+                .and_then(|r| r.user_display_message);
+            return AIApiError::QuotaLimit {
+                user_display_message,
+            }
+            .into();
         }
 
         // Try to deserialize error response as { "error": "message" }
@@ -1119,7 +1151,8 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status()?
+        .error_for_status_with_body()
+        .await?
         .json()
         .await?;
         Ok(response)
@@ -1143,7 +1176,8 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status()?
+        .error_for_status_with_body()
+        .await?
         .json()
         .await?;
 
@@ -1180,7 +1214,8 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status()?
+        .error_for_status_with_body()
+        .await?
         .json()
         .await?;
         Ok(response)
@@ -1203,7 +1238,8 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status()?
+        .error_for_status_with_body()
+        .await?
         .json()
         .await?;
         Ok(response)

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -148,18 +148,10 @@ pub enum DeserializationError {
     Transport(reqwest::Error),
 }
 
-#[derive(Deserialize, Debug)]
-struct OutOfCreditsResponse {
-    #[serde(default, rename = "userDisplayMessage")]
-    user_display_message: Option<String>,
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum AIApiError {
     #[error("Request failed due to lack of AI quota.")]
-    QuotaLimit {
-        user_display_message: Option<String>,
-    },
+    QuotaLimit,
 
     #[error("Warp is currently overloaded. Please try again later.")]
     ServerOverloaded,
@@ -189,12 +181,7 @@ pub enum AIApiError {
 
 impl From<http_client::ResponseError> for AIApiError {
     fn from(err: http_client::ResponseError) -> Self {
-        let http_client::ResponseError {
-            source,
-            headers,
-            body,
-        } = err;
-        Self::from_response_error(source, &headers, body)
+        Self::from_response_error(err.source, &err.headers)
     }
 }
 
@@ -213,15 +200,11 @@ impl From<serde_json::Error> for AIApiError {
 impl AIApiError {
     /// Converts a reqwest error to an AIApiError, using response headers to distinguish
     /// between different types of 429 errors.
-    fn from_response_error(
-        err: reqwest::Error,
-        headers: &::http::HeaderMap,
-        body: Option<String>,
-    ) -> Self {
+    fn from_response_error(err: reqwest::Error, headers: &::http::HeaderMap) -> Self {
         // For HTTP 429 errors, check the X-Warp-Error-Code header to distinguish
         // between out-of-credits and server-overload.
         if err.status() == Some(http::StatusCode::TOO_MANY_REQUESTS) {
-            return Self::error_for_429(headers, body);
+            return Self::error_for_429(headers);
         }
 
         Self::from_transport_error(err)
@@ -257,18 +240,13 @@ impl AIApiError {
     }
 
     /// Returns the appropriate error for a 429 response by checking the X-Warp-Error-Code header.
-    fn error_for_429(headers: &::http::HeaderMap, body: Option<String>) -> Self {
+    fn error_for_429(headers: &::http::HeaderMap) -> Self {
         if headers
             .get(WARP_ERROR_CODE_HEADER)
             .and_then(|v| v.to_str().ok())
             == Some(WARP_ERROR_CODE_OUT_OF_CREDITS)
         {
-            let user_display_message = body
-                .and_then(|body| serde_json::from_str::<OutOfCreditsResponse>(&body).ok())
-                .and_then(|r| r.user_display_message);
-            AIApiError::QuotaLimit {
-                user_display_message,
-            }
+            AIApiError::QuotaLimit
         } else {
             AIApiError::ServerOverloaded
         }
@@ -280,12 +258,8 @@ impl AIApiError {
         match err {
             reqwest_eventsource::Error::InvalidStatusCode(
                 http::StatusCode::TOO_MANY_REQUESTS,
-                res,
-            ) => {
-                let headers = res.headers().clone();
-                let body = res.text().await.ok();
-                Self::error_for_429(&headers, body)
-            }
+                ref res,
+            ) => Self::error_for_429(res.headers()),
             reqwest_eventsource::Error::InvalidStatusCode(status, res) => Self::ErrorStatus(
                 status,
                 res.text()
@@ -336,9 +310,9 @@ impl ErrorExt for AIApiError {
             AIApiError::Other(error) => error.is_actionable(),
             AIApiError::Stream { source, .. } => source.is_actionable(),
             AIApiError::ErrorStatus(_, _) => self.is_retryable(),
-            AIApiError::QuotaLimit { .. }
-            | AIApiError::ServerOverloaded
-            | AIApiError::NoContextFound => false,
+            AIApiError::QuotaLimit | AIApiError::ServerOverloaded | AIApiError::NoContextFound => {
+                false
+            }
         }
     }
 }
@@ -892,13 +866,7 @@ impl ServerApi {
             }
         }
         if status == StatusCode::TOO_MANY_REQUESTS && is_out_of_credits {
-            let user_display_message = serde_json::from_str::<OutOfCreditsResponse>(&response_text)
-                .ok()
-                .and_then(|r| r.user_display_message);
-            return AIApiError::QuotaLimit {
-                user_display_message,
-            }
-            .into();
+            return AIApiError::QuotaLimit.into();
         }
 
         // Try to deserialize error response as { "error": "message" }
@@ -926,6 +894,57 @@ impl ServerApi {
             .with_context(|| format!("Failed to deserialize response from {url}"))
     }
 
+    /// Sends a PUT request to a public API endpoint and returns the raw response on success.
+    async fn put_public_api_response<B>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<http_client::Response>
+    where
+        B: Serialize,
+    {
+        let auth_token = self
+            .get_or_refresh_access_token()
+            .await
+            .context("Failed to get access token for API request")?;
+
+        let url = format!("{}/api/v1/{}", ChannelState::server_root_url(), path);
+
+        let mut request = self.client.put(&url).json(body);
+        if let Some(token) = auth_token.as_bearer_token() {
+            request = request.bearer_auth(token);
+        }
+
+        for (name, value) in self.ambient_agent_headers().await? {
+            request = request.header(name, value);
+        }
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("Failed to send API request to {url}"))?;
+
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            Err(Self::error_from_response(response).await)
+        }
+    }
+
+    /// Sends a PUT request to a public API endpoint.
+    async fn put_public_api<B, R>(&self, path: &str, body: &B) -> Result<R>
+    where
+        B: Serialize,
+        R: serde::de::DeserializeOwned,
+    {
+        let response = self.put_public_api_response(path, body).await?;
+        let url = response.url().clone();
+        response
+            .json::<R>()
+            .await
+            .with_context(|| format!("Failed to deserialize response from {url}"))
+    }
+
     /// Sends a POST request to a public API endpoint that returns no response body.
     async fn post_public_api_unit<B>(&self, path: &str, body: &B) -> Result<()>
     where
@@ -933,6 +952,36 @@ impl ServerApi {
     {
         self.post_public_api_response(path, body).await?;
         Ok(())
+    }
+
+    /// Sends a DELETE request to a public API endpoint that returns no response body.
+    async fn delete_public_api_unit(&self, path: &str) -> Result<()> {
+        let auth_token = self
+            .get_or_refresh_access_token()
+            .await
+            .context("Failed to get access token for API request")?;
+
+        let url = format!("{}/api/v1/{}", ChannelState::server_root_url(), path);
+
+        let mut request = self.client.delete(&url);
+        if let Some(token) = auth_token.as_bearer_token() {
+            request = request.bearer_auth(token);
+        }
+
+        for (name, value) in self.ambient_agent_headers().await? {
+            request = request.header(name, value);
+        }
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("Failed to send API request to {url}"))?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(Self::error_from_response(response).await)
+        }
     }
 
     /// Sends a PATCH request to a public API endpoint that returns no response body.
@@ -1070,8 +1119,7 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status_with_body()
-        .await?
+        .error_for_status()?
         .json()
         .await?;
         Ok(response)
@@ -1095,8 +1143,7 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status_with_body()
-        .await?
+        .error_for_status()?
         .json()
         .await?;
 
@@ -1133,8 +1180,7 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status_with_body()
-        .await?
+        .error_for_status()?
         .json()
         .await?;
         Ok(response)
@@ -1157,8 +1203,7 @@ impl ServerApi {
         .json(request)
         .send()
         .await?
-        .error_for_status_with_body()
-        .await?
+        .error_for_status()?
         .json()
         .await?;
         Ok(response)

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -813,7 +813,7 @@ impl<'de> serde::Deserialize<'de> for ListRunsResponse {
 
 /// Source information for an agent skill.
 #[derive(Clone, serde::Deserialize, Debug, PartialEq)]
-pub struct AgentListSource {
+pub struct AgentSkillSource {
     pub owner: String,
     pub name: String,
     pub skill_path: String,
@@ -821,31 +821,93 @@ pub struct AgentListSource {
 
 /// Environment information for an agent skill.
 #[derive(Clone, serde::Deserialize, Debug, PartialEq)]
-pub struct AgentListEnvironment {
+pub struct AgentSkillEnvironment {
     pub uid: String,
     pub name: String,
 }
 
 /// A variant of an agent skill.
 #[derive(Clone, serde::Deserialize, Debug, PartialEq)]
-pub struct AgentListVariant {
+pub struct AgentSkillVariant {
     pub id: String,
     pub description: String,
     pub base_prompt: String,
-    pub source: AgentListSource,
-    pub environments: Vec<AgentListEnvironment>,
+    pub source: AgentSkillSource,
+    pub environments: Vec<AgentSkillEnvironment>,
 }
 
 /// An agent skill item with its variants.
 #[derive(Clone, serde::Deserialize, Debug, PartialEq)]
-pub struct AgentListItem {
+pub struct AgentSkillItem {
     pub name: String,
-    pub variants: Vec<AgentListVariant>,
+    pub variants: Vec<AgentSkillVariant>,
+}
+
+#[derive(serde::Deserialize)]
+struct ListSkillsResponse {
+    agents: Vec<AgentSkillItem>,
+}
+
+/// Reference to a managed secret by name.
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+pub struct SecretRef {
+    pub name: String,
+}
+
+/// JSON payload sent to `POST /agent/identities`.
+#[derive(Clone, serde::Serialize, Debug, PartialEq, Eq)]
+pub struct CreateAgentRequest {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub secrets: Vec<SecretRef>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<String>,
+}
+
+/// JSON payload sent to `PUT /agent/identities/{uid}`.
+#[derive(Clone, Default, serde::Serialize, Debug, PartialEq, Eq)]
+pub struct UpdateAgentRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<Vec<SecretRef>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skills: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<String>,
+}
+
+/// Public API representation of a named agent identity.
+#[derive(Clone, serde::Deserialize, serde::Serialize, Debug, PartialEq, Eq)]
+pub struct AgentResponse {
+    pub uid: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub available: bool,
+    pub created_at: DateTime<Utc>,
+    pub secrets: Vec<SecretRef>,
+    pub skills: Vec<String>,
+    pub base_model: Option<String>,
+    #[serde(default)]
+    pub environment_id: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
 struct ListAgentsResponse {
-    agents: Vec<AgentListItem>,
+    agents: Vec<AgentResponse>,
+}
+fn build_agent_url(uid: &str) -> String {
+    format!("agent/identities/{}", urlencoding::encode(uid))
 }
 
 #[derive(Clone, serde::Deserialize, Debug, PartialEq, Eq)]
@@ -1018,10 +1080,42 @@ pub trait AIClient: 'static + Send + Sync {
         server_conversation_token: String,
     ) -> anyhow::Result<(), anyhow::Error>;
 
-    async fn list_agents(
+    async fn list_skills(
         &self,
         repo: Option<String>,
-    ) -> anyhow::Result<Vec<AgentListItem>, anyhow::Error>;
+    ) -> anyhow::Result<Vec<AgentSkillItem>, anyhow::Error>;
+
+    async fn list_agents(&self) -> anyhow::Result<Vec<AgentResponse>, anyhow::Error>;
+
+    async fn list_agents_raw(&self) -> anyhow::Result<serde_json::Value, anyhow::Error>;
+
+    async fn get_agent(&self, uid: &str) -> anyhow::Result<AgentResponse, anyhow::Error>;
+
+    async fn get_agent_raw(&self, uid: &str) -> anyhow::Result<serde_json::Value, anyhow::Error>;
+
+    async fn create_agent(
+        &self,
+        request: CreateAgentRequest,
+    ) -> anyhow::Result<AgentResponse, anyhow::Error>;
+
+    async fn create_agent_raw(
+        &self,
+        request: CreateAgentRequest,
+    ) -> anyhow::Result<serde_json::Value, anyhow::Error>;
+
+    async fn update_agent(
+        &self,
+        uid: &str,
+        request: UpdateAgentRequest,
+    ) -> anyhow::Result<AgentResponse, anyhow::Error>;
+
+    async fn update_agent_raw(
+        &self,
+        uid: &str,
+        request: UpdateAgentRequest,
+    ) -> anyhow::Result<serde_json::Value, anyhow::Error>;
+
+    async fn delete_agent(&self, uid: &str) -> anyhow::Result<(), anyhow::Error>;
 
     async fn cancel_ambient_agent_task(
         &self,
@@ -1476,7 +1570,6 @@ impl AIClient for ServerApi {
                             .map(|m| crate::ai::harness_availability::HarnessModelInfo {
                                 id: m.id.into_inner(),
                                 display_name: m.display_name,
-                                reasoning_level: m.reasoning_level,
                             })
                             .collect(),
                     })
@@ -1984,16 +2077,67 @@ impl AIClient for ServerApi {
         }
     }
 
-    async fn list_agents(
+    async fn list_skills(
         &self,
         repo: Option<String>,
-    ) -> anyhow::Result<Vec<AgentListItem>, anyhow::Error> {
+    ) -> anyhow::Result<Vec<AgentSkillItem>, anyhow::Error> {
         let path = match repo {
             Some(repo) => format!("agent?repo={}", urlencoding::encode(&repo)),
             None => "agent".to_string(),
         };
-        let response: ListAgentsResponse = self.get_public_api(&path).await?;
+        let response: ListSkillsResponse = self.get_public_api(&path).await?;
         Ok(response.agents)
+    }
+
+    async fn list_agents(&self) -> anyhow::Result<Vec<AgentResponse>, anyhow::Error> {
+        let response: ListAgentsResponse = self.get_public_api("agent/identities").await?;
+        Ok(response.agents)
+    }
+
+    async fn list_agents_raw(&self) -> anyhow::Result<serde_json::Value, anyhow::Error> {
+        self.get_public_api("agent/identities").await
+    }
+
+    async fn get_agent(&self, uid: &str) -> anyhow::Result<AgentResponse, anyhow::Error> {
+        self.get_public_api(&build_agent_url(uid)).await
+    }
+
+    async fn get_agent_raw(&self, uid: &str) -> anyhow::Result<serde_json::Value, anyhow::Error> {
+        self.get_public_api(&build_agent_url(uid)).await
+    }
+
+    async fn create_agent(
+        &self,
+        request: CreateAgentRequest,
+    ) -> anyhow::Result<AgentResponse, anyhow::Error> {
+        self.post_public_api("agent/identities", &request).await
+    }
+
+    async fn create_agent_raw(
+        &self,
+        request: CreateAgentRequest,
+    ) -> anyhow::Result<serde_json::Value, anyhow::Error> {
+        self.post_public_api("agent/identities", &request).await
+    }
+
+    async fn update_agent(
+        &self,
+        uid: &str,
+        request: UpdateAgentRequest,
+    ) -> anyhow::Result<AgentResponse, anyhow::Error> {
+        self.put_public_api(&build_agent_url(uid), &request).await
+    }
+
+    async fn update_agent_raw(
+        &self,
+        uid: &str,
+        request: UpdateAgentRequest,
+    ) -> anyhow::Result<serde_json::Value, anyhow::Error> {
+        self.put_public_api(&build_agent_url(uid), &request).await
+    }
+
+    async fn delete_agent(&self, uid: &str) -> anyhow::Result<(), anyhow::Error> {
+        self.delete_public_api_unit(&build_agent_url(uid)).await
     }
 
     async fn cancel_ambient_agent_task(

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -1570,6 +1570,7 @@ impl AIClient for ServerApi {
                             .map(|m| crate::ai::harness_availability::HarnessModelInfo {
                                 id: m.id.into_inner(),
                                 display_name: m.display_name,
+                                reasoning_level: m.reasoning_level,
                             })
                             .collect(),
                     })

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -2,61 +2,55 @@
 //! connect to and communicate with the shared session.
 //! Adheres to the [`session-sharing-protocol`].
 
+use std::pin::pin;
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::bail;
 use async_channel::Receiver;
+use futures_util::stream::AbortHandle;
+use futures_util::{SinkExt, StreamExt};
 use instant::Instant;
-use std::{pin::pin, sync::Arc};
-use warpui::r#async::{SpawnedFutureHandle, Timer};
-
-use futures_util::{stream::AbortHandle, SinkExt, StreamExt};
-
 use parking_lot::FairMutex;
-use session_sharing_protocol::{
-    common::{
-        ActivePrompt, ActivePromptUpdate, AddGuestsResponse, AgentAttachment,
-        AgentPromptFailureReason, AgentPromptRequest, AgentPromptRequestId,
-        CommandExecutionFailureReason, ControlAction, ControlActionFailureReason, FeatureSupport,
-        InputOperationId, InputOperationSeqNo, InputUpdate, LinkAccessLevelUpdateResponse,
-        ParticipantId, ParticipantList, ParticipantPresenceUpdate, RemoveGuestResponse, Role,
-        RoleRequestId, RoleRequestResponse, Selection, SelectionUpdate, ServerConversationToken,
-        SessionId, TeamAccessLevelUpdateResponse, TeamAclData, TelemetryContext,
-        UniversalDeveloperInputContext, UniversalDeveloperInputContextUpdate,
-        UpdatePendingUserRoleResponse, UserID, WindowSize, WriteToPtyFailureReason,
-        WriteToPtyRequestId, WriteToPtySeqNo,
-    },
-    viewer::{
-        DownstreamMessage, InitPayload, RoleUpdatedReason, SessionEndedReason, UpstreamMessage,
-        ViewerRemovedReason,
-    },
+use session_sharing_protocol::common::{
+    ActivePrompt, ActivePromptUpdate, AddGuestsResponse, AgentAttachment, AgentPromptFailureReason,
+    AgentPromptRequest, AgentPromptRequestId, CommandExecutionFailureReason, ControlAction,
+    ControlActionFailureReason, FeatureSupport, InputOperationId, InputOperationSeqNo, InputUpdate,
+    LinkAccessLevelUpdateResponse, ParticipantId, ParticipantList, ParticipantPresenceUpdate,
+    RemoveGuestResponse, Role, RoleRequestId, RoleRequestResponse, Selection, SelectionUpdate,
+    ServerConversationToken, SessionId, TeamAccessLevelUpdateResponse, TeamAclData,
+    TelemetryContext, UniversalDeveloperInputContext, UniversalDeveloperInputContextUpdate,
+    UpdatePendingUserRoleResponse, UserID, WindowSize, WriteToPtyFailureReason,
+    WriteToPtyRequestId, WriteToPtySeqNo,
 };
-
-use std::time::Duration;
+use session_sharing_protocol::viewer::{
+    DownstreamMessage, InitPayload, RoleUpdatedReason, SessionEndedReason, UpstreamMessage,
+    ViewerRemovedReason,
+};
 use warp_core::features::FeatureFlag;
+use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{
     Entity, ModelContext, ModelHandle, RequestState, RetryOption, SingletonEntity, WeakViewHandle,
 };
 use websocket::{Message, Sink, Stream, WebsocketMessage as _};
 
-use crate::{
-    auth::{auth_state::AuthState, AuthStateProvider, UserUid},
-    editor::{CrdtOperation, ReplicaId},
-    server::{
-        server_api::{auth::AuthClient, ServerApiProvider},
-        telemetry::telemetry_context,
-    },
-    terminal::{
-        event_listener::ChannelEventListener,
-        model::block::BlockId,
-        shared_session::{
-            connect_endpoint,
-            network::heartbeat::{Event as HeartbeatEvent, Heartbeat},
-            viewer::event_loop::{EventLoop, SharedSessionInitialLoadMode},
-            EventNumber, SharedSessionSource, SELECTION_THROTTLE_PERIOD,
-        },
-        TerminalModel, TerminalView,
-    },
-    throttle::throttle,
+use crate::auth::auth_state::AuthState;
+use crate::auth::{AuthStateProvider, UserUid};
+use crate::editor::{CrdtOperation, ReplicaId};
+use crate::server::server_api::auth::AuthClient;
+use crate::server::server_api::ServerApiProvider;
+use crate::server::telemetry::telemetry_context;
+use crate::terminal::event_listener::ChannelEventListener;
+use crate::terminal::model::block::BlockId;
+use crate::terminal::shared_session::network::heartbeat::{Event as HeartbeatEvent, Heartbeat};
+use crate::terminal::shared_session::viewer::event_loop::{
+    EventLoop, SharedSessionInitialLoadMode,
 };
+use crate::terminal::shared_session::{
+    connect_endpoint, EventNumber, SharedSessionSource, SELECTION_THROTTLE_PERIOD,
+};
+use crate::terminal::{TerminalModel, TerminalView};
+use crate::throttle::throttle;
 
 /// The amount of time we will wait to batch consecutive write to pty requests before sending an event to the server.
 const PTY_WRITES_BATCH_THRESHOLD: Duration = if cfg!(test) {

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -11,16 +11,16 @@
 //! are not directly tested — they're thin wrappers that funnel responses
 //! through `apply_children_fetch`, which is what we cover here.
 
-use super::*;
-
 use chrono::Utc;
 use warp_core::features::FeatureFlag;
 use warpui::{App, EntityId, SingletonEntity};
 
+use super::*;
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::ambient_agents::task::{AgentConfigSnapshot, AmbientAgentTask};
-use crate::test_util::{add_window_with_terminal, terminal::initialize_app_for_terminal_view};
+use crate::test_util::add_window_with_terminal;
+use crate::test_util::terminal::initialize_app_for_terminal_view;
 
 // ---- Pure-function tests ----------------------------------------------------
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -256,7 +256,6 @@ use crate::ai::blocklist::telemetry_banner::{should_collect_ai_ugc_telemetry, Te
 use crate::ai::blocklist::usage::conversation_usage_view::{
     ConversationUsageInfo, ConversationUsageView, TimingInfo,
 };
-use crate::ai::blocklist::PendingAttachment;
 use crate::ai::blocklist::{
     ai_brand_color, block_context_from_terminal_model,
     get_ai_block_overflow_menu_element_position_id, get_attached_blocks_chip_element_position_id,
@@ -266,9 +265,9 @@ use crate::ai::blocklist::{
     ClientIdentifiers, ConversationStatusUpdate, InputConfig, InputType,
     InputTypeAutoDetectionSource, LegacyPassiveSuggestionsEvent, LegacyPassiveSuggestionsModel,
     MaaPassiveSuggestionsEvent, MaaPassiveSuggestionsModel, PassiveSuggestionsModels,
-    PendingQueryState, RequestFileEditsFormatKind, ShellCommandExecutor, ShellCommandExecutorEvent,
-    SlashCommandRequest, StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest,
-    ATTACH_AS_AGENT_MODE_CONTEXT_TEXT, PRE_REWIND_PREFIX,
+    PendingAttachment, PendingQueryState, RequestFileEditsFormatKind, ShellCommandExecutor,
+    ShellCommandExecutorEvent, SlashCommandRequest, StartAgentExecutor, StartAgentExecutorEvent,
+    StartAgentRequest, ATTACH_AS_AGENT_MODE_CONTEXT_TEXT, PRE_REWIND_PREFIX,
 };
 use crate::ai::conversation_utils;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel, AIDocumentVersion};

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -4,6 +4,9 @@
 //! offering users the option to bring in the agent. For CLI agent commands (e.g., Claude Code,
 //! Gemini CLI, Codex), it displays a specialized footer with additional functionality.
 
+use base64::Engine;
+use warpui::clipboard::{ClipboardContent, ImageData};
+
 use crate::ai::agent::ImageContext;
 use crate::ai::blocklist::agent_view::agent_input_footer::{
     AgentInputFooter, AgentInputFooterEvent,
@@ -14,70 +17,56 @@ use crate::terminal::shared_session::{
     SharedSessionActionSource, SharedSessionScrollbackType, SharedSessionSource,
 };
 use crate::util::image::{infer_mime_type, MAX_IMAGE_SIZE_BYTES_FOR_CLI_AGENT, MIME_SNIFF_BYTES};
-use base64::Engine;
-use warpui::clipboard::{ClipboardContent, ImageData};
 mod warpify_footer;
-
-pub use crate::terminal::CLIAgent;
-use warpify_footer::{WarpifyFooterView, WarpifyFooterViewEvent};
 
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
-use warpui::r#async::Timer;
-
-use crate::code_review::diff_state::GitDeltaPreference;
-use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
 use anyhow::anyhow;
 use parking_lot::FairMutex;
 use pathfinder_color::ColorU;
-use warp_core::{
-    features::FeatureFlag,
-    report_error, send_telemetry_from_ctx,
-    settings::Setting,
-    ui::{
-        appearance::Appearance,
-        color::contrast::{
-            high_enough_contrast, pick_best_foreground_color, MinimumAllowedContrast,
-        },
-        theme::{color::internal_colors, Fill as ThemeFill},
-    },
+use warp_core::features::FeatureFlag;
+use warp_core::settings::Setting;
+use warp_core::ui::appearance::Appearance;
+use warp_core::ui::color::contrast::{
+    high_enough_contrast, pick_best_foreground_color, MinimumAllowedContrast,
 };
-
+use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::Fill as ThemeFill;
+use warp_core::{report_error, send_telemetry_from_ctx};
+use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
+use warpify_footer::{WarpifyFooterView, WarpifyFooterViewEvent};
+use warpui::elements::{
+    ChildView, Container, CrossAxisAlignment, Empty, Expanded, Flex, MainAxisSize, ParentElement,
+};
+use warpui::keymap::Keystroke;
+use warpui::r#async::Timer;
 use warpui::{
-    elements::{
-        ChildView, Container, CrossAxisAlignment, Empty, Expanded, Flex, MainAxisSize,
-        ParentElement,
-    },
-    keymap::Keystroke,
     AppContext, Element, Entity, EntityId, ModelHandle, SingletonEntity, TypedActionView, View,
     ViewContext, ViewHandle,
 };
 
-use crate::{
-    ai::blocklist::{agent_view::agent_view_bg_fill, block::cli_controller::CLISubagentEvent},
-    cmd_or_ctrl_shift,
-    server::telemetry::{CLIAgentType, CLISubagentControlState, TelemetryEvent},
-    settings::{
-        AISettings, AISettingsChangedEvent, CompiledCommandsForCodingAgentToolbar,
-        InputModeSettings,
-    },
-    terminal::cli_agent_sessions::CLIAgentRichInputCloseReason,
-    terminal::{
-        model_events::{ModelEvent, ModelEventDispatcher},
-        TerminalModel,
-    },
-    ui_components::{blended_colors, icons::Icon},
-    view_components::action_button::{
-        ActionButton, ActionButtonTheme, ButtonSize, KeystrokeSource, TooltipAlignment,
-    },
-};
-
-use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
-
 use super::{RichContentInsertionPosition, TerminalAction, TerminalView};
+use crate::ai::blocklist::agent_view::agent_view_bg_fill;
+use crate::ai::blocklist::block::cli_controller::CLISubagentEvent;
+use crate::cmd_or_ctrl_shift;
+use crate::code_review::diff_state::GitDeltaPreference;
+use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
+use crate::server::telemetry::{CLIAgentType, CLISubagentControlState, TelemetryEvent};
+use crate::settings::{
+    AISettings, AISettingsChangedEvent, CompiledCommandsForCodingAgentToolbar, InputModeSettings,
+};
+use crate::terminal::cli_agent_sessions::CLIAgentRichInputCloseReason;
+use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 use crate::terminal::view::block_banner::WarpificationMode;
+pub use crate::terminal::CLIAgent;
+use crate::terminal::TerminalModel;
+use crate::ui_components::blended_colors;
+use crate::ui_components::icons::Icon;
+use crate::view_components::action_button::{
+    ActionButton, ActionButtonTheme, ButtonSize, KeystrokeSource, TooltipAlignment,
+};
 
 /// Small delay inserted between separate PTY writes to CLI agents.
 /// (Used both for the mode-switch prefix split and for the `DelayedEnter`

--- a/app/src/terminal/view/use_agent_footer/mod_tests.rs
+++ b/app/src/terminal/view/use_agent_footer/mod_tests.rs
@@ -3,34 +3,29 @@ use std::rc::Rc;
 use warp_core::settings::Setting as _;
 use warpui::{App, AppContext, SingletonEntity, ViewContext};
 
-use crate::{
-    ai::{
-        agent::{
-            conversation::AIConversationId, task::TaskId, AIAgentInput, ServerOutputId,
-            UserQueryMode,
-        },
-        blocklist::{
-            agent_view::AgentViewEntryOrigin,
-            block::cli_controller::UserTakeOverReason,
-            model::{AIBlockModel, AIBlockOutputStatus, AIRequestType, OutputStatusUpdateCallback},
-            AIBlock, ClientIdentifiers,
-        },
-        llms::LLMId,
-    },
-    features::FeatureFlag,
-    settings::AISettings,
-    terminal::cli_agent_sessions::{
-        CLIAgentInputState, CLIAgentSession, CLIAgentSessionContext, CLIAgentSessionStatus,
-        CLIAgentSessionsModel,
-    },
-    terminal::model::ansi::{BootstrappedValue, Handler as _, InitShellValue},
-    terminal::shared_session::SharedSessionSource,
-    terminal::CLIAgent,
-    test_util::{add_window_with_terminal, terminal::initialize_app_for_terminal_view},
-};
-
 use super::super::{AIBlockMetadata, RichContentMetadata, RichContentType};
 use super::*;
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::task::TaskId;
+use crate::ai::agent::{AIAgentInput, ServerOutputId, UserQueryMode};
+use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
+use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
+use crate::ai::blocklist::model::{
+    AIBlockModel, AIBlockOutputStatus, AIRequestType, OutputStatusUpdateCallback,
+};
+use crate::ai::blocklist::{AIBlock, ClientIdentifiers};
+use crate::ai::llms::LLMId;
+use crate::features::FeatureFlag;
+use crate::settings::AISettings;
+use crate::terminal::cli_agent_sessions::{
+    CLIAgentInputState, CLIAgentSession, CLIAgentSessionContext, CLIAgentSessionStatus,
+    CLIAgentSessionsModel,
+};
+use crate::terminal::model::ansi::{BootstrappedValue, Handler as _, InitShellValue};
+use crate::terminal::shared_session::SharedSessionSource;
+use crate::terminal::CLIAgent;
+use crate::test_util::add_window_with_terminal;
+use crate::test_util::terminal::initialize_app_for_terminal_view;
 
 struct PendingAIBlockModel {
     conversation_id: AIConversationId,

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -1,18 +1,3 @@
-use crate::ai::agent::conversation::ConversationStatus;
-use crate::ai::agent::task::TaskId;
-use crate::ai::agent::{
-    AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, UserQueryMode,
-};
-use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::cloud_environments::{
-    AmbientAgentEnvironment, CloudAmbientAgentEnvironment, CloudAmbientAgentEnvironmentModel,
-};
-use crate::cloud_object::model::persistence::CloudModel;
-use crate::cloud_object::{CloudObjectMetadata, CloudObjectPermissions};
-use crate::server::ids::{ClientId, SyncId};
-use chrono::Local;
-use parking_lot::FairMutex;
-use session_sharing_protocol::common::CLIAgentSessionState;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -20,26 +5,42 @@ use std::pin::pin;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::Arc;
+
+use chrono::Local;
+use parking_lot::FairMutex;
+use session_sharing_protocol::common::CLIAgentSessionState;
 use warp_cli::agent::Harness;
 use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
-use warpui::{
-    notification::UserNotification, platform::WindowStyle, Presenter, WindowInvalidation,
-};
-use warpui::{App, ReadModel};
+use warpui::notification::UserNotification;
+use warpui::platform::WindowStyle;
+use warpui::{App, Presenter, ReadModel, WindowInvalidation};
 
+use super::*;
+use crate::ai::agent::conversation::ConversationStatus;
+use crate::ai::agent::task::TaskId;
+use crate::ai::agent::{
+    AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, UserQueryMode,
+};
+use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
-use crate::ai::blocklist::agent_view::ExitAgentViewError;
+use crate::ai::blocklist::agent_view::{AgentViewEntryOrigin, AgentViewState, ExitAgentViewError};
 use crate::ai::blocklist::block::cli_controller::UserTakeOverReason;
 use crate::ai::blocklist::{
-    agent_view::{AgentViewEntryOrigin, AgentViewState},
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, InputConfig, InputType, ResponseStreamId,
 };
+use crate::ai::cloud_environments::{
+    AmbientAgentEnvironment, CloudAmbientAgentEnvironment, CloudAmbientAgentEnvironmentModel,
+};
 use crate::ai::llms::LLMId;
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::{CloudObjectMetadata, CloudObjectPermissions};
 use crate::context_chips::prompt::Prompt;
 use crate::editor::{AutosuggestionLocation, AutosuggestionType, CrdtOperation};
 use crate::features::FeatureFlag;
 use crate::pane_group::focus_state::PaneGroupFocusState;
-use crate::pane_group::{pane::PaneStack, BackingView, TerminalPaneId};
+use crate::pane_group::pane::PaneStack;
+use crate::pane_group::{BackingView, TerminalPaneId};
+use crate::server::ids::{ClientId, SyncId};
 use crate::server::server_api::ai::SpawnAgentRequest;
 use crate::settings::import::model::ImportedConfigModel;
 use crate::settings::{AISettings, AppEditorSettings, WarpPromptSeparator};
@@ -54,9 +55,7 @@ use crate::terminal::cli_agent_sessions::{
     CLIAgentInputEntrypoint, CLIAgentInputState, CLIAgentRichInputCloseReason, CLIAgentSession,
     CLIAgentSessionContext, CLIAgentSessionStatus, CLIAgentSessionsModel,
 };
-
-use crate::terminal::model::ansi::{self, InitShellValue};
-use crate::terminal::model::ansi::{BootstrappedValue, PreexecValue};
+use crate::terminal::model::ansi::{self, BootstrappedValue, InitShellValue, PreexecValue};
 use crate::terminal::model::block::AgentViewVisibility;
 use crate::terminal::model::blocks::{insert_block, TotalIndex};
 use crate::terminal::model::grid::Dimensions as _;
@@ -69,16 +68,13 @@ use crate::terminal::shared_session::{SharedSessionSource, SharedSessionStatus};
 use crate::terminal::view::ambient_agent::AmbientAgentViewModelEvent;
 use crate::terminal::view::load_ai_conversation::RestoredAIConversation;
 use crate::terminal::view::shared_session::ConversationEndedTombstoneView;
-use crate::terminal::CLIAgent;
-
-use crate::terminal::{MockTerminalManager, TerminalManager, TerminalModel};
-use crate::test_util::terminal::add_window_with_id_and_terminal;
-use crate::test_util::terminal::initialize_app_for_terminal_view;
+use crate::terminal::{CLIAgent, MockTerminalManager, TerminalManager, TerminalModel};
+use crate::test_util::terminal::{
+    add_window_with_id_and_terminal, initialize_app_for_terminal_view,
+};
 use crate::test_util::{add_window_with_terminal, assert_eventually};
 use crate::view_components::find::FindWithinBlockState;
 use crate::workspace::ToastStack;
-
-use super::*;
 
 fn add_window_with_cloud_mode_terminal(app: &mut App) -> ViewHandle<TerminalView> {
     let tips_model = app.add_model(|_| Default::default());

--- a/crates/input_classifier/src/heuristic_classifier/mod_tests.rs
+++ b/crates/input_classifier/src/heuristic_classifier/mod_tests.rs
@@ -1,7 +1,6 @@
-use warp_completer::{
-    ParsedTokenData, ParsedTokensSnapshot, meta::SpannedItem,
-    util::parse_current_commands_and_tokens,
-};
+use warp_completer::meta::SpannedItem;
+use warp_completer::util::parse_current_commands_and_tokens;
+use warp_completer::{ParsedTokenData, ParsedTokensSnapshot};
 
 use super::*;
 use crate::Context;

--- a/crates/input_classifier/src/lib.rs
+++ b/crates/input_classifier/src/lib.rs
@@ -7,12 +7,11 @@ pub mod test_utils;
 pub mod util;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-
 pub use heuristic_classifier::HeuristicClassifier;
 pub use input_type::InputType;
 #[cfg(feature = "onnx")]
 pub use onnx::{Model as OnnxModel, OnnxClassifier};
+use serde::{Deserialize, Serialize};
 
 /// Sources produced by the input classifier pipeline.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/input_classifier/src/onnx/mod.rs
+++ b/crates/input_classifier/src/onnx/mod.rs
@@ -228,7 +228,8 @@ impl HasPanicked {
 mod tests {
     use anyhow::Result;
     use futures::executor::block_on;
-    use warp_completer::{ParsedTokenData, ParsedTokensSnapshot, meta::SpannedItem};
+    use warp_completer::meta::SpannedItem;
+    use warp_completer::{ParsedTokenData, ParsedTokensSnapshot};
 
     use super::*;
 

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -4,8 +4,10 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 
+use crate::SortOrderArg;
 use crate::config_file::ConfigFileArgs;
 use crate::environment::EnvironmentCreateArgs;
+use crate::json_filter::JsonOutput;
 use crate::mcp::MCPSpec;
 use crate::model::ModelArgs;
 use crate::scope::ObjectScope;
@@ -283,8 +285,8 @@ pub struct RunAgentArgs {
     ///
     /// When used with --prompt, the skill provides the base context and the prompt is the task.
     ///
-    /// To automate a skill on a schedule, use `oz schedule create --skill <SPEC>`.
-    #[arg(long = "skill", value_name = "SPEC")]
+    /// To automate a skill on a schedule, use `oz schedule create --skill <SKILL>`.
+    #[arg(long = "skill", value_name = "SKILL")]
     pub skill: Option<SkillSpec>,
 
     /// Name for this agent task.
@@ -436,8 +438,8 @@ pub struct RunCloudArgs {
     ///
     /// When used with --prompt, the skill provides the base context and the prompt is the task.
     ///
-    /// To automate a skill on a schedule, use `oz schedule create --skill <SPEC>`.
-    #[arg(long = "skill", value_name = "SPEC")]
+    /// To automate a skill on a schedule, use `oz schedule create --skill <SKILL>`.
+    #[arg(long = "skill", value_name = "SKILL")]
     pub skill: Option<SkillSpec>,
 
     /// Name for this agent task.
@@ -525,15 +527,6 @@ pub enum AgentSortByArg {
     CreatedAt,
 }
 
-/// Sort direction for named agents.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum AgentSortOrderArg {
-    #[value(name = "asc")]
-    Asc,
-    #[value(name = "desc")]
-    Desc,
-}
-
 /// Arguments for listing named agents.
 #[derive(Debug, Clone, Args)]
 pub struct AgentListArgs {
@@ -543,7 +536,7 @@ pub struct AgentListArgs {
 
     /// Sort direction. Only supported for pretty, text, and ndjson output.
     #[arg(long = "sort-order", value_enum, value_name = "DIR")]
-    pub sort_order: Option<AgentSortOrderArg>,
+    pub sort_order: Option<SortOrderArg>,
 
     /// JSON formatting configuration.
     #[command(flatten)]
@@ -577,7 +570,7 @@ pub struct AgentCreateArgs {
     pub secrets: Vec<String>,
 
     /// Attach a skill to the agent. Repeat the flag for multiple skills.
-    #[arg(long = "skill", value_name = "SPEC")]
+    #[arg(long = "skill", value_name = "SKILL")]
     pub skills: Vec<String>,
 
     /// Base model for runs of this agent.
@@ -637,7 +630,7 @@ pub struct AgentUpdateArgs {
     /// Add a skill to the agent. Repeat the flag for multiple skills.
     #[arg(
         long = "add-skill",
-        value_name = "SPEC",
+        value_name = "SKILL",
         conflicts_with = "remove_all_skills"
     )]
     pub add_skills: Vec<String>,
@@ -645,7 +638,7 @@ pub struct AgentUpdateArgs {
     /// Remove a skill from the agent. Repeat the flag for multiple skills.
     #[arg(
         long = "remove-skill",
-        value_name = "SPEC",
+        value_name = "SKILL",
         conflicts_with = "remove_all_skills"
     )]
     pub remove_skills: Vec<String>,

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -240,7 +240,17 @@ pub enum AgentCommand {
     #[command(subcommand)]
     Profile(AgentProfileCommand),
     /// List all available agents.
-    List(ListAgentConfigsArgs),
+    List(AgentListArgs),
+    /// Get details of an agent.
+    Get(AgentGetArgs),
+    /// Create a new agent.
+    Create(AgentCreateArgs),
+    /// Update an existing agent.
+    Update(AgentUpdateArgs),
+    /// Delete an agent.
+    Delete(AgentDeleteArgs),
+    /// List available agent skills.
+    Skills(ListAgentSkillsArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -506,9 +516,187 @@ pub struct RunCloudArgs {
     pub claude_auth_secret: Option<String>,
 }
 
-/// Arguments for listing available agents.
+/// Sort field for named agents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum AgentSortByArg {
+    #[value(name = "name")]
+    Name,
+    #[value(name = "created-at")]
+    CreatedAt,
+}
+
+/// Sort direction for named agents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum AgentSortOrderArg {
+    #[value(name = "asc")]
+    Asc,
+    #[value(name = "desc")]
+    Desc,
+}
+
+/// Arguments for listing named agents.
 #[derive(Debug, Clone, Args)]
-pub struct ListAgentConfigsArgs {
+pub struct AgentListArgs {
+    /// Sort field. Only supported for pretty, text, and ndjson output.
+    #[arg(long = "sort-by", value_enum, value_name = "FIELD")]
+    pub sort_by: Option<AgentSortByArg>,
+
+    /// Sort direction. Only supported for pretty, text, and ndjson output.
+    #[arg(long = "sort-order", value_enum, value_name = "DIR")]
+    pub sort_order: Option<AgentSortOrderArg>,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+/// Arguments for getting a named agent.
+#[derive(Debug, Clone, Args)]
+pub struct AgentGetArgs {
+    /// UID of the agent to get.
+    pub uid: String,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+/// Arguments for creating a named agent.
+#[derive(Debug, Clone, Args)]
+pub struct AgentCreateArgs {
+    /// Name of the agent.
+    #[arg(long = "name", short = 'n')]
+    pub name: String,
+
+    /// Description of the agent.
+    #[arg(long = "description")]
+    pub description: Option<String>,
+
+    /// Attach a secret to the agent. Repeat the flag for multiple secrets.
+    #[arg(long = "secret", value_name = "NAME")]
+    pub secrets: Vec<String>,
+
+    /// Attach a skill to the agent. Repeat the flag for multiple skills.
+    #[arg(long = "skill", value_name = "SPEC")]
+    pub skills: Vec<String>,
+
+    /// Base model for runs of this agent.
+    #[arg(long = "base-model", value_name = "MODEL_ID")]
+    pub base_model: Option<String>,
+
+    /// Default cloud environment for runs of this agent.
+    #[arg(long = "environment", short = 'e', value_name = "ENVIRONMENT_ID")]
+    pub environment: Option<String>,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+/// Arguments for updating a named agent.
+#[derive(Debug, Clone, Args)]
+pub struct AgentUpdateArgs {
+    /// UID of the agent to update.
+    pub uid: String,
+
+    /// New name for the agent.
+    #[arg(long = "name", short = 'n')]
+    pub name: Option<String>,
+
+    /// Replacement description for the agent.
+    #[arg(long = "description", conflicts_with = "remove_description")]
+    pub description: Option<String>,
+
+    /// Remove the agent description.
+    #[arg(long = "remove-description", conflicts_with = "description")]
+    pub remove_description: bool,
+
+    /// Add a secret to the agent. Repeat the flag for multiple secrets.
+    #[arg(
+        long = "add-secret",
+        value_name = "NAME",
+        conflicts_with = "remove_all_secrets"
+    )]
+    pub add_secrets: Vec<String>,
+
+    /// Remove a secret from the agent. Repeat the flag for multiple secrets.
+    #[arg(
+        long = "remove-secret",
+        value_name = "NAME",
+        conflicts_with = "remove_all_secrets"
+    )]
+    pub remove_secrets: Vec<String>,
+
+    /// Remove all secrets from the agent.
+    #[arg(
+        long = "remove-all-secrets",
+        conflicts_with_all = ["add_secrets", "remove_secrets"]
+    )]
+    pub remove_all_secrets: bool,
+
+    /// Add a skill to the agent. Repeat the flag for multiple skills.
+    #[arg(
+        long = "add-skill",
+        value_name = "SPEC",
+        conflicts_with = "remove_all_skills"
+    )]
+    pub add_skills: Vec<String>,
+
+    /// Remove a skill from the agent. Repeat the flag for multiple skills.
+    #[arg(
+        long = "remove-skill",
+        value_name = "SPEC",
+        conflicts_with = "remove_all_skills"
+    )]
+    pub remove_skills: Vec<String>,
+
+    /// Remove all skills from the agent.
+    #[arg(
+        long = "remove-all-skills",
+        conflicts_with_all = ["add_skills", "remove_skills"]
+    )]
+    pub remove_all_skills: bool,
+
+    /// Replacement base model for runs executed by this agent.
+    #[arg(
+        long = "base-model",
+        value_name = "MODEL_ID",
+        conflicts_with = "remove_base_model"
+    )]
+    pub base_model: Option<String>,
+
+    /// Remove the agent base model.
+    #[arg(long = "remove-base-model", conflicts_with = "base_model")]
+    pub remove_base_model: bool,
+
+    /// Replacement default cloud environment for runs executed by this agent.
+    #[arg(
+        long = "environment",
+        short = 'e',
+        value_name = "ENVIRONMENT_ID",
+        conflicts_with = "remove_environment"
+    )]
+    pub environment: Option<String>,
+
+    /// Remove the agent default environment.
+    #[arg(long = "remove-environment", conflicts_with = "environment")]
+    pub remove_environment: bool,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+/// Arguments for deleting a named agent.
+#[derive(Debug, Clone, Args)]
+pub struct AgentDeleteArgs {
+    /// UID of the agent to delete.
+    pub uid: String,
+}
+
+/// Arguments for listing available agent skills.
+#[derive(Debug, Clone, Args)]
+pub struct ListAgentSkillsArgs {
     /// List skills from a specific GitHub repository.
     ///
     /// Format: `owner/repo` or `https://github.com/owner/repo`

--- a/crates/warp_cli/src/api_key.rs
+++ b/crates/warp_cli/src/api_key.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand, ValueEnum};
 
+use crate::SortOrderArg;
 use crate::date_time::parse_rfc3339;
 use crate::json_filter::JsonOutput;
 
@@ -24,7 +25,7 @@ pub struct ListApiKeysArgs {
 
     /// Sort direction.
     #[arg(long = "sort-order", value_enum, value_name = "DIR")]
-    pub sort_order: Option<ApiKeySortOrderArg>,
+    pub sort_order: Option<SortOrderArg>,
 
     /// JSON formatting configuration.
     #[command(flatten)]
@@ -93,15 +94,6 @@ pub enum ApiKeySortByArg {
     ExpiresAt,
     #[value(name = "scope")]
     Scope,
-}
-
-/// Sort-order values accepted by `--sort-order`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum ApiKeySortOrderArg {
-    #[value(name = "asc")]
-    Asc,
-    #[value(name = "desc")]
-    Desc,
 }
 
 #[cfg(test)]

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -16,6 +16,8 @@ mod process_handle;
 pub mod artifact;
 pub mod scope;
 pub mod skill;
+mod sort_order;
+pub use sort_order::SortOrderArg;
 
 pub mod agent;
 pub mod api_key;

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -9,7 +9,6 @@ use crate::environment::{EnvironmentCommand, ImageCommand};
 use crate::harness_support::{HarnessSupportCommand, TaskStatus};
 use crate::integration::IntegrationCommand;
 use crate::schedule::ScheduleSubcommand;
-use crate::secret::{CodexMethod, CreateProvider, SecretCommand};
 use crate::task::{MessageCommand, TaskCommand};
 
 fn set_env_var(name: &str, value: &str) -> Option<OsString> {
@@ -378,6 +377,36 @@ fn agent_run_cloud_accepts_run_ambient_alias() {
     let CliCommand::Agent(AgentCommand::RunCloud(_)) = boxed_cmd.as_ref() else {
         panic!("Expected `warp agent run-ambient` to parse as RunCloud");
     };
+}
+
+#[test]
+fn agent_update_rejects_conflicting_remove_flags() {
+    let result = Args::try_parse_from([
+        "warp",
+        "agent",
+        "update",
+        "agent_123",
+        "--description",
+        "new",
+        "--remove-description",
+    ]);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn agent_update_rejects_remove_all_secret_deltas() {
+    let result = Args::try_parse_from([
+        "warp",
+        "agent",
+        "update",
+        "agent_123",
+        "--add-secret",
+        "GITHUB_TOKEN",
+        "--remove-all-secrets",
+    ]);
+
+    assert!(result.is_err());
 }
 
 #[test]
@@ -1982,98 +2011,6 @@ fn report_shutdown_clean_parses() {
 
     assert!(shutdown_args.error_category.is_none());
     assert!(shutdown_args.error_message.is_none());
-}
-
-#[test]
-fn secret_create_codex_api_key_parses_minimal() {
-    warp_core::features::mark_initialized();
-
-    let args = Args::try_parse_from([
-        "warp",
-        "secret",
-        "create",
-        "codex",
-        "api-key",
-        "my-openai-key",
-    ])
-    .unwrap();
-
-    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
-        panic!("Expected `warp secret create codex api-key` command");
-    };
-    let CliCommand::Secret(SecretCommand::Create(create_args)) = boxed_cmd.as_ref() else {
-        panic!("Expected `warp secret create` command");
-    };
-    let Some(CreateProvider::Codex(codex)) = &create_args.provider else {
-        panic!("Expected `codex` provider subcommand");
-    };
-    let CodexMethod::ApiKey(api_key_args) = &codex.method;
-
-    assert_eq!(api_key_args.common.name, "my-openai-key");
-    assert!(api_key_args.common.description.is_none());
-    assert!(api_key_args.value.value_file.is_none());
-    assert!(api_key_args.base_url.is_none());
-}
-
-#[test]
-fn secret_create_codex_api_key_accepts_base_url_and_value_file() {
-    warp_core::features::mark_initialized();
-
-    let args = Args::try_parse_from([
-        "warp",
-        "secret",
-        "create",
-        "codex",
-        "api-key",
-        "my-openai-key",
-        "--value-file",
-        "key.txt",
-        "--base-url",
-        "https://us.api.openai.com/v1",
-        "--description",
-        "OpenAI key for Codex",
-        "--team",
-    ])
-    .unwrap();
-
-    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
-        panic!("Expected `warp secret create codex api-key` command");
-    };
-    let CliCommand::Secret(SecretCommand::Create(create_args)) = boxed_cmd.as_ref() else {
-        panic!("Expected `warp secret create` command");
-    };
-    let Some(CreateProvider::Codex(codex)) = &create_args.provider else {
-        panic!("Expected `codex` provider subcommand");
-    };
-    let CodexMethod::ApiKey(api_key_args) = &codex.method;
-
-    assert_eq!(api_key_args.common.name, "my-openai-key");
-    assert_eq!(
-        api_key_args.common.description.as_deref(),
-        Some("OpenAI key for Codex")
-    );
-    assert!(api_key_args.common.scope.team);
-    assert!(!api_key_args.common.scope.personal);
-    assert_eq!(
-        api_key_args
-            .value
-            .value_file
-            .as_ref()
-            .and_then(|p| p.to_str()),
-        Some("key.txt")
-    );
-    assert_eq!(
-        api_key_args.base_url.as_deref(),
-        Some("https://us.api.openai.com/v1")
-    );
-}
-
-#[test]
-fn secret_create_codex_api_key_requires_name() {
-    warp_core::features::mark_initialized();
-
-    let result = Args::try_parse_from(["warp", "secret", "create", "codex", "api-key"]);
-    assert!(result.is_err());
 }
 
 #[test]

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -9,6 +9,7 @@ use crate::environment::{EnvironmentCommand, ImageCommand};
 use crate::harness_support::{HarnessSupportCommand, TaskStatus};
 use crate::integration::IntegrationCommand;
 use crate::schedule::ScheduleSubcommand;
+use crate::secret::{CodexMethod, CreateProvider, SecretCommand};
 use crate::task::{MessageCommand, TaskCommand};
 
 fn set_env_var(name: &str, value: &str) -> Option<OsString> {
@@ -2011,6 +2012,98 @@ fn report_shutdown_clean_parses() {
 
     assert!(shutdown_args.error_category.is_none());
     assert!(shutdown_args.error_message.is_none());
+}
+
+#[test]
+fn secret_create_codex_api_key_parses_minimal() {
+    warp_core::features::mark_initialized();
+
+    let args = Args::try_parse_from([
+        "warp",
+        "secret",
+        "create",
+        "codex",
+        "api-key",
+        "my-openai-key",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp secret create codex api-key` command");
+    };
+    let CliCommand::Secret(SecretCommand::Create(create_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp secret create` command");
+    };
+    let Some(CreateProvider::Codex(codex)) = &create_args.provider else {
+        panic!("Expected `codex` provider subcommand");
+    };
+    let CodexMethod::ApiKey(api_key_args) = &codex.method;
+
+    assert_eq!(api_key_args.common.name, "my-openai-key");
+    assert!(api_key_args.common.description.is_none());
+    assert!(api_key_args.value.value_file.is_none());
+    assert!(api_key_args.base_url.is_none());
+}
+
+#[test]
+fn secret_create_codex_api_key_accepts_base_url_and_value_file() {
+    warp_core::features::mark_initialized();
+
+    let args = Args::try_parse_from([
+        "warp",
+        "secret",
+        "create",
+        "codex",
+        "api-key",
+        "my-openai-key",
+        "--value-file",
+        "key.txt",
+        "--base-url",
+        "https://us.api.openai.com/v1",
+        "--description",
+        "OpenAI key for Codex",
+        "--team",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp secret create codex api-key` command");
+    };
+    let CliCommand::Secret(SecretCommand::Create(create_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp secret create` command");
+    };
+    let Some(CreateProvider::Codex(codex)) = &create_args.provider else {
+        panic!("Expected `codex` provider subcommand");
+    };
+    let CodexMethod::ApiKey(api_key_args) = &codex.method;
+
+    assert_eq!(api_key_args.common.name, "my-openai-key");
+    assert_eq!(
+        api_key_args.common.description.as_deref(),
+        Some("OpenAI key for Codex")
+    );
+    assert!(api_key_args.common.scope.team);
+    assert!(!api_key_args.common.scope.personal);
+    assert_eq!(
+        api_key_args
+            .value
+            .value_file
+            .as_ref()
+            .and_then(|p| p.to_str()),
+        Some("key.txt")
+    );
+    assert_eq!(
+        api_key_args.base_url.as_deref(),
+        Some("https://us.api.openai.com/v1")
+    );
+}
+
+#[test]
+fn secret_create_codex_api_key_requires_name() {
+    warp_core::features::mark_initialized();
+
+    let result = Args::try_parse_from(["warp", "secret", "create", "codex", "api-key"]);
+    assert!(result.is_err());
 }
 
 #[test]

--- a/crates/warp_cli/src/schedule.rs
+++ b/crates/warp_cli/src/schedule.rs
@@ -114,7 +114,7 @@ pub struct CreateScheduleArgs {
     ///
     /// When used with --prompt, the skill provides the base context and the prompt is the user task.
     /// This is useful for running recurring workflows like code reviews, dependency updates, or reports.
-    #[arg(long = "skill", value_name = "SPEC")]
+    #[arg(long = "skill", value_name = "SKILL")]
     pub skill: Option<SkillSpec>,
 
     /// Where this job should be hosted.
@@ -186,7 +186,7 @@ pub struct UpdateScheduleArgs {
     ///
     /// Skills are searched in `.agents/skills/`, `.warp/skills/`, `.claude/skills/`, and `.codex/skills/` directories.
     /// The skill is resolved at runtime in the agent's cloud environment.
-    #[arg(long = "skill", value_name = "SPEC", conflicts_with = "remove_skill")]
+    #[arg(long = "skill", value_name = "SKILL", conflicts_with = "remove_skill")]
     pub skill: Option<SkillSpec>,
 
     /// Remove the skill from this scheduled agent.

--- a/crates/warp_cli/src/sort_order.rs
+++ b/crates/warp_cli/src/sort_order.rs
@@ -1,0 +1,10 @@
+use clap::ValueEnum;
+
+/// Sort-order values accepted by `--sort-order`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SortOrderArg {
+    #[value(name = "asc")]
+    Asc,
+    #[value(name = "desc")]
+    Desc,
+}

--- a/crates/warp_cli/src/task.rs
+++ b/crates/warp_cli/src/task.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand, ValueEnum};
 
+use crate::SortOrderArg;
 use crate::date_time::parse_rfc3339;
 use crate::json_filter::JsonOutput;
 
@@ -142,8 +143,8 @@ pub struct ListTasksArgs {
     #[arg(long = "environment", value_name = "ENV_ID")]
     pub environment: Option<String>,
 
-    /// Filter by skill specification (e.g. `owner/repo:path/to/SKILL.md`).
-    #[arg(long = "skill", value_name = "SPEC")]
+    /// Filter by skill (e.g. `owner/repo:path/to/SKILL.md`).
+    #[arg(long = "skill", value_name = "SKILL")]
     pub skill: Option<String>,
 
     /// Filter to runs created by a specific scheduled agent.
@@ -188,7 +189,7 @@ pub struct ListTasksArgs {
 
     /// Sort direction.
     #[arg(long = "sort-order", value_enum, value_name = "DIR")]
-    pub sort_order: Option<RunSortOrderArg>,
+    pub sort_order: Option<SortOrderArg>,
 
     /// Opaque pagination cursor from a previous list response.
     ///
@@ -281,15 +282,6 @@ pub enum RunSortByArg {
     Title,
     #[value(name = "agent")]
     Agent,
-}
-
-/// Sort-order values accepted by `--sort-order`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum RunSortOrderArg {
-    #[value(name = "asc")]
-    Asc,
-    #[value(name = "desc")]
-    Desc,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/warp_cli/src/task_tests.rs
+++ b/crates/warp_cli/src/task_tests.rs
@@ -123,7 +123,7 @@ fn all_filter_flags_parse() {
     );
     assert_eq!(args.query.as_deref(), Some("oz run"));
     assert_eq!(args.sort_by, Some(RunSortByArg::CreatedAt));
-    assert_eq!(args.sort_order, Some(RunSortOrderArg::Asc));
+    assert_eq!(args.sort_order, Some(SortOrderArg::Asc));
     assert_eq!(args.cursor.as_deref(), Some("abcd=="));
 }
 

--- a/specs/REMOTE-1374/PRODUCT.md
+++ b/specs/REMOTE-1374/PRODUCT.md
@@ -48,7 +48,7 @@ Filtering:
 - `--execution-location <LOC>` — Filter by where the run executed. Accepts `local`, `remote`.
 - `--creator <UID>` — Filter by creator UID (user or service account).
 - `--environment <ENV_ID>` — Filter by environment ID.
-- `--skill <SPEC>` — Filter by skill spec (e.g. `owner/repo:path/to/SKILL.md`).
+- `--skill <SKILL>` — Filter by skill (e.g. `owner/repo:path/to/SKILL.md`).
 - `--schedule <SCHEDULE_ID>` — Filter to runs created by a specific scheduled agent.
 - `--ancestor-run <RUN_ID>` — Filter to descendants of a specific run.
 - `--name <NAME>` — Filter by agent config name.

--- a/specs/REMOTE-1453/PRODUCT.md
+++ b/specs/REMOTE-1453/PRODUCT.md
@@ -3,7 +3,7 @@
 Service accounts can have a configured set of global skill specs that should be available in every Oz agent run. The client resolves those specs at agent-driver startup, clones any org-qualified source repos that are not already on disk, and loads skills before the first query runs.
 Global skills are intentionally not treated as permission to load every skill in their source repos. Repos that are part of the run's environment still use normal environment behavior and autodiscover all skills. Repos cloned only because they contain global skills load only the explicitly requested global skills.
 ## Problem
-Before this work, an `oz agent run` only saw skills that were already present on disk or explicitly requested with `--skill <SPEC>`. Service-account global skills exposed by `User.globalSkills` were not made available automatically, and a repo cloned only to satisfy one global skill could accidentally expose unrelated skills in that repo.
+Before this work, an `oz agent run` only saw skills that were already present on disk or explicitly requested with `--skill <SKILL>`. Service-account global skills exposed by `User.globalSkills` were not made available automatically, and a repo cloned only to satisfy one global skill could accidentally expose unrelated skills in that repo.
 ## Goals
 - For service-account-authenticated Oz agent runs, make every explicitly requested global skill available before the agent processes its first query.
 - Autodiscover all skills from repositories that are part of the configured environment.

--- a/specs/REMOTE-1696/PRODUCT.md
+++ b/specs/REMOTE-1696/PRODUCT.md
@@ -1,0 +1,45 @@
+# Product Spec: Oz CLI Named-Agent CRUD
+
+## Summary
+Add first-class Oz CLI commands for managing named agent identities. Developers can list, inspect, create, update, and delete named agents from the terminal with output modes that match existing Oz run commands.
+
+## Problem
+Named agents are manageable through the public API and related Oz surfaces, but the Oz CLI does not expose the full CRUD surface. The existing `oz agent list` command lists repository-discovered agent skills, so the CLI needs a clear split between named agents and skills before adding CRUD commands.
+
+## Goals
+- Make `oz agent list` mean "list named agents".
+- Preserve skill discovery by renaming the existing command to `oz agent skills`.
+- Provide terminal-friendly pretty output, script-friendly plain text, and JSON output with `--jq` filtering.
+- Preserve server patch semantics for updates so users only pass fields they want to modify.
+- Make list sorting predictable and client-side.
+
+## Non-goals
+- Changing the public API behavior or authorization model for named agents.
+- Adding interactive prompts for create or update.
+- Managing API keys for named agents.
+- Changing `oz agent run` or `oz agent run-cloud` semantics beyond continuing to accept an agent UID where already supported.
+
+## Behavior
+1. `oz agent skills` lists available agent skills using the current `oz agent list` behavior, including the existing `--repo` option and repository authorization flow.
+2. `oz agent list` lists named agent identities accessible to the authenticated user's team.
+3. `oz agent list` supports `--sort-by name` and `--sort-by created-at`.
+4. `oz agent list` supports `--sort-order asc` and `--sort-order desc`. If omitted, name sorting defaults to ascending, and timestamp sorting defaults to descending.
+5. Sorting is performed client-side after the API response is fetched and before rendering human-readable output formats.
+6. `oz agent get <uid>` retrieves a single named agent by UID.
+7. `oz agent create` creates a named agent. `--name` is required. Optional fields are accepted for the fields supported by the API: description, secrets, skills, base model, and default environment when that field is available.
+8. `oz agent update <uid>` partially updates a named agent. Users only pass fields they want to change.
+9. `oz agent update` preserves omitted fields. Passing an empty value through an explicit remove flag clears fields where the API supports clearing.
+10. `oz agent update` supports clearing optional scalar/list fields without requiring users to hand-write JSON. Clear operations should use explicit `--remove-*` flags, not ambiguous empty positional arguments.
+11. `oz agent delete <uid>` deletes a named agent and reports success. If the server rejects deletion, such as for the default agent, the CLI surfaces the server error.
+12. Pretty output for list uses a readable table with the core fields needed to identify and choose agents: UID, name, availability, created time, base model, default environment when present, secret count, and skill count.
+13. Pretty output for `oz agent list` also includes a hint for users looking for the old skill-discovery behavior: `Looking for agent skills? Use <binary> agent skills instead.`
+14. Pretty output for get/create/update uses a detail view that shows the same core fields plus full lists of secret names and skill specs.
+15. Plain-text output is stable and script-friendly. List output is tabular text with headers. Single-agent output is line-oriented key/value text.
+16. JSON output for list/get/create/update preserves the API response shape so scripts can consume fields exactly as returned by the public API.
+17. Sort flags are rejected for JSON output, including `--jq`, so raw API output remains raw.
+18. `--jq` implies JSON output even when the global output format is omitted or set to a human-readable format.
+19. `--jq` filters list/get/create/update JSON output using the same jq behavior as `oz run list` and `oz run get`, including unquoted scalar output.
+20. Delete has no JSON API response body. For JSON and `--jq`, the CLI emits a minimal operation result containing the deleted UID and `deleted: true`.
+21. All named-agent CRUD commands require authentication and reuse the existing CLI authentication and API-key behavior.
+22. If the server returns authorization, validation, conflict, or not-found errors, the CLI prints the server-facing error through the existing fatal-error path.
+23. The command hierarchy remains backward-compatible except for the intentional rename: users who want the previous skill list behavior must use `oz agent skills`.

--- a/specs/REMOTE-1696/PRODUCT.md
+++ b/specs/REMOTE-1696/PRODUCT.md
@@ -1,7 +1,7 @@
 # Product Spec: Oz CLI Named-Agent CRUD
 
 ## Summary
-Add first-class Oz CLI commands for managing named agent identities. Developers can list, inspect, create, update, and delete named agents from the terminal with output modes that match existing Oz run commands.
+Add first-class Oz CLI commands for managing named agents. Developers can list, inspect, create, update, and delete named agents from the terminal with output modes that match existing Oz run commands.
 
 ## Problem
 Named agents are manageable through the public API and related Oz surfaces, but the Oz CLI does not expose the full CRUD surface. The existing `oz agent list` command lists repository-discovered agent skills, so the CLI needs a clear split between named agents and skills before adding CRUD commands.
@@ -21,7 +21,7 @@ Named agents are manageable through the public API and related Oz surfaces, but 
 
 ## Behavior
 1. `oz agent skills` lists available agent skills using the current `oz agent list` behavior, including the existing `--repo` option and repository authorization flow.
-2. `oz agent list` lists named agent identities accessible to the authenticated user's team.
+2. `oz agent list` lists named agents accessible to the authenticated user's team.
 3. `oz agent list` supports `--sort-by name` and `--sort-by created-at`.
 4. `oz agent list` supports `--sort-order asc` and `--sort-order desc`. If omitted, name sorting defaults to ascending, and timestamp sorting defaults to descending.
 5. Sorting is performed client-side after the API response is fetched and before rendering human-readable output formats.
@@ -29,7 +29,7 @@ Named agents are manageable through the public API and related Oz surfaces, but 
 7. `oz agent create` creates a named agent. `--name` is required. Optional fields are accepted for the fields supported by the API: description, secrets, skills, base model, and default environment when that field is available.
 8. `oz agent update <uid>` partially updates a named agent. Users only pass fields they want to change.
 9. `oz agent update` preserves omitted fields. Passing an empty value through an explicit remove flag clears fields where the API supports clearing.
-10. `oz agent update` supports clearing optional scalar/list fields without requiring users to hand-write JSON. Clear operations should use explicit `--remove-*` flags, not ambiguous empty positional arguments.
+10. `oz agent update` supports add/remove operations for list fields without requiring users to hand-write replacement arrays. Secrets use `--add-secret <NAME>`, `--remove-secret <NAME>`, and `--remove-all-secrets`; skills use `--add-skill <SPEC>`, `--remove-skill <SPEC>`, and `--remove-all-skills`.
 11. `oz agent delete <uid>` deletes a named agent and reports success. If the server rejects deletion, such as for the default agent, the CLI surfaces the server error.
 12. Pretty output for list uses a readable table with the core fields needed to identify and choose agents: UID, name, availability, created time, base model, default environment when present, secret count, and skill count.
 13. Pretty output for `oz agent list` also includes a hint for users looking for the old skill-discovery behavior: `Looking for agent skills? Use <binary> agent skills instead.`
@@ -39,7 +39,7 @@ Named agents are manageable through the public API and related Oz surfaces, but 
 17. Sort flags are rejected for JSON output, including `--jq`, so raw API output remains raw.
 18. `--jq` implies JSON output even when the global output format is omitted or set to a human-readable format.
 19. `--jq` filters list/get/create/update JSON output using the same jq behavior as `oz run list` and `oz run get`, including unquoted scalar output.
-20. Delete has no JSON API response body. For JSON and `--jq`, the CLI emits a minimal operation result containing the deleted UID and `deleted: true`.
+20. Delete has no JSON API response body. For JSON output, the CLI emits a minimal operation result containing the deleted UID and `deleted: true`; delete does not support `--jq`.
 21. All named-agent CRUD commands require authentication and reuse the existing CLI authentication and API-key behavior.
 22. If the server returns authorization, validation, conflict, or not-found errors, the CLI prints the server-facing error through the existing fatal-error path.
 23. The command hierarchy remains backward-compatible except for the intentional rename: users who want the previous skill list behavior must use `oz agent skills`.

--- a/specs/REMOTE-1696/PRODUCT.md
+++ b/specs/REMOTE-1696/PRODUCT.md
@@ -24,22 +24,22 @@ Named agents are manageable through the public API and related Oz surfaces, but 
 2. `oz agent list` lists named agents accessible to the authenticated user's team.
 3. `oz agent list` supports `--sort-by name` and `--sort-by created-at`.
 4. `oz agent list` supports `--sort-order asc` and `--sort-order desc`. If omitted, name sorting defaults to ascending, and timestamp sorting defaults to descending.
-5. Sorting is performed client-side after the API response is fetched and before rendering human-readable output formats.
+5. Sorting is performed client-side after the API response is fetched and before rendering pretty, text, or ndjson output.
 6. `oz agent get <uid>` retrieves a single named agent by UID.
-7. `oz agent create` creates a named agent. `--name` is required. Optional fields are accepted for the fields supported by the API: description, secrets, skills, base model, and default environment when that field is available.
+7. `oz agent create` creates a named agent. `--name` is required. Optional fields are accepted for the fields supported by the API: description, secrets, skills, base model, and default environment.
 8. `oz agent update <uid>` partially updates a named agent. Users only pass fields they want to change.
 9. `oz agent update` preserves omitted fields. Passing an empty value through an explicit remove flag clears fields where the API supports clearing.
-10. `oz agent update` supports add/remove operations for list fields without requiring users to hand-write replacement arrays. Secrets use `--add-secret <NAME>`, `--remove-secret <NAME>`, and `--remove-all-secrets`; skills use `--add-skill <SPEC>`, `--remove-skill <SPEC>`, and `--remove-all-skills`.
+10. `oz agent update` supports add/remove operations for list fields without requiring users to hand-write replacement arrays. Secrets use `--add-secret <NAME>`, `--remove-secret <NAME>`, and `--remove-all-secrets`; skills use `--add-skill <SKILL>`, `--remove-skill <SKILL>`, and `--remove-all-skills`.
 11. `oz agent delete <uid>` deletes a named agent and reports success. If the server rejects deletion, such as for the default agent, the CLI surfaces the server error.
-12. Pretty output for list uses a readable table with the core fields needed to identify and choose agents: UID, name, availability, created time, base model, default environment when present, secret count, and skill count.
+12. Pretty output for list uses a readable table with the core fields needed to identify and choose agents: UID, name, created time, description, secret names, skill specs, base model, and default environment when present. Disabled agents are hidden from pretty and text list output; when any are hidden, the CLI prints `N disabled agents hidden` to stderr after stdout output. JSON output still preserves the raw API response.
 13. Pretty output for `oz agent list` also includes a hint for users looking for the old skill-discovery behavior: `Looking for agent skills? Use <binary> agent skills instead.`
-14. Pretty output for get/create/update uses a detail view that shows the same core fields plus full lists of secret names and skill specs.
-15. Plain-text output is stable and script-friendly. List output is tabular text with headers. Single-agent output is line-oriented key/value text.
-16. JSON output for list/get/create/update preserves the API response shape so scripts can consume fields exactly as returned by the public API.
+14. Pretty output for get/create/update uses the same readable table shape for the single returned agent.
+15. Plain-text output is stable and script-friendly tabular text with headers for both list and single-agent output.
+16. JSON output for list/get/create/update preserves the API response shape so scripts can consume fields exactly as returned by the public API. List JSON is an object with an `agents` array.
 17. Sort flags are rejected for JSON output, including `--jq`, so raw API output remains raw.
 18. `--jq` implies JSON output even when the global output format is omitted or set to a human-readable format.
 19. `--jq` filters list/get/create/update JSON output using the same jq behavior as `oz run list` and `oz run get`, including unquoted scalar output.
-20. Delete has no JSON API response body. For JSON output, the CLI emits a minimal operation result containing the deleted UID and `deleted: true`; delete does not support `--jq`.
+20. Delete has no JSON API response body. For JSON and ndjson output, the CLI emits a minimal operation result containing the deleted UID and `deleted: true`; pretty output reports the deleted UID in a sentence, text output prints the deleted UID, and delete does not support `--jq`.
 21. All named-agent CRUD commands require authentication and reuse the existing CLI authentication and API-key behavior.
 22. If the server returns authorization, validation, conflict, or not-found errors, the CLI prints the server-facing error through the existing fatal-error path.
 23. The command hierarchy remains backward-compatible except for the intentional rename: users who want the previous skill list behavior must use `oz agent skills`.

--- a/specs/REMOTE-1696/TECH.md
+++ b/specs/REMOTE-1696/TECH.md
@@ -3,49 +3,49 @@
 ## Context
 `specs/REMOTE-1696/PRODUCT.md` defines the user-visible behavior.
 
-The CLI command definitions live in `crates/warp_cli/src/agent.rs`. Today `AgentCommand::List(ListAgentConfigsArgs)` is documented as "List all available agents" but actually drives skill discovery with an optional `--repo` flag. The app-side dispatcher in `app/src/ai/agent_sdk/mod.rs:286` sends that variant to `agent_config::list_agents`.
+The CLI command definitions live in `crates/warp_cli/src/agent.rs`. The old skill-discovery command has moved to `AgentCommand::Skills(ListAgentSkillsArgs)` with an optional `--repo` flag. The app-side dispatcher in `app/src/ai/agent_sdk/mod.rs` sends that variant to `agent_config::list_skills`.
 
-The existing skill-discovery implementation is in `app/src/ai/agent_sdk/agent_config.rs (1-266)`. It calls `AIClient::list_agents(repo)` and renders repository-discovered `AgentListItem` values.
+The existing skill-discovery implementation is in `app/src/ai/agent_sdk/agent_config.rs`. It calls `AIClient::list_skills(repo)` and renders repository-discovered `AgentSkillItem` values.
 
 Run listing/getting in `app/src/ai/agent_sdk/ambient.rs (60-116)` is the output model to follow. It accepts `JsonOutput`, fetches raw API JSON for JSON or `--jq`, and uses `output::print_raw_json`. The reusable output helpers are in `app/src/ai/agent_sdk/output.rs (1-258)`.
 
-The public API methods and types flow through `app/src/server/server_api/ai.rs`. The current `AIClient` trait exposes skill listing at `app/src/server/server_api/ai.rs (1008-1012)` and implements it with `GET /api/v1/agent` at `app/src/server/server_api/ai.rs (1966-1976)`. The underlying `ServerApi` already has authenticated GET/POST helpers in `app/src/server/server_api.rs (680-813)` but does not yet expose typed PUT/DELETE helpers for public API commands.
+The public API methods and types flow through `app/src/server/server_api/ai.rs`. The `AIClient` trait exposes skill listing as `list_skills(repo)` and named-agent CRUD as `list_agents`, `list_agents_raw`, `get_agent`, `get_agent_raw`, `create_agent`, `create_agent_raw`, `update_agent`, `update_agent_raw`, and `delete_agent`. The underlying `ServerApi` exposes authenticated GET/POST/PUT/DELETE helpers for public API commands.
 
 The named-agent API reference is in `../warp-server/public_api/openapi.yaml`:
 - `POST /agent/identities` and `GET /agent/identities` at `../warp-server/public_api/openapi.yaml (2709-2781)`.
 - `GET /agent/identities/{uid}`, `PUT /agent/identities/{uid}`, and `DELETE /agent/identities/{uid}` at `../warp-server/public_api/openapi.yaml (2783-2917)`.
-- `CreateAgentRequest`, `UpdateAgentRequest`, `AgentResponse`, and `ListAgentIdentitiesResponse` at `../warp-server/public_api/openapi.yaml (5399-5539)`.
+- `CreateAgentRequest`, `UpdateAgentRequest`, `AgentResponse`, and `ListAgentsResponse` at `../warp-server/public_api/openapi.yaml (5399-5539)`.
 
-Related named-agent environment work for `REMOTE-1695` adds an optional `environment_uid` field to create/update/response models. The current checked-out OpenAPI schema does not yet show that field; the implementation should keep optional deserialization tolerant so the CLI can display it when the server begins returning it.
+Related named-agent environment work for `REMOTE-1695` adds an optional `environment_id` field to create/update/response models. The current checked-out OpenAPI schema does not yet show that field; the implementation should keep optional deserialization tolerant so the CLI can display it when the server begins returning it.
 
 ## Proposed changes
 Add a new named-agent CLI surface and move the old skill-discovery command:
-- Rename the current `AgentCommand::List(ListAgentConfigsArgs)` variant to `AgentCommand::Skills(ListAgentSkillsArgs)` with `#[command(name = "skills")]`.
+- Rename the old skill-discovery command to `AgentCommand::Skills(ListAgentSkillsArgs)` with `#[command(name = "skills")]`.
 - Add `AgentCommand::List(AgentListArgs)`, `Get(AgentGetArgs)`, `Create(AgentCreateArgs)`, `Update(AgentUpdateArgs)`, and `Delete(AgentDeleteArgs)`.
-- Keep `ListAgentConfigsArgs` behavior and `--repo` intact under the renamed skills command.
-- Add parse tests covering the rename, new CRUD commands, sort args, repeated list fields, remove flags, and `--jq`.
+- Keep the old skill-discovery behavior and `--repo` intact under the renamed skills command.
+- Keep parser tests focused on custom conflict behavior rather than retesting clap's ordinary subcommand and repeated-flag parsing.
 
 Command arguments:
 - `AgentListArgs`: `--sort-by <name|created-at>`, `--sort-order <asc|desc>`, and flattened `JsonOutput`.
 - `AgentGetArgs`: positional `uid` and flattened `JsonOutput`.
 - `AgentCreateArgs`: required `--name`; optional `--description`; repeatable `--secret <NAME>`; repeatable `--skill <SPEC>`; optional `--base-model <MODEL_ID>`; optional `--environment <ENVIRONMENT_ID>` once the API field is available; flattened `JsonOutput`.
-- `AgentUpdateArgs`: positional `uid`; optional `--name`; optional `--description` conflicting with `--remove-description`; repeatable `--secret` conflicting with `--remove-secrets`; repeatable `--skill` conflicting with `--remove-skills`; optional `--base-model` conflicting with `--remove-base-model`; optional `--environment` conflicting with `--remove-environment`; flattened `JsonOutput`.
-- `AgentDeleteArgs`: positional `uid` and flattened `JsonOutput`.
+- `AgentUpdateArgs`: positional `uid`; optional `--name`; optional `--description` conflicting with `--remove-description`; repeatable `--add-secret`; repeatable `--remove-secret`; `--remove-all-secrets` conflicting with individual secret add/remove flags; repeatable `--add-skill`; repeatable `--remove-skill`; `--remove-all-skills` conflicting with individual skill add/remove flags; optional `--base-model` conflicting with `--remove-base-model`; optional `--environment` conflicting with `--remove-environment`; flattened `JsonOutput`.
+- `AgentDeleteArgs`: positional `uid`. It intentionally does not flatten `JsonOutput` because delete has no API response body to filter with `--jq`.
 
 Add app-side named-agent command handling:
-- Create a new module such as `app/src/ai/agent_sdk/agent_identity.rs` to avoid mixing named-agent CRUD with skill discovery.
-- Route the renamed skills command to the existing `agent_config::list_agents`.
+- Create a new module such as `app/src/ai/agent_sdk/agent_management.rs` to avoid mixing named-agent CRUD with skill discovery.
+- Route the renamed skills command to the existing `agent_config::list_skills`.
 - Route named-agent CRUD commands from `run_agent` to the new module.
 - Update `command_requires_auth` so every named-agent command and the renamed skills command require authentication.
 - Add telemetry variants for `AgentSkills`, `AgentList`, `AgentGet`, `AgentCreate`, `AgentUpdate`, and `AgentDelete`, or at minimum preserve the existing `AgentList` telemetry for the renamed skills command and add distinct variants for new CRUD commands if the telemetry enum supports adding them.
 
 Add API types and methods in `app/src/server/server_api/ai.rs`:
-- Define serde types for `SecretRef`, `CreateAgentRequest`, `UpdateAgentRequest`, `AgentResponse`, `ListAgentIdentitiesResponse`, and a local `DeleteAgentResult`.
+- Define serde types for `SecretRef`, `CreateAgentRequest`, `UpdateAgentRequest`, `AgentResponse`, `ListAgentsResponse`, `AgentSkillItem`, and supporting skill response types.
 - Model `created_at` as `DateTime<Utc>`.
-- Model `environment_uid` as an optional field to tolerate both the currently checked-in schema and the related server work.
+- Model `environment_id` as an optional field to tolerate both the currently checked-in schema and the related server work.
 - For create requests, skip absent optional fields and omit empty lists.
 - For update requests, use nested `Option`/custom serde helpers as needed so omitted fields are not serialized, remove flags serialize empty string or empty array, and non-empty values serialize replacements.
-- Add `AIClient` trait methods for typed named-agent CRUD plus raw JSON list/get/create/update methods used by `--jq`.
+- Add `AIClient` trait methods for typed named-agent CRUD plus raw JSON list/get/create/update methods used by JSON output and `--jq`, using the names `list_agents`, `list_agents_raw`, `get_agent`, `get_agent_raw`, `create_agent`, `create_agent_raw`, `update_agent`, `update_agent_raw`, and `delete_agent`.
 - Implement the methods with `GET/POST/PUT/DELETE /api/v1/agent/identities`.
 - Add reusable `put_public_api`, `put_public_api_response`, and `delete_public_api_unit` helpers to `ServerApi` if no existing helper covers those verbs.
 
@@ -55,21 +55,18 @@ Output behavior:
 - Reject `--sort-by` or `--sort-order` when JSON output is requested or implied by `--jq`, because JSON mode should preserve raw API output rather than returning a client-mutated response.
 - In pretty list output, print `Looking for agent skills? Use <binary> agent skills instead.` after the named-agent list, where `<binary>` is resolved through the existing CLI binary-name helper.
 - For get/create/update, pretty output should render a detail table; text output should render stable key/value lines; JSON/`--jq` should process the raw API response.
-- For delete, text/pretty should say the agent was deleted; JSON/`--jq` should process `{ "uid": "<uid>", "deleted": true }`.
+- For delete, text/pretty should say the agent was deleted; JSON output should print `{ "uid": "<uid>", "deleted": true }`. Delete does not support `--jq`.
 
 Update references and naming:
 - Update user-facing help strings so "agents" means named agents and "skills" means repository-discovered skills.
 - Update examples only if the CLI docs/examples mention `oz agent list` as skill discovery.
 
 ## Testing and validation
-- Add CLI parse tests in `crates/warp_cli/src/lib_tests.rs` for:
-  - `agent skills --repo owner/repo` maps to the renamed skill-discovery command.
-  - `agent list --sort-by name --sort-order desc` parses.
-  - `agent get <uid> --jq .name` parses.
-  - `agent create --name deployer --secret FOO --skill warpdotdev/repo:.agents/skills/x/SKILL.md --base-model claude-4-6-opus-high` parses.
-  - `agent update <uid> --remove-description --remove-skills --remove-base-model` parses and conflicts with replacement flags.
-  - `agent delete <uid> --jq .deleted` parses.
+- Keep CLI parse tests only for custom conflicts:
+  - `agent update <uid> --description <value> --remove-description` is rejected.
+  - `agent update <uid> --add-secret <NAME> --remove-all-secrets` is rejected.
 - Add unit tests for update request serialization to prove omitted fields are absent, remove flags serialize empty values, and replacement values serialize correctly.
+- Add unit tests for client-side secret and skill delta helpers.
 - Add unit tests for list sorting by name and created time.
 - Add unit tests that list sort flags are rejected for JSON and `--jq` output.
 - Add output tests for named-agent detail text/pretty helpers where they can be tested without a full app context.
@@ -82,5 +79,5 @@ Parallel child agents are not necessary for the first implementation pass. The c
 
 ## Risks and mitigations
 - **Patch semantics are easy to break:** use serialization tests for omitted, remove, and replacement cases.
-- **The old `agent list` behavior is being renamed:** keep the renamed `agent skills` behavior otherwise unchanged, add parse tests, and include the pretty-output hint for users looking for skills.
+- **The old `agent list` behavior is being renamed:** keep the renamed `agent skills` behavior otherwise unchanged and include the pretty-output hint for users looking for skills.
 - **Raw JSON sorting can diverge from "raw API" expectations:** reject sort flags when producing JSON output.

--- a/specs/REMOTE-1696/TECH.md
+++ b/specs/REMOTE-1696/TECH.md
@@ -1,0 +1,86 @@
+# Technical Spec: Oz CLI Named-Agent CRUD
+
+## Context
+`specs/REMOTE-1696/PRODUCT.md` defines the user-visible behavior.
+
+The CLI command definitions live in `crates/warp_cli/src/agent.rs`. Today `AgentCommand::List(ListAgentConfigsArgs)` is documented as "List all available agents" but actually drives skill discovery with an optional `--repo` flag. The app-side dispatcher in `app/src/ai/agent_sdk/mod.rs:286` sends that variant to `agent_config::list_agents`.
+
+The existing skill-discovery implementation is in `app/src/ai/agent_sdk/agent_config.rs (1-266)`. It calls `AIClient::list_agents(repo)` and renders repository-discovered `AgentListItem` values.
+
+Run listing/getting in `app/src/ai/agent_sdk/ambient.rs (60-116)` is the output model to follow. It accepts `JsonOutput`, fetches raw API JSON for JSON or `--jq`, and uses `output::print_raw_json`. The reusable output helpers are in `app/src/ai/agent_sdk/output.rs (1-258)`.
+
+The public API methods and types flow through `app/src/server/server_api/ai.rs`. The current `AIClient` trait exposes skill listing at `app/src/server/server_api/ai.rs (1008-1012)` and implements it with `GET /api/v1/agent` at `app/src/server/server_api/ai.rs (1966-1976)`. The underlying `ServerApi` already has authenticated GET/POST helpers in `app/src/server/server_api.rs (680-813)` but does not yet expose typed PUT/DELETE helpers for public API commands.
+
+The named-agent API reference is in `../warp-server/public_api/openapi.yaml`:
+- `POST /agent/identities` and `GET /agent/identities` at `../warp-server/public_api/openapi.yaml (2709-2781)`.
+- `GET /agent/identities/{uid}`, `PUT /agent/identities/{uid}`, and `DELETE /agent/identities/{uid}` at `../warp-server/public_api/openapi.yaml (2783-2917)`.
+- `CreateAgentRequest`, `UpdateAgentRequest`, `AgentResponse`, and `ListAgentIdentitiesResponse` at `../warp-server/public_api/openapi.yaml (5399-5539)`.
+
+Related named-agent environment work for `REMOTE-1695` adds an optional `environment_uid` field to create/update/response models. The current checked-out OpenAPI schema does not yet show that field; the implementation should keep optional deserialization tolerant so the CLI can display it when the server begins returning it.
+
+## Proposed changes
+Add a new named-agent CLI surface and move the old skill-discovery command:
+- Rename the current `AgentCommand::List(ListAgentConfigsArgs)` variant to `AgentCommand::Skills(ListAgentSkillsArgs)` with `#[command(name = "skills")]`.
+- Add `AgentCommand::List(AgentListArgs)`, `Get(AgentGetArgs)`, `Create(AgentCreateArgs)`, `Update(AgentUpdateArgs)`, and `Delete(AgentDeleteArgs)`.
+- Keep `ListAgentConfigsArgs` behavior and `--repo` intact under the renamed skills command.
+- Add parse tests covering the rename, new CRUD commands, sort args, repeated list fields, remove flags, and `--jq`.
+
+Command arguments:
+- `AgentListArgs`: `--sort-by <name|created-at>`, `--sort-order <asc|desc>`, and flattened `JsonOutput`.
+- `AgentGetArgs`: positional `uid` and flattened `JsonOutput`.
+- `AgentCreateArgs`: required `--name`; optional `--description`; repeatable `--secret <NAME>`; repeatable `--skill <SPEC>`; optional `--base-model <MODEL_ID>`; optional `--environment <ENVIRONMENT_ID>` once the API field is available; flattened `JsonOutput`.
+- `AgentUpdateArgs`: positional `uid`; optional `--name`; optional `--description` conflicting with `--remove-description`; repeatable `--secret` conflicting with `--remove-secrets`; repeatable `--skill` conflicting with `--remove-skills`; optional `--base-model` conflicting with `--remove-base-model`; optional `--environment` conflicting with `--remove-environment`; flattened `JsonOutput`.
+- `AgentDeleteArgs`: positional `uid` and flattened `JsonOutput`.
+
+Add app-side named-agent command handling:
+- Create a new module such as `app/src/ai/agent_sdk/agent_identity.rs` to avoid mixing named-agent CRUD with skill discovery.
+- Route the renamed skills command to the existing `agent_config::list_agents`.
+- Route named-agent CRUD commands from `run_agent` to the new module.
+- Update `command_requires_auth` so every named-agent command and the renamed skills command require authentication.
+- Add telemetry variants for `AgentSkills`, `AgentList`, `AgentGet`, `AgentCreate`, `AgentUpdate`, and `AgentDelete`, or at minimum preserve the existing `AgentList` telemetry for the renamed skills command and add distinct variants for new CRUD commands if the telemetry enum supports adding them.
+
+Add API types and methods in `app/src/server/server_api/ai.rs`:
+- Define serde types for `SecretRef`, `CreateAgentRequest`, `UpdateAgentRequest`, `AgentResponse`, `ListAgentIdentitiesResponse`, and a local `DeleteAgentResult`.
+- Model `created_at` as `DateTime<Utc>`.
+- Model `environment_uid` as an optional field to tolerate both the currently checked-in schema and the related server work.
+- For create requests, skip absent optional fields and omit empty lists.
+- For update requests, use nested `Option`/custom serde helpers as needed so omitted fields are not serialized, remove flags serialize empty string or empty array, and non-empty values serialize replacements.
+- Add `AIClient` trait methods for typed named-agent CRUD plus raw JSON list/get/create/update methods used by `--jq`.
+- Implement the methods with `GET/POST/PUT/DELETE /api/v1/agent/identities`.
+- Add reusable `put_public_api`, `put_public_api_response`, and `delete_public_api_unit` helpers to `ServerApi` if no existing helper covers those verbs.
+
+Output behavior:
+- Implement `TableFormat` for a list row wrapper around `AgentResponse`.
+- For list, fetch typed responses for pretty/text/ndjson and raw JSON for JSON/`--jq`. Apply client-side sorting before output for pretty/text/ndjson only.
+- Reject `--sort-by` or `--sort-order` when JSON output is requested or implied by `--jq`, because JSON mode should preserve raw API output rather than returning a client-mutated response.
+- In pretty list output, print `Looking for agent skills? Use <binary> agent skills instead.` after the named-agent list, where `<binary>` is resolved through the existing CLI binary-name helper.
+- For get/create/update, pretty output should render a detail table; text output should render stable key/value lines; JSON/`--jq` should process the raw API response.
+- For delete, text/pretty should say the agent was deleted; JSON/`--jq` should process `{ "uid": "<uid>", "deleted": true }`.
+
+Update references and naming:
+- Update user-facing help strings so "agents" means named agents and "skills" means repository-discovered skills.
+- Update examples only if the CLI docs/examples mention `oz agent list` as skill discovery.
+
+## Testing and validation
+- Add CLI parse tests in `crates/warp_cli/src/lib_tests.rs` for:
+  - `agent skills --repo owner/repo` maps to the renamed skill-discovery command.
+  - `agent list --sort-by name --sort-order desc` parses.
+  - `agent get <uid> --jq .name` parses.
+  - `agent create --name deployer --secret FOO --skill warpdotdev/repo:.agents/skills/x/SKILL.md --base-model claude-4-6-opus-high` parses.
+  - `agent update <uid> --remove-description --remove-skills --remove-base-model` parses and conflicts with replacement flags.
+  - `agent delete <uid> --jq .deleted` parses.
+- Add unit tests for update request serialization to prove omitted fields are absent, remove flags serialize empty values, and replacement values serialize correctly.
+- Add unit tests for list sorting by name and created time.
+- Add unit tests that list sort flags are rejected for JSON and `--jq` output.
+- Add output tests for named-agent detail text/pretty helpers where they can be tested without a full app context.
+- Run `cargo fmt`.
+- Run targeted Rust tests for `warp_cli` and the new agent SDK module.
+- Run a focused clippy command if compile/test scope reveals warnings.
+
+## Parallelization
+Parallel child agents are not necessary for the first implementation pass. The change is medium-sized but tightly coupled across command definitions, SDK dispatch, API methods, and output tests; parallel edits would likely collide in `agent.rs`, `mod.rs`, and `ai.rs`. If this grows beyond the planned scope, validation can be delegated later to a child agent in a separate worktree after the main API/CLI shape lands.
+
+## Risks and mitigations
+- **Patch semantics are easy to break:** use serialization tests for omitted, remove, and replacement cases.
+- **The old `agent list` behavior is being renamed:** keep the renamed `agent skills` behavior otherwise unchanged, add parse tests, and include the pretty-output hint for users looking for skills.
+- **Raw JSON sorting can diverge from "raw API" expectations:** reject sort flags when producing JSON output.

--- a/specs/REMOTE-1696/TECH.md
+++ b/specs/REMOTE-1696/TECH.md
@@ -16,9 +16,9 @@ The named-agent API reference is in `../warp-server/public_api/openapi.yaml`:
 - `GET /agent/identities/{uid}`, `PUT /agent/identities/{uid}`, and `DELETE /agent/identities/{uid}` at `../warp-server/public_api/openapi.yaml (2783-2917)`.
 - `CreateAgentRequest`, `UpdateAgentRequest`, `AgentResponse`, and `ListAgentsResponse` at `../warp-server/public_api/openapi.yaml (5399-5539)`.
 
-Related named-agent environment work for `REMOTE-1695` adds an optional `environment_id` field to create/update/response models. The current checked-out OpenAPI schema does not yet show that field; the implementation should keep optional deserialization tolerant so the CLI can display it when the server begins returning it.
+Related named-agent environment work for `REMOTE-1695` adds an optional `environment_id` field to create/update/response models. The current checked-out OpenAPI schema may lag that server behavior, so the implementation keeps optional deserialization tolerant while still accepting `--environment` and `--remove-environment`.
 
-## Proposed changes
+## Implemented changes
 Add a new named-agent CLI surface and move the old skill-discovery command:
 - Rename the old skill-discovery command to `AgentCommand::Skills(ListAgentSkillsArgs)` with `#[command(name = "skills")]`.
 - Add `AgentCommand::List(AgentListArgs)`, `Get(AgentGetArgs)`, `Create(AgentCreateArgs)`, `Update(AgentUpdateArgs)`, and `Delete(AgentDeleteArgs)`.
@@ -28,7 +28,7 @@ Add a new named-agent CLI surface and move the old skill-discovery command:
 Command arguments:
 - `AgentListArgs`: `--sort-by <name|created-at>`, `--sort-order <asc|desc>`, and flattened `JsonOutput`.
 - `AgentGetArgs`: positional `uid` and flattened `JsonOutput`.
-- `AgentCreateArgs`: required `--name`; optional `--description`; repeatable `--secret <NAME>`; repeatable `--skill <SPEC>`; optional `--base-model <MODEL_ID>`; optional `--environment <ENVIRONMENT_ID>` once the API field is available; flattened `JsonOutput`.
+- `AgentCreateArgs`: required `--name`; optional `--description`; repeatable `--secret <NAME>`; repeatable `--skill <SKILL>`; optional `--base-model <MODEL_ID>`; optional `--environment <ENVIRONMENT_ID>`; flattened `JsonOutput`.
 - `AgentUpdateArgs`: positional `uid`; optional `--name`; optional `--description` conflicting with `--remove-description`; repeatable `--add-secret`; repeatable `--remove-secret`; `--remove-all-secrets` conflicting with individual secret add/remove flags; repeatable `--add-skill`; repeatable `--remove-skill`; `--remove-all-skills` conflicting with individual skill add/remove flags; optional `--base-model` conflicting with `--remove-base-model`; optional `--environment` conflicting with `--remove-environment`; flattened `JsonOutput`.
 - `AgentDeleteArgs`: positional `uid`. It intentionally does not flatten `JsonOutput` because delete has no API response body to filter with `--jq`.
 
@@ -50,12 +50,15 @@ Add API types and methods in `app/src/server/server_api/ai.rs`:
 - Add reusable `put_public_api`, `put_public_api_response`, and `delete_public_api_unit` helpers to `ServerApi` if no existing helper covers those verbs.
 
 Output behavior:
-- Implement `TableFormat` for a list row wrapper around `AgentResponse`.
+- Implement `TableFormat` for `AgentResponse`.
 - For list, fetch typed responses for pretty/text/ndjson and raw JSON for JSON/`--jq`. Apply client-side sorting before output for pretty/text/ndjson only.
 - Reject `--sort-by` or `--sort-order` when JSON output is requested or implied by `--jq`, because JSON mode should preserve raw API output rather than returning a client-mutated response.
 - In pretty list output, print `Looking for agent skills? Use <binary> agent skills instead.` after the named-agent list, where `<binary>` is resolved through the existing CLI binary-name helper.
-- For get/create/update, pretty output should render a detail table; text output should render stable key/value lines; JSON/`--jq` should process the raw API response.
-- For delete, text/pretty should say the agent was deleted; JSON output should print `{ "uid": "<uid>", "deleted": true }`. Delete does not support `--jq`.
+- List and single-agent pretty/text output share the same fields from `AgentResponse`: UID, name, created time, description, secret names, skill specs, base model, and environment.
+- Pretty/text list output filters out disabled agents. If any disabled agents are hidden, print `N disabled agents hidden` to stderr after stdout output. JSON output and `--jq` use the raw API response and do not filter or print this notice.
+- For get/create/update, pretty output renders a single-row table; text output renders stable tabular text with headers; JSON/`--jq` processes the raw API response.
+- List JSON is the raw public API response object with an `agents` array, so list `--jq` filters should address `.agents[]`.
+- For delete, pretty output says the agent was deleted, text output prints the deleted UID, and JSON/ndjson output prints `{ "uid": "<uid>", "deleted": true }`. Delete does not support `--jq`.
 
 Update references and naming:
 - Update user-facing help strings so "agents" means named agents and "skills" means repository-discovered skills.
@@ -73,9 +76,11 @@ Update references and naming:
 - Run `cargo fmt`.
 - Run targeted Rust tests for `warp_cli` and the new agent SDK module.
 - Run a focused clippy command if compile/test scope reveals warnings.
+- Manually validate against an authenticated staging server. On macOS, invoke the app runner with `WARP_CLI_MODE=1 ./script/run -- <cli args>` so the bundled app parses CLI subcommands rather than GUI URLs. For parallel manual validation, use the built binary with `WARP_CLI_MODE=1` to avoid concurrent `./script/run` rebundling and codesigning the same app path.
+- Manual validation should cover create/get/list/delete, update add/remove flags for skills and secrets, description/base-model/environment set and remove flags, invalid environment errors, nonexistent UID errors, update-with-no-flags errors, sort ordering by name and created time, JSON sort-flag rejection, pretty/text/ndjson/json output, and `--jq` scalar output.
 
 ## Parallelization
-Parallel child agents are not necessary for the first implementation pass. The change is medium-sized but tightly coupled across command definitions, SDK dispatch, API methods, and output tests; parallel edits would likely collide in `agent.rs`, `mod.rs`, and `ai.rs`. If this grows beyond the planned scope, validation can be delegated later to a child agent in a separate worktree after the main API/CLI shape lands.
+Parallel child agents are not necessary for implementation. The change is medium-sized but tightly coupled across command definitions, SDK dispatch, API methods, and output tests; parallel edits would likely collide in `agent.rs`, `mod.rs`, and `ai.rs`. Manual validation can be parallelized after the implementation lands because validators only run CLI commands and use isolated disposable named-agent prefixes.
 
 ## Risks and mitigations
 - **Patch semantics are easy to break:** use serialization tests for omitted, remove, and replacement cases.


### PR DESCRIPTION
## Description

This adds a set of CLI commands for operating on named agents:
* `oz agent create [options]` to define a new agent
* `oz agent list` and `oz agent get` to query agents
* `oz agent update` to patch agent configs (setting a base model, adding/removing skills, etc.)
* `oz agent delete` to delete an agent

## Testing

- [x] Added CLI validation tests
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/0f7f3f142ebe46f79582c22a6027b34e

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-IMPROVEMENT: The Oz CLI now has commands for operating over reusable agents
