### PR TITLE
Fix orchestration picker menu widths

### DIFF
--- a/app/src/ai/blocklist/inline_action/host_picker.rs
+++ b/app/src/ai/blocklist/inline_action/host_picker.rs
@@ -88,6 +88,7 @@ impl HostPicker {
         let dropdown = ctx.add_typed_action_view(|ctx_dropdown| {
             let mut dropdown = Dropdown::<InternalAction>::new(ctx_dropdown);
             dropdown.set_use_overlay_layer(false, ctx_dropdown);
+            dropdown.set_match_menu_width_to_top_bar(true, ctx_dropdown);
             dropdown.set_main_axis_size(MainAxisSize::Max, ctx_dropdown);
             dropdown.set_style(DropdownStyle::ActionButtonSecondary, ctx_dropdown);
             dropdown.set_top_bar_height(ORCHESTRATION_PICKER_HEIGHT, ctx_dropdown);

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -422,6 +422,7 @@ pub fn new_standard_picker_dropdown<A: OrchestrationControlAction, V: View>(
     ctx.add_typed_action_view(move |ctx_dropdown| {
         let mut dropdown = Dropdown::<A>::new(ctx_dropdown);
         dropdown.set_use_overlay_layer(false, ctx_dropdown);
+        dropdown.set_match_menu_width_to_top_bar(true, ctx_dropdown);
         dropdown.set_main_axis_size(MainAxisSize::Max, ctx_dropdown);
         dropdown.set_style(DropdownStyle::ActionButtonSecondary, ctx_dropdown);
         dropdown.set_top_bar_height(ORCHESTRATION_PICKER_HEIGHT, ctx_dropdown);
@@ -690,6 +691,7 @@ pub fn create_environment_picker<A: OrchestrationControlAction, V: View>(
     let dropdown_handle = ctx.add_typed_action_view(move |ctx_dropdown| {
         let mut dropdown = FilterableDropdown::<A>::new(ctx_dropdown);
         dropdown.set_use_overlay_layer(false, ctx_dropdown);
+        dropdown.set_match_menu_width_to_top_bar(true, ctx_dropdown);
         dropdown.set_main_axis_size(MainAxisSize::Max, ctx_dropdown);
         dropdown.set_button_variant(ButtonVariant::Secondary);
         dropdown.set_style(styles);
@@ -698,7 +700,6 @@ pub fn create_environment_picker<A: OrchestrationControlAction, V: View>(
         dropdown
     });
     dropdown_handle.update(ctx, |dropdown, ctx_dropdown| {
-        dropdown.set_menu_width(280.0, ctx_dropdown);
         let footer_mouse_state = footer_mouse_state.clone();
         dropdown.set_footer(
             move |app| render_new_environment_footer::<A>(footer_mouse_state.clone(), app),
@@ -801,32 +802,28 @@ fn render_new_environment_footer<A: OrchestrationControlAction>(
     let mouse_state = mouse_state.clone();
 
     Hoverable::new(mouse_state, move |_| {
-        ConstrainedBox::new(
-            Container::new(
-                Flex::row()
-                    .with_main_axis_size(MainAxisSize::Max)
-                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                    .with_spacing(8.)
-                    .with_child(
-                        ConstrainedBox::new(Icon::Plus.to_warpui_icon(text_color).finish())
-                            .with_width(icon_size)
-                            .with_height(icon_size)
-                            .finish(),
-                    )
-                    .with_child(
-                        Text::new_inline("New environment", font_family, font_size)
-                            .with_color(text_color.into())
-                            .finish(),
-                    )
-                    .finish(),
-            )
-            .with_horizontal_padding(12.)
-            .with_vertical_padding(8.)
-            .with_background(bg)
-            .with_border(Border::top(1.).with_border_fill(theme.outline()))
-            .finish(),
+        Container::new(
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_spacing(8.)
+                .with_child(
+                    ConstrainedBox::new(Icon::Plus.to_warpui_icon(text_color).finish())
+                        .with_width(icon_size)
+                        .with_height(icon_size)
+                        .finish(),
+                )
+                .with_child(
+                    Text::new_inline("New environment", font_family, font_size)
+                        .with_color(text_color.into())
+                        .finish(),
+                )
+                .finish(),
         )
-        .with_width(280.)
+        .with_horizontal_padding(12.)
+        .with_vertical_padding(8.)
+        .with_background(bg)
+        .with_border(Border::top(1.).with_border_fill(theme.outline()))
         .finish()
     })
     .on_click(|ctx, _, _| {

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -125,6 +125,9 @@ pub struct Menu<A: Action + Clone = ()> {
     /// Optional overrides for the depth-0 menu content padding.
     content_top_padding_override: Option<f32>,
     content_bottom_padding_override: Option<f32>,
+    /// Optional saved-position id whose last rendered width should override
+    /// the configured submenu width while this menu is rendered.
+    width_match_position_id: Option<String>,
     /// If false, selecting a menu item updates selection and emits menu events
     /// without dispatching the item's typed action directly from the menu.
     dispatch_item_actions: bool,
@@ -2144,6 +2147,7 @@ impl<A: Action + Clone> Menu<A> {
             pinned_header_builder: None,
             content_top_padding_override: None,
             content_bottom_padding_override: None,
+            width_match_position_id: None,
             dispatch_item_actions: true,
         }
     }
@@ -2225,6 +2229,9 @@ impl<A: Action + Clone> Menu<A> {
 
     pub fn set_width(&mut self, width: f32) {
         self.submenu_width = width;
+    }
+    pub fn set_width_match_position_id(&mut self, position_id: Option<String>) {
+        self.width_match_position_id = position_id;
     }
 
     pub fn set_border(&mut self, border: Option<Border>) {
@@ -2777,13 +2784,24 @@ impl<A: Action + Clone> View for Menu<A> {
             .as_ref()
             .filter(|st| st.is_suppressing())
             .and(self.menu.hovered_row_index);
+        let window_id = self.window_id(app);
+        let submenu_width = self
+            .width_match_position_id
+            .as_deref()
+            .and_then(|position_id| {
+                window_id.and_then(|window_id| {
+                    app.element_position_by_id_at_last_frame(window_id, position_id)
+                })
+            })
+            .map(|bounds| bounds.width())
+            .unwrap_or(self.submenu_width);
 
         self.menu.render(
             self.border,
-            self.submenu_width,
+            submenu_width,
             self.with_drop_shadow,
             self.origin,
-            self.window_id(app),
+            window_id,
             self.prevent_interaction_with_other_elements,
             self.dispatch_item_actions,
             self.ignore_hover_when_covered,

--- a/app/src/view_components/dropdown.rs
+++ b/app/src/view_components/dropdown.rs
@@ -113,6 +113,7 @@ pub struct Dropdown<A: Action + Clone> {
     /// `SelectableArea`. Tracked as P1.1 for the orchestrate
     /// confirmation card pickers.
     use_overlay_layer: bool,
+    match_menu_width_to_top_bar: bool,
 }
 
 #[derive(Clone)]
@@ -255,6 +256,7 @@ where
             vertical_margin: DROPDOWN_PADDING,
             top_bar_height: TOP_MENU_BAR_HEIGHT,
             use_overlay_layer: true,
+            match_menu_width_to_top_bar: false,
         }
     }
 
@@ -346,6 +348,22 @@ where
     ) {
         self.element_anchor = element_anchor;
         self.child_anchor = child_anchor;
+        ctx.notify();
+    }
+
+    /// When enabled, the open menu sizes itself to the last rendered width of
+    /// the dropdown's top bar. This is useful for flexible dropdowns whose
+    /// trigger width is determined by parent layout rather than a fixed max.
+    pub fn set_match_menu_width_to_top_bar(
+        &mut self,
+        match_width: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.match_menu_width_to_top_bar = match_width;
+        let top_bar_label = self.top_bar_label();
+        self.dropdown.update(ctx, |menu, _ctx| {
+            menu.set_width_match_position_id(match_width.then_some(top_bar_label));
+        });
         ctx.notify();
     }
 
@@ -490,6 +508,11 @@ where
     pub fn toggle_expanded(&mut self, ctx: &mut ViewContext<Self>) {
         self.is_expanded = !self.is_expanded;
         if self.is_expanded {
+            if self.match_menu_width_to_top_bar {
+                if let Some(bounds) = ctx.element_position_by_id(self.top_bar_label()) {
+                    self.set_menu_width(bounds.width(), ctx);
+                }
+            }
             ctx.focus(&self.dropdown);
             ctx.emit(DropdownEvent::ToggleExpanded);
         }

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -73,6 +73,7 @@ pub struct FilterableDropdown<A: Action + Clone> {
     /// picker) that need to render in the parent's Normal layer
     /// instead of an overlay.
     use_overlay_layer: bool,
+    match_menu_width_to_top_bar: bool,
 }
 
 impl<A> FilterableDropdown<A>
@@ -131,6 +132,7 @@ where
             vertical_margin: DROPDOWN_PADDING,
             top_bar_height: TOP_MENU_BAR_HEIGHT,
             use_overlay_layer: true,
+            match_menu_width_to_top_bar: false,
         }
     }
 
@@ -329,6 +331,22 @@ where
         })
     }
 
+    /// When enabled, the open menu sizes itself to the last rendered width of
+    /// the dropdown's top bar. This is useful for flexible dropdowns whose
+    /// trigger width is determined by parent layout rather than a fixed max.
+    pub fn set_match_menu_width_to_top_bar(
+        &mut self,
+        match_width: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.match_menu_width_to_top_bar = match_width;
+        let top_bar_label = self.top_bar_label();
+        self.dropdown.update(ctx, |menu, _ctx| {
+            menu.set_width_match_position_id(match_width.then_some(top_bar_label));
+        });
+        ctx.notify();
+    }
+
     pub fn set_disabled(&mut self, ctx: &mut ViewContext<Self>) {
         self.disabled = true;
         ctx.notify();
@@ -397,6 +415,11 @@ where
     pub(crate) fn toggle_expanded(&mut self, ctx: &mut ViewContext<Self>) {
         self.is_expanded = !self.is_expanded;
         if self.is_expanded {
+            if self.match_menu_width_to_top_bar {
+                if let Some(bounds) = ctx.element_position_by_id(self.top_bar_label()) {
+                    self.set_menu_width(bounds.width(), ctx);
+                }
+            }
             ctx.focus(&self.filter_editor);
             ctx.emit(FilterableDropdownEvent::ToggleExpanded);
         }


### PR DESCRIPTION
## Description
Fixes orchestration config picker menus so they match the width of their flexible picker fields in both the run-agents confirmation card and plan-card orchestration config UI.

The shared menu now has an opt-in width anchor that reads the latest saved picker width during render. The orchestration model, harness, host, environment, and auth secret pickers enable that behavior, including the environment picker footer. This keeps already-open menus in sync if the card or pane resizes.

## Linked Issue
Linear: https://linear.app/warpdotdev/issue/QUALITY-722/orchestration-config-ui-picker-menus-are-not-the-same-width-as-the

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

- `cargo fmt --check --all --manifest-path /Users/matthew/src/orch-menu-width/warp/Cargo.toml`
- `git -C /Users/matthew/src/orch-menu-width/warp --no-pager diff --check`
- `cargo check --manifest-path /Users/matthew/src/orch-menu-width/warp/Cargo.toml -p warp`
- `./script/run` built, bundled, and launched `WarpLocal.app`; the run was later interrupted after manual validation.
- Attempted `cargo clippy --manifest-path /Users/matthew/src/orch-menu-width/warp/Cargo.toml --workspace --all-targets --all-features --tests -- -D warnings`, but the local `command-signatures-v2` JS build is blocked by Yarn/Corepack setup (`packageManager` requires Yarn 4, shell has Yarn 1.22.22).

### Screenshots / Videos
Demo Loom: https://www.loom.com/share/6b31b3c5437f427b9fb0f9b360e9c3c1

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent conversation: https://staging.warp.dev/conversation/080f80ac-92e3-46da-9649-10851bd47400

CHANGELOG-BUG-FIX: Fixed orchestration config picker menus not matching their picker fields.

Co-Authored-By: Oz <oz-agent@warp.dev>
