### PR TITLE
Reset pane flex when double-clicking on a pane divider.

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -290,6 +290,7 @@ pub enum PaneGroupAction {
     Activate(PaneId, ActivationReason),
     ResizeMove(Vector2F),
     StartResizing(DraggedBorder),
+    ResetPaneSizes(EntityId),
     Move {
         id: PaneId,
         target_pane_id: PaneId,
@@ -6156,6 +6157,14 @@ impl PaneGroup {
         self.dragged_border = Some(info);
     }
 
+    pub fn reset_pane_sizes(&mut self, border_id: EntityId, ctx: &mut ViewContext<Self>) {
+        self.dragged_border = None;
+        if self.panes.reset_pane_sizes(border_id) {
+            ctx.notify();
+            ctx.emit(Event::AppStateChanged);
+        }
+    }
+
     pub fn end_resizing(&mut self, ctx: &mut ViewContext<Self>) {
         self.dragged_border = None;
         ctx.emit(Event::AppStateChanged);
@@ -8153,6 +8162,7 @@ impl TypedActionView for PaneGroup {
             Activate(view_id, reason) => self.focus_pane_on_mouse_event(*view_id, *reason, ctx),
             ResizeMove(position) => self.maybe_resize_pane(*position, ctx),
             StartResizing(border) => self.start_resizing(*border, ctx),
+            ResetPaneSizes(border_id) => self.reset_pane_sizes(*border_id, ctx),
             EndResizing => self.end_resizing(ctx),
             ResizeLeft => self.resize_left(ctx),
             ResizeRight => self.resize_right(ctx),

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -6160,6 +6160,7 @@ impl PaneGroup {
     pub fn reset_pane_sizes(&mut self, border_id: EntityId, ctx: &mut ViewContext<Self>) {
         self.dragged_border = None;
         if self.panes.reset_pane_sizes(border_id) {
+            self.clear_hidden_closed_panes(ctx);
             ctx.notify();
             ctx.emit(Event::AppStateChanged);
         }

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -533,6 +533,10 @@ impl PaneData {
         self.root.adjust_pane_size(border_id, delta, ctx);
     }
 
+    pub fn reset_pane_sizes(&mut self, border_id: EntityId) -> bool {
+        self.root.reset_pane_sizes(border_id)
+    }
+
     pub fn adjust_pane_size_by_id(
         &mut self,
         pane_id: PaneId,
@@ -758,6 +762,13 @@ impl PaneNode {
         match self {
             PaneNode::Leaf(_) => false,
             PaneNode::Branch(branch) => branch.adjust_pane_size(border_id, delta, ctx),
+        }
+    }
+
+    pub fn reset_pane_sizes(&mut self, border_id: EntityId) -> bool {
+        match self {
+            PaneNode::Leaf(_) => false,
+            PaneNode::Branch(branch) => branch.reset_pane_sizes(border_id),
         }
     }
 
@@ -1181,6 +1192,23 @@ impl PaneBranch {
         false
     }
 
+    pub fn reset_pane_sizes(&mut self, border_id: EntityId) -> bool {
+        if self.dividers.iter().any(|divider| divider.id == border_id) {
+            for (flex, _) in &mut self.nodes {
+                *flex = DEFAULT_FLEX_SIZE;
+            }
+            return true;
+        }
+
+        for (_, node) in &mut self.nodes {
+            if node.reset_pane_sizes(border_id) {
+                return true;
+            }
+        }
+
+        false
+    }
+
     // Get the size of a branch by recursively adding the size of its children.
     pub fn size(&self, ctx: &mut ViewContext<PaneGroup>) -> Vector2F {
         match self.axis {
@@ -1377,6 +1405,23 @@ fn create_divider_placeholder(direction: SplitDirection, position_id: &str) -> B
     SavePosition::new(placeholder, position_id).finish()
 }
 
+fn divider_mouse_down_action(
+    mouse_state: &MouseStateHandle,
+    border_id: EntityId,
+    direction: SplitDirection,
+    position: Vector2F,
+) -> PaneGroupAction {
+    if mouse_state.lock().unwrap().click_count() == Some(2) {
+        PaneGroupAction::ResetPaneSizes(border_id)
+    } else {
+        PaneGroupAction::StartResizing(DraggedBorder {
+            border_id,
+            direction,
+            previous_mouse_location: position,
+        })
+    }
+}
+
 fn create_divider(
     direction: SplitDirection,
     item: &Divider,
@@ -1394,21 +1439,19 @@ fn create_divider(
     };
 
     let border_id = item.id;
+    let mouse_state = item.mouse_state.clone();
 
-    Hoverable::new(item.mouse_state.clone(), |_| {
-        EventHandler::new(match direction {
-            SplitDirection::Horizontal => divider.with_width(get_divider_thickness()).finish(),
-            SplitDirection::Vertical => divider.with_height(get_divider_thickness()).finish(),
-        })
-        .on_left_mouse_down(move |ctx, _, position| {
-            ctx.dispatch_typed_action(PaneGroupAction::StartResizing(DraggedBorder {
-                border_id,
-                direction,
-                previous_mouse_location: position,
-            }));
-            DispatchEventResult::StopPropagation
-        })
-        .finish()
+    Hoverable::new(item.mouse_state.clone(), |_| match direction {
+        SplitDirection::Horizontal => divider.with_width(get_divider_thickness()).finish(),
+        SplitDirection::Vertical => divider.with_height(get_divider_thickness()).finish(),
+    })
+    .on_mouse_down(move |ctx, _, position| {
+        ctx.dispatch_typed_action(divider_mouse_down_action(
+            &mouse_state,
+            border_id,
+            direction,
+            position,
+        ));
     })
     .with_cursor(cursor_shape)
     .with_propagate_drag()
@@ -1432,31 +1475,28 @@ fn create_minimalist_divider(
     };
 
     let border_id = item.id;
-    let hoverable = Hoverable::new(item.mouse_state.clone(), |_| {
-        let container = match direction {
-            SplitDirection::Horizontal => {
-                Container::new(divider.with_width(get_divider_thickness()).finish())
-                    .with_padding_left(DIVIDER_RESIZE_PADDING)
-                    .with_padding_right(DIVIDER_RESIZE_PADDING)
-                    .finish()
-            }
-            SplitDirection::Vertical => {
-                Container::new(divider.with_height(get_divider_thickness()).finish())
-                    .with_padding_top(DIVIDER_RESIZE_PADDING)
-                    .with_padding_bottom(DIVIDER_RESIZE_PADDING)
-                    .finish()
-            }
-        };
-        EventHandler::new(container)
-            .on_left_mouse_down(move |ctx, _, position| {
-                ctx.dispatch_typed_action(PaneGroupAction::StartResizing(DraggedBorder {
-                    border_id,
-                    direction,
-                    previous_mouse_location: position,
-                }));
-                DispatchEventResult::StopPropagation
-            })
-            .finish()
+    let mouse_state = item.mouse_state.clone();
+    let hoverable = Hoverable::new(item.mouse_state.clone(), |_| match direction {
+        SplitDirection::Horizontal => {
+            Container::new(divider.with_width(get_divider_thickness()).finish())
+                .with_padding_left(DIVIDER_RESIZE_PADDING)
+                .with_padding_right(DIVIDER_RESIZE_PADDING)
+                .finish()
+        }
+        SplitDirection::Vertical => {
+            Container::new(divider.with_height(get_divider_thickness()).finish())
+                .with_padding_top(DIVIDER_RESIZE_PADDING)
+                .with_padding_bottom(DIVIDER_RESIZE_PADDING)
+                .finish()
+        }
+    })
+    .on_mouse_down(move |ctx, _, position| {
+        ctx.dispatch_typed_action(divider_mouse_down_action(
+            &mouse_state,
+            border_id,
+            direction,
+            position,
+        ));
     })
     .with_cursor(cursor_shape)
     .with_propagate_drag();

--- a/app/src/pane_group/tree_tests.rs
+++ b/app/src/pane_group/tree_tests.rs
@@ -609,6 +609,89 @@ fn test_are_rects_overlapping_on_axis() {
 }
 
 #[test]
+fn test_reset_pane_sizes_resets_containing_branch() {
+    let panes = [
+        PaneId::dummy_pane_id(),
+        PaneId::dummy_pane_id(),
+        PaneId::dummy_pane_id(),
+    ];
+    let mut tree = PaneData::new(panes[0]);
+
+    tree.split(panes[0], panes[1], Direction::Right);
+    tree.split(panes[1], panes[2], Direction::Right);
+
+    let root = tree.root.as_branch().expect("Should be a branch");
+    let border_id = root.dividers[0].id;
+
+    let root = match &mut tree.root {
+        PaneNode::Branch(root) => root,
+        PaneNode::Leaf(_) => panic!("Should be a branch"),
+    };
+    root.nodes[0].0 = PaneFlex(0.2);
+    root.nodes[1].0 = PaneFlex(0.5);
+    root.nodes[2].0 = PaneFlex(0.3);
+
+    assert!(tree.reset_pane_sizes(border_id));
+
+    let root = tree.root.as_branch().expect("Should be a branch");
+    assert_eq!(
+        root.nodes
+            .iter()
+            .map(|(flex, _)| flex.0)
+            .collect::<Vec<_>>(),
+        vec![DEFAULT_FLEX_VALUE, DEFAULT_FLEX_VALUE, DEFAULT_FLEX_VALUE]
+    );
+}
+
+#[test]
+fn test_reset_pane_sizes_only_resets_containing_branch() {
+    let panes = [
+        PaneId::dummy_pane_id(),
+        PaneId::dummy_pane_id(),
+        PaneId::dummy_pane_id(),
+    ];
+    let mut tree = PaneData::new(panes[0]);
+
+    tree.split(panes[0], panes[1], Direction::Down);
+    tree.split(panes[1], panes[2], Direction::Right);
+
+    let root = match &mut tree.root {
+        PaneNode::Branch(root) => root,
+        PaneNode::Leaf(_) => panic!("Should be a branch"),
+    };
+    root.nodes[0].0 = PaneFlex(0.25);
+    root.nodes[1].0 = PaneFlex(0.75);
+
+    let nested = match &mut root.nodes[1].1 {
+        PaneNode::Branch(nested) => nested,
+        PaneNode::Leaf(_) => panic!("Should be a branch"),
+    };
+    nested.nodes[0].0 = PaneFlex(0.8);
+    nested.nodes[1].0 = PaneFlex(0.2);
+    let nested_border_id = nested.dividers[0].id;
+
+    assert!(tree.reset_pane_sizes(nested_border_id));
+
+    let root = tree.root.as_branch().expect("Should be a branch");
+    assert_eq!(
+        root.nodes
+            .iter()
+            .map(|(flex, _)| flex.0)
+            .collect::<Vec<_>>(),
+        vec![0.25, 0.75]
+    );
+    let nested = root.node(1).as_branch().expect("Should be a branch");
+    assert_eq!(
+        nested
+            .nodes
+            .iter()
+            .map(|(flex, _)| flex.0)
+            .collect::<Vec<_>>(),
+        vec![DEFAULT_FLEX_VALUE, DEFAULT_FLEX_VALUE]
+    );
+}
+
+#[test]
 fn test_hide_and_show_child_agent_pane() {
     let panes = [PaneId::dummy_pane_id(), PaneId::dummy_pane_id()];
     let mut tree = PaneData::new(panes[0]);


### PR DESCRIPTION
## Description
Double-clicking a pane divider now resets the flex values for the containing split branch, evenly redistributing the panes in that branch. This matches the behavior users expect from other split-pane editors and provides a quick way to undo manual pane resizing without affecting nested or parent splits.

It annoyed me that we didn't support this (I use it regularly in VSCode), so had Oz fix it.

https://github.com/user-attachments/assets/f702e1c2-a881-47a3-9b7d-cd40f4b994d3

## Linked Issue
None.

## Testing
- `cargo fmt`
- `cargo nextest run -p warp -E 'test(test_reset_pane_sizes_resets_containing_branch) or test(test_reset_pane_sizes_only_resets_containing_branch)'`
- `cargo check -p warp`
- `./script/run` failed before switching Node versions.
- `nvm use default`
- `./script/run` succeeded.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added support for double-clicking pane dividers to evenly redistribute panes in a split.

Co-Authored-By: Oz <oz-agent@warp.dev>
