### PR TITLE
Fix MCP +Add path bypassing secret redaction check

### DIFF
--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -903,6 +903,18 @@ impl TypedActionView for MCPServersEditPageView {
                         return;
                     }
 
+                    for parsed_server in &parsed_servers {
+                        if self
+                            .detect_secrets_in_templatable_mcp_server(
+                                ctx,
+                                &parsed_server.templatable_mcp_server,
+                            )
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+
                     for parsed_server in parsed_servers {
                         TemplatableMCPServerManager::handle(ctx).update(
                             ctx,

--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -903,16 +903,17 @@ impl TypedActionView for MCPServersEditPageView {
                         return;
                     }
 
-                    for parsed_server in &parsed_servers {
-                        if self
-                            .detect_secrets_in_templatable_mcp_server(
+                    if parsed_servers
+                        .iter()
+                        .try_for_each(|parsed_server| {
+                            self.detect_secrets_in_templatable_mcp_server(
                                 ctx,
                                 &parsed_server.templatable_mcp_server,
                             )
-                            .is_err()
-                        {
-                            return;
-                        }
+                        })
+                        .is_err()
+                    {
+                        return;
                     }
 
                     for parsed_server in parsed_servers {


### PR DESCRIPTION
## Description

The "+ Add" (new MCP server) save path in `app/src/settings_view/mcp_servers/edit_page.rs` was calling `ParsedTemplatableMCPServerResult::from_user_json` directly and skipping the `detect_secrets_in_templatable_mcp_server` check that the edit-existing path runs via `parse_templatable_json`.

Net effect today: secrets pasted into a freshly added MCP server config are not blocked locally — the cloud-side `sync_queue` reject is the only guard, and the user sees a generic `Failed to create mcp server` toast instead of the actionable `This MCP server contains secrets. Visit Settings > Privacy ...` toast.

This PR reuses the existing per-server helper after parsing so both save paths get the same local guard.

## Linked Issue

Fixes #11265.

- [x] The linked issue is labeled `ready-to-implement`.

## Screenshots / Videos

Video showing error toast after the fix:

https://github.com/user-attachments/assets/4dc9ba93-9ebd-49c8-b959-1c5f60d1b8de


## Testing

Manual repro per #11265:

1. Settings → Privacy → confirm Secret redaction is ON and the default recommended regexes are loaded (click "Add all recommended" if the list is empty — see #11262)
2. Settings → MCP Servers → + Add
3. Paste:
   ```json
   {
     "demo-new-server-bypass": {
       "command": "/usr/bin/true",
       "args": ["--api-key=sk-FAKE0000000000FAKEdemoWARP8761"]
     }
   }
   ```
4. Click Save → expect the actionable redaction toast, save blocked.

No automated test added; the secret-detection helper is already exercised via the edit-existing path and the change is a 12-line reuse of that helper. Happy to add an integration test on request.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed newly-added MCP servers bypassing local secret redaction; the actionable Privacy settings toast now fires on the +Add path too.
-->