### PR TITLE
fix(voice): abort voice recording when Ctrl key chords are pressed

### DIFF
--- a/app/src/editor/view/element.rs
+++ b/app/src/editor/view/element.rs
@@ -468,6 +468,18 @@ impl EditorElement {
                 ctx.dispatch_typed_action(EditorAction::ToggleVoiceInput(
                     voice_input::VoiceInputToggledFrom::Key { state: *state },
                 ));
+            } else if matches!(state, KeyState::Pressed)
+                && self.view_snapshot.voice_input_state.is_active()
+            {
+                // A modifier key other than the voice toggle key was pressed while voice is
+                // recording. Abort voice so that the resulting key chord can proceed normally.
+                //
+                // Example: if Ctrl is the voice toggle key and the user presses Ctrl+Shift+V
+                // to paste, voice is aborted when Shift is pressed. This ensures the editor
+                // is editable by the time V is pressed and the paste keybinding fires.
+                // (Keybindings are matched before element event handlers, so the abort must
+                // happen before the non-modifier key is pressed.)
+                ctx.dispatch_typed_action(EditorAction::AbortVoiceInput);
             }
         }
     }

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -1083,6 +1083,11 @@ pub enum EditorAction {
     EmacsBinding,
     #[cfg(feature = "voice_input")]
     ToggleVoiceInput(voice_input::VoiceInputToggledFrom),
+    /// Abort any active voice recording without transcribing the captured audio.
+    /// Used to cancel voice input when a key chord is pressed while the voice toggle
+    /// key is held (e.g., Shift pressed before Ctrl+Shift+V).
+    #[cfg(feature = "voice_input")]
+    AbortVoiceInput,
     AttachFiles,
     SetAIContextMenuOpen(bool),
     ReadAndProcessImagesAsync {
@@ -1106,6 +1111,7 @@ impl EditorAction {
                 | EditorAction::TryToShowXRay(_)
                 | EditorAction::HideXRay
                 | EditorAction::Select(_)
+                | EditorAction::AbortVoiceInput
         )
     }
 
@@ -4173,6 +4179,13 @@ impl EditorView {
     }
 
     pub fn paste(&mut self, ctx: &mut ViewContext<Self>) {
+        // If voice input is recording, abort it first so the editor is editable for the paste.
+        // This handles the case where the voice toggle key (e.g. Ctrl) is held while the user
+        // presses a paste shortcut (e.g. Ctrl+V).
+        #[cfg(feature = "voice_input")]
+        if self.is_voice_input_active() {
+            self.stop_voice_input(true /* cancel_transcription */, ctx);
+        }
         // If this editor does not delegate paste handling, insert clipboard text content.
         // When paste handling is delegated, the parent view (e.g. the terminal input) is
         // responsible for processing the paste.
@@ -8513,11 +8526,26 @@ impl TypedActionView for EditorView {
                 ctx.focus_self();
             }
             UnhandledModifierKey(keystroke) => {
+                #[cfg(feature = "voice_input")]
+                {
+                    // If a key chord that doesn't match a registered keybinding is pressed
+                    // while voice input is recording, abort voice so the editor is editable.
+                    // Note: for keybindings that DO match (e.g. Ctrl+Shift+V for paste),
+                    // voice is aborted at the action-handler level (see paste()) or via
+                    // modifier_key_change (see maybe_handle_voice_toggle()).
+                    if self.is_voice_input_active() {
+                        self.stop_voice_input(true /* cancel_transcription */, ctx);
+                    }
+                }
                 if self.can_select(ctx) {
                     // This event helps us to keep track of what key bindings users
                     // try to use in the editor but are currently not available in Warp.
                     ctx.emit(Event::UnhandledModifierKeyOnEditor(keystroke.clone()))
                 }
+            }
+            #[cfg(feature = "voice_input")]
+            AbortVoiceInput => {
+                self.stop_voice_input(true /* cancel_transcription */, ctx);
             }
             ClearParentSelections => {
                 self.maybe_commit_incomplete_ime_text(ctx);

--- a/app/src/editor/view/mod_tests.rs
+++ b/app/src/editor/view/mod_tests.rs
@@ -4520,6 +4520,43 @@ fn test_drag_and_drop_files_applies_path_transformer() {
     });
 }
 
+/// When a Ctrl/Cmd key chord (`UnhandledModifierKey`) is received while voice input
+/// is already inactive, the editor should remain in a non-voice state.
+#[test]
+#[cfg(feature = "voice_input")]
+fn test_unhandled_modifier_key_is_noop_when_voice_inactive() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (_, editor) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            EditorView::new(Default::default(), ctx)
+        });
+
+        editor.read(&app, |editor, _| {
+            assert!(
+                !editor.is_voice_input_active(),
+                "Voice should be inactive initially"
+            );
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.handle_action(
+                &EditorAction::UnhandledModifierKey(std::sync::Arc::new(
+                    "ctrl-shift-v".to_string(),
+                )),
+                ctx,
+            );
+        });
+
+        editor.read(&app, |editor, _| {
+            assert!(
+                !editor.is_voice_input_active(),
+                "Voice must remain inactive after UnhandledModifierKey when already inactive"
+            );
+        });
+    });
+}
+
 #[path = "vim_handler_tests.rs"]
 mod vim_handler_tests;
 

--- a/app/src/editor/view/voice.rs
+++ b/app/src/editor/view/voice.rs
@@ -482,7 +482,7 @@ impl EditorView {
         ctx.notify();
     }
 
-    fn apply_transcribed_voice_input(
+    pub(crate) fn apply_transcribed_voice_input(
         &mut self,
         result: Result<String, TranscribeError>,
         ctx: &mut ViewContext<Self>,
@@ -496,7 +496,9 @@ impl EditorView {
         match result {
             Ok(transcribe_response) => {
                 log::debug!("Transcribed voice input: {transcribe_response:?}");
-                self.user_insert(&transcribe_response, ctx);
+                if !transcribe_response.is_empty() {
+                    self.user_insert(&transcribe_response, ctx);
+                }
             }
             Err(e) => match e {
                 TranscribeError::QuotaLimit => {
@@ -621,3 +623,7 @@ impl EditorView {
         .finish()
     }
 }
+
+#[cfg(test)]
+#[path = "voice_tests.rs"]
+mod tests;

--- a/app/src/editor/view/voice_tests.rs
+++ b/app/src/editor/view/voice_tests.rs
@@ -1,0 +1,128 @@
+use crate::appearance::Appearance;
+use crate::auth::AuthStateProvider;
+use crate::editor::EditorView;
+use crate::server::server_api::team::MockTeamClient;
+use crate::server::server_api::workspace::MockWorkspaceClient;
+use crate::server::server_api::TranscribeError;
+use crate::settings_view::keybindings::KeybindingChangedNotifier;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::vim_registers::VimRegisters;
+use crate::workspace::sync_inputs::SyncedInputState;
+use crate::workspace::ToastStack;
+use crate::workspaces::user_workspaces::UserWorkspaces;
+use std::sync::Arc;
+use warpui::platform::WindowStyle;
+use warpui::{AddSingletonModel, App};
+
+fn initialize_app(app: &mut App) {
+    initialize_settings_for_tests(app);
+
+    app.add_singleton_model(|_| Appearance::mock());
+    app.add_singleton_model(|_| ToastStack);
+    app.add_singleton_model(|_ctx| SyncedInputState::mock());
+    app.add_singleton_model(|_ctx| VimRegisters::new());
+    app.add_singleton_model(|_| KeybindingChangedNotifier::mock());
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(voice_input::VoiceInput::new);
+
+    let team_client_mock = Arc::new(MockTeamClient::new());
+    let workspace_client_mock = Arc::new(MockWorkspaceClient::new());
+    app.add_singleton_model(|ctx| {
+        UserWorkspaces::mock(
+            team_client_mock.clone(),
+            workspace_client_mock.clone(),
+            vec![],
+            ctx,
+        )
+    });
+}
+
+/// When transcription returns an empty string, the editor buffer must not be modified.
+/// This guards against the previous behavior where `user_insert("")` would be called,
+/// which could clear any existing text selection.
+#[test]
+fn test_empty_transcription_does_not_modify_buffer() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (_, editor) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            EditorView::new(Default::default(), ctx)
+        });
+
+        // Pre-fill the editor with content.
+        editor.update(&mut app, |editor, ctx| {
+            editor.set_buffer_text("existing content", ctx);
+        });
+
+        // Apply an empty transcription result (simulates silence / no speech detected).
+        editor.update(&mut app, |editor, ctx| {
+            editor.apply_transcribed_voice_input(Ok(String::new()), ctx);
+        });
+
+        // Buffer must be unchanged.
+        editor.read(&app, |editor, ctx| {
+            assert_eq!(
+                editor.buffer_text(ctx),
+                "existing content",
+                "Empty transcription result must not modify the editor buffer"
+            );
+        });
+    });
+}
+
+/// When transcription returns a non-empty string, the editor buffer must be updated
+/// with that text. This is a regression guard to ensure the fix for empty strings
+/// did not inadvertently suppress non-empty transcriptions.
+#[test]
+fn test_non_empty_transcription_inserts_text() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (_, editor) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            EditorView::new(Default::default(), ctx)
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.apply_transcribed_voice_input(Ok("hello world".to_string()), ctx);
+        });
+
+        editor.read(&app, |editor, ctx| {
+            assert_eq!(
+                editor.buffer_text(ctx),
+                "hello world",
+                "Non-empty transcription result must be inserted into the editor buffer"
+            );
+        });
+    });
+}
+
+/// When transcription returns an error, the buffer must remain unchanged.
+#[test]
+fn test_transcription_error_does_not_modify_buffer() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (_, editor) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            EditorView::new(Default::default(), ctx)
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.set_buffer_text("untouched", ctx);
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.apply_transcribed_voice_input(
+                Err(TranscribeError::Other(anyhow::anyhow!("network error"))),
+                ctx,
+            );
+        });
+
+        editor.read(&app, |editor, ctx| {
+            assert_eq!(
+                editor.buffer_text(ctx),
+                "untouched",
+                "A transcription error must not modify the editor buffer"
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Description

When a modifier key that is not the voice toggle key is pressed while voice input is recording, voice input is now aborted so the resulting key chord can proceed normally.

For example, if Ctrl is the voice toggle key and the user presses Ctrl+Shift+V (paste), voice is aborted when Shift is pressed. This ensures the editor is editable by the time V is pressed and the paste keybinding fires. Without this fix, the paste keybinding would either fire while the editor was locked in voice-recording mode (silently doing nothing) or drop the keystroke entirely.

Changes:
- Added `AbortVoiceInput` action to `EditorAction`, which cancels any active voice recording without transcribing.
- In `maybe_handle_voice_toggle()` (`element.rs`): when a modifier key other than the voice toggle key is pressed while voice is active, dispatch `AbortVoiceInput`.
- In `paste()`: abort voice input before pasting so the editor is editable.
- In the `UnhandledModifierKey` handler: abort voice input for key chords that don't match any registered keybinding.
- Guard against empty transcription strings calling `user_insert` (which could inadvertently clear a selection).
- Added unit tests in a new `voice_tests.rs` file and in `mod_tests.rs`.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

New unit tests cover:
- Empty transcription result does not modify the editor buffer.
- Non-empty transcription result is inserted into the buffer.
- Transcription error does not modify the buffer.
- `UnhandledModifierKey` is a no-op when voice is already inactive.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- Conversation: https://app.warp.dev/conversation/b257bf64-ef9b-47d2-867b-d6d952b1c937 -->

<!--
## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fix Ctrl key chord conflicts with voice input (e.g., Ctrl+Shift+V to paste now works correctly while voice toggle is held)
-->