### PR TITLE
Fix ask question speedbump dropdown selection

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -3549,9 +3549,13 @@ impl AIBlock {
                 *shown.lock() = true;
             }
             let terminal_view_id = self.terminal_view_id;
+            let permission = AIExecutionProfilesModel::as_ref(ctx)
+                .active_profile(Some(terminal_view_id), ctx)
+                .data()
+                .ask_user_question;
             view.update(ctx, |view, ctx| {
                 view.set_speedbump_settings_link(Some(settings_link_handle), ctx);
-                view.init_speedbump_dropdown(ctx);
+                view.init_speedbump_dropdown(permission, ctx);
                 view.refresh_speedbump_dropdown_selection(terminal_view_id, ctx);
             });
             true

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -847,7 +847,11 @@ impl AskUserQuestionView {
     }
 
     /// Creates the dropdown view for the speedbump footer. No-op if already initialized.
-    pub fn init_speedbump_dropdown(&mut self, ctx: &mut ViewContext<Self>) {
+    pub fn init_speedbump_dropdown(
+        &mut self,
+        selected_permission: AskUserQuestionPermission,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if self.speedbump_dropdown.is_some() {
             return;
         }
@@ -880,27 +884,35 @@ impl AskUserQuestionView {
                     .collect(),
                 ctx,
             );
+            dropdown.set_selected_by_name(selected_permission.label(), ctx);
             dropdown
         });
         self.speedbump_dropdown = Some(view);
     }
 
+    fn set_speedbump_dropdown_selection(
+        &mut self,
+        permission: AskUserQuestionPermission,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(dropdown) = self.speedbump_dropdown.clone() else {
+            return;
+        };
+        dropdown.update(ctx, |dropdown, ctx| {
+            dropdown.set_selected_by_name(permission.label(), ctx);
+        });
+    }
     /// Updates the dropdown's selected item to match the active execution profile.
     pub fn refresh_speedbump_dropdown_selection(
         &mut self,
         terminal_view_id: EntityId,
         ctx: &mut ViewContext<Self>,
     ) {
-        let Some(dropdown) = self.speedbump_dropdown.clone() else {
-            return;
-        };
         let permission = AIExecutionProfilesModel::as_ref(ctx)
             .active_profile(Some(terminal_view_id), ctx)
             .data()
             .ask_user_question;
-        dropdown.update(ctx, |dropdown, ctx| {
-            dropdown.set_selected_by_name(permission.label(), ctx);
-        });
+        self.set_speedbump_dropdown_selection(permission, ctx);
     }
 
     /// Recover completed/cancelled status even if the live action entry is gone, so restored
@@ -1704,6 +1716,7 @@ impl TypedActionView for AskUserQuestionView {
                 self.is_expanded = !self.is_expanded;
             }
             AskUserQuestionViewAction::SetPermission(permission) => {
+                self.set_speedbump_dropdown_selection(*permission, ctx);
                 ctx.emit(AskUserQuestionViewEvent::SpeedbumpPermissionChanged(
                     *permission,
                 ));

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -890,29 +890,22 @@ impl AskUserQuestionView {
         self.speedbump_dropdown = Some(view);
     }
 
-    fn set_speedbump_dropdown_selection(
-        &mut self,
-        permission: AskUserQuestionPermission,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        let Some(dropdown) = self.speedbump_dropdown.clone() else {
-            return;
-        };
-        dropdown.update(ctx, |dropdown, ctx| {
-            dropdown.set_selected_by_name(permission.label(), ctx);
-        });
-    }
     /// Updates the dropdown's selected item to match the active execution profile.
     pub fn refresh_speedbump_dropdown_selection(
         &mut self,
         terminal_view_id: EntityId,
         ctx: &mut ViewContext<Self>,
     ) {
+        let Some(dropdown) = self.speedbump_dropdown.clone() else {
+            return;
+        };
         let permission = AIExecutionProfilesModel::as_ref(ctx)
             .active_profile(Some(terminal_view_id), ctx)
             .data()
             .ask_user_question;
-        self.set_speedbump_dropdown_selection(permission, ctx);
+        dropdown.update(ctx, |dropdown, ctx| {
+            dropdown.set_selected_by_name(permission.label(), ctx);
+        });
     }
 
     /// Recover completed/cancelled status even if the live action entry is gone, so restored
@@ -1716,7 +1709,6 @@ impl TypedActionView for AskUserQuestionView {
                 self.is_expanded = !self.is_expanded;
             }
             AskUserQuestionViewAction::SetPermission(permission) => {
-                self.set_speedbump_dropdown_selection(*permission, ctx);
                 ctx.emit(AskUserQuestionViewEvent::SpeedbumpPermissionChanged(
                     *permission,
                 ));


### PR DESCRIPTION
## Description
Fixes the Ask-User-Question autonomy speedbump dropdown so the closed header is populated from the active execution profile on initialization and updates immediately when a permission is selected.

The fix stays scoped to the Ask-User-Question view instead of changing shared dropdown behavior.

Warp Agent Mode conversation: https://staging.warp.dev/conversation/7f70dcc8-f0b5-4e7b-8a8d-3f1c4dde5af5

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features --tests -- -D warnings`
- [x] `git --no-pager diff --check`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Draft PR: screenshots or a short recording should be attached before review to show the dropdown header populated on initial render and after selecting another option.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the Ask-User-Question speedbump dropdown header appearing blank after initialization or selection.

Co-Authored-By: Oz <oz-agent@warp.dev>
