### PR TITLE
Add basic nushell support.

### DIFF
--- a/app/assets/bundled/bootstrap/nu.nu
+++ b/app/assets/bundled/bootstrap/nu.nu
@@ -1,0 +1,226 @@
+# Note that WARP_SESSION_ID is expected to have been set when executing commands
+# to emit the InitShell payload, which includes the session ID.
+if (($env.WARP_BOOTSTRAPPED? | default "") == "") {
+    if (($env.WARP_INITIAL_WORKING_DIR? | default "") != "") {
+        try { cd $env.WARP_INITIAL_WORKING_DIR } catch { }
+        hide-env WARP_INITIAL_WORKING_DIR
+    }
+
+    if (($env.WARP_PATH_APPEND? | default "") != "") {
+        let path_append = ($env.WARP_PATH_APPEND | split row (char esep))
+        if (($env.PATH | describe) | str contains "list") {
+            $env.PATH = ($env.PATH | append $path_append)
+        } else {
+            $env.PATH = $"($env.PATH)(char esep)($env.WARP_PATH_APPEND)"
+        }
+        hide-env WARP_PATH_APPEND
+    }
+
+    def warp_session_id [] {
+        $env.WARP_SESSION_ID | into int
+    }
+
+    def warp_hex_encode_string [message] {
+        $message | ^od -An -v -tx1 | ^tr -d ' \n'
+    }
+
+    def warp_maybe_send_reset_grid_osc [] {
+        if (($env.WARP_USING_WINDOWS_CON_PTY? | default "false") == "true") {
+            print -n $"(ansi escape)]9279(char bel)"
+        }
+    }
+
+    def warp_send_json_message [message] {
+        let encoded_message = (warp_hex_encode_string $message)
+        if (($env.WARP_USING_WINDOWS_CON_PTY? | default "false") == "true") {
+            print -n $"(ansi escape)]9278;d;($encoded_message)(char bel)"
+        } else {
+            print -n $"(ansi escape)P$d($encoded_message)(ansi escape)\\"
+        }
+    }
+
+    def warp_send_hook [hook value] {
+        let message = ({ hook: $hook, value: $value } | to json -r)
+        warp_send_json_message $message
+    }
+
+    def warp_send_generator_output_osc_pre_hex_encoded [hex_encoded_message] {
+        let byte_count = ($hex_encoded_message | str length)
+        print -n $"(ansi escape)]9277;A(char bel)($byte_count);($hex_encoded_message)(ansi escape)]9277;B(char bel)"
+        warp_maybe_send_reset_grid_osc
+    }
+
+    def --env warp_run_generator_command [command_id command] {
+        $env._WARP_GENERATOR_COMMAND = "1"
+        let result = (^nu --commands $command | complete)
+        let output = $"($command_id;)($result.stdout)($result.stderr);($result.exit_code)"
+        let hex_encoded_message = (warp_hex_encode_string $output)
+        warp_send_generator_output_osc_pre_hex_encoded $hex_encoded_message
+    }
+
+    def warp_preexec [command] {
+        warp_send_hook "Preexec" { command: $command }
+        warp_maybe_send_reset_grid_osc
+    }
+
+    def warp_path_string [] {
+        let path = ($env.PATH? | default [])
+        if (($path | describe) | str contains "list") {
+            $path | str join (char esep)
+        } else {
+            $path | into string
+        }
+    }
+
+    def warp_command_names_by_type [command_type] {
+        try {
+            scope commands | where type == $command_type | get name | uniq | str join (char nl)
+        } catch {
+            ""
+        }
+    }
+
+    def warp_aliases [] {
+        try {
+            scope aliases | each {|alias| $"($alias.name)\t($alias.expansion)" } | str join (char nl)
+        } catch {
+            ""
+        }
+    }
+
+    def warp_os_category [] {
+        let os_name = ($nu.os-info.name? | default "")
+        if (($os_name | str downcase) | str contains "macos") {
+            "MacOS"
+        } else if (($os_name | str downcase) | str contains "linux") {
+            "Linux"
+        } else if (($os_name | str downcase) | str contains "windows") {
+            "Windows"
+        } else {
+            ""
+        }
+    }
+
+    def warp_linux_distribution [] {
+        try {
+            let os_release_path = if ("/etc/os-release" | path exists) { "/etc/os-release" } else { "/usr/lib/os-release" }
+            if ($os_release_path | path exists) {
+                open $os_release_path | lines | where {|line| $line | str starts-with "NAME=" } | first | str replace --regex '^NAME="?([^"]*)"?$' '$1'
+            } else {
+                ""
+            }
+        } catch {
+            ""
+        }
+    }
+
+    def --env warp_precmd [] {
+        let exit_code = ($env.LAST_EXIT_CODE? | default 0)
+        let block_id = ($env.WARP_BLOCK_ID? | default "0" | into int)
+        $env.WARP_BLOCK_ID = (($block_id + 1) | into string)
+        warp_send_hook "CommandFinished" {
+            exit_code: $exit_code,
+            next_block_id: $"precmd-($env.WARP_SESSION_ID)-($block_id)"
+        }
+        warp_maybe_send_reset_grid_osc
+
+        if (($env._WARP_GENERATOR_COMMAND? | default "") != "") {
+            hide-env _WARP_GENERATOR_COMMAND
+            warp_send_hook "Precmd" {
+                pwd: "",
+                ps1: "",
+                git_head: "",
+                git_branch: "",
+                virtual_env: "",
+                conda_env: "",
+                node_version: "",
+                session_id: (warp_session_id),
+                is_after_in_band_command: true
+            }
+            return
+        }
+
+        let git_branch = (try { ^git symbolic-ref --short HEAD | str trim } catch { "" })
+        let git_head = if $git_branch != "" { $git_branch } else { try { ^git rev-parse --short HEAD | str trim } catch { "" } }
+
+        warp_send_hook "Precmd" {
+            pwd: (pwd),
+            ps1: "",
+            rprompt: "",
+            git_head: $git_head,
+            git_branch: $git_branch,
+            virtual_env: ($env.VIRTUAL_ENV? | default ""),
+            conda_env: ($env.CONDA_DEFAULT_ENV? | default ""),
+            node_version: "",
+            session_id: (warp_session_id)
+        }
+    }
+
+    def warp_bootstrapped [] {
+        let aliases = (warp_aliases)
+        let functions = (warp_command_names_by_type custom)
+        let builtins = (warp_command_names_by_type "built-in")
+        let keywords = (warp_command_names_by_type keyword)
+        let env_var_names = ($env | columns | str join (char nl))
+        let version_info = (try { version } catch { {} })
+        let shell_version = (try { $version_info.version } catch { "" })
+        let shell_path = (try { $nu.current-exe | into string } catch { "" })
+        let histfile = (try { $nu.history-path | into string } catch { "" })
+
+        warp_send_hook "Bootstrapped" {
+            histfile: $histfile,
+            session_id: (warp_session_id),
+            shell: "nu",
+            home_dir: ($nu.home-dir? | default ($env.HOME? | default "")),
+            path: (warp_path_string),
+            cdpath: "",
+            editor: ($env.EDITOR? | default ""),
+            env_var_names: $env_var_names,
+            abbreviations: "",
+            aliases: $aliases,
+            function_names: $functions,
+            builtins: $builtins,
+            keywords: $keywords,
+            shell_version: $shell_version,
+            shell_options: "",
+            vi_mode_enabled: "",
+            os_category: (warp_os_category),
+            linux_distribution: (warp_linux_distribution),
+            wsl_name: ($env.WSL_DISTRO_NAME? | default ""),
+            shell_path: $shell_path
+        }
+    }
+
+    def clear [] {
+        warp_send_hook "Clear" {}
+    }
+
+    def warp_finish_update [update_id] {
+        warp_send_hook "FinishUpdate" { update_id: $update_id }
+    }
+
+    def warp_handle_dist_upgrade [source_file_name] {
+        let apt_sources_dir = (try { ^sh -c 'eval $(apt-config shell APT_SOURCESDIR "Dir::Etc::sourceparts/d"); echo $APT_SOURCESDIR' | str trim } catch { "" })
+        if $apt_sources_dir != "" {
+            let list_path = $"($apt_sources_dir)($source_file_name).list"
+            let sources_path = $"($apt_sources_dir)($source_file_name).sources"
+            let dist_upgrade_path = $"($list_path).distUpgrade"
+            if (not ($list_path | path exists)) and (not ($sources_path | path exists)) and ($dist_upgrade_path | path exists) {
+                print $"Executing: sudo cp \"($dist_upgrade_path)\" \"($list_path)\""
+                sudo cp $dist_upgrade_path $list_path
+            }
+        }
+    }
+
+    if (($env.WARP_HONOR_PS1? | default "0") == "0") {
+        $env.PROMPT_COMMAND = ""
+        $env.PROMPT_COMMAND_RIGHT = ""
+    }
+
+    $env.config = ($env.config | upsert hooks.pre_execution { default [] | append {|| warp_preexec (commandline) } })
+    $env.config = ($env.config | upsert hooks.pre_prompt { default [] | append {|| warp_precmd } })
+
+    warp_precmd
+    warp_bootstrapped
+    $env.WARP_BOOTSTRAPPED = "1"
+}

--- a/app/assets/bundled/bootstrap/nu_init_shell.nu
+++ b/app/assets/bundled/bootstrap/nu_init_shell.nu
@@ -1,0 +1,8 @@
+# This file is executed via `nu --execute` before Warp sources the full Nushell
+# bootstrap. Keep each statement semicolon-friendly because Rust compacts this file.
+$env.WARP_SESSION_ID = ((random int 1000000000..9999999999) | into string)
+let _hostname = (try { ^hostname | str trim } catch { "" })
+let _user = (try { ^whoami | str trim } catch { ($env.USER? | default "") })
+$env.WARP_USING_WINDOWS_CON_PTY = "@@USING_CON_PTY_BOOLEAN@@"
+let _msg = ({ hook: "InitShell", value: { session_id: ($env.WARP_SESSION_ID | into int), shell: "nu", user: $_user, hostname: $_hostname } } | to json -r | ^od -An -v -tx1 | ^tr -d ' \n')
+if $env.WARP_USING_WINDOWS_CON_PTY == "true" { print -n $"(ansi escape)]9278;d;($_msg)(char bel)" } else { print -n $"(ansi escape)P$d($_msg)(ansi escape)\\" }

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -200,6 +200,8 @@ impl ShellCommandExecutor {
             // Fish doesn't have grouping characters. We need to use begin; and end; to ensure the command
             // gets evaluated first.
             Some(ShellType::Fish) => format!("begin; {command} ;end | command cat"),
+            // Nushell uses blocks for grouping pipelines.
+            Some(ShellType::Nushell) => format!("do {{ {command} }} | ^cat"),
             // For powershell, we use Out-Host to send paged output to the
             // console. Add a backslash to avoid executing an alias.
             Some(ShellType::PowerShell) => format!("({command}) | \\Out-Host"),

--- a/app/src/autoupdate/linux.rs
+++ b/app/src/autoupdate/linux.rs
@@ -362,7 +362,7 @@ impl PackageManager {
                 distribution_update_disabled_repository,
             } => {
                 let dist_upgrade_fn = match shell_type {
-                    ShellType::Zsh | ShellType::Bash | ShellType::Fish => {
+                    ShellType::Zsh | ShellType::Bash | ShellType::Fish | ShellType::Nushell => {
                         "warp_handle_dist_upgrade"
                     }
                     ShellType::PowerShell => "Warp-Handle-DistUpgrade",
@@ -414,7 +414,9 @@ impl PackageManager {
         };
 
         let finish_update_fn = match shell_type {
-            ShellType::Zsh | ShellType::Bash | ShellType::Fish => "warp_finish_update",
+            ShellType::Zsh | ShellType::Bash | ShellType::Fish | ShellType::Nushell => {
+                "warp_finish_update"
+            }
             ShellType::PowerShell => "Warp-Finish-Update",
         };
         format!("{base_command}{and}{finish_update_fn} {update_id}")

--- a/app/src/env_vars/mod.rs
+++ b/app/src/env_vars/mod.rs
@@ -80,6 +80,11 @@ impl EnvVar {
     }
 
     pub fn get_initialization_string(&self, shell_type: ShellType) -> String {
+        if shell_type == ShellType::Nushell {
+            let name = nushell_env_var_name(&self.name);
+            let value = get_nushell_init_command_for_env_var(&self.value);
+            return format!("$env.{name} = {value};");
+        }
         let shell_family = ShellFamily::from(shell_type);
         let name = shell_family.escape(&self.name);
         let value = get_init_command_for_env_var(&self.value, shell_family);
@@ -91,6 +96,7 @@ impl EnvVar {
             ShellType::Fish => {
                 format!("set -x {name} {value};")
             }
+            ShellType::Nushell => unreachable!("handled before shell-family escaping"),
             ShellType::PowerShell => {
                 format!("$env:{name} = {value};")
             }
@@ -111,6 +117,45 @@ fn get_init_command_for_env_var(value: &EnvVarValue, shell_family: ShellFamily) 
     }
 }
 
+fn get_nushell_init_command_for_env_var(value: &EnvVarValue) -> String {
+    match value {
+        EnvVarValue::Constant(val) => nushell_string_literal(val),
+        EnvVarValue::Command(cmd) => format!("({})", cmd.command),
+        EnvVarValue::Secret(secret) => {
+            format!(
+                "({})",
+                secret.get_secret_extraction_command(ShellFamily::Posix)
+            )
+        }
+    }
+}
+
+fn nushell_env_var_name(name: &str) -> String {
+    if name
+        .chars()
+        .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        && name
+            .chars()
+            .next()
+            .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+    {
+        name.to_owned()
+    } else {
+        nushell_string_literal(name)
+    }
+}
+
+fn nushell_string_literal(value: &str) -> String {
+    format!(
+        "\"{}\"",
+        value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
+            .replace('\t', "\\t")
+    )
+}
 /// Defines the data model for a cloud synced collection of environment variables.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct EnvVarCollection {
@@ -255,12 +300,29 @@ pub fn serialize_variables_for_shell<'s, I: IntoIterator<Item = (&'s str, &'s En
         ShellType::Bash | ShellType::Zsh => {
             serialize_variables_internal(pairs, "", "=", "", " ", shell_type.into())
         }
+        ShellType::Nushell => serialize_nushell_variables_internal(pairs, " "),
         ShellType::PowerShell => {
             serialize_variables_internal(pairs, "$env:", " = ", ";", " ", shell_type.into())
         }
     }
 }
 
+fn serialize_nushell_variables_internal<'s, I: IntoIterator<Item = (&'s str, &'s EnvVarValue)>>(
+    pairs: I,
+    delimiter: &str,
+) -> String {
+    pairs
+        .into_iter()
+        .map(|(name, value)| {
+            format!(
+                "$env.{} = {};",
+                nushell_env_var_name(name),
+                get_nushell_init_command_for_env_var(value)
+            )
+        })
+        .collect_vec()
+        .join(delimiter)
+}
 // Prefix — what's prepended to each variable
 // Separator — what separates the variable name from the value
 // Postfix — what's appended to the end of each variable

--- a/app/src/integration_testing/terminal/util.rs
+++ b/app/src/integration_testing/terminal/util.rs
@@ -68,6 +68,14 @@ pub fn current_shell_starter_and_version() -> (DirectShellStarter, String) {
                 .stdout;
             String::from_utf8_lossy(&stdout).into_owned()
         }
+        shell::ShellType::Nushell => {
+            let stdout = Command::new(starter.logical_shell_path())
+                .args(["-c", "version | get version"])
+                .output()
+                .expect("version command should run")
+                .stdout;
+            String::from_utf8_lossy(&stdout).into_owned()
+        }
         shell::ShellType::PowerShell => {
             let stdout = Command::new(starter.logical_shell_path())
                 .args(["-Version"])
@@ -86,6 +94,7 @@ pub fn current_shell_starter_and_version() -> (DirectShellStarter, String) {
 pub fn default_histfile_directory(shell: &ShellType, home_dir: &Path) -> PathBuf {
     match shell {
         ShellType::Fish => home_dir.join(".local/share/fish"),
+        ShellType::Nushell => home_dir.join(".local/share/nushell"),
         #[cfg(not(windows))]
         ShellType::PowerShell => home_dir.join(".local/share/powershell/PSReadLine"),
         #[cfg(windows)]

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -39,6 +39,10 @@ pub(super) fn normalize_local_child_harness(harness_type: &str) -> Option<Harnes
 pub(super) fn validate_local_harness_shell(shell_type: Option<ShellType>) -> Result<(), String> {
     match shell_type {
         Some(ShellType::Bash) | Some(ShellType::Zsh) | Some(ShellType::Fish) => Ok(()),
+        Some(ShellType::Nushell) => Err(
+            "Local child harnesses currently require bash, zsh, or fish; Nushell is not supported."
+                .to_string(),
+        ),
         Some(ShellType::PowerShell) => Err(
             "Local child harnesses currently require bash, zsh, or fish; PowerShell is not supported."
                 .to_string(),

--- a/app/src/shell_indicator.rs
+++ b/app/src/shell_indicator.rs
@@ -35,7 +35,7 @@ impl TryFrom<&ShellLaunchData> for ShellIndicatorType {
         match shell_launch_data {
             ShellLaunchData::Executable { shell_type, .. } => match shell_type {
                 ShellType::PowerShell => Ok(Self::Powershell),
-                _ => Err(()),
+                ShellType::Bash | ShellType::Zsh | ShellType::Fish | ShellType::Nushell => Err(()),
             },
             ShellLaunchData::MSYS2 { .. } => Ok(Self::GitBash),
             ShellLaunchData::WSL { distro } => match distro.as_str() {

--- a/app/src/terminal/available_shells.rs
+++ b/app/src/terminal/available_shells.rs
@@ -120,6 +120,7 @@ impl AvailableShell {
                 "bash" => Cow::from("Bash"),
                 "zsh" => Cow::from("Zsh"),
                 "fish" => Cow::from("Fish"),
+                "nu" | "nu.exe" => Cow::from("Nushell"),
                 "pwsh" | "pwsh.exe" => Cow::from("PowerShell"),
                 "powershell" | "powershell.exe" => Cow::from("Windows PowerShell"),
                 _ => Cow::from(command),
@@ -631,6 +632,7 @@ impl AvailableShells {
                 StartupShell::Zsh,
                 StartupShell::Bash,
                 StartupShell::Fish,
+                StartupShell::Nushell,
                 StartupShell::PowerShell,
             ]
             .into_iter()
@@ -699,12 +701,14 @@ impl AvailableShells {
                 (ShellType::Zsh, "zsh.exe"),
                 (ShellType::Bash, "bash.exe"),
                 (ShellType::Fish, "fish.exe"),
+                (ShellType::Nushell, "nu.exe"),
             ]
         } else {
             vec![
                 (ShellType::Zsh, "zsh"),
                 (ShellType::Bash, "bash"),
                 (ShellType::Fish, "fish"),
+                (ShellType::Nushell, "nu"),
                 (ShellType::PowerShell, "pwsh"),
             ]
         }

--- a/app/src/terminal/available_shells_tests.rs
+++ b/app/src/terminal/available_shells_tests.rs
@@ -128,9 +128,11 @@ fn test_dedupe_symlinks_when_discovering_paths() {
 #[test]
 fn test_find_by_command_name_matches_known_shell() {
     let zsh_path = PathBuf::from("/bin/zsh");
+    let nu_path = PathBuf::from("/opt/homebrew/bin/nu");
     let pwsh_path = PathBuf::from("/opt/homebrew/bin/pwsh");
     let shells = make_available_shells(vec![
         AvailableShell::new_local_executable("zsh".to_string(), zsh_path.clone(), ShellType::Zsh),
+        AvailableShell::new_local_executable("nu".to_string(), nu_path.clone(), ShellType::Nushell),
         AvailableShell::new_local_executable(
             "pwsh".to_string(),
             pwsh_path.clone(),
@@ -145,6 +147,14 @@ fn test_find_by_command_name_matches_known_shell() {
         matched.id(),
         Some(format!("local:{}", pwsh_path.display()).as_str()),
     );
+    let matched = shells
+        .find_by_command_name("nu")
+        .expect("should find nu by command name");
+    assert_eq!(
+        matched.id(),
+        Some(format!("local:{}", nu_path.display()).as_str()),
+    );
+    assert_eq!(matched.short_name(), "Nushell");
 
     let matched = shells
         .find_by_command_name("zsh")
@@ -257,6 +267,8 @@ fn test_command_name_matches_windows() {
     assert!(command_name_matches("pwsh", "pwsh.exe", true));
     assert!(command_name_matches("pwsh.exe", "PWSH.EXE", true));
     assert!(command_name_matches("powershell.exe", "PowerShell", true));
+    assert!(command_name_matches("nu.exe", "nu", true));
+    assert!(command_name_matches("nu", "NU.EXE", true));
 
     // Distinct shells should not collide.
     assert!(!command_name_matches("pwsh", "powershell", true));

--- a/app/src/terminal/bootstrap.rs
+++ b/app/src/terminal/bootstrap.rs
@@ -74,6 +74,7 @@ pub fn should_use_rc_file_bootstrap_method(
                 .as_ref()
                 .is_some_and(|data| matches!(data, ShellLaunchData::MSYS2 { .. }));
             shell_type == ShellType::Fish
+                || shell_type == ShellType::Nushell
                 || shell_type == ShellType::PowerShell
                 || is_poetry_subshell
                 || ((is_pipenv_subshell
@@ -105,6 +106,7 @@ pub fn script_for_shell(shell_type: ShellType, assets: &dyn AssetProvider) -> Co
         ShellType::Bash => "bash.sh",
         ShellType::Zsh => "zsh.sh",
         ShellType::Fish => "fish.sh",
+        ShellType::Nushell => "nu.nu",
         ShellType::PowerShell => "pwsh.ps1",
     };
 
@@ -197,6 +199,8 @@ pub fn init_shell_script_for_shell(shell_type: ShellType, assets: &dyn AssetProv
         ShellType::Zsh => load_and_escape_script("bundled/bootstrap/zsh_init_shell.sh", assets),
         ShellType::Bash => load_and_escape_script("bundled/bootstrap/bash_init_shell.sh", assets),
         ShellType::Fish => load_and_escape_script("bundled/bootstrap/fish_init_shell.sh", assets),
+        ShellType::Nushell => load_script("bundled/bootstrap/nu_init_shell.nu", assets)
+            .replace("@@USING_CON_PTY_BOOLEAN@@", &(cfg!(windows).to_string())),
         ShellType::PowerShell => load_script("bundled/bootstrap/pwsh_init_shell.ps1", assets),
     }
 }
@@ -255,6 +259,8 @@ fn init_subshell_script_for_shell(
         ShellType::Fish => {
             load_and_escape_script("bundled/bootstrap/fish_init_subshell.sh", assets)
         }
+        // TODO: Add Nushell subshell bootstrap support.
+        ShellType::Nushell => todo!(),
         // TODO(PLAT-750)
         ShellType::PowerShell => todo!(),
     };
@@ -289,6 +295,7 @@ pub fn raw_init_shell_script_for_shell(
         ShellType::Bash => "bundled/bootstrap/bash_init_shell.sh",
         ShellType::Zsh => "bundled/bootstrap/zsh_init_shell.sh",
         ShellType::Fish => "bundled/bootstrap/fish_init_shell.sh",
+        ShellType::Nushell => "bundled/bootstrap/nu_init_shell.nu",
         ShellType::PowerShell => "bundled/bootstrap/pwsh_init_shell.ps1",
     };
     load_script(file, assets).replace("@@USING_CON_PTY_BOOLEAN@@", &(cfg!(windows).to_string()))

--- a/app/src/terminal/bootstrap_tests.rs
+++ b/app/src/terminal/bootstrap_tests.rs
@@ -7,6 +7,10 @@ impl AssetProvider for TestAssetProvider {
         let content = match path {
             "bundled/bootstrap/bash.sh" => "#include hello_world",
             "bundled/bootstrap/fish.sh" => "# this is a comment\nthis_is_a_command",
+            "bundled/bootstrap/nu.nu" => "# this is a comment\n$env.config = {}",
+            "bundled/bootstrap/nu_init_shell.nu" => {
+                r#"$env.WARP_USING_WINDOWS_CON_PTY = "@@USING_CON_PTY_BOOLEAN@@""#
+            }
             "bundled/bootstrap/zsh.sh" => {
                 "asdf\n#include whitespace\n    prepended whitespace\n\n\n"
             }
@@ -41,6 +45,10 @@ fn test_trims_comments() {
         decode_script(&script_for_shell(ShellType::Fish, &TestAssetProvider)),
         "this_is_a_command\n"
     );
+    assert_eq!(
+        decode_script(&script_for_shell(ShellType::Nushell, &TestAssetProvider)),
+        "$env.config = {}\n"
+    );
 }
 
 #[test]
@@ -59,6 +67,20 @@ fn test_trims_powershell_specifics() {
     );
 }
 
+#[test]
+fn test_nushell_init_shell_script_replaces_conpty_placeholder() {
+    assert_eq!(
+        init_shell_script_for_shell(ShellType::Nushell, &TestAssetProvider),
+        format!(r#"$env.WARP_USING_WINDOWS_CON_PTY = "{}""#, cfg!(windows))
+    );
+}
+
+#[test]
+fn test_nushell_bootstrap_env_mutating_helpers_are_env_commands() {
+    let script = decode_script(&script_for_shell(ShellType::Nushell, &crate::ASSETS));
+    assert!(script.contains("def --env warp_precmd []"));
+    assert!(script.contains("def --env warp_run_generator_command [command_id command]"));
+}
 fn decode_script(bytes: &[u8]) -> &str {
     std::str::from_utf8(bytes).expect("should not fail to decode")
 }

--- a/app/src/terminal/local_shell/mod.rs
+++ b/app/src/terminal/local_shell/mod.rs
@@ -106,6 +106,7 @@ impl LocalShellState {
         let command = match shell_type {
             ShellType::Bash | ShellType::Zsh => "echo $PATH",
             ShellType::Fish => "env | grep PATH",
+            ShellType::Nushell => "$env.PATH | str join (char esep)",
             ShellType::PowerShell => "echo $Env:PATH",
         };
 
@@ -248,6 +249,7 @@ async fn capture_interactive_shell_env(
     let command_str = match shell_type {
         ShellType::Bash | ShellType::Zsh => "echo $PATH",
         ShellType::Fish => "string join : $PATH",
+        ShellType::Nushell => "$env.PATH | str join (char esep)",
         ShellType::PowerShell => "echo $Env:PATH",
     };
 
@@ -275,6 +277,9 @@ async fn capture_interactive_shell_env(
         }
         ShellType::Fish => {
             command.args(["-i", "-l", "-c", command_str]);
+        }
+        ShellType::Nushell => {
+            command.args(["--login", "--commands", command_str]);
         }
         ShellType::PowerShell => {
             // Note: we intentionally omit `-Login` here. PowerShell 5.1

--- a/app/src/terminal/local_tty/shell.rs
+++ b/app/src/terminal/local_tty/shell.rs
@@ -486,6 +486,8 @@ impl WslShellStarter {
             ShellType::Zsh
         } else if shell_path.contains("fish") {
             ShellType::Fish
+        } else if shell_path.contains("nu") {
+            ShellType::Nushell
         } else {
             log::warn!("The shell {shell_path:#} is not yet supported in WSL");
             return None;
@@ -645,6 +647,12 @@ fn arguments_for_session_spawning_command(
                 .into(),
             ]
         }
+        ShellType::Nushell => {
+            vec![
+                "--execute".to_owned().into(),
+                init_shell_script_for_shell(ShellType::Nushell, &crate::ASSETS).into(),
+            ]
+        }
         ShellType::PowerShell => vec![
             // When PowerShell starts a session, it writes "PowerShell <version>" to the PTY. This
             // option suppresses that message.
@@ -679,7 +687,7 @@ fn wsl_arguments_for_session_spawning_command(
     // Note we typically go through bash so that we can launch the user's shell
     // with a leading '-', making it a login shell.
     match shell_type {
-        ShellType::Bash | ShellType::Zsh | ShellType::Fish => {
+        ShellType::Bash | ShellType::Zsh | ShellType::Fish | ShellType::Nushell => {
             args.extend(arguments_for_session_spawning_command(
                 shell_path, shell_type,
             ));
@@ -706,6 +714,7 @@ fn msys2_arguments_for_session_spawning_command(shell_type: ShellType) -> Vec<Os
                 "--no-config".to_string().into(),
             ]
         }
+        ShellType::Nushell => panic!("MSYS2 not supported for Nushell"),
         ShellType::PowerShell => panic!("MSYS2 not supported for PowerShell"),
     }
 }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -560,6 +560,51 @@ impl HostInfo {
     }
 }
 
+fn command_names_from_shell_output(shell_type: ShellType, output: &str) -> HashSet<SmolStr> {
+    let mut command_names = HashSet::new();
+    for line in output.lines() {
+        insert_command_name_variants(shell_type, line, |name| {
+            command_names.insert(name.into());
+        });
+    }
+    command_names
+}
+
+fn command_name_vec_from_shell_output(shell_type: ShellType, output: &str) -> Vec<SmolStr> {
+    let mut seen = HashSet::new();
+    let mut command_names = Vec::new();
+    for line in output.lines() {
+        insert_command_name_variants(shell_type, line, |name| {
+            let name = SmolStr::from(name);
+            if seen.insert(name.clone()) {
+                command_names.push(name);
+            }
+        });
+    }
+    command_names
+}
+
+fn insert_command_name_variants(
+    shell_type: ShellType,
+    command_name: &str,
+    mut insert: impl FnMut(&str),
+) {
+    let command_name = command_name.trim();
+    if command_name.is_empty() {
+        return;
+    }
+
+    insert(command_name);
+
+    if shell_type == ShellType::Nushell {
+        if let Some(top_level_command) = command_name.split_whitespace().next() {
+            if top_level_command != command_name {
+                insert(top_level_command);
+            }
+        }
+    }
+}
+
 /// Session information sent from the shell to the Rust app after bootstrap.
 ///
 /// This is an intermediate abstraction between the [`BootstrappedValue`] read from the pty at
@@ -733,15 +778,17 @@ impl SessionInfo {
 
         let function_names = bootstrapped_value
             .function_names
-            .map(|function_names_output| function_names_output.lines().map(Into::into).collect());
+            .map(|function_names_output| {
+                command_names_from_shell_output(shell_type, &function_names_output)
+            });
 
         let builtins = bootstrapped_value
             .builtins
-            .map(|builtins_output| builtins_output.lines().map(Into::into).collect());
+            .map(|builtins_output| command_names_from_shell_output(shell_type, &builtins_output));
 
-        let keywords = bootstrapped_value
-            .keywords
-            .map(|keywords_output| keywords_output.lines().map(Into::into).collect());
+        let keywords = bootstrapped_value.keywords.map(|keywords_output| {
+            command_name_vec_from_shell_output(shell_type, &keywords_output)
+        });
 
         let env_var_names = bootstrapped_value.env_var_names.map(|names| {
             // In zsh the output of `echo ${(k)parameters[(R)*export*]}` is a single line separated
@@ -749,7 +796,7 @@ impl SessionInfo {
             // a separate line.
             let split = match &self.shell.shell_type() {
                 ShellType::Zsh | ShellType::PowerShell => names.split(' '),
-                ShellType::Bash | ShellType::Fish => names.split('\n'),
+                ShellType::Bash | ShellType::Fish | ShellType::Nushell => names.split('\n'),
             };
             split.map(Into::into).collect::<HashSet<_>>()
         });
@@ -960,7 +1007,9 @@ impl Session {
 
     pub fn path_separators(&self) -> PathSeparators {
         match self.shell().shell_type() {
-            ShellType::Zsh | ShellType::Bash | ShellType::Fish => PathSeparators::for_unix(),
+            ShellType::Zsh | ShellType::Bash | ShellType::Fish | ShellType::Nushell => {
+                PathSeparators::for_unix()
+            }
             ShellType::PowerShell => PathSeparators::for_os(),
         }
     }

--- a/app/src/terminal/model/session/command_executor.rs
+++ b/app/src/terminal/model/session/command_executor.rs
@@ -394,7 +394,8 @@ pub mod testing {
         ) -> Result<CommandOutput> {
             let mut command_process = Command::new(match shell.shell_type() {
                 ShellType::PowerShell => "pwsh",
-                _ => "bash",
+                ShellType::Nushell => "nu",
+                ShellType::Bash | ShellType::Zsh | ShellType::Fish => "bash",
             });
 
             // Set environment variables, including $PATH.

--- a/app/src/terminal/model/session/command_executor/in_band_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/in_band_command_executor.rs
@@ -331,6 +331,15 @@ impl InBandCommandExecutor {
                     ShellType::PowerShell => {
                         format!("Warp-Run-GeneratorCommand {id} '{escaped_command}' -ErrorAction Ignore")
                     }
+                    ShellType::Nushell => {
+                        let escaped_command = command
+                            .replace('\\', "\\\\")
+                            .replace('"', "\\\"")
+                            .replace('\n', "\\n")
+                            .replace('\r', "\\r")
+                            .replace('\t', "\\t");
+                        format!("warp_run_generator_command {id} \"{escaped_command}\"")
+                    }
                     ShellType::Fish => {
                         // Add a leading space for in-band commands in fish, which omits them from
                         // history. Unlike bash and zsh, fish does not have a mechanism for

--- a/app/src/terminal/model/session/command_executor/local_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/local_command_executor.rs
@@ -92,6 +92,7 @@ impl LocalCommandExecutor {
             ShellType::Zsh => "-f",
             ShellType::Bash => "--norc",
             ShellType::Fish => "--no-config",
+            ShellType::Nushell => "--no-config-file",
             ShellType::PowerShell => "-NoProfile",
         };
 
@@ -113,6 +114,7 @@ impl LocalCommandExecutor {
     ) -> Result<CommandOutput> {
         let shell_config_flag = match self.shell_type {
             ShellType::Bash | ShellType::Zsh | ShellType::Fish => "-l",
+            ShellType::Nushell => "--login",
             ShellType::PowerShell => "-Login",
         };
 

--- a/app/src/terminal/model/session/command_executor/wsl_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/wsl_command_executor.rs
@@ -37,6 +37,7 @@ impl WslCommandExecutor {
             ShellType::Zsh => "-f",
             ShellType::Bash => "--norc",
             ShellType::Fish => "--no-config",
+            ShellType::Nushell => "--no-config-file",
             ShellType::PowerShell => "-NoProfile",
         };
 

--- a/app/src/terminal/model/session_tests.rs
+++ b/app/src/terminal/model/session_tests.rs
@@ -5,7 +5,12 @@ use warpui::{
     TypedActionView, View, ViewContext,
 };
 
-use super::{SessionId, Sessions, SessionsEvent};
+use crate::terminal::shell::ShellType;
+
+use super::{
+    command_name_vec_from_shell_output, command_names_from_shell_output, SessionId, Sessions,
+    SessionsEvent,
+};
 
 struct TestView {
     events: Vec<SessionsEvent>,
@@ -68,6 +73,34 @@ fn test_set_env_var_emits_event() {
             }
         });
     });
+}
+
+#[test]
+fn nushell_command_names_include_top_level_for_multiword_commands() {
+    let command_names =
+        command_names_from_shell_output(ShellType::Nushell, "str join\npath exists\nrandom\n");
+
+    assert!(command_names.contains("str join"));
+    assert!(command_names.contains("str"));
+    assert!(command_names.contains("path exists"));
+    assert!(command_names.contains("path"));
+    assert!(command_names.contains("random"));
+}
+
+#[test]
+fn command_names_do_not_split_multiword_commands_for_other_shells() {
+    let command_names = command_names_from_shell_output(ShellType::Bash, "str join\n");
+
+    assert!(command_names.contains("str join"));
+    assert!(!command_names.contains("str"));
+}
+
+#[test]
+fn command_name_vec_preserves_first_seen_order() {
+    let command_names =
+        command_name_vec_from_shell_output(ShellType::Nushell, "str join\nstr trim\n");
+
+    assert_eq!(command_names, vec!["str join", "str", "str trim"]);
 }
 
 #[test]

--- a/app/src/terminal/session_settings/startup_shell.rs
+++ b/app/src/terminal/session_settings/startup_shell.rs
@@ -2,19 +2,20 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 /// A user setting for the shell to start new terminal sessions with.
 ///
-/// Users choose between their login shell, the default versions of zsh/bash/fish
+/// Users choose between their login shell, the default versions of zsh/bash/fish/nushell
 /// (if installed, the first matching executable on their `$PATH`), and a
 /// custom path or command.
 #[derive(Debug, Clone, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[schemars(
     with = "Option<String>",
-    description = "Shell to start terminal sessions with. Use null for the system default, or one of \"bash\", \"zsh\", \"fish\", \"pwsh\", or a custom shell command/path."
+    description = "Shell to start terminal sessions with. Use null for the system default, or one of \"bash\", \"zsh\", \"fish\", \"nu\", \"pwsh\", or a custom shell command/path."
 )]
 pub enum StartupShell {
     #[default]
     Default,
     Bash,
     Fish,
+    Nushell,
     Zsh,
     PowerShell,
     Custom(String),
@@ -27,6 +28,7 @@ impl StartupShell {
             StartupShell::Default => None,
             StartupShell::Bash => Some("bash"),
             StartupShell::Fish => Some("fish"),
+            StartupShell::Nushell => Some("nu"),
             StartupShell::Zsh => Some("zsh"),
             StartupShell::PowerShell => Some("pwsh"),
             StartupShell::Custom(shell) => Some(shell),
@@ -62,6 +64,7 @@ impl From<Option<String>> for StartupShell {
             Some(shell) if shell == "bash" => StartupShell::Bash,
             Some(shell) if shell == "zsh" => StartupShell::Zsh,
             Some(shell) if shell == "fish" => StartupShell::Fish,
+            Some(shell) if shell == "nu" => StartupShell::Nushell,
             Some(shell) if shell == "pwsh" => StartupShell::PowerShell,
             Some(shell) => StartupShell::Custom(shell),
         }

--- a/app/src/terminal/ssh/warpify.rs
+++ b/app/src/terminal/ssh/warpify.rs
@@ -172,7 +172,8 @@ pub fn warpify_ssh_session_command(
             bundled_asset!("ssh/bash_zsh/warpify_ssh_session.sh")
         }
         (_, ShellType::Fish) => bundled_asset!("ssh/fish/warpify_ssh_session.sh"),
-        // PowerShell is not supported yet.
+        // PowerShell and Nushell are not supported yet.
+        (_, ShellType::Nushell) => return None,
         (_, ShellType::PowerShell) => return None,
     };
 

--- a/app/src/terminal/warpify/mod.rs
+++ b/app/src/terminal/warpify/mod.rs
@@ -29,6 +29,7 @@ fn get_subshell_bootstrap_success_block_path(shell_type: ShellType) -> Option<&'
             Some("bundled/bootstrap/bash_zsh_subshell_bootstrap_block_output.txt")
         }
         ShellType::Fish => Some("bundled/bootstrap/fish_subshell_bootstrap_block_output.txt"),
+        ShellType::Nushell => None,
         ShellType::PowerShell => None,
     }
 }

--- a/app/src/terminal/writeable_pty/bootstrap_file/mod.rs
+++ b/app/src/terminal/writeable_pty/bootstrap_file/mod.rs
@@ -20,9 +20,15 @@ where
     S: AsRef<str>,
 {
     let mut builder = tempfile::Builder::new();
-    // PowerShell will only source a file with the "ps1" extension.
-    if shell_type == ShellType::PowerShell {
-        builder.suffix(".ps1");
+    // PowerShell and Nushell will only source files with their script extensions.
+    match shell_type {
+        ShellType::PowerShell => {
+            builder.suffix(".ps1");
+        }
+        ShellType::Nushell => {
+            builder.suffix(".nu");
+        }
+        ShellType::Zsh | ShellType::Bash | ShellType::Fish => {}
     }
 
     match TempBootstrapFile::new(

--- a/app/src/terminal/writeable_pty/pty_controller.rs
+++ b/app/src/terminal/writeable_pty/pty_controller.rs
@@ -494,6 +494,13 @@ impl<T: EventLoopSender> PtyController<T> {
                 self.write_bytes(b" . ", ctx);
                 self.write_bytes(escaped.into_bytes(), ctx);
             }
+            ShellType::Nushell => {
+                let path_str = String::from_utf8_lossy(&path_to_script);
+                let escaped = path_str.replace('\\', "\\\\").replace('"', "\\\"");
+                self.write_bytes(b" source \"", ctx);
+                self.write_bytes(escaped.into_bytes(), ctx);
+                self.write_bytes(b"\"", ctx);
+            }
             _ => {
                 self.write_bytes(b" source '", ctx);
                 self.write_bytes(path_to_script, ctx);

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -153,7 +153,7 @@ impl Shell {
                 .is_some_and(|map| map.contains("autocd")),
             // autocd is always enabled in Fish, see https://fishshell.com/docs/current/cmds/cd.html.
             ShellType::Fish => true,
-            ShellType::PowerShell => false,
+            ShellType::Nushell | ShellType::PowerShell => false,
         }
     }
 
@@ -168,6 +168,7 @@ impl Shell {
         match self.shell_type {
             ShellType::PowerShell => Some([escape_sequences::C0::ESC, b'1']),
             ShellType::Fish | ShellType::Zsh => Some([escape_sequences::C0::ESC, b'i']),
+            ShellType::Nushell => None,
             ShellType::Bash => self
                 .version
                 .as_ref()
@@ -251,6 +252,7 @@ pub enum ShellType {
     Zsh,
     Bash,
     Fish,
+    Nushell,
     PowerShell,
 }
 
@@ -260,6 +262,9 @@ impl From<ShellType> for command_corrections::Shell {
             ShellType::Bash => command_corrections::Shell::Bash,
             ShellType::Zsh => command_corrections::Shell::Zsh,
             ShellType::Fish => command_corrections::Shell::Fish,
+            // Command corrections does not have nushell-specific syntax yet. Bash is the closest
+            // fallback for the commands we generate today.
+            ShellType::Nushell => command_corrections::Shell::Bash,
             ShellType::PowerShell => command_corrections::Shell::PowerShell,
         }
     }
@@ -268,7 +273,7 @@ impl From<ShellType> for command_corrections::Shell {
 impl From<ShellType> for warp_util::path::ShellFamily {
     fn from(value: ShellType) -> Self {
         match value {
-            ShellType::Zsh | ShellType::Bash | ShellType::Fish => Self::Posix,
+            ShellType::Zsh | ShellType::Bash | ShellType::Fish | ShellType::Nushell => Self::Posix,
             ShellType::PowerShell => Self::PowerShell,
         }
     }
@@ -288,6 +293,9 @@ impl ShellType {
             Some(ShellType::Zsh)
         } else if name == "fish" || name == "-fish" || name.ends_with("/fish") {
             Some(ShellType::Fish)
+        } else if name == "nu" || name == "-nu" || name.ends_with("/nu") || name.ends_with("nu.exe")
+        {
+            Some(ShellType::Nushell)
         } else if name == "pwsh"
             || name.ends_with("/pwsh")
             || name.ends_with("pwsh.exe")
@@ -307,6 +315,7 @@ impl ShellType {
             "bash" | "shell" | "sh" => Some(ShellType::Bash),
             "zsh" => Some(ShellType::Zsh),
             "fish" => Some(ShellType::Fish),
+            "nu" | "nushell" => Some(ShellType::Nushell),
             "powershell" | "pwsh" => Some(ShellType::PowerShell),
             _ => None,
         }
@@ -318,6 +327,10 @@ impl ShellType {
             ShellType::Zsh => vec!["~/.zsh_history".to_string(), "~/.zhistory".to_string()],
             ShellType::Bash => vec!["~/.bash_history".to_string()],
             ShellType::Fish => vec!["~/.local/share/fish/fish_history".to_string()],
+            ShellType::Nushell => vec![
+                "~/.local/share/nushell/history.sqlite3".to_string(),
+                "~/.local/share/nushell/history.txt".to_string(),
+            ],
             #[cfg(not(windows))]
             ShellType::PowerShell => {
                 vec!["~/.local/share/powershell/PSReadLine/ConsoleHost_history.txt".to_string()]
@@ -354,6 +367,10 @@ impl ShellType {
             (ShellType::Bash, _) => vec![Path::new(".bashrc")],
             (ShellType::Zsh, _) => vec![Path::new(".zshrc")],
             (ShellType::Fish, _) => vec![Path::new(".config/fish/config.fish")],
+            (ShellType::Nushell, _) => vec![
+                Path::new(".config/nushell/env.nu"),
+                Path::new(".config/nushell/config.nu"),
+            ],
         };
         relative_paths
             .iter()
@@ -369,6 +386,7 @@ impl ShellType {
         match self {
             ShellType::Bash | ShellType::Zsh | ShellType::PowerShell => " && ",
             ShellType::Fish => "; and ",
+            ShellType::Nushell => " and ",
         }
     }
 
@@ -382,6 +400,7 @@ impl ShellType {
         match self {
             ShellType::Bash | ShellType::Zsh | ShellType::PowerShell => " ; ",
             ShellType::Fish => "; or ",
+            ShellType::Nushell => "; ",
         }
     }
 
@@ -436,6 +455,16 @@ impl ShellType {
                     // escaped.
                     line.split_once(" -> ")
                         .filter(|(_, value)| !value.trim().is_empty())
+                        .and_then(|(key, value)| unescape_alias_key_value(key, value))
+                })
+                .collect(),
+            ShellType::Nushell => alias_output
+                .lines()
+                .filter_map(|line| {
+                    // The Nushell bootstrap emits aliases as tab-separated name/expansion pairs.
+                    // We do not use `alias` output directly because Nushell aliases can be listed
+                    // structurally via `scope aliases`.
+                    line.split_once('\t')
                         .and_then(|(key, value)| unescape_alias_key_value(key, value))
                 })
                 .collect(),
@@ -527,6 +556,18 @@ impl ShellType {
                     .map(fish_unescape_history_yaml)
                     .collect()
             }
+            ShellType::Nushell => {
+                if history_file_bytes.starts_with(b"SQLite format 3") {
+                    return Vec::new();
+                }
+
+                let history_file_contents = String::from_utf8_lossy(history_file_bytes);
+                history_lines = history_file_contents
+                    .lines()
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_owned())
+                    .collect()
+            }
 
             ShellType::PowerShell => {
                 let history_file_contents = String::from_utf8_lossy(history_file_bytes);
@@ -548,12 +589,15 @@ impl ShellType {
     /// `kill-whole-line` and must match the `bind` in `bash.sh`.  In fish this is a custom `bind`
     /// that clears the command line. PowerShell cannot use a binding that contains the letter "p"
     /// (DLE maps to ctrl-p) because it does virtual key code translation based on the current
-    /// layout, and not all layouts have the letter "p".
+    /// layout, and not all layouts have the letter "p". Nushell's default Ctrl-P binding recalls
+    /// history, so we use Ctrl-U to clear the current line instead.
     pub fn kill_buffer_bytes(self) -> &'static [u8] {
         const POWERSHELL_BINDING: [u8; 2] = [escape_sequences::C0::ESC, b'2'];
         const OTHER_BINDING: [u8; 1] = [escape_sequences::C0::DLE];
+        const NUSHELL_BINDING: [u8; 1] = [escape_sequences::C0::NAK];
         match self {
             ShellType::PowerShell => POWERSHELL_BINDING.as_slice(),
+            ShellType::Nushell => NUSHELL_BINDING.as_slice(),
             ShellType::Zsh | ShellType::Bash | ShellType::Fish => OTHER_BINDING.as_slice(),
         }
     }
@@ -561,7 +605,7 @@ impl ShellType {
     /// Bytes used to execute a command, once the command text is sent
     pub fn execute_command_bytes(self) -> &'static [u8] {
         match self {
-            ShellType::Bash | ShellType::Zsh => &b"\n"[..],
+            ShellType::Bash | ShellType::Zsh | ShellType::Nushell => &b"\n"[..],
             ShellType::PowerShell => &b"\r"[..],
             // For Fish, we send an extra space, immediately followed by backspace, and then
             // the newline character. The backspace ensures that any autosuggestions are
@@ -577,6 +621,7 @@ impl ShellType {
             ShellType::Zsh => "zsh",
             ShellType::Bash => "bash",
             ShellType::Fish => "fish",
+            ShellType::Nushell => "nu",
             ShellType::PowerShell => "pwsh",
         }
     }
@@ -585,7 +630,7 @@ impl ShellType {
     pub fn is_fully_supported_remotely(&self) -> bool {
         match self {
             ShellType::Zsh | ShellType::Bash => true,
-            ShellType::Fish | ShellType::PowerShell => false,
+            ShellType::Fish | ShellType::Nushell | ShellType::PowerShell => false,
         }
     }
 
@@ -621,6 +666,9 @@ impl ShellType {
                 // per line, we explicitly join the results with a newline.
                 "Get-Command -CommandType Application | Select-Object -ExpandProperty Name"
             }
+            ShellType::Nushell => {
+                "let path = ($env.PATH? | default []); let dirs = if (($path | describe) | str contains \"list\") { $path } else { $path | split row (char esep) }; $dirs | each {|dir| try { ls $dir | where type != \"dir\" | get name | path basename } catch { [] } } | flatten | uniq | str join (char nl)"
+            }
         }
     }
 
@@ -638,7 +686,7 @@ impl ShellType {
                     return Vec::new();
                 };
                 match self {
-                    ShellType::Bash | ShellType::Zsh => {
+                    ShellType::Bash | ShellType::Zsh | ShellType::Nushell => {
                         // For bash and zsh, we wrote the command such that the output is just
                         // a list of executable files.
                         if !is_msys2 {

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -75,6 +75,32 @@ fn test_parse_history_zsh_continuation_line_looks_like_prefix() {
 }
 
 #[test]
+fn test_parse_history_nushell_text() {
+    let history_lines = "\nls\npwd\n\nopen Cargo.toml\n";
+    assert_eq!(
+        ShellType::Nushell.parse_history(history_lines.as_bytes()),
+        vec![
+            "ls".to_string(),
+            "pwd".to_string(),
+            "open Cargo.toml".to_string()
+        ]
+    );
+}
+
+#[test]
+fn test_parse_history_nushell_sqlite() {
+    let sqlite_header = b"SQLite format 3\0more bytes";
+    assert_eq!(
+        ShellType::Nushell.parse_history(sqlite_header),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn test_nushell_kill_buffer_uses_clear_line_binding() {
+    assert_eq!(ShellType::Nushell.kill_buffer_bytes(), &[0x15]);
+}
+#[test]
 fn test_zsh_unmetafy() {
     let test_zsh_history = [
         227, 129, 131, 179, 227, 130, 131, 172, 227, 129, 175, 230, 131, 183, 165, 230, 131, 188,
@@ -107,6 +133,13 @@ fn test_from_name() {
         Some(ShellType::Fish),
         ShellType::from_name("/usr/local/bin/fish")
     );
+    assert_eq!(Some(ShellType::Nushell), ShellType::from_name("nu"));
+    assert_eq!(Some(ShellType::Nushell), ShellType::from_name("-nu"));
+    assert_eq!(
+        Some(ShellType::Nushell),
+        ShellType::from_name("/opt/homebrew/bin/nu")
+    );
+    assert_eq!(Some(ShellType::Nushell), ShellType::from_name("nu.exe"));
     assert_eq!(
         Some(ShellType::PowerShell),
         ShellType::from_name("pwsh.exe")
@@ -145,6 +178,14 @@ fn test_from_markdown_language_spec() {
     assert_eq!(
         Some(ShellType::Fish),
         ShellType::from_markdown_language_spec("fish")
+    );
+    assert_eq!(
+        Some(ShellType::Nushell),
+        ShellType::from_markdown_language_spec("nu")
+    );
+    assert_eq!(
+        Some(ShellType::Nushell),
+        ShellType::from_markdown_language_spec("nushell")
     );
     assert_eq!(
         Some(ShellType::PowerShell),
@@ -190,6 +231,26 @@ alias ehw 'echo \"Hello, world\"'";
     assert_eq!(aliases.get("g").unwrap(), "git");
     assert_eq!(aliases.get("rmi").unwrap(), "rm -i");
     assert_eq!(aliases.get("ehw").unwrap(), r#"echo "Hello, world""#);
+}
+
+#[test]
+fn test_nushell_parse_aliases() {
+    let raw_aliases = "ll\tls -l\ngco\tgit checkout";
+    let aliases = ShellType::Nushell.aliases(raw_aliases);
+
+    assert_eq!(aliases.len(), 2);
+    assert_eq!(aliases.get("ll").unwrap(), "ls -l");
+    assert_eq!(aliases.get("gco").unwrap(), "git checkout");
+}
+
+#[test]
+fn test_nushell_executable_command_uses_path_scan() {
+    let command = ShellType::Nushell.shell_command_to_get_executables();
+
+    assert!(command.contains("$env.PATH"));
+    assert!(command.contains("ls $dir"));
+    assert!(command.contains("path basename"));
+    assert!(!command.contains("type == external"));
 }
 
 #[test]


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
