### PR TITLE
[QUALITY-713] Add View in Oz to orchestration pill menu

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -9,6 +9,7 @@ use std::hash::{Hash, Hasher};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use warp_cli::agent::Harness;
+use warp_core::channel::ChannelState;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::color::coloru_with_opacity;
 use warp_core::ui::theme::Fill;
@@ -255,6 +256,8 @@ pub enum OrchestrationPillBarAction {
     OpenInNewPane(AIConversationId),
     /// Menu item: open this child in a new tab.
     OpenInNewTab(AIConversationId),
+    /// Menu item: open this child's run in the Oz web app.
+    ViewInOz(AIConversationId),
     /// Menu item: stop the in-progress task.
     Stop(AIConversationId),
     /// Menu item: cancel and remove from local history.
@@ -448,6 +451,13 @@ impl OrchestrationPillBar {
                 ),
             ]
         };
+        if Self::oz_run_url_for_conversation(conversation_id, ctx).is_some() {
+            items.push(item(
+                "View in Oz",
+                Icon::Oz,
+                OrchestrationPillBarAction::ViewInOz(conversation_id),
+            ));
+        }
         // Stop is shown only while the agent is in progress; Kill becomes
         // Delete once the agent's run has finished (Success / Error /
         // Cancelled). Blocked is treated as not-yet-finished (the agent
@@ -496,6 +506,17 @@ impl OrchestrationPillBar {
         }
         self.menu_open_for = None;
         ctx.notify();
+    }
+
+    fn oz_run_url_for_conversation(
+        conversation_id: AIConversationId,
+        app: &AppContext,
+    ) -> Option<String> {
+        let run_id = BlocklistAIHistoryModel::as_ref(app)
+            .conversation(&conversation_id)?
+            .run_id()?;
+        let oz_root_url = ChannelState::oz_root_url();
+        Some(format!("{oz_root_url}/runs/{run_id}"))
     }
 
     fn set_hovered_pill(
@@ -888,6 +909,18 @@ impl TypedActionView for OrchestrationPillBar {
                         },
                     ),
                 );
+            }
+            OrchestrationPillBarAction::ViewInOz(id) => {
+                self.emit_pill_bar_interaction(
+                    PillBarActionKind::ViewInOz,
+                    PillBarPillKind::Child,
+                    *id,
+                    ctx,
+                );
+                self.close_menu(ctx);
+                if let Some(url) = Self::oz_run_url_for_conversation(*id, ctx) {
+                    ctx.open_url(&url);
+                }
             }
             OrchestrationPillBarAction::Stop(id) => {
                 self.emit_pill_bar_interaction(

--- a/app/src/ai/blocklist/telemetry.rs
+++ b/app/src/ai/blocklist/telemetry.rs
@@ -241,6 +241,7 @@ pub(crate) enum PillBarActionKind {
     Kill,
     TogglePinOn,
     TogglePinOff,
+    ViewInOz,
     OpenMenu,
 }
 


### PR DESCRIPTION
## Description
Adds a View in Oz action to orchestration child-agent pill menus. The action appears when a pill has a run ID and opens the corresponding Oz run in the web app.

## Linked Issue
https://linear.app/warpdotdev/issue/QUALITY-713/link-to-oz-runs-when-starting-cloud-agents-via-orchestration

## Testing
- `cargo fmt`
- `PATH="/tmp/warp-corepack-shims:$PATH" cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo check -p warp --lib`
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Demo: https://www.loom.com/share/62c74353ed7549129f9fd326607833ce

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/d0012505-026c-4335-b549-544000bb7cda

CHANGELOG-OZ: Add a View in Oz action to orchestration child-agent pill menus.

Co-Authored-By: Oz <oz-agent@warp.dev>
