### PR TITLE
fix: show loading state when retrying code review diff load

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -7216,6 +7216,16 @@ impl TypedActionView for CodeReviewView {
                 self.save_files(unsaved_files.as_slice(), ctx);
             }
             CodeReviewAction::RefreshGitState => {
+                // Immediately transition the view to the loading state so the
+                // user sees a spinner while the retry is in progress. Without
+                // this, the view stays stuck on the error UI until the async
+                // diff load completes — which looks like the retry did nothing
+                // when the same error recurs.
+                if let Some(repo) = self.active_repo.as_mut() {
+                    repo.state = CodeReviewViewState::None;
+                }
+                ctx.notify();
+
                 self.diff_state_model.update(ctx, |model, ctx| {
                     model.load_diffs_for_current_repo(false, ctx);
                     model.refresh_metadata_and_pr_info(ctx);


### PR DESCRIPTION
## Description

When the code review panel encounters an error loading diffs (e.g., from git-lfs issues), pressing the **Retry** button previously appeared to do nothing. The view stayed stuck on the "Error loading diffs" screen because the view state was never updated to show a loading spinner during the async retry.

### Root Cause

The `RefreshGitState` action handler called `model.load_diffs_for_current_repo()` which set the *model* state to `Loading` and spawned an async git operation, but never updated the *view* state. The view only learned about state changes via the `NewDiffsComputed` event, which fires after the async operation completes.

This meant:
1. **If the error persisted** → the view transitioned from `Error(old)` → `Error(new)` with zero visual change. Users saw nothing happen.
2. **If the error was fixed** → the view jumped directly from Error → Loaded with no loading spinner.

### Fix

The `RefreshGitState` handler now immediately sets the view state to `CodeReviewViewState::None` (the loading/spinner state) and calls `ctx.notify()` before kicking off the async reload. Users now see:
- Press Retry → loading spinner appears
- If retry succeeds → diffs load normally
- If retry fails → error appears again (users know the retry actually ran)

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Verified the code compiles with `cargo check -p warp` and `cargo fmt` passes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed code review panel Retry button appearing to do nothing when diff loading fails
-->

_Conversation: https://staging.warp.dev/conversation/b8b773ab-6581-41ad-85ca-d2aa11e3c9e8_
_Run: https://oz.staging.warp.dev/runs/019e4128-18ba-7a6d-988d-84275f393ee1_

_This PR was generated with [Oz](https://warp.dev/oz)._
