### PR TITLE
Clear git chips after leaving repo

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1232,6 +1232,21 @@ impl CurrentPrompt {
             .for_each(|(_, state)| state.clear_cache());
     }
 
+    /// Clear git-backed chip values when the terminal navigates out of a git repository.
+    pub fn clear_git_chip_values(&mut self) {
+        for chip_kind in [
+            ContextChipKind::ShellGitBranch,
+            ContextChipKind::GitDiffStats,
+            ContextChipKind::GithubPullRequest,
+        ] {
+            if let Some(state) = self.states.get_mut(&chip_kind) {
+                state.clear_abort_handlers();
+                state.clear_cache();
+            }
+        }
+        let _ = self.update_tx.try_send(());
+    }
+
     /// Waits for any in-progress asynchronous generators to finish.
     #[cfg(test)]
     pub fn await_generators(

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -1291,6 +1291,70 @@ fn test_git_status_change_updates_chip_value() {
     });
 }
 
+#[test]
+fn test_clearing_git_chip_values_on_repo_exit() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [
+                    ContextChipKind::ShellGitBranch,
+                    ContextChipKind::GitDiffStats,
+                ],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |current_prompt, ctx| {
+            current_prompt.update_states_with_new_context(ctx);
+            current_prompt.update_chip_value(
+                &ContextChipKind::ShellGitBranch,
+                Some(crate::context_chips::ChipValue::Text(
+                    "feature-branch".to_string(),
+                )),
+            );
+            current_prompt.update_chip_value(
+                &ContextChipKind::GitDiffStats,
+                Some(crate::context_chips::ChipValue::GitDiffStats(
+                    crate::context_chips::display_chip::GitLineChanges {
+                        files_changed: 3,
+                        lines_added: 10,
+                        lines_removed: 2,
+                    },
+                )),
+            );
+
+            current_prompt.clear_git_chip_values();
+        });
+
+        app.read(|ctx| {
+            let prompt = current_prompt.as_ref(ctx);
+            assert_eq!(
+                prompt.latest_chip_value(&ContextChipKind::ShellGitBranch),
+                None
+            );
+            assert_eq!(
+                prompt.latest_chip_value(&ContextChipKind::GitDiffStats),
+                None
+            );
+        });
+    });
+}
+
 /// A [`CommandExecutor`] implementation that records which commands were run, but does not
 /// execute them.
 #[derive(Debug, Default)]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4850,6 +4850,13 @@ impl TerminalView {
     #[cfg(feature = "local_fs")]
     fn clear_git_repo_status(&mut self, ctx: &mut ViewContext<Self>) {
         self.clear_git_repo_status_subscription(ctx);
+        self.current_prompt.update(ctx, |prompt_type, ctx| {
+            if let PromptType::Dynamic { prompt } = prompt_type {
+                prompt.update(ctx, |current_prompt, _| {
+                    current_prompt.clear_git_chip_values();
+                });
+            }
+        });
         self.input.update(ctx, |input, ctx| {
             input.update_repo_path(None, ctx);
         });


### PR DESCRIPTION
## Description
Clears cached git-backed prompt chips when terminal repo detection transitions out of a git repository.

Previously, leaving a repo cleared the repo status watcher and input repo path, but the prompt chip cache could retain the previous repo's branch, diff stats, or PR chip values until another repo populated new values. This explicitly clears those git chip values on repo exit.

## Linked Issue
Slack report in `#feedback-app`.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all --check`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp context_chips::current_prompt::tests::test_clearing_git_chip_values_on_repo_exit --features local_fs`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --features local_fs`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --lib --features local_fs -- -D warnings`
- `script/wasm/bundle --check-only -c oss`

Notes:
- Full workspace/all-features clippy was attempted, but the sandbox lacks generated `dev_config.json` / `preview_config.json` files required by `app/src/bin/channel_config.rs`.
- Dev wasm check was attempted first and hit the same missing generated dev channel config; OSS wasm check passed.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; covered with a focused regression test for clearing stale chip values on repo exit.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed git stats chips staying stale after leaving a git repository.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/8defd157-633a-419c-ba9d-592a8a253cd0_
_Run: https://oz.staging.warp.dev/runs/019e4123-8245-7aac-899e-de7f4ea62d96_
_This PR was generated with [Oz](https://warp.dev/oz)._
