### PR TITLE
fix(context-chips): prevent GitHub PR chip from exhausting rate limit

### DIFF
--- a/app/src/context_chips/context_chip.rs
+++ b/app/src/context_chips/context_chip.rs
@@ -235,8 +235,12 @@ pub struct ChipRuntimePolicy {
     /// fingerprint and skips re-execution on future fetches — including periodic refreshes —
     /// until the fingerprint changes (e.g. branch or directory change).
     suppress_on_failure: bool,
-    /// Top-level command names (e.g. `["git", "gh", "gt"]`) whose execution should
-    /// invalidate this chip's fingerprint. Pair with `ChipFingerprintInput::InvalidatingCommandCount`.
+    /// Command patterns whose execution should invalidate this chip's fingerprint.
+    /// Each pattern is a whitespace-tokenized prefix of the alias-resolved command line:
+    /// `"git"` matches every `git ...` invocation, while `"gh pr create"` matches
+    /// `gh pr create ...` but not `gh pr view`. Use multi-token patterns to avoid
+    /// invalidating on read-only subcommands. Pair with
+    /// `ChipFingerprintInput::InvalidatingCommandCount`.
     invalidate_on_commands: Vec<String>,
 }
 

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1272,7 +1272,8 @@ impl CurrentPrompt {
             if let BlockType::User(UserBlockCompleted { command, .. }) =
                 &after_block_completed.block_type
             {
-                if let Some(cmd) = command.split_whitespace().next() {
+                let mut tokens = command.split_whitespace();
+                if let Some(cmd) = tokens.next() {
                     // Resolve aliases so that e.g. `alias g=git` followed by `g push`
                     // still triggers invalidation for chips watching "git".
                     let resolved = self
@@ -1281,16 +1282,20 @@ impl CurrentPrompt {
                         .and_then(|context| context.active_block_metadata.session_id())
                         .and_then(|session_id| self.sessions.as_ref(ctx).get(session_id))
                         .and_then(|session| session.alias_value(cmd).map(String::from));
-                    let effective_cmd = resolved.as_deref().unwrap_or(cmd);
+                    let effective_argv0 = resolved.as_deref().unwrap_or(cmd);
+                    let effective_command_line =
+                        std::iter::once(effective_argv0).chain(tokens).join(" ");
 
                     for (chip_kind, state) in &mut self.states {
                         if let Some(chip) = chip_kind.to_chip() {
-                            if chip
-                                .runtime_policy()
-                                .invalidate_on_commands()
-                                .iter()
-                                .any(|c| c == effective_cmd)
-                            {
+                            if chip.runtime_policy().invalidate_on_commands().iter().any(
+                                |pattern| {
+                                    command_matches_invalidation_pattern(
+                                        &effective_command_line,
+                                        pattern,
+                                    )
+                                },
+                            ) {
                                 state.invalidating_command_count += 1;
                             }
                         }
@@ -1621,4 +1626,82 @@ impl CurrentPrompt {
 
 impl Entity for CurrentPrompt {
     type Event = ();
+}
+
+/// Returns true when `pattern` is a whitespace-tokenized prefix of `command_line`.
+///
+/// A single-token pattern like `"git"` matches any command starting with `git`
+/// (e.g. `git status`, `git push origin main`). A multi-token pattern like
+/// `"gh pr create"` matches `gh pr create ...` but not `gh pr view` or `gh`.
+/// This lets chips invalidate only on specific subcommands without falsely
+/// matching every invocation of the top-level program.
+fn command_matches_invalidation_pattern(command_line: &str, pattern: &str) -> bool {
+    let mut cmd_tokens = command_line.split_whitespace();
+    let mut pattern_tokens = pattern.split_whitespace().peekable();
+    if pattern_tokens.peek().is_none() {
+        return false;
+    }
+    for pat in pattern_tokens {
+        match cmd_tokens.next() {
+            Some(tok) if tok == pat => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod invalidation_pattern_tests {
+    use super::command_matches_invalidation_pattern;
+
+    #[test]
+    fn single_token_pattern_matches_any_subcommand() {
+        assert!(command_matches_invalidation_pattern("git", "git"));
+        assert!(command_matches_invalidation_pattern("git status", "git"));
+        assert!(command_matches_invalidation_pattern(
+            "git push origin main",
+            "git"
+        ));
+    }
+
+    #[test]
+    fn multi_token_pattern_requires_exact_prefix() {
+        assert!(command_matches_invalidation_pattern(
+            "gh pr create --title x",
+            "gh pr create"
+        ));
+        assert!(command_matches_invalidation_pattern(
+            "gh pr create",
+            "gh pr create"
+        ));
+        assert!(!command_matches_invalidation_pattern(
+            "gh pr view",
+            "gh pr create"
+        ));
+        assert!(!command_matches_invalidation_pattern("gh", "gh pr create"));
+        assert!(!command_matches_invalidation_pattern(
+            "git pr create",
+            "gh pr create"
+        ));
+    }
+
+    #[test]
+    fn pattern_must_align_on_token_boundary() {
+        assert!(!command_matches_invalidation_pattern("github", "git"));
+        assert!(!command_matches_invalidation_pattern("ghost pr", "gh pr"));
+    }
+
+    #[test]
+    fn empty_pattern_never_matches() {
+        assert!(!command_matches_invalidation_pattern("git status", ""));
+        assert!(!command_matches_invalidation_pattern("", ""));
+    }
+
+    #[test]
+    fn extra_whitespace_is_tolerated() {
+        assert!(command_matches_invalidation_pattern(
+            "  gh   pr   create   --title x",
+            "gh pr create"
+        ));
+    }
 }

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -47,7 +47,7 @@ use crate::{
 use repo_metadata::DirectoryWatcher;
 use warp_completer::completer::{CommandExitStatus, CommandOutput};
 
-use super::{ChipUpdateStatus, CurrentPrompt, PromptContext};
+use super::{command_matches_invalidation_pattern, ChipUpdateStatus, CurrentPrompt, PromptContext};
 
 #[test]
 fn test_context_menu_items() {
@@ -345,11 +345,74 @@ fn test_github_pr_chip_runtime_policy_configuration() {
     );
     assert_eq!(
         policy.invalidate_on_commands(),
-        &["git".to_string(), "gh".to_string(), "gt".to_string()]
+        &[
+            "git push".to_string(),
+            "gh pr create".to_string(),
+            "gh pr close".to_string(),
+            "gh pr reopen".to_string(),
+            "gh pr edit".to_string(),
+            "gh pr merge".to_string(),
+            "gt submit".to_string(),
+            "gt create".to_string(),
+        ]
     );
     assert!(policy
         .fingerprint_inputs()
         .contains(&ChipFingerprintInput::InvalidatingCommandCount));
+}
+
+#[test]
+fn test_github_pr_chip_does_not_invalidate_on_read_only_commands() {
+    let _flag_guard = FeatureFlag::GithubPrPromptChip.override_enabled(true);
+    let chip = ContextChipKind::GithubPullRequest
+        .to_chip()
+        .expect("github pr chip should exist");
+    let patterns = chip.runtime_policy().invalidate_on_commands();
+
+    let matches_any = |command: &str| {
+        patterns
+            .iter()
+            .any(|p| command_matches_invalidation_pattern(command, p))
+    };
+
+    for cmd in [
+        "git status",
+        "git diff",
+        "git diff --cached",
+        "git log --oneline -20",
+        "git fetch",
+        "git show HEAD",
+        "git rev-parse HEAD",
+        "gh pr view",
+        "gh pr view --json url",
+        "gh pr list",
+        "gh pr diff",
+        "gh repo view",
+        "gt log",
+    ] {
+        assert!(
+            !matches_any(cmd),
+            "read-only command should not invalidate PR chip: {cmd}"
+        );
+    }
+
+    for cmd in [
+        "git push",
+        "git push origin main",
+        "git push --force-with-lease",
+        "gh pr create --title 'x' --body 'y'",
+        "gh pr close 123",
+        "gh pr reopen 123",
+        "gh pr edit --title 'x'",
+        "gh pr merge --squash",
+        "gt submit",
+        "gt create --message 'x'",
+    ] {
+        assert!(
+            matches_any(cmd),
+            "mutating command should invalidate PR chip: {cmd}"
+        );
+    }
 }
 
 #[test]

--- a/app/src/context_chips/mod.rs
+++ b/app/src/context_chips/mod.rs
@@ -317,7 +317,16 @@ impl ContextChipKind {
                     ],
                 )
                 .with_suppress_on_failure()
-                .with_invalidate_on_commands(["git", "gh", "gt"]);
+                .with_invalidate_on_commands([
+                    "git push",
+                    "gh pr create",
+                    "gh pr close",
+                    "gh pr reopen",
+                    "gh pr edit",
+                    "gh pr merge",
+                    "gt submit",
+                    "gt create",
+                ]);
                 Some(ContextChip::shell_builtin_with_runtime_policy(
                     "GitHub Pull Request",
                     generator,


### PR DESCRIPTION
## Description

Every read-only `git`/`gh`/`gt` invocation re-fetched the PR via GraphQL, so CLI agents (Claude Code, Codex, Gemini) hit the 5000/hr cap within minutes and the chip silently stopped resolving for the rest of the hour.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
