### PR TITLE
Allow ancestor directories of allowlisted git files

### DIFF
--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -360,26 +360,43 @@ pub fn matches_gitignores(
     })
 }
 
-/// Returns the path components after `.git` in a git-internal path,
-/// skipping the worktree indirection (`.git/worktrees/<name>/…`) if present.
-/// Returns `None` if the path has no `.git` component or nothing follows it.
+/// Returns the path components after the logical `.git/` root.
+///
+/// The "logical root" is whichever directory acts as `.git/` for a repo:
+///   - `.git/` itself (main repo).
+///   - `.git/worktrees/<name>/` (each linked worktree's gitdir).
+///
+/// Returns:
+///   - `None` if `path` has no `.git` component (not git-internal).
+///   - `Some(vec![])` if `path` *is* a logical root, or one of the worktree
+///     shells (`.git/worktrees/` and `.git/worktrees/<name>/`). Callers treat
+///     the empty vec as "this path is an ancestor of everything inside
+///     `.git/`" so the allowlist predicates can keep these directories in
+///     the watcher's watch set.
+///   - `Some([..])` with the components past the logical root otherwise. For
+///     `.git/worktrees/<name>/<rest>` the `worktrees/<name>` prefix is
+///     stripped, so callers see the same structure as a normal repo.
 fn git_suffix_components(path: &Path) -> Option<Vec<Component<'_>>> {
     let components: Vec<_> = path.components().collect();
     let git_index = components.iter().position(|c| c.as_os_str() == ".git")?;
 
     let after_git = &components[git_index + 1..];
+
+    // `.git/` itself.
     if after_git.is_empty() {
-        return None;
+        return Some(Vec::new());
     }
 
-    // For worktrees the layout is `.git/worktrees/<name>/…`.
-    // Skip the `worktrees/<name>` prefix so callers see the same
-    // logical structure as a normal repo.
-    if after_git.first().map(|c| c.as_os_str()) == Some(std::ffi::OsStr::new("worktrees"))
-        && after_git.len() >= 3
-    {
-        // after_git[0] = "worktrees", [1] = <name>, [2..] = actual content
-        return Some(after_git[2..].to_vec());
+    // Worktree layout. The shells `.git/worktrees/` and
+    // `.git/worktrees/<name>/` normalize to "empty suffix" — same logical
+    // position as `.git/` itself. Anything below normalizes by stripping the
+    // `worktrees/<name>/` prefix so callers see the same structure as a
+    // normal repo.
+    if after_git.first().map(|c| c.as_os_str()) == Some(std::ffi::OsStr::new("worktrees")) {
+        return match after_git.len() {
+            1 | 2 => Some(Vec::new()),
+            _ => Some(after_git[2..].to_vec()),
+        };
     }
 
     Some(after_git.to_vec())
@@ -427,32 +444,52 @@ pub(crate) fn is_shared_git_ref(path: &Path) -> bool {
 }
 
 /// Returns `true` for loose remote-tracking refs under the shared `.git`
-/// directory, e.g. `.git/refs/remotes/origin/main`.
+/// directory:
+/// - `.git/refs/remotes/origin/main`
+/// - `.git/refs/` (the ancestor directory that contains the refs/remotes/ directory)
+/// - `.git/refs/remotes/` (the ancestor directory that contains the refs/remotes/ directory)
+/// - `.git/refs/remotes/<remote>/` (the ancestor directory that contains the refs/remotes/<remote>/ directory)
 pub(crate) fn is_remote_tracking_ref(path: &Path) -> bool {
     if extract_worktree_git_dir(path).is_some() {
         return false;
     }
-    let components: Vec<_> = path.components().collect();
-    let Some(git_index) = components.iter().position(|c| c.as_os_str() == ".git") else {
+    let Some(suffix) = git_suffix_components(path) else {
         return false;
     };
-    let after_git = &components[git_index + 1..];
-    after_git.len() >= 4
-        && after_git[0].as_os_str() == "refs"
-        && after_git[1].as_os_str() == "remotes"
+    let names = suffix
+        .iter()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    matches!(
+        names.as_slice(),
+        [Some("refs")]                                              // .git/refs/ (ancestor)
+            | [Some("refs"), Some("remotes")]                       // .git/refs/remotes/ (ancestor)
+            | [Some("refs"), Some("remotes"), Some(_)]              // .git/refs/remotes/<remote>/ (ancestor)
+            | [Some("refs"), Some("remotes"), Some(_), Some(_), ..] // .git/refs/remotes/<remote>/<ref...>
+    )
 }
 
 /// Returns true for Git files that can change the current branch's tracked
-/// upstream ref.
+/// upstream ref:
+/// - `.git/HEAD`
+/// - `.git/config`
+/// - `.git/worktrees/*/config.worktree` (its worktree equivalent)
+/// - `.git/` (the logical `.git/` root that contains the HEAD file)
 pub(crate) fn is_tracking_state_git_file(path: &Path) -> bool {
     let Some(suffix) = git_suffix_components(path) else {
         return false;
     };
-    suffix.len() == 1
-        && matches!(
-            suffix[0].as_os_str().to_str(),
-            Some("HEAD" | "config" | "config.worktree")
-        )
+    let names = suffix
+        .iter()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    matches!(
+        names.as_slice(),
+        []                                  // logical `.git/` root (ancestor)
+            | [Some("HEAD")]                // `.git/HEAD`
+            | [Some("config")]              // `.git/config`
+            | [Some("config.worktree")] // `.git/<worktree>/config.worktree`
+    )
 }
 
 /// Returns true for `.git/config` in the shared Git directory.
@@ -469,27 +506,39 @@ pub(crate) fn is_common_git_config(path: &Path) -> bool {
 }
 
 /// Returns true for `.git/HEAD` and `.git/refs/heads/*`
-/// (and their worktree equivalents `.git/worktrees/*/HEAD`, etc.).
+/// - `.git/worktrees/*/HEAD` (its worktree equivalent)
+/// - `.git/` (the logical `.git/` root that contains the HEAD file)
+/// - `.git/refs/` (the ancestor directory that contains the refs/heads/ directory)
 pub(crate) fn is_commit_related_git_file(path: &Path) -> bool {
     let Some(suffix) = git_suffix_components(path) else {
         return false;
     };
-    match suffix.first().map(|c| c.as_os_str()) {
-        Some(name) if name == "HEAD" => true,
-        Some(name) if name == "refs" => {
-            suffix.get(1).map(|c| c.as_os_str()) == Some(std::ffi::OsStr::new("heads"))
-        }
-        _ => false,
-    }
+    let names = suffix
+        .iter()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    matches!(
+        names.as_slice(),
+        []                                          // logical `.git/` root (ancestor)
+            | [Some("HEAD")]                        // `.git/HEAD`
+            | [Some("refs")]                        // `.git/refs/` (ancestor of refs/heads/)
+            | [Some("refs"), Some("heads"), ..] // `.git/refs/heads/` and below
+    )
 }
 
-/// Returns true for `.git/index.lock`
-/// (and its worktree equivalent `.git/worktrees/*/index.lock`).
+/// Returns true for:
+/// - `.git/index.lock`
+/// - `.git/worktrees/*/index.lock` (its worktree equivalent)
+/// - `.git/` (the logical `.git/` root that contains the index.lock file)
 pub(crate) fn is_index_lock_file(path: &Path) -> bool {
     let Some(suffix) = git_suffix_components(path) else {
         return false;
     };
-    suffix.len() == 1 && suffix[0].as_os_str() == "index.lock"
+    let names = suffix
+        .iter()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    matches!(names.as_slice(), [] | [Some("index.lock")])
 }
 
 /// Determines if a git-related path should be ignored by the filesystem watcher.
@@ -497,6 +546,9 @@ pub(crate) fn is_index_lock_file(path: &Path) -> bool {
 /// Uses an allowlist approach: only commit-related files (HEAD, refs/heads/*),
 /// loose remote-tracking refs, tracked-upstream state files, and the index lock
 /// file are allowed through. Everything else inside `.git/` is ignored.
+///
+/// Note: this allowslist includes the ancestor directories of the allowlisted files.
+/// This is because the file watcher on Linux watches the directories themselves, not just the files inside them.
 pub fn should_ignore_git_path(path: &Path) -> bool {
     if !is_git_internal_path(path) {
         return false; // Not a git path, don't ignore

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -428,28 +428,67 @@ pub(crate) fn is_shared_git_ref(path: &Path) -> bool {
     if extract_worktree_git_dir(path).is_some() {
         return false;
     }
-    let components: Vec<_> = path.components().collect();
-    let Some(git_index) = components.iter().position(|c| c.as_os_str() == ".git") else {
+    let Some(suffix) = git_suffix_components(path) else {
         return false;
     };
-    let after_git = &components[git_index + 1..];
-    after_git
-        .first()
-        .map(|c| c.as_os_str() == "refs")
-        .unwrap_or(false)
-        && after_git
-            .get(1)
-            .map(|c| c.as_os_str() == "heads")
-            .unwrap_or(false)
+    let names = suffix
+        .iter()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    matches!(names.as_slice(), [Some("refs"), Some("heads"), Some(_), ..])
 }
 
-/// Returns `true` for loose remote-tracking refs under the shared `.git`
-/// directory:
+/// Returns `true` for shared ref paths or ancestors that must be routed through
+/// the shared common-git-dir path.
+pub(crate) fn is_shared_git_ref_or_ancestor(path: &Path) -> bool {
+    if is_shared_git_ref(path) {
+        return true;
+    }
+    if extract_worktree_git_dir(path).is_some() {
+        return false;
+    }
+    let Some(suffix) = git_suffix_components(path) else {
+        return false;
+    };
+    let names = suffix
+        .iter()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    matches!(
+        names.as_slice(),
+        [Some("refs")] | [Some("refs"), Some("heads")]
+    )
+}
+
+/// Returns `true` for loose remote-tracking ref files under the shared `.git`
+/// directory, such as `.git/refs/remotes/origin/main`.
+pub(crate) fn is_remote_tracking_ref(path: &Path) -> bool {
+    if extract_worktree_git_dir(path).is_some() {
+        return false;
+    }
+    let Some(suffix) = git_suffix_components(path) else {
+        return false;
+    };
+    let names = suffix
+        .iter()
+        .map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    matches!(
+        names.as_slice(),
+        [Some("refs"), Some("remotes"), Some(_), Some(_), ..]
+    )
+}
+
+/// Returns `true` for loose remote-tracking refs under the shared `.git` directory or their ancestor directories
+/// (note: this is for watcher allowlisting only; event classification should use [`is_remote_tracking_ref`] instead):
 /// - `.git/refs/remotes/origin/main`
 /// - `.git/refs/` (the ancestor directory that contains the refs/remotes/ directory)
 /// - `.git/refs/remotes/` (the ancestor directory that contains the refs/remotes/ directory)
 /// - `.git/refs/remotes/<remote>/` (the ancestor directory that contains the refs/remotes/<remote>/ directory)
-pub(crate) fn is_remote_tracking_ref(path: &Path) -> bool {
+pub(crate) fn is_remote_tracking_ref_or_ancestor(path: &Path) -> bool {
+    if is_remote_tracking_ref(path) {
+        return true;
+    }
     if extract_worktree_git_dir(path).is_some() {
         return false;
     }
@@ -556,7 +595,7 @@ pub fn should_ignore_git_path(path: &Path) -> bool {
     // Ignore everything inside .git/ except the allowlisted patterns.
     !is_commit_related_git_file(path)
         && !is_index_lock_file(path)
-        && !is_remote_tracking_ref(path)
+        && !is_remote_tracking_ref_or_ancestor(path)
         && !is_tracking_state_git_file(path)
 }
 

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -225,7 +225,8 @@ fn test_path_passes_filters_windows() {
 fn test_git_path_filtering_allowlist() {
     use super::{
         is_commit_related_git_file, is_common_git_config, is_index_lock_file,
-        is_remote_tracking_ref, is_tracking_state_git_file, should_ignore_git_path,
+        is_remote_tracking_ref, is_remote_tracking_ref_or_ancestor, is_tracking_state_git_file,
+        should_ignore_git_path,
     };
     use std::path::Path;
 
@@ -375,12 +376,26 @@ fn test_git_path_filtering_allowlist() {
     assert!(is_remote_tracking_ref(Path::new(
         "/repo/.git/refs/remotes/origin/feature/nested"
     )));
-    // Ancestor directories of remote-tracking refs are now matched too
-    // (needed to keep them in the watcher's watch set).
-    assert!(is_remote_tracking_ref(Path::new("/repo/.git/refs")));
-    assert!(is_remote_tracking_ref(Path::new("/repo/.git/refs/remotes")));
-    assert!(is_remote_tracking_ref(Path::new(
+    // Ancestor directories of remote-tracking refs are matched only by the
+    // watcher allowlist helper, not the event classifier.
+    assert!(!is_remote_tracking_ref(Path::new("/repo/.git/refs")));
+    assert!(!is_remote_tracking_ref(Path::new(
+        "/repo/.git/refs/remotes"
+    )));
+    assert!(!is_remote_tracking_ref(Path::new(
         "/repo/.git/refs/remotes/origin"
+    )));
+    assert!(is_remote_tracking_ref_or_ancestor(Path::new(
+        "/repo/.git/refs"
+    )));
+    assert!(is_remote_tracking_ref_or_ancestor(Path::new(
+        "/repo/.git/refs/remotes"
+    )));
+    assert!(is_remote_tracking_ref_or_ancestor(Path::new(
+        "/repo/.git/refs/remotes/origin"
+    )));
+    assert!(is_remote_tracking_ref_or_ancestor(Path::new(
+        "/repo/.git/refs/remotes/origin/main"
     )));
     // `.git/` itself is NOT claimed by this predicate; the other predicates
     // cover it for filtering, and including it would hijack routing.
@@ -426,7 +441,7 @@ fn test_git_path_filtering_allowlist() {
 
 #[test]
 fn test_is_shared_git_ref() {
-    use super::is_shared_git_ref;
+    use super::{is_shared_git_ref, is_shared_git_ref_or_ancestor};
     use std::path::Path;
 
     // Shared refs — broadcast to all repos
@@ -434,10 +449,19 @@ fn test_is_shared_git_ref() {
     assert!(is_shared_git_ref(Path::new(
         "/repo/.git/refs/heads/feature"
     )));
+    assert!(is_shared_git_ref_or_ancestor(Path::new("/repo/.git/refs")));
+    assert!(is_shared_git_ref_or_ancestor(Path::new(
+        "/repo/.git/refs/heads"
+    )));
+    assert!(is_shared_git_ref_or_ancestor(Path::new(
+        "/repo/.git/refs/heads/main"
+    )));
 
     // Repo-specific — NOT shared
     assert!(!is_shared_git_ref(Path::new("/repo/.git/HEAD")));
     assert!(!is_shared_git_ref(Path::new("/repo/.git/index.lock")));
+    assert!(!is_shared_git_ref(Path::new("/repo/.git/refs")));
+    assert!(!is_shared_git_ref(Path::new("/repo/.git/refs/heads")));
 
     // Worktree paths — NOT shared
     assert!(!is_shared_git_ref(Path::new(
@@ -450,6 +474,9 @@ fn test_is_shared_git_ref() {
     // Other .git internals — NOT shared
     assert!(!is_shared_git_ref(Path::new("/repo/.git/refs/tags/v1")));
     assert!(!is_shared_git_ref(Path::new(
+        "/repo/.git/refs/remotes/origin/main"
+    )));
+    assert!(!is_shared_git_ref_or_ancestor(Path::new(
         "/repo/.git/refs/remotes/origin/main"
     )));
     assert!(!is_shared_git_ref(Path::new("/repo/.git/config")));

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -77,8 +77,9 @@ fn test_path_passes_filters_unix() {
             &gitignores
         ));
 
-        // .git directory itself is still ignored
-        assert!(!path_passes_filters(
+        // `.git/` itself passes the watcher filter so the file watcher
+        // can deliver events for the allowlisted files inside it (HEAD, index.lock, etc.).
+        assert!(path_passes_filters(
             dirs.tests().join("my_repo/.git").as_path(),
             &gitignores
         ));
@@ -183,8 +184,9 @@ fn test_path_passes_filters_windows() {
             &gitignores
         ));
 
-        // .git directory itself is still ignored
-        assert!(!path_passes_filters(
+        // `.git/` itself passes the watcher filter so the file watcher
+        // can deliver events for the allowlisted files inside it (HEAD, index.lock, etc.).
+        assert!(path_passes_filters(
             dirs.tests().join(r"my_repo\.git").as_path(),
             &gitignores
         ));
@@ -235,8 +237,11 @@ fn test_git_path_filtering_allowlist() {
         "/home/user/project/README.md"
     )));
 
-    // .git directory itself should be ignored
-    assert!(should_ignore_git_path(Path::new("/home/user/project/.git")));
+    // `.git/` itself passes the watcher filter so the file watcher
+    // can deliver events for the allowlisted files inside it (HEAD, index.lock, etc.).
+    assert!(!should_ignore_git_path(Path::new(
+        "/home/user/project/.git"
+    )));
 
     // Allowlisted: commit-related files are NOT ignored
     assert!(!should_ignore_git_path(Path::new(
@@ -280,9 +285,6 @@ fn test_git_path_filtering_allowlist() {
         "/home/user/project/.git/refs/tags/v1.0"
     )));
     assert!(should_ignore_git_path(Path::new(
-        "/home/user/project/.git/refs/remotes/origin"
-    )));
-    assert!(should_ignore_git_path(Path::new(
         "/home/user/project/.git/objects/abc123"
     )));
     assert!(should_ignore_git_path(Path::new(
@@ -290,6 +292,17 @@ fn test_git_path_filtering_allowlist() {
     )));
     assert!(should_ignore_git_path(Path::new(
         "/home/user/project/.git/logs/HEAD"
+    )));
+
+    // Ancestor directories of allowlisted files must NOT be ignored, so the file watcher keeps them in the watch set.
+    assert!(!should_ignore_git_path(Path::new(
+        "/home/user/project/.git/refs"
+    )));
+    assert!(!should_ignore_git_path(Path::new(
+        "/home/user/project/.git/refs/remotes"
+    )));
+    assert!(!should_ignore_git_path(Path::new(
+        "/home/user/project/.git/refs/remotes/origin"
     )));
 
     // Worktree paths: allowlisted patterns under .git/worktrees/<name>/
@@ -309,11 +322,11 @@ fn test_git_path_filtering_allowlist() {
     assert!(should_ignore_git_path(Path::new(
         "/home/user/project/.git/worktrees/my-wt/COMMIT_EDITMSG"
     )));
-    // worktrees dir itself (no content after worktree name) is ignored
-    assert!(should_ignore_git_path(Path::new(
+    // Worktree ancestor directories must not be ignored, so the file watcher keeps them in the watch set.
+    assert!(!should_ignore_git_path(Path::new(
         "/home/user/project/.git/worktrees"
     )));
-    assert!(should_ignore_git_path(Path::new(
+    assert!(!should_ignore_git_path(Path::new(
         "/home/user/project/.git/worktrees/my-wt"
     )));
 
@@ -325,11 +338,26 @@ fn test_git_path_filtering_allowlist() {
     assert!(is_commit_related_git_file(Path::new(
         "/repo/.git/worktrees/wt/HEAD"
     )));
+    // Ancestor directories of commit-related files should be matched.
+    assert!(is_commit_related_git_file(Path::new("/repo/.git")));
+    assert!(is_commit_related_git_file(Path::new("/repo/.git/refs")));
+    assert!(is_commit_related_git_file(Path::new(
+        "/repo/.git/worktrees"
+    )));
+    assert!(is_commit_related_git_file(Path::new(
+        "/repo/.git/worktrees/wt"
+    )));
     assert!(!is_commit_related_git_file(Path::new(
         "/repo/.git/index.lock"
     )));
     assert!(!is_commit_related_git_file(Path::new(
         "/repo/.git/refs/tags/v1"
+    )));
+    // `.git/refs/remotes/*` is NOT a commit-related path; it's handled by
+    // `is_remote_tracking_ref` and we don't want this predicate to claim
+    // it (would re-route events through the wrong tier in find_repos).
+    assert!(!is_commit_related_git_file(Path::new(
+        "/repo/.git/refs/remotes/origin/main"
     )));
 
     // is_index_lock_file
@@ -347,9 +375,17 @@ fn test_git_path_filtering_allowlist() {
     assert!(is_remote_tracking_ref(Path::new(
         "/repo/.git/refs/remotes/origin/feature/nested"
     )));
-    assert!(!is_remote_tracking_ref(Path::new(
+    // Ancestor directories of remote-tracking refs are now matched too
+    // (needed to keep them in the watcher's watch set).
+    assert!(is_remote_tracking_ref(Path::new("/repo/.git/refs")));
+    assert!(is_remote_tracking_ref(Path::new("/repo/.git/refs/remotes")));
+    assert!(is_remote_tracking_ref(Path::new(
         "/repo/.git/refs/remotes/origin"
     )));
+    // `.git/` itself is NOT claimed by this predicate; the other predicates
+    // cover it for filtering, and including it would hijack routing.
+    assert!(!is_remote_tracking_ref(Path::new("/repo/.git")));
+    // Worktrees stay excluded — remote-tracking refs live in the main repo.
     assert!(!is_remote_tracking_ref(Path::new(
         "/repo/.git/worktrees/wt/refs/remotes/origin/main"
     )));

--- a/crates/repo_metadata/src/watcher.rs
+++ b/crates/repo_metadata/src/watcher.rs
@@ -20,7 +20,7 @@ cfg_if::cfg_if! {
         use crate::entry::{
             extract_worktree_git_dir, is_commit_related_git_file, is_git_internal_path,
             is_common_git_config, is_index_lock_file, is_remote_tracking_ref,
-            is_shared_git_ref, is_tracking_state_git_file,
+            is_shared_git_ref_or_ancestor, is_tracking_state_git_file,
         };
         /// Duration between filesystem watch events in milliseconds
         const FILESYSTEM_WATCHER_DEBOUNCE_MILLI_SECS: u64 = 500;
@@ -169,7 +169,7 @@ impl DirectoryWatcher {
                     affected.push(repo_handle.clone());
                 }
             }
-        } else if is_shared_git_ref(git_path) {
+        } else if is_shared_git_ref_or_ancestor(git_path) {
             // Tier 3: shared ref — broadcast to every repo whose
             // common_git_dir() is a prefix of the event path.
             log::debug!(

--- a/crates/repo_metadata/src/watcher_tests.rs
+++ b/crates/repo_metadata/src/watcher_tests.rs
@@ -515,7 +515,6 @@ fn test_common_config_routes_to_repos_sharing_common_git_dir() {
 }
 
 #[test]
-#[ignore = "flaky test: CODE-1492"]
 fn test_commit_related_files_excluded_from_update_lists() {
     VirtualFS::test("commit_files_excluded", |dirs, mut vfs| {
         log::info!("Start setting up test vfs");
@@ -575,23 +574,22 @@ fn test_commit_related_files_excluded_from_update_lists() {
             std::fs::write(&branch_file_path, "def456abc123").expect("Updating branch ref failed");
             log::info!("Wrote files: regular_file.txt, .git/HEAD, .git/refs/heads/main");
 
-            // Receive the update with timeout and retry
-            let update = loop {
-                futures::select! {
-                    update = futures::FutureExt::fuse(update_rx.next()) => {
-                        match update {
-                            Some(update) => {
-                                log::info!("Received update");
-                                break update;
-                            }
-                            None => {
-                                panic!("Update channel closed unexpectedly");
-                            }
+            // Receive the update with a bounded timeout so the test fails
+            // clearly instead of hanging if the watcher event is missed.
+            let update = futures::select! {
+                update = futures::FutureExt::fuse(update_rx.next()) => {
+                    match update {
+                        Some(update) => {
+                            log::info!("Received update");
+                            update
+                        }
+                        None => {
+                            panic!("Update channel closed unexpectedly");
                         }
                     }
-                    _ = futures::FutureExt::fuse(Timer::after(Duration::from_secs(5))) => {
-                        log::warn!("Waiting for update timed out after 5s, retrying...");
-                    }
+                }
+                _ = futures::FutureExt::fuse(Timer::after(Duration::from_secs(5))) => {
+                    panic!("Timed out waiting for repository update after modifying regular and git commit files");
                 }
             };
 

--- a/crates/repo_metadata/src/watcher_tests.rs
+++ b/crates/repo_metadata/src/watcher_tests.rs
@@ -465,6 +465,57 @@ fn test_remote_tracking_ref_routes_only_to_repos_tracking_that_ref() {
 }
 
 #[test]
+fn test_shared_ref_ancestor_routes_to_repos_sharing_common_git_dir() {
+    VirtualFS::test("shared_ref_ancestor_routes", |dirs, mut vfs| {
+        stub_git_repository(&mut vfs, "repo");
+        vfs.mkdir("repo/.git/refs");
+        vfs.mkdir("repo/.git/worktrees");
+        vfs.mkdir("repo/.git/worktrees/wt");
+        vfs.mkdir("wt");
+        vfs.with_files(vec![Stub::FileWithContent(
+            "repo/.git/worktrees/wt/HEAD",
+            "ref: refs/heads/feature",
+        )]);
+
+        let repo_path = dirs.tests().join("repo");
+        let worktree_path = dirs.tests().join("wt");
+        let external_git_dir = dirs.tests().join("repo/.git/worktrees/wt");
+        let refs_path = dirs.tests().join("repo/.git/refs");
+
+        App::test((), |mut app| async move {
+            let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+
+            let main_repo_handle = watcher_handle
+                .update(&mut app, |watcher, ctx| {
+                    watcher.add_directory(
+                        StandardizedPath::from_local_canonicalized(&repo_path).unwrap(),
+                        ctx,
+                    )
+                })
+                .unwrap();
+            let worktree_repo_handle = watcher_handle
+                .update(&mut app, |watcher, ctx| {
+                    watcher.add_directory_with_git_dir(
+                        StandardizedPath::from_local_canonicalized(&worktree_path).unwrap(),
+                        Some(
+                            StandardizedPath::from_local_canonicalized(&external_git_dir).unwrap(),
+                        ),
+                        ctx,
+                    )
+                })
+                .unwrap();
+
+            let affected = watcher_handle.update(&mut app, |watcher, ctx| {
+                watcher.find_repos_for_git_event(&refs_path, ctx)
+            });
+            assert_eq!(affected.len(), 2);
+            assert!(affected.contains(&main_repo_handle));
+            assert!(affected.contains(&worktree_repo_handle));
+        });
+    });
+}
+
+#[test]
 fn test_common_config_routes_to_repos_sharing_common_git_dir() {
     VirtualFS::test("common_config_routes", |dirs, mut vfs| {
         stub_git_repository(&mut vfs, "repo");


### PR DESCRIPTION
## Description
* Today we use a filesystem watcher to detect git changes (branch checkouts, commits, etc.) using an allowlist - this includes paths like `HEAD`, `refs/heads/*`, `index.lock`, and ignores paths like `.git/logs/` to reduce noice 
* The issue is that on linux, the notify crate uses `inotify` under the hood which is non-recursive by design and registers a watch handle per _directory_
  * See https://man7.org/linux/man-pages/man7/inotify.7.html and https://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib-inotify-add-watch.html 
  * Since `should_ignore_git_path` originally filtered out directories like `.git/`, many of the git events for the allowlisted paths were never getting fired 
* This PR updates the helper fns in `should_ignore_git_path` to allow the related ancestor directories to the allowlisted files and not just their files
  * Updates the relevant tests too

## Linked Issue
* [APP-4528](https://linear.app/warpdotdev/issue/APP-4528/bug-code-review-shows-inaccurate-diffs-when-switching-commits)
* I believe this also fixes the flaky test mentioned in for the same reasons [CODE-1492](https://linear.app/warpdotdev/issue/CODE-1492/fix-flaky-test-commit-related-files-excluded-from-update-lists)

## Testing
Repro steps: 
1. git checkout HEAD~1 
2. update base branch to master in code review view 
3. git checkout master

bug: code review would render old/inaccurate diffs
fix: code review refresh is triggered and shows clean state

https://www.loom.com/share/ea1a81e5c0654fc9a6d0f20b68f7d63e

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode