### PR TITLE
Rename empty orchestration environment label

### DIFF
--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -58,7 +58,7 @@ const DEFAULT_HOST_ENV_VAR: &str = "WARP_CLOUD_MODE_DEFAULT_HOST";
 // ── Shared constants ────────────────────────────────────────────────
 
 pub const ORCHESTRATION_WARP_WORKER_HOST: &str = "warp";
-pub const ORCHESTRATION_ENV_NONE_LABEL: &str = "(no environment)";
+pub const ORCHESTRATION_ENV_NONE_LABEL: &str = "Empty environment";
 
 pub const ORCHESTRATION_PICKER_HEIGHT: f32 = 36.;
 pub const ORCHESTRATION_PICKER_BORDER_WIDTH: f32 = 1.;


### PR DESCRIPTION
## Description
Rename the shared orchestration empty-environment picker entry from `(no environment)` to `Empty environment` so the run agents card and plan card match the Oz web wording.

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all`
- `cargo test --manifest-path /workspace/warp/app/Cargo.toml --lib orchestration_controls`
- `cargo clippy --manifest-path /workspace/warp/app/Cargo.toml --lib --all-features --tests -- -D warnings` *(fails on existing `warpui_core` clippy errors unrelated to this change)*

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/da7a0d5a-8778-4d14-8754-18c944c83617_
_Run: https://oz.staging.warp.dev/runs/019e4149-eb76-73e5-b8ea-9de14de7e8cd_

_This PR was generated with [Oz](https://warp.dev/oz)._
