### PR TITLE
Use async presentation on macOS where possible.

### DIFF
--- a/crates/warpui/src/platform/mac/objc/host_view.h
+++ b/crates/warpui/src/platform/mac/objc/host_view.h
@@ -13,5 +13,6 @@
              enableTitlebarDrag:(BOOL)enableTitlebarDrag
                        testMode:(BOOL)testMode;
 - (void)setAsyncCallback:(BOOL)shouldAsync;
+- (void)setPresentsWithTransaction:(BOOL)presentsWithTransaction;
 - (BOOL)keyDownImpl:(NSEvent *)event;
 @end

--- a/crates/warpui/src/platform/mac/objc/host_view.m
+++ b/crates/warpui/src/platform/mac/objc/host_view.m
@@ -153,6 +153,10 @@ void warp_marked_text_cleared(WarpHostView *);
 - (void)setAsyncCallback:(BOOL)shouldAsync {
     asyncCallback = shouldAsync;
 }
+- (void)setPresentsWithTransaction:(BOOL)presentsWithTransaction {
+    CAMetalLayer *layer = (CAMetalLayer *)self.layer;
+    layer.presentsWithTransaction = presentsWithTransaction;
+}
 
 - (void)keyDown:(NSEvent *)event {
     [self keyDownImpl:event];
@@ -275,7 +279,7 @@ void warp_marked_text_cleared(WarpHostView *);
     layer.allowsNextDrawableTimeout = NO;
     layer.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
     layer.needsDisplayOnBoundsChange = YES;
-    layer.presentsWithTransaction = YES;
+    layer.presentsWithTransaction = NO;
     layer.delegate = self;
     layer.opaque = NO;
     return layer;

--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -143,12 +143,20 @@ NSNumber *previouslyActiveAppPID;
     // we explicitly force callbacks to be synchronous if it's caused by the user instead
     // of another system call (such as the active screen changing)
     [warp_view setAsyncCallback:NO];
+
+    // While the user is dragging to resize the window, we want to present frames
+    // within transactions to ensure the resize is visually smooth and there is no
+    // stuttering resulting from asynchronous presentation.
+    [warp_view setPresentsWithTransaction:YES];
 }
 
 - (void)windowDidEndLiveResize:(NSNotification *)notification {
     WarpWindow *warp_window = notification.object;
     WarpHostView *warp_view = warp_window.contentView;
+
+    // Reset state changed in `windowWillStartLiveResize`.
     [warp_view setAsyncCallback:YES];
+    [warp_view setPresentsWithTransaction:NO];
 }
 
 - (void)setForceTermination {

--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -8,7 +8,6 @@ use warpui_core::{
 use super::frame_capture::capture_frame;
 use crate::platform::mac::rendering::renderer::Device;
 use crate::platform::mac::window::WindowState;
-use cocoa::base::id;
 use metal::{
     Function, MTLBlendFactor, MTLBlendOperation, MTLIndexType, MTLPrimitiveType,
     MTLResourceOptions, RenderPipelineDescriptor,
@@ -67,16 +66,24 @@ impl<'a> RenderPass<'a> {
         mut self,
         drawable_size: pathfinder_geometry::vector::Vector2F,
         should_capture: bool,
+        presents_with_transaction: bool,
     ) -> Option<CapturedFrame> {
         self.encoder.end_encoding();
-
         self.encoding_finished = true;
 
-        self.buffer.commit();
+        // If we're able to do asynchronous presentation, do so - it allows us to avoid
+        // blocking on the GPU for the duration of the frame.
+        if !should_capture && !presents_with_transaction {
+            self.buffer.present_drawable(self.drawable);
+            self.buffer.commit();
+            return None;
+        }
 
+        // Otherwise, commit the buffer and wait for it to complete before continuing.
+        self.buffer.commit();
         self.buffer.wait_until_completed();
 
-        let captured = if should_capture {
+        let capture = if should_capture {
             let texture = self.drawable.texture();
             capture_frame(texture, drawable_size)
         } else {
@@ -84,7 +91,7 @@ impl<'a> RenderPass<'a> {
         };
 
         self.drawable.present();
-        captured
+        capture
     }
 
     /// Creates a descriptor for a pass that renders into the provided drawable.
@@ -239,6 +246,7 @@ impl Renderer {
         scene: &Scene,
         ctx: &MetalDrawContext,
         should_capture: bool,
+        presents_with_transaction: bool,
     ) -> Option<CapturedFrame> {
         self.resources
             .glyph_cache
@@ -248,7 +256,11 @@ impl Renderer {
 
         Frame::new(scene, render_pass.encoder, &mut self.resources, ctx).draw();
 
-        render_pass.finish_with_capture(ctx.drawable_size, should_capture)
+        render_pass.finish_with_capture(
+            ctx.drawable_size,
+            should_capture,
+            presents_with_transaction,
+        )
     }
 }
 
@@ -959,11 +971,12 @@ impl super::super::Renderer for Renderer {
             return;
         };
 
-        let drawable = unsafe {
+        let (drawable, presents_with_transaction) = unsafe {
             let native_view = window.native_view();
-            let layer: id = msg_send![native_view, layer];
+            let layer: &metal::MetalLayerRef = msg_send![native_view, layer];
+            let presents_with_transaction = layer.presents_with_transaction();
             let drawable: &metal::MetalDrawableRef = msg_send![layer, nextDrawable];
-            drawable
+            (drawable, presents_with_transaction)
         };
 
         let ctx = &MetalDrawContext {
@@ -986,7 +999,7 @@ impl super::super::Renderer for Renderer {
 
         let capture_callback = window.capture_callback.borrow_mut().take();
         let should_capture = capture_callback.is_some();
-        let captured = Self::render(self, scene, ctx, should_capture);
+        let captured = Self::render(self, scene, ctx, should_capture, presents_with_transaction);
         if let (Some(frame), Some(callback)) = (captured, capture_callback) {
             callback(frame);
         }


### PR DESCRIPTION
## Description
This changes macOS Metal rendering to avoid transaction-backed presentation during normal frames, where it can force unnecessary CPU stalls while waiting on the command buffer.

The `CAMetalLayer` now defaults to async presentation, and Warp only re-enables `presentsWithTransaction` during live window resize. The renderer reads the layer's current transaction mode and uses the matching presentation path, preserving smoother live-resize behavior without paying the synchronization cost for ordinary rendering.

## Linked Issue
None.

## Testing
- [x] I have manually tested my changes locally with `./script/run`.
- Manually validated live resize behavior: with transactions disabled, I noticed jitter while resizing; with this patch, which re-enables transactions only during live resize, I did not notice that jitter.
- Ran `cargo fmt --package warpui`.
- Ran `./script/run-clang-format.py -i --extensions h,m crates/warpui/src/platform/mac/objc/host_view.h crates/warpui/src/platform/mac/objc/host_view.m crates/warpui/src/platform/mac/objc/window.m`.
- Ran `cargo check -p warpui`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
