### PR TITLE
Add remote control QR code entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10196,6 +10196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14437,6 +14443,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-build",
  "prost-types",
+ "qrcode",
  "rand 0.8.6",
  "rangemap",
  "rayon",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -163,6 +163,7 @@ plist = "1"
 pprof = { workspace = true, optional = true, features = ["protobuf-codec"] }
 prost.workspace = true
 prost-types.workspace = true
+qrcode = { version = "0.14.1", default-features = false }
 rand.workspace = true
 rangemap.workspace = true
 rayon.workspace = true

--- a/app/src/drive/sharing/dialog/mod.rs
+++ b/app/src/drive/sharing/dialog/mod.rs
@@ -34,7 +34,9 @@ use crate::TelemetryEvent;
 use email_address::EmailAddress;
 use inheritance::{InheritanceDetails, InheritanceState};
 use itertools::Itertools;
+use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
+use qrcode::{types::Color as QrColor, QrCode};
 use session_sharing_protocol::common::{Guest, PendingGuest, SessionId, TeamAclData};
 use warp_core::ui::appearance::Appearance;
 use warp_editor::editor::NavigationKey;
@@ -54,7 +56,7 @@ use warpui::{
     clipboard::ClipboardContent,
     elements::{
         Border, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Dismiss, Empty, Flex,
-        MainAxisAlignment, ParentElement, Radius,
+        MainAxisAlignment, ParentElement, Radius, Rect,
     },
     keymap::FixedBinding,
     ui_components::components::{UiComponent, UiComponentStyles},
@@ -76,6 +78,8 @@ const EMAIL_CHIP_WIDTH: f32 = 100.;
 const EMAIL_EDITOR_WIDTH: f32 = 100.;
 
 const SHARING_DIALOG_WIDTH: f32 = 425.;
+const SESSION_QR_CODE_SIZE: f32 = 240.;
+const SESSION_QR_CODE_PADDING: f32 = 16.;
 
 const NO_ACCESS_LABEL: &str = "No access";
 
@@ -727,11 +731,11 @@ impl SharingDialog {
         let Some(ShareableObject::Session {
             session_id: target_session_id,
             ..
-        }) = self.target
+        }) = self.target.as_ref()
         else {
             return;
         };
-        if session_id != target_session_id {
+        if &session_id != target_session_id {
             return;
         }
 
@@ -779,7 +783,7 @@ impl SharingDialog {
         // The permission states for shared sessions are managed differently
         // than other cloud objects. We return to avoid resetting the
         // permissions for sessions.
-        if matches!(self.target, Some(ShareableObject::Session { .. })) {
+        if matches!(self.target.as_ref(), Some(ShareableObject::Session { .. })) {
             return;
         }
 
@@ -904,7 +908,7 @@ impl SharingDialog {
     /// Copy the object's URL to the clipboard.
     pub fn copy_link(&self, ctx: &mut ViewContext<Self>) {
         if let Some(url) = self.target.as_ref().and_then(|target| target.link(ctx)) {
-            let event = match self.target {
+            let event = match self.target.as_ref() {
                 Some(ShareableObject::Session { .. }) => {
                     Some(TelemetryEvent::CopiedSharedSessionLink {
                         source: SharedSessionActionSource::SharingDialog,
@@ -949,11 +953,13 @@ impl SharingDialog {
         if let Some(guest) = self.guest_states.get(guest_index) {
             let current_access_level = guest.current_access_level;
             let inherited_access = guest.inheritance.is_some();
-            let is_ai_conversation =
-                matches!(self.target, Some(ShareableObject::AIConversation(_)));
+            let is_ai_conversation = matches!(
+                self.target.as_ref(),
+                Some(ShareableObject::AIConversation(_))
+            );
             // Check if this is a team guest - team removal is only supported for non-session targets
             let is_team_guest = matches!(guest.subject, Subject::Team(_));
-            let is_session = matches!(self.target, Some(ShareableObject::Session { .. }));
+            let is_session = matches!(self.target.as_ref(), Some(ShareableObject::Session { .. }));
 
             self.guest_menu.update(ctx, |menu, ctx| {
                 let mut items = vec![MenuItemFields::new(SharingAccessLevel::View.label())
@@ -1334,7 +1340,10 @@ impl SharingDialog {
 
     /// Reset the invite access level menu based on the current target.
     fn reset_invite_access_level_menu(&mut self, ctx: &mut ViewContext<Self>) {
-        let is_ai_conversation = matches!(self.target, Some(ShareableObject::AIConversation(_)));
+        let is_ai_conversation = matches!(
+            self.target.as_ref(),
+            Some(ShareableObject::AIConversation(_))
+        );
 
         self.invite_form.access_level_menu.update(ctx, |menu, ctx| {
             let mut items = vec![MenuItemFields::new(SharingAccessLevel::View.label())
@@ -1778,7 +1787,7 @@ impl SharingDialog {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Option<Box<dyn Element>> {
-        let Some(ShareableObject::Session { started_at, .. }) = self.target else {
+        let Some(ShareableObject::Session { started_at, .. }) = self.target.as_ref() else {
             return None;
         };
 
@@ -1995,7 +2004,10 @@ impl SharingDialog {
     fn reset_link_sharing_menu(&mut self, ctx: &mut ViewContext<Self>) {
         let inherited_access = self.link_sharing_state.inheritance.is_some();
         let current_access_level = self.link_sharing_state.access_level;
-        let is_ai_conversation = matches!(self.target, Some(ShareableObject::AIConversation(_)));
+        let is_ai_conversation = matches!(
+            self.target.as_ref(),
+            Some(ShareableObject::AIConversation(_))
+        );
 
         let mut items = vec![
             MenuItemFields::new("Only people invited")
@@ -2064,7 +2076,7 @@ impl SharingDialog {
         app: &AppContext,
     ) -> Option<Box<dyn Element>> {
         // Currently, we only allow editing the team ACL for sessions.
-        if !matches!(self.target, Some(ShareableObject::Session { .. })) {
+        if !matches!(self.target.as_ref(), Some(ShareableObject::Session { .. })) {
             return None;
         }
 
@@ -2468,6 +2480,86 @@ impl SharingDialog {
             .with_vertical_margin(style::ACL_ITEM_GAP / 2.)
             .finish()
     }
+
+    fn render_session_qr_code(
+        &self,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Option<Box<dyn Element>> {
+        if !matches!(self.target.as_ref(), Some(ShareableObject::Session { .. })) {
+            return None;
+        }
+
+        let url = self.target.as_ref().and_then(|target| target.link(app))?;
+        let code = QrCode::new(url.as_bytes()).ok()?;
+        let width = code.width();
+        let cell_size = SESSION_QR_CODE_SIZE / width as f32;
+        let mut rows = Flex::column();
+
+        for y in 0..width {
+            let mut row = Flex::row();
+            for x in 0..width {
+                let color = if code[(x, y)] == QrColor::Dark {
+                    ColorU::black()
+                } else {
+                    ColorU::white()
+                };
+
+                row.add_child(
+                    ConstrainedBox::new(Rect::new().with_background_color(color).finish())
+                        .with_width(cell_size)
+                        .with_height(cell_size)
+                        .finish(),
+                );
+            }
+            rows.add_child(row.finish());
+        }
+
+        let title = appearance
+            .ui_builder()
+            .span("Remote control QR code")
+            .with_style(UiComponentStyles {
+                font_color: Some(style::acl_primary_text_color(appearance)),
+                font_size: Some(style::PRIMARY_TEXT_SIZE),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        let subtitle = appearance
+            .ui_builder()
+            .span("Scan to open this session on another device.")
+            .with_style(UiComponentStyles {
+                font_color: Some(style::acl_secondary_text_color(appearance)),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        let qr_code = Container::new(rows.finish())
+            .with_uniform_padding(SESSION_QR_CODE_PADDING)
+            .with_background_color(ColorU::white())
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .with_border(Border::all(1.).with_border_color(style::form_border_color(appearance)))
+            .finish();
+
+        Some(
+            Container::new(
+                Flex::column()
+                    .with_main_axis_size(MainAxisSize::Min)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(8.)
+                    .with_child(title)
+                    .with_child(qr_code)
+                    .with_child(subtitle)
+                    .finish(),
+            )
+            .with_horizontal_padding(style::ACL_ITEM_PADDING)
+            .with_vertical_padding(style::ACL_ITEM_PADDING / 2.)
+            .with_vertical_margin(style::ACL_ITEM_GAP / 2.)
+            .finish(),
+        )
+    }
 }
 
 /// Render a tooltip that explains an ACL.
@@ -2521,6 +2613,7 @@ impl View for SharingDialog {
         }
 
         contents.add_child(self.render_object_link(appearance, app));
+        contents.extend(self.render_session_qr_code(appearance, app));
 
         let mut stack = Stack::new();
         stack.add_child(contents.finish());

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -841,6 +841,13 @@ impl PaneConfiguration {
     ) {
         ctx.emit(PaneConfigurationEvent::ToggleSharingDialog(source));
     }
+    pub fn open_sharing_dialog(
+        &mut self,
+        source: SharingDialogSource,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.emit(PaneConfigurationEvent::OpenSharingDialog(source));
+    }
 
     /// Notifies that the header content has changed and the pane header should re-render.
     /// Use this when the backing view's state has changed in a way that affects the header
@@ -867,6 +874,7 @@ pub enum PaneConfigurationEvent {
     RefreshPaneHeaderOverflowMenuItems,
     ShareableObjectChanged(Option<ShareableObject>),
     ToggleSharingDialog(SharingDialogSource),
+    OpenSharingDialog(SharingDialogSource),
     DimEvenIfFocusedUpdated,
     /// The header content has changed and should be re-rendered.
     /// This is used when the backing view's state changes in a way that

--- a/app/src/pane_group/pane/view/header/sharing.rs
+++ b/app/src/pane_group/pane/view/header/sharing.rs
@@ -143,6 +143,51 @@ impl<P: BackingView> PaneHeader<P> {
         ctx.notify();
     }
 
+    pub fn open_pane_sharing_dialog(
+        &mut self,
+        source: SharingDialogSource,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !self.is_sharing_dialog_enabled(ctx) {
+            return;
+        }
+
+        if !self
+            .sharing_dialog()
+            .as_ref(ctx)
+            .editability(ctx)
+            .can_edit()
+        {
+            self.sharing_dialog()
+                .update(ctx, |dialog, ctx| dialog.copy_link(ctx));
+            return;
+        }
+
+        let dialog_opened = match self.open_overlay {
+            OpenOverlay::OverflowMenu => {
+                self.open_overlay = OpenOverlay::SharingDialog;
+                ctx.emit(Event::PaneHeaderOverflowMenuToggled(false));
+                ctx.focus(&self.shared_content.sharing_dialog);
+                true
+            }
+            OpenOverlay::SharingDialog => {
+                ctx.focus(&self.shared_content.sharing_dialog);
+                false
+            }
+            OpenOverlay::None => {
+                self.open_overlay = OpenOverlay::SharingDialog;
+                ctx.focus(&self.shared_content.sharing_dialog);
+                true
+            }
+        };
+
+        if dialog_opened {
+            self.sharing_dialog()
+                .update(ctx, |dialog, ctx| dialog.report_open(source, ctx));
+        }
+
+        ctx.notify();
+    }
     fn handle_sharing_dialog_event(
         &mut self,
         event: &SharingDialogEvent,

--- a/app/src/pane_group/pane/view/mod.rs
+++ b/app/src/pane_group/pane/view/mod.rs
@@ -252,6 +252,11 @@ impl<P: BackingView> PaneView<P> {
                     header.share_pane_contents(*source, ctx);
                 });
             }
+            PaneConfigurationEvent::OpenSharingDialog(source) => {
+                self.header.update(ctx, |header, ctx| {
+                    header.open_pane_sharing_dialog(*source, ctx);
+                });
+            }
             _ => {}
         }
     }

--- a/app/src/terminal/shared_session/manager.rs
+++ b/app/src/terminal/shared_session/manager.rs
@@ -134,6 +134,7 @@ impl Manager {
         self.shared.insert(view_id, state);
         ctx.emit(ManagerEvent::StartedShare {
             session_id,
+            view_id,
             window_id,
         });
     }
@@ -215,6 +216,8 @@ pub enum ManagerEvent {
     /// A shared session was started.
     StartedShare {
         session_id: SessionId,
+        /// The view_id of the terminal that started sharing.
+        view_id: EntityId,
         /// The window that the session resides in.
         window_id: WindowId,
     },

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -491,6 +491,15 @@ impl TerminalView {
     pub fn open_share_session_denied_modal(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.emit(Event::OpenShareSessionDeniedModal);
     }
+    pub fn open_shared_session_sharing_dialog(
+        &mut self,
+        source: SharingDialogSource,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.pane_configuration.update(ctx, |pane_config, ctx| {
+            pane_config.open_sharing_dialog(source, ctx);
+        });
+    }
 
     /// Focuses the view by telling the parent view to focus this session.
     /// For example, in the common case, the parent pane group would consume

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -330,6 +330,9 @@ pub enum WorkspaceAction {
     OpenLinkOnDesktop(url::Url),
     ReopenClosedSession,
     OpenShareSessionModal(usize),
+    OpenSharedSessionDialog {
+        terminal_view_id: EntityId,
+    },
     StopSharingSessionFromTabMenu {
         terminal_view_id: EntityId,
     },
@@ -912,6 +915,7 @@ impl WorkspaceAction {
             | LogOut
             | OpenLink(_)
             | OpenShareSessionModal(_)
+            | OpenSharedSessionDialog { .. }
             | StopSharingSessionFromTabMenu { .. }
             | StopSharingAllSessionsInTab { .. }
             | CopySharedSessionLinkFromTab { .. }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -4216,6 +4216,28 @@ impl Workspace {
             });
         }
     }
+    fn open_shared_session_dialog(
+        &mut self,
+        terminal_view_id: EntityId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        use terminal::shared_session::manager::Manager;
+
+        if !self.focus_terminal_view_locally(terminal_view_id, ctx) {
+            self.focus_terminal_view_in_other_window(terminal_view_id, ctx);
+            return;
+        }
+
+        let manager = Manager::as_ref(ctx);
+        if let Some(terminal_view) = manager.shared_view_by_id(&terminal_view_id, ctx) {
+            terminal_view.update(ctx, |view, ctx| {
+                view.open_shared_session_sharing_dialog(
+                    SharingDialogSource::StartedSessionShare,
+                    ctx,
+                );
+            });
+        }
+    }
 
     fn copy_shared_session_link_from_tab(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
         // Get the pane group for the specified tab
@@ -4243,9 +4265,10 @@ impl Workspace {
                 ManagerEvent::StartedShare {
                     window_id,
                     session_id,
+                    view_id,
                 } => {
                     if *window_id == ctx.window_id() {
-                        me.copy_shared_session_link(session_id, ctx);
+                        me.copy_shared_session_link(session_id, *view_id, ctx);
                     }
                 }
                 #[cfg(target_family = "wasm")]
@@ -4281,6 +4304,7 @@ impl Workspace {
     fn copy_shared_session_link(
         &mut self,
         session_id: &SharedSessionId,
+        terminal_view_id: EntityId,
         ctx: &mut ViewContext<Self>,
     ) {
         ctx.clipboard().write(ClipboardContent::plain_text(
@@ -4288,7 +4312,12 @@ impl Workspace {
         ));
 
         self.toast_stack.update(ctx, |toast_stack, ctx| {
-            let toast = DismissibleToast::default("Remote control link copied.".to_string());
+            let toast = DismissibleToast::default("Remote control link copied.".to_string())
+                .with_link(
+                    ToastLink::new("View QR code".to_string()).with_onclick_action(
+                        WorkspaceAction::OpenSharedSessionDialog { terminal_view_id },
+                    ),
+                );
             toast_stack.add_ephemeral_toast(toast, ctx);
         });
     }
@@ -22263,6 +22292,9 @@ impl TypedActionView for Workspace {
             }
             OpenShareSessionModal(index) => {
                 self.open_share_session_modal(*index, ctx);
+            }
+            OpenSharedSessionDialog { terminal_view_id } => {
+                self.open_shared_session_dialog(*terminal_view_id, ctx);
             }
             StopSharingSessionFromTabMenu { terminal_view_id } => {
                 self.stop_sharing_session(terminal_view_id, SharedSessionActionSource::Tab, ctx)


### PR DESCRIPTION
## Description
Adds a QR-code view for remote-control shared session links in the existing sharing dialog, plus a small "View QR code" action on the "Remote control link copied." toast that opens the sharing dialog for the shared terminal session.

No new log statements were added.

## Linked Issue
N/A - Slack design request.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --locked`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; this was validated with formatting and compile checks in the sandbox.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/5b5a6f93-6516-468f-a04b-01ff76acd782_
_Run: https://oz.staging.warp.dev/runs/019e415e-ab26-7c4f-bf8b-bf8333e24cfb_
_This PR was generated with [Oz](https://warp.dev/oz)._
