### PR TITLE
Don't block on codebase indexing for self hosted oz runs

### DIFF
--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -172,20 +172,10 @@ async fn prepare_environment_impl(
     }
 
     if !github_repos.is_empty() {
-        // Wait for codebase indexing for all repositories after running setup commands.
-        // We skip this if running in Docker sandboxes since they don't have a cache volume.
-        // We also skip this in Namespace to reduce startup time.
-        #[cfg(not(target_family = "wasm"))]
-        let should_wait_for_indexing = !matches!(
-            warp_isolation_platform::detect(),
-            Some(
-                warp_isolation_platform::IsolationPlatformType::DockerSandbox
-                    | warp_isolation_platform::IsolationPlatformType::Namespace
-            )
-        );
-        #[cfg(target_family = "wasm")]
-        let should_wait_for_indexing = true;
-
+        // We need to skip this if running in Docker sandboxes since they don't have a cache volume.
+        // For now, we're also skipping for self hosted and Namespace to reduce startup time, since
+        // we should only wait for indexing if there's an optimized cache volume and it's quick.
+        let should_wait_for_indexing = false;
         if should_wait_for_indexing {
             let repos_indexed = join_all(codebase_context_receivers);
             if repos_indexed


### PR DESCRIPTION
## Description

I noticed this timing out when self hosted. It's possible a self hosted worker might have a cache to make this quick, but we have no way of detecting that currently. It's safer to not wait to avoid timing out and causing delays.

