### PR TITLE
Fix find highlights inside rich text links

### DIFF
--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -32,7 +32,7 @@ mod todos;
 use common::get_highlight_ranges_for_find_matches;
 use pathfinder_color::ColorU;
 use settings::Setting as _;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use warp_core::features::FeatureFlag;
 use warp_core::semantic_selection::SemanticSelection;
 use warpui::elements::{
@@ -153,6 +153,77 @@ fn add_slash_command_highlight(
             .with_foreground_color(slash_command_foreground_color)
             .with_properties(default_properties)
     }
+}
+
+fn merge_text_styles(base: TextStyle, overlay: TextStyle) -> TextStyle {
+    let mut merged = base;
+    if overlay.foreground_color.is_some() {
+        merged.foreground_color = overlay.foreground_color;
+    }
+    if overlay.syntax_color.is_some() {
+        merged.syntax_color = overlay.syntax_color;
+    }
+    if overlay.background_color.is_some() {
+        merged.background_color = overlay.background_color;
+    }
+    if overlay.border.is_some() {
+        merged.border = overlay.border;
+    }
+    if overlay.error_underline_color.is_some() {
+        merged.error_underline_color = overlay.error_underline_color;
+    }
+    if overlay.underline_color.is_some() {
+        merged.underline_color = overlay.underline_color;
+    }
+    if overlay.hyperlink_id.is_some() {
+        merged.hyperlink_id = overlay.hyperlink_id;
+    }
+    merged.show_strikethrough |= overlay.show_strikethrough;
+    merged
+}
+
+fn merge_highlights(base: Highlight, overlay: Highlight) -> Highlight {
+    let properties = if overlay.properties() == Properties::default() {
+        base.properties()
+    } else {
+        overlay.properties()
+    };
+    Highlight::new()
+        .with_text_style(merge_text_styles(*base.text_style(), *overlay.text_style()))
+        .with_properties(properties)
+}
+
+fn normalize_highlighted_ranges(ranges: Vec<HighlightedRange>) -> Vec<HighlightedRange> {
+    let mut highlights_by_index = BTreeMap::new();
+    for range in ranges {
+        for index in range.highlight_indices {
+            highlights_by_index
+                .entry(index)
+                .and_modify(|highlight| {
+                    *highlight = merge_highlights(*highlight, range.highlight);
+                })
+                .or_insert(range.highlight);
+        }
+    }
+
+    let mut normalized: Vec<HighlightedRange> = vec![];
+    for (index, highlight) in highlights_by_index {
+        if let Some(last_range) = normalized.last_mut() {
+            let is_contiguous = last_range
+                .highlight_indices
+                .last()
+                .is_some_and(|last_index| *last_index + 1 == index);
+            if is_contiguous && last_range.highlight == highlight {
+                last_range.highlight_indices.push(index);
+                continue;
+            }
+        }
+        normalized.push(HighlightedRange {
+            highlight,
+            highlight_indices: vec![index],
+        });
+    }
+    normalized
 }
 
 /// Adds the appropriate highlighting for secrets and links to the given text element.
@@ -598,12 +669,7 @@ pub(crate) fn add_highlights_to_rich_text(
             ));
         }
 
-        let merged_range = HighlightedRange::merge_overlapping_ranges(style_ranges);
-        let sorted_range = merged_range
-            .into_iter()
-            .sorted_by_key(|range| range.highlight_indices[0]);
-
-        formatted_text_element.add_styles(i, sorted_range);
+        formatted_text_element.add_styles(i, normalize_highlighted_ranges(style_ranges));
     }
     formatted_text_element
 }
@@ -1370,3 +1436,6 @@ impl AIAgentInput {
         }
     }
 }
+#[cfg(test)]
+#[path = "view_impl_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/block/view_impl_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl_tests.rs
@@ -1,0 +1,43 @@
+use pathfinder_color::ColorU;
+use warpui::elements::{Highlight, HighlightedRange};
+use warpui::text_layout::TextStyle;
+
+use super::normalize_highlighted_ranges;
+
+fn highlighted_range(range: std::ops::Range<usize>, highlight: Highlight) -> HighlightedRange {
+    HighlightedRange {
+        highlight,
+        highlight_indices: range.collect(),
+    }
+}
+
+#[test]
+fn normalize_highlighted_ranges_preserves_find_style_inside_url_link() {
+    let link_foreground = ColorU::new(20, 80, 240, 255);
+    let find_background = ColorU::new(255, 190, 80, 255);
+    let find_foreground = ColorU::new(0, 0, 0, 255);
+    let link_highlight = Highlight::new().with_text_style(
+        TextStyle::new()
+            .with_foreground_color(link_foreground)
+            .with_underline_color(link_foreground),
+    );
+    let find_highlight = Highlight::new().with_text_style(
+        TextStyle::new()
+            .with_background_color(find_background)
+            .with_foreground_color(find_foreground),
+    );
+
+    let normalized = normalize_highlighted_ranges(vec![
+        highlighted_range(0..10, link_highlight),
+        highlighted_range(4..9, find_highlight),
+    ]);
+
+    assert_eq!(normalized.len(), 3);
+    assert_eq!(normalized[0], highlighted_range(0..4, link_highlight));
+    assert_eq!(normalized[2], highlighted_range(9..10, link_highlight));
+    assert_eq!(normalized[1].highlight_indices, (4..9).collect::<Vec<_>>());
+    let combined_style = normalized[1].highlight.text_style();
+    assert_eq!(combined_style.foreground_color, Some(find_foreground));
+    assert_eq!(combined_style.background_color, Some(find_background));
+    assert_eq!(combined_style.underline_color, Some(link_foreground));
+}


### PR DESCRIPTION
## Description
Fixes AI block rich-text find highlighting when a search match overlaps another style range, such as a detected URL link. The previous rich-text path merged overlapping highlight ranges by keeping the first highlight style, which could cause link styling to swallow the find match background/foreground inside URLs. This change normalizes overlapping rich-text highlight ranges per character and merges compatible text-style fields so the find highlight remains visible while preserving link styling like underline where applicable.

## Linked Issue
Slack report in `#feedback-app`: find highlighting appeared offset/broken when searching for `figma` in a shared staging conversation containing Figma links.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all`
- [x] `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- [ ] `cargo nextest run --manifest-path /workspace/warp/Cargo.toml --no-fail-fast -p warp normalize_highlighted_ranges_preserves_find_style_inside_url_link` — attempted multiple times, but the sandbox killed `cargo test --no-run --package warp` with SIGKILL during test compilation.
- [ ] `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --lib --features gui -- -D warnings` — installed clippy and ran it, but it failed on existing clippy warnings in `crates/warpui_core` unrelated to this change.
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Captured screenshots from local Warp find UI searching for `figma` in synthetic URL-containing terminal output after launching the local build with `WARP_SKIP_COMMON_SKILLS_INSTALL=1 /workspace/warp/script/run`. The exact staging shared conversation could not be opened directly in the local app because no URL-open flow was visible and the session was unauthenticated.

Screenshots were uploaded as Oz conversation artifacts:
- `warp_find_highlight_figma_1.png`
- `warp_find_highlight_figma_2.png`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed find highlighting for matches that appear inside rich-text links in AI block output.

_Conversation: https://staging.warp.dev/conversation/5c7e0c83-8804-4e5c-92ad-35c6996e046e_
_Run: https://oz.staging.warp.dev/runs/019e417c-1a7e-7d27-ae0d-b2ef13b9d042_
_This PR was generated with [Oz](https://warp.dev/oz)._
