### PR TITLE
Fix review comment routing to use visible terminal views only

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -7867,6 +7867,17 @@ impl PaneGroup {
             .collect()
     }
 
+    /// Returns terminal views from layout-tree-visible panes only.
+    /// Unlike `terminal_views()`, this excludes off-tree child agent panes
+    /// and panes hidden for any reason (temporary replacement, child agent, etc.).
+    pub fn visible_terminal_views(&self, ctx: &AppContext) -> Vec<ViewHandle<TerminalView>> {
+        self.panes
+            .visible_pane_ids()
+            .into_iter()
+            .filter_map(|pane_id| self.terminal_view_from_pane_id(pane_id, ctx))
+            .collect()
+    }
+
     pub fn code_views(&self, ctx: &AppContext) -> Vec<ViewHandle<CodeView>> {
         self.panes_of::<CodePane>()
             .map(|p| p.file_view(ctx))

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -1591,7 +1591,7 @@ impl RightPanelView {
         ai_enabled: bool,
         ctx: &AppContext,
     ) -> Option<ViewHandle<TerminalView>> {
-        let terminal_views = pane_group.read(ctx, |pg, ctx| pg.terminal_views(ctx));
+        let terminal_views = pane_group.read(ctx, |pg, ctx| pg.visible_terminal_views(ctx));
         let focused_terminal = pane_group.read(ctx, |pg, ctx| pg.focused_session_view(ctx));
         let pane_group_id = pane_group.id();
         let preferred_terminal_id = self


### PR DESCRIPTION
## Description

https://www.loom.com/share/df056a57d54e4390b4636451c4b11315

With orchestration, child agent panes are created off-tree (in `pane_contents` but not in the layout tree) and can be swapped into visible pane slots via the pill bar. The code review comment system was considering ALL non-close-hidden terminal panes when determining which terminal to submit comments to and whether the send button should be enabled. This meant invisible off-tree child agent panes could be selected as review targets.

**Fix:** Add `PaneGroup::visible_terminal_views()` which uses `visible_pane_ids()` (layout tree leaves minus all hidden panes) to return only user-visible terminal views. Update `find_review_terminal()` to use it instead of `terminal_views()`.

This ensures:
- Off-tree child agent panes are excluded from review comment candidates
- Swapped-in child agents (visible in the tree) are correctly included
- Swapped-out orchestrators (hidden as temporary replacements) are excluded

[Warp conversation](https://staging.warp.dev/conversation/8831cbc7-f743-42ef-8413-c4647dc22bb4) | [Plan](https://staging.warp.dev/drive/notebook/5nxXDSkG1SSIGJahE1blwc)

## Linked Issue

Closes APP-4539

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

CHANGELOG-BUG-FIX: Fixed code review comments being routed to invisible child agent terminals during orchestration
