### PR TITLE
Downgrade missing snapshot script error log

### DIFF
--- a/app/src/ai/agent_sdk/driver/snapshot.rs
+++ b/app/src/ai/agent_sdk/driver/snapshot.rs
@@ -124,10 +124,11 @@ struct FileDeclaration<'a> {
 /// from `task_id`. The script appends to the file if it already exists, so
 /// repeated invocations within a single run accumulate repos instead of clobbering.
 ///
-/// A missing env var, a missing script, a non-zero exit status, a spawn failure, or a runtime
-/// exceeding `script_timeout` are each logged at `log::error!` and returned without aborting the
-/// caller — if a previous invocation already produced a declarations file on disk it remains
-/// usable; otherwise the upload pipeline becomes a no-op.
+/// A missing env var is expected in some paths and is logged at `log::info!`. A missing script,
+/// a non-zero exit status, a spawn failure, or a runtime exceeding `script_timeout` are each
+/// logged at `log::error!` and returned without aborting the caller — if a previous invocation
+/// already produced a declarations file on disk it remains usable; otherwise the upload pipeline
+/// becomes a no-op.
 ///
 /// Exposed as a standalone helper so future call sites can trigger declarations generation at
 /// other points in the run lifecycle (e.g. periodic mid-run snapshots).
@@ -137,7 +138,7 @@ pub(super) async fn run_declarations_script(
     script_timeout: Duration,
 ) {
     let Some(script_path) = std::env::var_os(DECLARATIONS_SCRIPT_PATH_ENV_VAR) else {
-        log::error!(
+        log::info!(
             "{DECLARATIONS_SCRIPT_PATH_ENV_VAR} is not set; skipping snapshot declarations script (task {task_id})"
         );
         return;


### PR DESCRIPTION
## Description

It's expected that the snapshot declarations script won't always be available (for ex., when running an agent locally using the CLI), and we handle this case already by skipping snapshotting, so we can downgrade this to a regular info log (in case this comes up in debugging around missing snapshots and this info is useful to have).

As a side-note, users can also define their own snapshot scripts and expose them using this env variable so that we actually do do snapshotting for local CLI runs. I'll coordinate with @hongyi-chen about adding some docs for this, although I expect this to be a workflow that's only used by real oz power users.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/e1b66b0c-bbd1-4cda-a453-46c5009c435f_
_Run: https://oz.staging.warp.dev/runs/019e41bf-95b5-70f1-956f-07e6cd07faf0_

_This PR was generated with [Oz](https://warp.dev/oz)._
