### PR TITLE
Update add-on credits billing v2 UI

### DIFF
--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -1443,6 +1443,12 @@ impl BillingAndUsagePageV2View {
                 ])
                 .finish();
             upper_section.add_child(spend_row);
+
+            if let Some(purchased_row) =
+                Self::render_purchased_this_month_row(workspace, appearance)
+            {
+                upper_section.add_child(purchased_row);
+            }
         }
 
         if state.has_admin_permissions || !state.auto_reload_enabled {
@@ -1468,6 +1474,66 @@ impl BillingAndUsagePageV2View {
             .with_padding_top(16.)
             .with_padding_bottom(16.)
             .finish()
+    }
+
+    fn render_purchased_this_month_row(
+        workspace: &Workspace,
+        appearance: &Appearance,
+    ) -> Option<Box<dyn Element>> {
+        let bonus_grants = &workspace.bonus_grants_purchased_this_month;
+        if bonus_grants.total_credits_purchased == 0 {
+            return None;
+        }
+
+        let credits_purchased = bonus_grants.total_credits_purchased;
+        let cost_dollars = bonus_grants.cents_spent as f64 / 100.0;
+        let theme = appearance.theme();
+
+        let label = Text::new_inline("Purchased this month", appearance.ui_font_family(), 12.)
+            .with_color(theme.active_ui_text_color().into())
+            .finish();
+
+        let credits_text = if credits_purchased == 1 {
+            "1 credit".to_string()
+        } else {
+            format!("{} credits", credits_purchased.separate_with_commas())
+        };
+
+        let credits_component = Container::new(
+            Text::new_inline(credits_text, appearance.ui_font_family(), 12.)
+                .with_color(blended_colors::text_disabled(theme, theme.surface_1()))
+                .finish(),
+        )
+        .with_margin_right(8.)
+        .finish();
+
+        let cost_component = Text::new_inline(
+            format!("${cost_dollars:.2}"),
+            appearance.ui_font_family(),
+            12.,
+        )
+        .with_color(blended_colors::text_sub(theme, theme.surface_1()))
+        .finish();
+
+        Some(
+            Container::new(
+                Flex::row()
+                    .with_child(label)
+                    .with_child(
+                        Flex::row()
+                            .with_child(credits_component)
+                            .with_child(cost_component)
+                            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                            .finish(),
+                    )
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .finish(),
+            )
+            .with_margin_bottom(4.)
+            .finish(),
+        )
     }
 
     fn render_addon_credits_lower_section(
@@ -1517,37 +1583,6 @@ impl BillingAndUsagePageV2View {
             purchase_button = purchase_button.disable();
         }
         let purchase_button = purchase_button.finish();
-
-        let auto_reload_switch_element = {
-            let switch_builder = appearance
-                .ui_builder()
-                .switch(self.buy_credits_mouse_states.auto_reload_switch.clone())
-                .check(auto_reload_enabled);
-            if state.auto_reload_switch_disabled {
-                switch_builder.disable().build().finish()
-            } else {
-                switch_builder
-                    .build()
-                    .on_click(move |ctx, _, _| {
-                        ctx.dispatch_typed_action(
-                            BillingAndUsagePageAction::UpdateAutoReloadEnabled {
-                                team_uid,
-                                enabled: !auto_reload_enabled,
-                            },
-                        );
-                    })
-                    .finish()
-            }
-        };
-        let auto_reload_info_icon = render_info_icon(
-            appearance,
-            AdditionalInfo::<BillingAndUsagePageAction> {
-                mouse_state: self.buy_credits_mouse_states.auto_reload_info.clone(),
-                on_click_action: None,
-                secondary_text: None,
-                tooltip_override_text: Some(state.auto_reload_tooltip_text.clone()),
-            },
-        );
         let price_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_child(
@@ -1556,30 +1591,68 @@ impl BillingAndUsagePageV2View {
                     .with_style(Properties::default().weight(Weight::Medium))
                     .finish(),
             );
-        let right_group = Flex::row()
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_children([
+
+        let mut right_group = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
+        if state.has_admin_permissions {
+            let auto_reload_switch_element = {
+                let switch_builder = appearance
+                    .ui_builder()
+                    .switch(self.buy_credits_mouse_states.auto_reload_switch.clone())
+                    .check(auto_reload_enabled);
+                if state.auto_reload_switch_disabled {
+                    switch_builder.disable().build().finish()
+                } else {
+                    switch_builder
+                        .build()
+                        .on_click(move |ctx, _, _| {
+                            ctx.dispatch_typed_action(
+                                BillingAndUsagePageAction::UpdateAutoReloadEnabled {
+                                    team_uid,
+                                    enabled: !auto_reload_enabled,
+                                },
+                            );
+                        })
+                        .finish()
+                }
+            };
+            let auto_reload_info_icon = render_info_icon(
+                appearance,
+                AdditionalInfo::<BillingAndUsagePageAction> {
+                    mouse_state: self.buy_credits_mouse_states.auto_reload_info.clone(),
+                    on_click_action: None,
+                    secondary_text: None,
+                    tooltip_override_text: Some(state.auto_reload_tooltip_text.clone()),
+                },
+            );
+
+            right_group.add_child(
                 Text::new_inline("Auto-reload", appearance.ui_font_family(), 14.)
                     .with_color(fg.into())
                     .with_style(Properties::default().weight(Weight::Semibold))
                     .finish(),
+            );
+            right_group.add_child(
                 Container::new(auto_reload_info_icon)
                     .with_margin_left(4.)
                     .finish(),
+            );
+            right_group.add_child(
                 Container::new(auto_reload_switch_element)
                     .with_margin_left(8.)
                     .finish(),
-                Container::new(purchase_button)
-                    .with_margin_left(16.)
-                    .finish(),
-            ])
-            .finish();
+            );
+        }
+        right_group.add_child(
+            Container::new(purchase_button)
+                .with_margin_left(if state.has_admin_permissions { 16. } else { 0. })
+                .finish(),
+        );
         let lower_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
             .with_main_axis_size(MainAxisSize::Max)
             .with_child(price_row.finish())
-            .with_child(right_group);
+            .with_child(right_group.finish());
         let mut lower_children: Vec<Box<dyn Element>> = vec![lower_row.finish()];
 
         if let Some(warning_text) = state.warning_text {

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -1625,22 +1625,18 @@ impl BillingAndUsagePageV2View {
                 },
             );
 
-            right_group.add_child(
+            right_group.add_children([
                 Text::new_inline("Auto-reload", appearance.ui_font_family(), 14.)
                     .with_color(fg.into())
                     .with_style(Properties::default().weight(Weight::Semibold))
                     .finish(),
-            );
-            right_group.add_child(
                 Container::new(auto_reload_info_icon)
                     .with_margin_left(4.)
                     .finish(),
-            );
-            right_group.add_child(
                 Container::new(auto_reload_switch_element)
                     .with_margin_left(8.)
                     .finish(),
-            );
+            ]);
         }
         right_group.add_child(
             Container::new(purchase_button)

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -944,7 +944,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::CustomInferenceEndpoints,
     FeatureFlag::RemoteCodebaseIndexing,
     FeatureFlag::RemoteCodeReview,
-    FeatureFlag::BillingAndUsagePageV2,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -944,6 +944,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::CustomInferenceEndpoints,
     FeatureFlag::RemoteCodebaseIndexing,
     FeatureFlag::RemoteCodeReview,
+    FeatureFlag::BillingAndUsagePageV2,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Noticed two issues I'm fixing:
1. Admins should be able to see how much addon credits have been purchased so far this month. The billing and usage page V2 originally removed that, and I'm adding it back in to match the v1.
2. Don't show the autoreload button at all for non-admins. It's confusing to explain.

## Testing
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] I have manually tested my changes locally with `./script/run`

Ran `./script/run` locally to confirm the state of the new UI. Will attach screenshots below.

### Screenshots / Videos

Admin view:
<img width="840" height="295" alt="image" src="https://github.com/user-attachments/assets/50c3fb5b-3c70-4408-b7a7-72b5fa6a8399" />

Non-admin view:
Autoreload on:
<img width="858" height="118" alt="image" src="https://github.com/user-attachments/assets/f400b482-05ab-4d0a-b446-54f9be751141" />

Autoreload off:
<img width="855" height="252" alt="image" src="https://github.com/user-attachments/assets/141e7828-e0dc-4d88-88d0-7649f581f788" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/0b417c6f-313e-4350-b917-8d2509157cc9

Co-Authored-By: Oz <oz-agent@warp.dev>