### PR TITLE
Update orchestration launch modal "Learn more" link to canonical Oz post (#11284)

### DIFF
--- a/app/src/workspace/view/orchestration_launch_modal/view.rs
+++ b/app/src/workspace/view/orchestration_launch_modal/view.rs
@@ -20,7 +20,7 @@ use crate::view_components::action_button::{ActionButton, ActionButtonTheme, But
 const MODAL_WIDTH: f32 = 420.;
 const HERO_HEIGHT: f32 = 92.;
 const HERO_IMAGE_PATH: &str = "async/png/onboarding/orchestration_launch_banner.png";
-const LEARN_MORE_URL: &str = "https://www.warp.dev/blog/multi-harness-cloud-agent-orchestration";
+const LEARN_MORE_URL: &str = "https://www.warp.dev/blog/oz-orchestration-platform-cloud-agents";
 fn modal_background(appearance: &Appearance) -> Fill {
     appearance.theme().surface_3()
 }


### PR DESCRIPTION
Closes #11284

## Summary

The orchestration launch modal's `LEARN_MORE_URL` constant pointed at `/blog/multi-harness-cloud-agent-orchestration`, a pre-rename slug. The canonical Oz launch post lives at `/blog/oz-orchestration-platform-cloud-agents`, which matches the modal's content ("Introducing Oz: the orchestration platform for cloud agents").

At the time of the issue report the old URL returned 404; it currently returns 200 but resolves to a different (generic overview) post, not the launch announcement the modal is supposed to point at.

## What changed

One-character change to one constant in `app/src/workspace/view/orchestration_launch_modal/view.rs`:

```diff
- const LEARN_MORE_URL: &str = "https://www.warp.dev/blog/multi-harness-cloud-agent-orchestration";
+ const LEARN_MORE_URL: &str = "https://www.warp.dev/blog/oz-orchestration-platform-cloud-agents";
```

## Verification

The reporter asked to check for other pre-rename slugs in the same release-notes payload. Verified no other stale `warp.dev/blog/*` URLs exist in `app/src/workspace/view/`:

```
$ grep -rn "warp\.dev/blog/" app/src/workspace/view/
app/src/workspace/view/orchestration_launch_modal/view.rs:23: (the one updated here)
```

The other launch modals (`openwarp_launch_modal`, `launch_modal/oz_launch.rs`) only reference `oz.warp.dev` (live) and `github.com/warpdotdev/warp` (live). no stale blog slugs.

URL responses verified at submission time:

```
$ curl -sI https://www.warp.dev/blog/oz-orchestration-platform-cloud-agents | head -1
HTTP/2 200
```

Title: "Introducing Oz: the orchestration platform for cloud agents | Warp"