### PR TITLE
[APP-4553] Defer undo-close cleanup during pane view updates

### DIFF
--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -1094,6 +1094,19 @@ fn test_restore_closed_pane_restores_hidden_child_when_parent_is_already_fullscr
 }
 
 #[test]
+fn test_undo_close_cleanup_defers_when_pane_group_is_updating() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+        let pane_group_for_cleanup = pane_group.clone();
+
+        pane_group.update(&mut app, |_, ctx| {
+            UndoCloseStack::clean_up_pane_group_for_test(&pane_group_for_cleanup, ctx);
+        });
+    });
+}
+
+#[test]
 fn test_replace_pane_restores_hidden_child_when_replacement_is_already_fullscreen() {
     let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 

--- a/app/src/undo_close/stack.rs
+++ b/app/src/undo_close/stack.rs
@@ -137,15 +137,43 @@ impl ClosedItem {
     }
 
     fn clean_up_pane_group(pane_group: &ViewHandle<PaneGroup>, ctx: &mut AppContext) {
+        Self::clean_up_pane_group_impl(pane_group, ctx, true);
+    }
+
+    fn clean_up_pane_group_impl(
+        pane_group: &ViewHandle<PaneGroup>,
+        ctx: &mut AppContext,
+        allow_defer: bool,
+    ) {
         let window_id = pane_group.window_id(ctx);
 
         if !ctx.is_window_open(window_id) {
             return;
         }
 
-        pane_group.update(ctx, |pane_group, ctx| {
-            pane_group.clean_up_panes(ctx);
-        });
+        if ctx
+            .view_with_id::<PaneGroup>(window_id, pane_group.id())
+            .is_some()
+        {
+            pane_group.update(ctx, |pane_group, ctx| {
+                pane_group.clean_up_panes(ctx);
+            });
+        } else if allow_defer {
+            let pane_group = pane_group.clone();
+            ctx.defer(move |ctx| {
+                Self::clean_up_pane_group_impl(&pane_group, ctx, false);
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+impl UndoCloseStack {
+    pub(crate) fn clean_up_pane_group_for_test(
+        pane_group: &ViewHandle<PaneGroup>,
+        ctx: &mut AppContext,
+    ) {
+        ClosedItem::clean_up_pane_group(pane_group, ctx);
     }
 }
 

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -1091,6 +1091,13 @@ impl AppContext {
         self.first_frame_callback = Some(Box::new(callback));
     }
 
+    /// Runs a callback after the current update finishes and pending effects are flushed.
+    pub fn defer<F: 'static + FnOnce(&mut AppContext)>(&mut self, callback: F) {
+        self.pending_effects.push_back(Effect::Deferred {
+            callback: Box::new(callback),
+        });
+    }
+
     ///  Callback that is called whenever a frame is successfully drawn.
     pub fn on_frame_drawn<F: 'static + Fn(&mut AppContext, WindowId)>(&mut self, callback: F) {
         self.frame_drawn_callback = Some(Box::new(callback));
@@ -3156,6 +3163,9 @@ impl AppContext {
                         arg,
                     } => {
                         self.dispatch_global_action_internal(name, location, arg.as_ref());
+                    }
+                    Effect::Deferred { callback } => {
+                        callback(self);
                     }
                 }
 

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -230,6 +230,9 @@ pub enum Effect {
         location: &'static std::panic::Location<'static>,
         arg: Box<dyn Any>,
     },
+    Deferred {
+        callback: Box<dyn FnOnce(&mut AppContext)>,
+    },
 }
 
 pub trait AnyView {


### PR DESCRIPTION
## Description
Fixes a crash where undo-close cleanup could attempt to update a PaneGroup while that same PaneGroup was already removed from AppContext for an active view update.

The cleanup path now checks whether the PaneGroup is currently materialized before updating it. If the view is temporarily unavailable, cleanup is deferred through AppContext's effect queue and retried after the current update finishes.

## Linked Issue
APP-4553

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt`
- [x] `cargo test -p warp test_undo_close_cleanup_defers_when_pane_group_is_updating`
- [x] `cargo clippy -p warp --all-targets -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a crash that could happen while cleaning up recently closed panes after an agent interaction.

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._