### PR TITLE
Add Reveal in Project Explorer to editor menu

### DIFF
--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -740,32 +740,36 @@ impl FileTreeView {
         // When a file is focused, scroll to show it in the file tree
         match event {
             ActiveFileEvent::ActiveFileChanged { location } => {
-                let file_std = match location {
-                    crate::code::buffer_location::LocalOrRemotePath::Local(path) => {
-                        match StandardizedPath::try_from_local(path) {
-                            Ok(std_path) => std_path,
-                            Err(_) => return,
-                        }
-                    }
-                    crate::code::buffer_location::LocalOrRemotePath::Remote(remote) => {
-                        remote.path.clone()
-                    }
-                };
-                // Prefer the currently-selected item's root if the file lives under it;
-                // otherwise fall back to the deepest matching root directory.
-                let repository_root = self
-                    .selected_item
-                    .as_ref()
-                    .filter(|id| file_std.starts_with(&id.root))
-                    .map(|id| id.root.clone())
-                    .or_else(|| self.find_deepest_root_for_file(&file_std));
-
-                let Some(repository_root) = repository_root else {
-                    return;
-                };
-                self.scroll_to_file(&repository_root, &file_std, ctx);
+                self.reveal_location(location, ctx);
             }
         }
+    }
+
+    fn standardized_path_for_location(location: &LocalOrRemotePath) -> Option<StandardizedPath> {
+        match location {
+            LocalOrRemotePath::Local(path) => StandardizedPath::try_from_local(path).ok(),
+            LocalOrRemotePath::Remote(remote) => Some(remote.path.clone()),
+        }
+    }
+
+    pub fn reveal_location(&mut self, location: &LocalOrRemotePath, ctx: &mut ViewContext<Self>) {
+        let Some(file_std) = Self::standardized_path_for_location(location) else {
+            return;
+        };
+
+        // Prefer the currently-selected item's root if the file lives under it;
+        // otherwise fall back to the deepest matching root directory.
+        let repository_root = self
+            .selected_item
+            .as_ref()
+            .filter(|id| file_std.starts_with(&id.root))
+            .map(|id| id.root.clone())
+            .or_else(|| self.find_deepest_root_for_file(&file_std));
+
+        let Some(repository_root) = repository_root else {
+            return;
+        };
+        self.scroll_to_file(&repository_root, &file_std, ctx);
     }
 
     /// Finds the deepest root directory that contains the given file path.

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -163,6 +163,9 @@ pub enum CodeViewAction {
     ToggleMaximized,
     #[cfg(feature = "local_fs")]
     CopyFilePath,
+    /// Reveal the active code tab's file in the Project Explorer.
+    #[cfg(feature = "local_fs")]
+    RevealInProjectExplorer,
     /// Open the active code tab's file in the platform's file manager
     /// (Finder on macOS, Explorer on Windows). No-op when the active tab has
     /// no resolvable local path.
@@ -656,6 +659,11 @@ impl CodeView {
                     .map(|p| p.to_path_buf())
             })
         })
+    }
+
+    fn active_tab_location(&self) -> Option<LocalOrRemotePath> {
+        self.tab_at(self.active_tab_index)
+            .and_then(|tab| tab.location.clone())
     }
 
     pub fn pane_configuration(&self) -> ModelHandle<PaneConfiguration> {
@@ -2024,7 +2032,7 @@ impl CodeView {
         ];
 
         #[cfg(feature = "local_fs")]
-        if let Some(path) = self.local_path(ctx) {
+        {
             let reveal_label = if cfg!(target_os = "macos") {
                 "Reveal in Finder"
             } else if cfg!(target_os = "windows") {
@@ -2032,22 +2040,38 @@ impl CodeView {
             } else {
                 "Reveal in file manager"
             };
-            items.extend([
-                MenuItem::Separator,
-                MenuItemFields::new("Copy file path")
-                    .with_on_select_action(CodeViewAction::CopyFilePath)
-                    .into_item(),
-                MenuItemFields::new(reveal_label)
-                    .with_on_select_action(CodeViewAction::RevealInFinder)
-                    .into_item(),
-            ]);
 
-            if is_markdown_file(&path) {
-                items.push(
-                    MenuItemFields::new("View Markdown preview")
-                        .with_on_select_action(CodeViewAction::RenderMarkdown)
+            let mut file_items = Vec::new();
+            if self.active_tab_location().is_some() {
+                file_items.push(
+                    MenuItemFields::new("Reveal in Project Explorer")
+                        .with_on_select_action(CodeViewAction::RevealInProjectExplorer)
                         .into_item(),
                 );
+            }
+
+            if let Some(path) = self.local_path(ctx) {
+                file_items.extend([
+                    MenuItemFields::new("Copy file path")
+                        .with_on_select_action(CodeViewAction::CopyFilePath)
+                        .into_item(),
+                    MenuItemFields::new(reveal_label)
+                        .with_on_select_action(CodeViewAction::RevealInFinder)
+                        .into_item(),
+                ]);
+
+                if is_markdown_file(&path) {
+                    file_items.push(
+                        MenuItemFields::new("View Markdown preview")
+                            .with_on_select_action(CodeViewAction::RenderMarkdown)
+                            .into_item(),
+                    );
+                }
+            }
+
+            if !file_items.is_empty() {
+                items.push(MenuItem::Separator);
+                items.extend(file_items);
             }
         }
 
@@ -2198,6 +2222,18 @@ impl TypedActionView for CodeView {
                 if let Some(path) = self.local_path(ctx) {
                     ctx.clipboard()
                         .write(ClipboardContent::plain_text(path.display().to_string()));
+                }
+            }
+            #[cfg(feature = "local_fs")]
+            CodeViewAction::RevealInProjectExplorer => {
+                if let Some(location) = self.active_tab_location() {
+                    ctx.dispatch_typed_action(&WorkspaceAction::RevealFileInProjectExplorer {
+                        location,
+                    });
+                } else {
+                    log::warn!(
+                        "Reveal in Project Explorer requested, but the active code tab has no file location"
+                    );
                 }
             }
             #[cfg(feature = "local_fs")]

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -10,6 +10,8 @@ use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentVersion};
 use crate::auth::auth_manager::LoginGatedFeature;
+#[cfg(feature = "local_fs")]
+use crate::code::buffer_location::LocalOrRemotePath;
 use crate::drive::items::WarpDriveItemId;
 use crate::drive::CloudObjectTypeAndId;
 use crate::palette::PaletteMode;
@@ -568,6 +570,10 @@ pub enum WorkspaceAction {
     NavigatePrevPaneOrPanel,
     NavigateNextPaneOrPanel,
     ToggleProjectExplorer,
+    #[cfg(feature = "local_fs")]
+    RevealFileInProjectExplorer {
+        location: LocalOrRemotePath,
+    },
     ToggleGlobalSearch,
     OpenGlobalSearch,
     ToggleConversationListView,
@@ -981,6 +987,8 @@ impl WorkspaceAction {
             | ShowCloudModeV2EnvironmentCreationModal
             | OpenCreateAuthSecretModal { .. }
             | OpenNetworkLogPane => false,
+            #[cfg(feature = "local_fs")]
+            RevealFileInProjectExplorer { .. } => false,
             #[cfg(debug_assertions)]
             ShowHoaOnboardingFlow => false,
             #[cfg(target_family = "wasm")]

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -22982,6 +22982,15 @@ impl TypedActionView for Workspace {
                     self.toggle_left_panel_view(&LeftPanelAction::ProjectExplorer, is_showing, ctx);
                 }
             }
+            #[cfg(feature = "local_fs")]
+            RevealFileInProjectExplorer { location } => {
+                if *CodeSettings::as_ref(ctx).show_project_explorer {
+                    self.open_left_panel_view(&LeftPanelAction::ProjectExplorer, ctx);
+                    self.left_panel_view.update(ctx, |left_panel, ctx| {
+                        left_panel.reveal_file_in_project_explorer(location, ctx);
+                    });
+                }
+            }
             ToggleWarpDrive => {
                 if WarpDriveSettings::is_warp_drive_enabled(ctx) {
                     let is_showing =

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -687,6 +687,20 @@ impl LeftPanelView {
         }
     }
 
+    pub fn reveal_file_in_project_explorer(
+        &mut self,
+        location: &LocalOrRemotePath,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        active_view_state::set(self, ToolPanelView::ProjectExplorer, ctx);
+        if let Some(file_tree_view) = self.active_file_tree_view(ctx) {
+            file_tree_view.update(ctx, |view, ctx| {
+                view.reveal_location(location, ctx);
+            });
+            ctx.focus(&file_tree_view);
+        }
+    }
+
     #[cfg(not(feature = "local_fs"))]
     fn handle_global_search_event(
         &mut self,


### PR DESCRIPTION
## Description
Adds a `Reveal in Project Explorer` option to the code editor overflow menu. The action opens the Project Explorer without toggling it closed, switches the left panel to Project Explorer, and directly selects/scrolls the current editor file into view.

## Linked Issue
Slack feedback thread in `#feedback-app`.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path app/Cargo.toml`
- `cargo fmt --manifest-path app/Cargo.toml --check`
- `cargo check --manifest-path app/Cargo.toml --lib`
- Attempted `./script/wasm/bundle --check-only --debug --channel local`; this failed in the sandbox while compiling dependencies with `can't find crate for core/std` for `wasm32-unknown-unknown`, even after installing the target. A minimal wasm Cargo smoke test outside the repo passed.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; manual GUI verification was not available in this sandbox.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a Reveal in Project Explorer action to the file editor menu.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/57a7b8f1-14dc-4307-8d18-24174d00736f_
_Run: https://oz.staging.warp.dev/runs/019e4221-cf45-7525-b129-d128277d6a71_
_This PR was generated with [Oz](https://warp.dev/oz)._
