### PR TITLE
Block secrets when adding MCP servers

### DIFF
--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -529,12 +529,12 @@ impl MCPServersEditPageView {
         footer.finish()
     }
 
-    fn detect_secrets_in_templatable_mcp_server(
+    fn detect_secrets_in_parsed_templatable_mcp_server(
         &self,
         ctx: &mut ViewContext<Self>,
-        templatable_mcp_server: &TemplatableMCPServer,
+        parsed_templatable_mcp_server: &ParsedTemplatableMCPServerResult,
     ) -> Result<(), String> {
-        if Self::templatable_mcp_server_contains_secrets(templatable_mcp_server) {
+        if Self::parsed_templatable_mcp_server_contains_secrets(parsed_templatable_mcp_server) {
             let window_id = ctx.window_id();
             ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                 toast_stack.add_ephemeral_toast(
@@ -553,6 +553,22 @@ impl MCPServersEditPageView {
         templatable_mcp_server: &TemplatableMCPServer,
     ) -> bool {
         !find_secrets_in_text(&templatable_mcp_server.template.json).is_empty()
+    }
+
+    fn parsed_templatable_mcp_server_contains_secrets(
+        parsed_templatable_mcp_server: &ParsedTemplatableMCPServerResult,
+    ) -> bool {
+        if Self::templatable_mcp_server_contains_secrets(
+            &parsed_templatable_mcp_server.templatable_mcp_server,
+        ) {
+            return true;
+        }
+
+        parsed_templatable_mcp_server
+            .templatable_mcp_server_installation
+            .as_ref()
+            .map(resolve_json)
+            .is_some_and(|resolved_json| !find_secrets_in_text(&resolved_json).is_empty())
     }
 
     fn parse_templatable_json(
@@ -578,9 +594,9 @@ impl MCPServersEditPageView {
             };
 
         for parsed_templatable_mcp_server_result in parsed_templatable_mcp_servers.iter() {
-            self.detect_secrets_in_templatable_mcp_server(
+            self.detect_secrets_in_parsed_templatable_mcp_server(
                 ctx,
-                &parsed_templatable_mcp_server_result.templatable_mcp_server,
+                parsed_templatable_mcp_server_result,
             )?;
         }
 

--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -534,10 +534,7 @@ impl MCPServersEditPageView {
         ctx: &mut ViewContext<Self>,
         templatable_mcp_server: &TemplatableMCPServer,
     ) -> Result<(), String> {
-        let contains_secrets =
-            !find_secrets_in_text(&templatable_mcp_server.template.json).is_empty();
-
-        if contains_secrets {
+        if Self::templatable_mcp_server_contains_secrets(templatable_mcp_server) {
             let window_id = ctx.window_id();
             ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                 toast_stack.add_ephemeral_toast(
@@ -552,42 +549,44 @@ impl MCPServersEditPageView {
         Ok(())
     }
 
+    fn templatable_mcp_server_contains_secrets(
+        templatable_mcp_server: &TemplatableMCPServer,
+    ) -> bool {
+        !find_secrets_in_text(&templatable_mcp_server.template.json).is_empty()
+    }
+
     fn parse_templatable_json(
         &self,
         ctx: &mut ViewContext<Self>,
         json: &str,
-    ) -> Vec<ParsedTemplatableMCPServerResult> {
+    ) -> Result<Vec<ParsedTemplatableMCPServerResult>, String> {
         let parsed_templatable_mcp_servers =
             match ParsedTemplatableMCPServerResult::from_user_json(json) {
                 Ok(parsed_servers) => parsed_servers,
                 Err(error) => {
+                    let error = error.to_string();
                     let window_id = ctx.window_id();
                     ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                         toast_stack.add_ephemeral_toast(
-                            DismissibleToast::error(error.to_string()),
+                            DismissibleToast::error(error.clone()),
                             window_id,
                             ctx,
                         );
                     });
-                    return vec![];
+                    return Err(error);
                 }
             };
 
         for parsed_templatable_mcp_server_result in parsed_templatable_mcp_servers.iter() {
-            if self
-                .detect_secrets_in_templatable_mcp_server(
-                    ctx,
-                    &parsed_templatable_mcp_server_result.templatable_mcp_server,
-                )
-                .is_err()
-            {
-                return vec![];
-            }
+            self.detect_secrets_in_templatable_mcp_server(
+                ctx,
+                &parsed_templatable_mcp_server_result.templatable_mcp_server,
+            )?;
         }
 
         // TODO(Pei): Stop and start servers
 
-        parsed_templatable_mcp_servers
+        Ok(parsed_templatable_mcp_servers)
     }
 
     fn build_templatable_mcp_server_result_from_json(
@@ -595,7 +594,7 @@ impl MCPServersEditPageView {
         ctx: &mut ViewContext<Self>,
         json: &str,
     ) -> Result<ParsedTemplatableMCPServerResult, String> {
-        let parsed_templatable_mcp_servers = self.parse_templatable_json(ctx, json);
+        let parsed_templatable_mcp_servers = self.parse_templatable_json(ctx, json)?;
 
         if parsed_templatable_mcp_servers.is_empty() {
             let window_id = ctx.window_id();
@@ -878,21 +877,9 @@ impl TypedActionView for MCPServersEditPageView {
                     // This is a new MCP server, we should treat it like a legacy MCP server
                     let json = self.json_editor.as_ref(ctx).text(ctx).into_string();
 
-                    let parsed_servers =
-                        match ParsedTemplatableMCPServerResult::from_user_json(&json) {
-                            Ok(parsed_templatable_mcp_servers) => parsed_templatable_mcp_servers,
-                            Err(error) => {
-                                let window_id = ctx.window_id();
-                                ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                                    toast_stack.add_ephemeral_toast(
-                                        DismissibleToast::error(error.to_string()),
-                                        window_id,
-                                        ctx,
-                                    );
-                                });
-                                return;
-                            }
-                        };
+                    let Ok(parsed_servers) = self.parse_templatable_json(ctx, &json) else {
+                        return;
+                    };
 
                     if parsed_servers.is_empty() {
                         let window_id = ctx.window_id();
@@ -952,3 +939,7 @@ impl TypedActionView for MCPServersEditPageView {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "edit_page_tests.rs"]
+mod tests;

--- a/app/src/settings_view/mcp_servers/edit_page_tests.rs
+++ b/app/src/settings_view/mcp_servers/edit_page_tests.rs
@@ -25,9 +25,59 @@ fn parsed_mcp_server_with_secret_in_args_is_detected() {
 
     assert_eq!(parsed_servers.len(), 1);
     assert!(
-        MCPServersEditPageView::templatable_mcp_server_contains_secrets(
-            &parsed_servers[0].templatable_mcp_server
-        )
+        MCPServersEditPageView::parsed_templatable_mcp_server_contains_secrets(&parsed_servers[0])
+    );
+}
+
+#[test]
+#[serial]
+fn parsed_mcp_server_with_secret_in_env_is_detected() {
+    secrets::set_user_and_enterprise_secret_regexes(
+        [&Regex::new("sk-test-secret-11265").expect("regex should compile")],
+        std::iter::empty(),
+    );
+
+    let parsed_servers = ParsedTemplatableMCPServerResult::from_user_json(
+        r#"{
+            "demo-env-server": {
+                "command": "/usr/bin/true",
+                "env": {
+                    "API_KEY": "sk-test-secret-11265"
+                }
+            }
+        }"#,
+    )
+    .expect("valid MCP server JSON should parse");
+
+    assert_eq!(parsed_servers.len(), 1);
+    assert!(
+        MCPServersEditPageView::parsed_templatable_mcp_server_contains_secrets(&parsed_servers[0])
+    );
+}
+
+#[test]
+#[serial]
+fn parsed_mcp_server_with_secret_in_headers_is_detected() {
+    secrets::set_user_and_enterprise_secret_regexes(
+        [&Regex::new("sk-test-secret-11265").expect("regex should compile")],
+        std::iter::empty(),
+    );
+
+    let parsed_servers = ParsedTemplatableMCPServerResult::from_user_json(
+        r#"{
+            "demo-http-server": {
+                "url": "https://example.com/mcp",
+                "headers": {
+                    "Authorization": "Bearer sk-test-secret-11265"
+                }
+            }
+        }"#,
+    )
+    .expect("valid MCP server JSON should parse");
+
+    assert_eq!(parsed_servers.len(), 1);
+    assert!(
+        MCPServersEditPageView::parsed_templatable_mcp_server_contains_secrets(&parsed_servers[0])
     );
 }
 
@@ -51,8 +101,6 @@ fn parsed_mcp_server_without_secrets_is_allowed() {
 
     assert_eq!(parsed_servers.len(), 1);
     assert!(
-        !MCPServersEditPageView::templatable_mcp_server_contains_secrets(
-            &parsed_servers[0].templatable_mcp_server
-        )
+        !MCPServersEditPageView::parsed_templatable_mcp_server_contains_secrets(&parsed_servers[0])
     );
 }

--- a/app/src/settings_view/mcp_servers/edit_page_tests.rs
+++ b/app/src/settings_view/mcp_servers/edit_page_tests.rs
@@ -1,0 +1,58 @@
+use regex::Regex;
+use serial_test::serial;
+
+use crate::{ai::mcp::parsing::ParsedTemplatableMCPServerResult, terminal::model::secrets};
+
+use super::MCPServersEditPageView;
+
+#[test]
+#[serial]
+fn parsed_mcp_server_with_secret_in_args_is_detected() {
+    secrets::set_user_and_enterprise_secret_regexes(
+        [&Regex::new("sk-test-secret-11265").expect("regex should compile")],
+        std::iter::empty(),
+    );
+
+    let parsed_servers = ParsedTemplatableMCPServerResult::from_user_json(
+        r#"{
+            "demo-new-server-bypass": {
+                "command": "/usr/bin/true",
+                "args": ["--api-key=sk-test-secret-11265"]
+            }
+        }"#,
+    )
+    .expect("valid MCP server JSON should parse");
+
+    assert_eq!(parsed_servers.len(), 1);
+    assert!(
+        MCPServersEditPageView::templatable_mcp_server_contains_secrets(
+            &parsed_servers[0].templatable_mcp_server
+        )
+    );
+}
+
+#[test]
+#[serial]
+fn parsed_mcp_server_without_secrets_is_allowed() {
+    secrets::set_user_and_enterprise_secret_regexes(
+        [&Regex::new("sk-test-secret-11265").expect("regex should compile")],
+        std::iter::empty(),
+    );
+
+    let parsed_servers = ParsedTemplatableMCPServerResult::from_user_json(
+        r#"{
+            "demo-clean-server": {
+                "command": "/usr/bin/true",
+                "args": ["--version"]
+            }
+        }"#,
+    )
+    .expect("valid MCP server JSON should parse");
+
+    assert_eq!(parsed_servers.len(), 1);
+    assert!(
+        !MCPServersEditPageView::templatable_mcp_server_contains_secrets(
+            &parsed_servers[0].templatable_mcp_server
+        )
+    );
+}


### PR DESCRIPTION
## Description

Routes the `+ Add` MCP server save path through the same templatable JSON parsing and secret detection flow used by existing-server edits.

This closes the local redaction bypass where new MCP servers called `ParsedTemplatableMCPServerResult::from_user_json` directly and could proceed to create/sync before the local secret toast was shown.

I also changed `parse_templatable_json` to return an error on parse/secret failures instead of collapsing those failures into an empty result, so callers do not stack an unrelated "No MCP Server specified" toast after the actionable parse/secret toast.

## Linked Issue

Closes #11265

- [x] The linked issue is labeled `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] Added regression coverage for parsed MCP server secret detection with a secret in `args`.
- [x] `cargo fmt --check`
- [ ] I have manually tested my changes locally with `./script/run`

Attempted:

```sh
cargo test -p warp parsed_mcp_server --lib
```

This local machine cannot complete the app test build because `warpui` requires Apple's `metal` compiler and the machine only has Command Line Tools installed:

```text
xcrun: error: unable to find utility "metal", not a developer tool or in PATH
```

### Screenshots / Videos

Not included because I could not run the app locally without the full Xcode Metal toolchain.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Block secret-containing MCP server configs when adding a new server from JSON.
