### PR TITLE
fix(mcp): run secret-redaction predicate on the new-server '+ Add' save path (#11265)

### DIFF
--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -26,6 +26,8 @@ use warpui::{
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
+use settings::Setting as _;
+
 use crate::ai::blocklist::secret_redaction::find_secrets_in_text;
 use crate::ai::mcp::parsing::{prettify_json, resolve_json, ParsedTemplatableMCPServerResult};
 use crate::ai::mcp::templatable::CloudTemplatableMCPServer;
@@ -46,6 +48,7 @@ use crate::settings_view::mcp_servers::destructive_mcp_confirmation_dialog::{
     DestructiveMCPConfirmationDialogVariant,
 };
 use crate::settings_view::mcp_servers::{style, ServerCardItemId};
+use crate::terminal::safe_mode_settings::SafeModeSettings;
 use crate::ui_components::buttons::icon_button;
 use crate::ui_components::icons::Icon;
 use crate::view_components::action_button::{
@@ -53,6 +56,7 @@ use crate::view_components::action_button::{
 };
 use crate::view_components::DismissibleToast;
 use crate::workspace::ToastStack;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::GlobalResourceHandlesProvider;
 
 const DEFAULT_JSON_TEXT: &str = r#"{
@@ -525,22 +529,26 @@ impl MCPServersEditPageView {
         ctx: &mut ViewContext<Self>,
         templatable_mcp_server: &TemplatableMCPServer,
     ) -> Result<(), String> {
+        let safe_mode_enabled = *SafeModeSettings::as_ref(ctx).safe_mode_enabled.value();
+        let enterprise_enforced =
+            UserWorkspaces::as_ref(ctx).is_enterprise_secret_redaction_enabled();
         let contains_secrets =
             !find_secrets_in_text(&templatable_mcp_server.template.json).is_empty();
 
-        if contains_secrets {
-            let window_id = ctx.window_id();
-            ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                toast_stack.add_ephemeral_toast(
-                    DismissibleToast::error("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string()),
-                    window_id,
-                    ctx,
-                );
-            });
-            return Err("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string());
+        if !should_block_save_for_secrets(safe_mode_enabled, enterprise_enforced, contains_secrets)
+        {
+            return Ok(());
         }
 
-        Ok(())
+        let window_id = ctx.window_id();
+        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            toast_stack.add_ephemeral_toast(
+                DismissibleToast::error("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string()),
+                window_id,
+                ctx,
+            );
+        });
+        Err("This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings.".to_string())
     }
 
     fn parse_templatable_json(
@@ -941,5 +949,72 @@ impl TypedActionView for MCPServersEditPageView {
                 }
             }
         }
+    }
+}
+
+/// Decide whether to block saving an MCP server config because secret
+/// redaction is in force AND the parsed config contains secret-shaped strings.
+///
+/// We block only when redaction is actually active — either the user-level
+/// Settings > Privacy > Secret redaction toggle is on, or the user's workspace
+/// has enterprise enforcement enabled. With both off, the user has explicitly
+/// opted to embed secrets in the config and we save it as written (#8761).
+fn should_block_save_for_secrets(
+    safe_mode_enabled: bool,
+    enterprise_enforced: bool,
+    contains_secrets: bool,
+) -> bool {
+    (safe_mode_enabled || enterprise_enforced) && contains_secrets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_block_save_for_secrets;
+
+    /// #8761: with redaction disabled and no enterprise enforcement, saving a
+    /// config that contains secrets must NOT be blocked.
+    #[test]
+    fn does_not_block_when_redaction_off_even_if_secrets_present() {
+        assert!(!should_block_save_for_secrets(false, false, true));
+    }
+
+    /// User-level toggle on AND secrets present → block. This is the case the
+    /// original check was written to catch; the redaction-aware predicate
+    /// must preserve it.
+    #[test]
+    fn blocks_when_user_redaction_on_and_secrets_present() {
+        assert!(should_block_save_for_secrets(true, false, true));
+    }
+
+    /// Enterprise enforcement alone is enough to gate the save, even if the
+    /// user toggled their personal redaction off — orgs that mandate redaction
+    /// must not be bypassed at the MCP-config layer.
+    #[test]
+    fn blocks_when_enterprise_enforced_and_secrets_present() {
+        assert!(should_block_save_for_secrets(false, true, true));
+    }
+
+    /// Configs without any detected secrets are never blocked, regardless of
+    /// the redaction-toggle state. The check is purely a guard against
+    /// accidentally persisting secrets — it has nothing to add when none exist.
+    #[test]
+    fn does_not_block_when_no_secrets_regardless_of_toggle() {
+        for safe_mode in [false, true] {
+            for enterprise in [false, true] {
+                assert!(
+                    !should_block_save_for_secrets(safe_mode, enterprise, false),
+                    "expected no block when contains_secrets=false \
+                     (safe_mode={safe_mode}, enterprise={enterprise})",
+                );
+            }
+        }
+    }
+
+    /// Both toggles on AND secrets present → block. Defensive: equivalent to
+    /// either one being on, but exhaustively pinned for the full 2x2x2 sweep
+    /// of (safe_mode, enterprise, contains_secrets).
+    #[test]
+    fn blocks_when_both_redactions_on_and_secrets_present() {
+        assert!(should_block_save_for_secrets(true, true, true));
     }
 }

--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -905,6 +905,23 @@ impl TypedActionView for MCPServersEditPageView {
                         return;
                     }
 
+                    // Run the same secret-redaction predicate that gates the
+                    // edit-existing save path. Without this loop the new-server
+                    // (`+ Add`) save bypasses `parse_templatable_json` (where
+                    // the predicate is wired) and ignores Settings → Privacy
+                    // → Secret redaction entirely (#11265).
+                    for parsed_server in &parsed_servers {
+                        if self
+                            .detect_secrets_in_templatable_mcp_server(
+                                ctx,
+                                &parsed_server.templatable_mcp_server,
+                            )
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+
                     for parsed_server in parsed_servers {
                         TemplatableMCPServerManager::handle(ctx).update(
                             ctx,


### PR DESCRIPTION
## Description

The new-MCP-server save branch in `MCPServersEditPageView::handle_action` calls `ParsedTemplatableMCPServerResult::from_user_json(&json)` directly and skips `parse_templatable_json` — which is where #10839's predicate (`detect_secrets_in_templatable_mcp_server` → `should_block_save_for_secrets`) is invoked. As a result, a config pasted into the **+ Add** dialog and saved bypasses the redaction check entirely, even with `Settings → Privacy → Secret redaction` enabled or enterprise enforcement active. The same JSON saved via the **edit-existing** flow is correctly blocked.

## Fix

Mirror the existing per-parsed-server detection loop from `parse_templatable_json` into the new-server branch in [`app/src/settings_view/mcp_servers/edit_page.rs`](app/src/settings_view/mcp_servers/edit_page.rs):

```rust
// Run the same secret-redaction predicate that gates the
// edit-existing save path. Without this loop the new-server
// (`+ Add`) save bypasses `parse_templatable_json` (where
// the predicate is wired) and ignores Settings → Privacy
// → Secret redaction entirely (#11265).
for parsed_server in &parsed_servers {
    if self
        .detect_secrets_in_templatable_mcp_server(
            ctx,
            &parsed_server.templatable_mcp_server,
        )
        .is_err()
    {
        return;
    }
}
```

The predicate itself (added in #10839 with the truth-table tests) is unchanged — this PR closes the gap by routing the `+ Add` path through it. Net diff: **+17 / -0 lines**.

## Stacked on #10839

This PR depends on `should_block_save_for_secrets` and `detect_secrets_in_templatable_mcp_server` from #10839. The branch was cut from `david/8761-mcp-secret-redaction-config-save` (the #10839 branch); once #10839 merges, the GitHub diff here will narrow to just the new-server-branch loop.

## Demo — fix in action

![#11360 fix in action](https://raw.githubusercontent.com/david-engelmann/warp-taper/main/docs/evidence/11360-mcp-add-server-fix/master.gif)

End-to-end Settings UI recording demonstrating the fix. Build state for this recording: PR #10839's predicate + this PR's new-server detection loop + DEMO-PATCH-B (so `SECRETS_REGEX` recompiles when the toggle is flipped — needed to demonstrate this PR's fix in isolation; the underlying recompile gap is tracked at #11262). The token sits in the top-level `url` to keep the demo isolated from #11263's env/headers templatization gap.

- **A** Settings → Privacy → Secret redaction toggle normalized to OFF.
- **B** Click toggle ON → "Secret visual redaction mode" dropdown appears (visual proof `safe_mode_enabled = true` at runtime).
- **C** Settings → MCP Servers → `+ Add` → paste a config with `sk-FAKE0000000000FAKEdemoWARP11360fix` in the top-level `url`.
- **D** Click Save → error toast appears: *"This MCP server contains secrets. Visit Settings > Privacy to modify your secret redaction settings."* The modal stays open with the secret-bearing JSON; no entry lands in `MY MCPS`.

Recipe: [`scripts/recipes/11360-mcp-add-server-fix.json`](https://github.com/david-engelmann/warp-taper/blob/main/scripts/recipes/11360-mcp-add-server-fix.json), driven by [`scripts/warp-driver.swift`](https://github.com/david-engelmann/warp-taper/blob/main/scripts/warp-driver.swift) (OCR-gated, no manual driving).

## Demo — pre-fix bypass (for contrast)

The earlier reproduction recording shows the same save proceeding silently against the unpatched build:

![#11265 reproduction](https://raw.githubusercontent.com/david-engelmann/warp-taper/main/docs/evidence/11265-mcp-add-server-bypass/master.gif)

Build state: DEMO-PATCH-B + DEMO-PATCH-C applied locally (the proposed fixes for #11262 / #11263), **this PR's fix not applied** — so the bug is fully isolated to the `+ Add` save branch. Phases:

- **A** Toggle starts OFF.
- **B** Click toggle ON → "Secret visual redaction mode" dropdown appears.
- **C** `+ Add` → paste a baseline (no-secret) config `demo-baseline-11265` → Save → established in `MY MCPS`. Establishes a server for the control comparison.
- **D** `+ Add` again → paste a config with `sk-FAKE0000000000FAKEdemoWARP11265` in the top-level `url` → Save → server lands in `MY MCPS` as `demo-add-bypass-11265`. **BUG**: the new-server save bypassed the predicate entirely.

Recipe: [`scripts/recipes/11265-mcp-add-server-bypass.json`](https://github.com/david-engelmann/warp-taper/blob/main/scripts/recipes/11265-mcp-add-server-bypass.json).

## Testing

```text
$ cargo nextest run -p warp -E 'test(should_block_save_for_secrets) or test(does_not_block_when) or test(blocks_when_)'
5 tests run: 5 passed

$ cargo clippy -p warp --tests -- -D warnings
clean

$ cargo fmt -p warp -- --check
clean
```

The predicate's existing 5-case truth-table tests (from #10839) continue to cover the logic — this PR only adds a new call site, not new logic. The local-repro recording above exercises the new call site end-to-end.

## Server API dependencies

None — this is client-only.

## Agent Mode

Unchecked (external contribution).

## Changelog

`CHANGELOG-BUG-FIX: Defining a new MCP server via Settings → MCP Servers → + Add no longer bypasses the secret-redaction check when Settings → Privacy → Secret redaction (or enterprise enforcement) is active.`

Fixes #11265

