### PR TITLE
Order orchestration pills by status (attention first, done by recency)

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -102,6 +102,44 @@ pub(crate) fn pill_initial(name: &str) -> char {
         .map(|c| c.to_ascii_uppercase())
         .unwrap_or('A')
 }
+
+/// Sort priority for a pill given its conversation status. Lower numbers
+/// sort to the start of their section, so attention-needing pills
+/// (Blocked, Error) lead and finished pills (Cancelled, Success) trail.
+/// Applied to both the pinned and the unpinned sections.
+///
+/// Cancelled and Success share the same key so the trailing "done"
+/// section is sorted by recency (most recently finished first — see
+/// `pill_done_recency_key`) rather than by completion type. Within the
+/// non-done buckets (Blocked / Error / InProgress) spawn order remains
+/// the tiebreaker so freshly-spawned siblings don't shuffle around
+/// while they run.
+///
+/// Orchestrator pills carry `status = None` but are never routed through
+/// this sort (they always render first), so the `None` arm just picks
+/// the same key as `InProgress` for safety.
+fn pill_status_sort_key(status: Option<&ConversationStatus>) -> u8 {
+    match status {
+        Some(ConversationStatus::Blocked { .. }) => 0,
+        Some(ConversationStatus::Error) => 1,
+        Some(ConversationStatus::InProgress) => 2,
+        Some(ConversationStatus::Cancelled) | Some(ConversationStatus::Success) => 3,
+        None => 2,
+    }
+}
+
+/// Tiebreaker for pills that fall in the trailing "done" bucket
+/// (`pill_status_sort_key` == 3). Returns a value that sorts ascending
+/// so the most recently finished pill ends up leftmost. Pills without a
+/// known finish time (`None`) sort to the end of the done section.
+///
+/// Implemented as the negation of the last-modified epoch-millis so a
+/// larger timestamp (more recent) yields a more-negative key. Missing
+/// timestamps map to `0`, which is greater than any populated negative
+/// value and therefore lands after them in ascending order.
+fn pill_done_recency_key(last_modified_ms: Option<i64>) -> i64 {
+    -last_modified_ms.unwrap_or(0)
+}
 /// Renders the orchestrator avatar disc shared by pill, breadcrumb, and transcript
 /// surfaces.
 pub(crate) fn render_orchestrator_avatar_disc(
@@ -170,6 +208,12 @@ struct PillSpec {
     pin_state: PillPinState,
     /// Child running on a remote worker; drives the cloud-shaped badge variant.
     is_remote_child: bool,
+    /// Epoch milliseconds of the conversation's last activity (latest
+    /// exchange's finish_time, falling back to its start_time). Used as
+    /// the recency tiebreaker for pills in the trailing "done" bucket so
+    /// the most recently completed pill renders leftmost. `None` for
+    /// the orchestrator and for conversations with no exchanges yet.
+    last_modified_ms: Option<i64>,
 }
 
 #[derive(Clone, Copy)]
@@ -592,6 +636,8 @@ impl OrchestrationPillBar {
             pin_state: PillPinState::Unpinned,
             // Unused: orchestrator pills don't render a status overlay.
             is_remote_child: false,
+            // Unused: orchestrator pills aren't sorted (they render first).
+            last_modified_ms: None,
         });
 
         // Stamp each child's current pin state; partitioning happens at render.
@@ -616,6 +662,7 @@ impl OrchestrationPillBar {
                 kind: PillKind::Child,
                 pin_state,
                 is_remote_child: child.is_remote_child(),
+                last_modified_ms: child.last_modified_at().map(|t| t.timestamp_millis()),
             });
         }
 
@@ -1022,11 +1069,17 @@ impl View for OrchestrationPillBar {
         // this id has been split off into another pane/tab.
         let self_terminal_view_id = self.agent_view_controller.as_ref(app).terminal_view_id();
         // Bucket pills so the row is: orchestrator, pinned, divider, unpinned.
-        // Spawn order within each child bucket is preserved by iteration order.
+        // Within each child bucket pills are sorted by status priority
+        // (Blocked, Error, InProgress, then a combined Done bucket that
+        // holds Cancelled + Success). For non-done pills spawn order is
+        // the tiebreaker; for done pills the tiebreaker is
+        // `pill_done_recency_key` so the most recently finished pill ends
+        // up leftmost in the trailing section.
+        const DONE_STATUS_KEY: u8 = 3;
         let mut orchestrator_pill: Option<Box<dyn Element>> = None;
-        let mut pinned_pills: Vec<Box<dyn Element>> = Vec::new();
-        let mut unpinned_pills: Vec<Box<dyn Element>> = Vec::new();
-        for spec in specs {
+        let mut pinned_pills: Vec<(u8, i64, usize, Box<dyn Element>)> = Vec::new();
+        let mut unpinned_pills: Vec<(u8, i64, usize, Box<dyn Element>)> = Vec::new();
+        for (spawn_index, spec) in specs.into_iter().enumerate() {
             let mouse_state = mouse_states
                 .entry(spec.conversation_id)
                 .or_default()
@@ -1046,6 +1099,15 @@ impl View for OrchestrationPillBar {
             let menu_is_open_for_this = menu_open_for == Some(spec.conversation_id);
             let kind = spec.kind;
             let pin_state = spec.pin_state;
+            let status_key = pill_status_sort_key(spec.status.as_ref());
+            // Recency wins inside the done bucket; spawn order rules the
+            // others (use 0 there so the secondary key collapses and the
+            // tertiary `spawn_index` decides).
+            let secondary_key = if status_key == DONE_STATUS_KEY {
+                pill_done_recency_key(spec.last_modified_ms)
+            } else {
+                0
+            };
             let pill = render_pill(
                 spec,
                 mouse_state,
@@ -1057,27 +1119,40 @@ impl View for OrchestrationPillBar {
             );
             match (kind, pin_state) {
                 (PillKind::Orchestrator, _) => orchestrator_pill = Some(pill),
-                (PillKind::Child, PillPinState::Pinned) => pinned_pills.push(pill),
-                (PillKind::Child, PillPinState::Unpinned) => unpinned_pills.push(pill),
+                (PillKind::Child, PillPinState::Pinned) => {
+                    pinned_pills.push((status_key, secondary_key, spawn_index, pill));
+                }
+                (PillKind::Child, PillPinState::Unpinned) => {
+                    unpinned_pills.push((status_key, secondary_key, spawn_index, pill));
+                }
             }
         }
         drop(mouse_states);
         drop(overflow_states);
         drop(pin_states);
 
+        // Sort each bucket by (status priority, recency-or-zero, spawn
+        // index). `sort_by_key` is stable, so the explicit `spawn_index`
+        // is belt-and-suspenders against any upstream change that might
+        // collect pills out of spawn order.
+        pinned_pills
+            .sort_by_key(|(key, secondary, spawn_index, _)| (*key, *secondary, *spawn_index));
+        unpinned_pills
+            .sort_by_key(|(key, secondary, spawn_index, _)| (*key, *secondary, *spawn_index));
+
         if let Some(pill) = orchestrator_pill {
             row.add_child(pill);
         }
         let has_pinned = !pinned_pills.is_empty();
         let has_unpinned = !unpinned_pills.is_empty();
-        for pill in pinned_pills {
+        for (_, _, _, pill) in pinned_pills {
             row.add_child(pill);
         }
         // Only show the divider when both sides actually have pills.
         if has_pinned && has_unpinned {
             row.add_child(render_pinned_divider(app));
         }
-        for pill in unpinned_pills {
+        for (_, _, _, pill) in unpinned_pills {
             row.add_child(pill);
         }
 

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -103,6 +103,10 @@ pub(crate) fn pill_initial(name: &str) -> char {
         .unwrap_or('A')
 }
 
+/// Status key for the trailing "done" bucket (Cancelled + Success).
+/// Named so render code and tests don't have to chase a literal `3`.
+pub(super) const DONE_STATUS_KEY: u8 = 3;
+
 /// Sort priority within a pill section. Lower sorts leftmost. Cancelled
 /// and Success share one "done" bucket; recency decides their order.
 fn pill_status_sort_key(status: Option<&ConversationStatus>) -> u8 {
@@ -110,16 +114,29 @@ fn pill_status_sort_key(status: Option<&ConversationStatus>) -> u8 {
         Some(ConversationStatus::Blocked { .. }) => 0,
         Some(ConversationStatus::Error) => 1,
         Some(ConversationStatus::InProgress) => 2,
-        Some(ConversationStatus::Cancelled) | Some(ConversationStatus::Success) => 3,
+        Some(ConversationStatus::Cancelled) | Some(ConversationStatus::Success) => DONE_STATUS_KEY,
         None => 2,
     }
 }
 
 /// Recency tiebreaker for done pills, sorted ascending: newer finish
-/// times sort first; unknown sorts last.
+/// times sort first; unknown sorts last. `saturating_neg` so a wild
+/// `i64::MIN` (impossible for real timestamps) couldn't panic.
 fn pill_done_recency_key(last_modified_ms: Option<i64>) -> i64 {
-    -last_modified_ms.unwrap_or(0)
+    last_modified_ms.unwrap_or(0).saturating_neg()
 }
+
+/// Combines status key + recency into the secondary sort key. Recency
+/// wins inside the done bucket; everything else collapses to 0 so the
+/// spawn-index tiebreaker decides. Shared so render and tests can't drift.
+pub(super) fn pill_secondary_sort_key(status_key: u8, last_modified_ms: Option<i64>) -> i64 {
+    if status_key == DONE_STATUS_KEY {
+        pill_done_recency_key(last_modified_ms)
+    } else {
+        0
+    }
+}
+
 /// Renders the orchestrator avatar disc shared by pill, breadcrumb, and transcript
 /// surfaces.
 pub(crate) fn render_orchestrator_avatar_disc(
@@ -611,8 +628,9 @@ impl OrchestrationPillBar {
             is_selected: orchestrator_id == active_id,
             kind: PillKind::Orchestrator,
             pin_state: PillPinState::Unpinned,
-            // Orchestrator-only fields below are unused (no status overlay, never sorted).
+            // Unused: orchestrator pills don't render a status overlay.
             is_remote_child: false,
+            // Unused: orchestrator pills aren't sorted (they render first).
             last_modified_ms: None,
         });
 
@@ -1047,7 +1065,6 @@ impl View for OrchestrationPillBar {
         // Row layout: orchestrator, pinned, divider, unpinned. Each
         // child bucket is sorted by status priority, then recency for
         // done pills and spawn order otherwise.
-        const DONE_STATUS_KEY: u8 = 3;
         let mut orchestrator_pill: Option<Box<dyn Element>> = None;
         let mut pinned_pills: Vec<(u8, i64, usize, Box<dyn Element>)> = Vec::new();
         let mut unpinned_pills: Vec<(u8, i64, usize, Box<dyn Element>)> = Vec::new();
@@ -1072,13 +1089,7 @@ impl View for OrchestrationPillBar {
             let kind = spec.kind;
             let pin_state = spec.pin_state;
             let status_key = pill_status_sort_key(spec.status.as_ref());
-            // Done bucket uses recency; everything else collapses to 0
-            // so the spawn-index tiebreaker decides.
-            let secondary_key = if status_key == DONE_STATUS_KEY {
-                pill_done_recency_key(spec.last_modified_ms)
-            } else {
-                0
-            };
+            let secondary_key = pill_secondary_sort_key(status_key, spec.last_modified_ms);
             let pill = render_pill(
                 spec,
                 mouse_state,
@@ -1112,14 +1123,14 @@ impl View for OrchestrationPillBar {
         }
         let has_pinned = !pinned_pills.is_empty();
         let has_unpinned = !unpinned_pills.is_empty();
-        for (_, _, _, pill) in pinned_pills {
+        for (.., pill) in pinned_pills {
             row.add_child(pill);
         }
         // Only show the divider when both sides actually have pills.
         if has_pinned && has_unpinned {
             row.add_child(render_pinned_divider(app));
         }
-        for (_, _, _, pill) in unpinned_pills {
+        for (.., pill) in unpinned_pills {
             row.add_child(pill);
         }
 

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -103,21 +103,8 @@ pub(crate) fn pill_initial(name: &str) -> char {
         .unwrap_or('A')
 }
 
-/// Sort priority for a pill given its conversation status. Lower numbers
-/// sort to the start of their section, so attention-needing pills
-/// (Blocked, Error) lead and finished pills (Cancelled, Success) trail.
-/// Applied to both the pinned and the unpinned sections.
-///
-/// Cancelled and Success share the same key so the trailing "done"
-/// section is sorted by recency (most recently finished first — see
-/// `pill_done_recency_key`) rather than by completion type. Within the
-/// non-done buckets (Blocked / Error / InProgress) spawn order remains
-/// the tiebreaker so freshly-spawned siblings don't shuffle around
-/// while they run.
-///
-/// Orchestrator pills carry `status = None` but are never routed through
-/// this sort (they always render first), so the `None` arm just picks
-/// the same key as `InProgress` for safety.
+/// Sort priority within a pill section. Lower sorts leftmost. Cancelled
+/// and Success share one "done" bucket; recency decides their order.
 fn pill_status_sort_key(status: Option<&ConversationStatus>) -> u8 {
     match status {
         Some(ConversationStatus::Blocked { .. }) => 0,
@@ -128,15 +115,8 @@ fn pill_status_sort_key(status: Option<&ConversationStatus>) -> u8 {
     }
 }
 
-/// Tiebreaker for pills that fall in the trailing "done" bucket
-/// (`pill_status_sort_key` == 3). Returns a value that sorts ascending
-/// so the most recently finished pill ends up leftmost. Pills without a
-/// known finish time (`None`) sort to the end of the done section.
-///
-/// Implemented as the negation of the last-modified epoch-millis so a
-/// larger timestamp (more recent) yields a more-negative key. Missing
-/// timestamps map to `0`, which is greater than any populated negative
-/// value and therefore lands after them in ascending order.
+/// Recency tiebreaker for done pills, sorted ascending: newer finish
+/// times sort first; unknown sorts last.
 fn pill_done_recency_key(last_modified_ms: Option<i64>) -> i64 {
     -last_modified_ms.unwrap_or(0)
 }
@@ -208,11 +188,8 @@ struct PillSpec {
     pin_state: PillPinState,
     /// Child running on a remote worker; drives the cloud-shaped badge variant.
     is_remote_child: bool,
-    /// Epoch milliseconds of the conversation's last activity (latest
-    /// exchange's finish_time, falling back to its start_time). Used as
-    /// the recency tiebreaker for pills in the trailing "done" bucket so
-    /// the most recently completed pill renders leftmost. `None` for
-    /// the orchestrator and for conversations with no exchanges yet.
+    /// Epoch ms of the conversation's last activity; recency tiebreaker
+    /// within the done bucket.
     last_modified_ms: Option<i64>,
 }
 
@@ -634,9 +611,8 @@ impl OrchestrationPillBar {
             is_selected: orchestrator_id == active_id,
             kind: PillKind::Orchestrator,
             pin_state: PillPinState::Unpinned,
-            // Unused: orchestrator pills don't render a status overlay.
+            // Orchestrator-only fields below are unused (no status overlay, never sorted).
             is_remote_child: false,
-            // Unused: orchestrator pills aren't sorted (they render first).
             last_modified_ms: None,
         });
 
@@ -1068,13 +1044,9 @@ impl View for OrchestrationPillBar {
         // the orchestrator pane, so any child whose owner differs from
         // this id has been split off into another pane/tab.
         let self_terminal_view_id = self.agent_view_controller.as_ref(app).terminal_view_id();
-        // Bucket pills so the row is: orchestrator, pinned, divider, unpinned.
-        // Within each child bucket pills are sorted by status priority
-        // (Blocked, Error, InProgress, then a combined Done bucket that
-        // holds Cancelled + Success). For non-done pills spawn order is
-        // the tiebreaker; for done pills the tiebreaker is
-        // `pill_done_recency_key` so the most recently finished pill ends
-        // up leftmost in the trailing section.
+        // Row layout: orchestrator, pinned, divider, unpinned. Each
+        // child bucket is sorted by status priority, then recency for
+        // done pills and spawn order otherwise.
         const DONE_STATUS_KEY: u8 = 3;
         let mut orchestrator_pill: Option<Box<dyn Element>> = None;
         let mut pinned_pills: Vec<(u8, i64, usize, Box<dyn Element>)> = Vec::new();
@@ -1100,9 +1072,8 @@ impl View for OrchestrationPillBar {
             let kind = spec.kind;
             let pin_state = spec.pin_state;
             let status_key = pill_status_sort_key(spec.status.as_ref());
-            // Recency wins inside the done bucket; spawn order rules the
-            // others (use 0 there so the secondary key collapses and the
-            // tertiary `spawn_index` decides).
+            // Done bucket uses recency; everything else collapses to 0
+            // so the spawn-index tiebreaker decides.
             let secondary_key = if status_key == DONE_STATUS_KEY {
                 pill_done_recency_key(spec.last_modified_ms)
             } else {
@@ -1131,14 +1102,10 @@ impl View for OrchestrationPillBar {
         drop(overflow_states);
         drop(pin_states);
 
-        // Sort each bucket by (status priority, recency-or-zero, spawn
-        // index). `sort_by_key` is stable, so the explicit `spawn_index`
-        // is belt-and-suspenders against any upstream change that might
-        // collect pills out of spawn order.
-        pinned_pills
-            .sort_by_key(|(key, secondary, spawn_index, _)| (*key, *secondary, *spawn_index));
-        unpinned_pills
-            .sort_by_key(|(key, secondary, spawn_index, _)| (*key, *secondary, *spawn_index));
+        // Explicit spawn-index tiebreaker keeps ordering deterministic.
+        let sort_key = |(k, s, idx, _): &(u8, i64, usize, _)| (*k, *s, *idx);
+        pinned_pills.sort_by_key(sort_key);
+        unpinned_pills.sort_by_key(sort_key);
 
         if let Some(pill) = orchestrator_pill {
             row.add_child(pill);

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -27,3 +27,152 @@ fn navigation_action_for_orchestrator_pill_switches_in_place() {
         } if actual_id == conversation_id
     ));
 }
+
+#[test]
+fn pill_status_sort_key_orders_attention_then_in_progress_then_done() {
+    // Pinned + unpinned pill sections are both sorted by this key.
+    // Lower values render closer to the start of their section, so
+    // attention-needing pills bubble up and finished pills sink down.
+    // Cancelled and Success deliberately share the same key so the
+    // trailing "done" section is ordered by recency rather than by
+    // completion type — see `pill_done_recency_key` and its tests.
+    let blocked = ConversationStatus::Blocked {
+        blocked_action: String::new(),
+    };
+    let error = ConversationStatus::Error;
+    let in_progress = ConversationStatus::InProgress;
+    let cancelled = ConversationStatus::Cancelled;
+    let success = ConversationStatus::Success;
+
+    let blocked_key = pill_status_sort_key(Some(&blocked));
+    let error_key = pill_status_sort_key(Some(&error));
+    let in_progress_key = pill_status_sort_key(Some(&in_progress));
+    let cancelled_key = pill_status_sort_key(Some(&cancelled));
+    let success_key = pill_status_sort_key(Some(&success));
+
+    assert!(blocked_key < error_key);
+    assert!(error_key < in_progress_key);
+    assert!(in_progress_key < cancelled_key);
+    assert_eq!(
+        cancelled_key, success_key,
+        "Cancelled and Success share the trailing done bucket so recency \
+         (not completion type) decides their relative order"
+    );
+}
+
+#[test]
+fn pill_status_sort_key_treats_none_as_in_progress() {
+    // Orchestrator pills carry `status = None` but are never routed
+    // through the sort (they render first unconditionally). Picking the
+    // same key as `InProgress` is a safety default — if a future caller
+    // ever passes a `None` status through the sort path, it lands in the
+    // middle bucket rather than corrupting the ordering at either end.
+    assert_eq!(
+        pill_status_sort_key(None),
+        pill_status_sort_key(Some(&ConversationStatus::InProgress)),
+    );
+}
+
+#[test]
+fn pill_done_recency_key_puts_most_recent_first_and_unknown_last() {
+    // Within the done bucket the sort key is
+    // `pill_done_recency_key(last_modified_ms)` sorted ascending; smaller
+    // values render leftmost. Larger timestamps (more recent) must
+    // therefore produce smaller keys, and `None` (unknown finish time)
+    // must produce a key greater than any populated finish time so it
+    // lands at the trailing edge of the done section.
+    let older = pill_done_recency_key(Some(1_000));
+    let newer = pill_done_recency_key(Some(2_000));
+    let unknown = pill_done_recency_key(None);
+    assert!(newer < older, "newer finish_time must sort first");
+    assert!(older < unknown, "unknown finish_time must sort last");
+}
+
+#[test]
+fn sort_pills_bubbles_attention_in_progress_keeps_spawn_done_uses_recency() {
+    // End-to-end check of the render-loop sort tuple. Each entry mimics
+    // a `(status_key, secondary_key, spawn_index)` triple as built in
+    // `View::render`. The secondary key is `pill_done_recency_key` for
+    // done pills and `0` for everything else, so spawn order is the
+    // tiebreaker in the non-done buckets.
+    const DONE_STATUS_KEY: u8 = 3;
+    let blocked = ConversationStatus::Blocked {
+        blocked_action: String::new(),
+    };
+    let secondary_for = |status: &ConversationStatus, last_modified_ms: Option<i64>| -> i64 {
+        if pill_status_sort_key(Some(status)) == DONE_STATUS_KEY {
+            pill_done_recency_key(last_modified_ms)
+        } else {
+            0
+        }
+    };
+    // Spawn order is the input index. Statuses + finish times:
+    //   0: Success, finished at t=100  (oldest done)
+    //   1: InProgress
+    //   2: Blocked
+    //   3: Cancelled, finished at t=300 (newest done)
+    //   4: InProgress
+    //   5: Error
+    //   6: Success, finished at t=200  (middle done)
+    let entries_input: Vec<(ConversationStatus, Option<i64>)> = vec![
+        (ConversationStatus::Success, Some(100)),
+        (ConversationStatus::InProgress, None),
+        (blocked.clone(), None),
+        (ConversationStatus::Cancelled, Some(300)),
+        (ConversationStatus::InProgress, None),
+        (ConversationStatus::Error, None),
+        (ConversationStatus::Success, Some(200)),
+    ];
+    let mut sortable: Vec<(u8, i64, usize)> = entries_input
+        .iter()
+        .enumerate()
+        .map(|(spawn_index, (status, last_modified_ms))| {
+            (
+                pill_status_sort_key(Some(status)),
+                secondary_for(status, *last_modified_ms),
+                spawn_index,
+            )
+        })
+        .collect();
+    sortable.sort_by_key(|(k, s, idx)| (*k, *s, *idx));
+    let spawn_order: Vec<usize> = sortable.iter().map(|(_, _, idx)| *idx).collect();
+    // Expected order:
+    //   - Blocked (spawn 2)
+    //   - Error (spawn 5)
+    //   - InProgress in spawn order (1, then 4)
+    //   - Done bucket sorted by recency: newest=Cancelled@300 (spawn 3),
+    //     then Success@200 (spawn 6), then Success@100 (spawn 0).
+    assert_eq!(spawn_order, vec![2, 5, 1, 4, 3, 6, 0]);
+}
+
+#[test]
+fn sort_pills_is_stable_within_in_progress_bucket() {
+    // Two `InProgress` pills should always come out in spawn order, even
+    // when the input is in reverse order. This guards against future
+    // changes that might collect pills out of spawn order — the explicit
+    // `spawn_index` tiebreaker keeps the result deterministic regardless.
+    let in_progress_key = pill_status_sort_key(Some(&ConversationStatus::InProgress));
+    let mut entries: Vec<(u8, i64, usize)> = vec![(in_progress_key, 0, 7), (in_progress_key, 0, 3)];
+    entries.sort_by_key(|(key, secondary, spawn_index)| (*key, *secondary, *spawn_index));
+    let spawn_order: Vec<usize> = entries.iter().map(|(_, _, idx)| *idx).collect();
+    assert_eq!(spawn_order, vec![3, 7]);
+}
+
+#[test]
+fn sort_pills_done_bucket_orders_by_recency_regardless_of_completion_type() {
+    // An old Cancelled pill should sink behind a freshly-finished Success
+    // pill: within the done bucket only recency matters, not whether the
+    // completion was successful or cancelled.
+    const DONE_STATUS_KEY: u8 = 3;
+    let cancelled_old: i64 = pill_done_recency_key(Some(100));
+    let success_new: i64 = pill_done_recency_key(Some(500));
+    let mut entries: Vec<(u8, i64, usize)> = vec![
+        (DONE_STATUS_KEY, cancelled_old, 0),
+        (DONE_STATUS_KEY, success_new, 1),
+    ];
+    entries.sort_by_key(|(key, secondary, spawn_index)| (*key, *secondary, *spawn_index));
+    let spawn_order: Vec<usize> = entries.iter().map(|(_, _, idx)| *idx).collect();
+    // Spawn index 1 (the newer Success) leads, spawn index 0 (the older
+    // Cancelled) trails.
+    assert_eq!(spawn_order, vec![1, 0]);
+}

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -66,16 +66,8 @@ fn pill_done_recency_key_puts_most_recent_first_and_unknown_last() {
 
 #[test]
 fn sort_pills_bubbles_attention_in_progress_keeps_spawn_done_uses_recency() {
-    const DONE_STATUS_KEY: u8 = 3;
     let blocked = ConversationStatus::Blocked {
         blocked_action: String::new(),
-    };
-    let secondary_for = |status: &ConversationStatus, ms: Option<i64>| -> i64 {
-        if pill_status_sort_key(Some(status)) == DONE_STATUS_KEY {
-            pill_done_recency_key(ms)
-        } else {
-            0
-        }
     };
     // (status, finish time) per spawn index.
     let inputs: Vec<(ConversationStatus, Option<i64>)> = vec![
@@ -91,11 +83,8 @@ fn sort_pills_bubbles_attention_in_progress_keeps_spawn_done_uses_recency() {
         .iter()
         .enumerate()
         .map(|(idx, (status, ms))| {
-            (
-                pill_status_sort_key(Some(status)),
-                secondary_for(status, *ms),
-                idx,
-            )
+            let status_key = pill_status_sort_key(Some(status));
+            (status_key, pill_secondary_sort_key(status_key, *ms), idx)
         })
         .collect();
     sortable.sort_by_key(|(k, s, idx)| (*k, *s, *idx));
@@ -116,9 +105,8 @@ fn sort_pills_is_stable_within_in_progress_bucket() {
 #[test]
 fn sort_pills_done_bucket_orders_by_recency_regardless_of_completion_type() {
     // Old Cancelled sinks behind a fresh Success.
-    const DONE_STATUS_KEY: u8 = 3;
-    let cancelled_old = pill_done_recency_key(Some(100));
-    let success_new = pill_done_recency_key(Some(500));
+    let cancelled_old = pill_secondary_sort_key(DONE_STATUS_KEY, Some(100));
+    let success_new = pill_secondary_sort_key(DONE_STATUS_KEY, Some(500));
     let mut entries: Vec<(u8, i64, usize)> = vec![
         (DONE_STATUS_KEY, cancelled_old, 0),
         (DONE_STATUS_KEY, success_new, 1),

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -30,43 +30,25 @@ fn navigation_action_for_orchestrator_pill_switches_in_place() {
 
 #[test]
 fn pill_status_sort_key_orders_attention_then_in_progress_then_done() {
-    // Pinned + unpinned pill sections are both sorted by this key.
-    // Lower values render closer to the start of their section, so
-    // attention-needing pills bubble up and finished pills sink down.
-    // Cancelled and Success deliberately share the same key so the
-    // trailing "done" section is ordered by recency rather than by
-    // completion type — see `pill_done_recency_key` and its tests.
     let blocked = ConversationStatus::Blocked {
         blocked_action: String::new(),
     };
-    let error = ConversationStatus::Error;
-    let in_progress = ConversationStatus::InProgress;
-    let cancelled = ConversationStatus::Cancelled;
-    let success = ConversationStatus::Success;
-
     let blocked_key = pill_status_sort_key(Some(&blocked));
-    let error_key = pill_status_sort_key(Some(&error));
-    let in_progress_key = pill_status_sort_key(Some(&in_progress));
-    let cancelled_key = pill_status_sort_key(Some(&cancelled));
-    let success_key = pill_status_sort_key(Some(&success));
+    let error_key = pill_status_sort_key(Some(&ConversationStatus::Error));
+    let in_progress_key = pill_status_sort_key(Some(&ConversationStatus::InProgress));
+    let cancelled_key = pill_status_sort_key(Some(&ConversationStatus::Cancelled));
+    let success_key = pill_status_sort_key(Some(&ConversationStatus::Success));
 
     assert!(blocked_key < error_key);
     assert!(error_key < in_progress_key);
     assert!(in_progress_key < cancelled_key);
-    assert_eq!(
-        cancelled_key, success_key,
-        "Cancelled and Success share the trailing done bucket so recency \
-         (not completion type) decides their relative order"
-    );
+    // Cancelled and Success share the done bucket; recency decides within it.
+    assert_eq!(cancelled_key, success_key);
 }
 
 #[test]
 fn pill_status_sort_key_treats_none_as_in_progress() {
-    // Orchestrator pills carry `status = None` but are never routed
-    // through the sort (they render first unconditionally). Picking the
-    // same key as `InProgress` is a safety default — if a future caller
-    // ever passes a `None` status through the sort path, it lands in the
-    // middle bucket rather than corrupting the ordering at either end.
+    // Safety default for the orchestrator path (never sorted in practice).
     assert_eq!(
         pill_status_sort_key(None),
         pill_status_sort_key(Some(&ConversationStatus::InProgress)),
@@ -75,46 +57,28 @@ fn pill_status_sort_key_treats_none_as_in_progress() {
 
 #[test]
 fn pill_done_recency_key_puts_most_recent_first_and_unknown_last() {
-    // Within the done bucket the sort key is
-    // `pill_done_recency_key(last_modified_ms)` sorted ascending; smaller
-    // values render leftmost. Larger timestamps (more recent) must
-    // therefore produce smaller keys, and `None` (unknown finish time)
-    // must produce a key greater than any populated finish time so it
-    // lands at the trailing edge of the done section.
     let older = pill_done_recency_key(Some(1_000));
     let newer = pill_done_recency_key(Some(2_000));
     let unknown = pill_done_recency_key(None);
-    assert!(newer < older, "newer finish_time must sort first");
-    assert!(older < unknown, "unknown finish_time must sort last");
+    assert!(newer < older);
+    assert!(older < unknown);
 }
 
 #[test]
 fn sort_pills_bubbles_attention_in_progress_keeps_spawn_done_uses_recency() {
-    // End-to-end check of the render-loop sort tuple. Each entry mimics
-    // a `(status_key, secondary_key, spawn_index)` triple as built in
-    // `View::render`. The secondary key is `pill_done_recency_key` for
-    // done pills and `0` for everything else, so spawn order is the
-    // tiebreaker in the non-done buckets.
     const DONE_STATUS_KEY: u8 = 3;
     let blocked = ConversationStatus::Blocked {
         blocked_action: String::new(),
     };
-    let secondary_for = |status: &ConversationStatus, last_modified_ms: Option<i64>| -> i64 {
+    let secondary_for = |status: &ConversationStatus, ms: Option<i64>| -> i64 {
         if pill_status_sort_key(Some(status)) == DONE_STATUS_KEY {
-            pill_done_recency_key(last_modified_ms)
+            pill_done_recency_key(ms)
         } else {
             0
         }
     };
-    // Spawn order is the input index. Statuses + finish times:
-    //   0: Success, finished at t=100  (oldest done)
-    //   1: InProgress
-    //   2: Blocked
-    //   3: Cancelled, finished at t=300 (newest done)
-    //   4: InProgress
-    //   5: Error
-    //   6: Success, finished at t=200  (middle done)
-    let entries_input: Vec<(ConversationStatus, Option<i64>)> = vec![
+    // (status, finish time) per spawn index.
+    let inputs: Vec<(ConversationStatus, Option<i64>)> = vec![
         (ConversationStatus::Success, Some(100)),
         (ConversationStatus::InProgress, None),
         (blocked.clone(), None),
@@ -123,56 +87,43 @@ fn sort_pills_bubbles_attention_in_progress_keeps_spawn_done_uses_recency() {
         (ConversationStatus::Error, None),
         (ConversationStatus::Success, Some(200)),
     ];
-    let mut sortable: Vec<(u8, i64, usize)> = entries_input
+    let mut sortable: Vec<(u8, i64, usize)> = inputs
         .iter()
         .enumerate()
-        .map(|(spawn_index, (status, last_modified_ms))| {
+        .map(|(idx, (status, ms))| {
             (
                 pill_status_sort_key(Some(status)),
-                secondary_for(status, *last_modified_ms),
-                spawn_index,
+                secondary_for(status, *ms),
+                idx,
             )
         })
         .collect();
     sortable.sort_by_key(|(k, s, idx)| (*k, *s, *idx));
     let spawn_order: Vec<usize> = sortable.iter().map(|(_, _, idx)| *idx).collect();
-    // Expected order:
-    //   - Blocked (spawn 2)
-    //   - Error (spawn 5)
-    //   - InProgress in spawn order (1, then 4)
-    //   - Done bucket sorted by recency: newest=Cancelled@300 (spawn 3),
-    //     then Success@200 (spawn 6), then Success@100 (spawn 0).
+    // Blocked, Error, InProgress (spawn order), then done by recency desc.
     assert_eq!(spawn_order, vec![2, 5, 1, 4, 3, 6, 0]);
 }
 
 #[test]
 fn sort_pills_is_stable_within_in_progress_bucket() {
-    // Two `InProgress` pills should always come out in spawn order, even
-    // when the input is in reverse order. This guards against future
-    // changes that might collect pills out of spawn order — the explicit
-    // `spawn_index` tiebreaker keeps the result deterministic regardless.
     let in_progress_key = pill_status_sort_key(Some(&ConversationStatus::InProgress));
     let mut entries: Vec<(u8, i64, usize)> = vec![(in_progress_key, 0, 7), (in_progress_key, 0, 3)];
-    entries.sort_by_key(|(key, secondary, spawn_index)| (*key, *secondary, *spawn_index));
+    entries.sort_by_key(|(k, s, idx)| (*k, *s, *idx));
     let spawn_order: Vec<usize> = entries.iter().map(|(_, _, idx)| *idx).collect();
     assert_eq!(spawn_order, vec![3, 7]);
 }
 
 #[test]
 fn sort_pills_done_bucket_orders_by_recency_regardless_of_completion_type() {
-    // An old Cancelled pill should sink behind a freshly-finished Success
-    // pill: within the done bucket only recency matters, not whether the
-    // completion was successful or cancelled.
+    // Old Cancelled sinks behind a fresh Success.
     const DONE_STATUS_KEY: u8 = 3;
-    let cancelled_old: i64 = pill_done_recency_key(Some(100));
-    let success_new: i64 = pill_done_recency_key(Some(500));
+    let cancelled_old = pill_done_recency_key(Some(100));
+    let success_new = pill_done_recency_key(Some(500));
     let mut entries: Vec<(u8, i64, usize)> = vec![
         (DONE_STATUS_KEY, cancelled_old, 0),
         (DONE_STATUS_KEY, success_new, 1),
     ];
-    entries.sort_by_key(|(key, secondary, spawn_index)| (*key, *secondary, *spawn_index));
+    entries.sort_by_key(|(k, s, idx)| (*k, *s, *idx));
     let spawn_order: Vec<usize> = entries.iter().map(|(_, _, idx)| *idx).collect();
-    // Spawn index 1 (the newer Success) leads, spawn index 0 (the older
-    // Cancelled) trails.
     assert_eq!(spawn_order, vec![1, 0]);
 }


### PR DESCRIPTION
Loom: https://www.loom.com/share/e011f21848864c4282c699fa426780a4
Fixes https://linear.app/warpdotdev/issue/QUALITY-739/move-done-agents-to-the-end-of-pill-bar

## Description
The orchestration pill bar should surface attention-needing agents and push inert agents out of the way, rather than rendering everything in spawn order.

This PR sorts both the pinned and unpinned sections of the pill bar by a status-priority key. The orchestrator pill is still first, the pinned/unpinned divider still appears between the two sections — only the order *within* each section changes.

### Ordering rules
Lower = closer to the start of each section (= more important to the user):

1. **Blocked** — waiting on the user, highest urgency
2. **Error** — needs the user to look
3. **InProgress** — running
4. **Done** (Cancelled + Success combined into a single bucket)

Within the non-done buckets the tiebreaker is **spawn order**, so freshly-spawned siblings stay where they were and don't shuffle while they run.

Within the **done** bucket the tiebreaker is **recency**: the most recently finished agent renders leftmost (based on the conversation's `last_modified_at` — latest exchange's `finish_time`). Pills with no known finish time sort to the trailing edge of the done section. Cancelled and Success share the same bucket key on purpose — once an agent is done, the only signal that matters for ordering is how recently it finished, not *how* it finished.

### Why these specific rules
- **Blocked > Error** — pills that explicitly need user input outrank pills that merely need attention.
- **Done bucket merged + sorted by recency** — a 5-minute-old Cancelled should sink behind a fresh Success. The user wants "left = more important", which for completed agents maps to "most recently active".
- **Re-sort on every render** — the pill bar already re-renders on `BlocklistAIHistoryEvent::UpdatedConversationStatus`, so status transitions (Blocked → InProgress when permission is granted, InProgress → Success when an agent finishes) reflect in the bar immediately. No extra plumbing needed.
- **Pinned section uses the same sort** — kept consistent with the unpinned section so users see the same ordering principle everywhere; pinned still wins the section-level ordering.

### Implementation
- New `pill_status_sort_key(Option<&ConversationStatus>) -> u8` helper (Blocked=0, Error=1, InProgress=2, Done=3).
- New `pill_done_recency_key(Option<i64>) -> i64` helper that returns the negation of the last-modified epoch-ms so larger timestamps (newer) sort first; missing timestamps sort last.
- `PillSpec` gains a `last_modified_ms: Option<i64>` field, populated via `AIConversation::last_modified_at()`.
- Render loop now collects `(status_key, secondary_key, spawn_index, Box<dyn Element>)` tuples per bucket and `sort_by_key`s each independently. `secondary_key` is the recency key for done pills and `0` everywhere else, so spawn order is the natural tiebreaker outside the done bucket.

## Testing
Five unit tests in `orchestration_pill_bar_tests.rs`:
- `pill_status_sort_key_orders_attention_then_in_progress_then_done` — Blocked < Error < InProgress < Done, with Cancelled == Success.
- `pill_status_sort_key_treats_none_as_in_progress` — orchestrator's `None` status safety default.
- `pill_done_recency_key_puts_most_recent_first_and_unknown_last` — direction of the recency key + None handling.
- `sort_pills_bubbles_attention_in_progress_keeps_spawn_done_uses_recency` — end-to-end mixed-status sort with recency tiebreaking inside done.
- `sort_pills_is_stable_within_in_progress_bucket` — InProgress pills keep spawn order regardless of input order.
- `sort_pills_done_bucket_orders_by_recency_regardless_of_completion_type` — an old Cancelled sinks behind a fresh Success.

