### PR TITLE
Clean up TMUX SSH warpification setting

### DIFF
--- a/app/src/settings_view/warpify_page.rs
+++ b/app/src/settings_view/warpify_page.rs
@@ -56,7 +56,11 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
     // Add all of the toggle settings from the Warpify Page that you want to show up on the Command Palette here.
     let mut toggle_binding_pairs = vec![];
 
-    if FeatureFlag::SSHTmuxWrapper.is_enabled() {
+    if FeatureFlag::SSHTmuxWrapper.is_enabled()
+        && WarpifySettings::as_ref(app)
+            .use_ssh_tmux_wrapper
+            .is_value_explicitly_set()
+    {
         toggle_binding_pairs.push(ToggleSettingActionPair::new(
             "SSH session detection for Warpification",
             builder(SettingsAction::WarpifyPageToggle(
@@ -734,6 +738,16 @@ impl SettingsWidget for SSHWidget {
                     .finish()
                 },
             );
+        }
+
+        // Only show the tmux warpification toggle if the user has explicitly changed
+        // the setting. We are gradually deprecating tmux warpification, so new users
+        // should not see this option, but existing users who opted in keep it.
+        if !WarpifySettings::as_ref(app)
+            .use_ssh_tmux_wrapper
+            .is_value_explicitly_set()
+        {
+            return column.finish();
         }
 
         add_setting(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3870,7 +3870,7 @@ impl TerminalView {
             Banner::new(BannerTextContent::formatted_text(vec![
                 FormattedTextFragment::plain_text("Seems like your completions are not working ("),
                 FormattedTextFragment::hyperlink("more info", CONTROLMASTER_ISSUES_URL),
-                FormattedTextFragment::plain_text("). Enabling tmux warpification in "),
+                FormattedTextFragment::plain_text("). Enabling the SSH extension in "),
                 FormattedTextFragment::hyperlink_action(
                     "settings",
                     TerminalAction::ShowWarpifySettings,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8679,13 +8679,6 @@ impl TerminalView {
         // probably won't happen often, but it's something that we might want to clean
         // up eventually.
         if self.control_master_error_banner_state.associated_session_id != active_session_id {
-            self.control_master_error_banner_state = ControlMasterErrorBannerState {
-                is_open: true,
-                associated_session_id: active_session_id,
-            };
-
-            ctx.notify();
-
             let has_remote_server = active_session_id.is_some_and(|session_id| {
                 self.sessions
                     .as_ref(ctx)
@@ -8700,6 +8693,16 @@ impl TerminalView {
                         )
                     })
             });
+
+            // Don't show the banner when the session already has a remote server
+            // active — the CTA to enable the SSH extension is irrelevant.
+            self.control_master_error_banner_state = ControlMasterErrorBannerState {
+                is_open: !has_remote_server,
+                associated_session_id: active_session_id,
+            };
+
+            ctx.notify();
+
             send_telemetry_from_ctx!(
                 TelemetryEvent::SSHControlMasterError { has_remote_server },
                 ctx


### PR DESCRIPTION
## Description
This does two things:
1. For user who haven't explicitly set tmux warpification, remove it from the settings page and command palette
2. For the CTA when user hits open failed channel issue, point them to enabling the SSH extension (if they don't have it enabled) instead of TMUX warpification
