### PR TITLE
Add reload credit confirmations for team actions

### DIFF
--- a/app/src/drive/cloud_action_confirmation_dialog.rs
+++ b/app/src/drive/cloud_action_confirmation_dialog.rs
@@ -1,5 +1,5 @@
 use warpui::{
-    elements::{CornerRadius, Dismiss, MouseStateHandle, Radius},
+    elements::{Container, CornerRadius, Dismiss, MouseStateHandle, Radius},
     fonts::Weight,
     platform::Cursor,
     ui_components::{
@@ -218,7 +218,11 @@ impl View for CloudActionConfirmationDialog {
             dialog_styles(appearance),
         )
         .with_bottom_row_child(cancel_button)
-        .with_bottom_row_child(confirm_button)
+        .with_bottom_row_child(
+            Container::new(confirm_button)
+                .with_margin_left(12.)
+                .finish(),
+        )
         .with_width(DIALOG_WIDTH)
         .build()
         .finish();

--- a/app/src/drive/cloud_action_confirmation_dialog.rs
+++ b/app/src/drive/cloud_action_confirmation_dialog.rs
@@ -31,13 +31,11 @@ const REMOVE_TEAM_MEMBER_TITLE_TEXT: &str = "Are you sure you want to remove thi
 
 const DELETE_TEAM_BODY_TEXT: &str = "Deleting this team will permanently delete it and all of its related content, including billing information or credits. You will not be able to restore them.";
 const LEAVE_TEAM_BODY_TEXT: &str = "You will need to be reinvited in order to rejoin.";
-const DELETE_TEAM_RELOAD_CREDITS_BODY_TEXT: &str = "Deleting this team will remove access to any remaining reload credits tied to it. Team members will no longer be able to use those credits.";
 const LEAVE_TEAM_RELOAD_CREDITS_BODY_TEXT: &str = "If you leave this team, you’ll lose access to any remaining reload credits tied to it. You’ll regain access to any unused, non-expired credits if you rejoin the same team later.";
 const REMOVE_TEAM_MEMBER_RELOAD_CREDITS_BODY_TEXT: &str = "This member will lose access to any remaining reload credits tied to this team. If they rejoin later, they’ll regain access to any unused, non-expired credits.";
 
 const DELETE_TEAM_CONFIRM_TEXT: &str = "Yes, delete";
 const LEAVE_TEAM_CONFIRM_TEXT: &str = "Yes, leave";
-const DELETE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT: &str = "Delete Team";
 const LEAVE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT: &str = "Leave Team";
 const REMOVE_TEAM_MEMBER_RELOAD_CREDITS_CONFIRM_TEXT: &str = "Remove Member";
 
@@ -57,7 +55,6 @@ pub enum CloudActionConfirmationDialogVariant {
     LeaveTeam,
     DeleteTeam,
     LeaveTeamReloadCredits,
-    DeleteTeamReloadCredits,
     RemoveTeamMemberReloadCredits,
     #[default]
     None,
@@ -94,10 +91,7 @@ impl CloudActionConfirmationDialog {
             | CloudActionConfirmationDialogVariant::LeaveTeamReloadCredits => {
                 LEAVE_TEAM_TITLE_TEXT.to_string()
             }
-            CloudActionConfirmationDialogVariant::DeleteTeam
-            | CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits => {
-                DELETE_TEAM_TITLE_TEXT.to_string()
-            }
+            CloudActionConfirmationDialogVariant::DeleteTeam => DELETE_TEAM_TITLE_TEXT.to_string(),
             CloudActionConfirmationDialogVariant::RemoveTeamMemberReloadCredits => {
                 REMOVE_TEAM_MEMBER_TITLE_TEXT.to_string()
             }
@@ -111,9 +105,6 @@ impl CloudActionConfirmationDialog {
             CloudActionConfirmationDialogVariant::DeleteTeam => DELETE_TEAM_BODY_TEXT.to_string(),
             CloudActionConfirmationDialogVariant::LeaveTeamReloadCredits => {
                 LEAVE_TEAM_RELOAD_CREDITS_BODY_TEXT.to_string()
-            }
-            CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits => {
-                DELETE_TEAM_RELOAD_CREDITS_BODY_TEXT.to_string()
             }
             CloudActionConfirmationDialogVariant::RemoveTeamMemberReloadCredits => {
                 REMOVE_TEAM_MEMBER_RELOAD_CREDITS_BODY_TEXT.to_string()
@@ -130,9 +121,6 @@ impl CloudActionConfirmationDialog {
             }
             CloudActionConfirmationDialogVariant::LeaveTeamReloadCredits => {
                 LEAVE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT.to_string()
-            }
-            CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits => {
-                DELETE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT.to_string()
             }
             CloudActionConfirmationDialogVariant::RemoveTeamMemberReloadCredits => {
                 REMOVE_TEAM_MEMBER_RELOAD_CREDITS_CONFIRM_TEXT.to_string()

--- a/app/src/drive/cloud_action_confirmation_dialog.rs
+++ b/app/src/drive/cloud_action_confirmation_dialog.rs
@@ -27,12 +27,19 @@ const CANCEL_TEXT: &str = "Cancel";
 
 const DELETE_TEAM_TITLE_TEXT: &str = "Are you sure you want to delete this team?";
 const LEAVE_TEAM_TITLE_TEXT: &str = "Are you sure you want to leave this team?";
+const REMOVE_TEAM_MEMBER_TITLE_TEXT: &str = "Are you sure you want to remove this member?";
 
 const DELETE_TEAM_BODY_TEXT: &str = "Deleting this team will permanently delete it and all of its related content, including billing information or credits. You will not be able to restore them.";
 const LEAVE_TEAM_BODY_TEXT: &str = "You will need to be reinvited in order to rejoin.";
+const DELETE_TEAM_RELOAD_CREDITS_BODY_TEXT: &str = "Deleting this team will remove access to any remaining reload credits tied to it. Team members will no longer be able to use those credits.";
+const LEAVE_TEAM_RELOAD_CREDITS_BODY_TEXT: &str = "If you leave this team, you’ll lose access to any remaining reload credits tied to it. You’ll regain access to any unused, non-expired credits if you rejoin the same team later.";
+const REMOVE_TEAM_MEMBER_RELOAD_CREDITS_BODY_TEXT: &str = "This member will lose access to any remaining reload credits tied to this team. If they rejoin later, they’ll regain access to any unused, non-expired credits.";
 
 const DELETE_TEAM_CONFIRM_TEXT: &str = "Yes, delete";
 const LEAVE_TEAM_CONFIRM_TEXT: &str = "Yes, leave";
+const DELETE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT: &str = "Delete Team";
+const LEAVE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT: &str = "Leave Team";
+const REMOVE_TEAM_MEMBER_RELOAD_CREDITS_CONFIRM_TEXT: &str = "Remove Member";
 
 pub enum CloudActionConfirmationDialogEvent {
     Cancel,
@@ -49,6 +56,9 @@ pub enum CloudActionConfirmationDialogAction {
 pub enum CloudActionConfirmationDialogVariant {
     LeaveTeam,
     DeleteTeam,
+    LeaveTeamReloadCredits,
+    DeleteTeamReloadCredits,
+    RemoveTeamMemberReloadCredits,
     #[default]
     None,
 }
@@ -80,9 +90,18 @@ impl CloudActionConfirmationDialog {
 
     fn title_text(&self) -> String {
         match self.variant {
-            CloudActionConfirmationDialogVariant::LeaveTeam => LEAVE_TEAM_TITLE_TEXT.to_string(),
-            CloudActionConfirmationDialogVariant::DeleteTeam => DELETE_TEAM_TITLE_TEXT.to_string(),
-            CloudActionConfirmationDialogVariant::None => "".to_string(),
+            CloudActionConfirmationDialogVariant::LeaveTeam
+            | CloudActionConfirmationDialogVariant::LeaveTeamReloadCredits => {
+                LEAVE_TEAM_TITLE_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::DeleteTeam
+            | CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits => {
+                DELETE_TEAM_TITLE_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::RemoveTeamMemberReloadCredits => {
+                REMOVE_TEAM_MEMBER_TITLE_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::None => String::new(),
         }
     }
 
@@ -90,7 +109,16 @@ impl CloudActionConfirmationDialog {
         match self.variant {
             CloudActionConfirmationDialogVariant::LeaveTeam => LEAVE_TEAM_BODY_TEXT.to_string(),
             CloudActionConfirmationDialogVariant::DeleteTeam => DELETE_TEAM_BODY_TEXT.to_string(),
-            CloudActionConfirmationDialogVariant::None => "".to_string(),
+            CloudActionConfirmationDialogVariant::LeaveTeamReloadCredits => {
+                LEAVE_TEAM_RELOAD_CREDITS_BODY_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits => {
+                DELETE_TEAM_RELOAD_CREDITS_BODY_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::RemoveTeamMemberReloadCredits => {
+                REMOVE_TEAM_MEMBER_RELOAD_CREDITS_BODY_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::None => String::new(),
         }
     }
 
@@ -100,7 +128,16 @@ impl CloudActionConfirmationDialog {
             CloudActionConfirmationDialogVariant::DeleteTeam => {
                 DELETE_TEAM_CONFIRM_TEXT.to_string()
             }
-            CloudActionConfirmationDialogVariant::None => "".to_string(),
+            CloudActionConfirmationDialogVariant::LeaveTeamReloadCredits => {
+                LEAVE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits => {
+                DELETE_TEAM_RELOAD_CREDITS_CONFIRM_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::RemoveTeamMemberReloadCredits => {
+                REMOVE_TEAM_MEMBER_RELOAD_CREDITS_CONFIRM_TEXT.to_string()
+            }
+            CloudActionConfirmationDialogVariant::None => String::new(),
         }
     }
 }

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -790,12 +790,9 @@ impl TeamsPageView {
 
         let team_action_confirmation_dialog =
             ctx.add_typed_action_view(|_| CloudActionConfirmationDialog::new());
-        ctx.subscribe_to_view(
-            &team_action_confirmation_dialog,
-            |me, _, event, ctx| {
-                me.handle_cloud_action_confirmation_dialog_event(event, ctx);
-            },
-        );
+        ctx.subscribe_to_view(&team_action_confirmation_dialog, |me, _, event, ctx| {
+            me.handle_cloud_action_confirmation_dialog_event(event, ctx);
+        });
 
         let transfer_ownership_modal_body =
             ctx.add_typed_action_view(|_| TransferOwnershipConfirmationModal::new());

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -545,13 +545,8 @@ impl TypedActionView for TeamsPageView {
                 );
             }
             TeamsPageAction::ShowDeleteTeamConfirmationDialog => {
-                let variant = if self.should_show_reload_credits_confirmation(ctx) {
-                    CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits
-                } else {
-                    CloudActionConfirmationDialogVariant::DeleteTeam
-                };
                 self.show_team_action_confirmation(
-                    variant,
+                    CloudActionConfirmationDialogVariant::DeleteTeam,
                     TeamActionConfirmationTarget::Delete,
                     ctx,
                 );

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -60,7 +60,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::{cmp::Ordering, collections::HashSet};
-use warp_core::ui::theme::color::internal_colors;
+use warp_core::{features::FeatureFlag, ui::theme::color::internal_colors};
 use warpui::FocusContext;
 
 use warpui::{
@@ -443,6 +443,15 @@ impl DiscoverableTeamState {
 pub struct OpenTeamsSettingsModalArgs {
     pub invite_email: Option<String>,
 }
+#[derive(Clone)]
+enum TeamActionConfirmationTarget {
+    Leave,
+    Delete,
+    RemoveUser {
+        user_uid: UserUid,
+        team_uid: ServerId,
+    },
+}
 
 pub struct TeamsPageView {
     page: PageType<Self>,
@@ -463,6 +472,7 @@ pub struct TeamsPageView {
     team_approved_domains_mouse_state_handles: Vec<MouseStateHandle>,
     delete_or_leave_team_confirmation_dialog: ViewHandle<CloudActionConfirmationDialog>,
     show_delete_or_leave_team_confirmation_dialog: bool,
+    pending_team_action_confirmation: Option<TeamActionConfirmationTarget>,
     transfer_ownership_modal_state: ModalViewState<Modal<TransferOwnershipConfirmationModal>>,
     clipped_scroll_state: ClippedScrollStateHandle,
     discoverable_teams_states: Vec<DiscoverableTeamState>,
@@ -501,7 +511,18 @@ impl TypedActionView for TeamsPageView {
             TeamsPageAction::LeaveTeam => self.leave_team(ctx),
             TeamsPageAction::CreateTeam => self.create_team(ctx),
             TeamsPageAction::RemoveUserFromTeam { user_uid, team_uid } => {
-                self.remove_user_from_team(*user_uid, *team_uid, ctx)
+                if FeatureFlag::BillingAndUsagePageV2.is_enabled() {
+                    self.show_team_action_confirmation(
+                        CloudActionConfirmationDialogVariant::RemoveTeamMemberReloadCredits,
+                        TeamActionConfirmationTarget::RemoveUser {
+                            user_uid: *user_uid,
+                            team_uid: *team_uid,
+                        },
+                        ctx,
+                    );
+                } else {
+                    self.remove_user_from_team(*user_uid, *team_uid, ctx);
+                }
             }
             TeamsPageAction::ChangeInviteViewOption(view_option) => {
                 self.change_invite_view_option(view_option, ctx);
@@ -512,22 +533,28 @@ impl TypedActionView for TeamsPageView {
             }
             TeamsPageAction::OpenWarpDrive => ctx.emit(TeamsPageViewEvent::OpenWarpDrive),
             TeamsPageAction::ShowLeaveTeamConfirmationDialog => {
-                self.delete_or_leave_team_confirmation_dialog
-                    .update(ctx, |dialog, ctx| {
-                        dialog.set_variant(CloudActionConfirmationDialogVariant::LeaveTeam);
-                        ctx.notify();
-                    });
-                self.show_delete_or_leave_team_confirmation_dialog = true;
-                self.enable_confirmation_dialog_confirm_button(ctx);
+                let variant = if self.should_show_reload_credits_confirmation(ctx) {
+                    CloudActionConfirmationDialogVariant::LeaveTeamReloadCredits
+                } else {
+                    CloudActionConfirmationDialogVariant::LeaveTeam
+                };
+                self.show_team_action_confirmation(
+                    variant,
+                    TeamActionConfirmationTarget::Leave,
+                    ctx,
+                );
             }
             TeamsPageAction::ShowDeleteTeamConfirmationDialog => {
-                self.delete_or_leave_team_confirmation_dialog
-                    .update(ctx, |dialog, ctx| {
-                        dialog.set_variant(CloudActionConfirmationDialogVariant::DeleteTeam);
-                        ctx.notify();
-                    });
-                self.show_delete_or_leave_team_confirmation_dialog = true;
-                self.enable_confirmation_dialog_confirm_button(ctx);
+                let variant = if self.should_show_reload_credits_confirmation(ctx) {
+                    CloudActionConfirmationDialogVariant::DeleteTeamReloadCredits
+                } else {
+                    CloudActionConfirmationDialogVariant::DeleteTeam
+                };
+                self.show_team_action_confirmation(
+                    variant,
+                    TeamActionConfirmationTarget::Delete,
+                    ctx,
+                );
             }
             TeamsPageAction::ToggleIsInviteLinkEnabled {
                 team_uid,
@@ -839,6 +866,7 @@ impl TeamsPageView {
             clipped_scroll_state: Default::default(),
             delete_or_leave_team_confirmation_dialog,
             show_delete_or_leave_team_confirmation_dialog: false,
+            pending_team_action_confirmation: None,
             transfer_ownership_modal_state: ModalViewState::new(transfer_ownership_modal),
             discoverable_teams_states: Vec::new(),
             rename_team_editor,
@@ -1037,6 +1065,56 @@ impl TeamsPageView {
         }
     }
 
+    fn should_show_reload_credits_confirmation(&self, ctx: &AppContext) -> bool {
+        FeatureFlag::BillingAndUsagePageV2.is_enabled()
+            && self
+                .ai_request_usage_model
+                .as_ref(ctx)
+                .total_user_interactive_bonus_credits_remaining()
+                > 0
+    }
+
+    fn show_team_action_confirmation(
+        &mut self,
+        variant: CloudActionConfirmationDialogVariant,
+        target: TeamActionConfirmationTarget,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.pending_team_action_confirmation = Some(target);
+        self.open_member_actions_menu_index = None;
+        self.delete_or_leave_team_confirmation_dialog
+            .update(ctx, |dialog, ctx| {
+                dialog.set_variant(variant);
+                dialog.set_confirmation_button_enabled(true);
+                ctx.notify();
+            });
+        self.show_delete_or_leave_team_confirmation_dialog = true;
+        ctx.notify();
+    }
+
+    fn hide_team_action_confirmation(&mut self, ctx: &mut ViewContext<Self>) {
+        self.pending_team_action_confirmation = None;
+        self.show_delete_or_leave_team_confirmation_dialog = false;
+        ctx.notify();
+    }
+
+    fn confirm_pending_team_action(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(target) = self.pending_team_action_confirmation.take() else {
+            self.hide_team_action_confirmation(ctx);
+            return;
+        };
+        self.show_delete_or_leave_team_confirmation_dialog = false;
+        match target {
+            TeamActionConfirmationTarget::Leave | TeamActionConfirmationTarget::Delete => {
+                self.leave_team(ctx);
+            }
+            TeamActionConfirmationTarget::RemoveUser { user_uid, team_uid } => {
+                self.remove_user_from_team(user_uid, team_uid, ctx);
+            }
+        }
+        ctx.notify();
+    }
+
     /// Scroll to the team membership settings. If an email is provided, it's prepopulated in the
     /// invite editor.
     pub fn open_team_members(&mut self, email: Option<&String>, ctx: &mut ViewContext<Self>) {
@@ -1087,12 +1165,10 @@ impl TeamsPageView {
     ) {
         match event {
             CloudActionConfirmationDialogEvent::Cancel => {
-                self.show_delete_or_leave_team_confirmation_dialog = false;
-                ctx.notify();
+                self.hide_team_action_confirmation(ctx);
             }
             CloudActionConfirmationDialogEvent::Confirm => {
-                self.leave_team(ctx);
-                self.show_delete_or_leave_team_confirmation_dialog = false;
+                self.confirm_pending_team_action(ctx);
             }
         }
     }
@@ -1313,13 +1389,6 @@ impl TeamsPageView {
             );
             ctx.notify();
         });
-    }
-
-    fn enable_confirmation_dialog_confirm_button(&mut self, ctx: &mut ViewContext<Self>) {
-        self.delete_or_leave_team_confirmation_dialog
-            .update(ctx, |dialog, _ctx| {
-                dialog.set_confirmation_button_enabled(true);
-            })
     }
 
     fn show_toast(
@@ -1756,6 +1825,9 @@ impl SettingsPageMeta for TeamsPageView {
             TeamUpdateManager::handle(ctx)
                 .update(ctx, |manager, ctx| manager.refresh_workspace_metadata(ctx)),
         );
+        self.ai_request_usage_model.update(ctx, |usage_model, ctx| {
+            usage_model.refresh_request_usage_async(ctx);
+        });
         self.update_team_members_state(ctx);
         self.update_approved_domains_state(ctx);
         if NetworkStatus::as_ref(ctx).is_online() {
@@ -2238,7 +2310,6 @@ impl TeamsWidget {
                 Container::new(self.render_leave_or_delete_team_button(
                     is_owner,
                     delete_disabled_reason.is_none(),
-                    view,
                     appearance,
                 ))
                 .with_padding_right(24.)
@@ -3233,11 +3304,8 @@ impl TeamsWidget {
         &self,
         is_team_owner: bool,
         can_team_be_deleted: bool,
-        view: &TeamsPageView,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
-        let mut stack = Stack::new();
-
         let (label, action) = if is_team_owner {
             (
                 DELETE_TEAM_BUTTON_LABEL,
@@ -3283,27 +3351,10 @@ impl TeamsWidget {
                 .with_cursor(Cursor::PointingHand)
                 .on_click(move |ctx, _, _| ctx.dispatch_typed_action(action.clone()))
         };
-
-        stack.add_child(
-            Container::new(hoverable.finish())
-                .with_padding_top(CONTENT_SEPARATION_PADDING)
-                .with_padding_bottom(CONTENT_SEPARATION_PADDING)
-                .finish(),
-        );
-
-        if view.show_delete_or_leave_team_confirmation_dialog {
-            stack.add_positioned_overlay_child(
-                ChildView::new(&view.delete_or_leave_team_confirmation_dialog).finish(),
-                OffsetPositioning::offset_from_parent(
-                    vec2f(0., 0.),
-                    ParentOffsetBounds::Unbounded,
-                    ParentAnchor::Center,
-                    ChildAnchor::BottomMiddle,
-                ),
-            );
-        }
-
-        stack.finish()
+        Container::new(hoverable.finish())
+            .with_padding_top(CONTENT_SEPARATION_PADDING)
+            .with_padding_bottom(CONTENT_SEPARATION_PADDING)
+            .finish()
     }
 
     fn render_delete_disabled_help_text(
@@ -4328,6 +4379,17 @@ impl SettingsWidget for TeamsWidget {
         if view.transfer_ownership_modal_state.is_open() {
             stack.add_positioned_overlay_child(
                 view.transfer_ownership_modal_state.render(),
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., 0.),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::Center,
+                    ChildAnchor::Center,
+                ),
+            );
+        }
+        if view.show_delete_or_leave_team_confirmation_dialog {
+            stack.add_positioned_overlay_child(
+                ChildView::new(&view.delete_or_leave_team_confirmation_dialog).finish(),
                 OffsetPositioning::offset_from_parent(
                     vec2f(0., 0.),
                     ParentOffsetBounds::WindowByPosition,

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -470,8 +470,8 @@ pub struct TeamsPageView {
     invite_view: TeamsInviteOption,
     team_members_mouse_state_handles: Vec<MouseStateHandle>,
     team_approved_domains_mouse_state_handles: Vec<MouseStateHandle>,
-    delete_or_leave_team_confirmation_dialog: ViewHandle<CloudActionConfirmationDialog>,
-    show_delete_or_leave_team_confirmation_dialog: bool,
+    team_action_confirmation_dialog: ViewHandle<CloudActionConfirmationDialog>,
+    show_team_action_confirmation_dialog: bool,
     pending_team_action_confirmation: Option<TeamActionConfirmationTarget>,
     transfer_ownership_modal_state: ModalViewState<Modal<TransferOwnershipConfirmationModal>>,
     clipped_scroll_state: ClippedScrollStateHandle,
@@ -788,10 +788,10 @@ impl TeamsPageView {
             ctx.notify()
         });
 
-        let delete_or_leave_team_confirmation_dialog =
+        let team_action_confirmation_dialog =
             ctx.add_typed_action_view(|_| CloudActionConfirmationDialog::new());
         ctx.subscribe_to_view(
-            &delete_or_leave_team_confirmation_dialog,
+            &team_action_confirmation_dialog,
             |me, _, event, ctx| {
                 me.handle_cloud_action_confirmation_dialog_event(event, ctx);
             },
@@ -859,8 +859,8 @@ impl TeamsPageView {
             team_members_mouse_state_handles,
             team_approved_domains_mouse_state_handles,
             clipped_scroll_state: Default::default(),
-            delete_or_leave_team_confirmation_dialog,
-            show_delete_or_leave_team_confirmation_dialog: false,
+            team_action_confirmation_dialog,
+            show_team_action_confirmation_dialog: false,
             pending_team_action_confirmation: None,
             transfer_ownership_modal_state: ModalViewState::new(transfer_ownership_modal),
             discoverable_teams_states: Vec::new(),
@@ -1077,19 +1077,19 @@ impl TeamsPageView {
     ) {
         self.pending_team_action_confirmation = Some(target);
         self.open_member_actions_menu_index = None;
-        self.delete_or_leave_team_confirmation_dialog
+        self.team_action_confirmation_dialog
             .update(ctx, |dialog, ctx| {
                 dialog.set_variant(variant);
                 dialog.set_confirmation_button_enabled(true);
                 ctx.notify();
             });
-        self.show_delete_or_leave_team_confirmation_dialog = true;
+        self.show_team_action_confirmation_dialog = true;
         ctx.notify();
     }
 
     fn hide_team_action_confirmation(&mut self, ctx: &mut ViewContext<Self>) {
         self.pending_team_action_confirmation = None;
-        self.show_delete_or_leave_team_confirmation_dialog = false;
+        self.show_team_action_confirmation_dialog = false;
         ctx.notify();
     }
 
@@ -1098,7 +1098,7 @@ impl TeamsPageView {
             self.hide_team_action_confirmation(ctx);
             return;
         };
-        self.show_delete_or_leave_team_confirmation_dialog = false;
+        self.show_team_action_confirmation_dialog = false;
         match target {
             TeamActionConfirmationTarget::Leave | TeamActionConfirmationTarget::Delete => {
                 self.leave_team(ctx);
@@ -1111,15 +1111,15 @@ impl TeamsPageView {
     }
 
     fn should_show_delete_or_leave_team_confirmation_dialog(&self) -> bool {
-        self.show_delete_or_leave_team_confirmation_dialog
+        self.show_team_action_confirmation_dialog
             && matches!(
                 &self.pending_team_action_confirmation,
                 Some(TeamActionConfirmationTarget::Leave | TeamActionConfirmationTarget::Delete)
             )
     }
 
-    fn should_show_centered_team_action_confirmation_dialog(&self) -> bool {
-        self.show_delete_or_leave_team_confirmation_dialog
+    fn should_show_remove_user_from_team_confirmation_dialog(&self) -> bool {
+        self.show_team_action_confirmation_dialog
             && matches!(
                 &self.pending_team_action_confirmation,
                 Some(TeamActionConfirmationTarget::RemoveUser { .. })
@@ -1836,9 +1836,6 @@ impl SettingsPageMeta for TeamsPageView {
             TeamUpdateManager::handle(ctx)
                 .update(ctx, |manager, ctx| manager.refresh_workspace_metadata(ctx)),
         );
-        self.ai_request_usage_model.update(ctx, |usage_model, ctx| {
-            usage_model.refresh_request_usage_async(ctx);
-        });
         self.update_team_members_state(ctx);
         self.update_approved_domains_state(ctx);
         if NetworkStatus::as_ref(ctx).is_online() {
@@ -3320,6 +3317,7 @@ impl TeamsWidget {
         appearance: &Appearance,
     ) -> Box<dyn Element> {
         let mut stack = Stack::new();
+
         let (label, action) = if is_team_owner {
             (
                 DELETE_TEAM_BUTTON_LABEL,
@@ -3375,7 +3373,7 @@ impl TeamsWidget {
 
         if view.should_show_delete_or_leave_team_confirmation_dialog() {
             stack.add_positioned_overlay_child(
-                ChildView::new(&view.delete_or_leave_team_confirmation_dialog).finish(),
+                ChildView::new(&view.team_action_confirmation_dialog).finish(),
                 OffsetPositioning::offset_from_parent(
                     vec2f(0., 0.),
                     ParentOffsetBounds::Unbounded,
@@ -4418,9 +4416,9 @@ impl SettingsWidget for TeamsWidget {
                 ),
             );
         }
-        if view.should_show_centered_team_action_confirmation_dialog() {
+        if view.should_show_remove_user_from_team_confirmation_dialog() {
             stack.add_positioned_overlay_child(
-                ChildView::new(&view.delete_or_leave_team_confirmation_dialog).finish(),
+                ChildView::new(&view.team_action_confirmation_dialog).finish(),
                 OffsetPositioning::offset_from_parent(
                     vec2f(0., 0.),
                     ParentOffsetBounds::WindowByPosition,

--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -1110,6 +1110,22 @@ impl TeamsPageView {
         ctx.notify();
     }
 
+    fn should_show_delete_or_leave_team_confirmation_dialog(&self) -> bool {
+        self.show_delete_or_leave_team_confirmation_dialog
+            && matches!(
+                &self.pending_team_action_confirmation,
+                Some(TeamActionConfirmationTarget::Leave | TeamActionConfirmationTarget::Delete)
+            )
+    }
+
+    fn should_show_centered_team_action_confirmation_dialog(&self) -> bool {
+        self.show_delete_or_leave_team_confirmation_dialog
+            && matches!(
+                &self.pending_team_action_confirmation,
+                Some(TeamActionConfirmationTarget::RemoveUser { .. })
+            )
+    }
+
     /// Scroll to the team membership settings. If an email is provided, it's prepopulated in the
     /// invite editor.
     pub fn open_team_members(&mut self, email: Option<&String>, ctx: &mut ViewContext<Self>) {
@@ -2305,6 +2321,7 @@ impl TeamsWidget {
                 Container::new(self.render_leave_or_delete_team_button(
                     is_owner,
                     delete_disabled_reason.is_none(),
+                    view,
                     appearance,
                 ))
                 .with_padding_right(24.)
@@ -3299,8 +3316,10 @@ impl TeamsWidget {
         &self,
         is_team_owner: bool,
         can_team_be_deleted: bool,
+        view: &TeamsPageView,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
+        let mut stack = Stack::new();
         let (label, action) = if is_team_owner {
             (
                 DELETE_TEAM_BUTTON_LABEL,
@@ -3346,10 +3365,27 @@ impl TeamsWidget {
                 .with_cursor(Cursor::PointingHand)
                 .on_click(move |ctx, _, _| ctx.dispatch_typed_action(action.clone()))
         };
-        Container::new(hoverable.finish())
-            .with_padding_top(CONTENT_SEPARATION_PADDING)
-            .with_padding_bottom(CONTENT_SEPARATION_PADDING)
-            .finish()
+
+        stack.add_child(
+            Container::new(hoverable.finish())
+                .with_padding_top(CONTENT_SEPARATION_PADDING)
+                .with_padding_bottom(CONTENT_SEPARATION_PADDING)
+                .finish(),
+        );
+
+        if view.should_show_delete_or_leave_team_confirmation_dialog() {
+            stack.add_positioned_overlay_child(
+                ChildView::new(&view.delete_or_leave_team_confirmation_dialog).finish(),
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., 0.),
+                    ParentOffsetBounds::Unbounded,
+                    ParentAnchor::Center,
+                    ChildAnchor::BottomMiddle,
+                ),
+            );
+        }
+
+        stack.finish()
     }
 
     fn render_delete_disabled_help_text(
@@ -4382,7 +4418,7 @@ impl SettingsWidget for TeamsWidget {
                 ),
             );
         }
-        if view.show_delete_or_leave_team_confirmation_dialog {
+        if view.should_show_centered_team_action_confirmation_dialog() {
             stack.add_positioned_overlay_child(
                 ChildView::new(&view.delete_or_leave_team_confirmation_dialog).finish(),
                 OffsetPositioning::offset_from_parent(


### PR DESCRIPTION
## Description
Adds reload-credit warning confirmation copy for team leave and member removal flows behind `BillingAndUsagePageV2`. Leave uses the reload-credit copy only when the current user has remaining user-level interactive bonus credits; member removal shows the warning whenever the feature flag is enabled. Delete team continues to use the existing delete confirmation.

## Testing
Removing a user from a team:
<img width="534" height="250" alt="image" src="https://github.com/user-attachments/assets/a0f9d72f-ad31-4ee3-9665-4139784e6dc9" />

Leaving a team:
<img width="520" height="232" alt="image" src="https://github.com/user-attachments/assets/6a12ff20-2437-4069-9601-d77034de83da" />

Deleting a team:
<img width="495" height="219" alt="image" src="https://github.com/user-attachments/assets/e299ce1a-0fda-4adc-b758-2aa7845a3130" />

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

CHANGELOG-NONE