### PR TITLE
Keep transcript thought snippets expanded

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -749,13 +749,16 @@ impl CollapsibleElementState {
         }
     }
 
-    fn finish_reasoning(&mut self, app: &AppContext) {
+    fn finish_reasoning(&mut self, app: &AppContext, keep_expanded_for_transcript_viewer: bool) {
         let should_auto_collapse = self.should_auto_collapse_reasoning_on_finish();
         let thinking_mode = AISettings::as_ref(app).thinking_display_mode;
 
         self.sync_finished_state(true);
 
-        if !thinking_mode.should_keep_expanded() && should_auto_collapse {
+        if !thinking_mode.should_keep_expanded()
+            && !keep_expanded_for_transcript_viewer
+            && should_auto_collapse
+        {
             self.expansion_state = CollapsibleExpansionState::Collapsed;
         } else if let CollapsibleExpansionState::Expanded {
             scroll_pinned_to_bottom,
@@ -2077,7 +2080,11 @@ impl AIBlock {
                     .entry(message.id.clone())
                     .or_default();
                 if finished_duration.is_some() {
-                    entry.finish_reasoning(ctx);
+                    let keep_expanded_for_transcript_viewer = self
+                        .terminal_model
+                        .lock()
+                        .is_conversation_transcript_viewer();
+                    entry.finish_reasoning(ctx, keep_expanded_for_transcript_viewer);
                 } else {
                     entry.sync_finished_state(false);
                 }

--- a/app/src/ai/blocklist/block_tests.rs
+++ b/app/src/ai/blocklist/block_tests.rs
@@ -22,7 +22,7 @@ fn reasoning_auto_collapses_when_user_has_not_manually_toggled() {
         initialize_settings_for_tests(&mut app);
         let mut state = CollapsibleElementState::default();
         app.update(|ctx| {
-            state.finish_reasoning(ctx);
+            state.finish_reasoning(ctx, false);
         });
 
         assert!(matches!(
@@ -101,7 +101,7 @@ fn always_show_thinking_stays_expanded_after_finish() {
 
         let mut state = CollapsibleElementState::default();
         app.update(|ctx| {
-            state.finish_reasoning(ctx);
+            state.finish_reasoning(ctx, false);
         });
 
         assert!(matches!(
@@ -122,7 +122,7 @@ fn manual_collapse_while_streaming_stays_collapsed_after_finish() {
 
         state.toggle_expansion();
         app.update(|ctx| {
-            state.finish_reasoning(ctx);
+            state.finish_reasoning(ctx, false);
         });
 
         assert!(matches!(
@@ -141,7 +141,26 @@ fn manual_reexpand_while_streaming_stays_expanded_after_finish() {
         state.toggle_expansion();
         state.toggle_expansion();
         app.update(|ctx| {
-            state.finish_reasoning(ctx);
+            state.finish_reasoning(ctx, false);
+        });
+
+        assert!(matches!(
+            state.expansion_state,
+            CollapsibleExpansionState::Expanded {
+                is_finished: true,
+                scroll_pinned_to_bottom: false
+            }
+        ));
+    });
+}
+
+#[test]
+fn transcript_viewer_reasoning_stays_expanded_after_finish() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let mut state = CollapsibleElementState::default();
+        app.update(|ctx| {
+            state.finish_reasoning(ctx, true);
         });
 
         assert!(matches!(


### PR DESCRIPTION
## Summary
- keep completed reasoning/thought snippets expanded by default in conversation transcript viewers
- preserve existing auto-collapse behavior for live agent panes unless the user has Always Show enabled
- add coverage for transcript-viewer reasoning expansion

## Tests
- `cargo test -p warp transcript_viewer_reasoning_stays_expanded_after_finish`
- `cargo test -p warp ai::blocklist::block::tests::`

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._