### PR TITLE
Pin orchestration runs while children are active

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1127,7 +1127,7 @@ impl AgentConversationsModel {
         let mut emitted_conversation_ids = HashSet::new();
 
         for task in self.tasks.values() {
-            let entry = entry::entry_for_task(task, history_model, app);
+            let entry = entry::entry_for_task(task, &self.tasks, history_model, app);
             if let Some(conversation_id) = entry.identity.local_conversation_id {
                 attached_conversation_ids.insert(conversation_id);
             }
@@ -1177,7 +1177,7 @@ impl AgentConversationsModel {
             AgentConversationEntryId::AmbientRun(task_id) => self
                 .tasks
                 .get(task_id)
-                .map(|task| entry::entry_for_task(task, history_model, app)),
+                .map(|task| entry::entry_for_task(task, &self.tasks, history_model, app)),
             AgentConversationEntryId::Conversation(conversation_id) => self
                 .conversations
                 .get(conversation_id)
@@ -1366,14 +1366,14 @@ impl AgentConversationsModel {
             task.conversation_id()
                 .is_some_and(|conversation_id| conversation_id == server_token.as_str())
         }) {
-            return Some(entry::entry_for_task(task, history_model, app));
+            return Some(entry::entry_for_task(task, &self.tasks, history_model, app));
         }
 
         let conversation_id = history_model.find_conversation_id_by_server_token(server_token)?;
         if let Some(task) = self.tasks.values().find(|task| {
             entry::conversation_id_shadowed_by_task(task, history_model) == Some(conversation_id)
         }) {
-            return Some(entry::entry_for_task(task, history_model, app));
+            return Some(entry::entry_for_task(task, &self.tasks, history_model, app));
         }
 
         self.get_entry_by_id(

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -4,12 +4,14 @@ use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::{AgentSource, AmbientAgentTask, AmbientAgentTaskId};
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
+use crate::ai::blocklist::orchestration_topology::descendant_conversation_ids_in_spawn_order;
 use crate::ai::conversation_navigation::ConversationNavigationData;
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::workspace::RestoreConversationLayout;
 use crate::workspaces::user_profiles::UserProfiles;
 use chrono::{DateTime, Utc};
 use session_sharing_protocol::common::SessionId;
+use std::collections::{HashMap, HashSet};
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
 use warpui::{AppContext, SingletonEntity};
@@ -382,6 +384,81 @@ fn conversation_display_status(
         .unwrap_or(AgentRunDisplayStatus::ConversationSucceeded)
 }
 
+fn has_working_descendant_conversation(
+    parent_id: AIConversationId,
+    history_model: &BlocklistAIHistoryModel,
+) -> bool {
+    descendant_conversation_ids_in_spawn_order(history_model, parent_id)
+        .into_iter()
+        .filter_map(|id| history_model.conversation(&id))
+        .any(|conversation| conversation.status().is_in_progress())
+}
+
+fn has_working_descendant_task(
+    task_id: AmbientAgentTaskId,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+    history_model: &BlocklistAIHistoryModel,
+    app: &AppContext,
+    visited: &mut HashSet<AmbientAgentTaskId>,
+) -> bool {
+    if !visited.insert(task_id) {
+        return false;
+    }
+
+    let Some(task) = tasks.get(&task_id) else {
+        return false;
+    };
+    let task_id_string = task_id.to_string();
+
+    tasks.values().any(|candidate| {
+        let is_direct_child = candidate
+            .parent_run_id
+            .as_deref()
+            .is_some_and(|parent_run_id| parent_run_id == task_id_string)
+            || task
+                .children
+                .iter()
+                .any(|child| child == &candidate.task_id.to_string());
+
+        if !is_direct_child {
+            return false;
+        }
+
+        AgentRunDisplayStatus::from_task(candidate, app).is_working()
+            || conversation_id_shadowed_by_task(candidate, history_model).is_some_and(
+                |conversation_id| {
+                    has_working_descendant_conversation(conversation_id, history_model)
+                },
+            )
+            || has_working_descendant_task(candidate.task_id, tasks, history_model, app, visited)
+    })
+}
+
+fn task_display_status(
+    task: &AmbientAgentTask,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+    history_model: &BlocklistAIHistoryModel,
+    app: &AppContext,
+) -> AgentRunDisplayStatus {
+    let status = AgentRunDisplayStatus::from_task(task, app);
+    if status.is_working() {
+        return status;
+    }
+
+    let local_conversation_has_working_descendant =
+        conversation_id_shadowed_by_task(task, history_model).is_some_and(|conversation_id| {
+            has_working_descendant_conversation(conversation_id, history_model)
+        });
+    let task_has_working_descendant =
+        has_working_descendant_task(task.task_id, tasks, history_model, app, &mut HashSet::new());
+
+    if local_conversation_has_working_descendant || task_has_working_descendant {
+        AgentRunDisplayStatus::ConversationInProgress
+    } else {
+        status
+    }
+}
+
 fn conversation_request_usage(
     metadata: &ConversationMetadata,
     history_model: &BlocklistAIHistoryModel,
@@ -413,6 +490,7 @@ fn conversation_artifacts(
 
 pub(super) fn entry_for_task(
     task: &AmbientAgentTask,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
     history_model: &BlocklistAIHistoryModel,
     app: &AppContext,
 ) -> AgentConversationEntry {
@@ -427,7 +505,7 @@ pub(super) fn entry_for_task(
                 server_conversation_token_for_conversation(conversation_id, None, history_model)
             })
         });
-    let status = AgentRunDisplayStatus::from_task(task, app);
+    let status = task_display_status(task, tasks, history_model, app);
     let has_active_session_id = task
         .active_execution_session_id()
         .and_then(parse_session_id)

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -566,6 +566,150 @@ fn test_status_filter_uses_display_status_for_task_backed_conversations() {
     });
 }
 
+#[test]
+fn test_parent_task_status_stays_working_while_child_task_is_working() {
+    App::test((), |mut app| async move {
+        add_entry_projection_test_models(&mut app);
+
+        let now = Utc::now();
+        let parent_task_id = make_uuid(4007);
+        let child_task_id = make_uuid(4008);
+
+        let mut parent_task = create_test_task(&parent_task_id, "user-a", now);
+        parent_task.state = AmbientAgentTaskState::Succeeded;
+        parent_task.children = vec![child_task_id.clone()];
+
+        let mut child_task = create_test_task(&child_task_id, "user-a", now);
+        child_task.state = AmbientAgentTaskState::InProgress;
+        child_task.parent_run_id = Some(parent_task_id.clone());
+
+        let mut model = create_test_model();
+        model.tasks.insert(parent_task.task_id, parent_task.clone());
+        model.tasks.insert(child_task.task_id, child_task);
+
+        app.update(|ctx| {
+            let parent_entry = model
+                .get_entry_by_id(
+                    &AgentConversationEntryId::AmbientRun(parent_task.task_id),
+                    ctx,
+                )
+                .expect("parent task entry should exist");
+
+            assert_eq!(
+                parent_entry.display.status,
+                AgentRunDisplayStatus::ConversationInProgress
+            );
+            assert_eq!(
+                parent_entry.display.status.status_filter(),
+                StatusFilter::Working
+            );
+            assert!(parent_entry.capabilities.can_cancel);
+        });
+    });
+}
+
+#[test]
+fn test_parent_task_status_stays_working_while_child_conversation_is_working() {
+    App::test((), |mut app| async move {
+        let _orchestration_v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
+        add_entry_projection_test_models(&mut app);
+        let history_model = BlocklistAIHistoryModel::handle(&app);
+
+        let now = Utc::now();
+        let parent_conversation_id = AIConversationId::new();
+        let child_conversation_id = AIConversationId::new();
+        let terminal_view_id = EntityId::new();
+        let parent_task_id = make_uuid(4009);
+        let child_task_id = make_uuid(4010);
+
+        let parent_conversation = create_restored_conversation(
+            parent_conversation_id,
+            "parent-root-task",
+            AgentConversationData {
+                server_conversation_token: None,
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: None,
+                agent_name: None,
+                orchestration_harness_type: None,
+                parent_conversation_id: None,
+                is_remote_child: false,
+                run_id: Some(parent_task_id.clone()),
+                autoexecute_override: None,
+                last_event_sequence: None,
+                pinned: false,
+            },
+        );
+        let mut child_conversation = create_restored_conversation(
+            child_conversation_id,
+            "child-root-task",
+            AgentConversationData {
+                server_conversation_token: None,
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: Some(parent_task_id.clone()),
+                agent_name: Some("child".to_string()),
+                orchestration_harness_type: None,
+                parent_conversation_id: Some(parent_conversation_id.to_string()),
+                is_remote_child: false,
+                run_id: Some(child_task_id),
+                autoexecute_override: None,
+                last_event_sequence: None,
+                pinned: false,
+            },
+        );
+        child_conversation.set_parent_conversation_id(parent_conversation_id);
+
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(
+                terminal_view_id,
+                vec![parent_conversation, child_conversation],
+                ctx,
+            );
+            model.update_conversation_status(
+                terminal_view_id,
+                parent_conversation_id,
+                ConversationStatus::Success,
+                ctx,
+            );
+            model.update_conversation_status(
+                terminal_view_id,
+                child_conversation_id,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+        });
+
+        let mut parent_task = create_test_task(&parent_task_id, "user-a", now);
+        parent_task.state = AmbientAgentTaskState::Succeeded;
+
+        let mut model = create_test_model();
+        model.tasks.insert(parent_task.task_id, parent_task.clone());
+
+        app.update(|ctx| {
+            let parent_entry = model
+                .get_entry_by_id(
+                    &AgentConversationEntryId::AmbientRun(parent_task.task_id),
+                    ctx,
+                )
+                .expect("parent task entry should exist");
+
+            assert_eq!(
+                parent_entry.display.status,
+                AgentRunDisplayStatus::ConversationInProgress
+            );
+            assert_eq!(
+                parent_entry.display.status.status_filter(),
+                StatusFilter::Working
+            );
+        });
+    });
+}
+
 /// Helper to generate a unique UUID for task IDs
 fn make_uuid(index: usize) -> String {
     format!("550e8400-e29b-41d4-a716-{:012}", index)


### PR DESCRIPTION
## Summary
- keep orchestration parent runs displayed as in progress while known child tasks or child conversations are still working
- use the existing conversation topology and task parent/child metadata when projecting management entries
- add regression coverage for active child task and active child conversation cases

## Tests
- cargo fmt --check
- git diff --check
- cargo test -p warp parent_task_status_stays -- --nocapture

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._