### PR TITLE
Split out our embedded assets to a `warp_assets` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14517,6 +14517,7 @@ dependencies = [
  "walkdir",
  "warp-command-signatures",
  "warp-workflows",
+ "warp_assets",
  "warp_cli",
  "warp_completer",
  "warp_core",
@@ -14600,6 +14601,15 @@ version = "0.1.0"
 source = "git+https://github.com/warpdotdev/workflows?rev=793a98ddda6ef19682aed66364faebd2829f0e01#793a98ddda6ef19682aed66364faebd2829f0e01"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "warp_assets"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "rust-embed 8.7.2",
+ "warpui_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ node_runtime = { path = "crates/node_runtime" }
 onboarding = { path = "crates/onboarding" }
 persistence = { path = "crates/persistence" }
 prevent_sleep = { path = "crates/prevent_sleep" }
+remote_server = { path = "crates/remote_server" }
 repo_metadata = { path = "crates/repo_metadata" }
 settings = { path = "crates/settings" }
 settings_value = { path = "crates/settings_value", default-features = false }
@@ -69,12 +70,12 @@ vim = { path = "crates/vim" }
 virtual-fs = { path = "crates/virtual_fs" }
 voice_input = { path = "crates/voice_input" }
 warp = { path = "app" }
+warp_assets = { path = "crates/warp_assets" }
 warp_cli = { path = "crates/warp_cli" }
 warp_completer = { path = "crates/warp_completer" }
 warp_core = { path = "crates/warp_core" }
 warp_editor = { path = "crates/editor" }
 warp_features = { path = "crates/warp_features" }
-remote_server = { path = "crates/remote_server" }
 warp_files = { path = "crates/warp_files" }
 warp_graphql = { path = "crates/graphql" }
 warp_graphql_schema = { path = "crates/warp_graphql_schema" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -222,6 +222,7 @@ version-compare.workspace = true
 vte.workspace = true
 walkdir.workspace = true
 warp-workflows.workspace = true
+warp_assets.workspace = true
 warp_completer.workspace = true
 warp_core.workspace = true
 warp_editor.workspace = true
@@ -784,7 +785,7 @@ session_sharing = []
 session_sharing_acls = []
 skip_login = []
 # This feature should only be enabled when building a self-contained binary with the bundle script.
-standalone = []
+standalone = ["warp_assets/standalone"]
 prompt_suggestions_via_maa = []
 voice_input = ["dep:voice_input"]
 system_theme = []

--- a/app/src/drive/index_tests.rs
+++ b/app/src/drive/index_tests.rs
@@ -29,7 +29,7 @@ use crate::{
     workspaces::{
         team_tester::TeamTesterStatus, user_profiles::UserProfiles, user_workspaces::UserWorkspaces,
     },
-    Assets,
+    ASSETS,
 };
 
 use super::{DriveIndex, DriveIndexAction};
@@ -121,7 +121,7 @@ fn label_for_menu_item(item: &MenuItem<DriveIndexAction>) -> &str {
 
 #[test]
 fn test_retry_menu_item_visibility() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let index = create_index(&mut app);
         let sync_id = create_workflow(&mut app);
@@ -171,7 +171,7 @@ fn test_retry_menu_item_visibility() {
 
 #[test]
 fn test_retry_menu_item_logic() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let index = create_index(&mut app);
         let sync_id = create_workflow(&mut app);

--- a/app/src/drive/panel_tests.rs
+++ b/app/src/drive/panel_tests.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     test_util::settings::initialize_settings_for_tests,
     workspaces::{team_tester::TeamTesterStatus, user_workspaces::UserWorkspaces},
-    Assets, ObjectActions,
+    ObjectActions, ASSETS,
 };
 
 use super::DrivePanel;
@@ -52,7 +52,7 @@ fn initialize_app(app: &mut App) {
 
 #[test]
 fn test_warp_drive_sections_with_no_team() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         // Instead of being in the panel module and depending on DrivePanel, this test should be in the index module.

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -263,7 +263,6 @@ use channel::ChannelState;
 use interval_timer::IntervalTimer;
 use itertools::Itertools;
 use referral_theme_status::ReferralThemeStatus;
-use rust_embed::RustEmbed;
 use server::server_api::ServerApiProvider;
 use settings::{ExtraMetaKeys, PrivacySettings};
 #[cfg(feature = "local_fs")]
@@ -281,7 +280,7 @@ use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
 use warp_managed_secrets::ManagedSecretManager;
 use workspace::sync_inputs::SyncedInputState;
 
-use warpui::{integration::TestDriver, App, AssetProvider, Event};
+use warpui::{integration::TestDriver, App, AssetProvider as _, Event};
 
 use self::features::FeatureFlag;
 use crate::app_state::AppState;
@@ -319,20 +318,8 @@ use warpui::platform::TerminationMode;
 use warpui::windowing::state::ApplicationStage;
 use warpui::{AppContext, SingletonEntity, WindowId};
 
-#[derive(Clone, Copy, RustEmbed)]
-#[folder = "assets"]
-#[include = "bundled/**"] // Should be kept in sync with BUNDLED_ASSETS_DIR.
-#[include = "async/**"] // Should be kept in sync with ASYNC_ASSETS_DIR.
-#[cfg_attr(target_family = "wasm", exclude = "async/**")]
-// Excludes take precedence.
-// Standalone CLI builds (the `oz` tarball) are headless and never render the
-// onboarding/theme imagery in `async/`, so we exclude those bytes from the
-// embedded asset set to keep the CLI binary small — mirroring the carve-out
-// already applied for the WASM target above.
-#[cfg_attr(feature = "standalone", exclude = "async/**")]
-pub struct Assets;
-
-pub static ASSETS: Assets = Assets;
+/// Our embedded application assets.
+pub static ASSETS: warp_assets::Assets = warp_assets::Assets;
 
 fn determine_agent_source(
     launch_mode: &LaunchMode,
@@ -560,14 +547,6 @@ impl LaunchMode {
             driver: Box::new(None),
             is_integration_test: false,
         }
-    }
-}
-
-impl AssetProvider for Assets {
-    fn get(&self, path: &str) -> Result<Cow<'_, [u8]>> {
-        <Assets as RustEmbed>::get(path)
-            .map(|f| f.data)
-            .ok_or_else(|| anyhow!("no asset exists at path {}", path))
     }
 }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -280,7 +280,7 @@ use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
 use warp_managed_secrets::ManagedSecretManager;
 use workspace::sync_inputs::SyncedInputState;
 
-use warpui::{integration::TestDriver, App, AssetProvider as _, Event};
+use warpui::{integration::TestDriver, App, Event};
 
 use self::features::FeatureFlag;
 use crate::app_state::AppState;
@@ -947,6 +947,7 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
         use warpui::platform::mac::AppExt;
+        use warpui::AssetProvider as _;
 
         let activate_on_launch = !launch_mode.is_integration_test()
             || std::env::var("WARPUI_USE_REAL_DISPLAY_IN_INTEGRATION_TESTS").is_ok();

--- a/app/src/notebooks/editor/notebook_command.rs
+++ b/app/src/notebooks/editor/notebook_command.rs
@@ -27,7 +27,7 @@ use warp_editor::{
 
 use markdown_parser::markdown_parser::CODE_BLOCK_DEFAULT_MARKDOWN_LANG;
 use warp_util::user_input::UserInput;
-use warpui::{elements::Align, platform::Cursor, r#async::SpawnedFutureHandle, AppContext};
+use warpui::{AppContext, r#async::SpawnedFutureHandle, elements::Align, platform::Cursor};
 use warpui::{
     elements::{
         Border, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, MainAxisAlignment,
@@ -66,7 +66,6 @@ use crate::{
     },
     view_components::{dropdown::DropdownAction, Dropdown},
     workflows::{workflow::Workflow, WorkflowType},
-    Assets,
 };
 
 use super::{
@@ -229,7 +228,7 @@ impl NotebookCommand {
 
         let syntax_config = {
             let ps = SyntaxSet::load_defaults_newlines();
-            if let Some(asset) = Assets::get("bundled/syntax_theme/base16.tmTheme") {
+            if let Some(asset) = warp_assets::Assets::get("bundled/syntax_theme/base16.tmTheme") {
                 let binary = asset.data;
                 let mut cursor = std::io::Cursor::new(binary);
                 match ThemeSet::load_from_reader(&mut cursor) {

--- a/app/src/notebooks/editor/notebook_command.rs
+++ b/app/src/notebooks/editor/notebook_command.rs
@@ -27,7 +27,9 @@ use warp_editor::{
 
 use markdown_parser::markdown_parser::CODE_BLOCK_DEFAULT_MARKDOWN_LANG;
 use warp_util::user_input::UserInput;
-use warpui::{elements::Align, platform::Cursor, r#async::SpawnedFutureHandle, AppContext};
+use warpui::{
+    elements::Align, platform::Cursor, r#async::SpawnedFutureHandle, AppContext, AssetProvider as _,
+};
 use warpui::{
     elements::{
         Border, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, MainAxisAlignment,
@@ -66,6 +68,7 @@ use crate::{
     },
     view_components::{dropdown::DropdownAction, Dropdown},
     workflows::{workflow::Workflow, WorkflowType},
+    ASSETS,
 };
 
 use super::{
@@ -228,9 +231,8 @@ impl NotebookCommand {
 
         let syntax_config = {
             let ps = SyntaxSet::load_defaults_newlines();
-            if let Some(asset) = warp_assets::Assets::get("bundled/syntax_theme/base16.tmTheme") {
-                let binary = asset.data;
-                let mut cursor = std::io::Cursor::new(binary);
+            if let Some(asset) = ASSETS.get("bundled/syntax_theme/base16.tmTheme").ok() {
+                let mut cursor = std::io::Cursor::new(asset);
                 match ThemeSet::load_from_reader(&mut cursor) {
                     Ok(theme) => Some((ps, theme)),
                     Err(e) => {

--- a/app/src/notebooks/editor/notebook_command.rs
+++ b/app/src/notebooks/editor/notebook_command.rs
@@ -27,7 +27,7 @@ use warp_editor::{
 
 use markdown_parser::markdown_parser::CODE_BLOCK_DEFAULT_MARKDOWN_LANG;
 use warp_util::user_input::UserInput;
-use warpui::{AppContext, r#async::SpawnedFutureHandle, elements::Align, platform::Cursor};
+use warpui::{elements::Align, platform::Cursor, r#async::SpawnedFutureHandle, AppContext};
 use warpui::{
     elements::{
         Border, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, MainAxisAlignment,

--- a/app/src/notebooks/editor/notebook_command.rs
+++ b/app/src/notebooks/editor/notebook_command.rs
@@ -231,7 +231,7 @@ impl NotebookCommand {
 
         let syntax_config = {
             let ps = SyntaxSet::load_defaults_newlines();
-            if let Some(asset) = ASSETS.get("bundled/syntax_theme/base16.tmTheme").ok() {
+            if let Ok(asset) = ASSETS.get("bundled/syntax_theme/base16.tmTheme") {
                 let mut cursor = std::io::Cursor::new(asset);
                 match ThemeSet::load_from_reader(&mut cursor) {
                     Ok(theme) => Some((ps, theme)),

--- a/app/src/server/cloud_objects/update_manager_tests.rs
+++ b/app/src/server/cloud_objects/update_manager_tests.rs
@@ -60,7 +60,7 @@ use crate::{
         CloudWorkflow, CloudWorkflowModel, WorkflowId,
     },
     workspaces::user_profiles::{UserProfileWithUID, UserProfiles},
-    Assets,
+    ASSETS,
 };
 
 use super::{GetCloudObjectResponse, InitialLoadResponse, UpdateManager};
@@ -637,7 +637,7 @@ fn mock_fetch_single_cloud_object(
 
 #[test]
 fn test_sync_state_after_creation_item_not_in_sync_queue_folder() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         let client_id = ClientId::new();
         initialize_app(&mut app);
         let object_id: FolderId = 123.into();
@@ -665,7 +665,7 @@ fn test_sync_state_after_creation_item_not_in_sync_queue_folder() {
 
 #[test]
 fn test_sync_state_after_creation_item_not_in_sync_queue_workflow() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         let client_id = ClientId::new();
         initialize_app(&mut app);
         let object_id: WorkflowId = 123.into();
@@ -693,7 +693,7 @@ fn test_sync_state_after_creation_item_not_in_sync_queue_workflow() {
 
 #[test]
 fn test_sync_state_after_creation_item_not_in_sync_queue_notebook() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         let client_id = ClientId::new();
         initialize_app(&mut app);
 
@@ -722,7 +722,7 @@ fn test_sync_state_after_creation_item_not_in_sync_queue_notebook() {
 
 #[test]
 fn test_sync_state_after_creation_item_not_in_sync_queue_generic_object() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         let client_id = ClientId::new();
         initialize_app(&mut app);
         let object_id: GenericStringObjectId = 123.into();
@@ -834,7 +834,7 @@ async fn run_sync_state_after_creation_item_not_in_sync_queue<K, M>(
 
 #[test]
 fn test_sync_state_after_creation_item_in_flight() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -921,7 +921,7 @@ fn test_sync_state_after_creation_item_in_flight() {
 
 #[test]
 fn test_sync_state_after_creation_fails_due_to_limit() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let client_id = ClientId::new();
@@ -1046,7 +1046,7 @@ fn test_sync_state_after_creation_fails_due_to_limit() {
 
 #[test]
 fn test_sync_state_after_update_item_not_in_sync_queue() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -1191,7 +1191,7 @@ fn test_sync_state_after_update_item_not_in_sync_queue() {
 
 #[test]
 fn test_create_sets_editor() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = mock_server_api();
@@ -1235,7 +1235,7 @@ fn test_create_sets_editor() {
 
 #[test]
 fn test_bulk_create_generic_string_objects() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let client_id_1 = ClientId::new();
@@ -1393,7 +1393,7 @@ fn test_bulk_create_generic_string_objects() {
 
 #[test]
 fn test_sync_state_after_update_item_not_in_sync_queue_generic_string_object() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let client_id = ClientId::new();
@@ -1524,7 +1524,7 @@ fn test_sync_state_after_update_item_not_in_sync_queue_generic_string_object() {
 
 #[test]
 fn test_sync_state_after_update_item_in_sync_queue() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -1641,7 +1641,7 @@ fn test_sync_state_after_update_item_in_sync_queue() {
 
 #[test]
 fn test_sync_state_after_creation_failure_item_not_in_sync_queue() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -1687,7 +1687,7 @@ fn test_sync_state_after_creation_failure_item_not_in_sync_queue() {
 
 #[test]
 fn test_sync_state_after_update_failure_item_in_sync_queue() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -1808,7 +1808,7 @@ fn test_sync_state_after_update_failure_item_in_sync_queue() {
 
 #[test]
 fn test_sync_state_after_object_with_dependencies_created() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -1958,7 +1958,7 @@ fn test_sync_state_after_object_with_dependencies_created() {
 
 #[test]
 fn test_fetch_single_cloud_object_not_pending_no_overwrite() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let client_id = ClientId::new();
@@ -2054,7 +2054,7 @@ fn test_fetch_single_cloud_object_not_pending_no_overwrite() {
 
 #[test]
 fn test_fetch_single_cloud_object_pending_no_overwrite() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -2154,7 +2154,7 @@ fn test_fetch_single_cloud_object_pending_no_overwrite() {
 
 #[test]
 fn test_fetch_single_cloud_object_pending_with_overwrite() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -2260,7 +2260,7 @@ fn test_fetch_single_cloud_object_pending_with_overwrite() {
 
 #[test]
 fn test_metadata_after_trash_item_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -2330,7 +2330,7 @@ fn test_metadata_after_trash_item_success() {
 
 #[test]
 fn test_pending_metadata_update_with_rtc() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
 
@@ -2437,7 +2437,7 @@ fn test_pending_metadata_update_with_rtc() {
 
 #[test]
 fn test_metadata_update_with_rtc_no_pending() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
 
@@ -2535,7 +2535,7 @@ fn test_metadata_update_with_rtc_no_pending() {
 
 #[test]
 fn test_metadata_after_trash_item_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -2604,7 +2604,7 @@ fn test_metadata_after_trash_item_failure() {
 
 #[test]
 fn test_pending_metadata_update_with_polling() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -2757,7 +2757,7 @@ fn test_pending_metadata_update_with_polling() {
 
 #[test]
 fn test_metadata_update_with_polling_no_pending() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
 
@@ -2874,7 +2874,7 @@ fn test_metadata_update_with_polling_no_pending() {
 
 #[test]
 fn test_metadata_after_untrash_item_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -2944,7 +2944,7 @@ fn test_metadata_after_untrash_item_success() {
 
 #[test]
 fn test_metadata_after_untrash_item_and_move_to_root() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -3017,7 +3017,7 @@ fn test_metadata_after_untrash_item_and_move_to_root() {
 
 #[test]
 fn test_metadata_after_untrash_item_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -3071,7 +3071,7 @@ fn test_metadata_after_untrash_item_failure() {
 
 #[test]
 fn test_metadata_after_optimistic_grab_baton_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -3143,7 +3143,7 @@ fn test_metadata_after_optimistic_grab_baton_success() {
 
 #[test]
 fn test_metadata_after_optimistic_grab_baton_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -3202,7 +3202,7 @@ fn test_metadata_after_optimistic_grab_baton_failure() {
 
 #[test]
 fn test_metadata_after_non_optimistic_grab_baton_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -3274,7 +3274,7 @@ fn test_metadata_after_non_optimistic_grab_baton_success() {
 
 #[test]
 fn test_metadata_after_non_optimistic_grab_baton_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -3332,7 +3332,7 @@ fn test_metadata_after_non_optimistic_grab_baton_failure() {
 
 #[test]
 fn test_report_initial_load() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
         let update_manager_struct = create_update_manager_struct(&mut app, Arc::new(server_api));
@@ -3417,7 +3417,7 @@ fn test_get_duplicate_object_name() {
 
 #[test]
 fn test_duplicate_workflow_not_pending_no_overwrite() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = mock_server_api();
@@ -3497,7 +3497,7 @@ fn test_duplicate_workflow_not_pending_no_overwrite() {
 
 #[test]
 fn test_replace_object_with_conflicts() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = mock_server_api();
@@ -3614,7 +3614,7 @@ fn test_replace_object_with_conflicts() {
 
 #[test]
 fn test_pending_conflict_correctly_clears_after_edits() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = mock_server_api();
@@ -3746,7 +3746,7 @@ fn test_pending_conflict_correctly_clears_after_edits() {
 
 #[test]
 fn test_pending_conflict_correctly_stays_after_edits() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = mock_server_api();
@@ -3877,7 +3877,7 @@ fn test_pending_self_conflict_clears_out_of_order() {
     // This tests the case where the client makes an edit and receives the RTC update for it
     // _before_ the server response to their edit.
 
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = MockObjectClient::new();
@@ -3972,7 +3972,7 @@ fn test_pending_self_conflict_clears_out_of_order() {
 fn test_pending_newer_conflict_remains_out_of_order() {
     // This tests the case where the client makes an edit which is eventually accepted by the
     // server, but receives an RTC update about a _newer_ edit in the meantime.
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = MockObjectClient::new();
@@ -4067,7 +4067,7 @@ fn test_pending_newer_conflict_remains_out_of_order() {
 
 #[test]
 fn test_accepts_new_metadata_with_force_refresh() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
         let server_id: ServerId = 123.into();
@@ -4160,7 +4160,7 @@ fn test_accepts_new_metadata_with_force_refresh() {
 
 #[test]
 fn test_delete_single_object() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4232,7 +4232,7 @@ fn test_delete_single_object() {
 
 #[test]
 fn test_empty_trash() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let ts = Utc::now();
@@ -4344,7 +4344,7 @@ fn test_empty_trash() {
 
 #[test]
 fn test_leave_shared_object() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4451,7 +4451,7 @@ fn test_leave_shared_object() {
 
 #[test]
 fn test_create_object_online_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4551,7 +4551,7 @@ fn test_create_object_online_success() {
 
 #[test]
 fn test_create_object_online_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4610,7 +4610,7 @@ fn test_create_object_online_failure() {
 
 #[test]
 fn test_create_object_online_user_facing_error() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4673,7 +4673,7 @@ fn test_create_object_online_user_facing_error() {
 
 #[test]
 fn test_create_object_online_with_folder_id() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4756,7 +4756,7 @@ fn test_create_object_online_with_folder_id() {
 
 #[test]
 fn test_create_object_online_with_client_folder_id_fails() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4808,7 +4808,7 @@ fn test_create_object_online_with_client_folder_id_fails() {
 
 #[test]
 fn test_record_object_action() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -4895,7 +4895,7 @@ fn test_record_object_action() {
 
 #[test]
 fn test_overwrite_object_action_history_no_actions_on_client() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
 
@@ -4963,7 +4963,7 @@ fn test_overwrite_object_action_history_no_actions_on_client() {
 
 #[test]
 fn test_overwrite_object_action_history_reject() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
 
@@ -5117,7 +5117,7 @@ fn test_overwrite_object_action_history_reject() {
 
 #[test]
 fn test_overwrite_object_action_history_ignores_pending_local_actions() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
 
@@ -5271,7 +5271,7 @@ fn test_overwrite_object_action_history_ignores_pending_local_actions() {
 
 #[test]
 fn test_object_action_histories_with_initial_load() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
 
@@ -5457,7 +5457,7 @@ fn test_object_action_histories_with_initial_load() {
 
 #[test]
 fn test_delete_single_object_with_actions() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -5581,7 +5581,7 @@ fn test_delete_single_object_with_actions() {
 /// changing the owner of an object, which implicitly also clears its parent folder.
 #[test]
 fn test_move_object_personal_to_team_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -5681,7 +5681,7 @@ fn test_move_object_personal_to_team_success() {
 /// optimistically update the model, and then roll those updates back on failure.
 #[test]
 fn test_move_object_personal_to_team_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -5787,7 +5787,7 @@ fn test_move_object_personal_to_team_failure() {
 /// space to a team drive.
 #[test]
 fn test_move_cloud_environment_personal_to_team_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -5886,7 +5886,7 @@ fn test_move_cloud_environment_personal_to_team_success() {
 /// and change the reference stored within the workflow to point to that enum.
 #[test]
 fn test_move_workflow_with_enums_personal_to_team_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let team = Space::Team {
@@ -6023,7 +6023,7 @@ fn test_move_workflow_with_enums_personal_to_team_success() {
 
 #[test]
 fn test_move_workflow_with_enums_personal_to_team_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
         let team = Space::Team {
@@ -6174,7 +6174,7 @@ fn test_move_workflow_with_enums_personal_to_team_failure() {
 /// `Some`.
 #[test]
 fn test_move_object_root_to_folder_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -6267,7 +6267,7 @@ fn test_move_object_root_to_folder_success() {
 /// optimistically update the model, and then roll back the updates on failure.
 #[test]
 fn test_move_object_root_to_folder_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -6366,7 +6366,7 @@ fn test_move_object_root_to_folder_failure() {
 /// during, and after a move where the object's parent folder changes from `Some` to `None`.
 #[test]
 fn test_move_object_folder_to_root_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -6459,7 +6459,7 @@ fn test_move_object_folder_to_root_success() {
 /// we optimistically clear its parent folder, and then restore it on failure.
 #[test]
 fn test_move_object_folder_to_root_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -6558,7 +6558,7 @@ fn test_move_object_folder_to_root_failure() {
 /// checks that we update the object's metadata and emit events correctly.
 #[test]
 fn test_move_object_folder_to_folder_success() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -6653,7 +6653,7 @@ fn test_move_object_folder_to_folder_success() {
 /// we optimistically apply the move in-memory and then undo it on failure.
 #[test]
 fn test_move_object_folder_to_folder_failure() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -6754,7 +6754,7 @@ fn test_move_object_folder_to_folder_failure() {
 /// object was trashed by another client.
 #[test]
 fn test_trash_object_over_rtc() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
         let workflow_id: WorkflowId = 123.into();
@@ -6831,7 +6831,7 @@ fn test_trash_object_over_rtc() {
 /// object was un-trashed by another client.
 #[test]
 fn test_untrash_object_over_rtc() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
         let workflow_id: WorkflowId = 123.into();
@@ -6908,7 +6908,7 @@ fn test_untrash_object_over_rtc() {
 /// object was moved from one folder to another in the same space by another client.
 #[test]
 fn test_move_object_from_folder_to_folder_over_rtc() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
         let workflow_id: WorkflowId = 123.into();
@@ -6989,7 +6989,7 @@ fn test_move_object_from_folder_to_folder_over_rtc() {
 /// object was moved from a folder to the root of its space by another client.
 #[test]
 fn test_move_object_from_folder_to_root_over_rtc() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
         let workflow_id: WorkflowId = 123.into();
@@ -7069,7 +7069,7 @@ fn test_move_object_from_folder_to_root_over_rtc() {
 /// an object was moved from the root of its space into a folder by another client.
 #[test]
 fn test_move_object_from_root_to_folder_over_rtc() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let server_api = mock_server_api();
         let workflow_id: WorkflowId = 123.into();
@@ -7147,7 +7147,7 @@ fn test_move_object_from_root_to_folder_over_rtc() {
 
 #[test]
 fn test_permissions_update_grants_access() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let mut server_api = mock_server_api();
@@ -7261,7 +7261,7 @@ fn test_permissions_update_grants_access() {
 fn test_permissions_update_existing_object() {
     let _guard = FeatureFlag::SharedWithMe.override_enabled(true);
 
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         let server_api = mock_server_api();
@@ -7322,7 +7322,7 @@ fn test_permissions_update_existing_object() {
 #[test]
 fn test_add_guest_success() {
     let _guard = FeatureFlag::SharedWithMe.override_enabled(true);
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 
@@ -7436,7 +7436,7 @@ fn test_add_guest_success() {
 #[test]
 fn test_add_guest_failure() {
     let _guard = FeatureFlag::SharedWithMe.override_enabled(true);
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
         let mut server_api = mock_server_api();
 

--- a/app/src/settings/cloud_preferences_syncer_tests.rs
+++ b/app/src/settings/cloud_preferences_syncer_tests.rs
@@ -28,7 +28,7 @@ use crate::{
         sync_queue::SyncQueue,
     },
     settings::cloud_preferences::{CloudPreferenceModel, CloudPreferencesSettings, Platform},
-    Assets,
+    ASSETS,
 };
 
 use warp_core::{
@@ -281,7 +281,7 @@ fn expect_bulk_create_generic_string_objects(
 
 #[test]
 fn test_sync_local_pref_to_cloud_after_initial_sync_creates_prefs_setting() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -327,7 +327,7 @@ fn test_sync_local_pref_to_cloud_after_initial_sync_creates_prefs_setting() {
 
 #[test]
 fn test_sync_local_pref_to_cloud_after_initial_sync() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -456,7 +456,7 @@ fn test_sync_local_pref_to_cloud_after_initial_sync() {
 }
 
 fn run_initial_sync_test(is_onboarded: bool) {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -598,7 +598,7 @@ fn test_sync_local_pref_to_cloud_on_initial_sync_for_returning_user() {
 
 #[test]
 fn test_sync_local_pref_to_cloud_updates_existing_pref() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -685,7 +685,7 @@ fn test_sync_local_pref_to_cloud_updates_existing_pref() {
 
 #[test]
 fn test_sync_cloud_pref_to_local_on_initial_load_or_collab_update() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -800,7 +800,7 @@ fn test_sync_cloud_pref_to_local_on_initial_load_or_collab_update() {
 
 #[test]
 fn test_cloud_preferences_setting_initial_load_skipped_when_setting_is_off() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -925,7 +925,7 @@ fn test_cloud_preferences_setting_initial_load_skipped_when_setting_is_off() {
 
 #[test]
 fn test_sync_local_pref_to_cloud_doesnt_update_equal_pref() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -1029,7 +1029,7 @@ fn test_sync_local_pref_to_cloud_doesnt_update_equal_pref() {
 
 #[test]
 fn test_cloud_preferences_setting_enabling_setting_syncs_prefs() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         // Start with cloud prefs disabled
         initialize_settings(&mut app);
 
@@ -1090,7 +1090,7 @@ fn test_cloud_preferences_setting_enabling_setting_syncs_prefs() {
 
 #[test]
 fn test_cloud_pref_not_synced_when_current_value_not_syncable() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -1152,7 +1152,7 @@ fn test_cloud_pref_not_synced_when_current_value_not_syncable() {
 
 #[test]
 fn test_ensure_no_duplicate_cloud_prefs() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         let mut server_api = mock_object_client_with_base_expectations();
@@ -1311,7 +1311,7 @@ fn write_stored_hash(app: &App, value: &str) {
 
 #[test]
 fn test_force_local_wins_on_startup_uploads_local_to_cloud() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         // Step 1: create a real temp settings.toml. The file's hash is
@@ -1402,7 +1402,7 @@ fn test_force_local_wins_on_startup_uploads_local_to_cloud() {
 
 #[test]
 fn test_no_force_local_when_hashes_match() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         // Create a file and seed the stored hash with its exact value
@@ -1460,7 +1460,7 @@ fn test_no_force_local_when_hashes_match() {
 
 #[test]
 fn test_force_local_suppressed_when_file_is_broken() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         // Create a file whose contents happen to hash to something,
@@ -1531,7 +1531,7 @@ fn test_force_local_suppressed_when_file_is_broken() {
 
 #[test]
 fn test_file_missing_with_stored_hash_lets_cloud_win() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         // Use a path that doesn't exist: the user has deleted their
@@ -1584,7 +1584,7 @@ fn test_file_missing_with_stored_hash_lets_cloud_win() {
 
 #[test]
 fn test_first_launch_with_no_stored_hash_lets_cloud_win() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         // Fresh install: a settings.toml exists but there is no
@@ -1640,7 +1640,7 @@ fn test_first_launch_with_no_stored_hash_lets_cloud_win() {
 
 #[test]
 fn test_offline_ui_change_does_not_update_hash_until_sync_succeeds() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_settings(&mut app);
 
         // Phase 1: normal startup. File and stored hash match, cloud

--- a/app/src/terminal/platform.rs
+++ b/app/src/terminal/platform.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use crate::{Assets, ASSETS};
 use anyhow::Result;
 
 pub fn init() -> Result<()> {

--- a/app/src/terminal/ssh/warpify_tests.rs
+++ b/app/src/terminal/ssh/warpify_tests.rs
@@ -2,7 +2,7 @@ use warpui::{assets::asset_cache::AssetSource, App};
 
 use crate::{
     terminal::ssh::util::convert_script_to_one_line,
-    test_util::settings::initialize_settings_for_tests, Assets,
+    test_util::settings::initialize_settings_for_tests, ASSETS,
 };
 
 use super::*;
@@ -38,7 +38,7 @@ fn get_script(asset_source: AssetSource, ctx: &AppContext) -> String {
 #[test]
 /// See [assert_script_is_short_enough_mac] for more information.
 fn test_mac_warpification_script_size() {
-    App::test(Assets, |mut app| async move {
+    App::test(ASSETS, |mut app| async move {
         initialize_app(&mut app);
 
         app.read(|ctx| {

--- a/crates/warp_assets/Cargo.toml
+++ b/crates/warp_assets/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "warp_assets"
+version = "0.0.0"
+edition = "2024"
+authors.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[features]
+standalone = []
+
+[dependencies]
+anyhow.workspace = true
+rust-embed.workspace = true
+warpui_core.workspace = true
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+# Make sure we embed the data into the wasm binary even when running in debug
+# mode, as it cannot be read directly from the filesystem.
+rust-embed = { workspace = true, features = ["debug-embed"] }

--- a/crates/warp_assets/src/lib.rs
+++ b/crates/warp_assets/src/lib.rs
@@ -1,0 +1,26 @@
+use std::borrow::Cow;
+
+use anyhow::{anyhow, Result};
+use rust_embed::RustEmbed;
+use warpui_core::AssetProvider;
+
+#[derive(Clone, Copy, RustEmbed)]
+#[folder = "../../app/assets"]
+#[include = "bundled/**"] // Should be kept in sync with BUNDLED_ASSETS_DIR.
+#[include = "async/**"] // Should be kept in sync with ASYNC_ASSETS_DIR.
+#[cfg_attr(target_family = "wasm", exclude = "async/**")]
+// Excludes take precedence.
+// Standalone CLI builds (the `oz` tarball) are headless and never render the
+// onboarding/theme imagery in `async/`, so we exclude those bytes from the
+// embedded asset set to keep the CLI binary small — mirroring the carve-out
+// already applied for the WASM target above.
+#[cfg_attr(feature = "standalone", exclude = "async/**")]
+pub struct Assets;
+
+impl AssetProvider for Assets {
+    fn get(&self, path: &str) -> Result<Cow<'_, [u8]>> {
+        <Assets as RustEmbed>::get(path)
+            .map(|f| f.data)
+            .ok_or_else(|| anyhow!("no asset exists at path {}", path))
+    }
+}

--- a/crates/warp_assets/src/lib.rs
+++ b/crates/warp_assets/src/lib.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use rust_embed::RustEmbed;
 use warpui_core::AssetProvider;
 


### PR DESCRIPTION
## Description

Should help a little with compilation times - profiling indicates we spend a bit of time expanding the `RustEmbed` proc macro.

## Testing

Manually tested that the embedded assets are still loaded properly with a native macOS build (`./script/run`) and with a wasm build (`./script/wasm/run`).