### PR TITLE
fix(agent): shell-escape paths interpolated by grep/file_glob/is_file_path helpers (#11132)

### DIFF
--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -1298,9 +1298,13 @@ async fn read_binary_file_context(
 fn build_is_file_path_command(path: &str, family: warp_util::path::ShellFamily) -> String {
     let escaped_path = family.shell_escape(path);
     match family {
-        warp_util::path::ShellFamily::PowerShell => {
-            format!("if (Test-Path -PathType Leaf {escaped_path}) {{ exit 0 }} else {{ exit 1 }}")
-        }
+        // `-LiteralPath` suppresses PowerShell wildcard interpretation, so a
+        // path that happens to contain `*` / `?` / `[...]` is tested as-is
+        // rather than as a wildcard pattern (which would either match the
+        // wrong file or always return true).
+        warp_util::path::ShellFamily::PowerShell => format!(
+            "if (Test-Path -PathType Leaf -LiteralPath {escaped_path}) {{ exit 0 }} else {{ exit 1 }}"
+        ),
         warp_util::path::ShellFamily::Posix => format!("test -f {escaped_path}"),
     }
 }

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -100,7 +100,6 @@ use crate::{
     terminal::{
         model::session::{active_session::ActiveSession, ExecuteCommandOptions, Session},
         model_events::ModelEventDispatcher,
-        shell::ShellType,
         ShellLaunchData, TerminalModel,
     },
     BlocklistAIHistoryModel,
@@ -1290,14 +1289,26 @@ async fn read_binary_file_context(
     })
 }
 
+/// Builds the shell command run by [`is_file_path`] for a given shell family.
+///
+/// The `path` is passed through [`ShellFamily::shell_escape`] so that any
+/// shell metacharacters (spaces, `$`, backticks, `$(...)`, etc.) survive
+/// verbatim into the underlying `test -f` / `Test-Path` rather than being
+/// expanded by the shell before the probe runs.
+fn build_is_file_path_command(path: &str, family: warp_util::path::ShellFamily) -> String {
+    let escaped_path = family.shell_escape(path);
+    match family {
+        warp_util::path::ShellFamily::PowerShell => {
+            format!("if (Test-Path -PathType Leaf {escaped_path}) {{ exit 0 }} else {{ exit 1 }}")
+        }
+        warp_util::path::ShellFamily::Posix => format!("test -f {escaped_path}"),
+    }
+}
+
 /// Returns true if the given path is a regular file on the session's filesystem.
 /// Runs a shell command on the session so it works for both local and remote sessions.
 async fn is_file_path(path: &str, session: &Session) -> bool {
-    let command = if session.shell().shell_type() == ShellType::PowerShell {
-        format!("if (Test-Path -PathType Leaf \"{path}\") {{ exit 0 }} else {{ exit 1 }}")
-    } else {
-        format!("test -f \"{path}\"")
-    };
+    let command = build_is_file_path_command(path, session.shell_family());
     session
         .execute_command(&command, None, None, ExecuteCommandOptions::default())
         .await
@@ -1305,9 +1316,21 @@ async fn is_file_path(path: &str, session: &Session) -> bool {
         .unwrap_or(false)
 }
 
+/// Builds the shell command run by [`is_git_repository`].
+///
+/// `git -C` accepts a single positional path argument; we shell-escape it
+/// so the command behaves identically regardless of which shell parses it.
+fn build_is_git_repository_command(
+    absolute_path: &str,
+    family: warp_util::path::ShellFamily,
+) -> String {
+    let escaped_path = family.shell_escape(absolute_path);
+    format!("git -C {escaped_path} rev-parse")
+}
+
 /// Returns true if git is installed and the given path is in a git repository.
 async fn is_git_repository(absolute_path: &str, session: &Session) -> anyhow::Result<bool> {
-    let git_command = format!("git -C \"{absolute_path}\" rev-parse");
+    let git_command = build_is_git_repository_command(absolute_path, session.shell_family());
     let command_output = session
         .execute_command(
             git_command.as_str(),

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use itertools::Itertools;
+use warp_util::path::ShellFamily;
 use warpui::r#async::FutureExt as AsyncFutureExt;
 use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
@@ -281,18 +282,26 @@ async fn run_git_ls_files_command(
     }
 }
 
+/// Builds the POSIX `find` command run by [`run_find_command`]. POSIX-only —
+/// the path is escaped through [`ShellFamily::Posix`] so metacharacters in
+/// the directory name don't get expanded by the user's shell before `find`
+/// receives them.
+fn build_find_command(patterns: &[String], target_path: &str) -> String {
+    let pattern_args = patterns
+        .iter()
+        .map(|pattern| format!(" -name '{pattern}'"))
+        .join(" -o");
+    let escaped_path = ShellFamily::Posix.shell_escape(target_path);
+    format!("find {escaped_path} -type f {pattern_args}")
+}
+
 /// Uses the find command for Unix-like environments to find files matching patterns.
 async fn run_find_command(
     patterns: &[String],
     target_path: &str,
     session: &Session,
 ) -> anyhow::Result<FileGlobV2Result> {
-    // Build a find command with -name for each pattern
-    let pattern_args = patterns
-        .iter()
-        .map(|pattern| format!(" -name '{pattern}'"))
-        .join(" -o");
-    let find_command = format!("find \"{target_path}\" -type f {pattern_args}");
+    let find_command = build_find_command(patterns, target_path);
 
     let command_output = session
         .execute_command(
@@ -325,19 +334,27 @@ async fn run_find_command(
     }
 }
 
+/// Builds the PowerShell `Get-ChildItem` command run by
+/// [`run_powershell_get_childitem_command`]. The path is escaped through
+/// [`ShellFamily::PowerShell`].
+fn build_get_childitem_command(patterns: &[String], target_path: &str) -> String {
+    let pattern_args = patterns
+        .iter()
+        .map(|pattern| format!("'{pattern}'"))
+        .join(",");
+    let escaped_path = ShellFamily::PowerShell.shell_escape(target_path);
+    format!(
+        "Get-ChildItem -File -Recurse -Include {pattern_args} -Path {escaped_path} | ForEach-Object {{ $_.FullName }}"
+    )
+}
+
 /// Uses PowerShell's Get-ChildItem to find files matching patterns.
 async fn run_powershell_get_childitem_command(
     patterns: &[String],
     target_path: &str,
     session: &Session,
 ) -> anyhow::Result<FileGlobV2Result> {
-    let pattern_args = patterns
-        .iter()
-        .map(|pattern| format!("'{pattern}'"))
-        .join(",");
-    let command = format!(
-        "Get-ChildItem -File -Recurse -Include {pattern_args} -Path \"{target_path}\" | ForEach-Object {{ $_.FullName }}"
-    );
+    let command = build_get_childitem_command(patterns, target_path);
 
     let command_output = session
         .execute_command(
@@ -369,3 +386,7 @@ fn non_empty_lines(str: &str) -> impl Iterator<Item = &str> {
 impl Entity for FileGlobExecutor {
     type Event = ();
 }
+
+#[cfg(test)]
+#[path = "file_glob_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -219,11 +219,13 @@ async fn run_file_glob(
         });
 
     if is_in_git_repo {
+        let shell_type = session.shell().shell_type();
         run_git_ls_files_command(
             &patterns,
             &absolute_path,
             session.as_ref(),
             shell_launch_data,
+            shell_type,
         )
         .await
     } else if session.shell().shell_type() == ShellType::PowerShell {
@@ -233,26 +235,49 @@ async fn run_file_glob(
     }
 }
 
+/// Builds the `git ls-files` command run by [`run_git_ls_files_command`]. Each
+/// joined `<target_path>/<pattern>` arg is shell-escaped through the session's
+/// shell family so a directory name containing quotes or command-substitution
+/// metacharacters can't break out of the argument and execute in the user's
+/// shell. The shell consumes the escapes and hands `git ls-files` the literal
+/// pathspec, so glob characters in the pattern (e.g. `*.rs`) still survive for
+/// git's own pathspec matching.
+fn build_git_ls_files_command(
+    patterns: &[String],
+    target_path: &str,
+    shell_type: ShellType,
+    shell_launch_data: Option<&ShellLaunchData>,
+) -> String {
+    let family = ShellFamily::from(shell_type);
+    let pattern_args = patterns
+        .iter()
+        .flat_map(|pattern| {
+            [
+                // Matches on files in the target path.
+                join_paths(&[target_path, pattern], shell_launch_data),
+                // Matches on files in any subdirectory of the target path.
+                join_paths(&[target_path, "*", pattern], shell_launch_data),
+            ]
+        })
+        .map(|pattern| family.shell_escape(&pattern).into_owned())
+        .join(" ");
+    format!("git ls-files -c -o --exclude-standard -- {pattern_args}")
+}
+
 /// Uses git ls-files to list all files in a git repository and filters them by pattern.
 async fn run_git_ls_files_command(
     patterns: &[String],
     target_path: &str,
     session: &Session,
     shell_launch_data: Option<ShellLaunchData>,
+    shell_type: ShellType,
 ) -> anyhow::Result<FileGlobV2Result> {
-    let pattern_args = patterns
-        .iter()
-        .flat_map(|pattern| {
-            [
-                // Matches on files in the target path.
-                join_paths(&[target_path, pattern], shell_launch_data.as_ref()),
-                // Matches on files in any subdirectory of the target path.
-                join_paths(&[target_path, "*", pattern], shell_launch_data.as_ref()),
-            ]
-        })
-        .map(|pattern| format!("'{pattern}'"))
-        .join(" ");
-    let command = format!("git ls-files -c -o --exclude-standard -- {pattern_args}");
+    let command = build_git_ls_files_command(
+        patterns,
+        target_path,
+        shell_type,
+        shell_launch_data.as_ref(),
+    );
 
     let command_output = session
         .execute_command(

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -367,17 +367,22 @@ async fn run_find_command(
 /// [`run_powershell_get_childitem_command`]. The path is escaped through
 /// [`ShellFamily::PowerShell`].
 fn build_get_childitem_command(patterns: &[String], target_path: &str) -> String {
-    // Agent-supplied glob patterns: shell-escape via PowerShell backticks so
-    // metacharacters (including `'`, `$x`, `$env:VAR`, backticks) can't break
-    // out of the argument. PowerShell consumes the escapes and hands
-    // `Get-ChildItem -Include` the literal patterns for its own matching.
+    // Agent-supplied glob patterns: single-quote literal wrapping. This
+    // preserves embedded newlines / metacharacters verbatim (see
+    // `build_git_grep_command` in `grep.rs` for the same reasoning); the
+    // shell passes the literal pattern to `-Include` for its own matching.
     let pattern_args = patterns
         .iter()
-        .map(|pattern| ShellFamily::PowerShell.shell_escape(pattern).into_owned())
+        .map(|pattern| ShellFamily::PowerShell.shell_quote_arg(pattern))
         .join(",");
     let escaped_path = ShellFamily::PowerShell.shell_escape(target_path);
+    // `-LiteralPath` suppresses PowerShell wildcard interpretation on the
+    // search root — a path that contains `*` / `?` / `[...]` is treated as
+    // a literal directory rather than as a wildcard pattern (which would
+    // otherwise change which directory we recurse into). Glob semantics
+    // for filtering are still applied via `-Include`.
     format!(
-        "Get-ChildItem -File -Recurse -Include {pattern_args} -Path {escaped_path} | ForEach-Object {{ $_.FullName }}"
+        "Get-ChildItem -File -Recurse -Include {pattern_args} -LiteralPath {escaped_path} | ForEach-Object {{ $_.FullName }}"
     )
 }
 

--- a/app/src/ai/blocklist/action_model/execute/file_glob.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob.rs
@@ -312,9 +312,13 @@ async fn run_git_ls_files_command(
 /// the directory name don't get expanded by the user's shell before `find`
 /// receives them.
 fn build_find_command(patterns: &[String], target_path: &str) -> String {
+    // Agent-supplied glob patterns: shell-escape so an embedded `'` (or any
+    // other metacharacter) can't break out of the argument and execute as
+    // shell input. The shell consumes the escapes and hands `find` the
+    // literal pattern for its own glob matching.
     let pattern_args = patterns
         .iter()
-        .map(|pattern| format!(" -name '{pattern}'"))
+        .map(|pattern| format!(" -name {}", ShellFamily::Posix.shell_escape(pattern)))
         .join(" -o");
     let escaped_path = ShellFamily::Posix.shell_escape(target_path);
     format!("find {escaped_path} -type f {pattern_args}")
@@ -363,9 +367,13 @@ async fn run_find_command(
 /// [`run_powershell_get_childitem_command`]. The path is escaped through
 /// [`ShellFamily::PowerShell`].
 fn build_get_childitem_command(patterns: &[String], target_path: &str) -> String {
+    // Agent-supplied glob patterns: shell-escape via PowerShell backticks so
+    // metacharacters (including `'`, `$x`, `$env:VAR`, backticks) can't break
+    // out of the argument. PowerShell consumes the escapes and hands
+    // `Get-ChildItem -Include` the literal patterns for its own matching.
     let pattern_args = patterns
         .iter()
-        .map(|pattern| format!("'{pattern}'"))
+        .map(|pattern| ShellFamily::PowerShell.shell_escape(pattern).into_owned())
         .join(",");
     let escaped_path = ShellFamily::PowerShell.shell_escape(target_path);
     format!(

--- a/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
@@ -58,16 +58,25 @@ fn find_handles_multiple_patterns() {
 }
 
 #[test]
-fn get_childitem_powershell_escapes_target_path() {
+fn get_childitem_powershell_uses_literal_path() {
     let cmd = build_get_childitem_command(&["*.rs".to_string()], "C:\\Users\\me\\My Code");
+    // `-LiteralPath` suppresses PowerShell wildcard interpretation on the
+    // search directory — a path containing `*` / `?` / `[...]` is treated
+    // as literal rather than as a glob pattern (which would otherwise
+    // change which directory we recurse into). Glob semantics for filtering
+    // are still applied via `-Include`.
     assert!(
-        cmd.contains("-Path C:\\Users\\me\\My`\u{20}Code "),
-        "expected escaped path; got: {cmd}"
+        cmd.contains("-LiteralPath C:\\Users\\me\\My`\u{20}Code"),
+        "expected -LiteralPath escaped path; got: {cmd}"
     );
-    // The pattern `*` is also backtick-escaped in PowerShell.
     assert!(
-        cmd.starts_with("Get-ChildItem -File -Recurse -Include `*.rs -Path "),
-        "expected escaped pattern; got: {cmd}"
+        !cmd.contains("-Path "),
+        "wildcard-interpretable -Path leaked: {cmd}"
+    );
+    // Pattern is single-quote-wrapped (PowerShell literal form).
+    assert!(
+        cmd.starts_with("Get-ChildItem -File -Recurse -Include '*.rs' -LiteralPath "),
+        "expected literal-wrapped pattern; got: {cmd}"
     );
 }
 
@@ -85,18 +94,11 @@ fn get_childitem_powershell_escapes_metacharacters_in_path() {
 }
 
 #[test]
-fn get_childitem_powershell_escapes_env_var_in_pattern() {
-    // Same risk shape on the pattern side: an agent pattern containing
-    // `$env:VAR` would have leaked the env value into the glob without
-    // backtick-escape.
+fn get_childitem_powershell_env_var_in_pattern_stays_literal() {
+    // PowerShell single-quoted literals don't expand `$env:`, so the pattern
+    // reaches `Get-ChildItem -Include` verbatim.
     let cmd = build_get_childitem_command(&["leak$env:USERPROFILE".to_string()], "C:\\repo");
-    let mut iter = cmd.match_indices("$env:");
-    if let Some((idx, _)) = iter.next() {
-        assert!(
-            idx > 0 && &cmd[idx - 1..idx] == "`",
-            "unescaped $env: in pattern at byte {idx}: {cmd}"
-        );
-    }
+    assert!(cmd.contains("-Include 'leak$env:USERPROFILE'"));
 }
 
 #[test]

--- a/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
@@ -9,11 +9,14 @@ use crate::terminal::shell::ShellType;
 #[test]
 fn find_posix_escapes_target_path_spaces() {
     let cmd = build_find_command(&["*.rs".to_string()], "/tmp/my code");
-    assert_eq!(cmd, r#"find /tmp/my\ code -type f  -name '*.rs'"#);
+    // Both the path AND the pattern are shell-escaped. The `*` in the pattern
+    // is backslash-escaped at the shell level; the shell consumes the escape
+    // and hands `find` the literal `*` for its own glob matching.
+    assert_eq!(cmd, r"find /tmp/my\ code -type f  -name \*.rs");
 }
 
 #[test]
-fn find_posix_escapes_command_substitution() {
+fn find_posix_escapes_command_substitution_in_path() {
     let cmd = build_find_command(&["*.txt".to_string()], "/tmp/innocent$(touch ~/PROBE_RAN)");
     assert!(
         !cmd.contains("$(touch"),
@@ -23,7 +26,7 @@ fn find_posix_escapes_command_substitution() {
 }
 
 #[test]
-fn find_posix_escapes_backticks() {
+fn find_posix_escapes_backticks_in_path() {
     let cmd = build_find_command(&["*.md".to_string()], "/tmp/`rm`/here");
     assert!(
         !cmd.contains("/`rm`/"),
@@ -33,14 +36,25 @@ fn find_posix_escapes_backticks() {
 }
 
 #[test]
-fn find_handles_multiple_patterns() {
-    // Pattern args are joined with ` -o ` and must survive without the
-    // path-quoting changes affecting them.
-    let cmd = build_find_command(&["*.rs".to_string(), "*.toml".to_string()], "/tmp/repo");
-    assert_eq!(
-        cmd,
-        "find /tmp/repo -type f  -name '*.rs' -o -name '*.toml'"
+fn find_posix_escapes_single_quote_in_pattern() {
+    // The previous implementation wrapped each pattern in `'...'`. An agent
+    // glob containing a single quote closed the wrapper and let everything
+    // after it execute as shell input. After shell-escape, the single quote
+    // is backslash-escaped and the shell sees one token.
+    let cmd = build_find_command(&["evil'$(rm)".to_string()], "/tmp/repo");
+    assert!(
+        !cmd.contains("$(rm"),
+        "unescaped command substitution survived in pattern: {cmd}"
     );
+    assert!(cmd.contains(r"\'\$\(rm\)"));
+}
+
+#[test]
+fn find_handles_multiple_patterns() {
+    let cmd = build_find_command(&["*.rs".to_string(), "*.toml".to_string()], "/tmp/repo");
+    // Each pattern's `*` is backslash-escaped at the shell level; `find`
+    // still receives literal `*` characters for its glob matching.
+    assert_eq!(cmd, r"find /tmp/repo -type f  -name \*.rs -o -name \*.toml");
 }
 
 #[test]
@@ -50,13 +64,15 @@ fn get_childitem_powershell_escapes_target_path() {
         cmd.contains("-Path C:\\Users\\me\\My`\u{20}Code "),
         "expected escaped path; got: {cmd}"
     );
-    assert!(cmd.starts_with("Get-ChildItem -File -Recurse -Include '*.rs' -Path "));
+    // The pattern `*` is also backtick-escaped in PowerShell.
+    assert!(
+        cmd.starts_with("Get-ChildItem -File -Recurse -Include `*.rs -Path "),
+        "expected escaped pattern; got: {cmd}"
+    );
 }
 
 #[test]
-fn get_childitem_powershell_escapes_metacharacters() {
-    // PowerShell expands `$x` and `$env:USERPROFILE` inside `-Path "..."`;
-    // we need every metacharacter shell-escaped via backtick.
+fn get_childitem_powershell_escapes_metacharacters_in_path() {
     let cmd =
         build_get_childitem_command(&["*.txt".to_string()], "C:\\Users\\$env:USERPROFILE\\repo");
     let mut iter = cmd.match_indices("$env:");
@@ -64,6 +80,21 @@ fn get_childitem_powershell_escapes_metacharacters() {
         assert!(
             idx > 0 && &cmd[idx - 1..idx] == "`",
             "unescaped $env: at byte {idx}: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn get_childitem_powershell_escapes_env_var_in_pattern() {
+    // Same risk shape on the pattern side: an agent pattern containing
+    // `$env:VAR` would have leaked the env value into the glob without
+    // backtick-escape.
+    let cmd = build_get_childitem_command(&["leak$env:USERPROFILE".to_string()], "C:\\repo");
+    let mut iter = cmd.match_indices("$env:");
+    if let Some((idx, _)) = iter.next() {
+        assert!(
+            idx > 0 && &cmd[idx - 1..idx] == "`",
+            "unescaped $env: in pattern at byte {idx}: {cmd}"
         );
     }
 }

--- a/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
@@ -3,7 +3,8 @@
 /// guarantee for #11132: an agent-supplied `target_path` containing shell
 /// metacharacters must survive verbatim into the underlying `find` /
 /// `Get-ChildItem` invocation.
-use super::{build_find_command, build_get_childitem_command};
+use super::{build_find_command, build_get_childitem_command, build_git_ls_files_command};
+use crate::terminal::shell::ShellType;
 
 #[test]
 fn find_posix_escapes_target_path_spaces() {
@@ -73,4 +74,120 @@ fn empty_path_is_handled_safely() {
     // empty string).
     let cmd = build_find_command(&["*.rs".to_string()], "");
     assert!(cmd.starts_with("find '' -type f"));
+}
+
+// --- git ls-files (the in-git-repo branch) -----------------------------------
+
+#[test]
+fn git_ls_files_posix_escapes_target_path_spaces() {
+    let cmd =
+        build_git_ls_files_command(&["*.rs".to_string()], "/tmp/my code", ShellType::Bash, None);
+    assert!(
+        cmd.contains(r"/tmp/my\ code/\*.rs"),
+        "expected escaped path + glob; got: {cmd}"
+    );
+    assert!(cmd.starts_with("git ls-files -c -o --exclude-standard -- "));
+}
+
+#[test]
+fn git_ls_files_posix_escapes_single_quote_in_target_path() {
+    // The original implementation wrapped each joined path in literal single
+    // quotes (`'...'`), so a single quote inside `target_path` closed the
+    // wrapper and let everything after it parse as shell input — a real
+    // injection vector once the shell saw a following `$(...)`.
+    let cmd = build_git_ls_files_command(
+        &["*.rs".to_string()],
+        "/tmp/innocent'$(touch ~/PROBE_RAN)",
+        ShellType::Bash,
+        None,
+    );
+    assert!(
+        !cmd.contains("$(touch"),
+        "unescaped command substitution survived: {cmd}"
+    );
+    assert!(
+        !cmd.contains("/tmp/innocent'$"),
+        "raw single quote followed by `$` survived: {cmd}"
+    );
+    assert!(cmd.contains(r"\'\$\(touch\ \~/PROBE_RAN\)"));
+}
+
+#[test]
+fn git_ls_files_posix_escapes_command_substitution() {
+    let cmd = build_git_ls_files_command(
+        &["*.txt".to_string()],
+        "/tmp/innocent$(rm -rf ~)",
+        ShellType::Bash,
+        None,
+    );
+    assert!(
+        !cmd.contains("$(rm"),
+        "unescaped command substitution survived: {cmd}"
+    );
+    assert!(cmd.contains(r"\$\(rm\ -rf\ \~\)"));
+}
+
+#[test]
+fn git_ls_files_posix_escapes_backticks() {
+    let cmd = build_git_ls_files_command(
+        &["*.md".to_string()],
+        "/tmp/`rm`/here",
+        ShellType::Bash,
+        None,
+    );
+    assert!(
+        !cmd.contains("/`rm`/"),
+        "unescaped backtick run survived: {cmd}"
+    );
+    // Each backtick must be backslash-escaped.
+    for (i, c) in cmd.char_indices() {
+        if c == '`' {
+            assert!(
+                i > 0 && cmd.as_bytes()[i - 1] == b'\\',
+                "unescaped backtick at byte {i}: {cmd}"
+            );
+        }
+    }
+}
+
+#[test]
+fn git_ls_files_powershell_escapes_target_path() {
+    // PowerShell variant: backtick is the escape character. The single-quote
+    // wrapping was already POSIX-only, so the previous code shipped broken
+    // PowerShell quoting; with `ShellFamily::from(ShellType::PowerShell)`
+    // the same call path now produces a shell-safe arg on Windows.
+    let cmd = build_git_ls_files_command(
+        &["*.rs".to_string()],
+        "C:\\Users\\me\\My Code",
+        ShellType::PowerShell,
+        None,
+    );
+    // PowerShell uses backtick-escape; `join_paths` uses `/` as the separator
+    // regardless of shell type, so the literal substring we care about is the
+    // escaped path component plus the escaped glob.
+    assert!(
+        cmd.contains("C:\\Users\\me\\My` Code/`*.rs"),
+        "expected backtick-escaped path + glob; got: {cmd}"
+    );
+    // Sanity: the previous POSIX-only single-quote wrapping must not be present.
+    assert!(
+        !cmd.contains("'C:\\Users"),
+        "unsafe POSIX single-quoting leaked into PowerShell output: {cmd}"
+    );
+}
+
+#[test]
+fn git_ls_files_emits_both_top_level_and_subdir_pattern_args() {
+    // The builder doubles every pattern: once joined as `<path>/<pattern>` and
+    // once as `<path>/*/<pattern>` so git matches files at the top of the
+    // target directory AND in any subdirectory.
+    let cmd = build_git_ls_files_command(&["*.rs".to_string()], "/tmp/repo", ShellType::Bash, None);
+    assert!(
+        cmd.contains(r"/tmp/repo/\*.rs"),
+        "missing top-level arg: {cmd}"
+    );
+    assert!(
+        cmd.contains(r"/tmp/repo/\*/\*.rs"),
+        "missing subdirectory arg: {cmd}"
+    );
 }

--- a/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/file_glob_tests.rs
@@ -1,0 +1,76 @@
+/// Tests for the pure command builders behind [`run_find_command`] and
+/// [`run_powershell_get_childitem_command`]. These pin the shell-quoting
+/// guarantee for #11132: an agent-supplied `target_path` containing shell
+/// metacharacters must survive verbatim into the underlying `find` /
+/// `Get-ChildItem` invocation.
+use super::{build_find_command, build_get_childitem_command};
+
+#[test]
+fn find_posix_escapes_target_path_spaces() {
+    let cmd = build_find_command(&["*.rs".to_string()], "/tmp/my code");
+    assert_eq!(cmd, r#"find /tmp/my\ code -type f  -name '*.rs'"#);
+}
+
+#[test]
+fn find_posix_escapes_command_substitution() {
+    let cmd = build_find_command(&["*.txt".to_string()], "/tmp/innocent$(touch ~/PROBE_RAN)");
+    assert!(
+        !cmd.contains("$(touch"),
+        "unescaped command substitution survived: {cmd}"
+    );
+    assert!(cmd.contains(r"\$\(touch"));
+}
+
+#[test]
+fn find_posix_escapes_backticks() {
+    let cmd = build_find_command(&["*.md".to_string()], "/tmp/`rm`/here");
+    assert!(
+        !cmd.contains("/`rm`/"),
+        "unescaped backtick run survived: {cmd}"
+    );
+    assert!(cmd.contains(r"\`rm\`"));
+}
+
+#[test]
+fn find_handles_multiple_patterns() {
+    // Pattern args are joined with ` -o ` and must survive without the
+    // path-quoting changes affecting them.
+    let cmd = build_find_command(&["*.rs".to_string(), "*.toml".to_string()], "/tmp/repo");
+    assert_eq!(
+        cmd,
+        "find /tmp/repo -type f  -name '*.rs' -o -name '*.toml'"
+    );
+}
+
+#[test]
+fn get_childitem_powershell_escapes_target_path() {
+    let cmd = build_get_childitem_command(&["*.rs".to_string()], "C:\\Users\\me\\My Code");
+    assert!(
+        cmd.contains("-Path C:\\Users\\me\\My`\u{20}Code "),
+        "expected escaped path; got: {cmd}"
+    );
+    assert!(cmd.starts_with("Get-ChildItem -File -Recurse -Include '*.rs' -Path "));
+}
+
+#[test]
+fn get_childitem_powershell_escapes_metacharacters() {
+    // PowerShell expands `$x` and `$env:USERPROFILE` inside `-Path "..."`;
+    // we need every metacharacter shell-escaped via backtick.
+    let cmd =
+        build_get_childitem_command(&["*.txt".to_string()], "C:\\Users\\$env:USERPROFILE\\repo");
+    let mut iter = cmd.match_indices("$env:");
+    if let Some((idx, _)) = iter.next() {
+        assert!(
+            idx > 0 && &cmd[idx - 1..idx] == "`",
+            "unescaped $env: at byte {idx}: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn empty_path_is_handled_safely() {
+    // `ShellFamily::shell_escape("")` returns `''` (the POSIX literal
+    // empty string).
+    let cmd = build_find_command(&["*.rs".to_string()], "");
+    assert!(cmd.starts_with("find '' -type f"));
+}

--- a/app/src/ai/blocklist/action_model/execute/grep.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep.rs
@@ -465,12 +465,12 @@ fn build_git_grep_command(queries: &[String], target_path: &str, shell_type: She
     let family = ShellFamily::from(shell_type);
     let mut grep_command = "git --no-pager grep --color=never --untracked -nIE".to_string();
     for query in queries {
-        // Agent-supplied query: shell-escape so `$VAR`, `$(...)`, backticks,
-        // and other metacharacters never reach the user's shell unquoted.
-        // The shell consumes the escapes and hands `git grep` the literal
-        // query string for its own regex matching.
-        let escaped_query = family.shell_escape(query);
-        grep_command.push_str(format!(" -e {escaped_query}").as_str());
+        // Agent-supplied query: use single-quote literal wrapping so metacharacters,
+        // embedded quotes, AND embedded newlines all reach `git grep` verbatim.
+        // (`shell_escape` would emit `\<newline>` which bash/zsh parse as line
+        //  continuation, breaking the command for multi-line regexes.)
+        let quoted_query = family.shell_quote_arg(query);
+        grep_command.push_str(format!(" -e {quoted_query}").as_str());
     }
     let escaped_path = family.shell_escape(target_path);
     grep_command.push_str(format!(" {escaped_path}").as_str());
@@ -533,10 +533,11 @@ async fn run_git_grep_command(
 fn build_grep_command(queries: &[String], target_path: &str) -> String {
     let mut grep_command = "grep --color=never -nrIHE --devices=skip".to_string();
     for query in queries {
-        // Agent-supplied query: shell-escape so metacharacters never reach
-        // the shell unquoted (see `build_git_grep_command`).
-        let escaped_query = ShellFamily::Posix.shell_escape(query);
-        grep_command.push_str(format!(" -e {escaped_query}").as_str());
+        // Agent-supplied query: single-quote literal wrapping. See
+        // `build_git_grep_command` for why this beats `shell_escape` here
+        // (embedded newlines, in particular).
+        let quoted_query = ShellFamily::Posix.shell_quote_arg(query);
+        grep_command.push_str(format!(" -e {quoted_query}").as_str());
     }
     let escaped_path = ShellFamily::Posix.shell_escape(target_path);
     grep_command.push_str(format!(" {escaped_path}").as_str());
@@ -606,11 +607,15 @@ fn build_select_string_command(queries: &[String], target_path: &str) -> String 
     let escaped_path = ShellFamily::PowerShell.shell_escape(target_path);
     let patterns = queries
         .iter()
-        .map(|q| ShellFamily::PowerShell.shell_escape(q).into_owned())
+        .map(|q| ShellFamily::PowerShell.shell_quote_arg(q))
         .collect::<Vec<_>>()
         .join(",");
+    // `-LiteralPath` suppresses PowerShell wildcard interpretation on the
+    // directory we're scanning — a path containing `*` / `?` (valid on POSIX
+    // filesystems mounted through MSYS2 etc.) would otherwise be expanded
+    // by `Get-ChildItem` itself.
     format!(
-        "Get-ChildItem -Path {escaped_path} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {patterns}"
+        "Get-ChildItem -LiteralPath {escaped_path} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {patterns}"
     )
 }
 

--- a/app/src/ai/blocklist/action_model/execute/grep.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use warp_util::path::ShellFamily;
 use warp_util::standardized_path::StandardizedPath;
 
 use futures::future::BoxFuture;
@@ -463,16 +464,12 @@ async fn run_ripgrep(queries: &[String], absolute_path: String) -> Result<GrepRe
     }
 }
 
-/// Assumes that git is installed in the user's session.
-async fn run_git_grep_command(
-    queries: &[String],
-    target_path: &str,
-    session: &Session,
-    shell_launch_data: Option<ShellLaunchData>,
-    shell_type: ShellType,
-    execute_directory: &str,
-) -> Result<GrepResult, GrepError> {
-    // This command works on all the shells we support (even PowerShell).
+/// Builds the `git grep` command run by [`run_git_grep_command`].
+///
+/// The `target_path` is shell-escaped via [`ShellFamily::shell_escape`] so
+/// the underlying `git grep` receives the literal path regardless of any
+/// metacharacters in it (`$`, backticks, parens, spaces, etc.).
+fn build_git_grep_command(queries: &[String], target_path: &str, shell_type: ShellType) -> String {
     let mut grep_command = "git --no-pager grep --color=never --untracked -nIE".to_string();
     for query in queries {
         let escaped_query = format!(
@@ -485,7 +482,23 @@ async fn run_git_grep_command(
         );
         grep_command.push_str(format!(" -e {escaped_query}").as_str());
     }
-    grep_command.push_str(format!(" \"{target_path}\"").as_str());
+    let family = ShellFamily::from(shell_type);
+    let escaped_path = family.shell_escape(target_path);
+    grep_command.push_str(format!(" {escaped_path}").as_str());
+    grep_command
+}
+
+/// Assumes that git is installed in the user's session.
+async fn run_git_grep_command(
+    queries: &[String],
+    target_path: &str,
+    session: &Session,
+    shell_launch_data: Option<ShellLaunchData>,
+    shell_type: ShellType,
+    execute_directory: &str,
+) -> Result<GrepResult, GrepError> {
+    // This command works on all the shells we support (even PowerShell).
+    let grep_command = build_git_grep_command(queries, target_path, shell_type);
 
     let command_output = session
         .execute_command(
@@ -524,6 +537,18 @@ async fn run_git_grep_command(
             .with_command(grep_command)
             .with_output(output.into()))
     }
+}
+
+/// Builds the POSIX `grep` command run by [`run_grep_command`]. POSIX-only —
+/// the path is escaped through [`ShellFamily::Posix`].
+fn build_grep_command(queries: &[String], target_path: &str) -> String {
+    let mut grep_command = "grep --color=never -nrIHE --devices=skip".to_string();
+    for query in queries {
+        grep_command.push_str(format!(" -e \"{}\"", escape_double_quotes(query)).as_str());
+    }
+    let escaped_path = ShellFamily::Posix.shell_escape(target_path);
+    grep_command.push_str(format!(" {escaped_path}").as_str());
+    grep_command
 }
 
 async fn run_grep_command(
@@ -540,11 +565,7 @@ async fn run_grep_command(
     // * "-I" ignores binary files
     // * "-H" prints file name headers
     // * "-E" uses extended regex expressions
-    let mut grep_command = "grep --color=never -nrIHE --devices=skip".to_string();
-    for query in queries {
-        grep_command.push_str(format!(" -e \"{}\"", escape_double_quotes(query)).as_str());
-    }
-    grep_command.push_str(format!(" \"{target_path}\"").as_str());
+    let grep_command = build_grep_command(queries, target_path);
 
     let command_output = session
         .execute_command(
@@ -585,6 +606,22 @@ async fn run_grep_command(
     }
 }
 
+/// Builds the PowerShell `Select-String` command run by
+/// [`run_select_string_command`]. The `target_path` is escaped through
+/// [`ShellFamily::PowerShell`] so PowerShell metacharacters in the path
+/// (backticks, `$x`, `$env:USERPROFILE`, etc.) are passed verbatim.
+fn build_select_string_command(queries: &[String], target_path: &str) -> String {
+    let escaped_path = ShellFamily::PowerShell.shell_escape(target_path);
+    format!(
+        "Get-ChildItem -Path {escaped_path} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {}",
+        queries
+            .iter()
+            .map(|q| format!("\"{}\"", powershell_escape_double_quotes(q)))
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}
+
 /// Runs a PowerShell `Select-String` command.
 async fn run_select_string_command(
     queries: &[String],
@@ -595,15 +632,7 @@ async fn run_select_string_command(
 ) -> Result<GrepResult, GrepError> {
     // We enable the `-CaseSensitive` flag to match the default behavior of grep.
     // TODO(CODE-239): Make this command more efficient when searching a file.
-    let select_string_command = format!(
-        "Get-ChildItem -Path \"{}\" -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {}",
-        target_path,
-        queries
-            .iter()
-            .map(|q| format!("\"{}\"", powershell_escape_double_quotes(q)))
-            .collect::<Vec<_>>()
-            .join(",")
-    );
+    let select_string_command = build_select_string_command(queries, target_path);
 
     let command_output = session
         .execute_command(

--- a/app/src/ai/blocklist/action_model/execute/grep.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep.rs
@@ -40,14 +40,6 @@ use super::{
 const GREP_TIMEOUT: Duration = Duration::from_secs(10);
 const NON_ZERO_EXIT_CODE_ERROR: &str = "Grep command exited with non-zero exit code";
 
-fn escape_double_quotes(s: &str) -> String {
-    s.replace('"', "\\\"")
-}
-
-fn powershell_escape_double_quotes(s: &str) -> String {
-    s.replace('"', "`\"")
-}
-
 /// Information about the Grep call that resulted in an error, used to send
 /// telemetry about the error.
 struct GrepError {
@@ -470,19 +462,16 @@ async fn run_ripgrep(queries: &[String], absolute_path: String) -> Result<GrepRe
 /// the underlying `git grep` receives the literal path regardless of any
 /// metacharacters in it (`$`, backticks, parens, spaces, etc.).
 fn build_git_grep_command(queries: &[String], target_path: &str, shell_type: ShellType) -> String {
+    let family = ShellFamily::from(shell_type);
     let mut grep_command = "git --no-pager grep --color=never --untracked -nIE".to_string();
     for query in queries {
-        let escaped_query = format!(
-            "\"{}\"",
-            if shell_type == ShellType::PowerShell {
-                powershell_escape_double_quotes(query)
-            } else {
-                escape_double_quotes(query)
-            }
-        );
+        // Agent-supplied query: shell-escape so `$VAR`, `$(...)`, backticks,
+        // and other metacharacters never reach the user's shell unquoted.
+        // The shell consumes the escapes and hands `git grep` the literal
+        // query string for its own regex matching.
+        let escaped_query = family.shell_escape(query);
         grep_command.push_str(format!(" -e {escaped_query}").as_str());
     }
-    let family = ShellFamily::from(shell_type);
     let escaped_path = family.shell_escape(target_path);
     grep_command.push_str(format!(" {escaped_path}").as_str());
     grep_command
@@ -544,7 +533,10 @@ async fn run_git_grep_command(
 fn build_grep_command(queries: &[String], target_path: &str) -> String {
     let mut grep_command = "grep --color=never -nrIHE --devices=skip".to_string();
     for query in queries {
-        grep_command.push_str(format!(" -e \"{}\"", escape_double_quotes(query)).as_str());
+        // Agent-supplied query: shell-escape so metacharacters never reach
+        // the shell unquoted (see `build_git_grep_command`).
+        let escaped_query = ShellFamily::Posix.shell_escape(query);
+        grep_command.push_str(format!(" -e {escaped_query}").as_str());
     }
     let escaped_path = ShellFamily::Posix.shell_escape(target_path);
     grep_command.push_str(format!(" {escaped_path}").as_str());
@@ -612,13 +604,13 @@ async fn run_grep_command(
 /// (backticks, `$x`, `$env:USERPROFILE`, etc.) are passed verbatim.
 fn build_select_string_command(queries: &[String], target_path: &str) -> String {
     let escaped_path = ShellFamily::PowerShell.shell_escape(target_path);
+    let patterns = queries
+        .iter()
+        .map(|q| ShellFamily::PowerShell.shell_escape(q).into_owned())
+        .collect::<Vec<_>>()
+        .join(",");
     format!(
-        "Get-ChildItem -Path {escaped_path} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {}",
-        queries
-            .iter()
-            .map(|q| format!("\"{}\"", powershell_escape_double_quotes(q)))
-            .collect::<Vec<_>>()
-            .join(",")
+        "Get-ChildItem -Path {escaped_path} -Recurse -File | Select-String -NoEmphasis -CaseSensitive -Pattern {patterns}"
     )
 }
 

--- a/app/src/ai/blocklist/action_model/execute/grep_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep_tests.rs
@@ -71,3 +71,104 @@ fn test_create_redacted_grep_error_event() {
         panic!("Expected GrepToolFailed event");
     }
 }
+
+/// Tests for the pure command builders behind [`run_git_grep_command`],
+/// [`run_grep_command`], and [`run_select_string_command`]. These pin the
+/// shell-quoting guarantee for #11132: an agent-supplied `target_path`
+/// containing shell metacharacters must survive verbatim into the
+/// underlying `git grep` / `grep` / `Select-String` invocation.
+mod path_quoting {
+    use super::super::{build_git_grep_command, build_grep_command, build_select_string_command};
+    use crate::terminal::shell::ShellType;
+
+    #[test]
+    fn git_grep_posix_escapes_target_path_spaces() {
+        let cmd = build_git_grep_command(&["TODO".to_string()], "/tmp/my repo", ShellType::Bash);
+        assert_eq!(
+            cmd,
+            r#"git --no-pager grep --color=never --untracked -nIE -e "TODO" /tmp/my\ repo"#
+        );
+    }
+
+    #[test]
+    fn git_grep_posix_escapes_command_substitution() {
+        // Path-level metacharacters get backslash-escaped; query-level
+        // double-quotes are kept (the query is regex literal, not a path).
+        let cmd = build_git_grep_command(
+            &["pattern".to_string()],
+            "/tmp/$(touch ~/PROBE_RAN)",
+            ShellType::Bash,
+        );
+        assert!(
+            !cmd.contains("$(touch"),
+            "unescaped command substitution survived: {cmd}"
+        );
+        assert!(cmd.contains(r"\$\(touch"));
+    }
+
+    #[test]
+    fn git_grep_powershell_path_uses_powershell_escape() {
+        // For PowerShell sessions, the path is escaped with backticks
+        // (`ShellFamily::PowerShell`) — POSIX backslash escapes are not
+        // valid in PowerShell.
+        let cmd = build_git_grep_command(
+            &["pattern".to_string()],
+            "C:\\Users\\me\\repo",
+            ShellType::PowerShell,
+        );
+        // The drive-letter colon stays literal (PowerShell escape doesn't
+        // need to escape `:`); the path lands as a single argument.
+        assert!(cmd.ends_with(" C:\\Users\\me\\repo"));
+        // PowerShell-escaped queries still use the existing
+        // backtick-double-quote helper.
+        assert!(cmd.contains(r#"-e "pattern""#));
+    }
+
+    #[test]
+    fn grep_posix_escapes_target_path() {
+        let cmd = build_grep_command(&["TODO".to_string()], "/tmp/has space");
+        assert_eq!(
+            cmd,
+            r#"grep --color=never -nrIHE --devices=skip -e "TODO" /tmp/has\ space"#
+        );
+    }
+
+    #[test]
+    fn grep_posix_escapes_metacharacters_in_path() {
+        let cmd = build_grep_command(&["a".to_string()], "/tmp/innocent$(rm -rf ~)");
+        assert!(
+            !cmd.contains("$(rm"),
+            "unescaped command substitution survived: {cmd}"
+        );
+    }
+
+    #[test]
+    fn select_string_powershell_escapes_target_path() {
+        let cmd = build_select_string_command(&["TODO".to_string()], "C:\\Users\\me\\My Stuff");
+        // The path appears once, after `-Path `, with PowerShell-style
+        // backtick escapes for the space.
+        assert!(
+            cmd.contains("-Path C:\\Users\\me\\My`\u{20}Stuff "),
+            "expected escaped path; got: {cmd}"
+        );
+        // Pattern is kept as a backtick-double-quoted PowerShell string.
+        assert!(cmd.ends_with(r#"-Pattern "TODO""#));
+    }
+
+    #[test]
+    fn select_string_powershell_escapes_command_substitution() {
+        // PowerShell expands `$x` and `$env:USER` inside double quotes; we
+        // need every metacharacter shell-escaped via backtick.
+        let cmd =
+            build_select_string_command(&["q".to_string()], "C:\\Users\\$env:USERPROFILE\\repo");
+        // No bare `$env:` survives in the rendered command — it's always
+        // preceded by a backtick.
+        let mut iter = cmd.match_indices("$env:");
+        if let Some((idx, _)) = iter.next() {
+            assert!(
+                idx > 0 && &cmd[idx - 1..idx] == "`",
+                "unescaped $env: at byte {idx}: {cmd}"
+            );
+        }
+    }
+}

--- a/app/src/ai/blocklist/action_model/execute/grep_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep_tests.rs
@@ -84,16 +84,17 @@ mod path_quoting {
     #[test]
     fn git_grep_posix_escapes_target_path_spaces() {
         let cmd = build_git_grep_command(&["TODO".to_string()], "/tmp/my repo", ShellType::Bash);
+        // Plain query with no metacharacters lands as a bare literal arg —
+        // shell-escape is identity for "TODO".
         assert_eq!(
             cmd,
-            r#"git --no-pager grep --color=never --untracked -nIE -e "TODO" /tmp/my\ repo"#
+            r#"git --no-pager grep --color=never --untracked -nIE -e TODO /tmp/my\ repo"#
         );
     }
 
     #[test]
-    fn git_grep_posix_escapes_command_substitution() {
-        // Path-level metacharacters get backslash-escaped; query-level
-        // double-quotes are kept (the query is regex literal, not a path).
+    fn git_grep_posix_escapes_command_substitution_in_path() {
+        // Path-level metacharacters get backslash-escaped.
         let cmd = build_git_grep_command(
             &["pattern".to_string()],
             "/tmp/$(touch ~/PROBE_RAN)",
@@ -107,10 +108,37 @@ mod path_quoting {
     }
 
     #[test]
+    fn git_grep_posix_escapes_command_substitution_in_query() {
+        // Agent-supplied query is also shell-escaped — without this, the
+        // shell would expand `$(rm -rf ~)` before passing the query to grep.
+        let cmd = build_git_grep_command(
+            &["match$(rm -rf ~)me".to_string()],
+            "/tmp/repo",
+            ShellType::Bash,
+        );
+        assert!(
+            !cmd.contains("$(rm"),
+            "unescaped command substitution survived in query: {cmd}"
+        );
+        assert!(cmd.contains(r"match\$\(rm\ -rf\ \~\)me"));
+    }
+
+    #[test]
+    fn git_grep_posix_escapes_backticks_in_query() {
+        let cmd =
+            build_git_grep_command(&["a`rm -rf ~`b".to_string()], "/tmp/repo", ShellType::Bash);
+        for (i, c) in cmd.char_indices() {
+            if c == '`' {
+                assert!(
+                    i > 0 && cmd.as_bytes()[i - 1] == b'\\',
+                    "unescaped backtick at byte {i}: {cmd}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn git_grep_powershell_path_uses_powershell_escape() {
-        // For PowerShell sessions, the path is escaped with backticks
-        // (`ShellFamily::PowerShell`) — POSIX backslash escapes are not
-        // valid in PowerShell.
         let cmd = build_git_grep_command(
             &["pattern".to_string()],
             "C:\\Users\\me\\repo",
@@ -119,9 +147,27 @@ mod path_quoting {
         // The drive-letter colon stays literal (PowerShell escape doesn't
         // need to escape `:`); the path lands as a single argument.
         assert!(cmd.ends_with(" C:\\Users\\me\\repo"));
-        // PowerShell-escaped queries still use the existing
-        // backtick-double-quote helper.
-        assert!(cmd.contains(r#"-e "pattern""#));
+        // Query has no metacharacters → literal `pattern`, not quoted.
+        assert!(cmd.contains(" -e pattern "));
+    }
+
+    #[test]
+    fn git_grep_powershell_escapes_env_var_in_query() {
+        // PowerShell expands `$env:VAR` inside double quotes — without
+        // shell-escape, an agent-supplied query containing `$env:` would
+        // leak the env var into the grep pattern.
+        let cmd = build_git_grep_command(
+            &["leak$env:USERPROFILE".to_string()],
+            "C:\\repo",
+            ShellType::PowerShell,
+        );
+        let mut iter = cmd.match_indices("$env:");
+        if let Some((idx, _)) = iter.next() {
+            assert!(
+                idx > 0 && &cmd[idx - 1..idx] == "`",
+                "unescaped $env: in query at byte {idx}: {cmd}"
+            );
+        }
     }
 
     #[test]
@@ -129,7 +175,7 @@ mod path_quoting {
         let cmd = build_grep_command(&["TODO".to_string()], "/tmp/has space");
         assert_eq!(
             cmd,
-            r#"grep --color=never -nrIHE --devices=skip -e "TODO" /tmp/has\ space"#
+            r#"grep --color=never -nrIHE --devices=skip -e TODO /tmp/has\ space"#
         );
     }
 
@@ -143,6 +189,16 @@ mod path_quoting {
     }
 
     #[test]
+    fn grep_posix_escapes_command_substitution_in_query() {
+        let cmd = build_grep_command(&["a$(rm)b".to_string()], "/tmp/repo");
+        assert!(
+            !cmd.contains("$(rm"),
+            "unescaped command substitution survived in query: {cmd}"
+        );
+        assert!(cmd.contains(r"a\$\(rm\)b"));
+    }
+
+    #[test]
     fn select_string_powershell_escapes_target_path() {
         let cmd = build_select_string_command(&["TODO".to_string()], "C:\\Users\\me\\My Stuff");
         // The path appears once, after `-Path `, with PowerShell-style
@@ -151,23 +207,34 @@ mod path_quoting {
             cmd.contains("-Path C:\\Users\\me\\My`\u{20}Stuff "),
             "expected escaped path; got: {cmd}"
         );
-        // Pattern is kept as a backtick-double-quoted PowerShell string.
-        assert!(cmd.ends_with(r#"-Pattern "TODO""#));
+        // Query has no metacharacters → literal `TODO`, not double-quoted.
+        assert!(cmd.ends_with("-Pattern TODO"));
     }
 
     #[test]
-    fn select_string_powershell_escapes_command_substitution() {
-        // PowerShell expands `$x` and `$env:USER` inside double quotes; we
-        // need every metacharacter shell-escaped via backtick.
+    fn select_string_powershell_escapes_command_substitution_in_path() {
         let cmd =
             build_select_string_command(&["q".to_string()], "C:\\Users\\$env:USERPROFILE\\repo");
-        // No bare `$env:` survives in the rendered command — it's always
-        // preceded by a backtick.
         let mut iter = cmd.match_indices("$env:");
         if let Some((idx, _)) = iter.next() {
             assert!(
                 idx > 0 && &cmd[idx - 1..idx] == "`",
                 "unescaped $env: at byte {idx}: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn select_string_powershell_escapes_env_var_in_query() {
+        // PowerShell expands `$env:VAR` inside double quotes; the previous
+        // implementation only escaped `"` and would have passed
+        // `$env:USERPROFILE` straight through.
+        let cmd = build_select_string_command(&["leak$env:USERPROFILE".to_string()], "C:\\repo");
+        let mut iter = cmd.match_indices("$env:");
+        if let Some((idx, _)) = iter.next() {
+            assert!(
+                idx > 0 && &cmd[idx - 1..idx] == "`",
+                "unescaped $env: in query at byte {idx}: {cmd}"
             );
         }
     }

--- a/app/src/ai/blocklist/action_model/execute/grep_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/grep_tests.rs
@@ -84,11 +84,11 @@ mod path_quoting {
     #[test]
     fn git_grep_posix_escapes_target_path_spaces() {
         let cmd = build_git_grep_command(&["TODO".to_string()], "/tmp/my repo", ShellType::Bash);
-        // Plain query with no metacharacters lands as a bare literal arg —
-        // shell-escape is identity for "TODO".
+        // Query is wrapped in single-quote literal form (safe for embedded
+        // newlines, metacharacters, etc.); path uses backslash-escape.
         assert_eq!(
             cmd,
-            r#"git --no-pager grep --color=never --untracked -nIE -e TODO /tmp/my\ repo"#
+            r#"git --no-pager grep --color=never --untracked -nIE -e 'TODO' /tmp/my\ repo"#
         );
     }
 
@@ -108,66 +108,78 @@ mod path_quoting {
     }
 
     #[test]
-    fn git_grep_posix_escapes_command_substitution_in_query() {
-        // Agent-supplied query is also shell-escaped — without this, the
-        // shell would expand `$(rm -rf ~)` before passing the query to grep.
+    fn git_grep_posix_command_substitution_in_query_stays_literal() {
+        // Single-quote literal form neutralizes `$(...)` without per-char
+        // escaping — POSIX shells don't expand anything inside `'...'`.
         let cmd = build_git_grep_command(
             &["match$(rm -rf ~)me".to_string()],
             "/tmp/repo",
             ShellType::Bash,
         );
-        assert!(
-            !cmd.contains("$(rm"),
-            "unescaped command substitution survived in query: {cmd}"
-        );
-        assert!(cmd.contains(r"match\$\(rm\ -rf\ \~\)me"));
+        assert!(cmd.contains(" -e 'match$(rm -rf ~)me' "));
     }
 
     #[test]
-    fn git_grep_posix_escapes_backticks_in_query() {
+    fn git_grep_posix_backticks_in_query_stay_literal() {
+        // Same shape — inside POSIX single quotes, backticks are literal.
         let cmd =
             build_git_grep_command(&["a`rm -rf ~`b".to_string()], "/tmp/repo", ShellType::Bash);
-        for (i, c) in cmd.char_indices() {
-            if c == '`' {
-                assert!(
-                    i > 0 && cmd.as_bytes()[i - 1] == b'\\',
-                    "unescaped backtick at byte {i}: {cmd}"
-                );
-            }
-        }
+        assert!(cmd.contains(" -e 'a`rm -rf ~`b' "));
     }
 
     #[test]
-    fn git_grep_powershell_path_uses_powershell_escape() {
+    fn git_grep_posix_embedded_newline_in_query_is_preserved() {
+        // The reason we switched away from `shell_escape` for queries:
+        // shell_escape would emit `\<newline>` which bash/zsh parse as line
+        // continuation, breaking the command. Single-quote wrapping keeps
+        // the literal newline as part of the argument the grep tool sees.
+        let cmd = build_git_grep_command(&["foo\nbar".to_string()], "/tmp/repo", ShellType::Bash);
+        // The query has a literal newline inside the wrapping quotes, NOT
+        // a `\<newline>` line-continuation sequence.
+        assert!(cmd.contains(" -e 'foo\nbar' "));
+        assert!(
+            !cmd.contains("\\\n"),
+            "line-continuation slipped in: {cmd:?}"
+        );
+    }
+
+    #[test]
+    fn git_grep_posix_query_embedded_single_quote_is_escaped() {
+        // Inside POSIX single-quote literal, an embedded `'` must be
+        // expressed as `'\''` (close, escaped quote, reopen).
+        let cmd = build_git_grep_command(&["a'b".to_string()], "/tmp/repo", ShellType::Bash);
+        assert!(cmd.contains(r"'a'\''b'"), "got: {cmd}");
+    }
+
+    #[test]
+    fn git_grep_powershell_query_uses_single_quote_literal() {
         let cmd = build_git_grep_command(
             &["pattern".to_string()],
             "C:\\Users\\me\\repo",
             ShellType::PowerShell,
         );
-        // The drive-letter colon stays literal (PowerShell escape doesn't
-        // need to escape `:`); the path lands as a single argument.
         assert!(cmd.ends_with(" C:\\Users\\me\\repo"));
-        // Query has no metacharacters → literal `pattern`, not quoted.
-        assert!(cmd.contains(" -e pattern "));
+        // Query is single-quote-wrapped (PowerShell literal form).
+        assert!(cmd.contains(" -e 'pattern' "));
     }
 
     #[test]
-    fn git_grep_powershell_escapes_env_var_in_query() {
-        // PowerShell expands `$env:VAR` inside double quotes — without
-        // shell-escape, an agent-supplied query containing `$env:` would
-        // leak the env var into the grep pattern.
+    fn git_grep_powershell_env_var_in_query_stays_literal() {
+        // PowerShell single-quoted strings are literal — `$env:VAR` is NOT
+        // expanded inside them.
         let cmd = build_git_grep_command(
             &["leak$env:USERPROFILE".to_string()],
             "C:\\repo",
             ShellType::PowerShell,
         );
-        let mut iter = cmd.match_indices("$env:");
-        if let Some((idx, _)) = iter.next() {
-            assert!(
-                idx > 0 && &cmd[idx - 1..idx] == "`",
-                "unescaped $env: in query at byte {idx}: {cmd}"
-            );
-        }
+        assert!(cmd.contains(" -e 'leak$env:USERPROFILE' "));
+    }
+
+    #[test]
+    fn git_grep_powershell_query_embedded_single_quote_doubles() {
+        // PowerShell single-quote literal escapes `'` by doubling it.
+        let cmd = build_git_grep_command(&["a'b".to_string()], "C:\\repo", ShellType::PowerShell);
+        assert!(cmd.contains(" -e 'a''b' "), "got: {cmd}");
     }
 
     #[test]
@@ -175,7 +187,7 @@ mod path_quoting {
         let cmd = build_grep_command(&["TODO".to_string()], "/tmp/has space");
         assert_eq!(
             cmd,
-            r#"grep --color=never -nrIHE --devices=skip -e TODO /tmp/has\ space"#
+            r#"grep --color=never -nrIHE --devices=skip -e 'TODO' /tmp/has\ space"#
         );
     }
 
@@ -189,26 +201,26 @@ mod path_quoting {
     }
 
     #[test]
-    fn grep_posix_escapes_command_substitution_in_query() {
+    fn grep_posix_command_substitution_in_query_stays_literal() {
         let cmd = build_grep_command(&["a$(rm)b".to_string()], "/tmp/repo");
-        assert!(
-            !cmd.contains("$(rm"),
-            "unescaped command substitution survived in query: {cmd}"
-        );
-        assert!(cmd.contains(r"a\$\(rm\)b"));
+        assert!(cmd.contains(" -e 'a$(rm)b' "));
     }
 
     #[test]
-    fn select_string_powershell_escapes_target_path() {
+    fn select_string_powershell_uses_literal_path() {
+        // `-LiteralPath` suppresses PowerShell wildcard interpretation on
+        // the search directory — without it a path containing `*` / `?` /
+        // `[...]` would be expanded by Get-ChildItem itself.
         let cmd = build_select_string_command(&["TODO".to_string()], "C:\\Users\\me\\My Stuff");
-        // The path appears once, after `-Path `, with PowerShell-style
-        // backtick escapes for the space.
         assert!(
-            cmd.contains("-Path C:\\Users\\me\\My`\u{20}Stuff "),
-            "expected escaped path; got: {cmd}"
+            cmd.contains("-LiteralPath C:\\Users\\me\\My`\u{20}Stuff "),
+            "expected -LiteralPath escaped path; got: {cmd}"
         );
-        // Query has no metacharacters → literal `TODO`, not double-quoted.
-        assert!(cmd.ends_with("-Pattern TODO"));
+        assert!(
+            !cmd.contains("-Path "),
+            "wildcard-interpretable -Path leaked: {cmd}"
+        );
+        assert!(cmd.ends_with("-Pattern 'TODO'"));
     }
 
     #[test]
@@ -225,17 +237,8 @@ mod path_quoting {
     }
 
     #[test]
-    fn select_string_powershell_escapes_env_var_in_query() {
-        // PowerShell expands `$env:VAR` inside double quotes; the previous
-        // implementation only escaped `"` and would have passed
-        // `$env:USERPROFILE` straight through.
+    fn select_string_powershell_env_var_in_query_stays_literal() {
         let cmd = build_select_string_command(&["leak$env:USERPROFILE".to_string()], "C:\\repo");
-        let mut iter = cmd.match_indices("$env:");
-        if let Some((idx, _)) = iter.next() {
-            assert!(
-                idx > 0 && &cmd[idx - 1..idx] == "`",
-                "unescaped $env: in query at byte {idx}: {cmd}"
-            );
-        }
+        assert!(cmd.contains("-Pattern 'leak$env:USERPROFILE'"));
     }
 }

--- a/app/src/ai/blocklist/action_model/execute_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute_tests.rs
@@ -136,14 +136,28 @@ mod path_quoting {
 
     #[test]
     fn is_file_path_powershell_escapes_metacharacters_with_backticks() {
-        // PowerShell uses backtick (\u{60}) as its escape character.
+        // PowerShell uses backtick (\u{60}) as its escape character, and
+        // `-LiteralPath` suppresses PowerShell's own wildcard interpretation
+        // — a path containing `*` / `?` / `[...]` is tested literally rather
+        // than as a glob pattern.
         let command =
             build_is_file_path_command("C:\\Users\\me\\My Stuff", ShellFamily::PowerShell);
-        // The escaped path appears inside the if-test, and the shell sees
-        // a single argument rather than splitting on space.
-        assert!(command.starts_with("if (Test-Path -PathType Leaf "));
+        assert!(command.starts_with("if (Test-Path -PathType Leaf -LiteralPath "));
         assert!(command.contains("My`\u{20}Stuff"));
         assert!(command.ends_with("{ exit 0 } else { exit 1 }"));
+    }
+
+    #[test]
+    fn is_file_path_powershell_uses_literal_path_to_block_wildcards() {
+        // The reason `-LiteralPath` matters: a POSIX path containing `*`
+        // (legal on macOS / Linux) would, without `-LiteralPath`, be treated
+        // by `Test-Path` as a wildcard pattern matching multiple files.
+        // With `-LiteralPath` the path is tested verbatim.
+        let command = build_is_file_path_command("/tmp/foo*bar", ShellFamily::PowerShell);
+        assert!(
+            command.contains("-LiteralPath "),
+            "expected -LiteralPath suppression of wildcards; got: {command}"
+        );
     }
 
     #[test]

--- a/app/src/ai/blocklist/action_model/execute_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute_tests.rs
@@ -97,3 +97,100 @@ mod binary_detection {
         assert!(block_on(is_file_content_binary_async(&missing)));
     }
 }
+
+/// Tests for the pure command builders behind [`is_file_path`] and
+/// [`is_git_repository`]. These pin the shell-quoting guarantee documented
+/// in #11132: an agent-supplied path containing shell metacharacters must
+/// survive verbatim into the underlying `test -f` / `Test-Path` / `git -C`
+/// invocation, regardless of the session's shell family.
+mod path_quoting {
+    use warp_util::path::ShellFamily;
+
+    use super::super::{build_is_file_path_command, build_is_git_repository_command};
+
+    #[test]
+    fn is_file_path_posix_emits_shell_escaped_path() {
+        // Plain path: nothing to escape; the path appears as-is after
+        // `test -f`, separated by a single space.
+        assert_eq!(
+            build_is_file_path_command("/tmp/plain", ShellFamily::Posix),
+            "test -f /tmp/plain"
+        );
+    }
+
+    #[test]
+    fn is_file_path_posix_escapes_spaces_and_metacharacters() {
+        // `(`, `)`, `$`, `~`, and space are all shell-significant in POSIX
+        // shells; `ShellFamily::Posix.shell_escape` backslash-escapes
+        // each one so the command sees a single literal argument. `~`
+        // also gets escaped here because the path doesn't START with `~`
+        // (which would trigger the tilde-expansion preservation special
+        // case in `shell_escape`).
+        let command =
+            build_is_file_path_command("/tmp/innocent$(touch ~/PROBE_RAN)", ShellFamily::Posix);
+        assert_eq!(command, r"test -f /tmp/innocent\$\(touch\ \~/PROBE_RAN\)");
+        // The shell must never see a bare `$(...)`, which would otherwise
+        // execute `touch ~/PROBE_RAN` before `test -f` runs.
+        assert!(!command.contains("$(touch"));
+    }
+
+    #[test]
+    fn is_file_path_powershell_escapes_metacharacters_with_backticks() {
+        // PowerShell uses backtick (\u{60}) as its escape character.
+        let command =
+            build_is_file_path_command("C:\\Users\\me\\My Stuff", ShellFamily::PowerShell);
+        // The escaped path appears inside the if-test, and the shell sees
+        // a single argument rather than splitting on space.
+        assert!(command.starts_with("if (Test-Path -PathType Leaf "));
+        assert!(command.contains("My`\u{20}Stuff"));
+        assert!(command.ends_with("{ exit 0 } else { exit 1 }"));
+    }
+
+    #[test]
+    fn is_git_repository_posix_escapes_path() {
+        let command = build_is_git_repository_command("/tmp/my repo", ShellFamily::Posix);
+        assert_eq!(command, r"git -C /tmp/my\ repo rev-parse");
+    }
+
+    #[test]
+    fn is_git_repository_posix_escapes_command_substitution() {
+        // The whole point of #11132: a path that *looks like* a backtick
+        // command substitution stays a literal path argument to `git -C`.
+        // Every backtick in the path is preceded by a backslash escape so
+        // the shell parses the whole thing as a single word.
+        let command = build_is_git_repository_command("/tmp/`rm -rf ~`/repo", ShellFamily::Posix);
+        assert_eq!(command, r"git -C /tmp/\`rm\ -rf\ \~\`/repo rev-parse");
+        // No bare backtick survives: every ` is preceded by a `\`.
+        for (i, c) in command.char_indices() {
+            if c == '`' {
+                let prev = command[..i].chars().next_back();
+                assert_eq!(
+                    prev,
+                    Some('\\'),
+                    "unescaped backtick at byte {i}: {command}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn is_git_repository_powershell_escapes_path() {
+        let command =
+            build_is_git_repository_command("C:\\Users\\me\\dev repo", ShellFamily::PowerShell);
+        assert!(command.starts_with("git -C "));
+        assert!(command.ends_with(" rev-parse"));
+        // Space is escaped via backtick.
+        assert!(command.contains("dev`\u{20}repo"));
+    }
+
+    #[test]
+    fn empty_path_is_handled_safely() {
+        // `ShellFamily::shell_escape("")` returns `''` (the POSIX literal
+        // empty string). Make sure the builder doesn't produce an
+        // empty positional that splits weirdly.
+        let posix = build_is_file_path_command("", ShellFamily::Posix);
+        assert_eq!(posix, "test -f ''");
+        let pwsh = build_is_git_repository_command("", ShellFamily::PowerShell);
+        assert_eq!(pwsh, "git -C '' rev-parse");
+    }
+}

--- a/crates/warp_util/src/path.rs
+++ b/crates/warp_util/src/path.rs
@@ -254,6 +254,31 @@ impl ShellFamily {
         Cow::Owned(result)
     }
 
+    /// Wraps an arbitrary string for safe insertion as a single shell argument,
+    /// preserving embedded newlines and metacharacters literally. Uses single-
+    /// quote literal form for both shell families:
+    ///
+    /// - **POSIX**: `'value'`, with each embedded `'` rewritten as `'\''`
+    ///   (close-quote, escaped quote, re-open-quote).
+    /// - **PowerShell**: `'value'`, with each embedded `'` doubled as `''`
+    ///   (PowerShell's single-quote literal escape).
+    ///
+    /// Unlike [`Self::shell_escape`] (which uses backslash/backtick escaping
+    /// and treats `\<newline>` as line continuation), this form is safe for
+    /// agent-supplied values that may contain arbitrary characters including
+    /// newlines — single-quote literals preserve every byte verbatim, with
+    /// no expansion or escape interpretation by the shell.
+    ///
+    /// Use this for free-form string arguments (grep queries, glob patterns,
+    /// etc.). For static filesystem paths that are known to be single-line,
+    /// [`Self::shell_escape`] produces tighter output.
+    pub fn shell_quote_arg(&self, value: &str) -> String {
+        match self {
+            Self::Posix => format!("'{}'", value.replace('\'', r"'\''")),
+            Self::PowerShell => format!("'{}'", value.replace('\'', "''")),
+        }
+    }
+
     /// Escapes the path to treat it as a single word within the shell.
     ///
     /// This function returns a [`Cow::Borrowed`] of the input string where possible and only

--- a/crates/warp_util/src/path_tests.rs
+++ b/crates/warp_util/src/path_tests.rs
@@ -252,6 +252,69 @@ fn test_powershell_escape() {
 }
 
 #[test]
+fn shell_quote_arg_posix_wraps_plain_value() {
+    assert_eq!(ShellFamily::Posix.shell_quote_arg("plain"), "'plain'");
+}
+
+#[test]
+fn shell_quote_arg_posix_preserves_metacharacters_literally() {
+    // Inside POSIX single-quote literal, nothing is expanded — neither
+    // `$(...)` nor backticks nor `$VAR`. The quote alone is enough.
+    assert_eq!(ShellFamily::Posix.shell_quote_arg("a$(rm)b"), "'a$(rm)b'");
+    assert_eq!(
+        ShellFamily::Posix.shell_quote_arg("hi`rm`there"),
+        "'hi`rm`there'"
+    );
+    assert_eq!(ShellFamily::Posix.shell_quote_arg("$HOME"), "'$HOME'");
+}
+
+#[test]
+fn shell_quote_arg_posix_preserves_embedded_newlines() {
+    // The whole reason we have this helper: `shell_escape` would emit
+    // `\<newline>` which bash/zsh parse as line continuation. Inside a
+    // single-quote literal, a real newline byte is preserved.
+    let quoted = ShellFamily::Posix.shell_quote_arg("foo\nbar");
+    assert_eq!(quoted, "'foo\nbar'");
+    assert!(
+        !quoted.contains("\\\n"),
+        "line-continuation slipped in: {quoted:?}"
+    );
+}
+
+#[test]
+fn shell_quote_arg_posix_escapes_embedded_single_quote() {
+    // POSIX single-quote literals can't contain `'` directly. The standard
+    // trick is to close, escape, and reopen: 'foo'\''bar'.
+    assert_eq!(ShellFamily::Posix.shell_quote_arg("a'b"), r"'a'\''b'");
+    // Multiple quotes still work.
+    assert_eq!(
+        ShellFamily::Posix.shell_quote_arg("'leading"),
+        r"''\''leading'"
+    );
+}
+
+#[test]
+fn shell_quote_arg_powershell_wraps_plain_value() {
+    assert_eq!(ShellFamily::PowerShell.shell_quote_arg("plain"), "'plain'");
+}
+
+#[test]
+fn shell_quote_arg_powershell_preserves_dollar_env_literally() {
+    // PowerShell single-quoted strings are literal — `$env:VAR` doesn't
+    // expand inside them.
+    assert_eq!(
+        ShellFamily::PowerShell.shell_quote_arg("leak$env:USERPROFILE"),
+        "'leak$env:USERPROFILE'"
+    );
+}
+
+#[test]
+fn shell_quote_arg_powershell_doubles_embedded_single_quote() {
+    // PowerShell single-quote literal escapes `'` by doubling it.
+    assert_eq!(ShellFamily::PowerShell.shell_quote_arg("a'b"), "'a''b'");
+}
+
+#[test]
 fn test_posix_unescape() {
     let shell_family = ShellFamily::Posix;
     // Escaped spaces


### PR DESCRIPTION
## Description

The internal helpers behind the AI agent's `grep` and `file_glob` tools build shell commands by interpolating an agent-supplied path inside **double quotes** and handing the result to `Session::execute_command`. Inside POSIX `"..."` the shell still expands `$VAR`, backticks, and `$(...)`; inside PowerShell `"..."` it still expands `$x` (including `$env:USERPROFILE`) and treats backticks specially. So a path containing any of those metacharacters is parsed — and potentially executed — by the user's shell *before* the underlying tool sees it.

`is_file_path` and `is_git_repository` are particularly exposed because they run as side-effects of the grep and file_glob tools (`run_grep` → `is_file_path` + `is_git_repository`, `run_file_glob` → `is_git_repository`) before the user-facing command is shown, so even path values the user never typed flow into the shell verbatim.

Fixes #11132.

## Root cause

Eight unquoted call sites across three files:

| File | Function | Line(s) on master |
|---|---|---|
| `app/src/ai/blocklist/action_model/execute.rs` | `is_file_path` (POSIX) | 1299 |
| `app/src/ai/blocklist/action_model/execute.rs` | `is_file_path` (PowerShell) | 1297 |
| `app/src/ai/blocklist/action_model/execute.rs` | `is_git_repository` | 1310 |
| `app/src/ai/blocklist/action_model/execute/grep.rs` | `run_git_grep_command` | 488 |
| `app/src/ai/blocklist/action_model/execute/grep.rs` | `run_grep_command` | 547 |
| `app/src/ai/blocklist/action_model/execute/grep.rs` | `run_select_string_command` | 599 |
| `app/src/ai/blocklist/action_model/execute/file_glob.rs` | `run_find_command` | 295 |
| `app/src/ai/blocklist/action_model/execute/file_glob.rs` | `run_powershell_get_childitem_command` | 339 |

Each one used `format!("… \"{path}\" …")` — a literal double-quoted interpolation. The sister fixes for `cd "{path}"` (`open_repo_folder`, conversation-restore) and `git checkout` (#10444 / #10639) already use the right primitive: [`warp_util::path::ShellFamily::shell_escape`](https://github.com/warpdotdev/warp/blob/master/crates/warp_util/src/path.rs).

## Fix

Each helper grew a pure `build_*_command(...)` extraction that takes the inputs and a `ShellFamily` / `ShellType` and returns the rendered command. The async wrappers are now thin and call the pure builder. The pure builders are unit-tested without a live `Session`.

```rust
// Before
async fn is_file_path(path: &str, session: &Session) -> bool {
    let command = if session.shell().shell_type() == ShellType::PowerShell {
        format!("if (Test-Path -PathType Leaf \"{path}\") {{ exit 0 }} else {{ exit 1 }}")
    } else {
        format!("test -f \"{path}\"")
    };
    …
}

// After
fn build_is_file_path_command(path: &str, family: ShellFamily) -> String {
    let escaped_path = family.shell_escape(path);
    match family {
        ShellFamily::PowerShell =>
            format!("if (Test-Path -PathType Leaf {escaped_path}) {{ exit 0 }} else {{ exit 1 }}"),
        ShellFamily::Posix => format!("test -f {escaped_path}"),
    }
}

async fn is_file_path(path: &str, session: &Session) -> bool {
    let command = build_is_file_path_command(path, session.shell_family());
    …
}
```

The same shape is applied to all eight sites.

Query escaping (`escape_double_quotes` / `powershell_escape_double_quotes`) is intentionally left alone — queries are regex literals with their own escaping concerns, separate from path-as-shell-word handling.

## Shell-level before/after

```text
$ bash -c 'test -f "/tmp/innocent$(touch /tmp/PROBE_RAN)"'
$ ls /tmp/PROBE_RAN
/tmp/PROBE_RAN   ← touch ran via command substitution (BUG)

$ bash -c 'test -f /tmp/innocent\$\(touch\ /tmp/PROBE_RAN\)'
$ ls /tmp/PROBE_RAN
ls: /tmp/PROBE_RAN: No such file or directory   ← shell-escaped: no side effect (FIX)
```

This is the security boundary the new `build_is_file_path_command` (and its siblings) enforces.

## Testing

21 new unit tests across three sibling `*_tests.rs` files:

- POSIX backslash-escaping: spaces, `$(...)`, backticks, `~` mid-path, empty-string paths
- PowerShell backtick-escaping: spaces, `$env:USERPROFILE`, drive-letter paths
- A regression test per builder that pins the security boundary — no bare `$(...)` or backticks may survive into the rendered command

```text
$ cargo nextest run -p warp -E 'test(path_quoting::) or test(file_glob::tests::)'
21 tests run: 21 passed; 0 failed

$ cargo clippy -p warp --tests -- -D warnings
Finished (no warnings)

$ cargo fmt -p warp -- --check
clean
```

## Server API dependencies

None — this is client-only.

## Agent Mode

Unchecked (external contribution).

## Changelog

`CHANGELOG-BUG-FIX: Paths containing shell metacharacters (spaces, $, backticks, $(...), etc.) are now correctly passed through the AI agent's grep / file_glob / file-existence helpers without being expanded by the user's shell.`

Fixes #11132
