### PR TITLE
Do not include cloud agent metadata on passive suggestions requests

### DIFF
--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2020,7 +2020,9 @@ impl BlocklistAIController {
                 forked_from_conversation_token: conversation
                     .forked_from_server_conversation_token()
                     .cloned(),
-                ambient_agent_task_id: self.ambient_agent_task_id,
+                // Do not tie passive suggestion requests to the cloud agent task, since they are
+                // separate, read-only requests.
+                ambient_agent_task_id: None,
                 existing_suggestions: None,
             };
             (conversation_id, task_id, conversation_data)
@@ -2036,7 +2038,9 @@ impl BlocklistAIController {
                 tasks: vec![],
                 server_conversation_token: None,
                 forked_from_conversation_token: None,
-                ambient_agent_task_id: self.ambient_agent_task_id,
+                // Do not tie passive suggestion requests to the cloud agent task, since they are
+                // separate, read-only requests.
+                ambient_agent_task_id: None,
                 existing_suggestions: None,
             };
             (conversation_id, task_id, conversation_data)
@@ -2146,6 +2150,11 @@ impl BlocklistAIController {
         self.action_model.update(ctx, |action_model, ctx| {
             action_model.set_ambient_agent_task_id(id, ctx);
         });
+    }
+
+    #[cfg(test)]
+    pub fn get_ambient_agent_task_id(&self) -> Option<AmbientAgentTaskId> {
+        self.ambient_agent_task_id
     }
 
     /// Set the per-session directory for downloading file attachments.
@@ -3183,3 +3192,7 @@ fn get_running_command(terminal_model: &TerminalModel) -> Option<RunningCommand>
         is_alt_screen_active,
     })
 }
+
+#[cfg(test)]
+#[path = "controller_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -1,0 +1,58 @@
+use crate::ai::agent::PassiveSuggestionTrigger;
+use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
+use uuid::Uuid;
+use warpui::{App, SingletonEntity};
+
+fn new_ambient_agent_task_id() -> AmbientAgentTaskId {
+    Uuid::new_v4().to_string().parse().unwrap()
+}
+
+#[test]
+fn passive_suggestions_request_params_omit_ambient_agent_task_id() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |terminal, ctx| {
+            let task_id = new_ambient_agent_task_id();
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    history_model.start_new_conversation(terminal.id(), false, false, false, ctx)
+                });
+
+            terminal.ai_controller().update(ctx, |controller, ctx| {
+                controller.set_ambient_agent_task_id(Some(task_id), ctx);
+
+                assert_eq!(controller.get_ambient_agent_task_id(), Some(task_id));
+                assert_eq!(
+                    controller
+                        .build_passive_suggestions_request_params(
+                            Some(conversation_id),
+                            PassiveSuggestionTrigger::FilesChanged,
+                            vec![],
+                            ctx,
+                        )
+                        .expect("existing conversation should build passive suggestion params")
+                        .1
+                        .ambient_agent_task_id,
+                    None
+                );
+                assert_eq!(
+                    controller
+                        .build_passive_suggestions_request_params(
+                            None,
+                            PassiveSuggestionTrigger::FilesChanged,
+                            vec![],
+                            ctx,
+                        )
+                        .expect("new conversation should build passive suggestion params")
+                        .1
+                        .ambient_agent_task_id,
+                    None
+                );
+            });
+        });
+    });
+}

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -9,7 +9,6 @@ use crate::{
             conversation::{
                 AIAgentHarness, AIConversation, AIConversationId, ServerAIConversationMetadata,
             },
-            PassiveSuggestionTrigger,
         },
         agent_conversations_model::AgentConversationsModel,
         ambient_agents::github_auth_notifier::GitHubAuthNotifier,
@@ -461,7 +460,6 @@ fn create_already_fullscreen_parent_pane_data(
 
 fn request_ambient_agent_task_id_for_hidden_child(
     panes: &PaneGroup,
-    child_conversation_id: AIConversationId,
     child_pane_id: PaneId,
     ctx: &mut ViewContext<PaneGroup>,
 ) -> Option<AmbientAgentTaskId> {
@@ -470,18 +468,7 @@ fn request_ambient_agent_task_id_for_hidden_child(
         .expect("child pane should have a terminal view");
     let ai_controller = terminal_view.as_ref(ctx).ai_controller().clone();
 
-    ai_controller.update(ctx, |controller, ctx| {
-        controller
-            .build_passive_suggestions_request_params(
-                Some(child_conversation_id),
-                PassiveSuggestionTrigger::FilesChanged,
-                vec![],
-                ctx,
-            )
-            .expect("child pane should build passive suggestion request params")
-            .1
-            .ambient_agent_task_id
-    })
+    ai_controller.update(ctx, |controller, _| controller.get_ambient_agent_task_id())
 }
 
 fn ambient_child_session_state(
@@ -726,12 +713,7 @@ fn test_hidden_child_creation_applies_ambient_task_id_to_controller() {
                 .expect("fresh hidden child pane should be tracked");
 
             assert_eq!(
-                request_ambient_agent_task_id_for_hidden_child(
-                    panes,
-                    child.conversation_id,
-                    child_pane_id,
-                    ctx,
-                ),
+                request_ambient_agent_task_id_for_hidden_child(panes, child_pane_id, ctx,),
                 Some(task_id)
             );
         });
@@ -765,12 +747,7 @@ fn test_restored_hidden_child_pane_reapplies_ambient_task_id_to_controller() {
                 .expect("restored hidden child pane should be tracked");
 
             assert_eq!(
-                request_ambient_agent_task_id_for_hidden_child(
-                    panes,
-                    child_conversation_id,
-                    child_pane_id,
-                    ctx,
-                ),
+                request_ambient_agent_task_id_for_hidden_child(panes, child_pane_id, ctx,),
                 Some(task_id)
             );
         });

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -1251,11 +1251,16 @@ impl ServerApi {
             }
         );
 
-        let ambient_workload_token = self
-            .get_or_create_ambient_workload_token()
-            .await
-            .map_err(Into::into)
-            .map_err(Arc::new)?;
+        let ambient_workload_token = if is_passive {
+            // Do not include cloud agent workload metadata in passive suggestion requests - they
+            // read from the main conversation, but cannot modify it.
+            None
+        } else {
+            self.get_or_create_ambient_workload_token()
+                .await
+                .map_err(Into::into)
+                .map_err(Arc::new)?
+        };
 
         let mut request_builder = self
             .client


### PR DESCRIPTION
## Description

We got a few reports of `not allowed to use the provided cloud agent` 403 errors while viewing cloud agents. Based on some agent investigation, this is most likely due to MAA passive suggestion requests.
Those requests included cloud agent metadata, but they're issued as the user _viewing_ the session, not the user or agent _executing_ the conversation. With warpdotdev/warp-server#11192, this is an error, since we want to ensure that clients viewing a cloud agent session can't accidentally modify its conversation state.

Issuing passive MAA suggestion requests while viewing a shared session is fine, and generally seems useful, but we don't need to falsely mark these as cloud agent requests.

I also considered:
* Disabling passive suggestions while viewing a shared session
* Not including prior conversation state at all when requesting passive suggestions in a shared session

Both seem like a strictly worse user experience.

## Testing

- [x] Added a regression unit test
- [ ] I have manually tested my changes locally with `./script/run`

This is nontrivial to reproduce, since it requires triggering a passive suggestion while viewing someone else's cloud agent session.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

