### PR TITLE
Bump linuxdeploy to bundle modern appimagetool with type-2-runtime

### DIFF
--- a/script/linux/install_linuxdeploy
+++ b/script/linux/install_linuxdeploy
@@ -43,7 +43,7 @@ download_appimage() {
 
 # Install linuxdeploy, a helper for constructing an AppDir (and then invoking
 # appimagetool).
-download_appimage "linuxdeploy" "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/"
+download_appimage "linuxdeploy" "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/"
 
 if [ ! -x "$(which linuxdeploy)" ]; then
   echo -e "⚠️  ${red}Please make sure that \"$LOCAL_BIN\" is on your PATH, otherwise some scripts may not work.${reset}"

--- a/script/linux/install_linuxdeploy
+++ b/script/linux/install_linuxdeploy
@@ -34,14 +34,13 @@ download_appimage() {
   APPIMAGE_PATH="$LOCAL_BIN/$APPIMAGE_NAME"
 
   if [ -x "$APPIMAGE_PATH" ] && [ "$(appimage_commit "$APPIMAGE_PATH")" = "$COMMIT" ]; then
-    echo "✅ Found $BINARY_NAME on your PATH."
-    return
+    echo "✅ Found $APPIMAGE_NAME in $LOCAL_BIN."
+  else
+    APPIMAGE_RELEASE_URL="$REPO_URL/releases/download/$VERSION/$APPIMAGE_NAME"
+    echo "⬇️ Downloading $APPIMAGE_RELEASE_URL..."
+    curl -fL "$APPIMAGE_RELEASE_URL" --output "$APPIMAGE_PATH"
+    chmod +x "$APPIMAGE_PATH"
   fi
-
-  APPIMAGE_RELEASE_URL="$REPO_URL/releases/download/$VERSION/$APPIMAGE_NAME"
-  echo "⬇️ Downloading $APPIMAGE_RELEASE_URL..."
-  curl -fL "$APPIMAGE_RELEASE_URL" --output "$APPIMAGE_PATH"
-  chmod +x "$APPIMAGE_PATH"
 
   # Create a symlink so we can invoke it like a normal binary.
   ln -sf "$APPIMAGE_PATH" "$LOCAL_BIN/$BINARY_NAME"

--- a/script/linux/install_linuxdeploy
+++ b/script/linux/install_linuxdeploy
@@ -6,42 +6,42 @@ set -e
 LOCAL_BIN="$HOME/.local/bin"
 mkdir -p "$LOCAL_BIN"
 
+# Extract the short commit baked into the linuxdeploy AppImage.
+appimage_commit() {
+  "$1" --version 2>&1 | grep -oE "git commit ID [0-9a-f]{7,40}" | cut -d' ' -f4
+}
+
 # A helper function to download an architecture-dependent AppImage and install
 # it in ~/.local/bin.
 #
 # Usage:
-#   download_appimage $BINARY_NAME $VERSION $DOWNLOAD_URL_BASE
+#   download_appimage $BINARY_NAME $VERSION $COMMIT $REPO_URL
 #
 # Args:
-#   BINARY_NAME:       The name of the AppImage-bundled binary we want to
-#                      download, e.g.: "appimagetool".
-#   VERSION:           The upstream release tag; embedded in the cached
-#                      filename so bumping it forces a re-download.
-#   DOWNLOAD_URL_BASE: The URL to the directory containing the architecture-
-#                      specific AppImages.
+#   BINARY_NAME: The name of the AppImage-bundled binary we want to download,
+#                e.g.: "linuxdeploy".
+#   VERSION:     The upstream release tag.
+#   COMMIT:      The (short) commit SHA the release tag points at; used to
+#                verify the cached binary matches the pinned version.
+#   REPO_URL:    The URL of the GitHub repository hosting the release.
 download_appimage() {
   BINARY_NAME="$1"
   VERSION="$2"
-  DOWNLOAD_URL_BASE="$3"
+  COMMIT="$3"
+  REPO_URL="$4"
 
-  ARCH="$(uname -m)"
-  APPIMAGE_PATH="$LOCAL_BIN/$BINARY_NAME-$VERSION-$ARCH.AppImage"
+  APPIMAGE_NAME="$BINARY_NAME-$(uname -m).AppImage"
+  APPIMAGE_PATH="$LOCAL_BIN/$APPIMAGE_NAME"
 
-  if [ ! -x "$APPIMAGE_PATH" ]; then
-    # Remove previously downloaded versions of this binary so they don't
-    # accumulate in ~/.local/bin every time the version is bumped.
-    for OLD_APPIMAGE in "$LOCAL_BIN/$BINARY_NAME"-*-"$ARCH.AppImage"; do
-      if [ -e "$OLD_APPIMAGE" ] && [ "$OLD_APPIMAGE" != "$APPIMAGE_PATH" ]; then
-        echo "🗑️  Removing old download $OLD_APPIMAGE..."
-        rm -f "$OLD_APPIMAGE"
-      fi
-    done
-
-    APPIMAGE_RELEASE_URL="$DOWNLOAD_URL_BASE/$BINARY_NAME-$ARCH.AppImage"
-    echo "⬇️  Downloading $APPIMAGE_RELEASE_URL..."
-    curl -fL "$APPIMAGE_RELEASE_URL" --output "$APPIMAGE_PATH"
-    chmod +x "$APPIMAGE_PATH"
+  if [ -x "$APPIMAGE_PATH" ] && [ "$(appimage_commit "$APPIMAGE_PATH")" = "$COMMIT" ]; then
+    echo "✅ Found $BINARY_NAME on your PATH."
+    return
   fi
+
+  APPIMAGE_RELEASE_URL="$REPO_URL/releases/download/$VERSION/$APPIMAGE_NAME"
+  echo "⬇️ Downloading $APPIMAGE_RELEASE_URL..."
+  curl -fL "$APPIMAGE_RELEASE_URL" --output "$APPIMAGE_PATH"
+  chmod +x "$APPIMAGE_PATH"
 
   # Create a symlink so we can invoke it like a normal binary.
   ln -sf "$APPIMAGE_PATH" "$LOCAL_BIN/$BINARY_NAME"
@@ -49,9 +49,8 @@ download_appimage() {
 
 # Install linuxdeploy, a helper for constructing an AppDir (and then invoking
 # appimagetool).
-LINUXDEPLOY_VERSION="1-alpha-20251107-1"
-download_appimage "linuxdeploy" "$LINUXDEPLOY_VERSION" \
-  "https://github.com/linuxdeploy/linuxdeploy/releases/download/$LINUXDEPLOY_VERSION/"
+download_appimage "linuxdeploy" "1-alpha-20251107-1" "cc7b864" \
+  "https://github.com/linuxdeploy/linuxdeploy"
 
 if [ ! -x "$(which linuxdeploy)" ]; then
   echo -e "⚠️  ${red}Please make sure that \"$LOCAL_BIN\" is on your PATH, otherwise some scripts may not work.${reset}"

--- a/script/linux/install_linuxdeploy
+++ b/script/linux/install_linuxdeploy
@@ -10,40 +10,37 @@ mkdir -p "$LOCAL_BIN"
 # it in ~/.local/bin.
 #
 # Usage:
-#   download_appimage $BINARY_NAME $DOWNLOAD_URL_BASE
+#   download_appimage $BINARY_NAME $VERSION $DOWNLOAD_URL_BASE
 #
 # Args:
 #   BINARY_NAME:       The name of the AppImage-bundled binary we want to
 #                      download, e.g.: "appimagetool".
+#   VERSION:           The upstream release tag; embedded in the cached
+#                      filename so bumping it forces a re-download.
 #   DOWNLOAD_URL_BASE: The URL to the directory containing the architecture-
 #                      specific AppImages.
 download_appimage() {
   BINARY_NAME="$1"
-  DOWNLOAD_URL_BASE="$2"
+  VERSION="$2"
+  DOWNLOAD_URL_BASE="$3"
 
-  APPIMAGE_NAME="$BINARY_NAME-$(uname -m).AppImage"
+  APPIMAGE_PATH="$LOCAL_BIN/$BINARY_NAME-$VERSION.AppImage"
 
-  if [ -x "$(which "$BINARY_NAME")" ]; then
-    echo "✅ Found $BINARY_NAME on your PATH."
-  elif [ -x "$(which "$APPIMAGE_NAME")" ]; then
-    APPIMAGE_PATH="$(which "$APPIMAGE_NAME")"
-    APPIMAGE_PARENT_DIR="$(dirname "$APPIMAGE_PATH")"
-    # Create a symlink so we can invoke it like a normal binary.
-    ln -s "$APPIMAGE_PATH" "$APPIMAGE_PARENT_DIR/$BINARY_NAME"
-    echo "✅ Found $APPIMAGE_NAME on your PATH; added $BINARY_NAME symlink."
-  else
-    echo "⬇️  Downloading $APPIMAGE_NAME..."
-    APPIMAGE_PATH="$LOCAL_BIN/$APPIMAGE_NAME"
-    curl -fL "$DOWNLOAD_URL_BASE/$APPIMAGE_NAME" --output "$APPIMAGE_PATH"
+  if [ ! -f "$APPIMAGE_PATH" ]; then
+    APPIMAGE_RELEASE_URL="$DOWNLOAD_URL_BASE/$BINARY_NAME-$(uname -m).AppImage"
+    echo "⬇️  Downloading $APPIMAGE_RELEASE_URL..."
+    curl -fL "$APPIMAGE_RELEASE_URL" --output "$APPIMAGE_PATH"
     chmod +x "$APPIMAGE_PATH"
     # Create a symlink so we can invoke it like a normal binary.
-    ln -s "$APPIMAGE_PATH" "$LOCAL_BIN/$BINARY_NAME"
+    ln -sf "$APPIMAGE_PATH" "$LOCAL_BIN/$BINARY_NAME"
   fi
 }
 
 # Install linuxdeploy, a helper for constructing an AppDir (and then invoking
 # appimagetool).
-download_appimage "linuxdeploy" "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/"
+LINUXDEPLOY_VERSION="1-alpha-20251107-1"
+download_appimage "linuxdeploy" "$LINUXDEPLOY_VERSION" \
+  "https://github.com/linuxdeploy/linuxdeploy/releases/download/$LINUXDEPLOY_VERSION/"
 
 if [ ! -x "$(which linuxdeploy)" ]; then
   echo -e "⚠️  ${red}Please make sure that \"$LOCAL_BIN\" is on your PATH, otherwise some scripts may not work.${reset}"

--- a/script/linux/install_linuxdeploy
+++ b/script/linux/install_linuxdeploy
@@ -26,14 +26,15 @@ download_appimage() {
 
   APPIMAGE_PATH="$LOCAL_BIN/$BINARY_NAME-$VERSION-$(uname -m).AppImage"
 
-  if [ ! -f "$APPIMAGE_PATH" ]; then
+  if [ ! -x "$APPIMAGE_PATH" ]; then
     APPIMAGE_RELEASE_URL="$DOWNLOAD_URL_BASE/$BINARY_NAME-$(uname -m).AppImage"
     echo "⬇️  Downloading $APPIMAGE_RELEASE_URL..."
     curl -fL "$APPIMAGE_RELEASE_URL" --output "$APPIMAGE_PATH"
     chmod +x "$APPIMAGE_PATH"
-    # Create a symlink so we can invoke it like a normal binary.
-    ln -sf "$APPIMAGE_PATH" "$LOCAL_BIN/$BINARY_NAME"
   fi
+
+  # Create a symlink so we can invoke it like a normal binary.
+  ln -sf "$APPIMAGE_PATH" "$LOCAL_BIN/$BINARY_NAME"
 }
 
 # Install linuxdeploy, a helper for constructing an AppDir (and then invoking

--- a/script/linux/install_linuxdeploy
+++ b/script/linux/install_linuxdeploy
@@ -24,10 +24,20 @@ download_appimage() {
   VERSION="$2"
   DOWNLOAD_URL_BASE="$3"
 
-  APPIMAGE_PATH="$LOCAL_BIN/$BINARY_NAME-$VERSION-$(uname -m).AppImage"
+  ARCH="$(uname -m)"
+  APPIMAGE_PATH="$LOCAL_BIN/$BINARY_NAME-$VERSION-$ARCH.AppImage"
 
   if [ ! -x "$APPIMAGE_PATH" ]; then
-    APPIMAGE_RELEASE_URL="$DOWNLOAD_URL_BASE/$BINARY_NAME-$(uname -m).AppImage"
+    # Remove previously downloaded versions of this binary so they don't
+    # accumulate in ~/.local/bin every time the version is bumped.
+    for OLD_APPIMAGE in "$LOCAL_BIN/$BINARY_NAME"-*-"$ARCH.AppImage"; do
+      if [ -e "$OLD_APPIMAGE" ] && [ "$OLD_APPIMAGE" != "$APPIMAGE_PATH" ]; then
+        echo "🗑️  Removing old download $OLD_APPIMAGE..."
+        rm -f "$OLD_APPIMAGE"
+      fi
+    done
+
+    APPIMAGE_RELEASE_URL="$DOWNLOAD_URL_BASE/$BINARY_NAME-$ARCH.AppImage"
     echo "⬇️  Downloading $APPIMAGE_RELEASE_URL..."
     curl -fL "$APPIMAGE_RELEASE_URL" --output "$APPIMAGE_PATH"
     chmod +x "$APPIMAGE_PATH"

--- a/script/linux/install_linuxdeploy
+++ b/script/linux/install_linuxdeploy
@@ -24,7 +24,7 @@ download_appimage() {
   VERSION="$2"
   DOWNLOAD_URL_BASE="$3"
 
-  APPIMAGE_PATH="$LOCAL_BIN/$BINARY_NAME-$VERSION.AppImage"
+  APPIMAGE_PATH="$LOCAL_BIN/$BINARY_NAME-$VERSION-$(uname -m).AppImage"
 
   if [ ! -f "$APPIMAGE_PATH" ]; then
     APPIMAGE_RELEASE_URL="$DOWNLOAD_URL_BASE/$BINARY_NAME-$(uname -m).AppImage"


### PR DESCRIPTION
## Description
The pinned linuxdeploy release (1-alpha-20240109-1) shipped an appimagetool that embeds an AppImage runtime dynamically linked against libfuse2. Fedora 44 and other modern distros have dropped libfuse2, so Warp's AppImage fails to launch there. Switching to 1-alpha-20251107-1 pulls in an appimagetool that embeds the type-2-runtime, which statically links libfuse3 and removes the libfuse2 dependency entirely.

## Linked Issue

Fixes #8451.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
