### PR TITLE
fix(tab-configs): let a focused picker own Space (#11138)

### DIFF
--- a/app/src/tab_configs/params_modal.rs
+++ b/app/src/tab_configs/params_modal.rs
@@ -40,18 +40,14 @@ pub fn init(app: &mut AppContext) {
             TabConfigParamsModalAction::Escape,
             id!("TabConfigParamsModal"),
         ),
-        // Enter and Space only fire when no EditorView descendant is focused.
-        // When a text field or picker filter editor has focus, the editor
-        // consumes these keys and the modal handles them via event
-        // subscriptions instead (see handle_editor_event).
+        // Enter only fires when no EditorView descendant is focused. When a
+        // text field or picker filter editor has focus, the editor consumes
+        // it and the modal handles submit via event subscriptions instead
+        // (see handle_editor_event). Space is owned by FilterableDropdown
+        // itself when a picker is focused, so the modal no longer binds it.
         FixedBinding::new(
             "enter",
             TabConfigParamsModalAction::Submit,
-            id!("TabConfigParamsModal") & !id!("EditorView"),
-        ),
-        FixedBinding::new(
-            "space",
-            TabConfigParamsModalAction::ToggleDropdown,
             id!("TabConfigParamsModal") & !id!("EditorView"),
         ),
     ]);
@@ -147,7 +143,6 @@ pub enum TabConfigParamsModalAction {
     Cancel,
     Submit,
     Escape,
-    ToggleDropdown,
 }
 
 impl TabConfigParamsModal {
@@ -322,10 +317,9 @@ impl TabConfigParamsModal {
 
         self.pending_config = Some(config);
 
-        // When the only fields are dropdowns, focus the modal itself so
-        // Enter (submit) and Space (toggle dropdown) fixed bindings fire.
-        // When there are text fields, focus the first one so the user can
-        // start typing immediately.
+        // When the only fields are dropdowns, focus the modal itself so the
+        // Enter (submit) fixed binding fires. When there are text fields,
+        // focus the first one so the user can start typing immediately.
         if self.has_text_fields() {
             self.focus_field(0, ctx);
         } else {
@@ -403,35 +397,6 @@ impl TabConfigParamsModal {
             .any(|(_, _, field)| matches!(field, ParamField::Text(_)))
     }
 
-    fn dropdown_count(&self) -> usize {
-        self.param_fields
-            .iter()
-            .filter(|(_, _, field)| !matches!(field, ParamField::Text(_)))
-            .count()
-    }
-
-    fn toggle_single_dropdown(&mut self, ctx: &mut ViewContext<Self>) {
-        let mut opened = false;
-        for (_, _, field) in &self.param_fields {
-            match field {
-                ParamField::Branch { picker, .. } => {
-                    opened = picker.update(ctx, |p, ctx| p.toggle_dropdown(ctx));
-                    break;
-                }
-                ParamField::Repo { picker, .. } => {
-                    opened = picker.update(ctx, |p, ctx| p.toggle_dropdown(ctx));
-                    break;
-                }
-                ParamField::Text(_) => {}
-            }
-        }
-        // When the dropdown just closed, reclaim focus so Enter/Space
-        // fixed bindings continue to work.
-        if !opened && !self.has_text_fields() {
-            ctx.focus_self();
-        }
-    }
-
     fn focus_field(&self, index: usize, ctx: &mut ViewContext<Self>) {
         if let Some((_, _, field)) = self.param_fields.get(index) {
             match field {
@@ -503,8 +468,8 @@ impl View for TabConfigParamsModal {
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
         // When focus arrives directly at this view (not at a child), keep
-        // self-focus so the Enter/Space fixed bindings fire. This happens
-        // on initial open (via focus_self in on_open) and when the Modal
+        // self-focus so the Enter fixed binding fires. This happens on
+        // initial open (via focus_self in on_open) and when the Modal
         // wrapper re-focuses the body after a child (like a dropdown)
         // releases focus.
         if focus_ctx.is_self_focused() && !self.has_text_fields() {
@@ -727,11 +692,6 @@ impl TypedActionView for TabConfigParamsModal {
                 ctx.emit(TabConfigParamsModalEvent::Close);
             }
             TabConfigParamsModalAction::Submit => self.try_submit(ctx),
-            TabConfigParamsModalAction::ToggleDropdown => {
-                if self.dropdown_count() <= 1 {
-                    self.toggle_single_dropdown(ctx);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #11138. In a tab config that mixes a `repo` param with a `text` param, pressing **Space** while the text field was focused opened the repo dropdown instead of inserting a literal space, making multi-word text params impossible to enter.

This revision is rebased on top of #11718 and is **much smaller** than the earlier picker-/`FilterableDropdown`-layer implementation. Per [@moirahuang's guidance](https://github.com/warpdotdev/warp/pull/11412#discussion_r-11718-merged), now that #11718 has landed, `FilterableDropdown` owns Space itself when a picker is focused — so the tab config modal no longer needs to special-case Space at all. The fix is now a **deletion** (+10 / −50, single file).

## Root cause

`app/src/tab_configs/params_modal.rs` registered a modal-level Space binding with the scope predicate `id!("TabConfigParamsModal") & !id!("EditorView")`, on the assumption that the `!id!("EditorView")` clause would suppress the binding while a descendant text editor was focused.

But keystroke dispatch evaluates each layer's `ContextPredicate` against **that layer's own** `keymap_context` only — it never merges ancestors with descendants. When the focused view is `EditorView`:

1. At the `EditorView` layer the context contains `"EditorView"` but **not** `"TabConfigParamsModal"`, so the predicate is false. The editor has no Space `FixedBinding`, so dispatch continues up the chain.
2. At the `TabConfigParamsModal` layer the context contains `"TabConfigParamsModal"` but **never** `"EditorView"` (the modal isn't an editor), so `!id!("EditorView")` is always true. The predicate matches, `ToggleDropdown` fires, and the editor never sees the space.

## Fix

Since #11718, `FilterableDropdown` dispatches `ToggleExpanded` on an unmodified Space when the picker is focused (`app/src/view_components/filterable_dropdown.rs`). That covers the "focused dropdown owns Space" behavior natively, so the modal-level binding is redundant — and harmful, because of the dispatch semantics above. This PR removes:

- the modal-level `space` → `ToggleDropdown` `FixedBinding`,
- the now-unused `TabConfigParamsModalAction::ToggleDropdown` variant and its handler arm,
- the dead `dropdown_count` / `toggle_single_dropdown` helpers.

Result:
- **Text field focused** → Space is no longer intercepted by the modal → the editor inserts a literal space. (Fixes #11138.)
- **Picker focused** → `FilterableDropdown`'s built-in Space handler toggles it.

## Scope note

For a config whose **only** param is a dropdown, the modal still self-focuses on open (so the Enter-to-submit `FixedBinding` fires), which means Space toggles that dropdown only once it is focused, rather than immediately on open. Auto-focusing the single dropdown on open was [called out as optional by @moirahuang](https://github.com/warpdotdev/warp/pull/11412) and is intentionally left out of this PR, since #11138 concerns the mixed `repo` + `text` case.

## Visual evidence

Both clips use the mixed `repo` + `text` config below. The user-facing behavior is identical to the earlier revisions of this PR, so the recordings still apply.

**Before — stable Warp** (`v0.2026.05.18.05.32.stable_02`): with the `tab_name` text field focused, pressing **Space** opens the `repo` dropdown instead of inserting a space — issue #11138.

https://github.com/user-attachments/assets/f17c33ea-27db-424c-a783-3a89f32ad1d7

**After** (local OSS build): the focused, collapsed `repo` picker toggles open on **Space** ("the dropdown owns Space"); the `tab_name` text field accepts literal spaces (typed `my tab   New`); the `repo` dropdown stays closed throughout.

https://github.com/user-attachments/assets/1c73b097-2b62-4c38-b719-111a1ce9d561

Tab config used for the repro:

```toml
name = "PR 11412 repro"

[[panes]]
id = "main"
type = "terminal"
directory = "{{repo}}"
commands = []

[params.repo]
type = "repo"
description = "Repository to open"

[params.tab_name]
type = "text"
description = "Tab name"
default = "my tab"
```

## Test plan

- [x] `cargo fmt -p warp -- --check` clean
- [x] `cargo clippy -p warp --lib --no-deps` clean
- [x] `cargo test -p warp --lib tab_configs::params_modal` — 3/3 pass
- [ ] Reviewer environment: open the mixed `repo` + `text` tab config above, focus the text field, press Space → a literal space is inserted; focus the repo picker, press Space → the dropdown toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
