### PR TITLE
fix(mcp): surface MCP config unmarshal errors in Settings

### DIFF
--- a/app/src/ai/mcp/dummy_file_based_manager.rs
+++ b/app/src/ai/mcp/dummy_file_based_manager.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
-use super::MCPProvider;
+use super::{ConfigParseError, MCPProvider};
 use crate::ai::mcp::templatable_installation::TemplatableMCPServerInstallation;
 
 pub struct FileBasedMCPManager {}
@@ -19,6 +19,10 @@ impl FileBasedMCPManager {
         _app: &AppContext,
     ) -> Vec<&TemplatableMCPServerInstallation> {
         vec![]
+    }
+
+    pub fn config_parse_errors(&self) -> std::iter::Empty<&ConfigParseError> {
+        std::iter::empty()
     }
 
     pub fn file_based_servers(&self) -> Vec<&TemplatableMCPServerInstallation> {

--- a/app/src/ai/mcp/file_based_manager.rs
+++ b/app/src/ai/mcp/file_based_manager.rs
@@ -9,7 +9,7 @@ use warp_core::features::FeatureFlag;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
-use super::{FileMCPWatcher, FileMCPWatcherEvent, MCPProvider};
+use super::{ConfigParseError, FileMCPWatcher, FileMCPWatcherEvent, MCPProvider};
 use crate::ai::mcp::templatable_installation::TemplatableMCPServerInstallation;
 use crate::ai::mcp::ParsedTemplatableMCPServerResult;
 use crate::settings::ai::AISettings;
@@ -28,6 +28,11 @@ pub struct FileBasedMCPManager {
     /// They are temporarily stored here and removed to emit FileBasedMCPManagerEvent::CloudEnvMcpScanComplete
     pending_scan_auto_started_servers_by_root:
         HashMap<PathBuf, HashMap<MCPProvider, HashSet<Uuid>>>,
+    /// Last unmarshal failure observed for each `(root_path, provider)` config
+    /// slot. Surfaced by the settings UI so the user sees why a config that
+    /// exists on disk produced no servers, instead of debugging via logs (see
+    /// issue #9807).
+    config_parse_errors: HashMap<(PathBuf, MCPProvider), ConfigParseError>,
 }
 
 impl FileBasedMCPManager {
@@ -48,6 +53,7 @@ impl FileBasedMCPManager {
             file_based_servers: Default::default(),
             file_based_servers_by_root: Default::default(),
             pending_scan_auto_started_servers_by_root: Default::default(),
+            config_parse_errors: Default::default(),
         }
     }
 
@@ -58,14 +64,26 @@ impl FileBasedMCPManager {
                 root_path,
                 provider,
                 servers,
+                error,
             } => {
                 self.apply_parsed_servers(root_path.clone(), *provider, servers.clone(), ctx);
+                let key = (root_path.clone(), *provider);
+                match error {
+                    Some(err) => {
+                        self.config_parse_errors.insert(key, err.clone());
+                    }
+                    None => {
+                        self.config_parse_errors.remove(&key);
+                    }
+                }
             }
             FileMCPWatcherEvent::ConfigRemoved {
                 root_path,
                 provider,
             } => {
                 self.remove_servers_for_root_provider(root_path, *provider, ctx);
+                self.config_parse_errors
+                    .remove(&(root_path.clone(), *provider));
             }
             FileMCPWatcherEvent::CloudEnvMcpScanComplete { repo_path } => {
                 self.handle_cloud_environment_scan_complete(repo_path, ctx);
@@ -98,6 +116,14 @@ impl FileBasedMCPManager {
             }
         }
         servers
+    }
+
+    /// Returns the most recent config-parse failures across all detected
+    /// `(root_path, provider)` slots. Surfaced by Settings → MCP Servers so the
+    /// user sees a structured reason when a config that exists on disk produced
+    /// no servers.
+    pub fn config_parse_errors(&self) -> impl Iterator<Item = &ConfigParseError> {
+        self.config_parse_errors.values()
     }
 
     /// Removes all tracked servers for the given `(root_path, provider)` pair,

--- a/app/src/ai/mcp/file_based_manager_tests.rs
+++ b/app/src/ai/mcp/file_based_manager_tests.rs
@@ -11,7 +11,10 @@ use warpui::{App, Entity, ModelHandle, SingletonEntity as _};
 use watcher::HomeDirectoryWatcher;
 
 use super::{CloudEnvMcpScanServer, FileBasedMCPManager, FileBasedMCPManagerEvent, MCPProvider};
-use crate::ai::mcp::{FileMCPWatcher, ParsedTemplatableMCPServerResult};
+use crate::ai::mcp::{
+    ConfigParseError, ConfigParseStage, FileMCPWatcher, FileMCPWatcherEvent,
+    ParsedTemplatableMCPServerResult,
+};
 use crate::auth::AuthStateProvider;
 use crate::settings::{AISettings, FocusedTerminalInfo};
 use crate::warp_managed_paths_watcher::{warp_managed_mcp_config_path, WarpManagedPathsWatcher};
@@ -606,6 +609,198 @@ fn test_update_file_based_servers_removes_server_only_when_no_refs() {
                 !manager.file_based_servers.contains_key(&server_hash),
                 "Server should be completely removed"
             );
+        });
+    });
+}
+
+// ---------- Issue #9807: config-parse error surfacing ----------
+
+fn make_parse_error(
+    path: &str,
+    provider: MCPProvider,
+    stage: ConfigParseStage,
+) -> ConfigParseError {
+    ConfigParseError {
+        path: PathBuf::from(path),
+        provider,
+        stage,
+        message: "test message".to_string(),
+    }
+}
+
+#[test]
+fn config_parse_error_is_recorded_on_failed_parse() {
+    let root = PathBuf::from("/tmp/test-repo-error");
+    let err = make_parse_error(
+        "/tmp/test-repo-error/.mcp.json",
+        MCPProvider::Claude,
+        ConfigParseStage::JsonParse,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigParsed {
+                    root_path: root.clone(),
+                    provider: MCPProvider::Claude,
+                    servers: vec![],
+                    error: Some(err.clone()),
+                },
+                ctx,
+            );
+
+            let recorded: Vec<_> = manager.config_parse_errors().collect();
+            assert_eq!(
+                recorded.len(),
+                1,
+                "manager should record exactly one config parse error"
+            );
+            assert_eq!(recorded[0].stage, ConfigParseStage::JsonParse);
+            assert_eq!(recorded[0].provider, MCPProvider::Claude);
+        });
+    });
+}
+
+#[test]
+fn successful_parse_clears_prior_config_parse_error() {
+    let root = PathBuf::from("/tmp/test-repo-clear");
+    let err = make_parse_error(
+        "/tmp/test-repo-clear/.mcp.json",
+        MCPProvider::Claude,
+        ConfigParseStage::JsonParse,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            // First parse fails.
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigParsed {
+                    root_path: root.clone(),
+                    provider: MCPProvider::Claude,
+                    servers: vec![],
+                    error: Some(err.clone()),
+                },
+                ctx,
+            );
+            assert_eq!(manager.config_parse_errors().count(), 1);
+
+            // Next parse for the same slot succeeds — error should be cleared.
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigParsed {
+                    root_path: root.clone(),
+                    provider: MCPProvider::Claude,
+                    servers: vec![],
+                    error: None,
+                },
+                ctx,
+            );
+            assert_eq!(
+                manager.config_parse_errors().count(),
+                0,
+                "subsequent successful parse should clear the recorded error"
+            );
+        });
+    });
+}
+
+#[test]
+fn config_removed_clears_config_parse_error() {
+    let root = PathBuf::from("/tmp/test-repo-removed");
+    let err = make_parse_error(
+        "/tmp/test-repo-removed/.mcp.json",
+        MCPProvider::Claude,
+        ConfigParseStage::JsonParse,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigParsed {
+                    root_path: root.clone(),
+                    provider: MCPProvider::Claude,
+                    servers: vec![],
+                    error: Some(err.clone()),
+                },
+                ctx,
+            );
+            assert_eq!(manager.config_parse_errors().count(), 1);
+
+            // Removing the config file should also drop the error.
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigRemoved {
+                    root_path: root.clone(),
+                    provider: MCPProvider::Claude,
+                },
+                ctx,
+            );
+            assert_eq!(
+                manager.config_parse_errors().count(),
+                0,
+                "ConfigRemoved should clear the recorded error for the same slot"
+            );
+        });
+    });
+}
+
+#[test]
+fn config_parse_errors_are_keyed_per_root_and_provider() {
+    // Two different `(root, provider)` slots can hold independent errors at the
+    // same time, and clearing one must not affect the other.
+    let root_a = PathBuf::from("/tmp/test-repo-a");
+    let root_b = PathBuf::from("/tmp/test-repo-b");
+    let err_a = make_parse_error(
+        "/tmp/test-repo-a/.mcp.json",
+        MCPProvider::Claude,
+        ConfigParseStage::JsonParse,
+    );
+    let err_b = make_parse_error(
+        "/tmp/test-repo-b/.codex/config.toml",
+        MCPProvider::Codex,
+        ConfigParseStage::TomlNormalize,
+    );
+
+    App::test((), |mut app| async move {
+        let manager_handle = setup_app(&mut app);
+
+        manager_handle.update(&mut app, |manager, ctx| {
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigParsed {
+                    root_path: root_a.clone(),
+                    provider: MCPProvider::Claude,
+                    servers: vec![],
+                    error: Some(err_a.clone()),
+                },
+                ctx,
+            );
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigParsed {
+                    root_path: root_b.clone(),
+                    provider: MCPProvider::Codex,
+                    servers: vec![],
+                    error: Some(err_b.clone()),
+                },
+                ctx,
+            );
+            assert_eq!(manager.config_parse_errors().count(), 2);
+
+            // Clearing the Claude slot should leave the Codex slot intact.
+            manager.handle_watcher_event(
+                &FileMCPWatcherEvent::ConfigRemoved {
+                    root_path: root_a.clone(),
+                    provider: MCPProvider::Claude,
+                },
+                ctx,
+            );
+            let remaining: Vec<_> = manager.config_parse_errors().collect();
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(remaining[0].provider, MCPProvider::Codex);
+            assert_eq!(remaining[0].stage, ConfigParseStage::TomlNormalize);
         });
     });
 }

--- a/app/src/ai/mcp/file_mcp_watcher.rs
+++ b/app/src/ai/mcp/file_mcp_watcher.rs
@@ -17,8 +17,10 @@ use warp_core::safe_warn;
 use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity};
 use watcher::HomeDirectoryWatcherEvent;
 
-use crate::ai::mcp::parsing::normalize_codex_toml_to_json;
-use crate::ai::mcp::{home_config_file_path, MCPProvider, ParsedTemplatableMCPServerResult};
+use crate::ai::mcp::{
+    home_config_file_path, parsing::normalize_codex_toml_to_json, ConfigParseError,
+    ConfigParseStage, MCPProvider, ParsedTemplatableMCPServerResult,
+};
 use crate::warp_managed_paths_watcher::{
     warp_managed_mcp_config_path, WarpManagedPathsWatcher, WarpManagedPathsWatcherEvent,
 };
@@ -546,10 +548,12 @@ impl FileMCPWatcher {
         let _ = ctx.spawn(
             async move { parse_mcp_config_file(&config_path, provider).await },
             move |_me, parsed, ctx| {
+                let (servers, error) = split_parse_result(parsed);
                 ctx.emit(FileMCPWatcherEvent::ConfigParsed {
                     root_path: root_path_for_callback,
                     provider,
-                    servers: parsed,
+                    servers,
+                    error,
                 });
             },
         );
@@ -567,12 +571,14 @@ impl FileMCPWatcher {
         let config_file_path = config_file_path.to_path_buf();
         let _ = ctx.spawn(
             async move { parse_mcp_config_file(&config_file_path, provider).await },
-            move |me, servers, ctx| {
+            move |me, parsed, ctx| {
                 let repo_path_for_countdown = root_path.clone();
+                let (servers, error) = split_parse_result(parsed);
                 ctx.emit(FileMCPWatcherEvent::ConfigParsed {
                     root_path,
                     provider,
                     servers,
+                    error,
                 });
                 if let Some(count) = me.cloud_env_pending.get_mut(&repo_path_for_countdown) {
                     *count = count.saturating_sub(1);
@@ -586,6 +592,21 @@ impl FileMCPWatcher {
                 }
             },
         );
+    }
+}
+
+/// Unwraps the parser's `Result` into the `(servers, error)` shape carried by
+/// [`FileMCPWatcherEvent::ConfigParsed`]. On failure the server list is empty
+/// so downstream "clear all servers for this slot" behavior is preserved.
+fn split_parse_result(
+    parsed: Result<Vec<ParsedTemplatableMCPServerResult>, ConfigParseError>,
+) -> (
+    Vec<ParsedTemplatableMCPServerResult>,
+    Option<ConfigParseError>,
+) {
+    match parsed {
+        Ok(servers) => (servers, None),
+        Err(err) => (vec![], Some(err)),
     }
 }
 
@@ -636,14 +657,18 @@ fn substitute_env_vars(json_content: &str) -> Result<String, anyhow::Error> {
 
 /// Asynchronously reads and parses an MCP config file and returns parsed MCP servers.
 /// Dispatches to the appropriate parser based on `provider` rather than inferring from path.
-/// Returns an empty vec if the file doesn't exist or parsing fails.
+///
+/// Returns `Ok(vec![])` if the file doesn't exist (a normal state for a provider
+/// the user hasn't configured). Returns `Err(ConfigParseError)` for any other
+/// failure so the watcher can surface it to the UI rather than silently
+/// dropping the config's servers.
 async fn parse_mcp_config_file(
     file_path: &Path,
     provider: MCPProvider,
-) -> Vec<ParsedTemplatableMCPServerResult> {
+) -> Result<Vec<ParsedTemplatableMCPServerResult>, ConfigParseError> {
     let file_contents = match async_fs::read_to_string(file_path).await {
         Ok(contents) => contents,
-        Err(err) if err.kind() == ErrorKind::NotFound => return vec![],
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(vec![]),
         Err(err) => {
             safe_warn!(
                 safe: (
@@ -656,7 +681,12 @@ async fn parse_mcp_config_file(
                     err
                 )
             );
-            return vec![];
+            return Err(ConfigParseError {
+                path: file_path.to_path_buf(),
+                provider,
+                stage: ConfigParseStage::Read,
+                message: err.to_string(),
+            });
         }
     };
 
@@ -675,7 +705,12 @@ async fn parse_mcp_config_file(
                         err
                     )
                 );
-                return vec![];
+                return Err(ConfigParseError {
+                    path: file_path.to_path_buf(),
+                    provider,
+                    stage: ConfigParseStage::TomlNormalize,
+                    message: format!("{err:#}"),
+                });
             }
         },
         MCPProvider::Claude | MCPProvider::Warp | MCPProvider::Agents => file_contents,
@@ -695,12 +730,17 @@ async fn parse_mcp_config_file(
                     err
                 )
             );
-            return vec![];
+            return Err(ConfigParseError {
+                path: file_path.to_path_buf(),
+                provider,
+                stage: ConfigParseStage::EnvSubstitute,
+                message: err.to_string(),
+            });
         }
     };
 
     match ParsedTemplatableMCPServerResult::from_config_file_json(&resolved_contents) {
-        Ok(parsed_servers) => parsed_servers,
+        Ok(parsed_servers) => Ok(parsed_servers),
         Err(err) => {
             safe_warn!(
                 safe: (
@@ -713,18 +753,27 @@ async fn parse_mcp_config_file(
                     err
                 )
             );
-            vec![]
+            Err(ConfigParseError {
+                path: file_path.to_path_buf(),
+                provider,
+                stage: ConfigParseStage::JsonParse,
+                message: format!("{err:#}"),
+            })
         }
     }
 }
 
 /// Events sent from [`FileMCPWatcher`] to [`FileBasedMCPManager`] via the watcher channel.
 pub enum FileMCPWatcherEvent {
-    /// A config file was successfully parsed; delivers the full snapshot for `(root_path, provider)`.
+    /// A config file was processed. `servers` carries the parsed snapshot for
+    /// `(root_path, provider)` on success, or is empty when `error` is `Some`.
+    /// Subscribers should treat the two fields as mutually exclusive — the
+    /// downstream manager clears servers for this slot in both branches.
     ConfigParsed {
         root_path: PathBuf,
         provider: MCPProvider,
         servers: Vec<ParsedTemplatableMCPServerResult>,
+        error: Option<ConfigParseError>,
     },
     /// A config file was deleted; all servers for `(root_path, provider)` should be removed.
     ConfigRemoved {

--- a/app/src/ai/mcp/file_mcp_watcher_tests.rs
+++ b/app/src/ai/mcp/file_mcp_watcher_tests.rs
@@ -1,6 +1,9 @@
 use std::env;
+use std::path::PathBuf;
+use tempfile::TempDir;
 
-use super::substitute_env_vars;
+use super::{parse_mcp_config_file, substitute_env_vars};
+use crate::ai::mcp::{ConfigParseStage, MCPProvider};
 
 fn cleanup_env_vars(vars: &[&str]) {
     for var in vars {
@@ -72,4 +75,101 @@ fn test_substitute_env_vars_missing_or_empty() {
 
     // Cleanup
     cleanup_env_vars(&["EMPTY_VAR"]);
+}
+
+/// Writes `contents` to `name` inside a fresh `TempDir` and returns both. The
+/// `TempDir` is kept alive by the caller so the file outlives the parser call.
+fn write_temp_file(name: &str, contents: &str) -> (TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join(name);
+    std::fs::write(&path, contents).expect("write temp file");
+    (dir, path)
+}
+
+#[tokio::test]
+async fn parse_missing_file_is_not_an_error() {
+    // NotFound is the normal state for an unconfigured provider: parsing returns
+    // `Ok(vec![])` so the UI doesn't blame the user for a file they haven't created.
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let path = dir.path().join("nonexistent.json");
+
+    let result = parse_mcp_config_file(&path, MCPProvider::Claude).await;
+    assert!(result.is_ok(), "missing config file should return Ok");
+    assert!(
+        result.unwrap().is_empty(),
+        "missing config file should yield zero servers"
+    );
+}
+
+#[tokio::test]
+async fn parse_valid_json_returns_servers_without_error() {
+    let json = r#"{"mcpServers":{"my-server":{"command":"node","args":["server.js"]}}}"#;
+    let (_dir, path) = write_temp_file(".mcp.json", json);
+
+    let result = parse_mcp_config_file(&path, MCPProvider::Claude).await;
+    let servers = result.expect("valid JSON should parse");
+    assert_eq!(servers.len(), 1, "expected one parsed server");
+}
+
+#[tokio::test]
+async fn parse_unreadable_path_emits_read_stage_error() {
+    // Passing the tempdir path itself (rather than a file inside it) trips the
+    // read fallback: `read_to_string` on a directory returns an I/O error that
+    // is not `NotFound`, so we should surface a `Read`-stage parse error.
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let dir_as_file = dir.path().to_path_buf();
+
+    let result = parse_mcp_config_file(&dir_as_file, MCPProvider::Claude).await;
+    let err = result.expect_err("reading a directory should fail");
+    assert_eq!(err.stage, ConfigParseStage::Read);
+    assert_eq!(err.provider, MCPProvider::Claude);
+    assert_eq!(err.path, dir_as_file);
+    assert!(
+        !err.message.is_empty(),
+        "Read-stage error should carry an underlying I/O message"
+    );
+}
+
+#[tokio::test]
+async fn parse_invalid_codex_toml_emits_toml_normalize_error() {
+    // Unterminated table header → toml parser rejects.
+    let (_dir, path) = write_temp_file("config.toml", "[[[invalid_toml");
+
+    let result = parse_mcp_config_file(&path, MCPProvider::Codex).await;
+    let err = result.expect_err("malformed Codex TOML should fail to parse");
+    assert_eq!(err.stage, ConfigParseStage::TomlNormalize);
+    assert_eq!(err.provider, MCPProvider::Codex);
+    assert_eq!(err.path, path);
+}
+
+#[tokio::test]
+async fn parse_missing_env_var_emits_env_substitute_error() {
+    // Use a deliberately unlikely variable name to avoid colliding with the host
+    // environment. `remove_var` is set on the same name for safety.
+    const VAR: &str = "WARP_TEST_NONEXISTENT_MCP_VAR_9807";
+    env::remove_var(VAR);
+
+    let json =
+        format!(r#"{{"mcpServers":{{"x":{{"command":"echo","env":{{"K":"${{{VAR}}}"}}}}}}}}"#);
+    let (_dir, path) = write_temp_file(".mcp.json", &json);
+
+    let result = parse_mcp_config_file(&path, MCPProvider::Claude).await;
+    let err = result.expect_err("missing env var should fail substitution");
+    assert_eq!(err.stage, ConfigParseStage::EnvSubstitute);
+    assert!(
+        err.message.contains(VAR),
+        "EnvSubstitute error should name the missing variable, got: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn parse_malformed_json_emits_json_parse_error() {
+    // Trailing brace mismatch — serde_json rejects.
+    let (_dir, path) = write_temp_file(".mcp.json", r#"{"mcpServers": { broken"#);
+
+    let result = parse_mcp_config_file(&path, MCPProvider::Claude).await;
+    let err = result.expect_err("malformed JSON should fail to parse");
+    assert_eq!(err.stage, ConfigParseStage::JsonParse);
+    assert_eq!(err.provider, MCPProvider::Claude);
 }

--- a/app/src/ai/mcp/mod.rs
+++ b/app/src/ai/mcp/mod.rs
@@ -44,6 +44,47 @@ cfg_if::cfg_if! {
     }
 }
 
+/// Identifies which step of MCP config-file processing produced a
+/// [`ConfigParseError`]. Used to format a user-facing message in Settings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigParseStage {
+    /// I/O error reading the config file (not "file is missing", which is normal).
+    Read,
+    /// TOML normalization failed (Codex configs only).
+    TomlNormalize,
+    /// A `${VAR}` reference could not be resolved from the environment.
+    EnvSubstitute,
+    /// JSON deserialization of the config contents failed.
+    JsonParse,
+}
+
+/// A structured record of a single config-file parse failure, carried alongside
+/// the (now empty) server list in `FileMCPWatcherEvent::ConfigParsed` so the
+/// settings UI can surface a banner instead of silently showing zero servers
+/// (issue #9807).
+#[derive(Debug, Clone)]
+pub struct ConfigParseError {
+    pub path: PathBuf,
+    pub provider: MCPProvider,
+    pub stage: ConfigParseStage,
+    /// The underlying error rendered with `{:#}`; safe for the local UI since
+    /// the user authored this config themselves.
+    pub message: String,
+}
+
+impl ConfigParseError {
+    /// Returns a short sentence suitable for an inline warning in Settings.
+    pub fn user_message(&self) -> String {
+        let what = match self.stage {
+            ConfigParseStage::Read => "Couldn't read this config file",
+            ConfigParseStage::TomlNormalize => "Invalid TOML",
+            ConfigParseStage::EnvSubstitute => "Missing required environment variable",
+            ConfigParseStage::JsonParse => "Invalid JSON",
+        };
+        format!("{what}: {}", self.message)
+    }
+}
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         pub mod file_based_manager;

--- a/app/src/settings_view/mcp_servers/list_page.rs
+++ b/app/src/settings_view/mcp_servers/list_page.rs
@@ -1203,6 +1203,12 @@ impl MCPServersListPageView {
             .with_spacing(style::PAGE_SPACING)
             .with_child(description);
 
+        // Surface MCP config-file parse failures above all other page content so
+        // the user sees them whether or not any servers were detected.
+        if let Some(error_banner) = self.render_config_parse_errors_banner(appearance, app) {
+            page.add_child(error_banner);
+        }
+
         let search_term = self.search_editor.as_ref(app).buffer_text(app);
 
         // Collect filtered server cards by ID.
@@ -1478,6 +1484,89 @@ impl MCPServersListPageView {
             ])
             .with_spacing(style::SERVER_CARD_LIST_SPACING)
             .finish()
+    }
+
+    /// Builds an inline banner section that flags any MCP config files that
+    /// failed to load. Returns `None` when there are no current parse errors so
+    /// the page body can skip allocating an empty container. Each banner names
+    /// the provider, the file path, and a short reason, so the user no longer
+    /// has to inspect logs to learn why a config that exists on disk produced
+    /// zero servers (issue #9807).
+    fn render_config_parse_errors_banner(
+        &self,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Option<Box<dyn Element>> {
+        let theme = appearance.theme();
+        let mut errors: Vec<_> = FileBasedMCPManager::as_ref(app)
+            .config_parse_errors()
+            .collect();
+        if errors.is_empty() {
+            return None;
+        }
+        // Stable order: by provider, then path. Avoids flicker between renders.
+        errors.sort_by(|a, b| {
+            (a.provider.display_name(), &a.path).cmp(&(b.provider.display_name(), &b.path))
+        });
+
+        let mut column = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(8.);
+        for error in errors {
+            let header_line = format!(
+                "{} · {}",
+                error.provider.display_name(),
+                error.path.display()
+            );
+            let icon = ConstrainedBox::new(
+                Icon::AlertTriangle
+                    .to_warpui_icon(theme.ui_error_color().into())
+                    .finish(),
+            )
+            .with_height(16.)
+            .with_width(16.)
+            .finish();
+
+            let text_column = Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .with_spacing(2.)
+                .with_child(
+                    Text::new(header_line, appearance.ui_font_family(), 12.)
+                        .with_color(theme.ui_error_color())
+                        .finish(),
+                )
+                .with_child(
+                    appearance
+                        .ui_builder()
+                        .wrappable_text(error.user_message(), true)
+                        .with_style(style::description_text(appearance))
+                        .build()
+                        .finish(),
+                )
+                .finish();
+
+            let row = Flex::row()
+                .with_cross_axis_alignment(CrossAxisAlignment::Start)
+                .with_child(
+                    Container::new(icon)
+                        .with_margin_right(8.)
+                        .with_margin_top(2.)
+                        .finish(),
+                )
+                .with_child(Expanded::new(1., text_column).finish())
+                .finish();
+
+            let banner = Container::new(row)
+                .with_padding_left(12.)
+                .with_padding_right(12.)
+                .with_padding_top(10.)
+                .with_padding_bottom(10.)
+                .with_border(Border::all(1.).with_border_color(theme.ui_error_color()))
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+                .finish();
+            column = column.with_child(banner);
+        }
+        Some(column.finish())
     }
 
     fn render_empty_state(&self, appearance: &Appearance, _app: &AppContext) -> Box<dyn Element> {

--- a/app/src/settings_view/mcp_servers/list_page.rs
+++ b/app/src/settings_view/mcp_servers/list_page.rs
@@ -1812,6 +1812,12 @@ impl MCPServersListPageView {
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     fn refresh_file_based_server_cards(&mut self, ctx: &mut ViewContext<Self>) {
         self.create_file_based_server_cards(ctx);
+        // Notify unconditionally so the parse-error banner re-renders even on
+        // ConfigParsed / ConfigRemoved events that don't create or clear any
+        // server cards (e.g. the first parse failure on a previously-empty
+        // config). Other call sites already notify via adjacent state changes,
+        // but the watcher path has no such side-effect.
+        ctx.notify();
     }
 
     fn toggle_server_running_file_based(


### PR DESCRIPTION
Fixes #9807.

## Why

Before this change, all four parse-failure sites in [parse_mcp_config_file](app/src/ai/mcp/file_mcp_watcher.rs) collapsed to `safe_warn!` + `return vec![]`. The downstream `FileBasedMCPManager` applied an empty snapshot, the Settings → MCP Servers page showed no servers for the affected `(root_path, provider)` slot, and the user had no way to learn why short of adding debug logging.

Per the issue reporter:
> Ended up spending a ton of time debugging and turns out we require (?) an empty args field in each MCP definition for it to be valid. […] Also separately, this just silently failed for me. We need better error messaging, I was only able to debug by actually getting agent mode to add debug logs to warp.

## What

Carries each parse failure forward as a structured `ConfigParseError`:

```rust
pub struct ConfigParseError {
    pub path: PathBuf,
    pub provider: MCPProvider,
    pub stage: ConfigParseStage,
    pub message: String,
}

pub enum ConfigParseStage {
    Read,            // I/O failure (not NotFound — that stays \"normal\")
    TomlNormalize,   // Codex config TOML doesn't parse
    EnvSubstitute,   // \${VAR} not found in environment
    JsonParse,       // serde_json rejected the (resolved) config
}
```

- `parse_mcp_config_file` now returns `Result<Vec<…>, ConfigParseError>`. NotFound still returns `Ok(vec![])` (an unconfigured provider isn't a user error).
- `FileMCPWatcherEvent::ConfigParsed` carries `error: Option<ConfigParseError>` alongside `servers`. The split happens in a new `split_parse_result` helper so the two existing call sites stay symmetric.
- `FileBasedMCPManager` now stores `config_parse_errors: HashMap<(PathBuf, MCPProvider), ConfigParseError>`. On `ConfigParsed { error: Some(_) }` it inserts; on `ConfigParsed { error: None }` or `ConfigRemoved` it clears. Exposed via `config_parse_errors()`.
- `MCPServersListPage` renders one inline warning banner per current error above the server cards section, using the existing `ui_error_color` + `Icon::AlertTriangle` pattern from `billing_and_usage_page.rs`. The page already subscribes to `FileMCPWatcherEvent::ConfigParsed` and refreshes on emit, so the banner updates as the user edits and saves their config.

## Banner layout

```
⚠ Claude · /Users/me/.claude.json
   Invalid JSON: expected ',' or '}' at line 5 column 17

⚠ Codex · /Users/me/.codex/config.toml
   Invalid TOML: invalid table header at line 1
```

## Scope notes

The reporter raised two concerns. **Confirmed**: silent failure on config errors → fixed here. **Unverified**: claim that `args` is required for command-based MCP servers — Oz's triage [confirmed](https://github.com/warpdotdev/warp/issues/9807#issuecomment-4360287089) the current parser already accepts omitted `args` and the issue is in `needs-info` on that point with no reporter reply. Not touched in this PR.

Per-server validation drops (entries with `templatable_mcp_server_installation: None` at [file_based_manager.rs:174](app/src/ai/mcp/file_based_manager.rs#L174)) are a separate code path and a different UX surface (per-card vs file-level). Followup work.

## Test plan

- [x] `cargo build -p warp --lib` — clean
- [x] `cargo test -p warp --lib ai::mcp::file_mcp_watcher` — 8/8 pass (2 existing + 6 new)
- [x] `cargo test -p warp --lib ai::mcp::file_based_manager` — 12/12 pass (8 existing + 4 new)
- [x] `cargo test -p warp --lib ai::mcp::` — 64/64 pass overall
- [x] `cargo clippy -p warp --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p warp -- --check` — clean

New test coverage:

Watcher (`parse_mcp_config_file`):
- `parse_missing_file_is_not_an_error` — NotFound stays `Ok(vec![])`
- `parse_valid_json_returns_servers_without_error` — happy path
- `parse_unreadable_path_emits_read_stage_error` — Read stage
- `parse_invalid_codex_toml_emits_toml_normalize_error` — TomlNormalize stage
- `parse_missing_env_var_emits_env_substitute_error` — EnvSubstitute stage
- `parse_malformed_json_emits_json_parse_error` — JsonParse stage

Manager (`FileBasedMCPManager::handle_watcher_event`):
- `config_parse_error_is_recorded_on_failed_parse`
- `successful_parse_clears_prior_config_parse_error`
- `config_removed_clears_config_parse_error`
- `config_parse_errors_are_keyed_per_root_and_provider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)