### PR TITLE
Hide admin panel link for non-enterprise billing pages

### DIFF
--- a/app/src/settings_view/billing_and_usage/billing_cycle_usage_section.rs
+++ b/app/src/settings_view/billing_and_usage/billing_cycle_usage_section.rs
@@ -611,6 +611,11 @@ impl BillingCycleUsageSectionView {
             .tier
             .usage_visibility_policy?
             .admin_granularity;
+        if admin_granularity == UsageVisibilityGranularity::FullBreakdown
+            && !workspace.billing_metadata.is_enterprise_plan()
+        {
+            return None;
+        }
         let (link_text, trailing_copy, action, leading_icon) =
             visibility_cta_for(admin_granularity)?;
 

--- a/app/src/settings_view/billing_and_usage_page.rs
+++ b/app/src/settings_view/billing_and_usage_page.rs
@@ -3596,8 +3596,10 @@ impl BillingAndUsagePageView {
                     right_side.add_child(admin_actions);
                 }
 
-                let admin_panel_button = self.render_admin_panel_button(team.uid, appearance);
-                right_side.add_child(admin_panel_button);
+                if team.billing_metadata.is_enterprise_plan() {
+                    let admin_panel_button = self.render_admin_panel_button(team.uid, appearance);
+                    right_side.add_child(admin_panel_button);
+                }
             }
         } else {
             let (plan_badge, compare_plans_button) =

--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -659,42 +659,44 @@ impl BillingAndUsagePageV2View {
                     );
                 }
 
-                let team_uid = team.uid;
-                let fg_color = appearance.theme().active_ui_text_color();
-                right_side.add_child(
-                    Container::new(
-                        appearance
-                            .ui_builder()
-                            .button(
-                                ButtonVariant::Link,
-                                self.plan_mouse_states.open_admin_panel_link.clone(),
-                            )
-                            .with_text_and_icon_label(
-                                TextAndIcon::new(
-                                    TextAndIconAlignment::IconFirst,
-                                    "Open admin panel",
-                                    Icon::Users.to_warpui_icon(fg_color),
-                                    MainAxisSize::Min,
-                                    MainAxisAlignment::Center,
-                                    vec2f(14., 14.),
+                if team.billing_metadata.is_enterprise_plan() {
+                    let team_uid = team.uid;
+                    let fg_color = appearance.theme().active_ui_text_color();
+                    right_side.add_child(
+                        Container::new(
+                            appearance
+                                .ui_builder()
+                                .button(
+                                    ButtonVariant::Link,
+                                    self.plan_mouse_states.open_admin_panel_link.clone(),
                                 )
-                                .with_inner_padding(4.),
-                            )
-                            .with_style(UiComponentStyles {
-                                font_color: Some(fg_color.into()),
-                                ..Default::default()
-                            })
-                            .build()
-                            .on_click(move |ctx, _, _| {
-                                ctx.dispatch_typed_action(
-                                    BillingAndUsagePageAction::OpenAdminPanel { team_uid },
-                                );
-                            })
-                            .finish(),
-                    )
-                    .with_margin_left(8.)
-                    .finish(),
-                );
+                                .with_text_and_icon_label(
+                                    TextAndIcon::new(
+                                        TextAndIconAlignment::IconFirst,
+                                        "Open admin panel",
+                                        Icon::Users.to_warpui_icon(fg_color),
+                                        MainAxisSize::Min,
+                                        MainAxisAlignment::Center,
+                                        vec2f(14., 14.),
+                                    )
+                                    .with_inner_padding(4.),
+                                )
+                                .with_style(UiComponentStyles {
+                                    font_color: Some(fg_color.into()),
+                                    ..Default::default()
+                                })
+                                .build()
+                                .on_click(move |ctx, _, _| {
+                                    ctx.dispatch_typed_action(
+                                        BillingAndUsagePageAction::OpenAdminPanel { team_uid },
+                                    );
+                                })
+                                .finish(),
+                        )
+                        .with_margin_left(8.)
+                        .finish(),
+                    );
+                }
             }
         } else {
             let current_user_id = self.auth_state.user_id().unwrap_or_default();


### PR DESCRIPTION
## Description
Hides the "Open admin panel" entry points on the Billing & Usage settings page when the team isn't on the Enterprise plan, so non-enterprise admins don't see a link to a page they should no longer reach.

- `billing_and_usage_page.rs` (v1): only adds the `render_admin_panel_button` to the right-hand plan header when `team.billing_metadata.is_enterprise_plan()`.
- `billing_and_usage_page_v2.rs` (v2): wraps the "Open admin panel" link in the same enterprise guard inside `render_plan_section`.
- `billing_cycle_usage_section.rs`: `render_visibility_cta_banner` returns early when the workspace's admin granularity is `FullBreakdown` but the team isn't on the Enterprise plan, so the contextual "Open the admin panel" CTA also disappears for non-enterprise teams that somehow hit that tier policy.

## Linked Issue
- [x] No specific issue; companion to the server-side admin billing visibility change (`warpdotdev/warp-server#11336`).

## Testing
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` (built clean using Corepack-resolved Yarn)
- [x] I have manually tested my changes locally with `./script/run`

<img width="847" height="247" alt="image" src="https://github.com/user-attachments/assets/13fb2d50-0696-422d-9f15-9e104236a5e9" />

<img width="742" height="154" alt="image" src="https://github.com/user-attachments/assets/3ce122ff-5d5c-4698-8c6b-8b60dad79c42" />


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Oz conversation](https://staging.warp.dev/conversation/b558f68c-0dc7-4e3b-ab91-0d0a29e105a8)

Co-Authored-By: Oz <oz-agent@warp.dev>

CHANGELOG-NONE
