### PR TITLE
Fix multiple connection across tabs causes 'unable to load content'

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -764,17 +764,14 @@ impl CodeReviewView {
             }
         }
 
-        // If the view is freshly created (state is None/loading) but the model
-        // already holds computed diffs (DiffState::Loaded), a non-forced load
-        // will no-op because the model thinks it's done. Force a reload so
-        // the model re-emits NewDiffsComputed and the view gets populated.
-        let view_needs_diffs = matches!(self.state(), CodeReviewViewState::None);
-        let model_already_loaded = matches!(self.diff_state(ctx), DiffState::Loaded);
-        let force = view_needs_diffs && model_already_loaded;
-
+        // Always reload diffs on open. For local, this re-reads the
+        // filesystem. For remote, this re-emits the model's current state
+        // (and will make an RPC once that path is wired). We pass
+        // should_fetch_base: false because re-opening the panel doesn't
+        // need to fetch the base branch from origin.
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(true, ctx);
-            model.load_diffs_for_current_repo(force, ctx);
+            model.load_diffs_for_current_repo(false, ctx);
         });
     }
 

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -537,7 +537,7 @@ impl DiffStateModel {
             Self::Remote(remote) => {
                 if force {
                     remote.update(ctx, |remote, ctx| {
-                        remote.replay_latest_diffs(ctx);
+                        remote.fetch_fresh_snapshot(ctx);
                     });
                 }
             }

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -527,19 +527,21 @@ impl DiffStateModel {
         }
     }
 
-    pub(crate) fn load_diffs_for_current_repo(&self, force: bool, ctx: &mut ModelContext<Self>) {
+    pub(crate) fn load_diffs_for_current_repo(
+        &self,
+        should_fetch_base: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
         match self {
             Self::Local(local) => {
                 local.update(ctx, |local, ctx| {
-                    local.load_diffs_for_current_repo(force, ctx);
+                    local.load_diffs_for_current_repo(should_fetch_base, ctx);
                 });
             }
             Self::Remote(remote) => {
-                if force {
-                    remote.update(ctx, |remote, ctx| {
-                        remote.fetch_fresh_snapshot(ctx);
-                    });
-                }
+                remote.update(ctx, |remote, ctx| {
+                    remote.fetch_fresh_snapshot(ctx);
+                });
             }
         }
     }

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -255,26 +255,22 @@ impl RemoteDiffStateModel {
 
     // ── Apply methods ──────────────────────────────────────────────────────
 
-    /// Re-emits `NewDiffsComputed` with the currently loaded diff data.
-    /// Called when a view subscribes after the initial snapshot was already processed.
-    pub(crate) fn replay_latest_diffs(&self, ctx: &mut ModelContext<Self>) {
-        match &self.state {
-            InternalRemoteDiffState::Loaded(diffs) => {
-                let base_content = GitDiffWithBaseContent::from(diffs);
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(Some(Arc::new(
-                    base_content,
-                ))));
-            }
-            InternalRemoteDiffState::NotInRepository => {
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
-            }
-            InternalRemoteDiffState::Error(_) => {
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
-            }
-            InternalRemoteDiffState::Loading | InternalRemoteDiffState::Disconnected => {
-                // Nothing to replay yet.
-            }
-        }
+    /// Requests a fresh diff snapshot from the remote server, including file
+    /// content. Unlike the former `replay_latest_diffs` (which reconstructed
+    /// data from cached `GitDiffData` and lost `content_at_head`), this sends
+    /// an actual `GetDiffState` RPC so the server can reload content from disk.
+    ///
+    /// Does NOT transition to `Loading` or emit `NewDiffsComputed(None)` first,
+    /// so existing views subscribed to this model won't flash a loading state.
+    /// The server response arrives as a `DiffStateSnapshotReceived` event and
+    /// flows through `apply_snapshot` normally.
+    pub(crate) fn fetch_fresh_snapshot(&self, ctx: &mut ModelContext<Self>) {
+        let remote_path = self.remote_path.clone();
+        let mode = self.mode.clone();
+        let session_id = self.session_id;
+        RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+            mgr.get_diff_state(session_id, remote_path, proto::DiffMode::from(&mode), ctx);
+        });
     }
 
     fn apply_snapshot(


### PR DESCRIPTION
## Description

### Problem
Opening code review in a second tab for the same remote SSH repo causes ALL diff editors across both tabs to show "Unable to load file content".

### Architecture Context
`DiffStateModel` is shared across tabs — `WorkingDirectoriesModel` (one per window) deduplicates models by `LocalOrRemotePath`. Since multiple SSH sessions to the same host share the same `HostId`, the `RemotePath` key is identical, so all tabs share one `DiffStateModel`. `CodeReviewView` instances, however, are per-tab (keyed by `(pane_group_id, repo_path)`).

Within the **same tab**, multiple panes to the same host/repo share both the `CodeReviewView` and `DiffStateModel`, and `on_open` returns early via the `is_open` guard — so this issue does NOT occur in the same-tab case.

### Root Cause
When Tab 2 creates a new `CodeReviewView` against the shared (already-`Loaded`) `DiffStateModel`, `on_open` detects `view_needs_diffs=true` (fresh view) + `model_already_loaded=true` → `force=true` → `replay_latest_diffs()`.

`replay_latest_diffs` reconstructed `GitDiffWithBaseContent` from cached `GitDiffData` via `From<&GitDiffData>`, which hard-codes `content_at_head: None` for every file. Both tabs' views subscribe to the shared model, so both receive this content-less event and rebuild with no editor state.

### Explored Solutions

**Option A: Store full `GitDiffWithBaseContent` in `InternalRemoteDiffState`** — preserves content across replays but stores full file content in memory for every changed file. Rejected due to memory cost.

**Option B: Per-tab `DiffStateModel` for remote repos** — key `DiffStateModelMap` by `(pane_group_id, LocalOrRemotePath)` for remote repos, giving each tab its own model and session. Eliminates cross-tab interference entirely and fixes session anchoring. Rejected as over-scoped for this fix: local models should remain shared (one file watcher per repo), creating an asymmetry, and duplicate server-side subscriptions add complexity. Could be revisited later.

**Option C (chosen): Replace `replay_latest_diffs` with a real `GetDiffState` RPC** — sends an actual request to the remote server, which already handles this correctly: `RemoteDiffStateManager::subscribe` spawns a content reload (`spawn_content_reload` → `load_diffs_with_content_for_mode`) and responds **only to the requesting connection** via `resolve_pending_responses`. Content reloads are coalesced server-side (`if !already_in_flight`).

### Why replacing `replay_latest_diffs` is safe
`replay_latest_diffs` was added to fix a race where a new `CodeReviewView` against an already-`Loaded` shared `DiffStateModel` would be permanently stuck in loading. The underlying issue was that no `NewDiffsComputed` event would fire for the new view. That fix is still needed — but the **mechanism** was wrong: it replayed from stripped cached data instead of asking the server for fresh data with content. The new `fetch_fresh_snapshot` method sends a `GetDiffState` RPC without transitioning to `Loading` (avoiding a flash on Tab 1), and the server response flows through `apply_snapshot` normally.

Trade-off: Tab 1's view gets a redundant `invalidate_all` rebuild when the server response arrives (since both views subscribe to the shared model). But the data has content, so the rebuild is correct — consistent with how local `force=true` handles the same pattern.

## Linked Issue
- [x] N/A (reported via internal feedback)

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- Verified fix by opening two tabs SSH'd to the same remote host/repo and confirming both tabs' code review panels load correctly
- Ran `cargo nextest run -- code_review::diff_state::remote` — all 22 tests pass

CHANGELOG-BUG-FIX: Fixed code review panel showing "Unable to load file content" when opening the same remote SSH repo in multiple tabs.
