### PR TITLE
Add host label for remote repos and files

### DIFF
--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -19,6 +19,7 @@ use crate::terminal::cli_agent::{
     build_selection_line_range_prompt, build_selection_substring_prompt,
 };
 use crate::terminal::view::CliAgentRouting;
+use crate::util::path::{display_name_with_host, display_path_with_host};
 use crate::workspace::util::get_context_target_terminal_view;
 use crate::workspace::TabBarDropTargetData;
 use crate::{code::EditorTabBarDropTargetData, pane_group::pane::ActionOrigin};
@@ -828,8 +829,7 @@ impl CodeView {
             .is_some_and(|t| t.editor_view.as_ref(ctx).is_new_file());
 
         let title = match &file_location {
-            Some(LocalOrRemotePath::Local(path)) => path.display().to_string(),
-            Some(LocalOrRemotePath::Remote(remote_path)) => remote_path.path.as_str().to_string(),
+            Some(location) => display_path_with_host(location, false, ctx),
             None => "Untitled".to_string(),
         };
 
@@ -1135,7 +1135,7 @@ impl CodeView {
             let file_name = tab
                 .location
                 .as_ref()
-                .map(|loc| loc.display_name().to_string())
+                .map(|loc| display_name_with_host(loc, ctx))
                 .filter(|n| !n.is_empty());
             let summary = UnsavedStateSummary::for_editor_tab(
                 file_name,
@@ -1482,6 +1482,7 @@ impl CodeView {
         is_hovered: bool,
         has_unsaved_changes: bool,
         appearance: &Appearance,
+        app: &AppContext,
     ) -> Box<dyn Element> {
         let theme = appearance.theme();
         let text_color = if is_active {
@@ -1497,7 +1498,7 @@ impl CodeView {
         let file_name = tab_data
             .location
             .as_ref()
-            .map(|loc| loc.display_name().to_string())
+            .map(|loc| display_name_with_host(loc, app))
             .filter(|n| !n.is_empty())
             .unwrap_or_else(|| "Untitled".to_string());
         let language_icon =
@@ -1533,6 +1534,7 @@ impl CodeView {
         )
         .with_color(text_color)
         .with_style(style)
+        .with_clip(ClipConfig::start())
         .finish();
         row.add_child(
             Shrinkable::new(
@@ -1713,6 +1715,7 @@ impl CodeView {
                             tab_handle.is_hovered(),
                             Self::has_unsaved_changes(tab_data, app),
                             appearance,
+                            app,
                         ))
                         .with_horizontal_margin(TAB_HORIZONTAL_MARGIN)
                         .with_padding(Padding::uniform(TAB_PADDING))
@@ -1874,7 +1877,7 @@ impl CodeView {
             .and_then(|tab| {
                 tab.location
                     .as_ref()
-                    .map(|loc| loc.display_name().to_string())
+                    .map(|loc| display_name_with_host(loc, app))
                     .filter(|n| !n.is_empty())
             })
             .unwrap_or_else(|| "Untitled".to_string());

--- a/app/src/util/mod.rs
+++ b/app/src/util/mod.rs
@@ -9,7 +9,6 @@ pub mod image;
 pub(crate) mod link_detection;
 pub mod links;
 pub mod openable_file_type;
-#[cfg(not(target_family = "wasm"))]
 pub mod path;
 pub mod repo_detection;
 pub mod time_format;

--- a/app/src/util/mod.rs
+++ b/app/src/util/mod.rs
@@ -9,7 +9,7 @@ pub mod image;
 pub(crate) mod link_detection;
 pub mod links;
 pub mod openable_file_type;
-#[cfg(feature = "local_tty")]
+#[cfg(not(target_family = "wasm"))]
 pub mod path;
 pub mod repo_detection;
 pub mod time_format;

--- a/app/src/util/path.rs
+++ b/app/src/util/path.rs
@@ -7,6 +7,60 @@ use std::{
 
 use is_executable::IsExecutable as _;
 use itertools::Itertools as _;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::{AppContext, SingletonEntity};
+
+use crate::remote_server::manager::RemoteServerManager;
+
+/// Fallback label used when a `RemotePath`'s host is not currently tracked.
+/// Matches the fallback in `terminal::writeable_pty::remote_server_controller::connection_label_from_user_and_host`.
+const UNKNOWN_HOST_LABEL: &str = "Remote host";
+
+/// Returns the display name of a local or remote path, prefixed with the
+/// host label for remote paths.
+pub fn display_name_with_host(path: &LocalOrRemotePath, ctx: &AppContext) -> String {
+    let name = path.display_name();
+    match path {
+        LocalOrRemotePath::Local(_) => name.to_string(),
+        LocalOrRemotePath::Remote(remote) => {
+            let host_label = RemoteServerManager::as_ref(ctx)
+                .host_label(&remote.host_id)
+                .unwrap_or(UNKNOWN_HOST_LABEL);
+            format!("{host_label}:{name}")
+        }
+    }
+}
+
+/// Returns the display path of a local or remote path,
+/// prefixed with the host label for remote paths.
+///
+/// When `abbreviate_home` is true, local paths under the user's home directory
+/// are abbreviated with a `~/` prefix. The flag is ignored for remote paths,
+/// whose home directory lives on a different machine.
+pub fn display_path_with_host(
+    path: &LocalOrRemotePath,
+    abbreviate_home: bool,
+    ctx: &AppContext,
+) -> String {
+    match path {
+        LocalOrRemotePath::Local(local_path) => {
+            if abbreviate_home {
+                dirs::home_dir()
+                    .and_then(|home| local_path.strip_prefix(&home).ok())
+                    .map(|relative| format!("~/{}", relative.display()))
+                    .unwrap_or_else(|| local_path.display().to_string())
+            } else {
+                path.display_path()
+            }
+        }
+        LocalOrRemotePath::Remote(remote) => {
+            let host_label = RemoteServerManager::as_ref(ctx)
+                .host_label(&remote.host_id)
+                .unwrap_or(UNKNOWN_HOST_LABEL);
+            format!("{host_label}:{}", path.display_path())
+        }
+    }
+}
 
 pub fn file_exists_and_is_executable(path: &Path) -> bool {
     // We need to check that the file exists, as the `is_executable` crate doesn't validate this on

--- a/app/src/util/path.rs
+++ b/app/src/util/path.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_family = "wasm"))]
 use std::{
     borrow::Cow,
     env,
@@ -5,7 +6,9 @@ use std::{
     path::{self, Path, PathBuf},
 };
 
+#[cfg(not(target_family = "wasm"))]
 use is_executable::IsExecutable as _;
+#[cfg(not(target_family = "wasm"))]
 use itertools::Itertools as _;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, SingletonEntity};
@@ -62,6 +65,7 @@ pub fn display_path_with_host(
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub fn file_exists_and_is_executable(path: &Path) -> bool {
     // We need to check that the file exists, as the `is_executable` crate doesn't validate this on
     // Windows.
@@ -75,6 +79,7 @@ pub fn file_exists_and_is_executable(path: &Path) -> bool {
 /// Callers that need to resolve against a different PATH (e.g. one
 /// captured from the user's interactive login shell) should use
 /// [`resolve_executable_in_path`] directly.
+#[cfg(not(target_family = "wasm"))]
 pub fn resolve_executable(command: &str) -> Option<Cow<'_, Path>> {
     let path_var = env::var_os("PATH").unwrap_or_default();
     resolve_executable_in_path(command, &path_var)
@@ -87,6 +92,7 @@ pub fn resolve_executable(command: &str) -> Option<Cow<'_, Path>> {
 /// captured from the user's interactive login shell, matching how
 /// MCP/LSP find binaries). Callers that want the process's PATH should
 /// use [`resolve_executable`] instead.
+#[cfg(not(target_family = "wasm"))]
 pub fn resolve_executable_in_path<'a>(command: &'a str, path_env: &OsStr) -> Option<Cow<'a, Path>> {
     if command.contains(path::MAIN_SEPARATOR) {
         let path = Path::new(command);
@@ -100,6 +106,7 @@ pub fn resolve_executable_in_path<'a>(command: &'a str, path_env: &OsStr) -> Opt
     None
 }
 
+#[cfg(not(target_family = "wasm"))]
 fn resolve_executable_in_dir(path_dir: &Path, command: &str) -> Option<PathBuf> {
     let resolved = path_dir.join(command);
     if file_exists_and_is_executable(&resolved) {
@@ -132,6 +139,6 @@ fn windows_path_extensions() -> impl Iterator<Item = String> {
         .into_iter()
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 #[path = "path_tests.rs"]
 mod tests;

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -18,6 +18,7 @@ use crate::ui_components::{buttons::icon_button_with_color, icons};
 use crate::util::bindings::{keybinding_name_to_display_string, CustomAction};
 #[cfg(feature = "local_fs")]
 use crate::util::openable_file_type::FileTarget;
+use crate::util::path::{display_name_with_host, display_path_with_host};
 use crate::view_components::action_button::{ActionButton, PaneHeaderTheme};
 #[cfg(feature = "local_fs")]
 use crate::view_components::action_button::{NakedTheme, TooltipAlignment};
@@ -285,9 +286,13 @@ impl CodeReviewState {
     }
 
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
-    fn get_repo_display_name(&self, repo_path: &LocalOrRemotePath) -> Option<String> {
-        let name = repo_path.display_name();
-        (!name.is_empty()).then(|| name.to_string())
+    fn get_repo_display_name(
+        &self,
+        repo_path: &LocalOrRemotePath,
+        ctx: &AppContext,
+    ) -> Option<String> {
+        let name = display_name_with_host(repo_path, ctx);
+        (!name.is_empty()).then_some(name)
     }
 
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
@@ -299,7 +304,7 @@ impl CodeReviewState {
                 .iter()
                 .map(|repo_path| {
                     let display_name = self
-                        .get_repo_display_name(repo_path)
+                        .get_repo_display_name(repo_path, ctx)
                         .unwrap_or_else(|| "Unknown".to_string());
                     DropdownItem::new(
                         display_name,
@@ -314,7 +319,7 @@ impl CodeReviewState {
             let selected_display_name = self
                 .selected_repo_path
                 .as_ref()
-                .and_then(|selected| self.get_repo_display_name(selected));
+                .and_then(|selected| self.get_repo_display_name(selected, ctx));
 
             (items, selected_display_name)
         };
@@ -921,13 +926,7 @@ impl RightPanelView {
         let diff_stats = crv.loaded_diff_stats();
 
         let repo_path_element = repo_path.map(|repo_path| {
-            let display_path = match repo_path.to_local_path() {
-                Some(path) => dirs::home_dir()
-                    .and_then(|home| path.strip_prefix(&home).ok())
-                    .map(|relative| format!("~/{}", relative.display()))
-                    .unwrap_or_else(|| path.display().to_string()),
-                None => repo_path.display_path(),
-            };
+            let display_path = display_path_with_host(repo_path, true, app);
             Container::new(
                 Text::new_inline(
                     format!("{display_path}:"),


### PR DESCRIPTION
## Description
* Adds helper fns to format the display name and display path to include the host label stored in `RemoteServerManager`
* Updates various callers within the code review view and code view to support the remote labels
* Updates clipping for the file titles in the multi-tab case to clip at the start instead of the end now that we also show the host label at the start 

## Linked Issue
[APP-4535](https://linear.app/warpdotdev/issue/APP-4535/add-host-to-repo-name)

## Testing
- [x] I have manually tested my changes locally with `./script/run`

<img width="641" height="175" alt="Screenshot 2026-05-20 at 1 12 31 PM" src="https://github.com/user-attachments/assets/9ddcdc53-87ed-455b-bdd6-3c8b555c10dd" />
<img width="803" height="343" alt="Screenshot 2026-05-20 at 1 07 55 PM" src="https://github.com/user-attachments/assets/a7cd6081-5528-476b-8ce8-de6ef7f87455" />
<img width="615" height="317" alt="Screenshot 2026-05-20 at 1 06 13 PM" src="https://github.com/user-attachments/assets/2d3718b1-54b6-4be3-8181-c18d371a212c" />
<img width="605" height="224" alt="Screenshot 2026-05-20 at 1 06 05 PM" src="https://github.com/user-attachments/assets/cc2592cb-a735-4ccd-8335-2af8933ca8f5" />
<img width="769" height="171" alt="Screenshot 2026-05-20 at 1 16 09 PM" src="https://github.com/user-attachments/assets/bdf5501d-38a0-4a67-ba3d-6633fa5a6fa6" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode