### PR TITLE
Fix markdown rendering on remote SSH sessions

### DIFF
--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -2608,6 +2608,32 @@ impl CodeDiffView {
             .file_path()
             .map(|p| p.to_string())
     }
+
+    /// Returns the primary file location as a `LocalOrRemotePath`,
+    /// using `diff_session_type` to correctly identify remote files.
+    pub fn primary_file_location(
+        &self,
+        app: &AppContext,
+    ) -> Option<crate::code::buffer_location::LocalOrRemotePath> {
+        let path_str = self.primary_file_path(app)?;
+        match &self.diff_session_type {
+            DiffSessionType::Local => Some(crate::code::buffer_location::LocalOrRemotePath::Local(
+                std::path::PathBuf::from(path_str),
+            )),
+            DiffSessionType::Remote(host_id) => {
+                warp_util::standardized_path::StandardizedPath::try_new(&path_str)
+                    .ok()
+                    .map(|path| {
+                        crate::code::buffer_location::LocalOrRemotePath::Remote(
+                            warp_util::remote_path::RemotePath {
+                                host_id: host_id.clone(),
+                                path,
+                            },
+                        )
+                    })
+            }
+        }
+    }
 }
 
 impl Entity for CodeDiffView {

--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -51,6 +51,7 @@ use warpui::{
 };
 
 use super::malformed_line_heuristics::has_malformed_terminal_correction_signal;
+use crate::code::buffer_location::LocalOrRemotePath;
 use crate::view_components::action_button::{ActionButton, NakedTheme};
 use crate::{
     ai::{
@@ -2611,26 +2612,17 @@ impl CodeDiffView {
 
     /// Returns the primary file location as a `LocalOrRemotePath`,
     /// using `diff_session_type` to correctly identify remote files.
-    pub fn primary_file_location(
-        &self,
-        app: &AppContext,
-    ) -> Option<crate::code::buffer_location::LocalOrRemotePath> {
+    pub fn primary_file_location(&self, app: &AppContext) -> Option<LocalOrRemotePath> {
         let path_str = self.primary_file_path(app)?;
         match &self.diff_session_type {
-            DiffSessionType::Local => Some(crate::code::buffer_location::LocalOrRemotePath::Local(
-                std::path::PathBuf::from(path_str),
-            )),
+            DiffSessionType::Local => Some(LocalOrRemotePath::Local(PathBuf::from(path_str))),
             DiffSessionType::Remote(host_id) => {
-                warp_util::standardized_path::StandardizedPath::try_new(&path_str)
-                    .ok()
-                    .map(|path| {
-                        crate::code::buffer_location::LocalOrRemotePath::Remote(
-                            warp_util::remote_path::RemotePath {
-                                host_id: host_id.clone(),
-                                path,
-                            },
-                        )
+                StandardizedPath::try_new(&path_str).ok().map(|path| {
+                    LocalOrRemotePath::Remote(warp_util::remote_path::RemotePath {
+                        host_id: host_id.clone(),
+                        path,
                     })
+                })
             }
         }
     }

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -52,7 +52,9 @@ use crate::terminal::view::{TerminalDropTargetData, TerminalView};
 use crate::ui_components::item_highlight::{ImageOrIcon, ItemHighlightState};
 #[cfg(feature = "local_fs")]
 use crate::util::file::external_editor::EditorSettings;
-use crate::util::openable_file_type::{is_file_content_binary, EditorLayout, FileTarget};
+use crate::util::openable_file_type::{
+    is_file_content_binary, is_markdown_file, EditorLayout, FileTarget,
+};
 #[cfg(feature = "local_fs")]
 use crate::util::openable_file_type::{
     resolve_file_target_to_open_in_warp, resolve_file_target_with_editor_choice,
@@ -2263,9 +2265,27 @@ impl FileTreeView {
                             host_id.clone(),
                             (*metadata.path).clone(),
                         );
+                        let path_str = metadata.path.as_str();
+                        let target = if is_markdown_file(Path::new(path_str)) {
+                            #[cfg(feature = "local_fs")]
+                            {
+                                let prefer_md = *EditorSettings::as_ref(ctx).prefer_markdown_viewer;
+                                if prefer_md {
+                                    FileTarget::MarkdownViewer(EditorLayout::SplitPane)
+                                } else {
+                                    FileTarget::CodeEditor(EditorLayout::SplitPane)
+                                }
+                            }
+                            #[cfg(not(feature = "local_fs"))]
+                            {
+                                FileTarget::CodeEditor(EditorLayout::SplitPane)
+                            }
+                        } else {
+                            FileTarget::CodeEditor(EditorLayout::SplitPane)
+                        };
                         ctx.emit(FileTreeEvent::OpenFile {
                             path: LocalOrRemotePath::Remote(remote_path),
-                            target: FileTarget::CodeEditor(EditorLayout::SplitPane),
+                            target,
                             line_col: None,
                         });
                     }

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -1945,10 +1945,10 @@ impl CodeView {
                 let mut stack = Stack::new();
                 stack.add_child(title_row.finish());
                 if hover_state.is_hovered() {
-                    let tooltip_relative_path = tab
-                        .and_then(|tab| tab.local_path())
-                        .map(|p| Self::relative_path(p, self.window_id, app));
-                    if let Some(ref path) = tooltip_relative_path {
+                    let tooltip_path = tab
+                        .and_then(|tab| tab.location())
+                        .map(|loc| loc.display_path());
+                    if let Some(ref path) = tooltip_path {
                         let tooltip = appearance
                             .ui_builder()
                             .tool_tip(path.clone())
@@ -2025,25 +2025,45 @@ impl CodeView {
         ];
 
         #[cfg(feature = "local_fs")]
-        if let Some(path) = self.local_path(ctx) {
-            let reveal_label = if cfg!(target_os = "macos") {
-                "Reveal in Finder"
-            } else if cfg!(target_os = "windows") {
-                "Reveal in Explorer"
-            } else {
-                "Reveal in file manager"
-            };
-            items.extend([
-                MenuItem::Separator,
-                MenuItemFields::new("Copy file path")
-                    .with_on_select_action(CodeViewAction::CopyFilePath)
-                    .into_item(),
-                MenuItemFields::new(reveal_label)
-                    .with_on_select_action(CodeViewAction::RevealInFinder)
-                    .into_item(),
-            ]);
+        {
+            let active_location = self
+                .tab_at(self.active_tab_index)
+                .and_then(|t| t.location.as_ref());
+            let local_path = self.local_path(ctx);
 
-            if is_markdown_file(&path) {
+            if active_location.is_some() {
+                items.push(MenuItem::Separator);
+                items.push(
+                    MenuItemFields::new("Copy file path")
+                        .with_on_select_action(CodeViewAction::CopyFilePath)
+                        .into_item(),
+                );
+            }
+
+            if local_path.is_some() {
+                let reveal_label = if cfg!(target_os = "macos") {
+                    "Reveal in Finder"
+                } else if cfg!(target_os = "windows") {
+                    "Reveal in Explorer"
+                } else {
+                    "Reveal in file manager"
+                };
+                items.push(
+                    MenuItemFields::new(reveal_label)
+                        .with_on_select_action(CodeViewAction::RevealInFinder)
+                        .into_item(),
+                );
+            }
+
+            let is_md = local_path
+                .as_ref()
+                .map(|p| is_markdown_file(p))
+                .unwrap_or_else(|| {
+                    active_location
+                        .map(|loc| is_markdown_file(std::path::Path::new(&loc.display_path())))
+                        .unwrap_or(false)
+                });
+            if is_md {
                 items.push(
                     MenuItemFields::new("View Markdown preview")
                         .with_on_select_action(CodeViewAction::RenderMarkdown)
@@ -2196,9 +2216,12 @@ impl TypedActionView for CodeView {
 
             #[cfg(feature = "local_fs")]
             CodeViewAction::CopyFilePath => {
-                if let Some(path) = self.local_path(ctx) {
+                if let Some(location) = self
+                    .tab_at(self.active_tab_index)
+                    .and_then(|t| t.location.as_ref())
+                {
                     ctx.clipboard()
-                        .write(ClipboardContent::plain_text(path.display().to_string()));
+                        .write(ClipboardContent::plain_text(location.display_path()));
                 }
             }
             #[cfg(feature = "local_fs")]

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -281,15 +281,11 @@ impl CodeView {
 
     #[cfg(feature = "local_fs")]
     fn update_markdown_mode_segmented_control(&mut self, ctx: &mut ViewContext<Self>) {
-        let path = self
-            .local_path(ctx)
-            .or_else(|| {
-                self.tab_at(self.active_tab_index)
-                    .and_then(|t| t.local_path())
-            })
-            .or_else(|| self.source.path());
-
-        let is_markdown = path.as_ref().map(is_markdown_file).unwrap_or(false);
+        let is_markdown = self
+            .tab_at(self.active_tab_index)
+            .and_then(|t| t.location.as_ref())
+            .map(|loc| is_markdown_file(std::path::Path::new(&loc.display_path())))
+            .unwrap_or(false);
 
         if !is_markdown {
             self.markdown_mode_segmented_control = None;
@@ -2212,12 +2208,11 @@ impl TypedActionView for CodeView {
             }
             #[cfg(feature = "local_fs")]
             CodeViewAction::RenderMarkdown => {
-                let path = self.local_path(ctx).or_else(|| {
-                    self.tab_at(self.active_tab_index)
-                        .and_then(|t| t.local_path())
-                });
+                let lor_path = self
+                    .tab_at(self.active_tab_index)
+                    .and_then(|t| t.location.clone());
 
-                if let Some(path) = path {
+                if let Some(lor_path) = lor_path {
                     let source = self.source.clone();
                     if self.active_tab_has_unsaved_changes(ctx) {
                         self.save_local(
@@ -2225,7 +2220,7 @@ impl TypedActionView for CodeView {
                             Some(Box::new(move |outcome, _me, ctx| {
                                 if outcome != SaveOutcome::Canceled {
                                     ctx.emit(CodeViewEvent::Pane(PaneEvent::ReplaceWithFilePane {
-                                        path: LocalOrRemotePath::Local(path.clone()),
+                                        path: lor_path.clone(),
                                         source: Some(source.clone()),
                                     }));
                                 }
@@ -2234,7 +2229,7 @@ impl TypedActionView for CodeView {
                         );
                     } else {
                         ctx.emit(CodeViewEvent::Pane(PaneEvent::ReplaceWithFilePane {
-                            path: LocalOrRemotePath::Local(path),
+                            path: lor_path,
                             source: Some(source),
                         }));
                     }

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -2225,7 +2225,7 @@ impl TypedActionView for CodeView {
                             Some(Box::new(move |outcome, _me, ctx| {
                                 if outcome != SaveOutcome::Canceled {
                                     ctx.emit(CodeViewEvent::Pane(PaneEvent::ReplaceWithFilePane {
-                                        path: path.clone(),
+                                        path: LocalOrRemotePath::Local(path.clone()),
                                         source: Some(source.clone()),
                                     }));
                                 }
@@ -2234,7 +2234,7 @@ impl TypedActionView for CodeView {
                         );
                     } else {
                         ctx.emit(CodeViewEvent::Pane(PaneEvent::ReplaceWithFilePane {
-                            path,
+                            path: LocalOrRemotePath::Local(path),
                             source: Some(source),
                         }));
                     }

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -2057,7 +2057,7 @@ impl CodeView {
 
             let is_md = local_path
                 .as_ref()
-                .map(|p| is_markdown_file(p))
+                .map(is_markdown_file)
                 .unwrap_or_else(|| {
                     active_location
                         .map(|loc| is_markdown_file(std::path::Path::new(&loc.display_path())))

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -227,6 +227,11 @@ pub enum PendingSaveIntent {
 }
 
 impl TabData {
+    /// Returns the file location (local or remote), if any.
+    pub fn location(&self) -> Option<&LocalOrRemotePath> {
+        self.location.as_ref()
+    }
+
     /// Returns the local filesystem path, if this tab is backed by a local file.
     /// Returns `None` for remote files and untitled tabs.
     pub fn local_path(&self) -> Option<PathBuf> {

--- a/app/src/code/wasm.rs
+++ b/app/src/code/wasm.rs
@@ -92,6 +92,11 @@ pub struct TabData {
 }
 
 impl TabData {
+    /// Returns the file location (local or remote), if any.
+    pub fn location(&self) -> Option<&LocalOrRemotePath> {
+        self.location.as_ref()
+    }
+
     /// Returns the local filesystem path, if this tab is backed by a local file.
     /// Returns `None` for remote files and untitled tabs.
     pub fn local_path(&self) -> Option<PathBuf> {

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -689,6 +689,11 @@ impl FileNotebookView {
         }
     }
 
+    /// The path to the currently-open file (local or remote), if any.
+    pub fn path(&self) -> Option<&LocalOrRemotePath> {
+        self.file_state.path()
+    }
+
     /// The path to the currently-open file, if it is local.
     pub fn local_path(&self) -> Option<PathBuf> {
         self.file_state.local_path().map(Path::to_path_buf)

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use pathfinder_geometry::vector::vec2f;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::path::user_friendly_path;
 #[cfg(feature = "local_fs")]
 use warpui::clipboard::ClipboardContent;
@@ -70,6 +71,7 @@ use warp_editor::model::CoreEditorModel;
 use warp_files::{FileModel, FileModelEvent};
 #[cfg(feature = "local_fs")]
 use warp_util::file::FileId;
+use warp_util::remote_path::RemotePath;
 
 pub use crate::util::openable_file_type::is_markdown_file;
 
@@ -153,33 +155,36 @@ impl From<ContextMenuAction> for FileNotebookAction {
 }
 
 /// Information about the notebook's backing file.
-// TODO: This should probably build on the `warp_files` abstractions.
 #[derive(Debug, Clone)]
 enum SourceFile {
-    Local {
-        /// The full path to the open file - for now, _only_ local files are supported.
-        ///
-        /// See [this comment](https://docs.google.com/document/d/18h7VzSAl6r5a94CovShlpPSahYqECX9WZliLjUqUsko/edit?disco=AAAA5Y1THuk);
-        /// we cannot use [`PathBuf`] to represent non-local paths.
-        local_path: PathBuf,
+    /// A file identified by a local or remote path.
+    FileBased {
+        path: LocalOrRemotePath,
+        /// The session context for this file. Only meaningful for local paths;
+        /// remote paths carry their own host information.
         session: Option<Arc<Session>>,
     },
-    Static {
-        title: String,
-    },
+    /// Static content provided inline (not backed by a file on disk).
+    Static { title: String },
 }
 
 impl SourceFile {
-    fn local_path(&self) -> Option<&Path> {
+    /// Returns the path for this source, if it is file-based.
+    fn path(&self) -> Option<&LocalOrRemotePath> {
         match self {
-            SourceFile::Local { local_path, .. } => Some(local_path.as_path()),
+            SourceFile::FileBased { path, .. } => Some(path),
             SourceFile::Static { .. } => None,
         }
     }
 
+    /// Returns the local path, if this is a local file-based source.
+    fn local_path(&self) -> Option<&Path> {
+        self.path().and_then(|p| p.to_local_path())
+    }
+
     fn display_name(&self) -> String {
         match self {
-            SourceFile::Local { local_path, .. } => local_path.display().to_string(),
+            SourceFile::FileBased { path, .. } => path.display_path(),
             SourceFile::Static { title } => title.clone(),
         }
     }
@@ -194,6 +199,11 @@ enum FileState {
 }
 
 impl FileState {
+    /// Returns the path for the open file, if it is file-based.
+    fn path(&self) -> Option<&LocalOrRemotePath> {
+        self.source().and_then(|src| src.path())
+    }
+
     /// The path to the open file, if it exists and is local.
     fn local_path(&self) -> Option<&Path> {
         self.source().and_then(|src| src.local_path())
@@ -370,6 +380,26 @@ impl FileNotebookView {
         ctx.notify();
     }
 
+    /// Open a file from a local or remote path.
+    ///
+    /// For local paths, uses `FileModel` to load and watch for changes.
+    /// For remote paths, fetches content via the remote server.
+    pub fn open(
+        &mut self,
+        path: LocalOrRemotePath,
+        session: Option<Arc<Session>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match path {
+            LocalOrRemotePath::Local(local_path) => {
+                self.open_local(local_path, session, ctx);
+            }
+            LocalOrRemotePath::Remote(remote_path) => {
+                self.open_remote(remote_path, ctx);
+            }
+        }
+    }
+
     /// Asynchronously open a local file, watching for local file changes.
     pub fn open_local(
         &mut self,
@@ -390,8 +420,8 @@ impl FileNotebookView {
             });
         }
 
-        self.file_state = FileState::Loading(SourceFile::Local {
-            local_path: local_path.clone(),
+        self.file_state = FileState::Loading(SourceFile::FileBased {
+            path: LocalOrRemotePath::Local(local_path.clone()),
             session: session.clone(),
         });
 
@@ -427,8 +457,8 @@ impl FileNotebookView {
                             // Record the canonical path instead of the input path when available.
                             if let Some(canonical_path) = file_model.as_ref(ctx).file_path(file_id)
                             {
-                                me.file_state = FileState::Loaded(SourceFile::Local {
-                                    local_path: canonical_path,
+                                me.file_state = FileState::Loaded(SourceFile::FileBased {
+                                    path: LocalOrRemotePath::Local(canonical_path),
                                     session: session.clone(),
                                 });
                             }
@@ -475,8 +505,8 @@ impl FileNotebookView {
                 safe: ("Local filesystem access is not available in this build"),
                 full: ("Local filesystem access is not available in this build (feature \"local_fs\" disabled)")
             );
-            self.file_state = FileState::Error(SourceFile::Local {
-                local_path,
+            self.file_state = FileState::Error(SourceFile::FileBased {
+                path: LocalOrRemotePath::Local(local_path),
                 session,
             });
             ctx.notify();
@@ -526,27 +556,124 @@ impl FileNotebookView {
     fn reload_file(&mut self, ctx: &mut ViewContext<Self>) {
         // We can take the file state here because either it's (a) already NoFile or (b) about to
         // be replaced with a loading state.
-        let (local_path, session) = match mem::replace(&mut self.file_state, FileState::NoFile) {
+        let (path, session) = match mem::replace(&mut self.file_state, FileState::NoFile) {
             FileState::NoFile => return,
             FileState::Loading(source) | FileState::Error(source) | FileState::Loaded(source) => {
                 match source {
-                    SourceFile::Local {
-                        local_path,
-                        session,
-                    } => (local_path, session),
+                    SourceFile::FileBased { path, session } => (path, session),
                     SourceFile::Static { .. } => return,
                 }
             }
         };
-        self.open_local(local_path, session, ctx);
+        self.open(path, session, ctx);
+    }
+
+    /// Open a remote file by fetching its content from the remote server.
+    fn open_remote(&mut self, remote_path: RemotePath, ctx: &mut ViewContext<Self>) {
+        let path_str = remote_path.path.as_str().to_string();
+        let display_name = remote_path
+            .path
+            .file_name()
+            .unwrap_or(path_str.as_str())
+            .to_string();
+
+        self.pane_configuration.update(ctx, |pane_config, ctx| {
+            pane_config.set_title(display_name, ctx);
+        });
+
+        let lor_path = LocalOrRemotePath::Remote(remote_path.clone());
+        self.file_state = FileState::Loading(SourceFile::FileBased {
+            path: lor_path,
+            session: None,
+        });
+
+        let host_id = remote_path.host_id.clone();
+        let manager = remote_server::manager::RemoteServerManager::handle(ctx);
+        let client = manager.as_ref(ctx).client_for_host(&host_id).cloned();
+
+        let Some(client) = client else {
+            safe_warn!(
+                safe: ("No remote server client for host when opening markdown file"),
+                full: ("No remote server client for host {host_id:?} when opening markdown file")
+            );
+            self.file_state = match mem::replace(&mut self.file_state, FileState::NoFile) {
+                FileState::Loading(source) => FileState::Error(source),
+                other => other,
+            };
+            ctx.notify();
+            return;
+        };
+
+        let request = remote_server::proto::ReadFileContextRequest {
+            files: vec![remote_server::proto::ReadFileContextFile {
+                path: path_str,
+                line_ranges: vec![],
+            }],
+            max_file_bytes: None,
+            max_batch_bytes: None,
+        };
+
+        ctx.spawn(
+            async move { client.read_file_context(request).await },
+            move |me, result, ctx| match result {
+                Ok(response) => {
+                    if let Some(file_ctx) = response.file_contexts.first() {
+                        let text = match &file_ctx.content {
+                            Some(
+                                remote_server::proto::file_context_proto::Content::TextContent(
+                                    text,
+                                ),
+                            ) => text.as_str(),
+                            _ => "",
+                        };
+                        me.set_content(text, ctx);
+                        me.file_state = match mem::replace(&mut me.file_state, FileState::NoFile) {
+                            FileState::Loading(source) => FileState::Loaded(source),
+                            other => other,
+                        };
+                        me.pane_configuration.update(ctx, |pane_config, ctx| {
+                            pane_config.refresh_pane_header_overflow_menu_items(ctx);
+                        });
+                        ctx.notify();
+                        ctx.emit(FileNotebookEvent::FileLoaded);
+                    } else if let Some(failed) = response.failed_files.first() {
+                        let error_msg = failed
+                            .error
+                            .as_ref()
+                            .map(|e| e.message.as_str())
+                            .unwrap_or("unknown error");
+                        safe_warn!(
+                            safe: ("Failed to read remote markdown file"),
+                            full: ("Failed to read remote markdown file: {error_msg}")
+                        );
+                        me.file_state = match mem::replace(&mut me.file_state, FileState::NoFile) {
+                            FileState::Loading(source) => FileState::Error(source),
+                            other => other,
+                        };
+                        ctx.notify();
+                    }
+                }
+                Err(err) => {
+                    safe_warn!(
+                        safe: ("Remote server error reading markdown file"),
+                        full: ("Remote server error reading markdown file: {err}")
+                    );
+                    me.file_state = match mem::replace(&mut me.file_state, FileState::NoFile) {
+                        FileState::Loading(source) => FileState::Error(source),
+                        other => other,
+                    };
+                    ctx.notify();
+                }
+            },
+        );
     }
 
     #[cfg(feature = "local_fs")]
     fn open_as_code(&mut self, ctx: &mut ViewContext<Self>) {
-        if let Some(path) = self.local_path() {
+        if let Some(path) = self.file_state.path().cloned() {
             // Emit an event to the pane group to handle the replacement
             ctx.emit(FileNotebookEvent::Pane(PaneEvent::ReplaceWithCodePane {
-                path: path.clone(),
+                path,
                 source: self.code_source.clone(),
             }));
         }
@@ -566,17 +693,11 @@ impl FileNotebookView {
         self.links.clone()
     }
 
-    #[cfg(feature = "local_fs")]
     fn is_markdown_file(&self) -> bool {
         self.file_state
-            .local_path()
-            .map(is_markdown_file)
+            .path()
+            .map(|p| is_markdown_file(Path::new(&p.display_path())))
             .unwrap_or(false)
-    }
-
-    #[cfg(not(feature = "local_fs"))]
-    fn is_markdown_file(&self) -> bool {
-        false
     }
 
     fn update_editor_display_mode(&mut self, ctx: &mut ViewContext<Self>) {
@@ -909,7 +1030,7 @@ impl TypedActionView for FileNotebookView {
                     MarkdownDisplayMode::Raw => {
                         #[cfg(feature = "local_fs")]
                         {
-                            if let Some(path) = self.local_path() {
+                            if let Some(path) = self.file_state.path().cloned() {
                                 ctx.emit(FileNotebookEvent::Pane(PaneEvent::ReplaceWithCodePane {
                                     path,
                                     source: self.code_source.clone(),
@@ -941,11 +1062,7 @@ impl BackingView for FileNotebookView {
         _ctx: &AppContext,
     ) -> Vec<MenuItem<FileNotebookAction>> {
         let mut actions = vec![];
-        if let Some(SourceFile::Local {
-            local_path: _local_path,
-            ..
-        }) = self.file_state.source()
-        {
+        if let Some(SourceFile::FileBased { .. }) = self.file_state.source() {
             actions.push(
                 MenuItemFields::new("Refresh file")
                     .with_on_select_action(FileNotebookAction::ReloadFile)

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -107,6 +107,8 @@ pub struct FileNotebookView {
     /// This is preserved so we can restore it when toggling between raw and rendered Markdown.
     #[cfg(feature = "local_fs")]
     code_source: Option<CodeSource>,
+    /// Persistent hover state for the header title tooltip.
+    header_title_mouse_state: MouseStateHandle,
 }
 
 #[derive(Debug, Clone)]
@@ -306,6 +308,7 @@ impl FileNotebookView {
             display_mode_segmented_control,
             #[cfg(feature = "local_fs")]
             code_source: None,
+            header_title_mouse_state: Default::default(),
         }
     }
 
@@ -1172,9 +1175,8 @@ impl BackingView for FileNotebookView {
                 if let Some(display_path) = self.file_state.path().map(|p| p.display_path()) {
                     use pathfinder_geometry::vector::vec2f;
                     use warpui::elements::{ChildAnchor, ParentAnchor, ParentOffsetBounds};
-                    use warpui::elements::{Hoverable, MouseStateHandle, OffsetPositioning, Stack};
-                    let mouse_state = MouseStateHandle::default();
-                    Hoverable::new(mouse_state, move |hover_state| {
+                    use warpui::elements::{Hoverable, OffsetPositioning, Stack};
+                    Hoverable::new(self.header_title_mouse_state.clone(), move |hover_state| {
                         let mut stack = Stack::new();
                         stack.add_child(title_text);
                         if hover_state.is_hovered() {

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -1002,24 +1002,30 @@ impl TypedActionView for FileNotebookView {
             FileNotebookAction::ReloadFile => self.reload_file(ctx),
             #[cfg(feature = "local_fs")]
             FileNotebookAction::CopyFilePath => {
-                if let Some(path) = self.local_path() {
+                if let Some(path) = self.file_state.path() {
                     ctx.clipboard()
-                        .write(ClipboardContent::plain_text(path.display().to_string()));
+                        .write(ClipboardContent::plain_text(path.display_path()));
                 }
             }
             #[cfg(feature = "local_fs")]
             FileNotebookAction::OpenInEditor => {
-                if let Some(path) = self.local_path() {
+                if let Some(local_path) = self.local_path() {
                     use crate::util::file::external_editor::EditorSettings;
                     use crate::util::openable_file_type::resolve_file_target;
                     // Resolve target and emit event - workspace will handle all cases
                     let settings = EditorSettings::as_ref(ctx);
-                    let target = resolve_file_target(&path, settings, None);
+                    let target = resolve_file_target(&local_path, settings, None);
                     ctx.emit(FileNotebookEvent::OpenFileWithTarget {
-                        path,
+                        path: local_path,
                         target,
                         line_col: None,
                     });
+                } else if let Some(path) = self.file_state.path().cloned() {
+                    // For remote files, open as a code editor pane.
+                    ctx.emit(FileNotebookEvent::Pane(PaneEvent::ReplaceWithCodePane {
+                        path,
+                        source: None,
+                    }));
                 }
             }
             #[cfg(feature = "local_fs")]

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -1167,10 +1167,43 @@ impl BackingView for FileNotebookView {
                 warpui::text_layout::ClipConfig::start(),
             );
 
+            // Wrap the title in a hoverable tooltip showing the full file path.
+            let title_element: Box<dyn Element> =
+                if let Some(display_path) = self.file_state.path().map(|p| p.display_path()) {
+                    use pathfinder_geometry::vector::vec2f;
+                    use warpui::elements::{ChildAnchor, ParentAnchor, ParentOffsetBounds};
+                    use warpui::elements::{Hoverable, MouseStateHandle, OffsetPositioning, Stack};
+                    let mouse_state = MouseStateHandle::default();
+                    Hoverable::new(mouse_state, move |hover_state| {
+                        let mut stack = Stack::new();
+                        stack.add_child(title_text);
+                        if hover_state.is_hovered() {
+                            let tooltip = appearance
+                                .ui_builder()
+                                .tool_tip(display_path.clone())
+                                .build()
+                                .finish();
+                            stack.add_positioned_overlay_child(
+                                tooltip,
+                                OffsetPositioning::offset_from_parent(
+                                    vec2f(0., 4.),
+                                    ParentOffsetBounds::Unbounded,
+                                    ParentAnchor::BottomMiddle,
+                                    ChildAnchor::TopMiddle,
+                                ),
+                            );
+                        }
+                        stack.finish()
+                    })
+                    .finish()
+                } else {
+                    title_text
+                };
+
             view::HeaderContent::Custom {
                 element: render_three_column_header(
                     Empty::new().finish(),
-                    title_text,
+                    title_element,
                     right_row.finish(),
                     CenteredHeaderEdgeWidth {
                         min: buttons_width,

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -383,6 +383,10 @@ impl FileNotebookView {
     /// Open a file from a local or remote path.
     ///
     /// For local paths, uses `FileModel` to load and watch for changes.
+    /// The `session` is used to resolve display names and link context for
+    /// local paths. If `None` for a local path, the view falls back to the
+    /// active local session when one becomes available. For remote paths the
+    /// session is ignored because the `RemotePath` already carries host info.
     /// For remote paths, fetches content via the remote server.
     pub fn open(
         &mut self,
@@ -392,6 +396,12 @@ impl FileNotebookView {
     ) {
         match path {
             LocalOrRemotePath::Local(local_path) => {
+                // For local paths, try to resolve a local session if none was provided.
+                let session = session.or_else(|| {
+                    ActiveSession::as_ref(ctx)
+                        .session(ctx.window_id())
+                        .filter(|s| s.is_local())
+                });
                 self.open_local(local_path, session, ctx);
             }
             LocalOrRemotePath::Remote(remote_path) => {

--- a/app/src/notebooks/file/mod_tests.rs
+++ b/app/src/notebooks/file/mod_tests.rs
@@ -30,7 +30,7 @@ use crate::{
     GlobalResourceHandles, GlobalResourceHandlesProvider,
 };
 
-use super::{FileNotebookView, FileState, MarkdownDisplayMode};
+use super::{FileNotebookView, FileState, MarkdownDisplayMode, SourceFile};
 use crate::notebooks::context_menu::MenuSource;
 use warp_editor::render::model::BlockItem;
 
@@ -125,10 +125,10 @@ fn test_load_before_session() {
             .update(&mut app, |file_notebook, ctx| {
                 file_notebook.open_local("../README.md", None, ctx);
                 match &file_notebook.file_state {
-                    FileState::Loading(source) => {
-                        assert_eq!(source.local_path(), Some(Path::new("../README.md")))
+                    FileState::Loading(SourceFile::FileBased { path, .. }) => {
+                        assert_eq!(path.to_local_path(), Some(Path::new("../README.md")))
                     }
-                    other => panic!("Expected FileState::Loading, got {other:?}"),
+                    other => panic!("Expected FileState::Loading(FileBased), got {other:?}"),
                 }
 
                 let file_id = file_notebook
@@ -150,10 +150,10 @@ fn test_load_before_session() {
             assert!(view.location.is_none());
 
             match &view.file_state {
-                FileState::Loaded(source) => {
-                    assert_eq!(source.local_path(), Some(expected_path.as_path()));
+                FileState::Loaded(SourceFile::FileBased { path, .. }) => {
+                    assert_eq!(path.to_local_path(), Some(expected_path.as_path()));
                 }
-                other => panic!("Expected FileState::Loaded, got {other:?}"),
+                other => panic!("Expected FileState::Loaded(FileBased), got {other:?}"),
             };
         });
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -5326,7 +5326,7 @@ impl PaneGroup {
         use crate::pane_group::CodePane;
 
         // Use the provided source if available, or construct from the path.
-        let source = source.unwrap_or_else(|| CodeSource::FileTree { location: path });
+        let source = source.unwrap_or(CodeSource::FileTree { location: path });
 
         let code_pane = CodePane::new(source, None, ctx);
         let success = self.replace_pane(file_pane_id, code_pane, false, ctx);

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -1717,7 +1717,7 @@ impl PaneGroup {
                         settings,
                     } => Box::new(NotebookPane::restore(notebook_id, &settings, ctx)?),
                     NotebookPaneSnapshot::LocalFileNotebook { path } => Box::new(FilePane::new(
-                        path,
+                        path.map(LocalOrRemotePath::Local),
                         None,
                         #[cfg(feature = "local_fs")]
                         None,
@@ -5318,19 +5318,15 @@ impl PaneGroup {
     fn replace_file_pane_with_code_pane(
         &mut self,
         file_pane_id: PaneId,
-        path: std::path::PathBuf,
+        path: LocalOrRemotePath,
         source: Option<crate::code::editor_management::CodeSource>,
         ctx: &mut ViewContext<Self>,
     ) {
         use crate::code::editor_management::CodeSource;
         use crate::pane_group::CodePane;
 
-        // Use the provided source if available.
-        let source = source.unwrap_or(CodeSource::Link {
-            path,
-            range_start: None,
-            range_end: None,
-        });
+        // Use the provided source if available, or construct from the path.
+        let source = source.unwrap_or_else(|| CodeSource::FileTree { location: path });
 
         let code_pane = CodePane::new(source, None, ctx);
         let success = self.replace_pane(file_pane_id, code_pane, false, ctx);
@@ -5344,7 +5340,7 @@ impl PaneGroup {
     fn replace_code_pane_with_file_pane(
         &mut self,
         code_pane_id: PaneId,
-        path: std::path::PathBuf,
+        path: LocalOrRemotePath,
         source: Option<crate::code::editor_management::CodeSource>,
         ctx: &mut ViewContext<Self>,
     ) {

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -542,7 +542,7 @@ pub enum Event {
     /// tell the workspace to open a file within Warp.
     OpenFileInWarp {
         /// The file path to open.
-        path: PathBuf,
+        path: LocalOrRemotePath,
         /// The session that the path was opened from.
         session: Arc<Session>,
     },

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -7905,46 +7905,43 @@ impl PaneGroup {
         })
     }
 
-    /// Get all code CWDs for this pane group.
+    /// Get all code editor paths (local and remote) for this pane group.
     /// This is used by the Workspace to refresh the active directories model.
-    pub fn code_view_local_paths<'a>(
+    pub fn code_view_paths<'a>(
         &'a self,
         ctx: &'a AppContext,
-    ) -> impl Iterator<Item = (EntityId, Option<String>)> + 'a {
+    ) -> impl Iterator<Item = (EntityId, Option<LocalOrRemotePath>)> + 'a {
         self.code_views(ctx).into_iter().map(move |code_view| {
             let id = code_view.id();
-            let local_path = code_view
+            let location = code_view
                 .as_ref(ctx)
-                .local_path(ctx)
-                .map(|p| p.display().to_string());
-            (id, local_path)
+                .tab_at(code_view.as_ref(ctx).active_tab_index())
+                .and_then(|tab| tab.location().cloned());
+            (id, location)
         })
     }
 
-    pub fn code_diff_view_local_paths<'a>(
+    pub fn code_diff_view_paths<'a>(
         &'a self,
         ctx: &'a AppContext,
-    ) -> impl Iterator<Item = (EntityId, Option<String>)> + 'a {
+    ) -> impl Iterator<Item = (EntityId, Option<LocalOrRemotePath>)> + 'a {
         self.code_diff_views(ctx).into_iter().map(move |diff_view| {
             let id = diff_view.id();
-            let local_path = diff_view.as_ref(ctx).primary_file_path(ctx);
-            (id, local_path)
+            let location = diff_view.as_ref(ctx).primary_file_location(ctx);
+            (id, location)
         })
     }
 
-    pub fn file_notebook_local_paths<'a>(
+    pub fn file_notebook_paths<'a>(
         &'a self,
         ctx: &'a AppContext,
-    ) -> impl Iterator<Item = (EntityId, Option<String>)> + 'a {
+    ) -> impl Iterator<Item = (EntityId, Option<LocalOrRemotePath>)> + 'a {
         self.file_notebook_views(ctx)
             .into_iter()
             .map(move |file_view| {
                 let id = file_view.id();
-                let local_path = file_view
-                    .as_ref(ctx)
-                    .local_path()
-                    .map(|p| p.display().to_string());
-                (id, local_path)
+                let path = file_view.as_ref(ctx).path().cloned();
+                (id, path)
             })
     }
 

--- a/app/src/pane_group/pane/file_pane.rs
+++ b/app/src/pane_group/pane/file_pane.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
+use warpui::{AppContext, ModelHandle, View, ViewContext, ViewHandle};
 
 #[cfg(feature = "local_fs")]
 use crate::code::editor_management::CodeSource;
@@ -10,7 +10,6 @@ use crate::{
     notebooks::file::{FileNotebookEvent, FileNotebookView},
     terminal::model::session::Session,
     workflows::WorkflowSelectionSource,
-    workspace::ActiveSession,
 };
 
 use super::{
@@ -54,19 +53,7 @@ impl FilePane {
             view.set_code_source(code_source);
 
             if let Some(path) = path {
-                match &path {
-                    LocalOrRemotePath::Local(_) => {
-                        let session = target_session.or_else(|| {
-                            ActiveSession::as_ref(ctx)
-                                .session(ctx.window_id())
-                                .filter(|session| session.is_local())
-                        });
-                        view.open(path, session, ctx);
-                    }
-                    LocalOrRemotePath::Remote(_) => {
-                        view.open(path, None, ctx);
-                    }
-                }
+                view.open(path, target_session, ctx);
             }
 
             view

--- a/app/src/pane_group/pane/file_pane.rs
+++ b/app/src/pane_group/pane/file_pane.rs
@@ -1,5 +1,6 @@
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
 
 #[cfg(feature = "local_fs")]
@@ -38,11 +39,11 @@ impl FilePane {
     }
 
     /// Create a new file notebook pane for the given path and optional target session. If `path`
-    /// is `None` or the target session is remote, the pane is created but left empty. If `path` is
-    /// `Some`, but there's no target session, the pane is created using the next focused local
-    /// session.
+    /// is `None`, the pane is created but left empty. For local paths without a target session,
+    /// the pane waits for a local session to become active. Remote paths are loaded directly
+    /// via the remote server.
     pub fn new<V: View>(
-        path: Option<PathBuf>,
+        path: Option<LocalOrRemotePath>,
         target_session: Option<Arc<Session>>,
         #[cfg(feature = "local_fs")] code_source: Option<CodeSource>,
         ctx: &mut ViewContext<V>,
@@ -53,19 +54,18 @@ impl FilePane {
             view.set_code_source(code_source);
 
             if let Some(path) = path {
-                if let Some(target_session) = target_session {
-                    // If the target session is Some, but non-local, do not fall back - the path is
-                    // remote, so we can't reliably use the fallback behavior.
-                    if target_session.is_local() {
-                        view.open_local(path, Some(target_session), ctx);
+                match &path {
+                    LocalOrRemotePath::Local(_) => {
+                        let session = target_session.or_else(|| {
+                            ActiveSession::as_ref(ctx)
+                                .session(ctx.window_id())
+                                .filter(|session| session.is_local())
+                        });
+                        view.open(path, session, ctx);
                     }
-                } else {
-                    // If the active session is None or remote, the pane will wait for a local
-                    // session to be activated.
-                    let session = ActiveSession::as_ref(ctx)
-                        .session(ctx.window_id())
-                        .filter(|session| session.is_local());
-                    view.open_local(path, session, ctx);
+                    LocalOrRemotePath::Remote(_) => {
+                        view.open(path, None, ctx);
+                    }
                 }
             }
 
@@ -150,6 +150,8 @@ impl PaneContent for FilePane {
     }
 
     fn snapshot(&self, app: &AppContext) -> LeafContents {
+        // Only persist local file paths in session snapshots; remote files
+        // are not restorable across sessions.
         let path = self.file_view(app).as_ref(app).local_path();
         LeafContents::Notebook(NotebookPaneSnapshot::LocalFileNotebook { path })
     }

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -55,7 +55,6 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
-use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
 use warpui::{
     elements::{DispatchEventResult, EventHandler, MouseInBehavior},

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -55,6 +55,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
+#[cfg(feature = "local_fs")]
+use crate::code::buffer_location::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
 use warpui::{
     elements::{DispatchEventResult, EventHandler, MouseInBehavior},

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -32,6 +32,8 @@ pub mod workflow_pane;
 
 use std::{any::Any, fmt::Display};
 
+#[cfg(feature = "local_fs")]
+use crate::code::buffer_location::LocalOrRemotePath;
 use crate::pane_group::focus_state::PaneFocusHandle;
 use crate::pane_group::pane::get_started_view::GetStartedView;
 use crate::view_components::action_button::ActionButton;
@@ -55,8 +57,6 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
-#[cfg(feature = "local_fs")]
-use crate::code::buffer_location::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
 use warpui::{
     elements::{DispatchEventResult, EventHandler, MouseInBehavior},

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -55,6 +55,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use url::Url;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
 use warpui::{
     elements::{DispatchEventResult, EventHandler, MouseInBehavior},
@@ -1115,12 +1116,12 @@ pub enum PaneEvent {
     ClearHoveredTabIndex,
     #[cfg(feature = "local_fs")]
     ReplaceWithCodePane {
-        path: warp_util::local_or_remote_path::LocalOrRemotePath,
+        path: LocalOrRemotePath,
         source: Option<crate::code::editor_management::CodeSource>,
     },
     #[cfg(feature = "local_fs")]
     ReplaceWithFilePane {
-        path: warp_util::local_or_remote_path::LocalOrRemotePath,
+        path: LocalOrRemotePath,
         source: Option<crate::code::editor_management::CodeSource>,
     },
 }

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -1115,12 +1115,12 @@ pub enum PaneEvent {
     ClearHoveredTabIndex,
     #[cfg(feature = "local_fs")]
     ReplaceWithCodePane {
-        path: std::path::PathBuf,
+        path: warp_util::local_or_remote_path::LocalOrRemotePath,
         source: Option<crate::code::editor_management::CodeSource>,
     },
     #[cfg(feature = "local_fs")]
     ReplaceWithFilePane {
-        path: std::path::PathBuf,
+        path: warp_util::local_or_remote_path::LocalOrRemotePath,
         source: Option<crate::code::editor_management::CodeSource>,
     },
 }

--- a/app/src/pane_group/pane/notebook_pane.rs
+++ b/app/src/pane_group/pane/notebook_pane.rs
@@ -179,7 +179,7 @@ pub(super) fn subscribe_to_link_model(
         LinkEvent::OpenFileNotebook { path, session } => {
             // Opening local files is delegated to the parent workspace.
             ctx.emit(crate::pane_group::Event::OpenFileInWarp {
-                path: path.clone(),
+                path: crate::code::buffer_location::LocalOrRemotePath::Local(path.clone()),
                 session: session.clone(),
             })
         }

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1,4 +1,5 @@
 //! Implementation of terminal panes.
+use crate::code::buffer_location::LocalOrRemotePath;
 #[cfg(feature = "local_fs")]
 use crate::pane_group::CodeSource;
 #[cfg(not(target_family = "wasm"))]
@@ -1188,7 +1189,7 @@ fn handle_terminal_view_event(
             }
             Event::OpenFileInWarp { path, session } => {
                 ctx.emit(pane_group::Event::OpenFileInWarp {
-                    path: path.clone(),
+                    path: LocalOrRemotePath::Local(path.clone()),
                     session: session.clone(),
                 });
             }

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 #[cfg(feature = "local_fs")]
 use std::path::Path;
+#[cfg(feature = "local_fs")]
 use std::path::PathBuf;
 #[cfg(feature = "local_fs")]
 use warp_util::remote_path::RemotePath;

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -577,6 +577,12 @@ impl WorkingDirectoriesModel {
                 DetectedRepositories::as_ref(ctx).get_root_for_path(&remote_key)
             {
                 new_remote_display_roots.push(repo_root);
+            } else if let Some(parent) = remote_path.path.parent() {
+                // Fall back to the parent directory, matching the local editor path behavior.
+                new_remote_display_roots.push(LocalOrRemotePath::Remote(RemotePath::new(
+                    remote_path.host_id.clone(),
+                    parent,
+                )));
             }
         }
 

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -667,8 +667,8 @@ impl WorkingDirectoriesModel {
         let mut new_repo_roots_wrapped: Vec<LocalOrRemotePath> = new_local_repo_roots
             .into_iter()
             .map(LocalOrRemotePath::Local)
-            .chain(new_remote_repo_roots.into_iter())
-            .chain(new_remote_display_roots.into_iter())
+            .chain(new_remote_repo_roots)
+            .chain(new_remote_display_roots)
             .collect();
         // Deduplicate (IndexSet handles this, but avoid duplicates in the input).
         let seen: HashSet<_> = new_repo_roots_wrapped.iter().cloned().collect();

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -79,7 +79,7 @@ impl DiffStateModelMap {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkingDirectory {
-    pub path: PathBuf,
+    pub path: LocalOrRemotePath,
     pub terminal_id: Option<EntityId>,
 }
 
@@ -117,20 +117,18 @@ pub enum WorkingDirectoriesEvent {
 /// Workspace model that tracks working directories across all pane groups.
 /// Emits events when the set of directories changes for any pane group.
 pub struct WorkingDirectoriesModel {
-    /// Per-pane-group tracking of active **local** directories as a deduplicated, ordered set.
+    /// Per-pane-group tracking of active directories (both local and remote) as a
+    /// deduplicated, ordered set.
     ///
-    /// IMPORTANT: This stores the *display roots* for the left panel (file tree / global search),
-    /// not the raw working directories reported by each pane. It is intentionally `PathBuf`
-    /// (not `LocalOrRemotePath`) because it is populated exclusively by `normalize_cwd()` →
-    /// `dunce::canonicalize()`, which only operates on local paths. Remote directories enter
-    /// the file tree through the separate `set_remote_root_directories` path on `FileTreeView`.
+    /// This stores the *display roots* for the left panel (file tree / global search),
+    /// not the raw working directories reported by each pane.
     ///
     /// Concretely, for each pane group's active paths we store:
     /// - the detected repository root when the path belongs to a repo
-    /// - otherwise, the normalized path itself
+    /// - otherwise, the normalized path itself (local) or the remote CWD/editor path
     ///
     /// IndexSet maintains insertion order - most recently added directories appear later.
-    pane_groups: HashMap<EntityId, IndexSet<PathBuf>>,
+    pane_groups: HashMap<EntityId, IndexSet<LocalOrRemotePath>>,
     /// Per-pane-group tracking of active repository roots as a deduplicated, ordered set.
     /// Covers both local and remote repositories in a single map.
     /// IndexSet maintains insertion order - most recently added repositories appear later.
@@ -170,19 +168,6 @@ pub struct WorkingDirectoriesModel {}
 /// Index Sets are ordered by insertion order. This function updates an index set to match a new set of items.
 #[cfg(feature = "local_fs")]
 pub fn update_index_set(
-    index_set: &mut IndexSet<PathBuf>,
-    new_items: impl IntoIterator<Item = PathBuf>,
-) {
-    let new_items: Vec<PathBuf> = new_items.into_iter().collect();
-    index_set.retain(|item| new_items.iter().any(|new_item| new_item == item));
-    for item in new_items {
-        index_set.insert(item);
-    }
-}
-
-/// Updates an index set of `LocalOrRemotePath` to match a new set of items.
-#[cfg(feature = "local_fs")]
-fn update_repo_index_set(
     index_set: &mut IndexSet<LocalOrRemotePath>,
     new_items: impl IntoIterator<Item = LocalOrRemotePath>,
 ) {
@@ -200,11 +185,10 @@ impl WorkingDirectoriesModel {
     }
 
     /// Get the unique directories for a specific pane group in insertion order (oldest first).
-    /// Returns local-only paths (see `pane_groups` field doc).
     fn least_recent_directories_for_pane_group(
         &self,
         pane_group_id: EntityId,
-    ) -> Option<&IndexSet<PathBuf>> {
+    ) -> Option<&IndexSet<LocalOrRemotePath>> {
         self.pane_groups.get(&pane_group_id)
     }
 
@@ -215,13 +199,9 @@ impl WorkingDirectoriesModel {
     ) -> Option<impl Iterator<Item = WorkingDirectory> + '_> {
         self.least_recent_directories_for_pane_group(pane_group_id)
             .map(move |dirs| {
-                dirs.iter().rev().map(move |path| {
-                    // pane_groups only contains local paths (see field doc), so Local() is correct.
-                    let key = LocalOrRemotePath::Local(path.clone());
-                    WorkingDirectory {
-                        path: path.clone(),
-                        terminal_id: self.get_terminal_id_for_root_path(pane_group_id, &key),
-                    }
+                dirs.iter().rev().map(move |lor| WorkingDirectory {
+                    path: lor.clone(),
+                    terminal_id: self.get_terminal_id_for_root_path(pane_group_id, lor),
                 })
             })
     }
@@ -499,13 +479,9 @@ impl WorkingDirectoriesModel {
             .least_recent_directories_for_pane_group(pane_group_id)
             .map(|dirs| {
                 dirs.iter()
-                    .map(|dir| {
-                        // pane_groups only contains local paths (see field doc).
-                        let key = LocalOrRemotePath::Local(dir.clone());
-                        WorkingDirectory {
-                            path: dir.clone(),
-                            terminal_id: self.get_terminal_id_for_root_path(pane_group_id, &key),
-                        }
+                    .map(|lor| WorkingDirectory {
+                        path: lor.clone(),
+                        terminal_id: self.get_terminal_id_for_root_path(pane_group_id, lor),
                     })
                     .collect()
             })
@@ -577,17 +553,44 @@ impl WorkingDirectoriesModel {
             })
             .collect();
 
-        // Build the local root paths (for pane_groups / file tree — local only).
-        let new_root_paths: Vec<PathBuf> = local_terminal_cwds
+        // Build the local root paths for pane_groups.
+        let new_local_root_paths: Vec<PathBuf> = local_terminal_cwds
             .iter()
             .chain(local_cwds.iter())
             .filter_map(|(_, cwd)| root_for_raw_path(cwd))
             .collect();
 
+        // Build remote root paths for pane_groups from remote terminal CWDs
+        // and remote editor paths (resolved to repo root when possible).
+        let mut new_remote_display_roots: Vec<LocalOrRemotePath> = Vec::new();
+        for (_terminal_id, remote_path) in &remote_terminal_cwds {
+            let remote_key = LocalOrRemotePath::Remote(remote_path.clone());
+            let root = DetectedRepositories::as_ref(ctx)
+                .get_root_for_path(&remote_key)
+                .unwrap_or(remote_key);
+            new_remote_display_roots.push(root);
+        }
+        for (_view_id, remote_path) in &remote_editor_paths {
+            let remote_key = LocalOrRemotePath::Remote(remote_path.clone());
+            if let Some(repo_root) =
+                DetectedRepositories::as_ref(ctx).get_root_for_path(&remote_key)
+            {
+                new_remote_display_roots.push(repo_root);
+            }
+        }
+
+        // Combine local + remote into the unified display roots set.
+        let new_display_roots: Vec<LocalOrRemotePath> = new_local_root_paths
+            .iter()
+            .cloned()
+            .map(LocalOrRemotePath::Local)
+            .chain(new_remote_display_roots.iter().cloned())
+            .collect();
+
         // Get or create the IndexSet for this pane group
         // (IndexSet maintains insertion order and auto-deduplicates)
         let pane_group_roots = self.pane_groups.entry(pane_group_id).or_default();
-        update_index_set(pane_group_roots, new_root_paths.clone());
+        update_index_set(pane_group_roots, new_display_roots);
 
         // Build repo roots and their terminal associations
         // First pass: collect all local repo roots and build initial mapping
@@ -596,11 +599,12 @@ impl WorkingDirectoriesModel {
             .get(&pane_group_id)
             .into_iter()
             .flat_map(|dirs| dirs.iter())
+            .filter_map(|lor| lor.to_local_path())
             .filter_map(|dir| self.get_repo_root_for_path(dir, ctx))
             .collect();
         let mut new_roots: HashSet<PathBuf> =
             HashSet::from_iter(new_local_repo_roots.iter().cloned());
-        new_roots.extend(new_root_paths.iter().cloned());
+        new_roots.extend(new_local_root_paths.iter().cloned());
 
         // Build mapping from directories to their terminal IDs (keyed by LocalOrRemotePath).
         // Local paths come from `root_for_raw_path` → `normalize_cwd`.
@@ -663,7 +667,8 @@ impl WorkingDirectoriesModel {
         let mut new_repo_roots_wrapped: Vec<LocalOrRemotePath> = new_local_repo_roots
             .into_iter()
             .map(LocalOrRemotePath::Local)
-            .chain(new_remote_repo_roots)
+            .chain(new_remote_repo_roots.into_iter())
+            .chain(new_remote_display_roots.into_iter())
             .collect();
         // Deduplicate (IndexSet handles this, but avoid duplicates in the input).
         let seen: HashSet<_> = new_repo_roots_wrapped.iter().cloned().collect();
@@ -674,7 +679,7 @@ impl WorkingDirectoriesModel {
         let _ = seen; // consumed by retain closure above
 
         let pane_group_repos = self.repository_roots.entry(pane_group_id).or_default();
-        update_repo_index_set(pane_group_repos, new_repo_roots_wrapped);
+        update_index_set(pane_group_repos, new_repo_roots_wrapped);
 
         self.directory_to_terminal
             .insert(pane_group_id, new_root_to_terminal);
@@ -684,13 +689,9 @@ impl WorkingDirectoriesModel {
             .get(&pane_group_id)
             .map(|dirs| {
                 dirs.iter()
-                    .map(|dir| {
-                        // pane_groups only contains local paths (see field doc).
-                        let key = LocalOrRemotePath::Local(dir.clone());
-                        WorkingDirectory {
-                            path: dir.clone(),
-                            terminal_id: self.get_terminal_id_for_root_path(pane_group_id, &key),
-                        }
+                    .map(|lor| WorkingDirectory {
+                        path: lor.clone(),
+                        terminal_id: self.get_terminal_id_for_root_path(pane_group_id, lor),
                     })
                     .collect()
             })

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -486,11 +486,11 @@ impl WorkingDirectoriesModel {
         &mut self,
         pane_group_id: EntityId,
         terminal_cwds: Vec<(EntityId, LocalOrRemotePath)>,
-        local_paths: Vec<(EntityId, String)>,
+        editor_paths: Vec<(EntityId, LocalOrRemotePath)>,
         focused_terminal_id: Option<EntityId>,
         ctx: &mut ModelContext<Self>,
     ) {
-        if terminal_cwds.is_empty() && local_paths.is_empty() {
+        if terminal_cwds.is_empty() && editor_paths.is_empty() {
             self.handle_empty_pane_group(pane_group_id, ctx);
             return;
         }
@@ -547,7 +547,21 @@ impl WorkingDirectoriesModel {
             .filter_map(|(_, cwd)| root_for_raw_path(cwd))
             .collect();
 
-        let local_cwds: Vec<(EntityId, String)> = local_paths
+        // Split editor paths into local and remote buckets.
+        let mut local_editor_paths: Vec<(EntityId, String)> = Vec::new();
+        let mut remote_editor_paths: Vec<(EntityId, RemotePath)> = Vec::new();
+        for (view_id, path) in &editor_paths {
+            match path {
+                LocalOrRemotePath::Local(p) => {
+                    local_editor_paths.push((*view_id, p.to_string_lossy().into_owned()));
+                }
+                LocalOrRemotePath::Remote(remote_path) => {
+                    remote_editor_paths.push((*view_id, remote_path.clone()));
+                }
+            }
+        }
+
+        let local_cwds: Vec<(EntityId, String)> = local_editor_paths
             .into_iter()
             .filter_map(|(view_id, path)| {
                 let path_buf = PathBuf::from(&path);
@@ -612,6 +626,16 @@ impl WorkingDirectoriesModel {
                 // No repo detected — still track the CWD → terminal mapping
                 // so `find_review_terminal` can resolve it.
                 new_root_to_terminal.insert(remote_key, *terminal_id);
+            }
+        }
+
+        // Resolve remote editor paths to their repo roots.
+        for (_view_id, remote_path) in &remote_editor_paths {
+            let remote_key = LocalOrRemotePath::Remote(remote_path.clone());
+            if let Some(repo_root) =
+                DetectedRepositories::as_ref(ctx).get_root_for_path(&remote_key)
+            {
+                new_remote_repo_roots.push(repo_root);
             }
         }
 
@@ -856,7 +880,7 @@ impl WorkingDirectoriesModel {
         &mut self,
         _pane_group_id: EntityId,
         _terminal_cwds: Vec<(EntityId, LocalOrRemotePath)>,
-        _local_paths: Vec<(EntityId, String)>,
+        _editor_paths: Vec<(EntityId, LocalOrRemotePath)>,
         _focused_terminal_id: Option<EntityId>,
         _ctx: &mut ModelContext<Self>,
     ) {

--- a/app/src/pane_group/working_directories_tests.rs
+++ b/app/src/pane_group/working_directories_tests.rs
@@ -45,27 +45,28 @@ fn refresh_working_directories_collapses_subroots_to_nearest_repo_root() {
         let terminal_2 = EntityId::new();
 
         let working_directories_handle = app.add_model(|_| WorkingDirectoriesModel::new());
-        let roots: Vec<PathBuf> = working_directories_handle.update(&mut app, |model, ctx| {
-            model.refresh_working_directories_for_pane_group(
-                pane_group_id,
-                vec![
-                    (terminal_1, LocalOrRemotePath::Local(repo_a.clone())),
-                    (terminal_2, LocalOrRemotePath::Local(repo_b.clone())),
-                ],
-                vec![],
-                Some(terminal_1),
-                ctx,
-            );
+        let roots: Vec<LocalOrRemotePath> =
+            working_directories_handle.update(&mut app, |model, ctx| {
+                model.refresh_working_directories_for_pane_group(
+                    pane_group_id,
+                    vec![
+                        (terminal_1, LocalOrRemotePath::Local(repo_a.clone())),
+                        (terminal_2, LocalOrRemotePath::Local(repo_b.clone())),
+                    ],
+                    vec![],
+                    Some(terminal_1),
+                    ctx,
+                );
 
-            model
-                .most_recent_directories_for_pane_group(pane_group_id)
-                .expect("pane group exists")
-                .map(|dir| dir.path)
-                .collect()
-        });
+                model
+                    .most_recent_directories_for_pane_group(pane_group_id)
+                    .expect("pane group exists")
+                    .map(|dir| dir.path)
+                    .collect()
+            });
 
         assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0], canonical_repo_root);
+        assert_eq!(roots[0], local(&canonical_repo_root));
     });
 }
 
@@ -91,30 +92,31 @@ fn refresh_working_directories_preserves_non_repo_paths_and_dedupes() {
         let terminal_3 = EntityId::new();
 
         let working_directories_handle = app.add_model(|_| WorkingDirectoriesModel::new());
-        let roots: HashSet<PathBuf> = working_directories_handle.update(&mut app, |model, ctx| {
-            model.refresh_working_directories_for_pane_group(
-                pane_group_id,
-                vec![
-                    (terminal_1, LocalOrRemotePath::Local(dir_1.clone())),
-                    (terminal_2, LocalOrRemotePath::Local(dir_2.clone())),
-                    // Duplicate root should be deduped.
-                    (terminal_3, LocalOrRemotePath::Local(dir_1.clone())),
-                ],
-                vec![],
-                Some(terminal_1),
-                ctx,
-            );
+        let roots: HashSet<LocalOrRemotePath> =
+            working_directories_handle.update(&mut app, |model, ctx| {
+                model.refresh_working_directories_for_pane_group(
+                    pane_group_id,
+                    vec![
+                        (terminal_1, LocalOrRemotePath::Local(dir_1.clone())),
+                        (terminal_2, LocalOrRemotePath::Local(dir_2.clone())),
+                        // Duplicate root should be deduped.
+                        (terminal_3, LocalOrRemotePath::Local(dir_1.clone())),
+                    ],
+                    vec![],
+                    Some(terminal_1),
+                    ctx,
+                );
 
-            model
-                .most_recent_directories_for_pane_group(pane_group_id)
-                .expect("pane group exists")
-                .map(|dir| dir.path)
-                .collect()
-        });
+                model
+                    .most_recent_directories_for_pane_group(pane_group_id)
+                    .expect("pane group exists")
+                    .map(|dir| dir.path)
+                    .collect()
+            });
 
         assert_eq!(
             roots,
-            HashSet::from_iter([canonical_1, canonical_2]),
+            HashSet::from_iter([local(&canonical_1), local(&canonical_2)]),
             "should preserve non-repo roots and dedupe exact paths"
         );
     });

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -1257,7 +1257,13 @@ fn open_file(window_id: Option<WindowId>, path: PathBuf, ctx: &mut AppContext) {
                 if let Some(workspace) = workspaces.into_iter().next() {
                     workspace.update(ctx, |workspace, ctx| {
                         let source = CodeSource::Finder { path: path.clone() };
-                        workspace.open_file_with_target(path, target, None, source, ctx);
+                        workspace.open_file_with_target(
+                            crate::code::buffer_location::LocalOrRemotePath::Local(path),
+                            target,
+                            None,
+                            source,
+                            ctx,
+                        );
                     });
                 }
             }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5893,7 +5893,12 @@ impl Workspace {
             FileTarget::MarkdownViewer(layout) => {
                 let session = self.get_active_session(ctx);
 
-                self.open_file_notebook(path.clone(), session, layout, ctx);
+                self.open_file_notebook(
+                    LocalOrRemotePath::Local(path.clone()),
+                    session,
+                    layout,
+                    ctx,
+                );
             }
             FileTarget::EnvEditor => {
                 let editor_value: Option<String> = self
@@ -5995,16 +6000,24 @@ impl Workspace {
                             ctx,
                         );
                     }
-                    LocalOrRemotePath::Remote(_) => {
+                    LocalOrRemotePath::Remote(_) =>
+                    {
                         #[cfg(feature = "local_fs")]
-                        self.open_code(
-                            code_source,
-                            crate::util::openable_file_type::EditorLayout::SplitPane,
-                            None,
-                            false,
-                            &[],
-                            ctx,
-                        );
+                        match target {
+                            FileTarget::MarkdownViewer(layout) => {
+                                self.open_file_notebook(location.clone(), None, *layout, ctx);
+                            }
+                            _ => {
+                                self.open_code(
+                                    code_source,
+                                    crate::util::openable_file_type::EditorLayout::SplitPane,
+                                    None,
+                                    false,
+                                    &[],
+                                    ctx,
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -7374,7 +7387,7 @@ impl Workspace {
     #[cfg(feature = "local_fs")]
     fn open_file_notebook(
         &mut self,
-        path: PathBuf,
+        path: LocalOrRemotePath,
         session: Option<Arc<Session>>,
         layout: EditorLayout,
         ctx: &mut ViewContext<Self>,
@@ -14338,7 +14351,12 @@ impl Workspace {
                 #[cfg(feature = "local_fs")]
                 {
                     let layout = *EditorSettings::as_ref(ctx).open_file_layout.value();
-                    self.open_file_notebook(path.clone(), Some(session.clone()), layout, ctx);
+                    self.open_file_notebook(
+                        LocalOrRemotePath::Local(path.clone()),
+                        Some(session.clone()),
+                        layout,
+                        ctx,
+                    );
                 }
             }
             pane_group::Event::MoveToSpace {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5776,7 +5776,7 @@ impl Workspace {
                         None,
                     );
                     self.open_file_with_target(
-                        path.clone(),
+                        LocalOrRemotePath::Local(path.clone()),
                         target,
                         None,
                         CodeSource::Link {
@@ -5857,7 +5857,7 @@ impl Workspace {
     #[cfg(not(feature = "local_fs"))]
     pub fn open_file_with_target(
         &mut self,
-        _path: PathBuf,
+        _path: LocalOrRemotePath,
         _target: FileTarget,
         _line_col: Option<LineAndColumnArg>,
         _code_source: CodeSource,
@@ -5868,107 +5868,121 @@ impl Workspace {
     #[cfg(feature = "local_fs")]
     pub fn open_file_with_target(
         &mut self,
-        path: PathBuf,
+        path: LocalOrRemotePath,
         target: FileTarget,
         line_col: Option<LineAndColumnArg>,
         code_source: CodeSource,
         ctx: &mut ViewContext<Self>,
     ) {
         // Handle directories for CodeEditor(NewTab) target by opening a new terminal tab
-        if path.is_dir() && matches!(target, FileTarget::CodeEditor(EditorLayout::NewTab)) {
-            self.add_tab_with_pane_layout(
-                PanesLayout::SingleTerminal(Box::new(NewTerminalOptions {
-                    initial_directory: Some(path.clone()),
-                    hide_homepage: true,
-                    ..Default::default()
-                })),
-                Arc::new(HashMap::new()),
-                None,
-                ctx,
-            );
-            return;
+        if let LocalOrRemotePath::Local(ref local_path) = path {
+            if local_path.is_dir() && matches!(target, FileTarget::CodeEditor(EditorLayout::NewTab))
+            {
+                self.add_tab_with_pane_layout(
+                    PanesLayout::SingleTerminal(Box::new(NewTerminalOptions {
+                        initial_directory: Some(local_path.clone()),
+                        hide_homepage: true,
+                        ..Default::default()
+                    })),
+                    Arc::new(HashMap::new()),
+                    None,
+                    ctx,
+                );
+                return;
+            }
         }
 
         match target {
             FileTarget::MarkdownViewer(layout) => {
                 let session = self.get_active_session(ctx);
-
-                self.open_file_notebook(
-                    LocalOrRemotePath::Local(path.clone()),
-                    session,
-                    layout,
-                    ctx,
-                );
-            }
-            FileTarget::EnvEditor => {
-                let editor_value: Option<String> = self
-                    .get_active_session(ctx)
-                    .and_then(|session| session.editor().map(|s| s.to_string()));
-
-                if let Some(ref editor_env) = editor_value {
-                    if let Ok(editor) = Editor::try_from(editor_env.as_str()) {
-                        crate::util::file::open_file_path_with_editor(
-                            line_col,
-                            path.clone(),
-                            Some(editor),
-                            ctx,
-                        );
-                        return;
-                    }
-
-                    // If we have an editor string but it's not a known Editor, we try to run it in a new pane
-                    let new_pane_id =
-                        self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
-                            pane_group.add_terminal_pane(
-                                Direction::Right,
-                                None, /*chosen_shell*/
-                                ctx,
-                            )
-                        });
-
-                    if let Some(terminal_view_handle) = self
-                        .active_tab_pane_group()
-                        .as_ref(ctx)
-                        .terminal_view_from_pane_id(new_pane_id, ctx)
-                    {
-                        let editor_ref = Some(editor_env.as_str());
-                        let path_clone = path.clone();
-                        terminal_view_handle.update(ctx, |terminal, ctx| {
-                            let editor_command =
-                                crate::util::file::external_editor::generate_editor_command(
-                                    &path_clone,
-                                    line_col,
-                                    editor_ref,
-                                );
-                            terminal.set_pending_command(&editor_command, ctx);
-                        });
-                        return;
-                    } else {
-                        log::error!(
-                            "Could not get terminal view handle for new pane when attempting to open file with $EDITOR."
-                        );
-                    }
-                }
-
-                crate::util::file::open_file_path_in_external_editor(line_col, path.clone(), ctx);
+                self.open_file_notebook(path, session, layout, ctx);
             }
             FileTarget::CodeEditor(layout) => {
                 let open_as_preview = false;
                 self.open_code(code_source, layout, line_col, open_as_preview, &[], ctx);
             }
-            FileTarget::ExternalEditor(editor) => {
-                crate::util::file::open_file_path_with_editor(
-                    line_col,
-                    path.clone(),
-                    Some(editor),
-                    ctx,
-                );
-            }
-            FileTarget::SystemDefault => {
-                crate::util::file::open_file_path_with_editor(line_col, path.clone(), None, ctx);
-            }
-            FileTarget::SystemGeneric => {
-                ctx.open_file_path(&path);
+            // The remaining targets only apply to local files.
+            _ => {
+                let Some(local_path) = path.to_local_path().map(Path::to_path_buf) else {
+                    log::warn!("FileTarget::{target:?} is not supported for remote files");
+                    return;
+                };
+                match target {
+                    FileTarget::EnvEditor => {
+                        let editor_value: Option<String> = self
+                            .get_active_session(ctx)
+                            .and_then(|session| session.editor().map(|s| s.to_string()));
+
+                        if let Some(ref editor_env) = editor_value {
+                            if let Ok(editor) = Editor::try_from(editor_env.as_str()) {
+                                crate::util::file::open_file_path_with_editor(
+                                    line_col,
+                                    local_path.clone(),
+                                    Some(editor),
+                                    ctx,
+                                );
+                                return;
+                            }
+
+                            // If we have an editor string but it's not a known Editor, we try to run it in a new pane
+                            let new_pane_id =
+                                self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
+                                    pane_group.add_terminal_pane(
+                                        Direction::Right,
+                                        None, /*chosen_shell*/
+                                        ctx,
+                                    )
+                                });
+
+                            if let Some(terminal_view_handle) = self
+                                .active_tab_pane_group()
+                                .as_ref(ctx)
+                                .terminal_view_from_pane_id(new_pane_id, ctx)
+                            {
+                                let editor_ref = Some(editor_env.as_str());
+                                let path_clone = local_path.clone();
+                                terminal_view_handle.update(ctx, |terminal, ctx| {
+                                    let editor_command =
+                                        crate::util::file::external_editor::generate_editor_command(
+                                            &path_clone,
+                                            line_col,
+                                            editor_ref,
+                                        );
+                                    terminal.set_pending_command(&editor_command, ctx);
+                                });
+                                return;
+                            } else {
+                                log::error!(
+                                    "Could not get terminal view handle for new pane when attempting to open file with $EDITOR."
+                                );
+                            }
+                        }
+
+                        crate::util::file::open_file_path_in_external_editor(
+                            line_col, local_path, ctx,
+                        );
+                    }
+                    FileTarget::ExternalEditor(editor) => {
+                        crate::util::file::open_file_path_with_editor(
+                            line_col,
+                            local_path,
+                            Some(editor),
+                            ctx,
+                        );
+                    }
+                    FileTarget::SystemDefault => {
+                        crate::util::file::open_file_path_with_editor(
+                            line_col, local_path, None, ctx,
+                        );
+                    }
+                    FileTarget::SystemGeneric => {
+                        ctx.open_file_path(&local_path);
+                    }
+                    // Already handled in the outer match above.
+                    FileTarget::MarkdownViewer(_) | FileTarget::CodeEditor(_) => {
+                        log::error!("FileTarget::{target:?} should have been handled before entering local-only branch");
+                    }
+                }
             }
         }
     }
@@ -5990,36 +6004,13 @@ impl Workspace {
                 let code_source = CodeSource::FileTree {
                     location: location.clone(),
                 };
-                match location {
-                    LocalOrRemotePath::Local(path) => {
-                        self.open_file_with_target(
-                            path.clone(),
-                            target.clone(),
-                            *line_col,
-                            code_source,
-                            ctx,
-                        );
-                    }
-                    LocalOrRemotePath::Remote(_) =>
-                    {
-                        #[cfg(feature = "local_fs")]
-                        match target {
-                            FileTarget::MarkdownViewer(layout) => {
-                                self.open_file_notebook(location.clone(), None, *layout, ctx);
-                            }
-                            _ => {
-                                self.open_code(
-                                    code_source,
-                                    crate::util::openable_file_type::EditorLayout::SplitPane,
-                                    None,
-                                    false,
-                                    &[],
-                                    ctx,
-                                );
-                            }
-                        }
-                    }
-                }
+                self.open_file_with_target(
+                    location.clone(),
+                    target.clone(),
+                    *line_col,
+                    code_source,
+                    ctx,
+                );
             }
             LeftPanelEvent::NewConversationInNewTab => {
                 self.add_terminal_tab_with_new_agent_view(ctx);
@@ -6062,7 +6053,7 @@ impl Workspace {
                 }
 
                 self.open_file_with_target(
-                    path.clone(),
+                    LocalOrRemotePath::Local(path.clone()),
                     target,
                     line_col,
                     CodeSource::Link {
@@ -6608,7 +6599,7 @@ impl Workspace {
         );
         send_telemetry_from_ctx!(TabConfigsTelemetryEvent::MenuCreateNewTabConfigClicked, ctx);
         self.open_file_with_target(
-            path.clone(),
+            LocalOrRemotePath::Local(path.clone()),
             target,
             None,
             CodeSource::Link {
@@ -6644,7 +6635,7 @@ impl Workspace {
                     None,
                 );
                 self.open_file_with_target(
-                    path.clone(),
+                    LocalOrRemotePath::Local(path.clone()),
                     target,
                     None,
                     CodeSource::Link {
@@ -9160,7 +9151,7 @@ impl Workspace {
                 line_col,
             } => {
                 self.open_file_with_target(
-                    path.clone(),
+                    LocalOrRemotePath::Local(path.clone()),
                     target.clone(),
                     *line_col,
                     CodeSource::Link {
@@ -14351,12 +14342,7 @@ impl Workspace {
                 #[cfg(feature = "local_fs")]
                 {
                     let layout = *EditorSettings::as_ref(ctx).open_file_layout.value();
-                    self.open_file_notebook(
-                        LocalOrRemotePath::Local(path.clone()),
-                        Some(session.clone()),
-                        layout,
-                        ctx,
-                    );
+                    self.open_file_notebook(path.clone(), Some(session.clone()), layout, ctx);
                 }
             }
             pane_group::Event::MoveToSpace {
@@ -15227,7 +15213,7 @@ impl Workspace {
                 line_col,
             } => {
                 self.open_file_with_target(
-                    path.clone(),
+                    LocalOrRemotePath::Local(path.clone()),
                     target.clone(),
                     *line_col,
                     CodeSource::Link {
@@ -21296,7 +21282,7 @@ impl TypedActionView for Workspace {
                         None,
                     );
                     self.open_file_with_target(
-                        path.clone(),
+                        LocalOrRemotePath::Local(path.clone()),
                         target,
                         None,
                         CodeSource::Link {
@@ -21347,7 +21333,7 @@ impl TypedActionView for Workspace {
                         None,
                     );
                     self.open_file_with_target(
-                        path.clone(),
+                        LocalOrRemotePath::Local(path.clone()),
                         target,
                         None,
                         CodeSource::Link {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -221,8 +221,6 @@ use crate::ai::conversation_details_panel::ConversationDetailsPanel;
 use crate::uri::browser_url_handler::{parse_current_url, update_browser_url};
 use crate::workflows::manager::WorkflowManager;
 use crate::workflows::workflow::Workflow;
-#[cfg(feature = "local_fs")]
-use repo_metadata::RemoteRepositoryIdentifier;
 #[cfg(target_family = "wasm")]
 use url::Url;
 
@@ -14674,30 +14672,12 @@ impl Workspace {
                     }
                 }
             }
-            #[cfg(feature = "local_fs")]
-            pane_group::Event::RemoteRepoNavigated { remote_path } => {
-                let remote_id = RemoteRepositoryIdentifier::new(
-                    remote_path.host_id.clone(),
-                    remote_path.path.clone(),
-                );
-                let pane_group_id = pane_group.id();
-                if let Some(file_tree_view) = self
-                    .working_directories_model
-                    .as_ref(ctx)
-                    .get_file_tree_view(pane_group_id)
-                {
-                    file_tree_view.update(ctx, |view, ctx| {
-                        view.set_remote_root_directories(std::slice::from_ref(&remote_id), ctx);
-                    });
-                }
-
-                // Remote repos now enter repository_roots through
-                // refresh_working_directories_for_pane_group (via
-                // pwd_as_local_or_remote). No need to register here —
-                // doing so would race with refresh and prevent stale
-                // DiffStateModels from being dropped.
-            }
-            #[cfg(not(feature = "local_fs"))]
+            // Remote repo navigation is handled entirely through
+            // refresh_working_directories_for_pane_group, which inserts
+            // remote paths into the unified `pane_groups` set. The
+            // resulting `DirectoriesChanged` event carries both local
+            // and remote dirs, so the left panel subscriber forwards
+            // them to `set_remote_root_directories` on the file tree.
             pane_group::Event::RemoteRepoNavigated { .. } => {}
             pane_group::Event::OpenChildAgentInNewTab { conversation_id } => {
                 // Move the existing child pane into a new tab so the live

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13217,25 +13217,25 @@ impl Workspace {
             .terminal_view_working_directories(ctx)
             .filter_map(|(id, cwd)| cwd.map(|c| (id, c)))
             .collect();
-        let code_local_paths: Vec<(EntityId, String)> = pane_group
+        let code_paths: Vec<(EntityId, LocalOrRemotePath)> = pane_group
             .as_ref(ctx)
-            .code_view_local_paths(ctx)
-            .filter_map(|(id, cwd)| cwd.map(|c| (id, c)))
+            .code_view_paths(ctx)
+            .filter_map(|(id, path)| path.map(|p| (id, p)))
             .collect();
-        let code_diff_local_paths: Vec<(EntityId, String)> = pane_group
+        let code_diff_paths: Vec<(EntityId, LocalOrRemotePath)> = pane_group
             .as_ref(ctx)
-            .code_diff_view_local_paths(ctx)
-            .filter_map(|(id, cwd)| cwd.map(|c| (id, c)))
+            .code_diff_view_paths(ctx)
+            .filter_map(|(id, path)| path.map(|p| (id, p)))
             .collect();
-        let notebook_local_paths: Vec<(EntityId, String)> = pane_group
+        let notebook_paths: Vec<(EntityId, LocalOrRemotePath)> = pane_group
             .as_ref(ctx)
-            .file_notebook_local_paths(ctx)
-            .filter_map(|(id, cwd)| cwd.map(|c| (id, c)))
+            .file_notebook_paths(ctx)
+            .filter_map(|(id, path)| path.map(|p| (id, p)))
             .collect();
-        let local_paths: Vec<(EntityId, String)> = code_local_paths
+        let editor_paths: Vec<(EntityId, LocalOrRemotePath)> = code_paths
             .into_iter()
-            .chain(notebook_local_paths)
-            .chain(code_diff_local_paths)
+            .chain(notebook_paths)
+            .chain(code_diff_paths)
             .collect();
 
         // Get the focused terminal ID to prioritize it in the repo_to_terminal map
@@ -13248,7 +13248,7 @@ impl Workspace {
             model.refresh_working_directories_for_pane_group(
                 pane_group_id,
                 terminal_cwds,
-                local_paths,
+                editor_paths,
                 focused_terminal_id,
                 ctx,
             );

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -306,9 +306,7 @@ impl LeftPanelView {
                     active_pane_group.as_ref(ctx).left_panel_open && me.is_file_tree_active();
                 file_tree_view.update(ctx, |view, ctx| {
                     view.set_root_directories(local_directories, ctx);
-                    if !remote_repos.is_empty() {
-                        view.set_remote_root_directories(&remote_repos, ctx);
-                    }
+                    view.set_remote_root_directories(&remote_repos, ctx);
                     view.set_has_terminal_session(has_terminal_session, ctx);
                     view.set_is_active(is_visible, ctx);
 
@@ -642,9 +640,7 @@ impl LeftPanelView {
         let is_visible = left_panel_open && self.is_file_tree_active();
         file_tree_view.update(ctx, |view, ctx| {
             view.set_root_directories(local_directories, ctx);
-            if !remote_repos.is_empty() {
-                view.set_remote_root_directories(&remote_repos, ctx);
-            }
+            view.set_remote_root_directories(&remote_repos, ctx);
             view.set_has_terminal_session(has_terminal_session, ctx);
             view.set_active_file_model(active_file_model, ctx);
             view.set_is_active(is_visible, ctx);

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -306,6 +306,7 @@ impl LeftPanelView {
                     active_pane_group.as_ref(ctx).left_panel_open && me.is_file_tree_active();
                 file_tree_view.update(ctx, |view, ctx| {
                     view.set_root_directories(local_directories, ctx);
+                    #[cfg(feature = "local_fs")]
                     view.set_remote_root_directories(&remote_repos, ctx);
                     view.set_has_terminal_session(has_terminal_session, ctx);
                     view.set_is_active(is_visible, ctx);
@@ -640,6 +641,7 @@ impl LeftPanelView {
         let is_visible = left_panel_open && self.is_file_tree_active();
         file_tree_view.update(ctx, |view, ctx| {
             view.set_root_directories(local_directories, ctx);
+            #[cfg(feature = "local_fs")]
             view.set_remote_root_directories(&remote_repos, ctx);
             view.set_has_terminal_session(has_terminal_session, ctx);
             view.set_active_file_model(active_file_model, ctx);

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -277,6 +277,7 @@ impl LeftPanelView {
                     .iter()
                     .filter_map(|d| d.path.to_local_path().map(|p| p.to_path_buf()))
                     .collect();
+                #[allow(unused_variables)]
                 let remote_repos: Vec<repo_metadata::RemoteRepositoryIdentifier> = directories
                     .iter()
                     .filter_map(|d| match &d.path {
@@ -613,6 +614,7 @@ impl LeftPanelView {
             .iter()
             .filter_map(|d| d.path.to_local_path().map(|p| p.to_path_buf()))
             .collect();
+        #[allow(unused_variables)]
         let remote_repos: Vec<repo_metadata::RemoteRepositoryIdentifier> = active_directories
             .iter()
             .filter_map(|d| match &d.path {

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -272,27 +272,43 @@ impl LeftPanelView {
                 }
                 let has_terminal_session = directories.iter().any(|dir| dir.terminal_id.is_some());
 
-                // Update GlobalSearchView root directories based on all working directories
-                let roots: Vec<PathBuf> = directories.iter().map(|d| d.path.clone()).collect();
+                // Split directories into local and remote.
+                let local_paths: Vec<PathBuf> = directories
+                    .iter()
+                    .filter_map(|d| d.path.to_local_path().map(|p| p.to_path_buf()))
+                    .collect();
+                let remote_repos: Vec<repo_metadata::RemoteRepositoryIdentifier> = directories
+                    .iter()
+                    .filter_map(|d| match &d.path {
+                        LocalOrRemotePath::Remote(remote_path) => {
+                            Some(repo_metadata::RemoteRepositoryIdentifier::new(
+                                remote_path.host_id.clone(),
+                                remote_path.path.clone(),
+                            ))
+                        }
+                        _ => None,
+                    })
+                    .collect();
 
+                // Update GlobalSearchView root directories (local only).
                 let global_search_view =
                     me.get_or_create_global_search_view_for_pane_group(active_pane_group.id(), ctx);
                 global_search_view.update(ctx, |view, view_ctx| {
-                    view.set_root_directories(roots, view_ctx);
+                    view.set_root_directories(local_paths.clone(), view_ctx);
                 });
 
-                let directories: Vec<PathBuf> =
-                    directories.iter().map(|dir| dir.path.clone()).collect();
-
                 // Directories are already in display order (most recent first) from the model
-                let directories = deduplicate_by_directory_name(directories);
+                let local_directories = deduplicate_by_directory_name(local_paths);
                 let file_tree_view =
                     me.get_or_create_file_tree_view_for_pane_group(active_pane_group.id(), ctx);
 
                 let is_visible =
                     active_pane_group.as_ref(ctx).left_panel_open && me.is_file_tree_active();
                 file_tree_view.update(ctx, |view, ctx| {
-                    view.set_root_directories(directories, ctx);
+                    view.set_root_directories(local_directories, ctx);
+                    if !remote_repos.is_empty() {
+                        view.set_remote_root_directories(&remote_repos, ctx);
+                    }
                     view.set_has_terminal_session(has_terminal_session, ctx);
                     view.set_is_active(is_visible, ctx);
 
@@ -593,26 +609,42 @@ impl LeftPanelView {
             .iter()
             .any(|dir| dir.terminal_id.is_some());
 
-        // Update GlobalSearchView root directories based on all working directories
-        let roots: Vec<PathBuf> = active_directories.iter().map(|d| d.path.clone()).collect();
+        // Split directories into local and remote.
+        let local_paths: Vec<PathBuf> = active_directories
+            .iter()
+            .filter_map(|d| d.path.to_local_path().map(|p| p.to_path_buf()))
+            .collect();
+        let remote_repos: Vec<repo_metadata::RemoteRepositoryIdentifier> = active_directories
+            .iter()
+            .filter_map(|d| match &d.path {
+                LocalOrRemotePath::Remote(remote_path) => {
+                    Some(repo_metadata::RemoteRepositoryIdentifier::new(
+                        remote_path.host_id.clone(),
+                        remote_path.path.clone(),
+                    ))
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Update GlobalSearchView root directories (local only).
         let global_search_view =
             self.get_or_create_global_search_view_for_pane_group(pane_group_id, ctx);
         global_search_view.update(ctx, |view, view_ctx| {
-            view.set_root_directories(roots, view_ctx);
+            view.set_root_directories(local_paths.clone(), view_ctx);
         });
 
-        let directories: Vec<PathBuf> = active_directories
-            .iter()
-            .map(|dir| dir.path.clone())
-            .collect();
-        let directories = deduplicate_by_directory_name(directories);
+        let local_directories = deduplicate_by_directory_name(local_paths);
         let active_file_model = pane_group.as_ref(ctx).active_file_model().clone();
 
         let file_tree_view = self.get_or_create_file_tree_view_for_pane_group(pane_group_id, ctx);
         let left_panel_open = pane_group.as_ref(ctx).left_panel_open;
         let is_visible = left_panel_open && self.is_file_tree_active();
         file_tree_view.update(ctx, |view, ctx| {
-            view.set_root_directories(directories, ctx);
+            view.set_root_directories(local_directories, ctx);
+            if !remote_repos.is_empty() {
+                view.set_remote_root_directories(&remote_repos, ctx);
+            }
             view.set_has_terminal_session(has_terminal_session, ctx);
             view.set_active_file_model(active_file_model, ctx);
             view.set_is_active(is_visible, ctx);


### PR DESCRIPTION
## Description

Enable markdown rendering for remote SSH sessions and fix file tree loading when only a remote editor pane is present.

### Core feature: Remote markdown rendering (Steps 1–6)
- Unified `SourceFile::FileBased` to carry `LocalOrRemotePath` instead of local-only `PathBuf`
- Unified `FilePane::new` and `open()` to accept `LocalOrRemotePath`
- File tree routes remote markdown files to the rendered viewer
- Workspace handles remote `MarkdownViewer` target
- Rendered/Raw toggle carries `LocalOrRemotePath`

### Bug fix: File tree loading with remote-only editor pane
- Root cause: `DirectoriesChanged` only carried local paths, so when only a remote editor pane existed (no terminal), the file tree never received remote directories
- Fix: Widened `WorkingDirectoriesModel.pane_groups` from `IndexSet<PathBuf>` to `IndexSet<LocalOrRemotePath>` so `DirectoriesChanged` now carries both local and remote directories
- Removed the redundant `RemoteRepoNavigated` → `set_remote_root_directories` handler in `workspace/view.rs` — remote repos now flow through `DirectoriesChanged` like local ones
- Left panel subscriber splits directories into local (for `set_root_directories` + global search) and remote (for `set_remote_root_directories`) at the consumer level

### Code review feedback
- Refactored `code_view_local_paths`/`file_notebook_local_paths`/`editor_remote_paths` into unified `code_view_paths`/`file_notebook_paths` returning `LocalOrRemotePath`
- Extended `CodeDiffView` with `primary_file_location()` for correct remote file identification

**Oz conversation**: https://staging.warp.dev/conversation/6553c367-f363-4afa-9f5f-64815bd27790

**Plans**:
- [Enable Markdown Rendering for Remote SSH Sessions](https://staging.warp.dev/drive/notebook/Vo1ZuSff06mWjwEkx0W0fG)
- [Unify DirectoriesChanged to carry both local and remote paths](https://staging.warp.dev/drive/notebook/tCa23ahOapSWYSujLs4aAt)

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Markdown files opened from remote SSH sessions now render in the markdown viewer with Rendered/Raw toggle support.