### PR TITLE
Fix deadlock in secret redaction due to mutex ordering mismatch.

### DIFF
--- a/app/src/ai/blocklist/block/secret_redaction.rs
+++ b/app/src/ai/blocklist/block/secret_redaction.rs
@@ -6,7 +6,7 @@ use warpui::elements::{MouseStateHandle, PartialClickableElement, SecretRange};
 use warpui::platform::Cursor;
 
 use crate::ai::agent::{AIAgentOutput, AIAgentTextSection, AgentOutputText};
-use crate::terminal::model::secrets::{SecretLevel, REGEX_LEVEL_METADATA, SECRETS_REGEX};
+use crate::terminal::model::secrets::{SecretLevel, SecretsRegex, SECRETS_REGEX};
 
 use super::{AIBlockAction, TextLocation};
 
@@ -22,11 +22,11 @@ pub(crate) fn find_secrets_in_text(text: &str) -> Vec<SecretRange> {
 
 /// Returns the ranges of detected secrets in the given text along with their SecretLevel.
 pub(crate) fn find_secrets_in_text_with_levels(text: &str) -> Vec<(SecretRange, SecretLevel)> {
-    // Combine all regex patterns into a single regex pattern with non-capturing groups, for efficiency.
-    // Note that we purposely use regex::Regex instead of RegexDFAs since we are working a Text (containing
-    // a normal String) rather than the Grid (where text is in Cells with 1 character each).
-    let regex = SECRETS_REGEX.read();
-    let metadata = REGEX_LEVEL_METADATA.read();
+    let _guard = SECRETS_REGEX.read();
+    let SecretsRegex {
+        regex,
+        level_metadata: metadata,
+    } = &*_guard;
 
     let mut secret_ranges = vec![];
     let mut byte_to_char_index = vec![0; text.len() + 1]; // Map byte index to char index

--- a/app/src/ai/blocklist/block/secret_redaction.rs
+++ b/app/src/ai/blocklist/block/secret_redaction.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use itertools::Itertools;
 use similar::DiffableStr;
@@ -22,11 +23,22 @@ pub(crate) fn find_secrets_in_text(text: &str) -> Vec<SecretRange> {
 
 /// Returns the ranges of detected secrets in the given text along with their SecretLevel.
 pub(crate) fn find_secrets_in_text_with_levels(text: &str) -> Vec<(SecretRange, SecretLevel)> {
-    let _guard = SECRETS_REGEX.read();
+    let secrets_regex: Arc<SecretsRegex> = {
+        SECRETS_REGEX.lock().clone()
+    };
+
+    find_secrets_in_text_with_levels_using_regex(text, &secrets_regex)
+}
+
+pub(crate) fn find_secrets_in_text_with_levels_using_regex(
+    text: &str,
+    secrets_regex: &SecretsRegex,
+) -> Vec<(SecretRange, SecretLevel)> {
     let SecretsRegex {
         regex,
         level_metadata,
-    } = &*_guard;
+        ..
+    } = secrets_regex;
 
     let mut secret_ranges = vec![];
     let mut byte_to_char_index = vec![0; text.len() + 1]; // Map byte index to char index

--- a/app/src/ai/blocklist/block/secret_redaction.rs
+++ b/app/src/ai/blocklist/block/secret_redaction.rs
@@ -23,9 +23,7 @@ pub(crate) fn find_secrets_in_text(text: &str) -> Vec<SecretRange> {
 
 /// Returns the ranges of detected secrets in the given text along with their SecretLevel.
 pub(crate) fn find_secrets_in_text_with_levels(text: &str) -> Vec<(SecretRange, SecretLevel)> {
-    let secrets_regex: Arc<SecretsRegex> = {
-        SECRETS_REGEX.lock().clone()
-    };
+    let secrets_regex: Arc<SecretsRegex> = { SECRETS_REGEX.lock().clone() };
 
     find_secrets_in_text_with_levels_using_regex(text, &secrets_regex)
 }

--- a/app/src/ai/blocklist/block/secret_redaction.rs
+++ b/app/src/ai/blocklist/block/secret_redaction.rs
@@ -25,7 +25,7 @@ pub(crate) fn find_secrets_in_text_with_levels(text: &str) -> Vec<(SecretRange, 
     let _guard = SECRETS_REGEX.read();
     let SecretsRegex {
         regex,
-        level_metadata: metadata,
+        level_metadata,
     } = &*_guard;
 
     let mut secret_ranges = vec![];
@@ -49,12 +49,12 @@ pub(crate) fn find_secrets_in_text_with_levels(text: &str) -> Vec<(SecretRange, 
 
         // Determine which pattern matched by getting the pattern ID and map via counts
         let pattern_id = mat.pattern().as_usize();
-        let total_patterns = metadata.enterprise_count + metadata.user_count;
+        let total_patterns = level_metadata.enterprise_count + level_metadata.user_count;
         if pattern_id >= total_patterns {
             log::error!("Secret level not found for pattern ID {pattern_id}");
             continue;
         }
-        let secret_level = if pattern_id < metadata.enterprise_count {
+        let secret_level = if pattern_id < level_metadata.enterprise_count {
             SecretLevel::Enterprise
         } else {
             SecretLevel::User

--- a/app/src/terminal/model/grid/secrets.rs
+++ b/app/src/terminal/model/grid/secrets.rs
@@ -1,16 +1,18 @@
+use std::sync::Arc;
 use std::{collections::HashSet, ops::RangeInclusive};
 
 use itertools::Itertools as _;
 
-use crate::ai::blocklist::block::secret_redaction::find_secrets_in_text_with_levels;
+use crate::ai::blocklist::block::secret_redaction::find_secrets_in_text_with_levels_using_regex;
 use crate::terminal::model::grid::{grapheme_cursor, Dimensions as _};
+use crate::terminal::model::secrets::SecretsRegex;
 use crate::terminal::model::terminal_model::RangeInModel;
 use crate::terminal::model::{
     grid::RespectDisplayedOutput,
     index::{Direction, Point},
     secrets::{
         IsObfuscated, ObfuscateSecrets, Secret, SecretAndHandle, SecretHandle, SecretLevel,
-        SECRETS_DFA,
+        SECRETS_REGEX,
     },
 };
 
@@ -226,12 +228,15 @@ impl GridHandler {
             end_point = end_point.max(*cleared_secrets_range.end());
         }
 
+        let secrets_regex: Arc<SecretsRegex> = {
+            SECRETS_REGEX.lock().clone()
+        };
         let matches = self
             .regex_iter(
                 start_point,
                 end_point,
                 Direction::Right,
-                &SECRETS_DFA.read(),
+                &secrets_regex.dfas,
             )
             .collect_vec();
 
@@ -247,7 +252,7 @@ impl GridHandler {
             };
 
             // Determine the secret level by re-scanning the plaintext
-            let secret_level = self.determine_secret_level(&plaintext);
+            let secret_level = self.determine_secret_level(&plaintext, &secrets_regex);
 
             self.mark_secret_range(secret_match, is_obfuscated, plaintext, secret_level);
         }
@@ -272,8 +277,8 @@ impl GridHandler {
 
     /// Determines the secret level by re-scanning the plaintext using the rich content detection
     /// which includes secret level information
-    fn determine_secret_level(&self, plaintext: &str) -> SecretLevel {
-        let secrets_with_levels = find_secrets_in_text_with_levels(plaintext);
+    fn determine_secret_level(&self, plaintext: &str, regex: &SecretsRegex) -> SecretLevel {
+        let secrets_with_levels = find_secrets_in_text_with_levels_using_regex(plaintext, regex);
 
         // Find the first match that corresponds to our plaintext
         // In case of multiple matches, we return the highest priority level

--- a/app/src/terminal/model/grid/secrets.rs
+++ b/app/src/terminal/model/grid/secrets.rs
@@ -228,9 +228,7 @@ impl GridHandler {
             end_point = end_point.max(*cleared_secrets_range.end());
         }
 
-        let secrets_regex: Arc<SecretsRegex> = {
-            SECRETS_REGEX.lock().clone()
-        };
+        let secrets_regex: Arc<SecretsRegex> = { SECRETS_REGEX.lock().clone() };
         let matches = self
             .regex_iter(
                 start_point,

--- a/app/src/terminal/model/secrets.rs
+++ b/app/src/terminal/model/secrets.rs
@@ -5,10 +5,11 @@ use crate::terminal::model::index::Point;
 use anyhow::anyhow;
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use parking_lot::RwLock;
+use parking_lot::Mutex;
 use rangemap::{RangeInclusiveMap, StepLite};
 use std::collections::HashMap;
 use std::ops::{Not, RangeInclusive};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use warpui::elements::SecretRange;
 use warpui::EntityId;
@@ -20,8 +21,12 @@ use crate::terminal::model::find::RegexDFAs;
 
 /// A regex pattern that can be used to detect secrets in text.
 pub struct SecretsRegex {
-    /// The regex pattern to match secrets.  This is a meta::Regex which supports multiple patterns.
+    /// The regex pattern to match secrets in strings.  This is a meta::Regex which supports
+    /// multiple patterns.
     pub regex: regex_automata::meta::Regex,
+
+    /// The DFAs used to search for secrets in the grid.
+    pub dfas: RegexDFAs,
 
     /// Metadata about the regex pattern, including which secret levels it corresponds to.
     pub level_metadata: RegexLevelMetadata,
@@ -37,23 +42,23 @@ pub struct RegexLevelMetadata {
 }
 
 lazy_static! {
-    /// Used for secret redaction in the Grid.
-    /// Initially empty - will be populated with user-defined regexes when safe mode is enabled.
-    pub(in crate::terminal::model) static ref SECRETS_DFA: RwLock<RegexDFAs> = RwLock::new(
-        RegexDFAs::new_many(&[], true, true)
-            .expect("should be able to construct empty regex DFA")
-    );
-    /// Used for secret redaction in simple text strings (e.g.: rich content blocks).
-    /// Initially empty - will be populated with user-defined regexes when safe mode is enabled.
-    pub static ref SECRETS_REGEX: RwLock<SecretsRegex> = RwLock::new(
-        SecretsRegex {
+    /// The information needed to search for secrets in strings or terminal grids.
+    /// 
+    /// These are initially empty, and will be populated with regexes when safe mode is enabled.
+    /// 
+    /// This is wrapped in an Arc so that readers can clone it cheaply to keep the critical section
+    /// short, allowing writers to set a new set of regexes for future readers without being blocked
+    /// on any users of the old patterns.
+    pub static ref SECRETS_REGEX: Mutex<Arc<SecretsRegex>> = Mutex::new(
+        Arc::new(SecretsRegex {
             regex: regex_automata::meta::Regex::new_many(&[] as &[&str])
                 .expect("should be able to construct empty regex"),
+            dfas: RegexDFAs::new_many(&[], true, true).expect("should be able to construct empty regex DFA"),
             level_metadata: RegexLevelMetadata {
                 enterprise_count: 0,
                 user_count: 0,
             },
-        }
+        })
     );
 }
 
@@ -334,16 +339,17 @@ impl SecretMap {
     }
 }
 
-/// Updates secret scanning to separate user-defined regexes from enterprise ones.
-/// Ensures enterprise secrets are handled differently, maintaining separation from user settings.
-/// If the internal [`RegexDFAs`] can't be constructed from the new regexes for any reason,
-/// the current DFA is kept unchanged.
+/// Updates secret scanning with a new set of user-defined and enterprise regexes.
+///
+/// The implementation here ensures enterprise secrets are handled differently, maintaining separation
+/// from the user's configuration in their settings.
+///
+/// If the internal [`RegexDFAs`] or [`regex_automata::meta::Regex`] can't be constructed from the
+/// new regexes for any reason, the current regexes are kept unchanged.
 pub fn set_user_and_enterprise_secret_regexes<'a>(
     user_secrets: impl IntoIterator<Item = &'a regex::Regex>,
     enterprise_secrets: impl IntoIterator<Item = &'a regex::Regex>,
 ) {
-    let mut secrets = SECRETS_DFA.write();
-
     // Collect enterprise and user secrets into vectors to count them
     let enterprise_secrets_vec: Vec<&'a regex::Regex> = enterprise_secrets.into_iter().collect();
     let user_secrets_vec: Vec<&'a regex::Regex> = user_secrets.into_iter().collect();
@@ -364,30 +370,32 @@ pub fn set_user_and_enterprise_secret_regexes<'a>(
         .chain(filtered_user_secrets_vec.iter().map(|regex| regex.as_str()))
         .collect_vec();
 
-    let mut secrets_regex = SECRETS_REGEX.write();
-    match regex_automata::meta::Regex::new_many(&all_secrets) {
-        Ok(regex) => {
-            *secrets_regex = SecretsRegex {
-                regex,
-                level_metadata: RegexLevelMetadata {
-                    enterprise_count: enterprise_secrets_vec.len(),
-                    user_count: filtered_user_secrets_vec.len(),
-                },
-            };
-        }
-        Err(err) => {
-            log::error!("Failed to construct new Regex with combined secrets: {err:?}");
-        }
-    }
-
-    match RegexDFAs::new_many(&all_secrets, true, true) {
-        Ok(dfa) => {
-            *secrets = dfa;
-        }
+    // Make sure we can compile both the regex and the DFA before we attempt to replace the live
+    // ones.
+    let dfas = match RegexDFAs::new_many(&all_secrets, true, true) {
+        Ok(dfas) => dfas,
         Err(err) => {
             log::error!("Failed to construct new RegexDFA with combined secrets: {err:?}");
+            return;
         }
     };
+    let secrets_regex = match regex_automata::meta::Regex::new_many(&all_secrets) {
+        Ok(regex) => SecretsRegex {
+            regex,
+            dfas,
+            level_metadata: RegexLevelMetadata {
+                enterprise_count: enterprise_secrets_vec.len(),
+                user_count: filtered_user_secrets_vec.len(),
+            },
+        },
+        Err(err) => {
+            log::error!("Failed to construct new Regex with combined secrets: {err:?}");
+            return;
+        }
+    };
+
+    // Store a shareable reference to the new compiled regex, DFAs, and metadata.
+    *SECRETS_REGEX.lock() = Arc::new(secrets_regex);
 }
 
 /// A wrapper around a [`Point`] that implements [`StepLite`], allowing us to store it in a

--- a/app/src/terminal/model/secrets.rs
+++ b/app/src/terminal/model/secrets.rs
@@ -18,6 +18,15 @@ use super::grid::{Dimensions as _, RespectDisplayedOutput};
 use super::terminal_model::RangeInModel;
 use crate::terminal::model::find::RegexDFAs;
 
+/// A regex pattern that can be used to detect secrets in text.
+pub struct SecretsRegex {
+    /// The regex pattern to match secrets.  This is a meta::Regex which supports multiple patterns.
+    pub regex: regex_automata::meta::Regex,
+
+    /// Metadata about the regex pattern, including which secret levels it corresponds to.
+    pub level_metadata: RegexLevelMetadata,
+}
+
 /// Tracks counts to infer which regex patterns correspond to which secret levels
 #[derive(Debug, Clone)]
 pub struct RegexLevelMetadata {
@@ -36,15 +45,14 @@ lazy_static! {
     );
     /// Used for secret redaction in simple text strings (e.g.: rich content blocks).
     /// Initially empty - will be populated with user-defined regexes when safe mode is enabled.
-    pub static ref SECRETS_REGEX: RwLock<regex_automata::meta::Regex> = RwLock::new(
-        regex_automata::meta::Regex::new_many(&[] as &[&str])
-            .expect("should be able to construct empty regex")
-    );
-    /// Tracks counts to infer which regex patterns correspond to which secret levels
-    pub static ref REGEX_LEVEL_METADATA: RwLock<RegexLevelMetadata> = RwLock::new(
-        RegexLevelMetadata {
-            enterprise_count: 0,
-            user_count: 0,
+    pub static ref SECRETS_REGEX: RwLock<SecretsRegex> = RwLock::new(
+        SecretsRegex {
+            regex: regex_automata::meta::Regex::new_many(&[] as &[&str])
+                .expect("should be able to construct empty regex"),
+            level_metadata: RegexLevelMetadata {
+                enterprise_count: 0,
+                user_count: 0,
+            },
         }
     );
 }
@@ -356,15 +364,16 @@ pub fn set_user_and_enterprise_secret_regexes<'a>(
         .chain(filtered_user_secrets_vec.iter().map(|regex| regex.as_str()))
         .collect_vec();
 
-    // Update the metadata counts first to ensure it's ready when the new regexes are set
-    let mut metadata = REGEX_LEVEL_METADATA.write();
-    metadata.enterprise_count = enterprise_secrets_vec.len();
-    metadata.user_count = filtered_user_secrets_vec.len();
-
     let mut secrets_regex = SECRETS_REGEX.write();
     match regex_automata::meta::Regex::new_many(&all_secrets) {
         Ok(regex) => {
-            *secrets_regex = regex;
+            *secrets_regex = SecretsRegex {
+                regex,
+                level_metadata: RegexLevelMetadata {
+                    enterprise_count: enterprise_secrets_vec.len(),
+                    user_count: filtered_user_secrets_vec.len(),
+                },
+            };
         }
         Err(err) => {
             log::error!("Failed to construct new Regex with combined secrets: {err:?}");

--- a/app/src/terminal/model/secrets.rs
+++ b/app/src/terminal/model/secrets.rs
@@ -9,8 +9,8 @@ use parking_lot::Mutex;
 use rangemap::{RangeInclusiveMap, StepLite};
 use std::collections::HashMap;
 use std::ops::{Not, RangeInclusive};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use warpui::elements::SecretRange;
 use warpui::EntityId;
 
@@ -43,9 +43,9 @@ pub struct RegexLevelMetadata {
 
 lazy_static! {
     /// The information needed to search for secrets in strings or terminal grids.
-    /// 
+    ///
     /// These are initially empty, and will be populated with regexes when safe mode is enabled.
-    /// 
+    ///
     /// This is wrapped in an Arc so that readers can clone it cheaply to keep the critical section
     /// short, allowing writers to set a new set of regexes for future readers without being blocked
     /// on any users of the old patterns.


### PR DESCRIPTION
## Description

This fixes a potential deadlock in secret redaction caused by inconsistent mutex acquisition order between the read and write paths. Previously, the secret-redaction DFA, meta regex, and regex-level metadata were stored behind separate locks. If a reader acquired one lock at the same time that a writer acquired another, each path could then block forever waiting for the lock held by the other path.

The secret-redaction state is now stored as a single `SecretsRegex` snapshot containing the meta regex, grid-search DFAs, and level metadata. That snapshot is wrapped in an `Arc`, and the global state only stores the current `Arc`. Readers clone the current `Arc` under a very short critical section, then use that same snapshot for both DFA matching and level classification. Writers compile the replacement meta regex and DFAs before touching global state, then swap in one new `Arc` only after both structures have been built successfully.

This gives us a few stronger guarantees:

- There is only one global lock involved in publishing or reading secret-redaction state, so the original lock-order deadlock is no longer possible.
- If either the meta regex or DFA compilation fails, the current secret-redaction state is left unchanged, matching the function's documented behavior.
- Grid redaction uses one generation-consistent snapshot for both match detection and secret-level lookup, avoiding mixed old/new regex state during updates.
- Regex compilation no longer happens while holding the global lock, improving responsiveness while secret-redaction settings are refreshed.

The global lock is now a `Mutex` rather than an `RwLock`. Since readers only hold the lock long enough to clone an `Arc`, the critical section is extremely short, and the simpler/faster synchronization primitive is a better fit than reader/writer locking.

## Testing

- Ran `cargo fmt` via `cf`.

Co-Authored-By: Oz <oz-agent@warp.dev>
