### PR TITLE
[REMOTE-1748] Avoid invalid takeover errors during cloud agent setup

### DIFF
--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -311,7 +311,11 @@ impl CLISubagentController {
         });
     }
 
-    pub fn switch_control_to_user(&self, reason: UserTakeOverReason, ctx: &mut ModelContext<Self>) {
+    pub fn switch_control_to_user(
+        &self,
+        reason: UserTakeOverReason,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
         let should_cancel_conversation = !reason.is_transfer_from_agent();
         let mut terminal_model = self.terminal_model.lock();
 
@@ -319,13 +323,22 @@ impl CLISubagentController {
         let block_id = active_block.id().clone();
         let interaction_mode_debug = format!("{:?}", active_block.interaction_mode());
         let lrc_state_debug = format!("{:?}", active_block.long_running_control_state());
+        if !active_block.is_agent_in_control() {
+            log::debug!(
+                "Ignoring user take-control request because agent is not in control: \
+                 reason={reason:?}, block_id={block_id:?}, \
+                 interaction_mode={interaction_mode_debug}, lrc_state={lrc_state_debug}"
+            );
+            return false;
+        }
+
         if let Err(e) = active_block.take_over_control_for_user(reason.clone()) {
             log::error!(
                 "Failed to take control for user: {e:?}, reason={reason:?}, \
                  block_id={block_id:?}, interaction_mode={interaction_mode_debug}, \
                  lrc_state={lrc_state_debug}"
             );
-            return;
+            return false;
         }
 
         let action_id = active_block.requested_command_action_id().cloned();
@@ -363,6 +376,8 @@ impl CLISubagentController {
             },
             ctx
         );
+
+        true
     }
 
     pub fn handoff_active_command_control_to_agent(&self, ctx: &mut ModelContext<Self>) {

--- a/app/src/terminal/view/use_agent_footer/mod_tests.rs
+++ b/app/src/terminal/view/use_agent_footer/mod_tests.rs
@@ -1,6 +1,8 @@
 use std::rc::Rc;
 
-use session_sharing_protocol::sharer::SessionSourceType;
+use session_sharing_protocol::{
+    common::LongRunningCommandAgentInteractionState, sharer::SessionSourceType,
+};
 use warp_core::settings::Setting as _;
 use warpui::{App, AppContext, SingletonEntity, ViewContext};
 
@@ -329,6 +331,50 @@ fn use_agent_footer_hidden_during_cloud_agent_setup_lrc() {
                     .last_non_hidden_rich_content_block_after_block(Some(active_block_index))
                     .is_none(),
                 "footer rich content should not be in the blocklist during cloud setup",
+            );
+        });
+    })
+}
+
+#[test]
+fn cloud_agent_setup_state_updates_do_not_try_to_take_control_from_user_block() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            simulate_user_started_long_running_command(view);
+            view.model
+                .lock()
+                .set_shared_session_source_type(SessionSourceType::AmbientAgent { task_id: None });
+
+            let did_take_control = view.cli_subagent_controller.update(ctx, |controller, ctx| {
+                controller.switch_control_to_user(UserTakeOverReason::Manual, ctx)
+            });
+            assert!(
+                !did_take_control,
+                "plain cloud-agent setup LRC should not be treated as an agent takeover",
+            );
+
+            view.apply_long_running_command_agent_interaction_state(
+                LongRunningCommandAgentInteractionState::NotInteracting,
+                ctx,
+            );
+            view.apply_long_running_command_agent_interaction_state(
+                LongRunningCommandAgentInteractionState::NotInteracting,
+                ctx,
+            );
+
+            let model = view.model.lock();
+            let active_block = model.block_list().active_block();
+            assert!(
+                active_block.agent_interaction_metadata().is_none(),
+                "cloud-agent setup state updates should leave a user command in user mode",
+            );
+            assert!(
+                active_block.long_running_control_state().is_none(),
+                "cloud-agent setup state updates should not add LRC control metadata",
             );
         });
     })


### PR DESCRIPTION
## Description
Avoid noisy `InvalidTakeOver` error logs when cloud-agent/shared-session startup state repeatedly asks the desktop client to put the user in control while the active long-running block is already a plain user-controlled block. `switch_control_to_user` now treats that case as an idempotent debug no-op, and still logs real transition failures after eligibility is established.

## Linked Issue
REMOTE-1748

## Testing
- `cargo test -p warp cloud_agent_setup_state_updates_do_not_try_to_take_control_from_user_block`
- `cargo clippy -p warp --tests -- -D warnings`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed repeated InvalidTakeOver error logs during cloud agent startup.

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._