### PR TITLE
[REV-1601] Show zero remaining addon credits

### DIFF
--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -244,9 +244,6 @@ impl ClassifiedGrants {
             if grant.expiration.is_some_and(|exp| now >= exp) {
                 continue;
             }
-            if grant.request_credits_remaining <= 0 {
-                continue;
-            }
             let in_user_scope = grant.scope == BonusGrantScope::User;
             let in_workspace_scope =
                 workspace_uid.is_some_and(|uid| grant.scope == BonusGrantScope::Workspace(uid));


### PR DESCRIPTION
## Description
Removes the remaining-credit filter in `ClassifiedGrants::new()` so zero-balance personal/team grants are still classified and rendered in the balance box as `0 remaining`.

Expired and ambient-only grants continue to be excluded.

## Linked Issue
REV-1601

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`

Not manually tested locally with `./script/run`.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Show zero remaining add-on credit balances in the billing balance box.

_Conversation: https://staging.warp.dev/conversation/6181798d-6437-45f7-8188-d89bcc4b8a08_
_Run: https://oz.staging.warp.dev/runs/019e46db-e225-71bc-8eda-44fff536bd6b_
_This PR was generated with [Oz](https://warp.dev/oz)._
