### PR TITLE
[REV-1606] Hide empty other members usage row

### DIFF
--- a/app/src/settings_view/billing_and_usage/billing_cycle_usage_common.rs
+++ b/app/src/settings_view/billing_and_usage/billing_cycle_usage_common.rs
@@ -203,14 +203,17 @@ pub fn filter_legacy_buckets(entries: &[BillingCycleUsageEntry]) -> Vec<BillingC
 
 /// "Is there any data in `entries` that's not my own?"
 pub fn has_non_viewer_data(entries: &[BillingCycleUsageEntry], viewer_uid: Option<&str>) -> bool {
-    entries.iter().any(|e| match &e.subject_type {
-        AiCreditsUsageAndCostSubjectType::Team => true,
-        _ => match (e.subject_uid.as_deref(), viewer_uid) {
-            (Some(uid), Some(viewer)) => uid != viewer,
-            // Unknown subject — conservatively treat as non-viewer.
-            _ => true,
-        },
-    })
+    entries
+        .iter()
+        .filter(|e| e.credits_used != 0 || e.cost_cents != 0)
+        .any(|e| match &e.subject_type {
+            AiCreditsUsageAndCostSubjectType::Team => true,
+            _ => match (e.subject_uid.as_deref(), viewer_uid) {
+                (Some(uid), Some(viewer)) => uid != viewer,
+                // Unknown subject — conservatively treat as non-viewer.
+                _ => true,
+            },
+        })
 }
 
 pub fn format_credits(credits: i64) -> String {

--- a/app/src/settings_view/billing_and_usage/billing_cycle_usage_common_tests.rs
+++ b/app/src/settings_view/billing_and_usage/billing_cycle_usage_common_tests.rs
@@ -73,6 +73,25 @@ fn has_non_viewer_data_returns_true_for_team_aggregate_row() {
 }
 
 #[test]
+fn has_non_viewer_data_returns_false_for_empty_team_aggregate_row() {
+    // The server can send a zero Team aggregate row for a solo workspace. That
+    // placeholder should not create the "Other members" row.
+    let entries = vec![
+        viewer_user_entry(),
+        entry(
+            AiCreditsUsageAndCostSubjectType::Team,
+            None,
+            AiCreditsUsageAndCostType::Aggregate,
+            AiCreditsUsageBucket::Aggregate,
+            AiCreditsUsageSource::Aggregate,
+            0,
+            0,
+        ),
+    ];
+    assert!(!has_non_viewer_data(&entries, Some(VIEWER_UID)));
+}
+
+#[test]
 fn has_non_viewer_data_returns_true_for_other_user_row() {
     // PerUserTotals / FullBreakdown emit per-user rows, so a departed teammate
     // shows up as a User entry with a non-viewer UID.


### PR DESCRIPTION
## Description
Fixes the billing v2 member usage predicate so zero-value Team aggregate entries do not count as other-member data. This hides the stray "Other members" row for solo workspaces while still showing it when historical aggregate usage exists for other members.

## Linked Issue
REV-1606

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --check`
- `cargo test -p warp has_non_viewer_data --lib`
- `cargo clippy -p warp --lib -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Hide the empty "Other members" row on the billing and usage page for solo teams.

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._