### PR TITLE
Enable SoloUserByok and BillingAndUsagePageV2 in stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -648,6 +648,8 @@ default = [
     "cloud_mode_setup_v2",
     "handoff_cloud_cloud",
     "remote_codebase_indexing",
+    "solo_user_byok",
+    "billing_and_usage_page_v2",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.
@@ -950,6 +952,7 @@ open_code_notifications = []
 transfer_control_tool = []
 skip_firebase_anonymous_user = []
 solo_user_byok = []
+billing_and_usage_page_v2 = []
 configurable_toolbar = []
 warpify_footer = []
 hoa_onboarding_flow = []

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -463,6 +463,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::WarpifyFooter,
         #[cfg(feature = "solo_user_byok")]
         FeatureFlag::SoloUserByok,
+        #[cfg(feature = "billing_and_usage_page_v2")]
+        FeatureFlag::BillingAndUsagePageV2,
         #[cfg(feature = "skip_firebase_anonymous_user")]
         FeatureFlag::SkipFirebaseAnonymousUser,
         #[cfg(feature = "hoa_onboarding_flow")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -940,10 +940,8 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
     FeatureFlag::DragTabsToWindows,
-    FeatureFlag::SoloUserByok,
     FeatureFlag::CustomInferenceEndpoints,
     FeatureFlag::RemoteCodebaseIndexing,
-    FeatureFlag::BillingAndUsagePageV2,
     FeatureFlag::RemoteCodeReview,
 ];
 


### PR DESCRIPTION
## Description
Promotes the `SoloUserByok` and `BillingAndUsagePageV2` feature flags to production for the client.

For each flag:
- Adds (`billing_and_usage_page_v2`) or reuses (`solo_user_byok`) the Cargo feature in `app/Cargo.toml`'s `default = [...]` array, so it ships in stable builds.
- Wires the new `billing_and_usage_page_v2` Cargo feature to `FeatureFlag::BillingAndUsagePageV2` in `enabled_features()` (`solo_user_byok` was already wired).
- Removes the flag from `DOGFOOD_FLAGS` in `crates/warp_features/src/lib.rs`.

The flags themselves remain in the `FeatureFlag` enum so rollback is a one-line revert of the entries in `default`.

## Linked Issue
None.

## Testing
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` ✅

This is a feature rollout configuration change; behavior for both flags has been validated previously while they were in dogfood.

- [ ] I have manually tested my changes locally with \`./script/run\`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Agent conversation:
https://staging.warp.dev/conversation/d95f54cf-cf49-405e-b5c2-252f23059479

Co-Authored-By: Oz <oz-agent@warp.dev>