### PR TITLE
Allow common skills install failures to continue scripts

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -120,9 +120,13 @@ maybe_install_common_skills() {
     fi
     if [[ "${COMMON_SKILLS_TARGET}" = "project" || "${COMMON_SKILLS_TARGET}" = "global" ]]; then
       target_args=("--${COMMON_SKILLS_TARGET}")
-      ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "${target_args[@]}" --if-needed
+      if ! ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "${target_args[@]}" --if-needed; then
+        echo "error: unable to install common skills; continuing without them." >&2
+      fi
     else
-      ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" --if-needed --prompt-for-target
+      if ! ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" --if-needed --prompt-for-target; then
+        echo "error: unable to install common skills; continuing without them." >&2
+      fi
     fi
   fi
 }

--- a/script/run
+++ b/script/run
@@ -98,6 +98,11 @@ done
 common_skills_match_lock() {
   ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "$@" --verify-only --quiet >/dev/null 2>&1
 }
+install_common_skills_or_continue() {
+  if ! ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "$@"; then
+    echo "error: unable to install common skills; continuing without them." >&2
+  fi
+}
 if [[ "$INSTALL_COMMON_SKILLS" -eq 1 ]]; then
   COMMON_SKILLS_ARGS=()
   if [[ "${COMMON_SKILLS_TARGET}" = "project" || "${COMMON_SKILLS_TARGET}" = "global" ]]; then
@@ -107,17 +112,17 @@ if [[ "$INSTALL_COMMON_SKILLS" -eq 1 ]]; then
     :
   elif [[ "$FORCE_COMMON_SKILLS" -eq 1 ]]; then
     if [[ "${#COMMON_SKILLS_ARGS[@]}" -gt 0 ]]; then
-      ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "${COMMON_SKILLS_ARGS[@]}" --force
+      install_common_skills_or_continue "${COMMON_SKILLS_ARGS[@]}" --force
     else
-      ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" --force --prompt-for-target
+      install_common_skills_or_continue --force --prompt-for-target
     fi
   elif common_skills_match_lock "${COMMON_SKILLS_ARGS[@]}"; then
     :
   else
     if [[ "${#COMMON_SKILLS_ARGS[@]}" -gt 0 ]]; then
-      ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" "${COMMON_SKILLS_ARGS[@]}" --if-needed --quiet
+      install_common_skills_or_continue "${COMMON_SKILLS_ARGS[@]}" --if-needed --quiet
     else
-      ./script/resolve_common_skills install_common_skills -- --repo-root "${REPO_ROOT}" --if-needed --prompt-for-target --quiet
+      install_common_skills_or_continue --if-needed --prompt-for-target --quiet
     fi
   fi
 fi


### PR DESCRIPTION
## Description
- Make common-skills install failures non-fatal in `script/run` and `script/bootstrap`.
- Print a clear stderr line when installation cannot complete, then continue the normal run/bootstrap flow.
- Keep strict resolver/install behavior unchanged outside the entrypoint failure handling.

Oz conversation: https://staging.warp.dev/conversation/2fff0589-38e0-48ec-869e-707afcc1b10b

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `bash -n script/run script/bootstrap`
- [x] Isolated temp-directory harness that forces `script/resolve_common_skills` to fail and confirms both entrypoints continue.
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>