### PR TITLE
Fix dead blog URL in launch modal and make CLI agent names clickable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## About
 
-[Warp](https://www.warp.dev) is an agentic development environment, born out of the terminal. Use Warp's built-in coding agent, or bring your own CLI agent (Claude Code, Codex, Gemini CLI, and others).
+[Warp](https://www.warp.dev) is an agentic development environment, born out of the terminal. Use Warp's built-in coding agent, or bring your own CLI agent ([Claude Code](https://www.warp.dev/agents/claude-code), [Codex](https://www.warp.dev/agents/codex), [Gemini CLI](https://www.warp.dev/agents/gemini-cli), and others).
 
 ## Installation
 

--- a/app/src/workspace/view/orchestration_launch_modal/view.rs
+++ b/app/src/workspace/view/orchestration_launch_modal/view.rs
@@ -20,7 +20,7 @@ use crate::view_components::action_button::{ActionButton, ActionButtonTheme, But
 const MODAL_WIDTH: f32 = 420.;
 const HERO_HEIGHT: f32 = 92.;
 const HERO_IMAGE_PATH: &str = "async/png/onboarding/orchestration_launch_banner.png";
-const LEARN_MORE_URL: &str = "https://www.warp.dev/blog/multi-harness-cloud-agent-orchestration";
+const LEARN_MORE_URL: &str = "https://www.warp.dev/blog/oz-orchestration-platform-cloud-agents";
 fn modal_background(appearance: &Appearance) -> Fill {
     appearance.theme().surface_3()
 }


### PR DESCRIPTION
## Summary

- **Fix dead URL (#11284):** The "What's New" / orchestration launch modal links to `/blog/multi-harness-cloud-agent-orchestration` which returns 404. Updated to the live canonical URL `/blog/oz-orchestration-platform-cloud-agents` (confirmed 200).
- **Make CLI agent names clickable (#11384):** Claude Code, Codex, and Gemini CLI in the README About section are now hyperlinked to their respective Warp documentation pages (`warp.dev/agents/*`). All URLs verified live.

## Test plan

- [ ] Verified all 4 URLs return HTTP 200 via curl
- [ ] `LEARN_MORE_URL` change is a const string swap — no logic change
- [ ] README links render correctly in GitHub markdown preview

Closes #11284
Closes #11384

CHANGELOG-BUG-FIX