### PR TITLE
Add PR merge status to GitHub PR chips

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/chips.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/chips.rs
@@ -1,6 +1,7 @@
 use crate::context_chips::{
     display_chip::{DisplayChip, GitLineChanges, PromptDisplayChipEvent},
-    git_line_changes_from_chips,
+    github_pr_info::GithubPrInfo,
+    github_pr_info_from_chips, git_line_changes_from_chips,
     prompt_type::PromptType,
     ChipResult,
 };
@@ -38,6 +39,7 @@ impl AgentInputFooter {
         &self,
         new_chips: &[ChipResult],
         git_line_changes_info: Option<GitLineChanges>,
+        github_pr_info: Option<GithubPrInfo>,
         ctx: &mut ViewContext<Self>,
     ) -> Vec<ViewHandle<DisplayChip>> {
         let mut display_chips = Vec::with_capacity(new_chips.len());
@@ -56,6 +58,7 @@ impl AgentInputFooter {
                     ctx,
                 );
                 chip.maybe_set_git_line_changes_info(git_line_changes_info.clone());
+                chip.maybe_set_github_pr_info(github_pr_info.clone());
                 chip.update_session_context(self.display_chip_config.session_context.clone(), ctx);
                 chip
             });
@@ -96,11 +99,13 @@ impl AgentInputFooter {
     fn update_existing_display_chips(
         display_chips: &[ViewHandle<DisplayChip>],
         git_line_changes_info: Option<GitLineChanges>,
+        github_pr_info: Option<GithubPrInfo>,
         ctx: &mut ViewContext<Self>,
     ) {
         for chip_view in display_chips {
             chip_view.update(ctx, |chip, ctx| {
                 chip.maybe_set_git_line_changes_info(git_line_changes_info.clone());
+                chip.maybe_set_github_pr_info(github_pr_info.clone());
                 ctx.notify();
             });
         }
@@ -140,6 +145,7 @@ impl AgentInputFooter {
             .filter(|chip| chip.value().is_some())
             .collect::<Vec<ChipResult>>();
         let git_line_changes_info = git_line_changes_from_chips(&new_chips);
+        let github_pr_info = github_pr_info_from_chips(&new_chips);
 
         let should_update_left =
             Self::check_if_chip_values_have_changed(&self.left_display_chips, &new_left_chips, ctx);
@@ -150,23 +156,33 @@ impl AgentInputFooter {
         );
 
         if should_update_left {
-            self.left_display_chips =
-                self.create_display_chips(&new_left_chips, git_line_changes_info.clone(), ctx);
+            self.left_display_chips = self.create_display_chips(
+                &new_left_chips,
+                git_line_changes_info.clone(),
+                github_pr_info.clone(),
+                ctx,
+            );
         } else {
             Self::update_existing_display_chips(
                 &self.left_display_chips,
                 git_line_changes_info.clone(),
+                github_pr_info.clone(),
                 ctx,
             );
         }
 
         if should_update_right {
-            self.right_display_chips =
-                self.create_display_chips(&new_right_chips, git_line_changes_info.clone(), ctx);
+            self.right_display_chips = self.create_display_chips(
+                &new_right_chips,
+                git_line_changes_info.clone(),
+                github_pr_info.clone(),
+                ctx,
+            );
         } else {
             Self::update_existing_display_chips(
                 &self.right_display_chips,
                 git_line_changes_info.clone(),
+                github_pr_info.clone(),
                 ctx,
             );
         }
@@ -182,12 +198,17 @@ impl AgentInputFooter {
         let should_update_cli =
             Self::check_if_chip_values_have_changed(&self.cli_display_chips, &new_cli_chips, ctx);
         if should_update_cli {
-            self.cli_display_chips =
-                self.create_display_chips(&new_cli_chips, git_line_changes_info.clone(), ctx);
+            self.cli_display_chips = self.create_display_chips(
+                &new_cli_chips,
+                git_line_changes_info.clone(),
+                github_pr_info.clone(),
+                ctx,
+            );
         } else {
             Self::update_existing_display_chips(
                 &self.cli_display_chips,
                 git_line_changes_info,
+                github_pr_info,
                 ctx,
             );
         }

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -857,7 +857,17 @@ impl CurrentPrompt {
                                 }
                             }
                         }
-                        me.update_chip_value(&chip_kind, output.map(ChipValue::Text));
+                        let chip_value = if matches!(chip_kind, ContextChipKind::GithubPullRequest) {
+                            output.and_then(|raw| {
+                                crate::context_chips::github_pr_info::parse_github_pr_command_output(
+                                    &raw,
+                                )
+                                .map(ChipValue::GithubPullRequest)
+                            })
+                        } else {
+                            output.map(ChipValue::Text)
+                        };
+                        me.update_chip_value(&chip_kind, chip_value);
                         me.set_chip_update_status(&chip_kind, status);
                     },
                 );

--- a/app/src/context_chips/display.rs
+++ b/app/src/context_chips/display.rs
@@ -25,7 +25,7 @@ use warpui::{
 
 use super::{
     display_chip::{DisplayChip, DisplayChipConfig, PromptDisplayChipEvent},
-    git_line_changes_from_chips,
+    github_pr_info_from_chips, git_line_changes_from_chips,
     prompt_type::PromptType,
     ChipResult, ContextChipKind,
 };
@@ -210,6 +210,7 @@ impl PromptDisplay {
 
     fn reset_chips(&mut self, new_chips: &[ChipResult], ctx: &mut ViewContext<Self>) {
         let git_line_changes_info = git_line_changes_from_chips(new_chips);
+        let github_pr_info = github_pr_info_from_chips(new_chips);
 
         self.display_chips.clear();
         let mut display_chips = new_chips.iter().peekable();
@@ -239,6 +240,7 @@ impl PromptDisplay {
                     },
                 );
                 chip.maybe_set_git_line_changes_info(git_line_changes_info.clone());
+                chip.maybe_set_github_pr_info(github_pr_info.clone());
                 chip
             });
 

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -59,8 +59,14 @@ use super::{
     display_menu::{
         ChipMenuType, DisplayChipMenu, FixedFooter, GenericMenuItem, PromptDisplayMenuEvent,
     },
-    github_pr_display_text_from_url, render_text_from_kind, ChipResult, ContextChipKind,
+    github_pr_display_text_from_url, github_pr_info::github_pr_info_from_chip_value,
+    github_pr_status::{
+        github_pr_chip_label, github_pr_status_indicator, github_pr_status_tooltip,
+        render_github_pr_status_indicator, GithubPrStatusIndicatorKind,
+    },
+    render_text_from_kind, ChipResult, ContextChipKind,
 };
+use super::github_pr_info::GithubPrInfo;
 use crate::workspace::view::TOGGLE_RIGHT_PANEL_BINDING_NAME;
 
 /// Helper function to render git diff stats content (file icon or +- icons, file count, bullet, +/- counts)
@@ -383,7 +389,9 @@ pub enum DisplayChipKind {
         menu_open: bool,
         menu: ViewHandle<DisplayChipMenu>,
     },
-    GithubPullRequest,
+    GithubPullRequest {
+        pr_info: Option<GithubPrInfo>,
+    },
     GitDiffStats {
         line_changes_info: Option<GitLineChanges>,
     },
@@ -395,7 +403,7 @@ impl DisplayChipKind {
             DisplayChipKind::WorkingDirectory { menu_open, .. } => *menu_open,
             DisplayChipKind::NodeVersion { popup_open, .. } => *popup_open,
             DisplayChipKind::GitBranch { menu_open, .. } => *menu_open,
-            DisplayChipKind::GithubPullRequest
+            DisplayChipKind::GithubPullRequest { .. }
             | DisplayChipKind::GitDiffStats { .. }
             | DisplayChipKind::Text
             | DisplayChipKind::Ssh
@@ -648,7 +656,12 @@ impl DisplayChip {
             ContextChipKind::GitDiffStats => DisplayChipKind::GitDiffStats {
                 line_changes_info: None,
             },
-            ContextChipKind::GithubPullRequest => DisplayChipKind::GithubPullRequest,
+            ContextChipKind::GithubPullRequest => DisplayChipKind::GithubPullRequest {
+                pr_info: chip_result
+                    .value
+                    .as_ref()
+                    .and_then(github_pr_info_from_chip_value),
+            },
             ContextChipKind::WorkingDirectory => {
                 let dir_path = chip_result
                     .value
@@ -863,7 +876,15 @@ impl DisplayChip {
         Self {
             mouse_state: Default::default(),
             diff_stats_mouse_state: Default::default(),
-            text: chip_result.value.map(|v| v.to_string()).unwrap_or_default(),
+            text: chip_result
+                .value
+                .as_ref()
+                .and_then(|v| {
+                    github_pr_info_from_chip_value(v)
+                        .map(|info| info.url.clone())
+                        .or_else(|| v.as_text().map(str::to_owned))
+                })
+                .unwrap_or_default(),
             chip_kind: chip_result.kind,
             display_chip_kind,
             next_chip_kind,
@@ -958,7 +979,7 @@ impl DisplayChip {
             | DisplayChipKind::CondaEnvironment
             | DisplayChipKind::NodeVersion { .. }
             | DisplayChipKind::AgentPlanAndTodoList { .. }
-            | DisplayChipKind::GithubPullRequest => {}
+            | DisplayChipKind::GithubPullRequest { .. } => {}
         }
         false
     }
@@ -972,6 +993,17 @@ impl DisplayChip {
         } = &mut self.display_chip_kind
         {
             *line_changes_info = git_line_changes_info;
+        }
+    }
+
+    pub fn maybe_set_github_pr_info(&mut self, pr_info: Option<GithubPrInfo>) {
+        if let DisplayChipKind::GithubPullRequest { pr_info: slot } =
+            &mut self.display_chip_kind
+        {
+            *slot = pr_info.clone();
+            if let Some(info) = pr_info {
+                self.text = info.url;
+            }
         }
     }
 
@@ -1138,15 +1170,29 @@ impl DisplayChip {
 
     fn github_pull_request_chip(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
         let font_color = if self.is_in_agent_view {
             agent_view_chip_color(appearance)
         } else {
-            appearance.theme().ansi_fg_green()
+            theme.ansi_fg_green()
         };
-        let chip_text =
-            github_pr_display_text_from_url(&self.text).unwrap_or_else(|| self.text.clone());
+        let pr_info = match &self.display_chip_kind {
+            DisplayChipKind::GithubPullRequest { pr_info } => pr_info.clone(),
+            _ => None,
+        };
+        let chip_text = pr_info
+            .as_ref()
+            .map(github_pr_chip_label)
+            .unwrap_or_else(|| {
+                github_pr_display_text_from_url(&self.text).unwrap_or_else(|| self.text.clone())
+            });
+        let tooltip_text = pr_info
+            .as_ref()
+            .map(github_pr_status_tooltip)
+            .unwrap_or_else(|| "View pull request".to_string());
         let url = self.text.clone();
         let is_in_agent_view = self.is_in_agent_view;
+        let status_indicator = pr_info.as_ref().map(github_pr_status_indicator);
 
         let hover = Hoverable::new(self.mouse_state.clone(), move |state| {
             let mut config =
@@ -1155,13 +1201,19 @@ impl DisplayChip {
             if is_in_agent_view {
                 config = config.for_agent_view();
             }
-            let chip_element = render_udi_chip(config, appearance);
+            let mut chip_row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
+            chip_row.add_child(render_udi_chip(config, appearance));
+            if let Some(indicator) = status_indicator {
+                if indicator.kind != GithubPrStatusIndicatorKind::Unknown {
+                    chip_row.add_child(render_github_pr_status_indicator(indicator, theme));
+                }
+            }
 
-            let mut stack = Stack::new().with_child(chip_element);
+            let mut stack = Stack::new().with_child(chip_row.finish());
             if state.is_hovered() {
                 let tool_tip = appearance
                     .ui_builder()
-                    .tool_tip("View pull request".to_string())
+                    .tool_tip(tooltip_text.clone())
                     .build()
                     .finish();
                 stack.add_positioned_overlay_child(tool_tip, udi_tooltip_positioning());
@@ -1565,7 +1617,9 @@ impl DisplayChip {
             DisplayChipKind::GitBranch { menu_open, menu } => {
                 Some(self.git_branch_chip(*menu_open, menu, app))
             }
-            DisplayChipKind::GithubPullRequest => Some(self.github_pull_request_chip(app)),
+            DisplayChipKind::GithubPullRequest { .. } => {
+                Some(self.github_pull_request_chip(app))
+            }
             DisplayChipKind::GitDiffStats { line_changes_info } => {
                 self.git_diff_stats_chip(line_changes_info, app)
             }
@@ -1658,7 +1712,7 @@ impl TypedActionView for DisplayChip {
                 | DisplayChipKind::CondaEnvironment
                 | DisplayChipKind::AgentPlanAndTodoList { .. }
                 | DisplayChipKind::Text
-                | DisplayChipKind::GithubPullRequest
+                | DisplayChipKind::GithubPullRequest { .. }
                 | DisplayChipKind::GitDiffStats { .. } => {}
                 DisplayChipKind::NodeVersion { popup_open, .. } => {
                     *popup_open = false;

--- a/app/src/context_chips/display_chip_tests.rs
+++ b/app/src/context_chips/display_chip_tests.rs
@@ -4,7 +4,8 @@ use super::{
 };
 use crate::context_chips::display_menu::GenericMenuItem;
 use crate::context_chips::{
-    git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url, ContextChipKind,
+    git_branch_on_click::GitBranchOnClickValue, github_pr_display_text_from_url,
+    github_pr_info::GithubPrInfo, ContextChipKind,
 };
 use crate::ui_components::icons::Icon;
 
@@ -30,11 +31,25 @@ fn test_github_pr_display_text_from_url_rejects_non_pr_urls() {
 
 #[test]
 fn test_github_pr_chip_display_value_formats_url() {
-    let value =
-        crate::context_chips::ChipValue::Text("https://github.com/warp/warp/pull/456".to_string());
+    let value = crate::context_chips::ChipValue::GithubPullRequest(GithubPrInfo::from_url_with_defaults(
+        "https://github.com/warp/warp/pull/456".to_string(),
+    ));
     assert_eq!(
         ContextChipKind::GithubPullRequest.display_value(&value),
         "PR #456"
+    );
+}
+
+#[test]
+fn test_github_pr_chip_display_value_includes_merged_suffix() {
+    let mut info = GithubPrInfo::from_url_with_defaults(
+        "https://github.com/warp/warp/pull/456".to_string(),
+    );
+    info.state = crate::context_chips::github_pr_info::GithubPrState::Merged;
+    let value = crate::context_chips::ChipValue::GithubPullRequest(info);
+    assert_eq!(
+        ContextChipKind::GithubPullRequest.display_value(&value),
+        "PR #456 · merged"
     );
 }
 

--- a/app/src/context_chips/github_pr_info.rs
+++ b/app/src/context_chips/github_pr_info.rs
@@ -1,0 +1,130 @@
+use serde::{Deserialize, Serialize};
+
+use super::{github_pr_number_from_url, ChipValue};
+
+/// Lifecycle state of a GitHub pull request from `gh pr view`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GithubPrState {
+    Open,
+    Closed,
+    Merged,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Whether GitHub considers the PR mergeable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GithubPrMergeable {
+    Mergeable,
+    Conflicting,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Merge readiness from `mergeStateStatus` in `gh pr view`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GithubPrMergeStateStatus {
+    Behind,
+    Blocked,
+    Clean,
+    Dirty,
+    Draft,
+    HasHooks,
+    Unstable,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Structured GitHub PR data for the prompt context chip.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GithubPrInfo {
+    pub url: String,
+    pub state: GithubPrState,
+    pub is_draft: bool,
+    pub mergeable: GithubPrMergeable,
+    pub merge_state_status: GithubPrMergeStateStatus,
+}
+
+#[derive(Deserialize)]
+struct GhPrViewJson {
+    url: String,
+    state: GithubPrState,
+    #[serde(rename = "isDraft", default)]
+    is_draft: bool,
+    mergeable: Option<GithubPrMergeable>,
+    #[serde(rename = "mergeStateStatus")]
+    merge_state_status: Option<GithubPrMergeStateStatus>,
+}
+
+impl GithubPrInfo {
+    pub fn from_url_with_defaults(url: String) -> Self {
+        Self {
+            url,
+            state: GithubPrState::Open,
+            is_draft: false,
+            mergeable: GithubPrMergeable::Unknown,
+            merge_state_status: GithubPrMergeStateStatus::Unknown,
+        }
+    }
+}
+
+/// Parses one-line JSON emitted by `github_pull_request_prompt_chip` scripts.
+pub fn parse_github_pr_command_output(raw: &str) -> Option<GithubPrInfo> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Backward compatibility: legacy chip output was a bare PR URL.
+    if !trimmed.starts_with('{') {
+        let url = trimmed.to_string();
+        if github_pr_number_from_url(&url).is_some() || !url.is_empty() {
+            return Some(GithubPrInfo::from_url_with_defaults(url));
+        }
+        return None;
+    }
+
+    let parsed: GhPrViewJson = serde_json::from_str(trimmed).ok()?;
+    let url = parsed.url.trim().to_string();
+    if url.is_empty() {
+        return None;
+    }
+    Some(GithubPrInfo {
+        url,
+        state: parsed.state,
+        is_draft: parsed.is_draft,
+        mergeable: parsed
+            .mergeable
+            .unwrap_or(GithubPrMergeable::Unknown),
+        merge_state_status: parsed
+            .merge_state_status
+            .unwrap_or(GithubPrMergeStateStatus::Unknown),
+    })
+}
+
+/// Extracts PR info from a chip value, including legacy text URLs.
+pub fn github_pr_info_from_chip_value(value: &ChipValue) -> Option<GithubPrInfo> {
+    match value {
+        ChipValue::GithubPullRequest(info) => Some(info.clone()),
+        ChipValue::Text(url) => {
+            let url = url.trim();
+            if url.is_empty() {
+                None
+            } else {
+                Some(GithubPrInfo::from_url_with_defaults(url.to_string()))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Stable string used for display-chip change detection and logging.
+pub fn github_pr_info_cache_key(info: &GithubPrInfo) -> String {
+    format!(
+        "{}|{:?}|{}|{:?}|{:?}",
+        info.url, info.state, info.is_draft, info.mergeable, info.merge_state_status
+    )
+}

--- a/app/src/context_chips/github_pr_status.rs
+++ b/app/src/context_chips/github_pr_status.rs
@@ -1,0 +1,233 @@
+use pathfinder_color::ColorU;
+use warp_core::ui::icons::Icon as WarpIcon;
+use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::{Fill, WarpTheme};
+use warpui::elements::{
+    ConstrainedBox, Container, CrossAxisAlignment, Element, Flex, ParentElement,
+};
+use warpui::fonts::FamilyId;
+use warpui::elements::Text;
+
+use super::github_pr_info::{
+    GithubPrInfo, GithubPrMergeStateStatus, GithubPrMergeable, GithubPrState,
+};
+use super::github_pr_display_text_from_url;
+
+/// Compact visual treatment for PR merge status.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GithubPrStatusIndicatorKind {
+    Merged,
+    Closed,
+    Draft,
+    Conflicts,
+    Blocked,
+    Ready,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GithubPrStatusIndicator {
+    pub kind: GithubPrStatusIndicatorKind,
+}
+
+const STATUS_DOT_SIZE: f32 = 6.;
+const STATUS_ICON_SIZE: f32 = 8.;
+
+pub fn github_pr_chip_label(info: &GithubPrInfo) -> String {
+    github_pr_display_text_from_url(&info.url)
+        .map(|label| label.strip_prefix("PR ").unwrap_or(&label).to_string())
+        .unwrap_or_else(|| info.url.clone())
+}
+
+pub fn github_pr_chip_label_from_url(url: &str) -> String {
+    github_pr_display_text_from_url(url)
+        .map(|label| label.strip_prefix("PR ").unwrap_or(&label).to_string())
+        .unwrap_or_else(|| url.to_string())
+}
+
+pub fn github_pr_status_indicator(info: &GithubPrInfo) -> GithubPrStatusIndicator {
+    let kind = if info.state == GithubPrState::Merged {
+        GithubPrStatusIndicatorKind::Merged
+    } else if info.state == GithubPrState::Closed {
+        GithubPrStatusIndicatorKind::Closed
+    } else if info.is_draft || info.merge_state_status == GithubPrMergeStateStatus::Draft {
+        GithubPrStatusIndicatorKind::Draft
+    } else if info.mergeable == GithubPrMergeable::Conflicting
+        || info.merge_state_status == GithubPrMergeStateStatus::Dirty
+    {
+        GithubPrStatusIndicatorKind::Conflicts
+    } else if matches!(
+        info.merge_state_status,
+        GithubPrMergeStateStatus::Blocked | GithubPrMergeStateStatus::Behind
+    ) {
+        GithubPrStatusIndicatorKind::Blocked
+    } else if info.merge_state_status == GithubPrMergeStateStatus::Clean
+        && info.mergeable == GithubPrMergeable::Mergeable
+    {
+        GithubPrStatusIndicatorKind::Ready
+    } else {
+        GithubPrStatusIndicatorKind::Unknown
+    };
+    GithubPrStatusIndicator { kind }
+}
+
+pub fn github_pr_status_tooltip(info: &GithubPrInfo) -> String {
+    let label = github_pr_display_text_from_url(&info.url).unwrap_or_else(|| info.url.clone());
+    let status = match github_pr_status_indicator(info).kind {
+        GithubPrStatusIndicatorKind::Merged => "Merged",
+        GithubPrStatusIndicatorKind::Closed => "Closed",
+        GithubPrStatusIndicatorKind::Draft => "Draft",
+        GithubPrStatusIndicatorKind::Conflicts => "Merge conflicts",
+        GithubPrStatusIndicatorKind::Blocked => "Blocked from merging",
+        GithubPrStatusIndicatorKind::Ready => "Ready to merge",
+        GithubPrStatusIndicatorKind::Unknown => "Pull request",
+    };
+    format!("{label} · {status}")
+}
+
+pub fn github_pr_status_search_suffix(info: &GithubPrInfo) -> String {
+    match github_pr_status_indicator(info).kind {
+        GithubPrStatusIndicatorKind::Merged => "merged".to_string(),
+        GithubPrStatusIndicatorKind::Closed => "closed".to_string(),
+        GithubPrStatusIndicatorKind::Draft => "draft".to_string(),
+        GithubPrStatusIndicatorKind::Conflicts => "conflicts".to_string(),
+        GithubPrStatusIndicatorKind::Blocked => "blocked".to_string(),
+        GithubPrStatusIndicatorKind::Ready => "ready".to_string(),
+        GithubPrStatusIndicatorKind::Unknown => String::new(),
+    }
+}
+
+fn indicator_color(kind: GithubPrStatusIndicatorKind, theme: &WarpTheme) -> ColorU {
+    match kind {
+        GithubPrStatusIndicatorKind::Merged | GithubPrStatusIndicatorKind::Ready => {
+            theme.ansi_fg_green()
+        }
+        GithubPrStatusIndicatorKind::Closed | GithubPrStatusIndicatorKind::Draft => {
+            internal_colors::neutral_6(theme)
+        }
+        GithubPrStatusIndicatorKind::Conflicts | GithubPrStatusIndicatorKind::Blocked => {
+            theme.ui_warning_color()
+        }
+        GithubPrStatusIndicatorKind::Unknown => internal_colors::neutral_5(theme),
+    }
+}
+
+/// Renders a compact status dot or check icon for prompt chips and vertical-tab badges.
+pub fn render_github_pr_status_indicator(
+    indicator: GithubPrStatusIndicator,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    let color = indicator_color(indicator.kind, theme);
+    let fill = Fill::Solid(color);
+    match indicator.kind {
+        GithubPrStatusIndicatorKind::Merged => Container::new(
+            ConstrainedBox::new(WarpIcon::Check.to_warpui_icon(fill).finish())
+                .with_width(STATUS_ICON_SIZE)
+                .with_height(STATUS_ICON_SIZE)
+                .finish(),
+        )
+        .with_margin_left(4.)
+        .finish(),
+        GithubPrStatusIndicatorKind::Unknown => warpui::elements::Empty::new().finish(),
+        _ => Container::new(
+            ConstrainedBox::new(WarpIcon::CircleFilled.to_warpui_icon(fill).finish())
+                .with_width(STATUS_DOT_SIZE)
+                .with_height(STATUS_DOT_SIZE)
+                .finish(),
+        )
+        .with_margin_left(4.)
+        .finish(),
+    }
+}
+
+/// Badge content: GitHub icon, PR number, and optional status indicator.
+pub fn render_github_pr_badge_content(
+    label: &str,
+    info: Option<&GithubPrInfo>,
+    sub_text_color: ColorU,
+    font_family: FamilyId,
+    theme: &WarpTheme,
+    github_icon: Box<dyn Element>,
+) -> Box<dyn Element> {
+    let mut row = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_spacing(4.)
+        .with_child(github_icon);
+
+    row.add_child(
+        Text::new_inline(label.to_string(), font_family, 10.)
+            .with_color(sub_text_color.into())
+            .finish(),
+    );
+
+    if let Some(info) = info {
+        let indicator = github_pr_status_indicator(info);
+        if indicator.kind != GithubPrStatusIndicatorKind::Unknown {
+            row.add_child(render_github_pr_status_indicator(indicator, theme));
+        }
+    }
+
+    row.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context_chips::github_pr_info::parse_github_pr_command_output;
+
+    fn sample_info(state: GithubPrState) -> GithubPrInfo {
+        GithubPrInfo {
+            url: "https://github.com/warp/warp/pull/42".to_string(),
+            state,
+            is_draft: false,
+            mergeable: GithubPrMergeable::Mergeable,
+            merge_state_status: GithubPrMergeStateStatus::Clean,
+        }
+    }
+
+    #[test]
+    fn test_parse_github_pr_command_output_json() {
+        let raw = r#"{"url":"https://github.com/warp/warp/pull/1","state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN"}"#;
+        let info = parse_github_pr_command_output(raw).expect("parse");
+        assert_eq!(info.state, GithubPrState::Open);
+        assert!(!info.is_draft);
+    }
+
+    #[test]
+    fn test_parse_github_pr_command_output_legacy_url() {
+        let info = parse_github_pr_command_output("https://github.com/warp/warp/pull/9")
+            .expect("parse");
+        assert_eq!(info.url, "https://github.com/warp/warp/pull/9");
+        assert_eq!(info.state, GithubPrState::Open);
+    }
+
+    #[test]
+    fn test_github_pr_status_indicator_merged() {
+        let info = GithubPrInfo {
+            state: GithubPrState::Merged,
+            ..sample_info(GithubPrState::Merged)
+        };
+        assert_eq!(
+            github_pr_status_indicator(&info).kind,
+            GithubPrStatusIndicatorKind::Merged
+        );
+    }
+
+    #[test]
+    fn test_github_pr_status_indicator_conflicts() {
+        let info = GithubPrInfo {
+            mergeable: GithubPrMergeable::Conflicting,
+            ..sample_info(GithubPrState::Open)
+        };
+        assert_eq!(
+            github_pr_status_indicator(&info).kind,
+            GithubPrStatusIndicatorKind::Conflicts
+        );
+    }
+
+    #[test]
+    fn test_github_pr_chip_label_strips_pr_prefix() {
+        let info = sample_info(GithubPrState::Open);
+        assert_eq!(github_pr_chip_label(&info), "#42");
+    }
+}

--- a/app/src/context_chips/logging_tests.rs
+++ b/app/src/context_chips/logging_tests.rs
@@ -49,7 +49,7 @@ fn test_format_log_entry_preserves_stdout_and_stderr_sections() {
         phase: PromptChipExecutionPhase::OnClick,
         shell_type: ShellType::Zsh,
         working_directory: Some("/tmp/project"),
-        command: "gh pr view --json url --jq .url",
+        command: "gh pr view --state all --json url,state,isDraft,mergeable,mergeStateStatus",
         output: Some(&output),
         timed_out: false,
     });
@@ -57,7 +57,9 @@ fn test_format_log_entry_preserves_stdout_and_stderr_sections() {
     assert!(entry.contains("phase: on_click"));
     assert!(entry.contains("status: success"));
     assert!(entry.contains("working_directory: /tmp/project"));
-    assert!(entry.contains("command:\n<<<COMMAND\ngh pr view --json url --jq .url\n>>>COMMAND"));
+    assert!(entry.contains(
+        "command:\n<<<COMMAND\ngh pr view --state all --json url,state,isDraft,mergeable,mergeStateStatus\n>>>COMMAND"
+    ));
     assert!(entry.contains(
         "stdout:\n<<<STDOUT\nhttps://github.com/warpdotdev/warp-internal/pull/123\n>>>STDOUT"
     ));

--- a/app/src/context_chips/mod.rs
+++ b/app/src/context_chips/mod.rs
@@ -6,6 +6,8 @@ pub mod directory_fetcher;
 pub mod display;
 pub mod display_chip;
 pub mod display_menu;
+pub mod github_pr_info;
+pub mod github_pr_status;
 pub(crate) mod git_branch_on_click;
 pub(crate) mod logging;
 pub mod node_version_popup;
@@ -46,6 +48,7 @@ use self::{
 pub enum ChipValue {
     Text(String),
     GitDiffStats(display_chip::GitLineChanges),
+    GithubPullRequest(github_pr_info::GithubPrInfo),
 }
 
 impl ChipValue {
@@ -54,6 +57,7 @@ impl ChipValue {
         match self {
             ChipValue::Text(s) => Some(s),
             ChipValue::GitDiffStats(_) => None,
+            ChipValue::GithubPullRequest(info) => Some(info.url.as_str()),
         }
     }
 
@@ -61,7 +65,15 @@ impl ChipValue {
     pub fn as_git_diff_stats(&self) -> Option<&display_chip::GitLineChanges> {
         match self {
             ChipValue::GitDiffStats(g) => Some(g),
-            ChipValue::Text(_) => None,
+            ChipValue::Text(_) | ChipValue::GithubPullRequest(_) => None,
+        }
+    }
+
+    /// Returns structured GitHub PR data when available.
+    pub fn as_github_pr_info(&self) -> Option<&github_pr_info::GithubPrInfo> {
+        match self {
+            ChipValue::GithubPullRequest(info) => Some(info),
+            _ => None,
         }
     }
 }
@@ -82,6 +94,9 @@ impl std::fmt::Display for ChipValue {
                     "{} • +{} -{}",
                     g.files_changed, g.lines_added, g.lines_removed
                 )
+            }
+            ChipValue::GithubPullRequest(info) => {
+                f.write_str(&github_pr_info::github_pr_info_cache_key(info))
             }
         }
     }
@@ -393,7 +408,11 @@ impl ContextChipKind {
             Self::Hostname => ChipValue::Text("ubuntu-04".to_string()),
             Self::ShellGitBranch => ChipValue::Text("git-feature-branch".to_string()),
             Self::GitDiffStats => ChipValue::Text("3 • +10 -2".to_string()),
-            Self::GithubPullRequest => ChipValue::Text("PR #123".to_string()),
+            Self::GithubPullRequest => ChipValue::GithubPullRequest(
+                github_pr_info::GithubPrInfo::from_url_with_defaults(
+                    "https://github.com/warp/warp/pull/123".to_string(),
+                ),
+            ),
             Self::VirtualEnvironment => ChipValue::Text("pyenv".to_string()),
             Self::CondaEnvironment => ChipValue::Text("condaenv".to_string()),
             Self::NodeVersion => ChipValue::Text("v18.17.0".to_string()),
@@ -467,7 +486,20 @@ impl ContextChipKind {
         let text = value.to_string();
         match self {
             Self::ShellGitBranch => format!("git:({text})"),
-            Self::GithubPullRequest => github_pr_display_text_from_url(&text).unwrap_or(text),
+            Self::GithubPullRequest => {
+                if let Some(info) = github_pr_info::github_pr_info_from_chip_value(value) {
+                    let number_label =
+                        github_pr_display_text_from_url(&info.url).unwrap_or(info.url.clone());
+                    let suffix = github_pr_status::github_pr_status_search_suffix(&info);
+                    if suffix.is_empty() {
+                        number_label
+                    } else {
+                        format!("{number_label} · {suffix}")
+                    }
+                } else {
+                    github_pr_display_text_from_url(&text).unwrap_or(text)
+                }
+            }
             Self::KubernetesContext => format!("⎈ {text}"),
             Self::SvnBranch => format!("svn:({text})"),
             Self::SvnDirtyItems => format!("±{text}"),
@@ -576,6 +608,17 @@ pub fn available_chips() -> Vec<ContextChipKind> {
 ///
 /// Used as a fallback when `GitRepoStatusModel` is unavailable (e.g. remote sessions,
 /// local subshells).
+pub fn github_pr_info_from_chips(chips: &[ChipResult]) -> Option<github_pr_info::GithubPrInfo> {
+    chips.iter().find_map(|chip| {
+        if matches!(chip.kind(), ContextChipKind::GithubPullRequest) {
+            chip.value()
+                .and_then(github_pr_info::github_pr_info_from_chip_value)
+        } else {
+            None
+        }
+    })
+}
+
 pub fn git_line_changes_from_chips(chips: &[ChipResult]) -> Option<display_chip::GitLineChanges> {
     chips.iter().find_map(|chip| {
         if matches!(chip.kind(), ContextChipKind::GitDiffStats) {
@@ -589,6 +632,11 @@ pub fn git_line_changes_from_chips(chips: &[ChipResult]) -> Option<display_chip:
                         lines_added: 0,
                         lines_removed: 0,
                     }),
+                ChipValue::GithubPullRequest(_) => display_chip::GitLineChanges {
+                    files_changed: 0,
+                    lines_added: 0,
+                    lines_removed: 0,
+                },
             })
         } else {
             None

--- a/app/src/context_chips/scripts/github_pull_request_prompt_chip.fish
+++ b/app/src/context_chips/scripts/github_pull_request_prompt_chip.fish
@@ -4,7 +4,8 @@ git symbolic-ref --quiet --short HEAD >/dev/null 2>/dev/null; or exit 0
 set remote_url (git remote get-url origin 2>/dev/null); or exit 0
 string match -rq '^(git@github\.com:|https?://github\.com/|ssh://git@github\.com/)' -- $remote_url; or exit 0
 
-set output (gh pr view --json url --jq .url 2>&1)
+set output (gh pr view --state all --json url,state,isDraft,mergeable,mergeStateStatus \
+    --jq '{url,state,isDraft,mergeable,mergeStateStatus}' 2>&1)
 set exit_code $status
 
 if test $exit_code -eq 0

--- a/app/src/context_chips/scripts/github_pull_request_prompt_chip.ps1
+++ b/app/src/context_chips/scripts/github_pull_request_prompt_chip.ps1
@@ -8,7 +8,8 @@ $remoteUrl = git remote get-url origin 2>$null
 if ($LASTEXITCODE -ne 0) { exit 0 }
 if ($remoteUrl -notmatch '^(git@github\.com:|https?://github\.com/|ssh://git@github\.com/)') { exit 0 }
 
-$output = gh pr view --json url --jq .url 2>&1 | Out-String
+$output = gh pr view --state all --json url,state,isDraft,mergeable,mergeStateStatus `
+    --jq '{url,state,isDraft,mergeable,mergeStateStatus}' 2>&1 | Out-String
 $exitCode = $LASTEXITCODE
 $output = $output.TrimEnd()
 

--- a/app/src/context_chips/scripts/github_pull_request_prompt_chip.sh
+++ b/app/src/context_chips/scripts/github_pull_request_prompt_chip.sh
@@ -10,7 +10,8 @@ case "$remote_url" in
         ;;
 esac
 
-output=$(gh pr view --json url --jq .url 2>&1)
+output=$(gh pr view --state all --json url,state,isDraft,mergeable,mergeStateStatus \
+    --jq '{url,state,isDraft,mergeable,mergeStateStatus}' 2>&1)
 exit_code=$?
 
 if [ $exit_code -eq 0 ]; then

--- a/app/src/search/command_palette/navigation/render.rs
+++ b/app/src/search/command_palette/navigation/render.rs
@@ -163,6 +163,7 @@ fn render_prompt_udi(snapshot: &PromptSnapshot, appearance: &Appearance) -> Box<
                     };
                     parsed
                 }
+                ChipValue::GithubPullRequest(_) => continue,
             };
             let font_size = udi_font_size(appearance);
             let content = render_git_diff_stats_content(

--- a/app/src/terminal/view/tab_metadata.rs
+++ b/app/src/terminal/view/tab_metadata.rs
@@ -1,5 +1,8 @@
 use crate::context_chips::display_chip::GitLineChanges;
-use crate::context_chips::{git_line_changes_from_chips, ContextChipKind};
+use crate::context_chips::github_pr_info::GithubPrInfo;
+use crate::context_chips::{
+    github_pr_info::github_pr_info_from_chip_value, git_line_changes_from_chips, ContextChipKind,
+};
 use crate::terminal::TerminalView;
 use warpui::AppContext;
 
@@ -76,12 +79,17 @@ impl TerminalView {
         self.terminal_title_from_shell()
     }
 
-    pub fn current_pull_request_url(&self, ctx: &AppContext) -> Option<String> {
+    pub fn current_github_pr_info(&self, ctx: &AppContext) -> Option<GithubPrInfo> {
         self.current_prompt
             .as_ref(ctx)
             .latest_chip_value(&ContextChipKind::GithubPullRequest, ctx)
-            .map(|v| v.to_string())
-            .filter(|value| !value.trim().is_empty())
+            .and_then(|value| github_pr_info_from_chip_value(&value))
+    }
+
+    pub fn current_pull_request_url(&self, ctx: &AppContext) -> Option<String> {
+        self.current_github_pr_info(ctx)
+            .map(|info| info.url)
+            .filter(|url| !url.trim().is_empty())
     }
 
     #[cfg_attr(not(feature = "local_fs"), allow(clippy::unnecessary_lazy_evaluations))]

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -25,7 +25,11 @@ use std::sync::{Arc, Mutex};
 
 use crate::appearance::Appearance;
 use crate::context_chips::display_chip::GitLineChanges;
-use crate::context_chips::github_pr_display_text_from_url;
+use crate::context_chips::github_pr_info::GithubPrInfo;
+use crate::context_chips::github_pr_status::{
+    github_pr_chip_label, github_pr_status_search_suffix, github_pr_status_tooltip,
+    render_github_pr_badge_content,
+};
 use crate::drive::{cloud_object_styling::warp_drive_icon_color, DriveObjectType};
 use crate::editor::EditorView;
 use crate::pane_group::pane::IPaneType;
@@ -768,7 +772,7 @@ struct VerticalTabsSummaryBranchEntry {
     repo_path: PathBuf,
     branch_name: String,
     diff_stats: Option<GitLineChanges>,
-    pull_request_label: Option<String>,
+    pull_request_info: Option<GithubPrInfo>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -924,8 +928,8 @@ fn coalesce_summary_branch_entries(
             if existing.diff_stats.is_none() {
                 existing.diff_stats = entry.diff_stats;
             }
-            if existing.pull_request_label.is_none() {
-                existing.pull_request_label = entry.pull_request_label;
+            if existing.pull_request_info.is_none() {
+                existing.pull_request_info = entry.pull_request_info;
             }
         } else {
             indices.insert(key, coalesced.len());
@@ -956,8 +960,8 @@ fn summary_search_text_fragments(
     fragments.extend(summary.working_directories.iter().cloned());
     for entry in &summary.branch_entries {
         fragments.push(entry.branch_name.clone());
-        if let Some(pull_request_label) = &entry.pull_request_label {
-            fragments.push(pull_request_label.clone());
+        if let Some(pr_info) = &entry.pull_request_info {
+            fragments.push(terminal_pull_request_search_label(pr_info));
         }
         if let Some(diff_stats) = &entry.diff_stats {
             fragments.push(vtab_diff_stats_text(diff_stats));
@@ -2780,11 +2784,7 @@ fn build_vertical_tabs_summary_data(
                         repo_path,
                         branch_name,
                         diff_stats: terminal_view.current_diff_line_changes(app),
-                        pull_request_label: terminal_view
-                            .current_pull_request_url(app)
-                            .as_deref()
-                            .map(terminal_pull_request_badge_label)
-                            .and_then(|label| normalize_summary_text(&label)),
+                        pull_request_info: terminal_view.current_github_pr_info(app),
                     });
                 }
             }
@@ -3016,9 +3016,9 @@ fn terminal_pane_search_text_fragments(
             .to_string()
         });
     let pull_request_label = terminal_view
-        .current_pull_request_url(app)
-        .as_deref()
-        .map(terminal_pull_request_badge_label);
+        .current_github_pr_info(app)
+        .as_ref()
+        .map(terminal_pull_request_search_label);
 
     terminal_search_text_fragments(
         primary_text,
@@ -3188,10 +3188,18 @@ fn terminal_agent_text(terminal_view: &TerminalView, app: &AppContext) -> Termin
     agent_text
 }
 
-fn terminal_pull_request_badge_label(pull_request_url: &str) -> String {
-    github_pr_display_text_from_url(pull_request_url)
-        .map(|label| label.strip_prefix("PR ").unwrap_or(&label).to_string())
-        .unwrap_or_else(|| pull_request_url.to_string())
+pub(crate) fn terminal_pull_request_display_label(info: &GithubPrInfo) -> String {
+    github_pr_chip_label(info)
+}
+
+pub(crate) fn terminal_pull_request_search_label(info: &GithubPrInfo) -> String {
+    let label = terminal_pull_request_display_label(info);
+    let suffix = github_pr_status_search_suffix(info);
+    if suffix.is_empty() {
+        label
+    } else {
+        format!("{label} {suffix}")
+    }
 }
 
 fn vtab_diff_stats_tokens(line_changes: &GitLineChanges) -> Vec<String> {
@@ -4083,9 +4091,9 @@ fn render_summary_branch_line(
         ));
         has_right_badges = true;
     }
-    if let Some(pull_request_label) = &entry.pull_request_label {
+    if let Some(pr_info) = &entry.pull_request_info {
         right_badges.add_child(render_passive_terminal_pull_request_badge(
-            pull_request_label,
+            pr_info,
             appearance,
         ));
         has_right_badges = true;
@@ -4285,11 +4293,9 @@ fn render_terminal_right_badges(
     }
 
     if show_pr_link {
-        if let Some(pull_request_url) = terminal_view.current_pull_request_url(app) {
-            let label = terminal_pull_request_badge_label(&pull_request_url);
+        if let Some(pr_info) = terminal_view.current_github_pr_info(app) {
             right_badges.add_child(render_terminal_pull_request_badge(
-                label,
-                pull_request_url,
+                pr_info,
                 entrypoint,
                 badge_mouse_states.pull_request.clone(),
                 appearance,
@@ -4339,13 +4345,15 @@ fn render_terminal_diff_stats_badge(
 }
 
 fn render_terminal_pull_request_badge(
-    label: String,
-    url: String,
+    pr_info: GithubPrInfo,
     entrypoint: VerticalTabsChipEntrypoint,
     mouse_state: MouseStateHandle,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
+    let label = terminal_pull_request_display_label(&pr_info);
+    let url = pr_info.url.clone();
+    let tooltip_text = github_pr_status_tooltip(&pr_info);
 
     Hoverable::new(mouse_state, move |state| {
         let bg = if state.is_hovered() {
@@ -4353,7 +4361,27 @@ fn render_terminal_pull_request_badge(
         } else {
             internal_colors::fg_overlay_1(theme)
         };
-        render_badge_container(render_pull_request_badge_content(&label, appearance), bg)
+        let mut stack = Stack::new().with_child(render_badge_container(
+            render_pull_request_badge_content(&label, Some(&pr_info), appearance),
+            bg,
+        ));
+        if state.is_hovered() {
+            let tool_tip = appearance
+                .ui_builder()
+                .tool_tip(tooltip_text.clone())
+                .build()
+                .finish();
+            stack.add_positioned_overlay_child(
+                tool_tip,
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., -4.),
+                    ParentOffsetBounds::Unbounded,
+                    ParentAnchor::TopMiddle,
+                    ChildAnchor::BottomMiddle,
+                ),
+            );
+        }
+        stack.finish()
     })
     .on_click(move |ctx, app, _| {
         send_telemetry_from_app_ctx!(
@@ -4367,11 +4395,12 @@ fn render_terminal_pull_request_badge(
 }
 
 fn render_passive_terminal_pull_request_badge(
-    label: &str,
+    pr_info: &GithubPrInfo,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
+    let label = terminal_pull_request_display_label(pr_info);
     render_badge_container(
-        render_pull_request_badge_content(label, appearance),
+        render_pull_request_badge_content(&label, Some(pr_info), appearance),
         internal_colors::fg_overlay_1(appearance.theme()),
     )
 }
@@ -4433,25 +4462,26 @@ fn render_badge_container(content: Box<dyn Element>, background: ThemeFill) -> B
         .finish()
 }
 
-fn render_pull_request_badge_content(label: &str, appearance: &Appearance) -> Box<dyn Element> {
+fn render_pull_request_badge_content(
+    label: &str,
+    pr_info: Option<&GithubPrInfo>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
     let theme = appearance.theme();
     let main_text_color = theme.main_text_color(theme.background());
-    let sub_text_color = theme.sub_text_color(theme.background());
-    Flex::row()
-        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_spacing(4.)
-        .with_child(
-            ConstrainedBox::new(UiIcon::Github.to_warpui_icon(main_text_color).finish())
-                .with_width(BADGE_ICON_SIZE)
-                .with_height(BADGE_ICON_SIZE)
-                .finish(),
-        )
-        .with_child(
-            Text::new_inline(label.to_string(), appearance.ui_font_family(), 10.)
-                .with_color(sub_text_color.into())
-                .finish(),
-        )
-        .finish()
+    let sub_text_color = theme.sub_text_color(theme.background()).into();
+    let github_icon = ConstrainedBox::new(UiIcon::Github.to_warpui_icon(main_text_color).finish())
+        .with_width(BADGE_ICON_SIZE)
+        .with_height(BADGE_ICON_SIZE)
+        .finish();
+    render_github_pr_badge_content(
+        label,
+        pr_info,
+        sub_text_color,
+        appearance.ui_font_family(),
+        theme,
+        github_icon,
+    )
 }
 
 fn compute_tab_group_color_mode(
@@ -5718,10 +5748,9 @@ fn render_terminal_detail_section(
         ));
         has_right_badges = true;
     }
-    if let Some(pull_request_url) = terminal_view.current_pull_request_url(app) {
+    if let Some(pr_info) = terminal_view.current_github_pr_info(app) {
         right_badges.add_child(render_terminal_pull_request_badge(
-            terminal_pull_request_badge_label(&pull_request_url),
-            pull_request_url,
+            pr_info,
             VerticalTabsChipEntrypoint::DetailsSidecar,
             props.badge_mouse_states.pull_request.clone(),
             appearance,

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -1,5 +1,6 @@
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::context_chips::display_chip::GitLineChanges;
+use crate::context_chips::github_pr_info::GithubPrInfo;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
@@ -20,13 +21,19 @@ use super::{
     select_summary_pane_kind_icons, should_keep_detail_sidecar_visible_for_mouse_position,
     sort_summary_primary_labels_status_first, summary_overflow_count,
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
-    terminal_pull_request_badge_label, terminal_search_text_fragments,
+    terminal_pull_request_search_label, terminal_search_text_fragments,
     terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
     vtab_diff_stats_text, AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons,
     TerminalAgentText, TerminalPrimaryLineData, TerminalPrimaryLineFont, VerticalTabsDetailTarget,
     VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
     VerticalTabsSummaryPrimaryLabel,
 };
+
+fn sample_pr_info(number: &str) -> GithubPrInfo {
+    GithubPrInfo::from_url_with_defaults(format!(
+        "https://github.com/warpdotdev/warp-internal/pull/{number}"
+    ))
+}
 
 fn label(text: &str) -> VerticalTabsSummaryPrimaryLabel {
     VerticalTabsSummaryPrimaryLabel {
@@ -760,9 +767,7 @@ fn terminal_search_fragments_include_rendered_terminal_badges() {
         "~/warp".to_string(),
         Some("main".to_string()),
         terminal_kind_badge_label(false, Some(CLIAgent::Claude)),
-        Some(terminal_pull_request_badge_label(
-            "https://github.com/warpdotdev/warp-internal/pull/12345",
-        )),
+        Some(terminal_pull_request_search_label(&sample_pr_info("12345"))),
         Some(GitLineChanges {
             files_changed: 1,
             lines_added: 2,
@@ -914,7 +919,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
             repo_path: repo_a.clone(),
             branch_name: "main".to_string(),
             diff_stats: None,
-            pull_request_label: None,
+            pull_request_info: None,
         },
         VerticalTabsSummaryBranchEntry {
             repo_path: repo_a.clone(),
@@ -924,7 +929,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                 lines_added: 2,
                 lines_removed: 3,
             }),
-            pull_request_label: Some("#123".to_string()),
+            pull_request_info: Some(sample_pr_info("123")),
         },
         VerticalTabsSummaryBranchEntry {
             repo_path: repo_b.clone(),
@@ -934,7 +939,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                 lines_added: 5,
                 lines_removed: 6,
             }),
-            pull_request_label: Some("#456".to_string()),
+            pull_request_info: Some(sample_pr_info("456")),
         },
     ];
 
@@ -949,7 +954,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                     lines_added: 2,
                     lines_removed: 3,
                 }),
-                pull_request_label: Some("#123".to_string()),
+                pull_request_info: Some(sample_pr_info("123")),
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: repo_b,
@@ -959,7 +964,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                     lines_added: 5,
                     lines_removed: 6,
                 }),
-                pull_request_label: Some("#456".to_string()),
+                pull_request_info: Some(sample_pr_info("456")),
             },
         ]
     );
@@ -1107,25 +1112,25 @@ fn summary_search_fragments_include_hidden_overflow_values() {
                     lines_added: 2,
                     lines_removed: 3,
                 }),
-                pull_request_label: Some("#123".to_string()),
+                pull_request_info: Some(sample_pr_info("123")),
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: PathBuf::from("/tmp/repo-b"),
                 branch_name: "feature/hidden".to_string(),
                 diff_stats: None,
-                pull_request_label: None,
+                pull_request_info: None,
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: PathBuf::from("/tmp/repo-c"),
                 branch_name: "cleanup".to_string(),
                 diff_stats: None,
-                pull_request_label: None,
+                pull_request_info: None,
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: PathBuf::from("/tmp/repo-d"),
                 branch_name: "hidden-branch".to_string(),
                 diff_stats: None,
-                pull_request_label: Some("#789".to_string()),
+                pull_request_info: Some(sample_pr_info("789")),
             },
         ],
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the GitHub PR context chip to fetch structured PR state from `gh pr view` and show a compact merge-status indicator in three surfaces that already share the chip pipeline:

- Terminal prompt (`DisplayChip`)
- Agent input footer toolbar
- Vertical tabs PR badges (expanded rows, summary mode, detail sidecar)

## Data model

- New `GithubPrInfo` + `ChipValue::GithubPullRequest` variant (mirrors `GitDiffStats` structured values)
- Shell scripts now run `gh pr view --state all --json url,state,isDraft,mergeable,mergeStateStatus`
- `CurrentPrompt` parses JSON into structured values; legacy bare-URL output still works
- Shared helpers in `github_pr_status.rs` for labels, tooltips, and compact indicators (check for merged, dot for draft/blocked/conflicts/ready)

## Behavior

- **Merged PRs** stay visible on the branch after merge (previously hidden because only open PRs were queried)
- **Invalid JSON** does not cache failure fingerprints (retryable per APP-4014)
- **Vertical tabs search** includes status suffixes (e.g. `#123 merged`)
- Hover tooltips show human-readable status (e.g. `PR #123 · Ready to merge`)

## Testing

- Added unit tests in `github_pr_info` / `github_pr_status`, `display_chip_tests`, and updated `vertical_tabs_tests` / `logging_tests`
- `cargo check -p warp` passes locally

## Follow-ups (out of scope)

- CI/check rollup (`statusCheckRollup`)
- Parity with orchestration pill bar cloud PR artifacts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fbde1d6-53e6-4f1f-b46d-6b781b581c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fbde1d6-53e6-4f1f-b46d-6b781b581c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

