### PR TITLE
add Intel(R) HD Graphics 2500 to buggy iGPU adapters

### DIFF
--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -521,6 +521,7 @@ pub fn adapter_has_rendering_offset_bug(adapter_info: &wgpu::AdapterInfo) -> boo
     // Known affected Intel integrated GPU models. This list is based on user reports from
     // https://github.com/warpdotdev/Warp/issues/6120.
     let affected_models = [
+        "Intel(R) HD Graphics 2500",
         "Intel(R) HD Graphics 4000",
         "Intel(R) HD Graphics 4400",
         "Intel(R) HD Graphics 4600",


### PR DESCRIPTION
## Description

We have a list of known buggy Intel iGPU adapters which is incomplete. We received a new report so I'm just adding it to the list.

## Linked Issue

Closes #11394.

## Testing

Unable to test it myself without the hardware, but I'll send the user a pre-release build to verify

