### PR TITLE
Update filesystem watch filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,6 +4765,7 @@ dependencies = [
 [[package]]
 name = "file-id"
 version = "0.2.2"
+source = "git+https://github.com/warpdotdev/notify?rev=91b719849bc04ef251bcb2cc61076b099204e970#91b719849bc04ef251bcb2cc61076b099204e970"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -8384,6 +8385,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notify"
 version = "8.0.0"
+source = "git+https://github.com/warpdotdev/notify?rev=91b719849bc04ef251bcb2cc61076b099204e970#91b719849bc04ef251bcb2cc61076b099204e970"
 dependencies = [
  "bitflags 2.9.4",
  "filetime",
@@ -8401,6 +8403,7 @@ dependencies = [
 [[package]]
 name = "notify-debouncer-full"
 version = "0.5.0"
+source = "git+https://github.com/warpdotdev/notify?rev=91b719849bc04ef251bcb2cc61076b099204e970#91b719849bc04ef251bcb2cc61076b099204e970"
 dependencies = [
  "file-id",
  "log",
@@ -8426,6 +8429,7 @@ dependencies = [
 [[package]]
 name = "notify-types"
 version = "2.0.0"
+source = "git+https://github.com/warpdotdev/notify?rev=91b719849bc04ef251bcb2cc61076b099204e970#91b719849bc04ef251bcb2cc61076b099204e970"
 
 [[package]]
 name = "ntapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,7 +4765,6 @@ dependencies = [
 [[package]]
 name = "file-id"
 version = "0.2.2"
-source = "git+https://github.com/warpdotdev/notify?rev=f3afcda3058941e17e09689afea40e2a2db057e0#f3afcda3058941e17e09689afea40e2a2db057e0"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -8385,7 +8384,6 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notify"
 version = "8.0.0"
-source = "git+https://github.com/warpdotdev/notify?rev=f3afcda3058941e17e09689afea40e2a2db057e0#f3afcda3058941e17e09689afea40e2a2db057e0"
 dependencies = [
  "bitflags 2.9.4",
  "filetime",
@@ -8403,7 +8401,6 @@ dependencies = [
 [[package]]
 name = "notify-debouncer-full"
 version = "0.5.0"
-source = "git+https://github.com/warpdotdev/notify?rev=f3afcda3058941e17e09689afea40e2a2db057e0#f3afcda3058941e17e09689afea40e2a2db057e0"
 dependencies = [
  "file-id",
  "log",
@@ -8429,7 +8426,6 @@ dependencies = [
 [[package]]
 name = "notify-types"
 version = "2.0.0"
-source = "git+https://github.com/warpdotdev/notify?rev=f3afcda3058941e17e09689afea40e2a2db057e0#f3afcda3058941e17e09689afea40e2a2db057e0"
 
 [[package]]
 name = "ntapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,13 +186,7 @@ mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev
 mime_guess = "2.0"
 minimp4 = "0.1.2"
 nix = { version = "0.26.4", default-features = false, features = ["signal"] }
-# TODO: After the dual-predicate `WatchFilter` PR (CODE-XXXX) lands on
-# `warpdotdev/notify-8.0.0`, bump this `rev` to the new commit and remove the
-# `[patch]` override at the bottom of this file. The split into separate
-# emit/descend predicates is required by `repo_metadata::entry::repo_watch_filter`
-# and `ai::index::full_source_code_embedding::manager::CodebaseIndexManager::watch_path`,
-# so the warp-public callers won't compile against the old rev.
-notify-debouncer-full = { git = "https://github.com/warpdotdev/notify", rev = "f3afcda3058941e17e09689afea40e2a2db057e0" }
+notify-debouncer-full = { git = "https://github.com/warpdotdev/notify", rev = "91b719849bc04ef251bcb2cc61076b099204e970" }
 nom = "7.1.1"
 num-traits = "0.2"
 oauth2 = { version = "5.0.0", default-features = false }
@@ -384,17 +378,6 @@ streaming-iterator = "0.1.0"
 derivative = "2.2.0"
 parquet = { version = "55.0.0", features = ["arrow"] }
 rmcp = { version = "1.6" }
-
-# Local development override: routes the workspace's `notify-debouncer-full`
-# (and transitive `notify`) to the working copy of `warpdotdev/notify` at
-# `/Users/maggieshan/Warp/notify`, which carries the dual-predicate
-# `WatchFilter` changes that are referenced by `repo_metadata::entry` and the
-# code-indexing manager. Remove this `[patch]` block once the notify PR lands
-# and the `rev` in `[workspace.dependencies]` above has been bumped to the new
-# commit. Do not commit this `[patch]` to the PR.
-[patch."https://github.com/warpdotdev/notify"]
-notify-debouncer-full = { path = "/Users/maggieshan/Warp/notify/notify-debouncer-full" }
-notify = { path = "/Users/maggieshan/Warp/notify/notify" }
 
 [profile.release]
 # Use line-tables-only (debug = 1) rather than full debuginfo (debug = 2 /

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,12 @@ mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev
 mime_guess = "2.0"
 minimp4 = "0.1.2"
 nix = { version = "0.26.4", default-features = false, features = ["signal"] }
+# TODO: After the dual-predicate `WatchFilter` PR (CODE-XXXX) lands on
+# `warpdotdev/notify-8.0.0`, bump this `rev` to the new commit and remove the
+# `[patch]` override at the bottom of this file. The split into separate
+# emit/descend predicates is required by `repo_metadata::entry::repo_watch_filter`
+# and `ai::index::full_source_code_embedding::manager::CodebaseIndexManager::watch_path`,
+# so the warp-public callers won't compile against the old rev.
 notify-debouncer-full = { git = "https://github.com/warpdotdev/notify", rev = "f3afcda3058941e17e09689afea40e2a2db057e0" }
 nom = "7.1.1"
 num-traits = "0.2"
@@ -378,6 +384,17 @@ streaming-iterator = "0.1.0"
 derivative = "2.2.0"
 parquet = { version = "55.0.0", features = ["arrow"] }
 rmcp = { version = "1.6" }
+
+# Local development override: routes the workspace's `notify-debouncer-full`
+# (and transitive `notify`) to the working copy of `warpdotdev/notify` at
+# `/Users/maggieshan/Warp/notify`, which carries the dual-predicate
+# `WatchFilter` changes that are referenced by `repo_metadata::entry` and the
+# code-indexing manager. Remove this `[patch]` block once the notify PR lands
+# and the `rev` in `[workspace.dependencies]` above has been bumped to the new
+# commit. Do not commit this `[patch]` to the PR.
+[patch."https://github.com/warpdotdev/notify"]
+notify-debouncer-full = { path = "/Users/maggieshan/Warp/notify/notify-debouncer-full" }
+notify = { path = "/Users/maggieshan/Warp/notify/notify" }
 
 [profile.release]
 # Use line-tables-only (debug = 1) rather than full debuginfo (debug = 2 /

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -1182,7 +1182,6 @@ fn test_entering_remote_parent_agent_view_lazily_restores_local_hidden_child_pan
             assert_eq!(
                 request_ambient_agent_task_id_for_hidden_child(
                     panes,
-                    local_child_conversation_id,
                     child_pane_id,
                     ctx,
                 ),

--- a/app/src/warp_managed_paths_watcher.rs
+++ b/app/src/warp_managed_paths_watcher.rs
@@ -246,11 +246,15 @@ impl WarpManagedPathsWatcher {
             let config_local_dir = warp_core::paths::config_local_dir();
             let should_register_config_local_dir = config_local_dir != data_dir;
             let worktrees_dir = data_dir.join("worktrees");
+            // Safe to use for both directory registration and event emission.
+            // If this rejects `worktrees_dir`, every descendant should be rejected too,
+            // so the recursive watcher never prunes an ancestor needed to reach an allowed path.
+            let filter = Arc::new(move |path: &Path| !path.starts_with(&worktrees_dir));
             Self::register_path(
                 ctx,
                 &watcher,
                 data_dir.clone(),
-                WatchFilter::with_filter(Arc::new(move |path| !path.starts_with(&worktrees_dir))),
+                WatchFilter::with_filter(filter.clone(), filter),
                 RecursiveMode::Recursive,
                 "Warp data directory",
             );
@@ -288,13 +292,14 @@ impl WarpManagedPathsWatcher {
                     && (!should_register_config_local_dir
                         || !warp_home_config_dir.starts_with(&config_local_dir))
                 {
+                    // Watch the config directory non-recursively,
+                    // and ignore events for files other than the MCP config file.
+                    let emit = Arc::new(move |path: &Path| path == warp_home_mcp_config_path);
                     Self::register_path(
                         ctx,
                         &watcher,
                         warp_home_config_dir,
-                        WatchFilter::with_filter(Arc::new(move |path| {
-                            path == warp_home_mcp_config_path
-                        })),
+                        WatchFilter::with_filter(Arc::new(|_: &Path| true), emit),
                         RecursiveMode::NonRecursive,
                         "Warp home MCP config directory",
                     );

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         use chrono::Utc;
         use super::changed_files::ChangedFiles;
-        use crate::index::path_passes_filters;
+        use crate::index::{path_passes_filters, path_passes_gitignore, should_descend_into_git_path};
         use ignore::gitignore::Gitignore;
         use notify_debouncer_full::notify::{RecursiveMode, WatchFilter};
         use warp_core::features::FeatureFlag;
@@ -842,9 +842,21 @@ impl CodebaseIndexManager {
         gitignores: Arc<Vec<Gitignore>>,
         ctx: &mut ModelContext<Self>,
     ) {
-        let watch_filter = WatchFilter::with_filter(Arc::new(move |path| {
-            path_passes_filters(path, gitignores.as_slice())
-        }));
+        // Only emit events for paths that pass the existing gitignore
+        // and `.git/` allowlist rules.
+        let emit_gitignores = gitignores.clone();
+        let should_emit_event =
+            Arc::new(move |path: &Path| path_passes_filters(path, emit_gitignores.as_slice()));
+
+        // Descend through gitignore-allowed directories and
+        // through `.git/` paths that may contain allowlisted files like `.git/HEAD`.
+        let descend_gitignores = gitignores;
+        let should_register_directory = Arc::new(move |path: &Path| {
+            path_passes_gitignore(path, descend_gitignores.as_slice())
+                && should_descend_into_git_path(path)
+        });
+
+        let watch_filter = WatchFilter::with_filter(should_register_directory, should_emit_event);
         self.watcher.update(ctx, |watcher, _ctx| {
             std::mem::drop(watcher.register_path(
                 root_path,

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         use chrono::Utc;
         use super::changed_files::ChangedFiles;
-        use crate::index::{path_passes_filters, path_passes_gitignore, should_descend_into_git_path};
+        use crate::index::{is_git_internal_path, matches_gitignores};
         use ignore::gitignore::Gitignore;
         use notify_debouncer_full::notify::{RecursiveMode, WatchFilter};
         use warp_core::features::FeatureFlag;
@@ -842,21 +842,21 @@ impl CodebaseIndexManager {
         gitignores: Arc<Vec<Gitignore>>,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Only emit events for paths that pass the existing gitignore
-        // and `.git/` allowlist rules.
-        let emit_gitignores = gitignores.clone();
-        let should_emit_event =
-            Arc::new(move |path: &Path| path_passes_filters(path, emit_gitignores.as_slice()));
-
-        // Descend through gitignore-allowed directories and
-        // through `.git/` paths that may contain allowlisted files like `.git/HEAD`.
-        let descend_gitignores = gitignores;
-        let should_register_directory = Arc::new(move |path: &Path| {
-            path_passes_gitignore(path, descend_gitignores.as_slice())
-                && should_descend_into_git_path(path)
+        // The codebase indexer only cares about source files:
+        // skip anything inside `.git/` and anything matched by gitignore
+        // (including descendants of an ignored ancestor directory).
+        // The same predicate gates both directory descent and event emission.
+        let filter = Arc::new(move |path: &Path| {
+            !is_git_internal_path(path)
+                && !matches_gitignores(
+                    path,
+                    path.is_dir(),
+                    gitignores.as_slice(),
+                    true, /* check_ancestors */
+                )
         });
 
-        let watch_filter = WatchFilter::with_filter(should_register_directory, should_emit_event);
+        let watch_filter = WatchFilter::with_filter(filter.clone(), filter);
         self.watcher.update(ctx, |watcher, _ctx| {
             std::mem::drop(watcher.register_path(
                 root_path,

--- a/crates/ai/src/index/mod.rs
+++ b/crates/ai/src/index/mod.rs
@@ -13,6 +13,7 @@ pub use repo_metadata::{BuildTreeError, DirectoryEntry, Entry, FileId, FileMetad
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
+        pub use repo_metadata::entry::{path_passes_gitignore, should_descend_into_git_path};
         pub use repo_metadata::{
             matches_gitignores, path_passes_filters,
         };

--- a/crates/ai/src/index/mod.rs
+++ b/crates/ai/src/index/mod.rs
@@ -13,10 +13,8 @@ pub use repo_metadata::{BuildTreeError, DirectoryEntry, Entry, FileId, FileMetad
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
-        pub use repo_metadata::entry::{path_passes_gitignore, should_descend_into_git_path};
-        pub use repo_metadata::{
-            matches_gitignores, path_passes_filters,
-        };
+        pub use repo_metadata::entry::{is_git_internal_path, should_watch_directory_in_git_path};
+        pub use repo_metadata::matches_gitignores;
     }
 }
 

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -1,10 +1,12 @@
 #![cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 
 use ignore::gitignore::Gitignore;
+#[cfg(feature = "local_fs")]
 use notify_debouncer_full::notify::WatchFilter;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(feature = "local_fs")]
 use std::sync::Arc;
 use thiserror::Error;
 use warp_util::standardized_path::StandardizedPath;
@@ -580,6 +582,7 @@ fn descend_allowlist_matches(suffix: &[Component<'_>]) -> bool {
 /// watches on those subtrees, but still descends into `.git/`,
 /// `.git/refs/heads/`, `.git/refs/remotes/<r>/`, and `.git/worktrees/<n>/`
 /// so the allowlisted children remain reachable on Linux.
+#[cfg(feature = "local_fs")]
 pub fn repo_watch_filter() -> WatchFilter {
     WatchFilter::with_filter(
         Arc::new(should_descend_into_git_path),
@@ -619,12 +622,7 @@ pub fn path_passes_filters(path: &Path, gitignores: &[Gitignore]) -> bool {
         path.to_path_buf()
     };
 
-    !matches_gitignores(
-        &to_check_path,
-        to_check_path.is_dir(),
-        gitignores,
-        true, /* check_ancestors */
-    ) && !should_ignore_git_path(&to_check_path)
+    path_passes_gitignore(&to_check_path, gitignores) && !should_ignore_git_path(&to_check_path)
 }
 
 /// Determines whether a file should be parsed by a treesitter query. For now the main criteria is it shouldn't

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -514,7 +514,7 @@ pub fn should_ignore_git_path(path: &Path) -> bool {
 
 /// Returns `true` when the directory at `path` should be registered for watching.
 /// Specifically for prefixes that lead to an allowlisted file and `false` for everything else inside `.git/`.
-pub fn should_descend_into_git_path(path: &Path) -> bool {
+pub fn should_watch_directory_in_git_path(path: &Path) -> bool {
     if !is_git_internal_path(path) {
         return true;
     }
@@ -546,27 +546,27 @@ pub fn should_descend_into_git_path(path: &Path) -> bool {
     descend_allowlist_matches(&suffix)
 }
 
-/// Returns `true` for an in-`.git/` path suffix that lies on the way to an allowlisted file.
-/// `suffix` is the component sequence after the `.git` component (worktree indirection already stripped).
+/// Returns `true` for an in-`.git/` directory suffix that lies on the way to an allowlisted file.
+/// `suffix` is the component sequence after the `.git` component (worktree indirection already stripped),
+/// so e.g. `.git/worktrees/<name>/refs/heads` is seen here as just `["refs", "heads"]`.
+///
+/// Only the first two components are inspected:
+/// - `top_level_dir` is the directory immediately under `.git/` (e.g. `refs`, `objects`, `worktrees`)
+///   and decides which subtree we're descending into.
+/// - `refs_subdir` is meaningful only when `top_level_dir == "refs"`, where it distinguishes
+///   the watched ref subtrees (`heads`, `remotes`) from pruned ones (`tags`, etc.).
 fn descend_allowlist_matches(suffix: &[Component<'_>]) -> bool {
-    let first = suffix.first().and_then(|c| c.as_os_str().to_str());
-    let second = suffix.get(1).and_then(|c| c.as_os_str().to_str());
-    match first {
-        // `.git/refs`, `.git/refs/heads`, `.git/refs/heads/...`,
-        // `.git/refs/remotes`, `.git/refs/remotes/<r>`,
-        // `.git/refs/remotes/<r>/...`.
-        Some("refs") => match second {
-            None => true,            // `.git/refs`
-            Some("heads") => true,   // `.git/refs/heads[/...]`
-            Some("remotes") => true, // `.git/refs/remotes[/<r>[/...]]`
-            Some(_) => false,        // `.git/refs/tags/*`, etc.
-        },
+    let top_level_dir = suffix.first().and_then(|c| c.as_os_str().to_str());
+    let refs_subdir = suffix.get(1).and_then(|c| c.as_os_str().to_str());
+    match top_level_dir {
+        // `.git/refs`, `.git/refs/heads[/...]`, `.git/refs/remotes[/<r>[/...]]`.
+        // `.git/refs/tags/*` and other refs subtrees stay pruned.
+        Some("refs") => matches!(refs_subdir, None | Some("heads") | Some("remotes")),
         // Worktree dispatcher — needed to reach `.git/worktrees/<name>/...`.
         Some("worktrees") => true,
-        // Other top-level entries are only descendable when they are allowlisted files.
-        // Non-allowlisted directories such as `.git/objects`, `.git/hooks`, and `.git/logs` must be pruned.
-        Some("HEAD" | "index.lock" | "config" | "config.worktree") if suffix.len() == 1 => true,
+        // All other `.git/` subdirectories (objects, hooks, logs, info, lfs, …) are pruned.
         Some(_) => false,
+        // `.git/` itself — descend so allowlisted children stay reachable.
         None => true,
     }
 }
@@ -585,44 +585,9 @@ fn descend_allowlist_matches(suffix: &[Component<'_>]) -> bool {
 #[cfg(feature = "local_fs")]
 pub fn repo_watch_filter() -> WatchFilter {
     WatchFilter::with_filter(
-        Arc::new(should_descend_into_git_path),
+        Arc::new(should_watch_directory_in_git_path),
         Arc::new(|path: &Path| !should_ignore_git_path(path)),
     )
-}
-
-/// Returns true if `path` is not matched by any of the supplied gitignores.
-/// Canonicalizes the path first (when it exists on disk) and consults
-/// ancestor `.gitignore` rules so children of an ignored directory are also
-/// reported as ignored.
-pub fn path_passes_gitignore(path: &Path, gitignores: &[Gitignore]) -> bool {
-    let to_check_path = if path.exists() {
-        match dunce::canonicalize(path) {
-            Ok(canonical_path) => canonical_path,
-            Err(_) => return false,
-        }
-    } else {
-        path.to_path_buf()
-    };
-
-    !matches_gitignores(
-        &to_check_path,
-        to_check_path.is_dir(),
-        gitignores,
-        true, /* check_ancestors */
-    )
-}
-
-pub fn path_passes_filters(path: &Path, gitignores: &[Gitignore]) -> bool {
-    let to_check_path = if path.exists() {
-        match dunce::canonicalize(path) {
-            Ok(canonical_path) => canonical_path,
-            Err(_) => return false,
-        }
-    } else {
-        path.to_path_buf()
-    };
-
-    path_passes_gitignore(&to_check_path, gitignores) && !should_ignore_git_path(&to_check_path)
 }
 
 /// Determines whether a file should be parsed by a treesitter query. For now the main criteria is it shouldn't

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -1,9 +1,11 @@
 #![cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 
 use ignore::gitignore::Gitignore;
+use notify_debouncer_full::notify::WatchFilter;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use thiserror::Error;
 use warp_util::standardized_path::StandardizedPath;
 
@@ -506,6 +508,105 @@ pub fn should_ignore_git_path(path: &Path) -> bool {
         && !is_index_lock_file(path)
         && !is_remote_tracking_ref(path)
         && !is_tracking_state_git_file(path)
+}
+
+/// Returns `true` when the directory at `path` should be registered for watching.
+/// Specifically for prefixes that lead to an allowlisted file and `false` for everything else inside `.git/`.
+pub fn should_descend_into_git_path(path: &Path) -> bool {
+    if !is_git_internal_path(path) {
+        return true;
+    }
+
+    // Worktree paths: `.git/worktrees/<name>/...` only descends along the
+    // path needed to reach the allowlisted children (HEAD, index.lock,
+    // config.worktree, refs/heads/*, refs/remotes/<r>/*).
+    if let Some(worktree_dir) = extract_worktree_git_dir(path) {
+        // `path` is either the worktree gitdir itself or something under it.
+        // Anything up to and including `.git/worktrees/<name>` must
+        // be descended into so we can reach children.
+        if path == worktree_dir || worktree_dir.starts_with(path) {
+            return true;
+        }
+        // Inside `.git/worktrees/<name>/...`. Apply the same allowlist logic as for the shared `.git/`.
+        let Some(suffix) = git_suffix_components(path) else {
+            return false;
+        };
+        return descend_allowlist_matches(&suffix);
+    }
+
+    // Common `.git/` directory: allow descending along the path to
+    // `.git/`, `.git/refs/heads/`, `.git/refs/remotes/<remote>/`, and
+    // `.git/worktrees/<name>/`.
+    let Some(suffix) = git_suffix_components(path) else {
+        // Path is `.git/` itself — needed so we can reach allowlisted children.
+        return true;
+    };
+    descend_allowlist_matches(&suffix)
+}
+
+/// Returns `true` for an in-`.git/` path suffix that lies on the way to an allowlisted file.
+/// `suffix` is the component sequence after the `.git` component (worktree indirection already stripped).
+fn descend_allowlist_matches(suffix: &[Component<'_>]) -> bool {
+    let first = suffix.first().and_then(|c| c.as_os_str().to_str());
+    let second = suffix.get(1).and_then(|c| c.as_os_str().to_str());
+    match first {
+        // `.git/refs`, `.git/refs/heads`, `.git/refs/heads/...`,
+        // `.git/refs/remotes`, `.git/refs/remotes/<r>`,
+        // `.git/refs/remotes/<r>/...`.
+        Some("refs") => match second {
+            None => true,            // `.git/refs`
+            Some("heads") => true,   // `.git/refs/heads[/...]`
+            Some("remotes") => true, // `.git/refs/remotes[/<r>[/...]]`
+            Some(_) => false,        // `.git/refs/tags/*`, etc.
+        },
+        // Worktree dispatcher — needed to reach `.git/worktrees/<name>/...`.
+        Some("worktrees") => true,
+        // Other top-level entries are only descendable when they are allowlisted files.
+        // Non-allowlisted directories such as `.git/objects`, `.git/hooks`, and `.git/logs` must be pruned.
+        Some("HEAD" | "index.lock" | "config" | "config.worktree") if suffix.len() == 1 => true,
+        Some(_) => false,
+        None => true,
+    }
+}
+
+/// Returns the [`WatchFilter`] used by repository file watchers.
+///
+/// Emit predicate: forwards events for everything outside `.git/` plus the
+/// allowlisted files inside `.git/` (HEAD, refs/heads/*, index.lock,
+/// config, config.worktree, refs/remotes/<r>/*, and worktree equivalents).
+///
+/// Descend predicate: prunes `.git/objects/`, `.git/hooks/`, `.git/logs/`,
+/// `.git/info/`, `.git/lfs/`, etc. so the recursive walk does not register
+/// watches on those subtrees, but still descends into `.git/`,
+/// `.git/refs/heads/`, `.git/refs/remotes/<r>/`, and `.git/worktrees/<n>/`
+/// so the allowlisted children remain reachable on Linux.
+pub fn repo_watch_filter() -> WatchFilter {
+    WatchFilter::with_filter(
+        Arc::new(should_descend_into_git_path),
+        Arc::new(|path: &Path| !should_ignore_git_path(path)),
+    )
+}
+
+/// Returns true if `path` is not matched by any of the supplied gitignores.
+/// Canonicalizes the path first (when it exists on disk) and consults
+/// ancestor `.gitignore` rules so children of an ignored directory are also
+/// reported as ignored.
+pub fn path_passes_gitignore(path: &Path, gitignores: &[Gitignore]) -> bool {
+    let to_check_path = if path.exists() {
+        match dunce::canonicalize(path) {
+            Ok(canonical_path) => canonical_path,
+            Err(_) => return false,
+        }
+    } else {
+        path.to_path_buf()
+    };
+
+    !matches_gitignores(
+        &to_check_path,
+        to_check_path.is_dir(),
+        gitignores,
+        true, /* check_ancestors */
+    )
 }
 
 pub fn path_passes_filters(path: &Path, gitignores: &[Gitignore]) -> bool {

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -389,6 +389,44 @@ fn test_git_path_filtering_allowlist() {
 }
 
 #[test]
+fn should_descend_into_git_path_prunes_git_objects_and_allows_git_head() {
+    use super::should_descend_into_git_path;
+    use std::path::Path;
+    for path in [
+        "/repo/.git",
+        "/repo/.git/refs",
+        "/repo/.git/refs/heads",
+        "/repo/.git/refs/remotes",
+        "/repo/.git/refs/remotes/origin",
+        "/repo/.git/worktrees",
+        "/repo/.git/worktrees/my-wt",
+        "/repo/.git/worktrees/my-wt/refs",
+        "/repo/.git/worktrees/my-wt/refs/heads",
+    ] {
+        assert!(
+            should_descend_into_git_path(Path::new(path)),
+            "{path} should remain traversable so allowlisted git children stay reachable"
+        );
+    }
+
+    for path in [
+        "/repo/.git/objects",
+        "/repo/.git/hooks",
+        "/repo/.git/logs",
+        "/repo/.git/worktrees/my-wt/objects",
+        "/repo/.git/worktrees/my-wt/logs",
+    ] {
+        assert!(
+            !should_descend_into_git_path(Path::new(path)),
+            "{path} should be pruned from recursive watcher registration"
+        );
+    }
+    assert!(!should_descend_into_git_path(Path::new(
+        "/repo/.git/objects/ab/blob"
+    )));
+    assert!(should_descend_into_git_path(Path::new("/repo/.git/HEAD")));
+}
+#[test]
 fn test_is_shared_git_ref() {
     use super::is_shared_git_ref;
     use std::path::Path;

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -1,224 +1,3 @@
-use super::path_passes_filters;
-use ignore::gitignore::Gitignore;
-use virtual_fs::{Stub, VirtualFS};
-
-#[cfg(unix)]
-#[test]
-fn test_path_passes_filters_unix() {
-    VirtualFS::test("test_path_passes_filters", |dirs, mut sandbox| {
-        sandbox.mkdir("my_repo");
-        sandbox.mkdir("my_repo/.git");
-        sandbox.mkdir("my_repo/.git/refs");
-        sandbox.mkdir("my_repo/.git/refs/heads");
-        sandbox.mkdir("my_repo/src");
-        sandbox.mkdir("my_repo/target");
-        sandbox.mkdir("my_repo/target/debug");
-        sandbox.mkdir("outside_of_codebase");
-        sandbox.with_files(vec![
-            Stub::EmptyFile("my_repo/README.txt"),
-            Stub::EmptyFile("my_repo/.git/blob.txt"),
-            Stub::EmptyFile("my_repo/.git/HEAD"),
-            Stub::EmptyFile("my_repo/.git/refs/heads/main"),
-            Stub::EmptyFile("my_repo/.git/refs/heads/feature-branch"),
-            Stub::EmptyFile("my_repo/src/main.rs"),
-            Stub::EmptyFile("my_repo/target/debug/a.out"),
-            Stub::EmptyFile("outside_of_codebase/text.txt"),
-        ]);
-        sandbox.with_files(vec![Stub::FileWithContent("my_repo/.gitignore", "target")]);
-
-        let test_gitignore_entry = dirs.tests().join("my_repo/.gitignore");
-        let gitignores = vec![Gitignore::new(test_gitignore_entry).0];
-
-        // Do NOT ignore a file that does not exist (for deletions)
-        assert!(path_passes_filters(
-            dirs.tests().join("my_repo/does_not_exist.txt").as_path(),
-            &gitignores
-        ));
-
-        assert!(path_passes_filters(
-            dirs.tests().join("my_repo/src").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join("my_repo/src/main.rs").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join("outside_of_codebase/text.txt").as_path(),
-            &gitignores
-        ));
-
-        // Allow .git internal files that provide useful signals
-        assert!(path_passes_filters(
-            dirs.tests().join("my_repo/.git/HEAD").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join("my_repo/.git/refs/heads").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join("my_repo/.git/refs/heads/main").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests()
-                .join("my_repo/.git/refs/heads/feature-branch")
-                .as_path(),
-            &gitignores
-        ));
-        // Non-allowlisted .git/ internal files are filtered out
-        assert!(!path_passes_filters(
-            dirs.tests().join("my_repo/.git/index").as_path(),
-            &gitignores
-        ));
-        assert!(!path_passes_filters(
-            dirs.tests().join("my_repo/.git/blob.txt").as_path(),
-            &gitignores
-        ));
-
-        // .git directory itself is still ignored
-        assert!(!path_passes_filters(
-            dirs.tests().join("my_repo/.git").as_path(),
-            &gitignores
-        ));
-
-        // Ignore .gitignored paths and their children.
-        assert!(!path_passes_filters(
-            dirs.tests().join("my_repo/target/").as_path(),
-            &gitignores
-        ));
-        assert!(!path_passes_filters(
-            dirs.tests().join("my_repo/target/debug").as_path(),
-            &gitignores
-        ));
-        assert!(!path_passes_filters(
-            dirs.tests().join("my_repo/target/debug/a.out").as_path(),
-            &gitignores
-        ));
-
-        // Ignore a .gitignored file that does not exist (for deletions)
-        assert!(!path_passes_filters(
-            &dirs.tests().join("my_repo/target/does_not_exist.txt"),
-            &gitignores
-        ));
-
-        // Ensure paths are canonicalized before being matched against gitignores.
-        assert!(path_passes_filters(
-            dirs.tests()
-                .join("outside_of_codebase/../my_repo/README.txt")
-                .as_path(),
-            &gitignores
-        ));
-        assert!(!path_passes_filters(
-            dirs.tests()
-                .join("outside_of_codebase/../my_repo/target/debug/a.out")
-                .as_path(),
-            &gitignores
-        ));
-    });
-}
-
-#[cfg_attr(
-    windows,
-    ignore = "TODO(CODE-312): issue with Gitignore matching on Windows"
-)]
-#[cfg(windows)]
-#[test]
-fn test_path_passes_filters_windows() {
-    VirtualFS::test("test_path_passes_filters", |dirs, mut sandbox| {
-        sandbox.mkdir("my_repo");
-        sandbox.mkdir(r"my_repo\.git");
-        sandbox.mkdir(r"my_repo\.git\refs");
-        sandbox.mkdir(r"my_repo\.git\refs\heads");
-        sandbox.mkdir(r"my_repo\src");
-        sandbox.mkdir(r"my_repo\target");
-        sandbox.mkdir(r"my_repo\target\debug");
-        sandbox.mkdir("outside_of_codebase");
-        sandbox.with_files(vec![
-            Stub::EmptyFile(r"my_repo\README.txt"),
-            Stub::EmptyFile(r"my_repo\.git\blob.txt"),
-            Stub::EmptyFile(r"my_repo\.git\HEAD"),
-            Stub::EmptyFile(r"my_repo\.git\refs\heads\main"),
-            Stub::EmptyFile(r"my_repo\.git\refs\heads\feature-branch"),
-            Stub::EmptyFile(r"my_repo\src\main.rs"),
-            Stub::EmptyFile(r"my_repo\target\debug\a.out"),
-            Stub::EmptyFile(r"outside_of_codebase\text.txt"),
-        ]);
-        sandbox.with_files(vec![Stub::FileWithContent(r"my_repo\.gitignore", "target")]);
-
-        let test_gitignore_entry = dirs.tests().join(r"my_repo\.gitignore");
-        let gitignores = vec![Gitignore::new(test_gitignore_entry).0];
-
-        assert!(path_passes_filters(
-            dirs.tests().join(r"my_repo\src").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join(r"my_repo\src\main.rs").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join(r"outside_of_codebase\text.txt").as_path(),
-            &gitignores
-        ));
-
-        // Allow .git internal files that provide useful signals
-        assert!(path_passes_filters(
-            dirs.tests().join(r"my_repo\.git\HEAD").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join(r"my_repo\.git\refs\heads").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests().join(r"my_repo\.git\refs\heads\main").as_path(),
-            &gitignores
-        ));
-        assert!(path_passes_filters(
-            dirs.tests()
-                .join(r"my_repo\.git\refs\heads\feature-branch")
-                .as_path(),
-            &gitignores
-        ));
-
-        // .git directory itself is still ignored
-        assert!(!path_passes_filters(
-            dirs.tests().join(r"my_repo\.git").as_path(),
-            &gitignores
-        ));
-
-        // Ignore .gitignored paths and their children.
-        assert!(!path_passes_filters(
-            dirs.tests().join(r"my_repo\target").as_path(),
-            &gitignores
-        ));
-        assert!(!path_passes_filters(
-            dirs.tests().join(r"my_repo\target\debug").as_path(),
-            &gitignores
-        ));
-        assert!(!path_passes_filters(
-            dirs.tests().join(r"my_repo\target\debug\a.out").as_path(),
-            &gitignores
-        ));
-
-        // Ensure paths are canonicalized before being matched against gitignores.
-        assert!(path_passes_filters(
-            dirs.tests()
-                .join(r"outside_of_codebase\..\my_repo\README.txt")
-                .as_path(),
-            &gitignores
-        ));
-        assert!(!path_passes_filters(
-            dirs.tests()
-                .join(r"outside_of_codebase\..\my_repo\target\debug\a.out")
-                .as_path(),
-            &gitignores
-        ));
-    });
-}
-
 #[test]
 fn test_git_path_filtering_allowlist() {
     use super::{
@@ -389,8 +168,8 @@ fn test_git_path_filtering_allowlist() {
 }
 
 #[test]
-fn should_descend_into_git_path_prunes_git_objects_and_allows_git_head() {
-    use super::should_descend_into_git_path;
+fn should_watch_directory_in_git_path_prunes_non_allowlisted_subtrees() {
+    use super::should_watch_directory_in_git_path;
     use std::path::Path;
     for path in [
         "/repo/.git",
@@ -404,7 +183,7 @@ fn should_descend_into_git_path_prunes_git_objects_and_allows_git_head() {
         "/repo/.git/worktrees/my-wt/refs/heads",
     ] {
         assert!(
-            should_descend_into_git_path(Path::new(path)),
+            should_watch_directory_in_git_path(Path::new(path)),
             "{path} should remain traversable so allowlisted git children stay reachable"
         );
     }
@@ -413,18 +192,29 @@ fn should_descend_into_git_path_prunes_git_objects_and_allows_git_head() {
         "/repo/.git/objects",
         "/repo/.git/hooks",
         "/repo/.git/logs",
+        "/repo/.git/info",
+        "/repo/.git/lfs",
+        "/repo/.git/refs/tags",
         "/repo/.git/worktrees/my-wt/objects",
         "/repo/.git/worktrees/my-wt/logs",
     ] {
         assert!(
-            !should_descend_into_git_path(Path::new(path)),
+            !should_watch_directory_in_git_path(Path::new(path)),
             "{path} should be pruned from recursive watcher registration"
         );
     }
-    assert!(!should_descend_into_git_path(Path::new(
+    assert!(!should_watch_directory_in_git_path(Path::new(
         "/repo/.git/objects/ab/blob"
     )));
-    assert!(should_descend_into_git_path(Path::new("/repo/.git/HEAD")));
+    // The predicate is only consulted on directories during recursive registration;
+    // file paths like `.git/HEAD` would never actually reach it, but the default
+    // false return here documents that they're not treated as descend roots.
+    assert!(!should_watch_directory_in_git_path(Path::new(
+        "/repo/.git/HEAD"
+    )));
+    assert!(!should_watch_directory_in_git_path(Path::new(
+        "/repo/.git/config"
+    )));
 }
 #[test]
 fn test_is_shared_git_ref() {

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -43,8 +43,8 @@ pub mod watcher;
 pub mod wrapper_model;
 
 pub use entry::{
-    gitignores_for_directory, matches_gitignores, path_passes_filters, should_ignore_git_path,
-    BuildTreeError, DirectoryEntry, Entry, FileId, FileMetadata,
+    gitignores_for_directory, matches_gitignores, should_ignore_git_path, BuildTreeError,
+    DirectoryEntry, Entry, FileId, FileMetadata,
 };
 
 // Re-export the local model's event under its original name for backward compatibility.

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -33,7 +33,8 @@ use crate::{
 };
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
-        use notify_debouncer_full::notify::{RecursiveMode, WatchFilter};
+        use notify_debouncer_full::notify::RecursiveMode;
+        use crate::entry::repo_watch_filter;
         use crate::repositories::{DetectedRepositories, DetectedRepositoriesEvent};
         use watcher::{BulkFilesystemWatcher, BulkFilesystemWatcherEvent};
         use warpui::SingletonEntity as _;
@@ -400,13 +401,9 @@ impl LocalRepoMetadataModel {
             if let Some(ref watcher) = self.watcher {
                 let watch_path = local_path.clone();
                 watcher.update(ctx, |watcher, _ctx| {
-                    use crate::entry::should_ignore_git_path;
-                    let watch_filter = WatchFilter::with_filter(Arc::new(move |watch_path| {
-                        !should_ignore_git_path(watch_path)
-                    }));
                     std::mem::drop(watcher.register_path(
                         &watch_path,
-                        watch_filter,
+                        repo_watch_filter(),
                         RecursiveMode::Recursive,
                     ));
                 });

--- a/crates/repo_metadata/src/watcher.rs
+++ b/crates/repo_metadata/src/watcher.rs
@@ -323,15 +323,14 @@ impl DirectoryWatcher {
         let registration_future = if let Some(ref watcher) = self.watcher {
             if let Some(local_path) = local_path.clone() {
                 watcher.update(ctx, |watcher, _ctx| {
-                    use crate::entry::should_ignore_git_path;
-                    use notify_debouncer_full::notify::{RecursiveMode, WatchFilter};
-                    use std::sync::Arc;
+                    use crate::entry::repo_watch_filter;
+                    use notify_debouncer_full::notify::RecursiveMode;
 
-                    let watch_filter = WatchFilter::with_filter(Arc::new(move |watch_path| {
-                        !should_ignore_git_path(watch_path)
-                    }));
-
-                    Some(watcher.register_path(&local_path, watch_filter, RecursiveMode::Recursive))
+                    Some(watcher.register_path(
+                        &local_path,
+                        repo_watch_filter(),
+                        RecursiveMode::Recursive,
+                    ))
                 })
             } else {
                 log::warn!("Cannot watch non-local path: {directory_path}");

--- a/crates/repo_metadata/src/watcher_tests.rs
+++ b/crates/repo_metadata/src/watcher_tests.rs
@@ -10,7 +10,7 @@ use crate::repository::{RepositorySubscriber, TrackedRemoteRef};
 use crate::watcher::{DirectoryWatcher, TaskQueue};
 use crate::{CanonicalizedPath, RepoMetadataError, Repository, RepositoryUpdate};
 use futures::channel::mpsc;
-use futures::StreamExt as _;
+use futures::{FutureExt as _, StreamExt as _};
 use virtual_fs::{Stub, VirtualFS};
 use warp_util::standardized_path::StandardizedPath;
 use warpui::r#async::Timer;
@@ -515,7 +515,6 @@ fn test_common_config_routes_to_repos_sharing_common_git_dir() {
 }
 
 #[test]
-#[ignore = "flaky test: CODE-1492"]
 fn test_commit_related_files_excluded_from_update_lists() {
     VirtualFS::test("commit_files_excluded", |dirs, mut vfs| {
         log::info!("Start setting up test vfs");
@@ -560,7 +559,14 @@ fn test_commit_related_files_excluded_from_update_lists() {
             log::info!("Finished setting up watcher");
 
             // Wait for initial scan to complete
-            scan_rx.next().await.expect("Scan should complete");
+            futures::select! {
+                scan = scan_rx.next().fuse() => {
+                    scan.expect("Scan channel closed while waiting for initial repository scan");
+                }
+                _ = futures::FutureExt::fuse(Timer::after(Duration::from_secs(5))) => {
+                    panic!("Timed out waiting for initial repository scan");
+                }
+            }
             log::info!("Initial scan completed");
 
             // Update both a regular file and a commit-related file
@@ -575,52 +581,79 @@ fn test_commit_related_files_excluded_from_update_lists() {
             std::fs::write(&branch_file_path, "def456abc123").expect("Updating branch ref failed");
             log::info!("Wrote files: regular_file.txt, .git/HEAD, .git/refs/heads/main");
 
-            // Receive the update with timeout and retry
-            let update = loop {
+            let update_timeout = Duration::from_secs(5);
+            let timeout = futures::FutureExt::fuse(Timer::after(update_timeout));
+            futures::pin_mut!(timeout);
+            let mut updates = Vec::new();
+
+            loop {
+                if updates
+                    .iter()
+                    .any(|update: &RepositoryUpdate| update.commit_updated)
+                    && updates.iter().any(|update| {
+                        update
+                            .added_or_modified()
+                            .any(|file| file.path == regular_file_path)
+                    })
+                {
+                    break;
+                }
                 futures::select! {
-                    update = futures::FutureExt::fuse(update_rx.next()) => {
+                    update = update_rx.next().fuse() => {
                         match update {
                             Some(update) => {
-                                log::info!("Received update");
-                                break update;
+                                log::info!("Received update: {update:?}");
+                                updates.push(update);
                             }
                             None => {
-                                panic!("Update channel closed unexpectedly");
+                                panic!(
+                                    "Update channel closed while waiting for watcher updates after modifying regular_file.txt, .git/HEAD, and .git/refs/heads/main. Received {} update(s): {updates:#?}",
+                                    updates.len()
+                                );
                             }
                         }
                     }
-                    _ = futures::FutureExt::fuse(Timer::after(Duration::from_secs(5))) => {
-                        log::warn!("Waiting for update timed out after 5s, retrying...");
+                    _ = timeout => {
+                        panic!(
+                            "Timed out after {update_timeout:?} waiting for watcher updates after modifying regular_file.txt, .git/HEAD, and .git/refs/heads/main. Expected at least one update with commit_updated=true and one update containing {}. Received {} update(s): {updates:#?}",
+                            regular_file_path.display(),
+                            updates.len()
+                        );
                     }
                 }
-            };
+            }
 
             // Verify that commit_updated is true
             assert!(
-                update.commit_updated,
+                updates.iter().any(|update| update.commit_updated),
                 "commit_updated should be true when git commit files change"
             );
 
             // Verify that git files are NOT in the added list, but regular files are
-            use crate::TargetFile;
             assert!(
-                update
-                    .contains_added_or_modified(&TargetFile::new(regular_file_path.clone(), false)),
+                updates.iter().any(|update| update
+                    .added_or_modified()
+                    .any(|file| file.path == regular_file_path)),
                 "Regular file should be in added/modified list"
             );
             assert!(
-                !update.contains_added_or_modified(&TargetFile::new(head_file_path.clone(), false)),
+                updates.iter().all(|update| update
+                    .added_or_modified()
+                    .all(|file| file.path != head_file_path)),
                 "Git HEAD file should NOT be in added/modified list"
             );
             assert!(
-                !update
-                    .contains_added_or_modified(&TargetFile::new(branch_file_path.clone(), false)),
+                updates.iter().all(|update| update
+                    .added_or_modified()
+                    .all(|file| file.path != branch_file_path)),
                 "Git branch ref file should NOT be in added/modified list"
             );
 
             // The update should not be considered empty due to commit_updated being true
             assert!(
-                !update.is_empty(),
+                updates
+                    .iter()
+                    .any(|update| update.commit_updated && !update.is_empty()),
                 "Update should not be empty when commit_updated is true"
             );
 


### PR DESCRIPTION
## Description
* Based on change to the `notify` crate https://github.com/warpdotdev/notify/pull/3 (will update cargo.toml once it's merged)
  * Which introduces 2 filter fns within the watch filter - `should_emit_event` and `should_register_directory`
  * Updates all callers of `WatchFilter::with_filter` to include the right predicates 
    * Where `should_emit_event` filters out specific files while `should_register_directory` includes ancestors to allowlisted paths such that the directories are correctly registered
* Today we use a filesystem watcher to detect git changes (branch checkouts, commits, etc.) using an allowlist - this includes paths like `HEAD`, `refs/heads/*`, `index.lock`, and ignores paths like `.git/logs/` to reduce noice 
  * The issue is that on linux, the notify crate uses `inotify` which uses the filter to decide which directories to register/watch 
  * This meant that with out filter `should_ignore_git_path`, directories like `./git` and `./git/refs` were not getting registered 
* Better fix to https://github.com/warpdotdev/warp/pull/11321  

## Linked Issue
* [APP-4528](https://linear.app/warpdotdev/issue/APP-4528/bug-code-review-shows-inaccurate-diffs-when-switching-commits)
* I believe this also fixes the flaky test mentioned in for the same reasons [CODE-1492](https://linear.app/warpdotdev/issue/CODE-1492/fix-flaky-test-commit-related-files-excluded-from-update-lists)

## Testing
Tested various git commands and repo updates in a linux devbox 

Tested original repro steps where diffs weren't getting the events for checkout:
1. git checkout HEAD~1 
2. update base branch to master in code review view 
3. git checkout master
4. Bug: code review renders old/inaccurate diffs 
5. Fix: code review refresh is triggered and shows clean state 
https://www.loom.com/share/ea1a81e5c0654fc9a6d0f20b68f7d63e 

Also verified that we're not properly watching changes to remote refs - so pushing commits to a remote branch is tracked: 
1. git commit and git push changes to a branch
2. Bug: code review git button shows "push" as the primary action 
3. Fix: code review git button shows "create pr" as the primary action

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Oz plan: https://staging.warp.dev/drive/notebook/Linux-inotify-dual-predicate-watch-filter-Warp-caller-updates-5HQUBSdF5ZqO5e8GxJmuAe

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixes linux file watcher bug where certain git events were not getting sent
