### PR TITLE
Fix inactive pane dimming on dark themes and make intensity configurable

### DIFF
--- a/app/src/pane_group/pane/view/mod.rs
+++ b/app/src/pane_group/pane/view/mod.rs
@@ -111,6 +111,7 @@ impl<P: BackingView> PaneView<P> {
             if matches!(
                 event,
                 PaneSettingsChangedEvent::ShouldDimInactivePanes { .. }
+                    | PaneSettingsChangedEvent::InactivePaneDimmingPercentage { .. }
             ) {
                 ctx.notify();
             }
@@ -400,17 +401,20 @@ impl<P: BackingView> View for PaneView<P> {
         }
 
         // Dim inactive panes.
-        let should_dim_inactive_panes = *PaneSettings::as_ref(app).should_dim_inactive_panes;
+        let pane_settings = PaneSettings::as_ref(app);
+        let should_dim_inactive_panes = *pane_settings.should_dim_inactive_panes;
+        let dimming_opacity = *pane_settings.inactive_pane_dimming_percentage;
         let dim_even_if_focused = pane_configuration.dim_even_if_focused();
         if should_dim_inactive_panes {
+            let dimming_overlay = appearance
+                .theme()
+                .inactive_pane_overlay_with_opacity(dimming_opacity);
             if dim_even_if_focused {
                 // Focus is in a side panel: dim this pane regardless of split state or focus.
-                container =
-                    container.with_foreground_overlay(appearance.theme().inactive_pane_overlay());
+                container = container.with_foreground_overlay(dimming_overlay);
             } else if split_pane_state.is_in_split_pane() && !split_pane_state.is_focused() {
                 // Normal behavior: in a split, dim only unfocused panes.
-                container =
-                    container.with_foreground_overlay(appearance.theme().inactive_pane_overlay());
+                container = container.with_foreground_overlay(dimming_overlay);
             }
         }
 

--- a/app/src/settings/pane.rs
+++ b/app/src/settings/pane.rs
@@ -11,6 +11,16 @@ define_settings_group!(PaneSettings, settings: [
         toml_path: "appearance.panes.should_dim_inactive_panes",
         description: "Whether inactive panes are visually dimmed.",
     },
+    inactive_pane_dimming_percentage: InactivePaneDimmingPercentage {
+        type: u8,
+        default: 10,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "appearance.panes.inactive_pane_dimming_percentage",
+        description: "How strongly inactive panes are dimmed, from 0 to 100 percent. \
+            Only applies when inactive panes are dimmed.",
+    },
     focus_panes_on_hover: FocusPaneOnHover {
         type: bool,
         default: false,
@@ -21,3 +31,12 @@ define_settings_group!(PaneSettings, settings: [
         description: "Whether panes are focused when hovered over.",
     }
 ]);
+
+impl InactivePaneDimmingPercentage {
+    pub const MIN: u8 = 0;
+    pub const MAX: u8 = 100;
+
+    fn validate(&self, new_value: u8) -> u8 {
+        new_value.clamp(Self::MIN, Self::MAX)
+    }
+}

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -59,9 +59,9 @@ use crate::settings::app_icon::{AppIcon, AppIconSettings};
 use crate::settings::{
     active_theme_kind, respect_system_theme, AIFontName, AppEditorSettings, CursorBlink,
     CursorBlinkEnabled, CursorDisplayType, EnforceMinimumContrast, FocusPaneOnHover, FontSettings,
-    FontSettingsChangedEvent, GPUSettings, InputBoxType, InputModeSettings, InputModeState,
-    InputSettings, InputSettingsChangedEvent, MonospaceFontName, PaneSettings,
-    ShouldDimInactivePanes, ThemeSettings, UseSystemTheme, UseThinStrokes,
+    FontSettingsChangedEvent, GPUSettings, InactivePaneDimmingPercentage, InputBoxType,
+    InputModeSettings, InputModeState, InputSettings, InputSettingsChangedEvent, MonospaceFontName,
+    PaneSettings, ShouldDimInactivePanes, ThemeSettings, UseSystemTheme, UseThinStrokes,
     DEFAULT_MONOSPACE_FONT_NAME,
 };
 use crate::terminal::block_list_viewport::InputMode;
@@ -421,6 +421,8 @@ pub enum AppearancePageAction {
     SetBlur(f32),
     OpacitySliderDragged(f32),
     BlurSliderDragged(f32),
+    SetDimmingPercentage(f32),
+    DimmingPercentageSliderDragged(f32),
     SetFontFamily(String),
     SetAIFontFamily(String),
     SetThinStrokes(ThinStrokes),
@@ -579,6 +581,9 @@ impl TypedActionView for AppearanceSettingsPageView {
             SetCursorType(cursor_display_type) => self.set_cursor_type(*cursor_display_type, ctx),
             OpacitySliderDragged(val) => self.set_opacity(*val, false, ctx),
             BlurSliderDragged(val) => self.set_blur(*val, false, ctx),
+            SetDimmingPercentage(val) | DimmingPercentageSliderDragged(val) => {
+                self.set_dimming_percentage(*val, ctx)
+            }
             OpenUrl(url) => {
                 ctx.open_url(url);
             }
@@ -1304,6 +1309,7 @@ impl AppearanceSettingsPageView {
             "Panes",
             vec![
                 Box::new(DimInactivePanesWidget::default()),
+                Box::new(InactivePaneDimmingWidget::default()),
                 Box::new(FocusFollowsMouseWidget::default()),
             ],
         ));
@@ -1753,6 +1759,15 @@ impl AppearanceSettingsPageView {
             report_if_error!(window_settings
                 .background_opacity
                 .set_value(opacity_value as u8, ctx));
+        });
+        ctx.notify();
+    }
+
+    fn set_dimming_percentage(&mut self, percentage: f32, ctx: &mut ViewContext<Self>) {
+        PaneSettings::handle(ctx).update(ctx, |pane_settings, ctx| {
+            report_if_error!(pane_settings
+                .inactive_pane_dimming_percentage
+                .set_value(percentage as u8, ctx));
         });
         ctx.notify();
     }
@@ -3523,6 +3538,71 @@ impl SettingsWidget for DimInactivePanesWidget {
                 .on_click(move |ctx, _, _| {
                     ctx.dispatch_typed_action(AppearancePageAction::ToggleDimInactivePanes);
                 })
+                .finish(),
+            None,
+        )
+    }
+}
+
+#[derive(Default)]
+struct InactivePaneDimmingWidget {
+    slider_state: SliderStateHandle,
+}
+
+impl SettingsWidget for InactivePaneDimmingWidget {
+    type View = AppearanceSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "inactive pane dimming percentage amount"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let pane_settings = PaneSettings::as_ref(app);
+        // Only relevant when dimming is enabled; hide otherwise.
+        if !*pane_settings.should_dim_inactive_panes {
+            return Empty::new().finish();
+        }
+
+        let dimming_value = *pane_settings.inactive_pane_dimming_percentage;
+        render_body_item::<AppearancePageAction>(
+            format!("Inactive pane dimming: {dimming_value}%"),
+            None,
+            LocalOnlyIconState::for_setting(
+                InactivePaneDimmingPercentage::storage_key(),
+                InactivePaneDimmingPercentage::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .slider(self.slider_state.clone())
+                .with_range(
+                    InactivePaneDimmingPercentage::MIN as f32
+                        ..InactivePaneDimmingPercentage::MAX as f32,
+                )
+                .with_default_value(dimming_value as f32)
+                .with_style(UiComponentStyles {
+                    width: Some(OPACITY_SLIDER_WIDTH),
+                    // Margin is 3. to add up with 7. padding on slider for a total of 10.
+                    margin: Some(Coords::default().top(3.).bottom(3.)),
+                    ..Default::default()
+                })
+                .on_drag(|ctx, _, val| {
+                    ctx.dispatch_typed_action(AppearancePageAction::DimmingPercentageSliderDragged(
+                        val,
+                    ))
+                })
+                .on_change(|ctx, _, val| {
+                    ctx.dispatch_typed_action(AppearancePageAction::SetDimmingPercentage(val))
+                })
+                .build()
                 .finish(),
             None,
         )

--- a/crates/warp_core/src/ui/theme/color.rs
+++ b/crates/warp_core/src/ui/theme/color.rs
@@ -344,10 +344,14 @@ impl WarpTheme {
     }
 
     /// Overlay used to dim inactive panes at a caller-specified opacity (0-100).
-    /// `fg_overlay_2` (opacity 10) is the historical default; see
-    /// `InactivePaneDimmingPercentage`.
+    ///
+    /// Fades the pane toward the window background so inactive panes recede on
+    /// both light and dark themes. The legacy overlay (`fg_overlay_2`, still
+    /// used elsewhere) blended toward the foreground, which *brightened*
+    /// inactive panes on dark themes instead of dimming them — see GH#5401.
+    /// The intensity is controlled by `InactivePaneDimmingPercentage`.
     pub fn inactive_pane_overlay_with_opacity(&self, opacity: Opacity) -> Fill {
-        self.foreground().with_opacity(opacity)
+        Fill::Solid(self.background().into_solid()).with_opacity(opacity)
     }
 
     pub fn subshell_background(&self) -> Fill {

--- a/crates/warp_core/src/ui/theme/color.rs
+++ b/crates/warp_core/src/ui/theme/color.rs
@@ -343,6 +343,13 @@ impl WarpTheme {
         fg_overlay_2(self)
     }
 
+    /// Overlay used to dim inactive panes at a caller-specified opacity (0-100).
+    /// `fg_overlay_2` (opacity 10) is the historical default; see
+    /// `InactivePaneDimmingPercentage`.
+    pub fn inactive_pane_overlay_with_opacity(&self, opacity: Opacity) -> Fill {
+        self.foreground().with_opacity(opacity)
+    }
+
     pub fn subshell_background(&self) -> Fill {
         Fill::Solid(neutral_4(self))
     }

--- a/crates/warp_core/src/ui/theme/theme_tests.rs
+++ b/crates/warp_core/src/ui/theme/theme_tests.rs
@@ -339,3 +339,26 @@ fn infer_from_foreground_color_test() {
         ColorScheme::DarkOnLight
     );
 }
+
+#[test]
+fn inactive_pane_overlay_dims_toward_background_not_foreground() {
+    // Regression test for GH#5401: on dark themes the dimming overlay must fade
+    // inactive panes toward the (dark) background, not the (light) foreground —
+    // otherwise enabling "Dim inactive panes" brightens them instead of dimming.
+    let background = ColorU::from_u32(0x101010FF);
+    let foreground = ColorU::from_u32(0xF0F0F0FF);
+    let theme = WarpTheme::new(
+        Fill::Solid(background),
+        foreground,
+        Fill::Solid(ColorU::from_u32(0x20A5BAFF)),
+        None,
+        None,
+        mock_terminal_colors(),
+        None,
+        None,
+    );
+
+    let overlay = theme.inactive_pane_overlay_with_opacity(50);
+    assert_eq!(overlay, Fill::Solid(background).with_opacity(50));
+    assert_ne!(overlay, Fill::Solid(foreground).with_opacity(50));
+}


### PR DESCRIPTION
## Description

Fixes inactive-pane dimming on dark themes and makes the dimming intensity user-configurable.

**Bug fix (GH#5401):** the "Dim inactive panes" overlay blended toward the theme **foreground** color. On dark themes the foreground is light, so dimming actually *brightened* inactive panes. The overlay now fades toward the window **background**, so inactive panes recede on both light and dark themes. (`WarpTheme::inactive_pane_overlay_with_opacity`; the legacy `inactive_pane_overlay` used for modal/header scrims is unchanged.)

**New setting:** `appearance.panes.inactive_pane_dimming_percentage` (`u8`, `0–100`, default `10`), surfaced as a slider under **Settings → Appearance → Panes**, shown only when "Dim inactive panes" is enabled. The pane re-renders on `PaneSettingsChangedEvent::InactivePaneDimmingPercentage`; synced to cloud like the existing toggle.

Files: `app/src/settings/pane.rs`, `app/src/pane_group/pane/view/mod.rs`, `app/src/settings_view/appearance_page.rs`, `crates/warp_core/src/ui/theme/color.rs`.

## Linked Issue

Closes #5401

Supersedes #11472 (filed by me, then flagged as a duplicate of #5401 by Oz).

> Note: feature/bug request — opening as **draft** pending a `ready-to-spec` / `ready-to-implement` label (and a spec under `specs/` if the team wants one) per `CONTRIBUTING.md`.

## Testing

- [x] Manually tested locally with `./script/run` (macOS OSS build): on a dark theme, enabling "Dim inactive panes" now darkens the inactive split instead of brightening it; the slider changes intensity live; default (10) is a subtle dim.
- `cargo fmt -- --check` ✅
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` ✅ (+ `-p warp_completer` ✅)
- `cargo test --doc` ✅
- Touched-code unit tests pass; the only local `nextest` failures were environment-dependent (SSH integration tests needing a backend, and a non-hermetic settings-migration test that reads the real `~/.warp/settings.toml`), unrelated to this change.

### Screenshots / Videos



https://github.com/user-attachments/assets/e340c01a-9ca0-4ab0-97c4-07d6cb9b6d62



## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: "Dim inactive panes" now dims (rather than brightens) inactive panes on dark themes.
CHANGELOG-IMPROVEMENT: Inactive pane dimming intensity is now configurable in Settings → Appearance → Panes.
