### PR TITLE
Handle session reconnecting for remote server executor

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -413,6 +413,7 @@ repo_metadata = { workspace = true, features = ["test-util"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "time"] }
+tokio-util = { workspace = true, features = ["compat"] }
 
 [build-dependencies]
 anyhow = "1.0"

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -170,6 +170,13 @@ impl RemoteDiffStateModel {
             } if *session_id == self.session_id && host_id == &self.remote_path.host_id => {
                 self.mark_disconnected(ctx);
             }
+            RemoteServerManagerEvent::SessionReconnecting {
+                session_id,
+                host_id,
+                ..
+            } if *session_id == self.session_id && host_id == &self.remote_path.host_id => {
+                self.mark_disconnected(ctx);
+            }
             RemoteServerManagerEvent::SessionReconnected {
                 session_id,
                 host_id,

--- a/app/src/code_review/diff_state/remote_tests.rs
+++ b/app/src/code_review/diff_state/remote_tests.rs
@@ -9,6 +9,7 @@ use crate::code_review::diff_state::{
     DiffStateModelEvent, DiffStats, FileDiff, FileDiffAndContent, GitDiffData,
     GitDiffWithBaseContent, GitFileStatus, RemoteDiffStateModel,
 };
+use crate::remote_server::manager::RemoteServerManagerEvent;
 use crate::util::git::{Commit, PrInfo};
 
 use super::InternalRemoteDiffState;
@@ -650,6 +651,60 @@ fn apply_file_delta_none_removes_file() {
             };
             assert!(diffs.files.is_empty());
         });
+    });
+}
+
+#[test]
+fn session_reconnecting_marks_model_disconnected() {
+    warpui::App::test((), |mut app| async move {
+        let handle = app.add_model(|_ctx| {
+            RemoteDiffStateModel::new_for_test(
+                DiffMode::Head,
+                InternalRemoteDiffState::Loaded(GitDiffData {
+                    files: vec![],
+                    total_additions: 0,
+                    total_deletions: 0,
+                    files_changed: 0,
+                }),
+                None,
+            )
+        });
+        let events = Arc::new(Mutex::new(Vec::new()));
+        {
+            let events = events.clone();
+            app.update(|ctx| {
+                ctx.subscribe_to_model(&handle, move |_, event, _| {
+                    if matches!(event, DiffStateModelEvent::ConnectionLost) {
+                        events
+                            .lock()
+                            .expect("event mutex should not be poisoned")
+                            .push(());
+                    }
+                });
+            });
+        }
+
+        handle.update(&mut app, |model, ctx| {
+            model.handle_manager_event(
+                &RemoteServerManagerEvent::SessionReconnecting {
+                    session_id: SessionId::default(),
+                    host_id: remote_server::HostId::new("test-host".to_string()),
+                    exit_status: None,
+                },
+                ctx,
+            );
+        });
+
+        handle.read(&app, |model, _| {
+            assert!(matches!(model.get(), DiffState::Disconnected));
+        });
+        assert_eq!(
+            events
+                .lock()
+                .expect("event mutex should not be poisoned")
+                .len(),
+            1
+        );
     });
 }
 

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -369,6 +369,7 @@ impl RemoteCodebaseIndexModel {
             }
             RemoteServerManagerEvent::SessionConnecting { .. }
             | RemoteServerManagerEvent::SessionConnectionFailed { .. }
+            | RemoteServerManagerEvent::SessionReconnecting { .. }
             | RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -138,10 +138,10 @@ impl Sessions {
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         // Track the connected host_id on the `Session` type so downstream
-        // code can distinguish hosts. The `RemoteServerCommandExecutor`
-        // client itself is baked in at session construction time
-        // (see `new_command_executor_for_local_tty_session`) so we no
-        // longer need to wire it here on connect/disconnect.
+        // code can distinguish hosts. A `RemoteServerCommandExecutor` is
+        // only constructed after startup has a live connected client, but
+        // reconnecting/disconnected events clear that client slot here and
+        // reconnects reattach the replacement client below.
         #[cfg(feature = "local_tty")]
         if FeatureFlag::SshRemoteServer.is_enabled() {
             let mgr = RemoteServerManager::handle(ctx);
@@ -154,10 +154,38 @@ impl Sessions {
                         session.set_remote_host_id(Some(host_id.clone()));
                     }
                 }
+                RemoteServerManagerEvent::SessionReconnecting {
+                    session_id: sid, ..
+                } => {
+                    if let Some(session) = sessions.sessions.get(sid) {
+                        let executor = session.command_executor.read().clone();
+                        if let Some(remote_executor) = executor
+                            .as_ref()
+                            .as_any()
+                            .downcast_ref::<RemoteServerCommandExecutor>()
+                        {
+                            remote_executor.clear_client();
+                            log::info!(
+                                "Cleared remote server command executor client for reconnecting session {sid:?}"
+                            );
+                        }
+                    }
+                }
                 RemoteServerManagerEvent::SessionDisconnected {
                     session_id: sid, ..
                 } => {
                     if let Some(session) = sessions.sessions.get(sid) {
+                        let executor = session.command_executor.read().clone();
+                        if let Some(remote_executor) = executor
+                            .as_ref()
+                            .as_any()
+                            .downcast_ref::<RemoteServerCommandExecutor>()
+                        {
+                            remote_executor.clear_client();
+                            log::info!(
+                                "Cleared remote server command executor client for disconnected session {sid:?}"
+                            );
+                        }
                         session.set_remote_host_id(None);
                     }
                 }
@@ -195,10 +223,24 @@ impl Sessions {
                     ..
                 } => {
                     if let Some(session) = sessions.sessions.get(sid) {
-                        let new_executor =
-                            Arc::new(RemoteServerCommandExecutor::new(*sid, client.clone()));
-                        session.set_command_executor(new_executor);
-                        log::info!("Swapped command executor for session {sid:?} after reconnect");
+                        let executor = session.command_executor.read().clone();
+                        if let Some(remote_executor) = executor
+                            .as_ref()
+                            .as_any()
+                            .downcast_ref::<RemoteServerCommandExecutor>()
+                        {
+                            remote_executor.set_client(client.clone());
+                            log::info!(
+                                "Reattached remote server command executor client for session {sid:?} after reconnect"
+                            );
+                        } else {
+                            let new_executor =
+                                Arc::new(RemoteServerCommandExecutor::new(*sid, client.clone()));
+                            session.set_command_executor(new_executor);
+                            log::warn!(
+                                "Session {sid:?} reconnected without a remote server command executor; installed a replacement"
+                            );
+                        }
                     }
                 }
             });
@@ -359,9 +401,10 @@ impl Sessions {
 
         // For warpified-remote sessions, pick up the current host_id from
         // the manager so session.remote_host_id() is populated without
-        // waiting for the next SessionConnected event. The
-        // RemoteServerCommandExecutor already has its client baked in, so
-        // nothing else needs to be wired here.
+        // waiting for the next SessionConnected event.
+        // The initial RemoteServerCommandExecutor already starts with its connected
+        // client; later disconnect/reconnect client changes are handled by
+        // the manager subscription in `Sessions::new`.
         #[cfg(feature = "local_tty")]
         if FeatureFlag::SshRemoteServer.is_enabled()
             && matches!(
@@ -1071,9 +1114,10 @@ impl Session {
         &self.info.subshell_info
     }
 
-    /// Replaces the command executor for this session. Used after a remote
-    /// server reconnect to swap in a new `RemoteServerCommandExecutor`
-    /// backed by the reconnected client.
+    /// Replaces the command executor for this session. Remote-server
+    /// reconnects normally reattach a client to the existing executor, but
+    /// this remains as a defensive fallback if a reconnect event reaches a
+    /// session whose executor no longer matches its remote-server state.
     pub fn set_command_executor(&self, executor: Arc<dyn CommandExecutor>) {
         *self.command_executor.write() = executor;
     }

--- a/app/src/terminal/model/session/command_executor/remote_server_executor.rs
+++ b/app/src/terminal/model/session/command_executor/remote_server_executor.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::remote_server::client::RemoteServerClient;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use parking_lot::RwLock;
 use warp_completer::completer::{CommandExitStatus, CommandOutput};
 use warp_core::command::ExitCode;
 use warp_core::SessionId;
@@ -21,8 +22,11 @@ use crate::terminal::shell::Shell;
 /// after the session reached the `Connected` state. The manager owns the
 /// authoritative per-session client; this executor holds a cloned `Arc` to
 /// the same underlying channels and transitively keeps them alive as long
-/// as the `Session` is alive.
+/// as the `Session` is alive. If that connection later disconnects, the
+/// client slot is cleared until the manager reconnects the session and
+/// supplies a replacement client.
 ///
+/// Commands issued while the client is disconnected will fail locally.
 /// If the underlying SSH connection is torn down mid-session,
 /// [`RemoteServerClient::run_command`] will fail naturally and
 /// [`execute_command`] surfaces that as an `Err`. We deliberately do *not*
@@ -32,7 +36,7 @@ use crate::terminal::shell::Shell;
 /// produce incorrect results.
 pub struct RemoteServerCommandExecutor {
     session_id: SessionId,
-    client: Arc<RemoteServerClient>,
+    client: RwLock<Option<Arc<RemoteServerClient>>>,
 }
 
 impl std::fmt::Debug for RemoteServerCommandExecutor {
@@ -47,7 +51,22 @@ impl RemoteServerCommandExecutor {
     /// Creates a new executor backed by an already-connected
     /// [`RemoteServerClient`].
     pub fn new(session_id: SessionId, client: Arc<RemoteServerClient>) -> Self {
-        Self { session_id, client }
+        Self {
+            session_id,
+            client: RwLock::new(Some(client)),
+        }
+    }
+
+    /// Reattaches this executor to the client created by a successful
+    /// remote-server reconnect.
+    pub(crate) fn set_client(&self, client: Arc<RemoteServerClient>) {
+        *self.client.write() = Some(client);
+    }
+
+    /// Prevents new commands from being sent after the manager has observed
+    /// that this session's remote-server connection is gone.
+    pub(crate) fn clear_client(&self) {
+        *self.client.write() = None;
     }
 }
 
@@ -61,8 +80,14 @@ impl CommandExecutor for RemoteServerCommandExecutor {
         environment_variables: Option<HashMap<String, String>>,
         _execute_command_options: ExecuteCommandOptions,
     ) -> Result<CommandOutput> {
-        let response = self
-            .client
+        let Some(client) = self.client.read().clone() else {
+            return Err(anyhow!(
+                "Remote command skipped because the remote server client is not connected (session={:?})",
+                self.session_id,
+            ));
+        };
+
+        let response = client
             .run_command(
                 self.session_id,
                 command.to_owned(),
@@ -123,3 +148,7 @@ impl CommandExecutor for RemoteServerCommandExecutor {
         true
     }
 }
+
+#[cfg(test)]
+#[path = "remote_server_executor_tests.rs"]
+mod tests;

--- a/app/src/terminal/model/session/command_executor/remote_server_executor_tests.rs
+++ b/app/src/terminal/model/session/command_executor/remote_server_executor_tests.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use async_channel::TryRecvError;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use warp_core::SessionId;
+use warpui::r#async::executor;
+
+use super::*;
+use crate::terminal::shell::ShellType;
+
+#[tokio::test]
+async fn disconnected_executor_skips_run_command_before_reaching_the_client() {
+    let (client_stream, _server_stream) = tokio::io::duplex(4096);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    let background_executor = executor::Background::default();
+    let (client, _event_rx, failure_rx) = RemoteServerClient::new(
+        client_read.compat(),
+        client_write.compat_write(),
+        &background_executor,
+    );
+    let client = Arc::new(client);
+    let command_executor =
+        RemoteServerCommandExecutor::new(SessionId::from(42u64), Arc::clone(&client));
+    command_executor.clear_client();
+
+    let shell = Shell::new(ShellType::Zsh, None, None, Default::default(), None);
+    let error = command_executor
+        .execute_command(
+            "echo should-not-run",
+            &shell,
+            None,
+            None,
+            ExecuteCommandOptions::default(),
+        )
+        .await
+        .expect_err("detached executors should fail locally");
+
+    assert!(
+        error.to_string().contains("not connected"),
+        "unexpected detached executor error: {error:#}"
+    );
+    assert!(matches!(failure_rx.try_recv(), Err(TryRecvError::Empty)));
+}

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4656,6 +4656,7 @@ impl TerminalView {
                         });
                     }
                     RemoteServerManagerEvent::SessionConnecting { .. }
+                    | RemoteServerManagerEvent::SessionReconnecting { .. }
                     | RemoteServerManagerEvent::HostConnected { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -135,6 +135,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 me.on_session_connection_failed(*session_id, ctx);
             }
             RemoteServerManagerEvent::SessionConnecting { .. }
+            | RemoteServerManagerEvent::SessionReconnecting { .. }
             | RemoteServerManagerEvent::SessionDisconnected { .. }
             | RemoteServerManagerEvent::SessionReconnected { .. }
             | RemoteServerManagerEvent::SessionDeregistered { .. }

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -388,19 +388,16 @@ pub enum RemoteServerManagerEvent {
         /// banners) should skip when this is `true`.
         is_cancelled: bool,
     },
-    /// This session's connection dropped. Carries `host_id` so consumers
-    /// don't need to look it up from the already-transitioned state.
-    /// This session's underlying connection is no longer usable: the
-    /// stream closed (EOF/error), the initialize handshake failed, or the
-    /// session was explicitly deregistered while `Connected`. Signals to
-    /// subscribers that they should drop any `Arc<RemoteServerClient>` they
-    /// hold for this session. Carries `host_id` so consumers don't need to
-    /// look it up from the already-transitioned state.
+    /// This session has reached a disconnected lifecycle state. Carries
+    /// `host_id` so consumers don't need to look it up from the
+    /// already-transitioned state.
     ///
-    /// Note this is about *transport* state, not manager tracking: after
-    /// this event fires the session may still be present in the manager
-    /// in the `Disconnected` state (e.g. when the stream dropped on its
-    /// own). Use `SessionDeregistered` to observe removal from the manager.
+    /// For reconnectable stream drops, `SessionReconnecting` is emitted
+    /// instead until reconnect attempts are exhausted. This event remains
+    /// reserved for the existing disconnect telemetry/UI lifecycle:
+    /// non-reconnectable drops, exhausted reconnect attempts, and explicit
+    /// connected-session deregistration. Use `SessionDeregistered` to observe
+    /// removal from the manager.
     SessionDisconnected {
         session_id: SessionId,
         host_id: HostId,
@@ -413,6 +410,17 @@ pub enum RemoteServerManagerEvent {
         /// deregistrations. Used by the view layer to distinguish
         /// reconnect-exhausted telemetry from regular disconnections.
         was_reconnect_attempt: bool,
+    },
+    /// The connected stream dropped, but the manager is keeping the session
+    /// alive while it attempts to reconnect. Subscribers holding cloned
+    /// `Arc<RemoteServerClient>` references should drop or detach them when
+    /// this fires; `SessionReconnected` will carry the replacement client if a
+    /// reconnect succeeds.
+    SessionReconnecting {
+        session_id: SessionId,
+        host_id: HostId,
+        /// Exit status of the remote server subprocess, if available.
+        exit_status: Option<RemoteServerExitStatus>,
     },
     /// A reconnection attempt succeeded. Downstream owners (e.g.
     /// `RemoteServerCommandExecutor`) should swap their client reference
@@ -428,9 +436,8 @@ pub enum RemoteServerManagerEvent {
     /// exactly once per session, and only on explicit teardown (never as
     /// a result of a spontaneous connection drop).
     ///
-    /// If the session was `Connected` at the point of deregistration, a
-    /// `SessionDisconnected` event is emitted first so transport-level
-    /// subscribers can release their client references.
+    /// If the session had an associated host at the point of deregistration,
+    /// `SessionDisconnected` is emitted before this event.
     SessionDeregistered { session_id: SessionId },
 
     // --- Host-scoped events ---
@@ -591,6 +598,7 @@ impl RemoteServerManagerEvent {
             RemoteServerManagerEvent::SessionConnecting { session_id }
             | RemoteServerManagerEvent::SessionConnected { session_id, .. }
             | RemoteServerManagerEvent::SessionConnectionFailed { session_id, .. }
+            | RemoteServerManagerEvent::SessionReconnecting { session_id, .. }
             | RemoteServerManagerEvent::SessionDisconnected { session_id, .. }
             | RemoteServerManagerEvent::SessionReconnected { session_id, .. }
             | RemoteServerManagerEvent::SessionDeregistered { session_id }
@@ -1327,12 +1335,12 @@ impl RemoteServerManager {
     ///
     /// Two separate events can fire here, and they mean different things:
     ///
-    /// * `SessionDisconnected` -- the *transport* went away. Emitted only
-    ///   when the session was `Connected` at the time of deregistration.
-    ///   Subscribers can use this to drop their
-    ///   `Arc<RemoteServerClient>` references and cancel in-flight
-    ///   requests. The same event also fires independently from
-    ///   `mark_session_disconnected` when the stream drops on its own.
+    /// * `SessionDisconnected` -- the user-facing disconnected lifecycle
+    ///   signal for connected-session teardown. Subscribers should drop their
+    ///   `Arc<RemoteServerClient>` references and cancel in-flight requests
+    ///   when this fires. It also fires from `mark_session_disconnected` for
+    ///   non-reconnectable disconnects or after reconnect retries are
+    ///   exhausted.
     /// * `SessionDeregistered` -- the manager is no longer *tracking* this
     ///   session. Always emitted, regardless of which state the session
     ///   was in, because the entry is being removed from `sessions`
@@ -2479,6 +2487,13 @@ impl RemoteServerManager {
                 control_path: control_path.clone(),
             },
         );
+        if attempt == 1 {
+            ctx.emit(RemoteServerManagerEvent::SessionReconnecting {
+                session_id,
+                host_id: host_id.clone(),
+                exit_status: exit_status.clone(),
+            });
+        }
 
         let spawner = self.spawner.clone();
         let executor = ctx.background_executor().clone();


### PR DESCRIPTION
## Description
* Context: https://warpdev.slack.com/archives/C0AMRA82ZKL/p1779143889865059
* We're getting a lot of client error related to the run command request failing when the session is disconnected - this pr ensures that we're not sending any run command requests unless the remote server client is actually connected 
  * We now hold a `RwLock<Option<Arc<RemoteServerClient>>>` so that we can clear/set a `RemoteServerClient` during disconnection and reconnection 
  * We add a `SessionReconnecting` event to cover 
* We are getting flooded with client errors from sending run command request when the session is already disconnected. I don’t think this is an actual user-facing error but we should avoid sending the request when we know the remote server is disconnected (https://warp.metabaseapp.com/question/42606-daily-client-request-error-rate-by-operation-error-type) 

## Testing
Verified locally that on disconnection the run command request does not get sent + client error is not logged. 
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode