### PR TITLE
Fix arity of request_ambient_agent_task_id_for_hidden_child test call

### DIFF
--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -1182,7 +1182,6 @@ fn test_entering_remote_parent_agent_view_lazily_restores_local_hidden_child_pan
             assert_eq!(
                 request_ambient_agent_task_id_for_hidden_child(
                     panes,
-                    local_child_conversation_id,
                     child_pane_id,
                     ctx,
                 ),


### PR DESCRIPTION
## Description
Fix a pre-existing compile error in `app/src/pane_group/mod_tests.rs` that breaks every Warp CI job that builds the `warp` test binary (`Formatting + Clippy (MacOS / Linux / Windows)` and the `Run *Tests` jobs).

The call site in `test_entering_remote_parent_agent_view_lazily_restores_local_hidden_child_pane` was passing 4 arguments to `request_ambient_agent_task_id_for_hidden_child`, but the helper at `app/src/pane_group/mod_tests.rs:574` only takes 3 (`panes`, `child_pane_id`, `ctx`). The stray `local_child_conversation_id` argument was added in #10794 and isn't part of the signature, so `rustc` rejects it with E0061. The two other in-tree call sites already use the correct 3-arg shape.

This is currently masking CI on every open PR that triggers Warp CI (e.g. #11479's `dependabot/cargo/openssl-0.10.80`). The fix is the exact removal `rustc` itself suggests.

Diagnosis context: [conversation](https://staging.warp.dev/conversation/7e6b9f40-55c9-4235-bc3c-1a5424213cc4), [plan](https://staging.warp.dev/drive/notebook/kmgJ7rLA29QP3bvmIzBNS6).

## Linked Issue
None — this is a bare compile-fix for a regression in test code introduced by #10794.

## Testing
Validated locally in a worktree off `origin/master`:
- `cargo fmt --all -- --check` — clean.
- `cargo check -p warp --tests` — succeeds (previously failed with E0061).
- `cargo clippy --locked -p warp --tests --all-targets -- -D warnings` — succeeds.

(Workspace-wide clippy hit an unrelated local `command-signatures-v2` build-script error tied to a `corepack`/`yarn` mismatch in my environment, not introduced by this change; CI will exercise the full workspace.)

- [x] I have manually tested my changes locally with `cargo check`/`cargo clippy` (no runtime behavior changes — this is a test-only call-site fix).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
