### PR TITLE
Update telemetry for code review over remote sessions

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2403,27 +2403,6 @@ impl AIConversation {
                         Some(api::message::Message::UpdateReviewComments(comments)) => {
                             if let Some(comments_op) = comments.operation.as_ref() {
                                 if let Some(active_code_review) = self.code_review.as_mut() {
-                                    let is_local = match comments_op {
-                                        api::message::update_review_comments::Operation::AddressReviewComments(
-                                            addressed_comments,
-                                        ) => active_code_review
-                                            .pending_comments
-                                            .iter()
-                                            .filter(|item| {
-                                                addressed_comments
-                                                    .comment_ids
-                                                    .iter()
-                                                    .any(|comment_id| {
-                                                        item.id.to_string() == *comment_id
-                                                    })
-                                            })
-                                            .find_map(|item| {
-                                                item.diff
-                                                    .file_path
-                                                    .as_ref()
-                                                    .map(|path| path.is_local())
-                                            }),
-                                    };
                                     let resolved_count = update_comment_from_comment_operation(
                                         active_code_review,
                                         comments_op.clone(),
@@ -2431,7 +2410,6 @@ impl AIConversation {
                                     if resolved_count > 0 {
                                         send_telemetry_from_ctx!(
                                             CodeReviewTelemetryEvent::CommentResolved {
-                                                is_local,
                                                 resolved_count
                                             },
                                             ctx

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2403,6 +2403,27 @@ impl AIConversation {
                         Some(api::message::Message::UpdateReviewComments(comments)) => {
                             if let Some(comments_op) = comments.operation.as_ref() {
                                 if let Some(active_code_review) = self.code_review.as_mut() {
+                                    let is_local = match comments_op {
+                                        api::message::update_review_comments::Operation::AddressReviewComments(
+                                            addressed_comments,
+                                        ) => active_code_review
+                                            .pending_comments
+                                            .iter()
+                                            .filter(|item| {
+                                                addressed_comments
+                                                    .comment_ids
+                                                    .iter()
+                                                    .any(|comment_id| {
+                                                        item.id.to_string() == *comment_id
+                                                    })
+                                            })
+                                            .find_map(|item| {
+                                                item.diff
+                                                    .file_path
+                                                    .as_ref()
+                                                    .map(|path| path.is_local())
+                                            }),
+                                    };
                                     let resolved_count = update_comment_from_comment_operation(
                                         active_code_review,
                                         comments_op.clone(),
@@ -2410,6 +2431,7 @@ impl AIConversation {
                                     if resolved_count > 0 {
                                         send_telemetry_from_ctx!(
                                             CodeReviewTelemetryEvent::CommentResolved {
+                                                is_local,
                                                 resolved_count
                                             },
                                             ctx

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -4523,6 +4523,7 @@ impl AIBlock {
         if !self.model.is_restored() {
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::CommentsReceived {
+                    is_local: Some(repo_location.is_local()),
                     raw_count,
                     converted_count,
                     thread_count,

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -29,7 +29,6 @@ use vim::{
 };
 use warp_core::platform::SessionPlatform;
 use warp_core::semantic_selection::SemanticSelection;
-use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::theme::Fill;
 use warp_editor::content::anchor::Anchor;
 use warp_editor::content::buffer::{
@@ -72,7 +71,6 @@ use super::line::EditorLineLocation;
 use crate::appearance::Appearance;
 use crate::code::editor::line_iterator::LineIterator;
 use crate::code_review::comments::{CommentId, CommentOrigin, LineDiffContent};
-use crate::code_review::CodeReviewTelemetryEvent;
 use crate::editor::InteractionState;
 use crate::notebooks::editor::model::word_unit;
 use crate::themes::theme::AnsiColorIdentifier;
@@ -3826,9 +3824,6 @@ impl CoreEditorModel for CodeEditorModel {
 
 impl CodeEditorModel {
     pub fn open_comment_line(&mut self, line: &EditorLineLocation, ctx: &mut ModelContext<Self>) {
-        // Telemetry: comment editor opened for a new inline review comment.
-        send_telemetry_from_ctx!(CodeReviewTelemetryEvent::CommentEditorOpened, ctx);
-
         self.comments.update(ctx, |comments, ctx| {
             comments.pending_comment = PendingComment::Open { line: line.clone() };
             ctx.emit(PendingCommentEvent::NewPendingComment(line.clone()));
@@ -3843,9 +3838,6 @@ impl CodeEditorModel {
         origin: &CommentOrigin,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Telemetry: comment editor opened for editing an existing inline review comment.
-        send_telemetry_from_ctx!(CodeReviewTelemetryEvent::CommentEditorOpened, ctx);
-
         self.comments.update(ctx, |comments, ctx| {
             comments.pending_comment = PendingComment::Open { line: line.clone() };
             ctx.emit(PendingCommentEvent::ReopenPendingComment {

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -120,6 +120,8 @@ pub enum CodeEditorEvent {
     },
     /// Emitted when a diff hunk is reverted
     DiffReverted,
+    /// Emitted when the inline comment editor is opened.
+    CommentEditorOpened,
     HiddenSectionExpanded,
     /// Emitted when a comment is saved. This gets propagated up so that it
     /// can be augmented with the file and repo paths and saved to the comment model.
@@ -2108,6 +2110,7 @@ impl CodeEditorView {
         self.model.update(ctx, |editor_model, ctx| {
             editor_model.reopen_comment_line(id, location, comment_text, origin, ctx);
         });
+        ctx.emit(CodeEditorEvent::CommentEditorOpened);
 
         ctx.notify();
     }

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -22,6 +22,7 @@ use warpui::keymap::{EditableBinding, FixedBinding, Keystroke, PerPlatformKeystr
 use warpui::units::Pixels;
 use warpui::{AppContext, TypedActionView, ViewContext, WeakViewHandle};
 
+use crate::cmd_or_ctrl_shift;
 use crate::code::editor::line::EditorLineLocation;
 use crate::code::editor::model::CodeEditorModel;
 use crate::code::editor::view::{CodeEditorEvent, CodeEditorView, VimMode};
@@ -30,7 +31,6 @@ use crate::editor::InteractionState;
 use crate::features::FeatureFlag;
 use crate::notebooks::editor::model::word_unit;
 use crate::util::bindings::CustomAction;
-use crate::cmd_or_ctrl_shift;
 
 /// Limit the keybindings that conflict with the Agent Mode embedded editor.
 const NON_EDITABLE_KEYMAP_CONTEXT: &str = "NonEditableKeymapContext";

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -26,12 +26,11 @@ use crate::code::editor::line::EditorLineLocation;
 use crate::code::editor::model::CodeEditorModel;
 use crate::code::editor::view::{CodeEditorEvent, CodeEditorView, VimMode};
 use crate::code_review::comments::CommentId;
-use crate::code_review::telemetry_event::CodeReviewTelemetryEvent;
 use crate::editor::InteractionState;
 use crate::features::FeatureFlag;
 use crate::notebooks::editor::model::word_unit;
 use crate::util::bindings::CustomAction;
-use crate::{cmd_or_ctrl_shift, send_telemetry_from_ctx};
+use crate::cmd_or_ctrl_shift;
 
 /// Limit the keybindings that conflict with the Agent Mode embedded editor.
 const NON_EDITABLE_KEYMAP_CONTEXT: &str = "NonEditableKeymapContext";
@@ -1066,8 +1065,6 @@ impl TypedActionView for CodeEditorView {
             }
             RevertDiffHunk { line_range } => {
                 if FeatureFlag::RevertDiffHunk.is_enabled() {
-                    send_telemetry_from_ctx!(CodeReviewTelemetryEvent::RevertHunkClicked, ctx);
-
                     // Convert line range to diff hunk index and revert it
                     let hunk_index = self
                         .model
@@ -1092,6 +1089,7 @@ impl TypedActionView for CodeEditorView {
                     self.model.update(ctx, |model: &mut CodeEditorModel, ctx| {
                         model.open_comment_line(line_info, ctx);
                     });
+                    ctx.emit(CodeEditorEvent::CommentEditorOpened);
 
                     ctx.focus(&self.active_comment_editor);
                     ctx.notify();

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -3,8 +3,7 @@ use std::mem;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-
-use instant::Instant;
+use std::time::Duration;
 
 use ai::project_context::model::ProjectContextModel;
 use indexmap::IndexMap;
@@ -645,10 +644,6 @@ pub struct CodeReviewView {
     code_review_footer: Option<ViewHandle<CodeFooterView>>,
     /// Active git-operation dialog overlay (commit / push / publish), if open.
     git_dialog: Option<ViewHandle<GitDialog>>,
-    /// Timestamp captured when a diff load is initiated. Cleared when the
-    /// corresponding `DiffLoadCompleted` telemetry event is emitted, so the
-    /// elapsed time between request and completion can be reported.
-    diff_load_start_time: Option<Instant>,
 }
 
 impl CodeReviewView {
@@ -729,10 +724,9 @@ impl CodeReviewView {
         // (and will make an RPC once that path is wired). We pass
         // should_fetch_base: false because re-opening the panel doesn't
         // need to fetch the base branch from origin.
-        self.start_diff_load_timer();
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(true, ctx);
-            model.load_diffs_for_current_repo(false, ctx);
+            model.load_diffs_for_current_repo(false, true, ctx);
         });
     }
 
@@ -751,11 +745,6 @@ impl CodeReviewView {
         ctx.unsubscribe_to_model(&self.diff_state_model);
 
         self.code_review_footer = None;
-
-        // Drop any pending diff-load timer; the in-flight load (if any) will
-        // never reach `DiffLoadCompleted` for this view, so leaving the start
-        // time around would skew the next reported duration.
-        self.diff_load_start_time = None;
 
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(false, ctx);
@@ -1329,28 +1318,19 @@ impl CodeReviewView {
             is_open: false,
             code_review_footer: None,
             git_dialog: None,
-            diff_load_start_time: None,
         };
         view.set_active_repo_comment_model(comment_batch_model, ctx);
         if has_repo {
             view.fetch_branches_and_setup_dropdown(ctx);
         }
         if has_repo {
-            // The diff-load timer is intentionally not started here. The view
-            // isn't subscribed to `diff_state_model` until `on_open`, so any
-            // completion event would not be delivered to this view. `on_open`
-            // starts a fresh timer paired with `load_diffs_for_current_repo`.
-            view.invalidate_all(None, ctx);
+            // Tracked diff loading starts in `on_open`, after this view is
+            // subscribed to `diff_state_model`, so the completion event can
+            // be observed and logged.
+            view.invalidate_all(None, None, ctx);
         }
 
         view
-    }
-
-    /// Records the moment a diff load was requested so we can report the
-    /// elapsed time when the load completes. Overwrites any prior pending
-    /// timer — only the most recent request is tracked.
-    fn start_diff_load_timer(&mut self) {
-        self.diff_load_start_time = Some(Instant::now());
     }
 
     pub fn set_terminal_view(&mut self, terminal_view: WeakViewHandle<TerminalView>) {
@@ -1574,12 +1554,11 @@ impl CodeReviewView {
             ctx
         );
 
-        self.start_diff_load_timer();
         self.diff_state_model.update(ctx, |model, ctx| {
-            model.set_diff_mode(mode, false, ctx);
+            model.set_diff_mode(mode, false, true, ctx);
         });
         self.update_diff_selector_selection(ctx);
-        self.invalidate_all(None, ctx);
+        self.invalidate_all(None, None, ctx);
     }
 
     fn handle_find_event(
@@ -2295,8 +2274,11 @@ impl CodeReviewView {
                 self.fetch_branches_and_setup_dropdown(ctx);
                 self.update_diff_selector_selection(ctx);
             }
-            DiffStateModelEvent::NewDiffsComputed(diffs) => {
-                self.invalidate_all(diffs.as_ref().map(|d| d.as_ref()), ctx);
+            DiffStateModelEvent::NewDiffsComputed {
+                diffs,
+                load_duration,
+            } => {
+                self.invalidate_all(diffs.as_ref().map(|d| d.as_ref()), *load_duration, ctx);
                 if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
                     self.update_git_operations_ui(ctx);
                 }
@@ -2442,12 +2424,10 @@ impl CodeReviewView {
     fn invalidate_all(
         &mut self,
         diff_data: Option<&GitDiffWithBaseContent>,
+        load_duration: Option<Duration>,
         ctx: &mut ViewContext<Self>,
     ) {
         if self.active_repo.is_none() {
-            // No load is associated with this view; drop any stale timer so a
-            // future call doesn't fold pre-repo time into the duration.
-            self.diff_load_start_time = None;
             return;
         };
 
@@ -2473,10 +2453,6 @@ impl CodeReviewView {
                     );
                     repo.state = CodeReviewViewState::NoRepoFound;
                 }
-                // No `DiffLoadCompleted` event will fire from this terminal
-                // state; drop the timer so a later recovery doesn't report an
-                // inflated duration.
-                self.diff_load_start_time = None;
                 ctx.notify();
                 return;
             }
@@ -2484,10 +2460,6 @@ impl CodeReviewView {
                 if let Some(repo) = self.active_repo.as_mut() {
                     repo.state = CodeReviewViewState::Error(err);
                 }
-                // Load did not complete successfully; drop the timer so a
-                // subsequent successful load doesn't include time spent in
-                // the error state.
-                self.diff_load_start_time = None;
                 ctx.notify();
                 return;
             }
@@ -2495,9 +2467,6 @@ impl CodeReviewView {
                 // Disconnected state is handled via the ConnectionLost event
                 // path, which preserves stale diffs. If invalidate_all is
                 // called while disconnected (e.g. from a stale push), ignore.
-                // Drop the timer so a reconnect-then-load (potentially much
-                // later) doesn't report the disconnect interval as load time.
-                self.diff_load_start_time = None;
                 return;
             }
             DiffState::Loaded => (),
@@ -2540,10 +2509,6 @@ impl CodeReviewView {
             });
         }
 
-        let load_duration = self
-            .diff_load_start_time
-            .take()
-            .map(|start| start.elapsed());
         send_telemetry_from_ctx!(
             CodeReviewTelemetryEvent::DiffLoadCompleted {
                 is_local,
@@ -5963,12 +5928,11 @@ impl CodeReviewView {
     }
 
     pub(crate) fn set_diff_base(&mut self, diff_mode: DiffMode, ctx: &mut ViewContext<Self>) {
-        self.start_diff_load_timer();
         self.diff_state_model.update(ctx, |diff_state_model, ctx| {
             diff_state_model.set_diff_mode_and_fetch_base(diff_mode, ctx);
         });
         self.update_diff_selector_selection(ctx);
-        self.invalidate_all(None, ctx);
+        self.invalidate_all(None, None, ctx);
     }
 
     /// Insert diff hunk as an inline attachment in the terminal input
@@ -7165,9 +7129,8 @@ impl TypedActionView for CodeReviewView {
                 self.save_files(unsaved_files.as_slice(), ctx);
             }
             CodeReviewAction::RefreshGitState => {
-                self.start_diff_load_timer();
                 self.diff_state_model.update(ctx, |model, ctx| {
-                    model.load_diffs_for_current_repo(false, ctx);
+                    model.load_diffs_for_current_repo(false, true, ctx);
                     model.refresh_metadata_and_pr_info(ctx);
                 });
             }

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -650,6 +650,10 @@ impl CodeReviewView {
         self.active_repo.as_ref().map(|repo| &repo.repo_path)
     }
 
+    pub(crate) fn repo_is_local(&self) -> Option<bool> {
+        self.repo_path().map(LocalOrRemotePath::is_local)
+    }
+
     fn to_standardized_path(&self, repo_relative_path: &str) -> Option<StandardizedPath> {
         if Path::new(repo_relative_path).is_absolute() {
             Some(StandardizedPath::from_local_absolute_unchecked(Path::new(
@@ -1539,7 +1543,10 @@ impl CodeReviewView {
         }
 
         send_telemetry_from_ctx!(
-            CodeReviewTelemetryEvent::BaseChanged { mode: mode.clone() },
+            CodeReviewTelemetryEvent::BaseChanged {
+                is_local: self.repo_is_local(),
+                mode: mode.clone(),
+            },
             ctx
         );
 
@@ -2204,7 +2211,10 @@ impl CodeReviewView {
         }
 
         send_telemetry_from_ctx!(
-            CodeReviewTelemetryEvent::FindBarToggled { is_open: true },
+            CodeReviewTelemetryEvent::FindBarToggled {
+                is_local: self.repo_is_local(),
+                is_open: true,
+            },
             ctx
         );
         ctx.focus(&self.find_bar);
@@ -2225,7 +2235,10 @@ impl CodeReviewView {
         });
 
         send_telemetry_from_ctx!(
-            CodeReviewTelemetryEvent::FindBarToggled { is_open: false },
+            CodeReviewTelemetryEvent::FindBarToggled {
+                is_local: self.repo_is_local(),
+                is_open: false,
+            },
             ctx
         );
 
@@ -2473,6 +2486,8 @@ impl CodeReviewView {
         self.viewported_list_state = Self::create_list_state(ctx);
 
         let file_states_vec = self.build_view_state_for_file_diffs(&diff_data.files, ctx);
+        let is_local = self.repo_is_local();
+        let diff_mode = self.diff_state_model.as_ref(ctx).diff_mode(ctx);
 
         if let Some(repo) = self.active_repo.as_mut() {
             repo.state = CodeReviewViewState::Loaded(LoadedState {
@@ -2485,6 +2500,18 @@ impl CodeReviewView {
                 files_changed: diff_data.files_changed,
             });
         }
+
+        send_telemetry_from_ctx!(
+            CodeReviewTelemetryEvent::DiffLoadCompleted {
+                is_local,
+                mode: diff_mode,
+                file_count: diff_data.files.len(),
+                files_changed: diff_data.files_changed,
+                total_additions: diff_data.total_additions,
+                total_deletions: diff_data.total_deletions,
+            },
+            ctx
+        );
 
         if self.all_editors_loaded() {
             let diff_mode = self.diff_state_model.as_ref(ctx).diff_mode(ctx);
@@ -2693,9 +2720,19 @@ impl CodeReviewView {
 
         // Telemetry: record whether this was a new comment or an edit.
         if is_existing {
-            send_telemetry_from_ctx!(CodeReviewTelemetryEvent::CommentEdited, ctx);
+            send_telemetry_from_ctx!(
+                CodeReviewTelemetryEvent::CommentEdited {
+                    is_local: self.repo_is_local(),
+                },
+                ctx
+            );
         } else {
-            send_telemetry_from_ctx!(CodeReviewTelemetryEvent::CommentAdded, ctx);
+            send_telemetry_from_ctx!(
+                CodeReviewTelemetryEvent::CommentAdded {
+                    is_local: self.repo_is_local(),
+                },
+                ctx
+            );
         }
     }
 
@@ -2723,7 +2760,10 @@ impl CodeReviewView {
             });
 
             send_telemetry_from_ctx!(
-                CodeReviewTelemetryEvent::CommentDeleted { is_imported },
+                CodeReviewTelemetryEvent::CommentDeleted {
+                    is_local: self.repo_is_local(),
+                    is_imported,
+                },
                 ctx
             );
         }
@@ -3095,7 +3135,12 @@ impl CodeReviewView {
     ) {
         match event {
             LocalCodeEditorEvent::FileSaved => {
-                send_telemetry_from_ctx!(CodeReviewTelemetryEvent::FileSaved, ctx);
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::FileSaved {
+                        is_local: self.repo_is_local(),
+                    },
+                    ctx
+                );
             }
             LocalCodeEditorEvent::FailedToSave { .. } => {}
             LocalCodeEditorEvent::DelayedRenderingFlushed
@@ -3512,7 +3557,10 @@ impl CodeReviewView {
 
         if fallback_count > 0 {
             send_telemetry_from_ctx!(
-                CodeReviewTelemetryEvent::CommentRelocationFailed { fallback_count },
+                CodeReviewTelemetryEvent::CommentRelocationFailed {
+                    is_local: self.repo_is_local(),
+                    fallback_count,
+                },
                 ctx
             );
         }
@@ -3530,6 +3578,7 @@ impl CodeReviewView {
                 });
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::CommentsAttached {
+                    is_local: self.repo_is_local(),
                     active_count,
                     outdated_count,
                 },
@@ -4156,6 +4205,7 @@ impl CodeReviewView {
 
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::ReviewSubmitted {
+                        is_local: self.repo_is_local(),
                         comment_count,
                         file_count,
                         destination,
@@ -5502,6 +5552,12 @@ impl CodeReviewView {
                 self.insert_diff_hunk_as_context(file_path, line_range.clone(), ctx);
             }
             CodeEditorEvent::DiffReverted => {
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::RevertHunkClicked {
+                        is_local: self.repo_is_local(),
+                    },
+                    ctx
+                );
                 // Show toast notification that diff was removed.
                 let version = editor.as_ref(ctx).version(ctx);
                 self.last_revert = Some((editor, version));
@@ -5531,6 +5587,14 @@ impl CodeReviewView {
             }
             CodeEditorEvent::Focused => {
                 ctx.emit(CodeReviewViewEvent::Pane(PaneEvent::FocusSelf));
+            }
+            CodeEditorEvent::CommentEditorOpened => {
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::CommentEditorOpened {
+                        is_local: self.repo_is_local(),
+                    },
+                    ctx
+                );
             }
             CodeEditorEvent::ContentChanged { origin, .. } => {
                 if origin.from_user() {
@@ -5586,6 +5650,7 @@ impl CodeReviewView {
                 };
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::AddToContext {
+                        is_local: self.repo_is_local(),
                         origin: AddToContextOrigin::SelectedText,
                         destination,
                         diff_set_scope: None,
@@ -5614,6 +5679,7 @@ impl CodeReviewView {
             let location = format!("{file_path}:{start_line}-{end_line} ");
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::AddToContext {
+                    is_local: self.repo_is_local(),
                     origin: AddToContextOrigin::SelectedText,
                     destination: CodeReviewContextDestination::AgentInput,
                     diff_set_scope: None,
@@ -5694,6 +5760,7 @@ impl CodeReviewView {
                     };
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::AddToContext {
+                            is_local: self.repo_is_local(),
                             origin: AddToContextOrigin::CodeReviewHeader,
                             destination,
                             diff_set_scope: Some(diff_set_scope),
@@ -5774,6 +5841,7 @@ impl CodeReviewView {
 
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::AddToContext {
+                        is_local: self.repo_is_local(),
                         origin: AddToContextOrigin::CodeReviewHeader,
                         destination: CodeReviewContextDestination::AgentAttachment,
                         diff_set_scope: Some(diff_set_scope),
@@ -5898,6 +5966,7 @@ impl CodeReviewView {
                     };
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::AddToContext {
+                            is_local: self.repo_is_local(),
                             origin: AddToContextOrigin::Gutter,
                             destination,
                             diff_set_scope: None,
@@ -5921,6 +5990,7 @@ impl CodeReviewView {
                 });
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::AddToContext {
+                        is_local: self.repo_is_local(),
                         origin: AddToContextOrigin::Gutter,
                         destination: CodeReviewContextDestination::ActiveCommandBuffer,
                         diff_set_scope: None,
@@ -5978,6 +6048,7 @@ impl CodeReviewView {
 
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::AddToContext {
+                        is_local: self.repo_is_local(),
                         origin: AddToContextOrigin::Gutter,
                         destination: CodeReviewContextDestination::AgentAttachment,
                         diff_set_scope: None,
@@ -7032,7 +7103,10 @@ impl TypedActionView for CodeReviewView {
                 };
 
                 send_telemetry_from_ctx!(
-                    CodeReviewTelemetryEvent::PaneStateChanged { state_change },
+                    CodeReviewTelemetryEvent::PaneStateChanged {
+                        is_local: self.repo_is_local(),
+                        state_change,
+                    },
                     ctx
                 );
 
@@ -7235,6 +7309,7 @@ impl TypedActionView for CodeReviewView {
             CodeReviewAction::OpenCommitDialog => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::GitButtonTriggered {
+                        is_local: self.repo_is_local(),
                         button: GitButtonKind::Commit,
                     },
                     ctx
@@ -7244,6 +7319,7 @@ impl TypedActionView for CodeReviewView {
             CodeReviewAction::PublishBranch => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::GitButtonTriggered {
+                        is_local: self.repo_is_local(),
                         button: GitButtonKind::Publish,
                     },
                     ctx
@@ -7253,6 +7329,7 @@ impl TypedActionView for CodeReviewView {
             CodeReviewAction::OpenPushDialog => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::GitButtonTriggered {
+                        is_local: self.repo_is_local(),
                         button: GitButtonKind::Push,
                     },
                     ctx
@@ -7262,6 +7339,7 @@ impl TypedActionView for CodeReviewView {
             CodeReviewAction::OpenCreatePrDialog => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::GitButtonTriggered {
+                        is_local: self.repo_is_local(),
                         button: GitButtonKind::CreatePr,
                     },
                     ctx
@@ -7271,6 +7349,7 @@ impl TypedActionView for CodeReviewView {
             CodeReviewAction::ViewPr(url) => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::GitButtonTriggered {
+                        is_local: self.repo_is_local(),
                         button: GitButtonKind::ViewPr,
                     },
                     ctx

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -4,6 +4,8 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use instant::Instant;
+
 use ai::project_context::model::ProjectContextModel;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -643,6 +645,10 @@ pub struct CodeReviewView {
     code_review_footer: Option<ViewHandle<CodeFooterView>>,
     /// Active git-operation dialog overlay (commit / push / publish), if open.
     git_dialog: Option<ViewHandle<GitDialog>>,
+    /// Timestamp captured when a diff load is initiated. Cleared when the
+    /// corresponding `DiffLoadCompleted` telemetry event is emitted, so the
+    /// elapsed time between request and completion can be reported.
+    diff_load_start_time: Option<Instant>,
 }
 
 impl CodeReviewView {
@@ -723,6 +729,7 @@ impl CodeReviewView {
         // (and will make an RPC once that path is wired). We pass
         // should_fetch_base: false because re-opening the panel doesn't
         // need to fetch the base branch from origin.
+        self.start_diff_load_timer();
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(true, ctx);
             model.load_diffs_for_current_repo(false, ctx);
@@ -744,6 +751,11 @@ impl CodeReviewView {
         ctx.unsubscribe_to_model(&self.diff_state_model);
 
         self.code_review_footer = None;
+
+        // Drop any pending diff-load timer; the in-flight load (if any) will
+        // never reach `DiffLoadCompleted` for this view, so leaving the start
+        // time around would skew the next reported duration.
+        self.diff_load_start_time = None;
 
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_code_review_metadata_refresh_enabled(false, ctx);
@@ -1317,16 +1329,28 @@ impl CodeReviewView {
             is_open: false,
             code_review_footer: None,
             git_dialog: None,
+            diff_load_start_time: None,
         };
         view.set_active_repo_comment_model(comment_batch_model, ctx);
         if has_repo {
             view.fetch_branches_and_setup_dropdown(ctx);
         }
         if has_repo {
+            // The diff-load timer is intentionally not started here. The view
+            // isn't subscribed to `diff_state_model` until `on_open`, so any
+            // completion event would not be delivered to this view. `on_open`
+            // starts a fresh timer paired with `load_diffs_for_current_repo`.
             view.invalidate_all(None, ctx);
         }
 
         view
+    }
+
+    /// Records the moment a diff load was requested so we can report the
+    /// elapsed time when the load completes. Overwrites any prior pending
+    /// timer — only the most recent request is tracked.
+    fn start_diff_load_timer(&mut self) {
+        self.diff_load_start_time = Some(Instant::now());
     }
 
     pub fn set_terminal_view(&mut self, terminal_view: WeakViewHandle<TerminalView>) {
@@ -1550,6 +1574,7 @@ impl CodeReviewView {
             ctx
         );
 
+        self.start_diff_load_timer();
         self.diff_state_model.update(ctx, |model, ctx| {
             model.set_diff_mode(mode, false, ctx);
         });
@@ -2420,6 +2445,9 @@ impl CodeReviewView {
         ctx: &mut ViewContext<Self>,
     ) {
         if self.active_repo.is_none() {
+            // No load is associated with this view; drop any stale timer so a
+            // future call doesn't fold pre-repo time into the duration.
+            self.diff_load_start_time = None;
             return;
         };
 
@@ -2445,6 +2473,10 @@ impl CodeReviewView {
                     );
                     repo.state = CodeReviewViewState::NoRepoFound;
                 }
+                // No `DiffLoadCompleted` event will fire from this terminal
+                // state; drop the timer so a later recovery doesn't report an
+                // inflated duration.
+                self.diff_load_start_time = None;
                 ctx.notify();
                 return;
             }
@@ -2452,6 +2484,10 @@ impl CodeReviewView {
                 if let Some(repo) = self.active_repo.as_mut() {
                     repo.state = CodeReviewViewState::Error(err);
                 }
+                // Load did not complete successfully; drop the timer so a
+                // subsequent successful load doesn't include time spent in
+                // the error state.
+                self.diff_load_start_time = None;
                 ctx.notify();
                 return;
             }
@@ -2459,6 +2495,9 @@ impl CodeReviewView {
                 // Disconnected state is handled via the ConnectionLost event
                 // path, which preserves stale diffs. If invalidate_all is
                 // called while disconnected (e.g. from a stale push), ignore.
+                // Drop the timer so a reconnect-then-load (potentially much
+                // later) doesn't report the disconnect interval as load time.
+                self.diff_load_start_time = None;
                 return;
             }
             DiffState::Loaded => (),
@@ -2501,6 +2540,10 @@ impl CodeReviewView {
             });
         }
 
+        let load_duration = self
+            .diff_load_start_time
+            .take()
+            .map(|start| start.elapsed());
         send_telemetry_from_ctx!(
             CodeReviewTelemetryEvent::DiffLoadCompleted {
                 is_local,
@@ -2509,6 +2552,7 @@ impl CodeReviewView {
                 files_changed: diff_data.files_changed,
                 total_additions: diff_data.total_additions,
                 total_deletions: diff_data.total_deletions,
+                load_duration,
             },
             ctx
         );
@@ -7120,6 +7164,7 @@ impl TypedActionView for CodeReviewView {
                 self.save_files(unsaved_files.as_slice(), ctx);
             }
             CodeReviewAction::RefreshGitState => {
+                self.start_diff_load_timer();
                 self.diff_state_model.update(ctx, |model, ctx| {
                     model.load_diffs_for_current_repo(false, ctx);
                     model.refresh_metadata_and_pr_info(ctx);

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -5963,6 +5963,7 @@ impl CodeReviewView {
     }
 
     pub(crate) fn set_diff_base(&mut self, diff_mode: DiffMode, ctx: &mut ViewContext<Self>) {
+        self.start_diff_load_timer();
         self.diff_state_model.update(ctx, |diff_state_model, ctx| {
             diff_state_model.set_diff_mode_and_fetch_base(diff_mode, ctx);
         });

--- a/app/src/code_review/comment_list_view.rs
+++ b/app/src/code_review/comment_list_view.rs
@@ -46,7 +46,7 @@ use crate::code_review::comments::{
     AttachedReviewComment, AttachedReviewCommentTarget, CommentId, CommentOrigin,
     ReviewCommentBatch, ReviewCommentBatchEvent,
 };
-use crate::code_review::CodeReviewTelemetryEvent;
+use crate::code_review::telemetry_event::CodeReviewTelemetryEvent;
 use crate::menu::{Event, Menu, MenuItem, MenuItemFields};
 use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorView};
 use crate::send_telemetry_from_ctx;
@@ -278,6 +278,10 @@ impl CommentListView {
             self.review_destination = destination;
             ctx.notify();
         }
+    }
+
+    fn repo_is_local(&self) -> Option<bool> {
+        self.repo_path.as_ref().map(LocalOrRemotePath::is_local)
     }
 
     pub fn debug_state(&self, ctx: &AppContext) -> CommentListDebugState {
@@ -1179,6 +1183,7 @@ impl TypedActionView for CommentListView {
                     // Telemetry: comment list view expanded.
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::CommentListExpanded {
+                            is_local: self.repo_is_local(),
                             comment_count: self.comments_by_id.len(),
                         },
                         ctx
@@ -1267,7 +1272,12 @@ impl TypedActionView for CommentListView {
                 self.close_overflow_menu(ctx);
             }
             CommentListAction::JumpToCommentLocation(comment_id) => {
-                send_telemetry_from_ctx!(CodeReviewTelemetryEvent::CommentListItemClicked, ctx);
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::CommentListItemClicked {
+                        is_local: self.repo_is_local(),
+                    },
+                    ctx
+                );
                 ctx.emit(CommentListEvent::JumpToCommentLocation(*comment_id));
             }
         }

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use instant::Instant;
 #[cfg(feature = "local_fs")]
 use warp_util::standardized_path::StandardizedPath;
 
@@ -193,6 +194,8 @@ pub struct LocalDiffStateModel {
     computing_diffs_abort_handle: Option<SpawnedFutureHandle>,
     computing_metadata_abort_handle: Option<SpawnedFutureHandle>,
     refreshing_pr_info_handle: Option<SpawnedFutureHandle>,
+    /// Start time for the latest caller-tracked full diff load.
+    tracked_diff_load_start_time: Option<Instant>,
     /// Branch name for which `refresh_pr_info` has been called at least once.
     /// Gates the metadata-refresh fallback so it only retries `gh pr view` once
     /// per branch when `pr_info` is `None` (e.g. branch has no PR, lookup
@@ -250,7 +253,7 @@ impl LocalDiffStateModel {
                             CodeReviewTelemetryEvent::LoadDiffFailed {
                                 is_local: Some(true),
                                 mode: me.mode.clone(),
-                                error: "File invalidation error".to_string(),
+                                error: err.to_string(),
                             },
                             ctx
                         );
@@ -269,6 +272,7 @@ impl LocalDiffStateModel {
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
+            tracked_diff_load_start_time: None,
             pr_info_attempted_for_branch: None,
             metadata_refresh_enabled: false,
             file_invalidation: FileInvalidationState::new(queue),
@@ -296,7 +300,11 @@ impl LocalDiffStateModel {
                 // Repo detection completed but found no repository.
                 // Emit so subscribers (e.g. the server model) can drain
                 // pending responses with the NotInRepository state.
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+                me.tracked_diff_load_start_time = None;
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+                    diffs: None,
+                    load_duration: None,
+                });
             });
         }
         model
@@ -311,6 +319,7 @@ impl LocalDiffStateModel {
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
+            tracked_diff_load_start_time: None,
             pr_info_attempted_for_branch: None,
             metadata_refresh_enabled: false,
         }
@@ -496,11 +505,12 @@ impl LocalDiffStateModel {
         &mut self,
         mode: DiffMode,
         should_fetch_base: bool,
+        track_load_duration: bool,
         ctx: &mut ModelContext<Self>,
     ) {
         if self.mode != mode {
             self.mode = mode;
-            self.load_diffs_for_current_repo(should_fetch_base, ctx);
+            self.load_diffs_for_current_repo(should_fetch_base, track_load_duration, ctx);
         }
     }
 
@@ -509,7 +519,7 @@ impl LocalDiffStateModel {
     /// This is intended for the `insert_code_review_comments` flow where the
     /// requested base branch may never have been checked out.
     pub fn set_diff_mode_and_fetch_base(&mut self, mode: DiffMode, ctx: &mut ModelContext<Self>) {
-        self.set_diff_mode(mode, true, ctx);
+        self.set_diff_mode(mode, true, true, ctx);
     }
 
     /// Loads the actual diffs for the current repo.
@@ -518,8 +528,12 @@ impl LocalDiffStateModel {
     pub fn load_diffs_for_current_repo(
         &mut self,
         should_fetch_base: bool,
+        track_load_duration: bool,
         ctx: &mut ModelContext<Self>,
     ) {
+        if track_load_duration {
+            self.tracked_diff_load_start_time = Some(Instant::now());
+        }
         // Cancels in-flight per-file invalidation tasks so that stale queue results cannot
         // race with the new full reload.
         self.queue_full_invalidation();
@@ -550,6 +564,7 @@ impl LocalDiffStateModel {
     pub fn load_diffs_for_current_repo(
         &mut self,
         _should_fetch_base: bool,
+        _track_load_duration: bool,
         _ctx: &mut ModelContext<Self>,
     ) {
         // Noop on WASM builds.
@@ -842,7 +857,7 @@ impl LocalDiffStateModel {
             },
             |me, result, ctx| match result {
                 Ok(_) => {
-                    me.load_diffs_for_current_repo(false, ctx);
+                    me.load_diffs_for_current_repo(false, false, ctx);
                     me.refresh_diff_metadata_for_current_repo(false, ctx);
                 }
                 Err(err) => {
@@ -1034,7 +1049,7 @@ impl LocalDiffStateModel {
         }
 
         if commit_updated || remote_ref_updated {
-            self.load_diffs_for_current_repo(false, ctx);
+            self.load_diffs_for_current_repo(false, false, ctx);
             // Don't emit MetadataRefreshed here — metadata hasn't been
             // recomputed yet. NewDiffsComputed handles the immediate UI
             // refresh, and the throttled metadata refresh will emit
@@ -1043,7 +1058,7 @@ impl LocalDiffStateModel {
         } else if index_lock_detected {
             if self.file_invalidation.invalidate_all_pending {
                 // Lock was released while a full invalidation was pending — reload now.
-                self.load_diffs_for_current_repo(false, ctx);
+                self.load_diffs_for_current_repo(false, false, ctx);
                 return true;
             }
             // Lock just appeared — suppress the per-file queue (data may be stale
@@ -1057,7 +1072,7 @@ impl LocalDiffStateModel {
         // by forcing a full reload. Without this, all subsequent file
         // invalidations would be silently deferred forever.
         if self.file_invalidation.invalidate_all_pending {
-            self.load_diffs_for_current_repo(false, ctx);
+            self.load_diffs_for_current_repo(false, false, ctx);
             return true;
         }
 
@@ -1084,7 +1099,7 @@ impl LocalDiffStateModel {
         });
 
         if gitignore_modified {
-            self.load_diffs_for_current_repo(false, ctx);
+            self.load_diffs_for_current_repo(false, false, ctx);
         } else {
             self.enqueue_file_invalidations(changed_files, ctx);
         }
@@ -1410,12 +1425,12 @@ impl LocalDiffStateModel {
                 metadata.pr_info = previous_pr_info;
                 self.metadata = Some(metadata);
             }
-            Err(_) => {
+            Err(e) => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadMetadataFailed {
                         is_local: Some(true),
                         mode: self.mode.clone(),
-                        error: "Load metadata failed".to_string(),
+                        error: e.to_string(),
                     },
                     ctx
                 );
@@ -1449,7 +1464,7 @@ impl LocalDiffStateModel {
         }
 
         if should_reload_diffs {
-            self.load_diffs_for_current_repo(false, ctx);
+            self.load_diffs_for_current_repo(false, false, ctx);
         }
         if let Some(metadata) = self.metadata.clone() {
             ctx.emit(DiffStateModelEvent::MetadataRefreshed(metadata));
@@ -1462,23 +1477,32 @@ impl LocalDiffStateModel {
         diffs: DiffsWithBaseContent,
         ctx: &mut ModelContext<Self>,
     ) {
-        if diffs.changes.is_err() {
-            send_telemetry_from_ctx!(
-                CodeReviewTelemetryEvent::LoadDiffFailed {
-                    is_local: Some(true),
-                    mode: self.mode.clone(),
-                    error: "Load diff data failed".to_string(),
-                },
-                ctx
-            );
-        }
+        let load_duration = match &diffs.changes {
+            Ok(_) => self
+                .tracked_diff_load_start_time
+                .take()
+                .map(|start| start.elapsed()),
+            Err(e) => {
+                self.tracked_diff_load_start_time = None;
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::LoadDiffFailed {
+                        is_local: Some(true),
+                        mode: self.mode.clone(),
+                        error: e.to_string(),
+                    },
+                    ctx
+                );
+                None
+            }
+        };
 
         self.state = InternalDiffState::Loaded((&diffs).into());
         // Compute merge base and flush deferred invalidations before emitting.
         self.recompute_merge_base_and_flush(ctx);
-        ctx.emit(DiffStateModelEvent::NewDiffsComputed(
-            diffs.changes.ok().map(Arc::new),
-        ));
+        ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+            diffs: diffs.changes.ok().map(Arc::new),
+            load_duration,
+        });
     }
 
     /// Returns the number of lines in a given file. Returns `None` if the file is a binary file
@@ -2719,6 +2743,7 @@ impl LocalDiffStateModel {
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
             refreshing_pr_info_handle: None,
+            tracked_diff_load_start_time: None,
             pr_info_attempted_for_branch: None,
             metadata_refresh_enabled: false,
             #[cfg(feature = "local_fs")]

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -1410,12 +1410,12 @@ impl LocalDiffStateModel {
                 metadata.pr_info = previous_pr_info;
                 self.metadata = Some(metadata);
             }
-            Err(e) => {
+            Err(_) => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadMetadataFailed {
                         is_local: Some(true),
                         mode: self.mode.clone(),
-                        error: "Decode metadata update failed".to_string(),
+                        error: "Load metadata failed".to_string(),
                     },
                     ctx
                 );
@@ -1462,12 +1462,12 @@ impl LocalDiffStateModel {
         diffs: DiffsWithBaseContent,
         ctx: &mut ModelContext<Self>,
     ) {
-        if let Err(e) = &diffs.changes {
+        if diffs.changes.is_err() {
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::LoadDiffFailed {
                     is_local: Some(true),
                     mode: self.mode.clone(),
-                    error: "Decode diff data failed".to_string(),
+                    error: "Load diff data failed".to_string(),
                 },
                 ctx
             );

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -248,6 +248,7 @@ impl LocalDiffStateModel {
                         log::error!("File invalidation error: {err}");
                         send_telemetry_from_ctx!(
                             CodeReviewTelemetryEvent::LoadDiffFailed {
+                                is_local: Some(true),
                                 error: err.to_string(),
                             },
                             ctx
@@ -1411,6 +1412,7 @@ impl LocalDiffStateModel {
             Err(e) => {
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::CalculateDiffMetadataFailed {
+                        is_local: Some(true),
                         error: e.to_string()
                     },
                     ctx
@@ -1461,6 +1463,7 @@ impl LocalDiffStateModel {
         if let Err(e) = &diffs.changes {
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::LoadDiffFailed {
+                    is_local: Some(true),
                     error: e.to_string(),
                 },
                 ctx

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -249,7 +249,8 @@ impl LocalDiffStateModel {
                         send_telemetry_from_ctx!(
                             CodeReviewTelemetryEvent::LoadDiffFailed {
                                 is_local: Some(true),
-                                error: err.to_string(),
+                                mode: me.mode.clone(),
+                                error: "File invalidation error".to_string(),
                             },
                             ctx
                         );
@@ -1411,9 +1412,10 @@ impl LocalDiffStateModel {
             }
             Err(e) => {
                 send_telemetry_from_ctx!(
-                    CodeReviewTelemetryEvent::CalculateDiffMetadataFailed {
+                    CodeReviewTelemetryEvent::LoadMetadataFailed {
                         is_local: Some(true),
-                        error: e.to_string()
+                        mode: self.mode.clone(),
+                        error: "Decode metadata update failed".to_string(),
                     },
                     ctx
                 );
@@ -1464,7 +1466,8 @@ impl LocalDiffStateModel {
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::LoadDiffFailed {
                     is_local: Some(true),
-                    error: e.to_string(),
+                    mode: self.mode.clone(),
+                    error: "Decode diff data failed".to_string(),
                 },
                 ctx
             );

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -254,6 +254,9 @@ impl LocalDiffStateModel {
                                 is_local: Some(true),
                                 mode: me.mode.clone(),
                                 error: err.to_string(),
+                                // Per-file invalidation errors are not tied to a full
+                                // tracked load, so `load_duration` is intentionally `None`.
+                                load_duration: None,
                             },
                             ctx
                         );
@@ -1483,12 +1486,16 @@ impl LocalDiffStateModel {
                 .take()
                 .map(|start| start.elapsed()),
             Err(e) => {
-                self.tracked_diff_load_start_time = None;
+                let load_duration = self
+                    .tracked_diff_load_start_time
+                    .take()
+                    .map(|start| start.elapsed());
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadDiffFailed {
                         is_local: Some(true),
                         mode: self.mode.clone(),
                         error: e.to_string(),
+                        load_duration,
                     },
                     ctx
                 );

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -7,6 +7,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -307,7 +308,10 @@ pub enum DiffStateModelEvent {
     /// Event dispatched when the current branch changes.
     CurrentBranchChanged,
     /// Event dispatched when new diffs are computed (full reload).
-    NewDiffsComputed(Option<Arc<GitDiffWithBaseContent>>),
+    NewDiffsComputed {
+        diffs: Option<Arc<GitDiffWithBaseContent>>,
+        load_duration: Option<Duration>,
+    },
     /// Event dispatched when a single file's diff is updated incrementally.
     SingleFileUpdated {
         /// Repo-relative path for the updated file.
@@ -372,8 +376,14 @@ impl DiffStateModel {
             DiffStateModelEvent::CurrentBranchChanged => {
                 ctx.emit(DiffStateModelEvent::CurrentBranchChanged);
             }
-            DiffStateModelEvent::NewDiffsComputed(diffs) => {
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(diffs.clone()));
+            DiffStateModelEvent::NewDiffsComputed {
+                diffs,
+                load_duration,
+            } => {
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+                    diffs: diffs.clone(),
+                    load_duration: *load_duration,
+                });
             }
             DiffStateModelEvent::SingleFileUpdated { path, diff } => {
                 ctx.emit(DiffStateModelEvent::SingleFileUpdated {
@@ -492,17 +502,18 @@ impl DiffStateModel {
         &self,
         mode: DiffMode,
         should_fetch_base: bool,
+        track_load_duration: bool,
         ctx: &mut ModelContext<Self>,
     ) {
         match self {
             Self::Local(local) => {
                 local.update(ctx, |local, ctx| {
-                    local.set_diff_mode(mode, should_fetch_base, ctx);
+                    local.set_diff_mode(mode, should_fetch_base, track_load_duration, ctx);
                 });
             }
             Self::Remote(model) => {
                 model.update(ctx, |model, ctx| {
-                    model.set_diff_mode(mode, ctx);
+                    model.set_diff_mode(mode, track_load_duration, ctx);
                 });
             }
         }
@@ -521,7 +532,7 @@ impl DiffStateModel {
             }
             Self::Remote(model) => {
                 model.update(ctx, |model, ctx| {
-                    model.set_diff_mode(mode, ctx);
+                    model.set_diff_mode(mode, true, ctx);
                 });
             }
         }
@@ -530,17 +541,18 @@ impl DiffStateModel {
     pub(crate) fn load_diffs_for_current_repo(
         &self,
         should_fetch_base: bool,
+        track_load_duration: bool,
         ctx: &mut ModelContext<Self>,
     ) {
         match self {
             Self::Local(local) => {
                 local.update(ctx, |local, ctx| {
-                    local.load_diffs_for_current_repo(should_fetch_base, ctx);
+                    local.load_diffs_for_current_repo(should_fetch_base, track_load_duration, ctx);
                 });
             }
             Self::Remote(remote) => {
                 remote.update(ctx, |remote, ctx| {
-                    remote.fetch_fresh_snapshot(ctx);
+                    remote.fetch_fresh_snapshot(track_load_duration, ctx);
                 });
             }
         }

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -200,9 +200,9 @@ impl RemoteDiffStateModel {
     /// Re-sends `GetDiffState` through the model's existing `session_id`
     /// and transitions to `Loading` while waiting for a fresh snapshot.
     fn resubscribe(&mut self, track_load_duration: bool, ctx: &mut ModelContext<Self>) {
-        if track_load_duration {
-            self.tracked_diff_load_start_time = Some(Instant::now());
-        }
+        // Always overwrite to avoid carrying a stale `Instant` from a prior
+        // tracked load that was interrupted by a session blip.
+        self.tracked_diff_load_start_time = track_load_duration.then(Instant::now);
         let remote_path = self.remote_path.clone();
         let mode = self.mode.clone();
         let session_id = self.session_id;
@@ -334,12 +334,16 @@ impl RemoteDiffStateModel {
                 });
             }
             DiffState::Error(msg) => {
-                self.tracked_diff_load_start_time = None;
+                let load_duration = self
+                    .tracked_diff_load_start_time
+                    .take()
+                    .map(|start| start.elapsed());
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadDiffFailed {
                         is_local: Some(false),
                         mode: self.mode.clone(),
                         error: "Server reported diff error".to_string(),
+                        load_duration,
                     },
                     ctx
                 );
@@ -353,12 +357,16 @@ impl RemoteDiffStateModel {
                 let Some(base_content) = diffs else {
                     let error =
                         "Server reported loaded state but no diff data was available".to_string();
-                    self.tracked_diff_load_start_time = None;
+                    let load_duration = self
+                        .tracked_diff_load_start_time
+                        .take()
+                        .map(|start| start.elapsed());
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::LoadDiffFailed {
                             is_local: Some(false),
                             mode: self.mode.clone(),
                             error: "Empty diff data".to_string(),
+                            load_duration,
                         },
                         ctx
                     );

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -9,6 +9,7 @@
 //! new mode.
 
 use crate::code_review::telemetry_event::CodeReviewTelemetryEvent;
+use instant::Instant;
 use std::sync::Arc;
 
 use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
@@ -48,6 +49,8 @@ pub struct RemoteDiffStateModel {
     metadata: Option<DiffMetadata>,
     /// The session through which the current server-side subscription was established.
     session_id: SessionId,
+    /// Start time for the latest caller-tracked full diff snapshot request.
+    tracked_diff_load_start_time: Option<Instant>,
 }
 
 impl warpui::Entity for RemoteDiffStateModel {
@@ -85,6 +88,7 @@ impl RemoteDiffStateModel {
             state: InternalRemoteDiffState::Loading,
             metadata: None,
             session_id,
+            tracked_diff_load_start_time: None,
         }
     }
 
@@ -176,7 +180,7 @@ impl RemoteDiffStateModel {
                 host_id,
                 ..
             } if *session_id == self.session_id && host_id == &self.remote_path.host_id => {
-                self.resubscribe(ctx);
+                self.resubscribe(false, ctx);
             }
             _ => {}
         }
@@ -188,13 +192,17 @@ impl RemoteDiffStateModel {
         if matches!(self.state, InternalRemoteDiffState::Disconnected) {
             return;
         }
+        self.tracked_diff_load_start_time = None;
         self.state = InternalRemoteDiffState::Disconnected;
         ctx.emit(DiffStateModelEvent::ConnectionLost);
     }
 
     /// Re-sends `GetDiffState` through the model's existing `session_id`
     /// and transitions to `Loading` while waiting for a fresh snapshot.
-    fn resubscribe(&mut self, ctx: &mut ModelContext<Self>) {
+    fn resubscribe(&mut self, track_load_duration: bool, ctx: &mut ModelContext<Self>) {
+        if track_load_duration {
+            self.tracked_diff_load_start_time = Some(Instant::now());
+        }
         let remote_path = self.remote_path.clone();
         let mode = self.mode.clone();
         let session_id = self.session_id;
@@ -202,7 +210,10 @@ impl RemoteDiffStateModel {
             mgr.get_diff_state(session_id, remote_path, proto::DiffMode::from(&mode), ctx);
         });
         self.state = InternalRemoteDiffState::Loading;
-        ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+        ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+            diffs: None,
+            load_duration: None,
+        });
     }
 
     // ── Proto → state conversion helpers ────────────────────────────────────────────────
@@ -215,14 +226,10 @@ impl RemoteDiffStateModel {
         match try_decode_snapshot(snapshot) {
             Ok((metadata, state, diffs)) => self.apply_snapshot(metadata, state, diffs, ctx),
             Err(error) => {
-                log::warn!("RemoteDiffStateModel: invalid diff state snapshot: {error}");
-                send_telemetry_from_ctx!(
-                    CodeReviewTelemetryEvent::LoadDiffFailed {
-                        is_local: Some(false),
-                        mode: self.mode.clone(),
-                        error: "Decode snapshot failed".to_string(),
-                    },
-                    ctx
+                self.tracked_diff_load_start_time = None;
+                warp_core::safe_error!(
+                    safe: ("RemoteDiffStateModel: failed to decode diff state snapshot"),
+                    full: ("RemoteDiffStateModel: failed to decode diff state snapshot: {error}")
                 );
             }
         }
@@ -242,14 +249,9 @@ impl RemoteDiffStateModel {
             Ok(Some(metadata)) => self.apply_metadata_update(&metadata, ctx),
             Ok(None) => {}
             Err(error) => {
-                log::warn!("RemoteDiffStateModel: invalid diff state metadata update: {error}");
-                send_telemetry_from_ctx!(
-                    CodeReviewTelemetryEvent::LoadMetadataFailed {
-                        is_local: Some(false),
-                        mode: self.mode.clone(),
-                        error: "Decode metadata update failed".to_string(),
-                    },
-                    ctx
+                warp_core::safe_error!(
+                    safe: ("RemoteDiffStateModel: failed to decode diff state metadata update"),
+                    full: ("RemoteDiffStateModel: failed to decode diff state metadata update: {error}")
                 );
             }
         }
@@ -265,14 +267,9 @@ impl RemoteDiffStateModel {
                 self.apply_file_delta(file_path, diff, metadata, ctx)
             }
             Err(error) => {
-                log::warn!("RemoteDiffStateModel: invalid diff state file delta: {error}");
-                send_telemetry_from_ctx!(
-                    CodeReviewTelemetryEvent::LoadDiffFailed {
-                        is_local: Some(false),
-                        mode: self.mode.clone(),
-                        error: "Decode file delta failed".to_string(),
-                    },
-                    ctx
+                warp_core::safe_error!(
+                    safe: ("RemoteDiffStateModel: failed to decode diff state file delta"),
+                    full: ("RemoteDiffStateModel: failed to decode diff state file delta: {error}")
                 );
             }
         }
@@ -289,7 +286,14 @@ impl RemoteDiffStateModel {
     /// so existing views subscribed to this model won't flash a loading state.
     /// The server response arrives as a `DiffStateSnapshotReceived` event and
     /// flows through `apply_snapshot` normally.
-    pub(crate) fn fetch_fresh_snapshot(&self, ctx: &mut ModelContext<Self>) {
+    pub(crate) fn fetch_fresh_snapshot(
+        &mut self,
+        track_load_duration: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if track_load_duration {
+            self.tracked_diff_load_start_time = Some(Instant::now());
+        }
         let remote_path = self.remote_path.clone();
         let mode = self.mode.clone();
         let session_id = self.session_id;
@@ -315,14 +319,22 @@ impl RemoteDiffStateModel {
             // Disconnected is never produced by proto deserialization.
             DiffState::Disconnected => {}
             DiffState::NotInRepository => {
+                self.tracked_diff_load_start_time = None;
                 self.state = InternalRemoteDiffState::NotInRepository;
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+                    diffs: None,
+                    load_duration: None,
+                });
             }
             DiffState::Loading => {
                 self.state = InternalRemoteDiffState::Loading;
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+                    diffs: None,
+                    load_duration: None,
+                });
             }
             DiffState::Error(msg) => {
+                self.tracked_diff_load_start_time = None;
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadDiffFailed {
                         is_local: Some(false),
@@ -332,12 +344,16 @@ impl RemoteDiffStateModel {
                     ctx
                 );
                 self.state = InternalRemoteDiffState::Error(msg);
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+                    diffs: None,
+                    load_duration: None,
+                });
             }
             DiffState::Loaded => {
                 let Some(base_content) = diffs else {
                     let error =
                         "Server reported loaded state but no diff data was available".to_string();
+                    self.tracked_diff_load_start_time = None;
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::LoadDiffFailed {
                             is_local: Some(false),
@@ -347,14 +363,22 @@ impl RemoteDiffStateModel {
                         ctx
                     );
                     self.state = InternalRemoteDiffState::Error(error);
-                    ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
+                    ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+                        diffs: None,
+                        load_duration: None,
+                    });
                     return;
                 };
                 let diffs = GitDiffData::from(&base_content);
+                let load_duration = self
+                    .tracked_diff_load_start_time
+                    .take()
+                    .map(|start| start.elapsed());
                 self.state = InternalRemoteDiffState::Loaded(diffs);
-                ctx.emit(DiffStateModelEvent::NewDiffsComputed(Some(Arc::new(
-                    base_content,
-                ))));
+                ctx.emit(DiffStateModelEvent::NewDiffsComputed {
+                    diffs: Some(Arc::new(base_content)),
+                    load_duration,
+                });
             }
         }
     }
@@ -523,7 +547,12 @@ impl RemoteDiffStateModel {
 
     // ── Write API ────────────────────────────────────────────────────
 
-    pub fn set_diff_mode(&mut self, mode: DiffMode, ctx: &mut ModelContext<Self>) {
+    pub fn set_diff_mode(
+        &mut self,
+        mode: DiffMode,
+        track_load_duration: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
         if self.mode == mode {
             return;
         }
@@ -532,7 +561,7 @@ impl RemoteDiffStateModel {
         // GetDiffState for the new mode through the same session.
         self.unsubscribe(ctx);
         self.mode = mode;
-        self.resubscribe(ctx);
+        self.resubscribe(track_load_duration, ctx);
     }
 
     /// Fetches branches for the remote repository via the `GetBranches` RPC.

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -8,10 +8,11 @@
 //! from the old `(repo_path, mode)` subscription and re-subscribing with the
 //! new mode.
 
+use crate::code_review::telemetry_event::CodeReviewTelemetryEvent;
 use std::sync::Arc;
 
 use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
-use warp_core::{HostId, SessionId};
+use warp_core::{send_telemetry_from_ctx, HostId, SessionId};
 use warp_util::remote_path::RemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::{ModelContext, SingletonEntity};
@@ -215,6 +216,14 @@ impl RemoteDiffStateModel {
             Ok((metadata, state, diffs)) => self.apply_snapshot(metadata, state, diffs, ctx),
             Err(error) => {
                 log::warn!("RemoteDiffStateModel: invalid diff state snapshot: {error}");
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::LoadDiffFailed {
+                        is_local: Some(false),
+                        mode: self.mode.clone(),
+                        error: "Decode snapshot failed".to_string(),
+                    },
+                    ctx
+                );
             }
         }
     }
@@ -234,6 +243,14 @@ impl RemoteDiffStateModel {
             Ok(None) => {}
             Err(error) => {
                 log::warn!("RemoteDiffStateModel: invalid diff state metadata update: {error}");
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::LoadMetadataFailed {
+                        is_local: Some(false),
+                        mode: self.mode.clone(),
+                        error: "Decode metadata update failed".to_string(),
+                    },
+                    ctx
+                );
             }
         }
     }
@@ -249,6 +266,14 @@ impl RemoteDiffStateModel {
             }
             Err(error) => {
                 log::warn!("RemoteDiffStateModel: invalid diff state file delta: {error}");
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::LoadDiffFailed {
+                        is_local: Some(false),
+                        mode: self.mode.clone(),
+                        error: "Decode file delta failed".to_string(),
+                    },
+                    ctx
+                );
             }
         }
     }
@@ -298,14 +323,30 @@ impl RemoteDiffStateModel {
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
             }
             DiffState::Error(msg) => {
+                send_telemetry_from_ctx!(
+                    CodeReviewTelemetryEvent::LoadDiffFailed {
+                        is_local: Some(false),
+                        mode: self.mode.clone(),
+                        error: "Server reported diff error".to_string(),
+                    },
+                    ctx
+                );
                 self.state = InternalRemoteDiffState::Error(msg);
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
             }
             DiffState::Loaded => {
                 let Some(base_content) = diffs else {
-                    self.state = InternalRemoteDiffState::Error(
-                        "Server reported loaded state but no diff data was available".to_string(),
+                    let error =
+                        "Server reported loaded state but no diff data was available".to_string();
+                    send_telemetry_from_ctx!(
+                        CodeReviewTelemetryEvent::LoadDiffFailed {
+                            is_local: Some(false),
+                            mode: self.mode.clone(),
+                            error: "Empty diff data".to_string(),
+                        },
+                        ctx
                     );
+                    self.state = InternalRemoteDiffState::Error(error);
                     ctx.emit(DiffStateModelEvent::NewDiffsComputed(None));
                     return;
                 };

--- a/app/src/code_review/diff_state/remote_tests.rs
+++ b/app/src/code_review/diff_state/remote_tests.rs
@@ -28,6 +28,7 @@ impl RemoteDiffStateModel {
             session_id: SessionId::default(),
             state,
             metadata,
+            tracked_diff_load_start_time: None,
         }
     }
 }
@@ -171,7 +172,10 @@ fn apply_snapshot_loaded_preserves_content_at_base_in_event() {
             let emitted_content = emitted_content.clone();
             app.update(|ctx| {
                 ctx.subscribe_to_model(&handle, move |_, event, _| {
-                    if let DiffStateModelEvent::NewDiffsComputed(Some(diffs)) = event {
+                    if let DiffStateModelEvent::NewDiffsComputed {
+                        diffs: Some(diffs), ..
+                    } = event
+                    {
                         emitted_content
                             .lock()
                             .expect("emitted content mutex should not be poisoned")
@@ -450,7 +454,10 @@ fn apply_snapshot_emits_event_with_repo_relative_paths() {
             let emitted_paths = emitted_paths.clone();
             app.update(|ctx| {
                 ctx.subscribe_to_model(&handle, move |_, event, _| {
-                    if let DiffStateModelEvent::NewDiffsComputed(Some(diffs)) = event {
+                    if let DiffStateModelEvent::NewDiffsComputed {
+                        diffs: Some(diffs), ..
+                    } = event
+                    {
                         emitted_paths
                             .lock()
                             .expect("emitted paths mutex should not be poisoned")

--- a/app/src/code_review/diff_state/remote_tests.rs
+++ b/app/src/code_review/diff_state/remote_tests.rs
@@ -4,12 +4,14 @@ use warp_core::SessionId;
 use warp_util::remote_path::RemotePath;
 
 use super::InternalRemoteDiffState;
+use crate::auth::AuthStateProvider;
 use crate::code_review::diff_size_limits::DiffSize;
 use crate::code_review::diff_state::{
     DiffHunk, DiffLine, DiffLineType, DiffMetadata, DiffMetadataAgainstBase, DiffMode, DiffState,
     DiffStateModelEvent, DiffStats, FileDiff, FileDiffAndContent, GitDiffData,
     GitDiffWithBaseContent, GitFileStatus, RemoteDiffStateModel,
 };
+use crate::server::telemetry::context_provider::AppTelemetryContextProvider;
 use crate::util::git::{Commit, PrInfo};
 
 impl RemoteDiffStateModel {
@@ -132,6 +134,10 @@ fn test_metadata(branch: &str) -> DiffMetadata {
     }
 }
 
+fn initialize_test_app(app: &mut warpui::App) {
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+}
 #[test]
 fn apply_snapshot_loaded_with_diffs() {
     warpui::App::test((), |mut app| async move {
@@ -215,6 +221,7 @@ fn apply_snapshot_loaded_preserves_content_at_base_in_event() {
 #[test]
 fn apply_snapshot_loaded_without_diffs_becomes_error() {
     warpui::App::test((), |mut app| async move {
+        initialize_test_app(&mut app);
         let handle = app.add_model(|_ctx| {
             RemoteDiffStateModel::new_for_test(
                 DiffMode::Head,
@@ -255,6 +262,7 @@ fn apply_snapshot_not_in_repository() {
 #[test]
 fn apply_snapshot_error_stores_message() {
     warpui::App::test((), |mut app| async move {
+        initialize_test_app(&mut app);
         let handle = app.add_model(|_ctx| {
             RemoteDiffStateModel::new_for_test(
                 DiffMode::Head,

--- a/app/src/code_review/find_model.rs
+++ b/app/src/code_review/find_model.rs
@@ -97,6 +97,12 @@ impl CodeReviewFindModel {
         self.results = None;
     }
 
+    fn repo_is_local(&self, ctx: &AppContext) -> Option<bool> {
+        self.weak_view_handle
+            .upgrade(ctx)
+            .and_then(|view| view.as_ref(ctx).repo_is_local())
+    }
+
     pub fn update_query(
         &mut self,
         query: Option<String>,
@@ -116,6 +122,7 @@ impl CodeReviewFindModel {
         self.case_sensitive = case_sensitive;
         send_telemetry_from_ctx!(
             CodeReviewTelemetryEvent::FindBarModeChanged {
+                is_local: self.repo_is_local(ctx),
                 case_sensitive: self.case_sensitive,
                 regex: self.regex,
             },
@@ -133,6 +140,7 @@ impl CodeReviewFindModel {
         self.regex = regex;
         send_telemetry_from_ctx!(
             CodeReviewTelemetryEvent::FindBarModeChanged {
+                is_local: self.repo_is_local(ctx),
                 case_sensitive: self.case_sensitive,
                 regex: self.regex,
             },
@@ -156,7 +164,13 @@ impl CodeReviewFindModel {
             return;
         }
 
-        send_telemetry_from_ctx!(CodeReviewTelemetryEvent::FindNavigated { direction }, ctx);
+        send_telemetry_from_ctx!(
+            CodeReviewTelemetryEvent::FindNavigated {
+                is_local: self.repo_is_local(ctx),
+                direction,
+            },
+            ctx
+        );
 
         let next_index = if let Some(selected) = &self.selected_match {
             match direction {

--- a/app/src/code_review/git_dialog/commit.rs
+++ b/app/src/code_review/git_dialog/commit.rs
@@ -447,6 +447,7 @@ pub(super) fn start_confirm(me: &mut GitDialog, ctx: &mut ViewContext<GitDialog>
             }
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::GitDialogCompleted {
+                    is_local: Some(true),
                     operation,
                     status,
                     error,

--- a/app/src/code_review/git_dialog/mod.rs
+++ b/app/src/code_review/git_dialog/mod.rs
@@ -812,6 +812,7 @@ impl TypedActionView for GitDialog {
                     };
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::GitDialogCompleted {
+                            is_local: Some(true),
                             operation,
                             status: GitDialogStatus::Cancelled,
                             error: None,

--- a/app/src/code_review/git_dialog/pr.rs
+++ b/app/src/code_review/git_dialog/pr.rs
@@ -161,6 +161,7 @@ pub(super) fn start_confirm(me: &mut GitDialog, ctx: &mut ViewContext<GitDialog>
             }
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::GitDialogCompleted {
+                    is_local: Some(true),
                     operation: GitOperationKind::CreatePr,
                     status,
                     error,

--- a/app/src/code_review/git_dialog/push.rs
+++ b/app/src/code_review/git_dialog/push.rs
@@ -168,6 +168,7 @@ pub(super) fn start_confirm(me: &mut GitDialog, ctx: &mut ViewContext<GitDialog>
             }
             send_telemetry_from_ctx!(
                 CodeReviewTelemetryEvent::GitDialogCompleted {
+                    is_local: Some(true),
                     operation: if publish {
                         GitOperationKind::Publish
                     } else {

--- a/app/src/code_review/telemetry_event.rs
+++ b/app/src/code_review/telemetry_event.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use serde::Serialize;
 use serde_json::json;
 use serde_with::SerializeDisplay;
+use std::time::Duration;
 use strum_macros::{EnumDiscriminants, EnumIter};
 use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
 
@@ -229,6 +230,10 @@ pub enum CodeReviewTelemetryEvent {
         files_changed: usize,
         total_additions: usize,
         total_deletions: usize,
+        /// Time elapsed between when the diff load was requested and when the
+        /// diffs were ready. `None` if the load was not initiated through a
+        /// tracked entry point (e.g. background refresh).
+        load_duration: Option<Duration>,
     },
     /// Emitted when the code review find bar is opened or closed.
     FindBarToggled {
@@ -384,6 +389,7 @@ impl TelemetryEvent for CodeReviewTelemetryEvent {
                 files_changed,
                 total_additions,
                 total_deletions,
+                load_duration,
             } => Some(json!({
                 "is_local": is_local,
                 "mode": mode,
@@ -391,6 +397,7 @@ impl TelemetryEvent for CodeReviewTelemetryEvent {
                 "files_changed": files_changed,
                 "total_additions": total_additions,
                 "total_deletions": total_deletions,
+                "load_duration": load_duration,
             })),
             CodeReviewTelemetryEvent::FindBarToggled { is_local, is_open } => {
                 Some(json!({ "is_local": is_local, "is_open": is_open }))

--- a/app/src/code_review/telemetry_event.rs
+++ b/app/src/code_review/telemetry_event.rs
@@ -213,13 +213,15 @@ pub enum CodeReviewTelemetryEvent {
         mode: DiffMode,
     },
     /// Failure when we are calculating the diff metadata.
-    CalculateDiffMetadataFailed {
+    LoadMetadataFailed {
         is_local: Option<bool>,
+        mode: DiffMode,
         error: String,
     },
     /// Failure when we are loading the actual diff content.
     LoadDiffFailed {
         is_local: Option<bool>,
+        mode: DiffMode,
         error: String,
     },
     /// Emitted when a full diff load completes successfully.
@@ -376,12 +378,16 @@ impl TelemetryEvent for CodeReviewTelemetryEvent {
             CodeReviewTelemetryEvent::BaseChanged { is_local, mode } => {
                 Some(json!({ "is_local": is_local, "mode": mode }))
             }
-            CodeReviewTelemetryEvent::CalculateDiffMetadataFailed { is_local, error } => {
-                Some(json!({ "is_local": is_local, "error": error }))
-            }
-            CodeReviewTelemetryEvent::LoadDiffFailed { is_local, error } => {
-                Some(json!({ "is_local": is_local, "error": error }))
-            }
+            CodeReviewTelemetryEvent::LoadMetadataFailed {
+                is_local,
+                mode,
+                error,
+            } => Some(json!({ "is_local": is_local, "mode": mode, "error": error })),
+            CodeReviewTelemetryEvent::LoadDiffFailed {
+                is_local,
+                mode,
+                error,
+            } => Some(json!({ "is_local": is_local, "mode": mode, "error": error })),
             CodeReviewTelemetryEvent::DiffLoadCompleted {
                 is_local,
                 mode,
@@ -523,7 +529,7 @@ impl TelemetryEventDesc for CodeReviewTelemetryEventDiscriminants {
             Self::FileSaved => "CodeReview.FileSaved",
             Self::PaneStateChanged => "CodeReview.PaneStateChanged",
             Self::BaseChanged => "CodeReview.BaseChanged",
-            Self::CalculateDiffMetadataFailed => "CodeReview.CalculateDiffMetadataFailed",
+            Self::LoadMetadataFailed => "CodeReview.LoadMetadataFailed",
             Self::LoadDiffFailed => "CodeReview.LoadDiffFailed",
             Self::DiffLoadCompleted => "CodeReview.DiffLoadCompleted",
             Self::FindBarToggled => "CodeReview.FindBarToggled",
@@ -553,7 +559,7 @@ impl TelemetryEventDesc for CodeReviewTelemetryEventDiscriminants {
             Self::FileSaved => "File saved in code review pane",
             Self::PaneStateChanged => "Code review pane minimized or maximized",
             Self::BaseChanged => "Diff base changed in code review",
-            Self::CalculateDiffMetadataFailed => "Failure when calculating diff metadata",
+            Self::LoadMetadataFailed => "Failure when calculating diff metadata",
             Self::LoadDiffFailed => "Failure when loading diff content",
             Self::DiffLoadCompleted => "Diff content loaded successfully",
             Self::FindBarToggled => "Code review find bar opened or closed",

--- a/app/src/code_review/telemetry_event.rs
+++ b/app/src/code_review/telemetry_event.rs
@@ -294,7 +294,6 @@ pub enum CodeReviewTelemetryEvent {
     },
     /// Emitted when one or more comments are resolved.
     CommentResolved {
-        is_local: Option<bool>,
         /// Number of comments resolved by this operation.
         resolved_count: usize,
     },
@@ -456,10 +455,9 @@ impl TelemetryEvent for CodeReviewTelemetryEvent {
                 is_local,
                 fallback_count,
             } => Some(json!({ "is_local": is_local, "fallback_count": fallback_count })),
-            CodeReviewTelemetryEvent::CommentResolved {
-                is_local,
-                resolved_count,
-            } => Some(json!({ "is_local": is_local, "resolved_count": resolved_count })),
+            CodeReviewTelemetryEvent::CommentResolved { resolved_count } => {
+                Some(json!({ "resolved_count": resolved_count }))
+            }
             CodeReviewTelemetryEvent::CommentsReceived {
                 is_local,
                 raw_count,

--- a/app/src/code_review/telemetry_event.rs
+++ b/app/src/code_review/telemetry_event.rs
@@ -223,6 +223,10 @@ pub enum CodeReviewTelemetryEvent {
         is_local: Option<bool>,
         mode: DiffMode,
         error: String,
+        /// Time elapsed between when the tracked diff load was requested and
+        /// when this failure was observed. `None` if no tracked load was in
+        /// flight (e.g. a background invalidation error).
+        load_duration: Option<Duration>,
     },
     /// Emitted when a full diff load completes successfully.
     DiffLoadCompleted {
@@ -386,7 +390,13 @@ impl TelemetryEvent for CodeReviewTelemetryEvent {
                 is_local,
                 mode,
                 error,
-            } => Some(json!({ "is_local": is_local, "mode": mode, "error": error })),
+                load_duration,
+            } => Some(json!({
+                "is_local": is_local,
+                "mode": mode,
+                "error": error,
+                "load_duration": load_duration,
+            })),
             CodeReviewTelemetryEvent::DiffLoadCompleted {
                 is_local,
                 mode,

--- a/app/src/code_review/telemetry_event.rs
+++ b/app/src/code_review/telemetry_event.rs
@@ -183,6 +183,7 @@ pub enum PaneStateChange {
 pub enum CodeReviewTelemetryEvent {
     /// Emitted when the code review pane is opened.
     PaneOpened {
+        is_local: Option<bool>,
         entrypoint: CodeReviewPaneEntrypoint,
         is_code_mode_v2: bool,
         /// The CLI agent type if opened from a CLI agent footer (e.g., Claude Code).
@@ -190,32 +191,54 @@ pub enum CodeReviewTelemetryEvent {
     },
     /// Emitted when a user adds content to AI context from code review.
     AddToContext {
+        is_local: Option<bool>,
         origin: AddToContextOrigin,
         destination: CodeReviewContextDestination,
         diff_set_scope: Option<DiffSetContextScope>,
     },
     /// Emitted when a user clicks the revert hunk button.
-    RevertHunkClicked,
+    RevertHunkClicked { is_local: Option<bool> },
     /// Emitted when a file is saved in the code review pane.
-    FileSaved,
+    FileSaved { is_local: Option<bool> },
     /// Emitted when the code review pane is minimized or maximized.
-    PaneStateChanged { state_change: PaneStateChange },
+    PaneStateChanged {
+        is_local: Option<bool>,
+        state_change: PaneStateChange,
+    },
     /// Emitted when the diff base is changed (e.g., from uncommitted to main branch).
     BaseChanged {
+        is_local: Option<bool>,
         /// The new diff mode.
         mode: DiffMode,
     },
     /// Failure when we are calculating the diff metadata.
-    CalculateDiffMetadataFailed { error: String },
+    CalculateDiffMetadataFailed {
+        is_local: Option<bool>,
+        error: String,
+    },
     /// Failure when we are loading the actual diff content.
-    LoadDiffFailed { error: String },
+    LoadDiffFailed {
+        is_local: Option<bool>,
+        error: String,
+    },
+    /// Emitted when a full diff load completes successfully.
+    DiffLoadCompleted {
+        is_local: Option<bool>,
+        mode: DiffMode,
+        file_count: usize,
+        files_changed: usize,
+        total_additions: usize,
+        total_deletions: usize,
+    },
     /// Emitted when the code review find bar is opened or closed.
     FindBarToggled {
+        is_local: Option<bool>,
         /// Whether the find bar is now open.
         is_open: bool,
     },
     /// Emitted when search mode settings are changed.
     FindBarModeChanged {
+        is_local: Option<bool>,
         /// Whether case-sensitive search is enabled.
         case_sensitive: bool,
         /// Whether regex search is enabled.
@@ -223,24 +246,30 @@ pub enum CodeReviewTelemetryEvent {
     },
     /// Emitted when the user navigates to the next or previous match.
     FindNavigated {
+        is_local: Option<bool>,
         /// Direction of navigation.
         direction: FindDirection,
     },
     /// Emitted when the inline comment editor is opened in the code review pane.
-    CommentEditorOpened,
+    CommentEditorOpened { is_local: Option<bool> },
     /// Emitted when a new comment is added to the inline review.
-    CommentAdded,
+    CommentAdded { is_local: Option<bool> },
     /// Emitted when an existing comment is edited.
-    CommentEdited,
+    CommentEdited { is_local: Option<bool> },
     /// Emitted when a comment is deleted from the inline review.
-    CommentDeleted { is_imported: bool },
+    CommentDeleted {
+        is_local: Option<bool>,
+        is_imported: bool,
+    },
     /// Emitted when the bottom comment list panel is expanded.
     CommentListExpanded {
+        is_local: Option<bool>,
         /// Number of comments currently in the list.
         comment_count: usize,
     },
     /// Emitted when the user submits an inline review to the agent.
     ReviewSubmitted {
+        is_local: Option<bool>,
         /// Number of comments in the submitted review.
         comment_count: usize,
         /// Number of unique files with comments.
@@ -249,19 +278,22 @@ pub enum CodeReviewTelemetryEvent {
         destination: CodeReviewContextDestination,
     },
     /// Emitted when a comment in the list view is clicked to jump to its location.
-    CommentListItemClicked,
+    CommentListItemClicked { is_local: Option<bool> },
     /// Emitted when one or more comments fail to be precisely relocated after code changes.
     CommentRelocationFailed {
+        is_local: Option<bool>,
         /// Number of comments that could not be matched to an exact line and had to fall back.
         fallback_count: usize,
     },
     /// Emitted when one or more comments are resolved.
     CommentResolved {
+        is_local: Option<bool>,
         /// Number of comments resolved by this operation.
         resolved_count: usize,
     },
     /// Emitted when the agent's insert_code_review_comments tool call is received and processed.
     CommentsReceived {
+        is_local: Option<bool>,
         /// Number of raw InsertReviewComment items from the tool call.
         raw_count: usize,
         /// Number of successfully converted PendingImportedReviewComments.
@@ -271,6 +303,7 @@ pub enum CodeReviewTelemetryEvent {
     },
     /// Emitted after newly-imported comments are relocated against editor lines.
     CommentsAttached {
+        is_local: Option<bool>,
         /// Number of non-outdated imported comments after relocation.
         active_count: usize,
         /// Number of outdated imported comments after relocation.
@@ -278,10 +311,14 @@ pub enum CodeReviewTelemetryEvent {
     },
     /// Emitted when a user clicks a git operation button in the code review
     /// header (primary button or dropdown item).
-    GitButtonTriggered { button: GitButtonKind },
+    GitButtonTriggered {
+        is_local: Option<bool>,
+        button: GitButtonKind,
+    },
     /// Emitted when a git dialog reaches a terminal state — either the async
     /// op succeeded / failed, or the user cancelled before confirming.
     GitDialogCompleted {
+        is_local: Option<bool>,
         /// The git operation that ran or would have run (e.g. `commit_and_push`
         /// for the commit dialog with that chained intent).
         operation: GitOperationKind,
@@ -300,93 +337,146 @@ impl TelemetryEvent for CodeReviewTelemetryEvent {
     fn payload(&self) -> Option<serde_json::Value> {
         match self {
             CodeReviewTelemetryEvent::PaneOpened {
+                is_local,
                 entrypoint,
                 is_code_mode_v2,
                 cli_agent,
-            } => Some(
-                json!({ "entrypoint": entrypoint, "is_code_mode_v2": is_code_mode_v2, "agent_name": cli_agent}),
-            ),
+            } => Some(json!({
+                "is_local": is_local,
+                "entrypoint": entrypoint,
+                "is_code_mode_v2": is_code_mode_v2,
+                "agent_name": cli_agent,
+            })),
             CodeReviewTelemetryEvent::AddToContext {
+                is_local,
                 origin,
                 destination,
                 diff_set_scope,
             } => Some(json!({
+                "is_local": is_local,
                 "origin": origin,
                 "destination": destination,
                 "diff_set_scope": diff_set_scope,
             })),
-            CodeReviewTelemetryEvent::RevertHunkClicked => None,
-            CodeReviewTelemetryEvent::FileSaved => None,
-            CodeReviewTelemetryEvent::PaneStateChanged { state_change } => {
-                Some(json!({ "state_change": state_change }))
+            CodeReviewTelemetryEvent::RevertHunkClicked { is_local } => {
+                Some(json!({ "is_local": is_local }))
             }
-            CodeReviewTelemetryEvent::BaseChanged { mode } => Some(json!({ "mode": mode })),
-            CodeReviewTelemetryEvent::CalculateDiffMetadataFailed { error } => {
-                Some(json!({ "error": error }))
+            CodeReviewTelemetryEvent::FileSaved { is_local } => {
+                Some(json!({ "is_local": is_local }))
             }
-            CodeReviewTelemetryEvent::LoadDiffFailed { error } => Some(json!({ "error": error })),
-            CodeReviewTelemetryEvent::FindBarToggled { is_open } => {
-                Some(json!({ "is_open": is_open }))
+            CodeReviewTelemetryEvent::PaneStateChanged {
+                is_local,
+                state_change,
+            } => Some(json!({ "is_local": is_local, "state_change": state_change })),
+            CodeReviewTelemetryEvent::BaseChanged { is_local, mode } => {
+                Some(json!({ "is_local": is_local, "mode": mode }))
+            }
+            CodeReviewTelemetryEvent::CalculateDiffMetadataFailed { is_local, error } => {
+                Some(json!({ "is_local": is_local, "error": error }))
+            }
+            CodeReviewTelemetryEvent::LoadDiffFailed { is_local, error } => {
+                Some(json!({ "is_local": is_local, "error": error }))
+            }
+            CodeReviewTelemetryEvent::DiffLoadCompleted {
+                is_local,
+                mode,
+                file_count,
+                files_changed,
+                total_additions,
+                total_deletions,
+            } => Some(json!({
+                "is_local": is_local,
+                "mode": mode,
+                "file_count": file_count,
+                "files_changed": files_changed,
+                "total_additions": total_additions,
+                "total_deletions": total_deletions,
+            })),
+            CodeReviewTelemetryEvent::FindBarToggled { is_local, is_open } => {
+                Some(json!({ "is_local": is_local, "is_open": is_open }))
             }
             CodeReviewTelemetryEvent::FindBarModeChanged {
+                is_local,
                 case_sensitive,
                 regex,
             } => Some(json!({
+                "is_local": is_local,
                 "case_sensitive": case_sensitive,
                 "regex": regex,
             })),
-            CodeReviewTelemetryEvent::FindNavigated { direction } => {
-                Some(json!({ "direction": direction }))
+            CodeReviewTelemetryEvent::FindNavigated {
+                is_local,
+                direction,
+            } => Some(json!({ "is_local": is_local, "direction": direction })),
+            CodeReviewTelemetryEvent::CommentEditorOpened { is_local } => {
+                Some(json!({ "is_local": is_local }))
             }
-            CodeReviewTelemetryEvent::CommentEditorOpened => None,
-            CodeReviewTelemetryEvent::CommentAdded => None,
-            CodeReviewTelemetryEvent::CommentEdited => None,
-            CodeReviewTelemetryEvent::CommentDeleted { is_imported } => {
-                Some(json!({ "is_imported": is_imported }))
+            CodeReviewTelemetryEvent::CommentAdded { is_local } => {
+                Some(json!({ "is_local": is_local }))
             }
-            CodeReviewTelemetryEvent::CommentListExpanded { comment_count } => {
-                Some(json!({ "comment_count": comment_count }))
+            CodeReviewTelemetryEvent::CommentEdited { is_local } => {
+                Some(json!({ "is_local": is_local }))
             }
+            CodeReviewTelemetryEvent::CommentDeleted {
+                is_local,
+                is_imported,
+            } => Some(json!({ "is_local": is_local, "is_imported": is_imported })),
+            CodeReviewTelemetryEvent::CommentListExpanded {
+                is_local,
+                comment_count,
+            } => Some(json!({ "is_local": is_local, "comment_count": comment_count })),
             CodeReviewTelemetryEvent::ReviewSubmitted {
+                is_local,
                 comment_count,
                 file_count,
                 destination,
             } => Some(json!({
+                "is_local": is_local,
                 "comment_count": comment_count,
                 "file_count": file_count,
                 "destination": destination,
             })),
-            CodeReviewTelemetryEvent::CommentListItemClicked => None,
-            CodeReviewTelemetryEvent::CommentRelocationFailed { fallback_count } => {
-                Some(json!({ "fallback_count": fallback_count }))
+            CodeReviewTelemetryEvent::CommentListItemClicked { is_local } => {
+                Some(json!({ "is_local": is_local }))
             }
-            CodeReviewTelemetryEvent::CommentResolved { resolved_count } => {
-                Some(json!({ "resolved_count": resolved_count }))
-            }
+            CodeReviewTelemetryEvent::CommentRelocationFailed {
+                is_local,
+                fallback_count,
+            } => Some(json!({ "is_local": is_local, "fallback_count": fallback_count })),
+            CodeReviewTelemetryEvent::CommentResolved {
+                is_local,
+                resolved_count,
+            } => Some(json!({ "is_local": is_local, "resolved_count": resolved_count })),
             CodeReviewTelemetryEvent::CommentsReceived {
+                is_local,
                 raw_count,
                 converted_count,
                 thread_count,
             } => Some(json!({
+                "is_local": is_local,
                 "raw_count": raw_count,
                 "converted_count": converted_count,
                 "thread_count": thread_count,
             })),
             CodeReviewTelemetryEvent::CommentsAttached {
+                is_local,
                 active_count,
                 outdated_count,
             } => Some(json!({
+                "is_local": is_local,
                 "active_count": active_count,
                 "outdated_count": outdated_count,
             })),
-            CodeReviewTelemetryEvent::GitButtonTriggered { button } => {
-                Some(json!({ "button": button }))
+            CodeReviewTelemetryEvent::GitButtonTriggered { is_local, button } => {
+                Some(json!({ "is_local": is_local, "button": button }))
             }
             CodeReviewTelemetryEvent::GitDialogCompleted {
+                is_local,
                 operation,
                 status,
                 error,
             } => Some(json!({
+                "is_local": is_local,
                 "operation": operation,
                 "status": status,
                 "error": error,
@@ -428,6 +518,7 @@ impl TelemetryEventDesc for CodeReviewTelemetryEventDiscriminants {
             Self::BaseChanged => "CodeReview.BaseChanged",
             Self::CalculateDiffMetadataFailed => "CodeReview.CalculateDiffMetadataFailed",
             Self::LoadDiffFailed => "CodeReview.LoadDiffFailed",
+            Self::DiffLoadCompleted => "CodeReview.DiffLoadCompleted",
             Self::FindBarToggled => "CodeReview.FindBarToggled",
             Self::FindBarModeChanged => "CodeReview.FindBarModeChanged",
             Self::FindNavigated => "CodeReview.FindNavigated",
@@ -457,6 +548,7 @@ impl TelemetryEventDesc for CodeReviewTelemetryEventDiscriminants {
             Self::BaseChanged => "Diff base changed in code review",
             Self::CalculateDiffMetadataFailed => "Failure when calculating diff metadata",
             Self::LoadDiffFailed => "Failure when loading diff content",
+            Self::DiffLoadCompleted => "Diff content loaded successfully",
             Self::FindBarToggled => "Code review find bar opened or closed",
             Self::FindBarModeChanged => "Search mode changed in code review find bar",
             Self::FindNavigated => "Navigated to next or previous match in code review find bar",

--- a/app/src/remote_server/diff_state_tracker.rs
+++ b/app/src/remote_server/diff_state_tracker.rs
@@ -280,7 +280,7 @@ impl RemoteDiffStateManager {
             let mode = key.mode.clone();
             let model = ctx.add_model(|ctx| {
                 let mut m = LocalDiffStateModel::new(Some(repo_path_str), ctx);
-                m.set_diff_mode(mode, false, ctx);
+                m.set_diff_mode(mode, false, false, ctx);
                 m.set_code_review_metadata_refresh_enabled(true, ctx);
                 m
             });
@@ -305,7 +305,7 @@ impl RemoteDiffStateManager {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
-            DiffStateModelEvent::NewDiffsComputed(diffs) => {
+            DiffStateModelEvent::NewDiffsComputed { diffs, .. } => {
                 let Some((state, metadata)) = self.read_state_and_metadata(key, ctx) else {
                     log::warn!("NewDiffsComputed for absent model key={key:?}");
                     return;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8304,6 +8304,10 @@ impl Workspace {
                 }
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::PaneOpened {
+                        is_local: panel_update_params
+                            .review_pane_context
+                            .and_then(|context| context.repo_path.as_ref())
+                            .map(LocalOrRemotePath::is_local),
                         entrypoint: panel_update_params.entrypoint.unwrap_or_default(),
                         is_code_mode_v2: true,
                         cli_agent: panel_update_params.cli_agent.map(Into::into),


### PR DESCRIPTION
## Description 
* Wires is_local through existing code review view events 
  * Some(true) => local, Some(false) => remote, None => no repo
* Moves event emission to code review for access to repo path
* Tracks load diff latency 
* Emits events for decode or empty errors   

## Testing 
Verified by running locally with_sandbox_telemetry

## Agent mode
- [x] Warp Agent Mode 