### PR TITLE
Avoid cloning protobuf request bodies

### DIFF
--- a/crates/http_client/src/lib.rs
+++ b/crates/http_client/src/lib.rs
@@ -42,6 +42,8 @@ pub mod headers {
     pub(crate) const WARP_CLIENT_ID: &str = "X-Warp-Client-ID";
 }
 
+#[cfg(test)]
+mod lib_tests;
 /// The environment variable containing extra HTTP headers to attach to requests.
 /// Only read when the channel is `Channel::Integration`. The value is a newline-separated
 /// list of `Name:Value` pairs, where each pair is split on the first colon.
@@ -391,7 +393,6 @@ impl<'a> RequestBuilder<'a> {
 
     pub fn proto<T: prost::Message>(self, proto: &T) -> RequestBuilder<'a> {
         let bytes = proto.encode_to_vec();
-        let serialized = String::from_utf8(bytes.clone());
 
         Self {
             wrapped: self
@@ -401,7 +402,7 @@ impl<'a> RequestBuilder<'a> {
                     HeaderValue::from_static("application/x-protobuf"),
                 )
                 .body(bytes),
-            serialized_payload: serialized.ok(),
+            serialized_payload: None,
             ..self
         }
     }

--- a/crates/http_client/src/lib_tests.rs
+++ b/crates/http_client/src/lib_tests.rs
@@ -1,0 +1,59 @@
+use prost::Message;
+
+use super::*;
+
+#[derive(Clone, PartialEq, Message)]
+struct Utf8Proto {
+    #[prost(string, tag = "1")]
+    value: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct BinaryProto {
+    #[prost(bytes = "vec", tag = "1")]
+    value: Vec<u8>,
+}
+
+#[test]
+fn proto_request_preserves_utf8_body_without_serialized_payload() {
+    let proto = Utf8Proto {
+        value: "hello".to_string(),
+    };
+    let expected_bytes = proto.encode_to_vec();
+
+    let request = Client::new()
+        .post("https://example.com/proto")
+        .proto(&proto)
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        request.wrapped.headers().get(http::header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static("application/x-protobuf"))
+    );
+    assert_eq!(
+        request.wrapped.body().and_then(reqwest::Body::as_bytes),
+        Some(expected_bytes.as_slice())
+    );
+    assert_eq!(request.serialized_payload, None);
+}
+
+#[test]
+fn proto_request_preserves_binary_body_without_serialized_payload() {
+    let proto = BinaryProto {
+        value: vec![0xff, 0xfe, 0xfd],
+    };
+    let expected_bytes = proto.encode_to_vec();
+
+    let request = Client::new()
+        .post("https://example.com/proto")
+        .proto(&proto)
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        request.wrapped.body().and_then(reqwest::Body::as_bytes),
+        Some(expected_bytes.as_slice())
+    );
+    assert_eq!(request.serialized_payload, None);
+}


### PR DESCRIPTION
## Description
Warp sends protobuf API requests for several features, including Agent/Oz requests and passive suggestions. Large Agent conversation payloads can make these request bodies very large.

This keeps the protobuf request body unchanged, but stops trying to copy that binary body into the optional text payload used by request logging hooks. JSON and form requests still provide their text payloads as before.

## Linked Issue
- APP-4525
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo check -p http_client`
- `cargo fmt`
- `cargo test -p http_client`
- `cargo clippy -p http_client -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/687f7401-8671-409e-afdc-5175fc676ed1_
_Run: https://oz.staging.warp.dev/runs/019e4c0f-302b-7a8b-bd5e-c6c03f8ca4ea_
_Plans_:
- _[APP-4525 definitive fix PR series](https://staging.warp.dev/drive/notebook/7TnZ0sEuPMLG36BkwBdR3G)_
- _[APP-4525 server passive token context PR](https://staging.warp.dev/drive/notebook/ap99qTBszsYt42G3xiAKGh)_
_This PR was generated with [Oz](https://warp.dev/oz)._
