### PR TITLE
[WARP-XXXX] Enable custom endpoint usage tracking and display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14926,7 +14926,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=9a2d2425c5d1eb40fb547956e659511906e03f9e#9a2d2425c5d1eb40fb547956e659511906e03f9e"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=c67de64fc4949f693a679552dc88cebc9f7d0180#c67de64fc4949f693a679552dc88cebc9f7d0180"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "9a2d2425c5d1eb40fb547956e659511906e03f9e" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "c67de64fc4949f693a679552dc88cebc9f7d0180" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -115,7 +115,7 @@ fn footer_model_token_usage(
     for (config_key, usage) in &usage_metadata.custom_endpoint_token_usage {
         let label = custom_endpoint_display_label(config_key);
         let entry = token_usage
-            .entry(format!("custom_endpoint~{config_key}"))
+            .entry(config_key.clone())
             .or_insert_with(|| ModelTokenUsage {
                 model_id: label,
                 custom_endpoint_config_key: Some(config_key.clone()),

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -70,7 +70,7 @@ use crate::terminal::model::block::{
     AgentInteractionMetadata, AgentViewVisibility, BlockId, SerializedAIMetadata, SerializedBlock,
 };
 use crate::ui_components::icons::Icon;
-use crate::{BlocklistAIHistoryModel, GlobalResourceHandlesProvider, LLMPreferences};
+use crate::{BlocklistAIHistoryModel, GlobalResourceHandlesProvider};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TodoStatus {

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -20,7 +20,7 @@ use warp_multi_agent_api::response_event::stream_finished;
 use warp_multi_agent_api::response_event::stream_finished::TokenUsage;
 use warp_multi_agent_api::{self as api};
 use warpui::color::ColorU;
-use warpui::{EntityId, ModelContext, SingletonEntity};
+use warpui::{AppContext, EntityId, ModelContext, SingletonEntity};
 
 use super::api::ServerConversationToken;
 use super::task::helper::*;
@@ -85,6 +85,59 @@ impl TodoStatus {
     pub fn is_cancelled(&self) -> bool {
         matches!(self, TodoStatus::Cancelled)
     }
+}
+
+fn footer_model_token_usage(
+    usage_metadata: &stream_finished::ConversationUsageMetadata,
+    custom_endpoint_display_label: impl Fn(&str) -> String,
+) -> Vec<ModelTokenUsage> {
+    let mut token_usage: HashMap<_, ModelTokenUsage> = HashMap::new();
+    for (model_id, usage) in &usage_metadata.warp_token_usage {
+        let entry = token_usage.entry(model_id.clone()).or_default();
+        entry.warp_tokens += usage.total_tokens;
+        for (category, tokens) in &usage.token_usage_by_category {
+            *entry
+                .warp_token_usage_by_category
+                .entry(category.clone())
+                .or_default() += *tokens;
+        }
+    }
+    for (model_id, usage) in &usage_metadata.byok_token_usage {
+        let entry = token_usage.entry(model_id.clone()).or_default();
+        entry.byok_tokens += usage.total_tokens;
+        for (category, tokens) in &usage.token_usage_by_category {
+            *entry
+                .byok_token_usage_by_category
+                .entry(category.clone())
+                .or_default() += *tokens;
+        }
+    }
+    for (config_key, usage) in &usage_metadata.custom_endpoint_token_usage {
+        let label = custom_endpoint_display_label(config_key);
+        let entry = token_usage
+            .entry(format!("custom_endpoint~{config_key}"))
+            .or_insert_with(|| ModelTokenUsage {
+                model_id: label,
+                ..Default::default()
+            });
+        entry.byok_tokens += usage.total_tokens;
+        for (category, tokens) in &usage.token_usage_by_category {
+            *entry
+                .byok_token_usage_by_category
+                .entry(category.clone())
+                .or_default() += *tokens;
+        }
+    }
+
+    token_usage
+        .into_iter()
+        .map(|(name, mut usage)| {
+            if usage.model_id.is_empty() {
+                usage.model_id = name;
+            }
+            usage
+        })
+        .collect()
 }
 
 // basic info for creating a dummy command block based on an exchange's inputs
@@ -1707,6 +1760,7 @@ impl AIConversation {
         token_usage: Vec<TokenUsage>,
         usage_metadata: Option<stream_finished::ConversationUsageMetadata>,
         was_user_initiated_request: bool,
+        ctx: &AppContext,
     ) -> Result<(), UpdateConversationError> {
         for usage in token_usage.into_iter() {
             let entry = self
@@ -1749,36 +1803,11 @@ impl AIConversation {
             self.conversation_usage_metadata.context_window_usage =
                 usage_metadata.context_window_usage;
             self.conversation_usage_metadata.credits_spent = usage_metadata.credits_spent;
-
-            let mut token_usage: HashMap<_, ModelTokenUsage> = HashMap::new();
-            for (model_id, usage) in usage_metadata.warp_token_usage {
-                let entry = token_usage.entry(model_id.clone()).or_default();
-                entry.warp_tokens += usage.total_tokens;
-                for (category, tokens) in usage.token_usage_by_category {
-                    *entry
-                        .warp_token_usage_by_category
-                        .entry(category)
-                        .or_default() += tokens;
-                }
-            }
-            for (model_id, usage) in usage_metadata.byok_token_usage {
-                let entry = token_usage.entry(model_id.clone()).or_default();
-                entry.byok_tokens += usage.total_tokens;
-                for (category, tokens) in usage.token_usage_by_category {
-                    *entry
-                        .byok_token_usage_by_category
-                        .entry(category)
-                        .or_default() += tokens;
-                }
-            }
-
-            self.conversation_usage_metadata.token_usage = token_usage
-                .into_iter()
-                .map(|(name, mut usage)| {
-                    usage.model_id = name;
-                    usage
-                })
-                .collect();
+            let llm_preferences = LLMPreferences::as_ref(ctx);
+            self.conversation_usage_metadata.token_usage =
+                footer_model_token_usage(&usage_metadata, |config_key| {
+                    llm_preferences.custom_endpoint_usage_display_label(config_key)
+                });
 
             self.conversation_usage_metadata.tool_usage_metadata = usage_metadata
                 .tool_usage_metadata

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1804,7 +1804,7 @@ impl AIConversation {
             self.conversation_usage_metadata.context_window_usage =
                 usage_metadata.context_window_usage;
             self.conversation_usage_metadata.credits_spent = usage_metadata.credits_spent;
-            let llm_preferences = LLMPreferences::as_ref(ctx);
+            let llm_preferences = crate::ai::llms::LLMPreferences::as_ref(ctx);
             self.conversation_usage_metadata.token_usage =
                 footer_model_token_usage(&usage_metadata, |config_key| {
                     llm_preferences.custom_endpoint_usage_display_label(config_key)

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -56,6 +56,7 @@ use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, ConversationStatusUpdate, RequestInput, ResponseStreamId,
     SerializedBlockListItem,
 };
+use crate::ai::llms::LLMPreferences;
 use crate::ai::skills::SkillDescriptor;
 use crate::code_review::CodeReviewTelemetryEvent;
 use crate::notebooks::NotebookId;
@@ -89,11 +90,22 @@ impl TodoStatus {
 
 fn footer_model_token_usage(
     usage_metadata: &stream_finished::ConversationUsageMetadata,
-    custom_endpoint_display_label: impl Fn(&str) -> String,
+    llm_preferences: &LLMPreferences,
 ) -> Vec<ModelTokenUsage> {
-    let mut token_usage: HashMap<_, ModelTokenUsage> = HashMap::new();
+    // warp + byok rows merge on their server-known model id. Custom endpoint
+    // rows live in a separate bucket keyed by their upstream `config_key` so
+    // they never collide with a warp/byok row that happens to share the same
+    // resolved alias. The `config_key` itself is not retained on
+    // `ModelTokenUsage`; it is translated to an alias up front and only the
+    // alias flows downstream (display + shared-session replay).
+    let mut standard_usage: HashMap<String, ModelTokenUsage> = HashMap::new();
     for (model_id, usage) in &usage_metadata.warp_token_usage {
-        let entry = token_usage.entry(model_id.clone()).or_default();
+        let entry = standard_usage
+            .entry(model_id.clone())
+            .or_insert_with(|| ModelTokenUsage {
+                model_id: model_id.clone(),
+                ..Default::default()
+            });
         entry.warp_tokens += usage.total_tokens;
         for (category, tokens) in &usage.token_usage_by_category {
             *entry
@@ -103,7 +115,12 @@ fn footer_model_token_usage(
         }
     }
     for (model_id, usage) in &usage_metadata.byok_token_usage {
-        let entry = token_usage.entry(model_id.clone()).or_default();
+        let entry = standard_usage
+            .entry(model_id.clone())
+            .or_insert_with(|| ModelTokenUsage {
+                model_id: model_id.clone(),
+                ..Default::default()
+            });
         entry.byok_tokens += usage.total_tokens;
         for (category, tokens) in &usage.token_usage_by_category {
             *entry
@@ -112,13 +129,14 @@ fn footer_model_token_usage(
                 .or_default() += *tokens;
         }
     }
+
+    let mut custom_usage: HashMap<String, ModelTokenUsage> = HashMap::new();
     for (config_key, usage) in &usage_metadata.custom_endpoint_token_usage {
-        let label = custom_endpoint_display_label(config_key);
-        let entry = token_usage
+        let label = llm_preferences.custom_endpoint_usage_display_label(config_key);
+        let entry = custom_usage
             .entry(config_key.clone())
             .or_insert_with(|| ModelTokenUsage {
                 model_id: label,
-                custom_endpoint_config_key: Some(config_key.clone()),
                 ..Default::default()
             });
         entry.custom_endpoint_tokens += usage.total_tokens;
@@ -130,14 +148,9 @@ fn footer_model_token_usage(
         }
     }
 
-    token_usage
-        .into_iter()
-        .map(|(name, mut usage)| {
-            if usage.model_id.is_empty() {
-                usage.model_id = name;
-            }
-            usage
-        })
+    standard_usage
+        .into_values()
+        .chain(custom_usage.into_values())
         .collect()
 }
 
@@ -1804,11 +1817,9 @@ impl AIConversation {
             self.conversation_usage_metadata.context_window_usage =
                 usage_metadata.context_window_usage;
             self.conversation_usage_metadata.credits_spent = usage_metadata.credits_spent;
-            let llm_preferences = crate::ai::llms::LLMPreferences::as_ref(ctx);
+            let llm_preferences = LLMPreferences::as_ref(ctx);
             self.conversation_usage_metadata.token_usage =
-                footer_model_token_usage(&usage_metadata, |config_key| {
-                    llm_preferences.custom_endpoint_usage_display_label(config_key)
-                });
+                footer_model_token_usage(&usage_metadata, llm_preferences);
 
             self.conversation_usage_metadata.tool_usage_metadata = usage_metadata
                 .tool_usage_metadata

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -70,7 +70,7 @@ use crate::terminal::model::block::{
     AgentInteractionMetadata, AgentViewVisibility, BlockId, SerializedAIMetadata, SerializedBlock,
 };
 use crate::ui_components::icons::Icon;
-use crate::{BlocklistAIHistoryModel, GlobalResourceHandlesProvider};
+use crate::{BlocklistAIHistoryModel, GlobalResourceHandlesProvider, LLMPreferences};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TodoStatus {

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -118,12 +118,13 @@ fn footer_model_token_usage(
             .entry(format!("custom_endpoint~{config_key}"))
             .or_insert_with(|| ModelTokenUsage {
                 model_id: label,
+                custom_endpoint_config_key: Some(config_key.clone()),
                 ..Default::default()
             });
-        entry.byok_tokens += usage.total_tokens;
+        entry.custom_endpoint_tokens += usage.total_tokens;
         for (category, tokens) in &usage.token_usage_by_category {
             *entry
-                .byok_token_usage_by_category
+                .custom_endpoint_token_usage_by_category
                 .entry(category.clone())
                 .or_default() += *tokens;
         }

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use ai::api_keys::ApiKeyManager;
+use std::collections::HashMap;
 
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
@@ -238,10 +238,6 @@ fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
             .iter()
             .find(|usage| usage.model_id == "Friendly alias")
             .expect("custom endpoint alias should resolve into footer usage");
-        assert_eq!(
-            usage.custom_endpoint_config_key.as_deref(),
-            Some("config-key")
-        );
         assert_eq!(usage.custom_endpoint_tokens, 6);
         assert_eq!(usage.byok_tokens, 0);
         assert_eq!(
@@ -277,10 +273,6 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
             .iter()
             .find(|usage| usage.model_id == "Custom endpoint")
             .expect("unknown custom endpoint usage should use the fallback label");
-        assert_eq!(
-            usage.custom_endpoint_config_key.as_deref(),
-            Some("missing-config-key")
-        );
         assert_eq!(usage.custom_endpoint_tokens, 9);
         assert_eq!(usage.byok_tokens, 0);
         assert_eq!(
@@ -295,107 +287,124 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
 #[allow(deprecated)]
 #[test]
 fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_labeled_models() {
-    let category = "primary_agent".to_string();
-    let usage_metadata = api::response_event::stream_finished::ConversationUsageMetadata {
-        context_window_usage: 0.0,
-        credits_spent: 0.0,
-        platform_credits_spent: 0.0,
-        summarized: false,
-        #[allow(deprecated)]
-        token_usage: vec![],
-        tool_usage_metadata: None,
-        warp_token_usage: HashMap::new(),
-        byok_token_usage: HashMap::from([(
-            "Resolved custom".to_string(),
-            api::response_event::stream_finished::ModelTokenUsage {
-                model_id: "Resolved custom".to_string(),
-                total_tokens: 4,
-                token_usage_by_category: HashMap::from([(category.clone(), 4)]),
-            },
-        )]),
-        custom_endpoint_token_usage: HashMap::from([(
-            "config-key".to_string(),
-            api::response_event::stream_finished::ModelTokenUsage {
-                model_id: "config-key".to_string(),
-                total_tokens: 6,
-                token_usage_by_category: HashMap::from([(category.clone(), 6)]),
-            },
-        )]),
-    };
+    App::test((), |mut app| async move {
+        initialize_custom_endpoint_usage_test_app(&mut app);
+        ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.add_custom_endpoint(
+                "Endpoint".to_string(),
+                "https://custom.example".to_string(),
+                "key".to_string(),
+                vec![(
+                    "raw-model".to_string(),
+                    Some("Resolved custom".to_string()),
+                    Some("config-key".to_string()),
+                )],
+                ctx,
+            );
+        });
+        app.add_singleton_model(LLMPreferences::new);
 
-    let model_usage = footer_model_token_usage(&usage_metadata, |_| "Resolved custom".to_string());
-    let byok_usage = model_usage
-        .iter()
-        .find(|usage| usage.model_id == "Resolved custom" && usage.byok_tokens == 4)
-        .expect("existing model usage should be present");
-    let custom_usage = model_usage
-        .iter()
-        .find(|usage| usage.model_id == "Resolved custom" && usage.custom_endpoint_tokens == 6)
-        .expect("custom endpoint usage should remain distinct");
+        let category = "primary_agent".to_string();
+        let usage_metadata = api::response_event::stream_finished::ConversationUsageMetadata {
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            platform_credits_spent: 0.0,
+            summarized: false,
+            #[allow(deprecated)]
+            token_usage: vec![],
+            tool_usage_metadata: None,
+            warp_token_usage: HashMap::new(),
+            byok_token_usage: HashMap::from([(
+                "Resolved custom".to_string(),
+                api::response_event::stream_finished::ModelTokenUsage {
+                    model_id: "Resolved custom".to_string(),
+                    total_tokens: 4,
+                    token_usage_by_category: HashMap::from([(category.clone(), 4)]),
+                },
+            )]),
+            custom_endpoint_token_usage: HashMap::from([(
+                "config-key".to_string(),
+                api::response_event::stream_finished::ModelTokenUsage {
+                    model_id: "config-key".to_string(),
+                    total_tokens: 6,
+                    token_usage_by_category: HashMap::from([(category.clone(), 6)]),
+                },
+            )]),
+        };
 
-    assert_eq!(model_usage.len(), 2);
-    assert_eq!(
-        byok_usage.byok_token_usage_by_category.get(&category),
-        Some(&4)
-    );
-    assert_eq!(
-        custom_usage
-            .custom_endpoint_token_usage_by_category
-            .get(&category),
-        Some(&6)
-    );
-    assert_eq!(byok_usage.warp_tokens, 0);
-    assert_eq!(custom_usage.warp_tokens, 0);
-    assert_eq!(custom_usage.byok_tokens, 0);
-    assert_eq!(
-        custom_usage.custom_endpoint_config_key.as_deref(),
-        Some("config-key")
-    );
+        let model_usage =
+            app.read(|ctx| footer_model_token_usage(&usage_metadata, LLMPreferences::as_ref(ctx)));
+        let byok_usage = model_usage
+            .iter()
+            .find(|usage| usage.model_id == "Resolved custom" && usage.byok_tokens == 4)
+            .expect("existing model usage should be present");
+        let custom_usage = model_usage
+            .iter()
+            .find(|usage| usage.model_id == "Resolved custom" && usage.custom_endpoint_tokens == 6)
+            .expect("custom endpoint usage should remain distinct");
+
+        assert_eq!(model_usage.len(), 2);
+        assert_eq!(
+            byok_usage.byok_token_usage_by_category.get(&category),
+            Some(&4)
+        );
+        assert_eq!(
+            custom_usage
+                .custom_endpoint_token_usage_by_category
+                .get(&category),
+            Some(&6)
+        );
+        assert_eq!(byok_usage.warp_tokens, 0);
+        assert_eq!(custom_usage.warp_tokens, 0);
+        assert_eq!(custom_usage.byok_tokens, 0);
+    });
 }
 #[allow(deprecated)]
 #[test]
 fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fallback_label() {
-    let category = "primary_agent".to_string();
-    let usage_metadata = api::response_event::stream_finished::ConversationUsageMetadata {
-        context_window_usage: 0.0,
-        credits_spent: 0.0,
-        platform_credits_spent: 0.0,
-        summarized: false,
-        #[allow(deprecated)]
-        token_usage: vec![],
-        tool_usage_metadata: None,
-        warp_token_usage: HashMap::new(),
-        byok_token_usage: HashMap::new(),
-        custom_endpoint_token_usage: HashMap::from([(
-            "missing-config-key".to_string(),
-            api::response_event::stream_finished::ModelTokenUsage {
-                model_id: "missing-config-key".to_string(),
-                total_tokens: 9,
-                token_usage_by_category: HashMap::from([(category.clone(), 9)]),
-            },
-        )]),
-    };
+    App::test((), |mut app| async move {
+        initialize_custom_endpoint_usage_test_app(&mut app);
+        app.add_singleton_model(LLMPreferences::new);
 
-    let model_usage = footer_model_token_usage(&usage_metadata, |_| "Custom endpoint".to_string());
-    let custom_usage = model_usage
-        .iter()
-        .find(|usage| usage.model_id == "Custom endpoint")
-        .expect("fallback custom endpoint usage should be present");
+        let category = "primary_agent".to_string();
+        let usage_metadata = api::response_event::stream_finished::ConversationUsageMetadata {
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            platform_credits_spent: 0.0,
+            summarized: false,
+            #[allow(deprecated)]
+            token_usage: vec![],
+            tool_usage_metadata: None,
+            warp_token_usage: HashMap::new(),
+            byok_token_usage: HashMap::new(),
+            custom_endpoint_token_usage: HashMap::from([(
+                "missing-config-key".to_string(),
+                api::response_event::stream_finished::ModelTokenUsage {
+                    model_id: "missing-config-key".to_string(),
+                    total_tokens: 9,
+                    token_usage_by_category: HashMap::from([(category.clone(), 9)]),
+                },
+            )]),
+        };
 
-    assert_eq!(model_usage.len(), 1);
-    assert_eq!(custom_usage.custom_endpoint_tokens, 9);
-    assert_eq!(custom_usage.byok_tokens, 0);
-    assert_eq!(
-        custom_usage
-            .custom_endpoint_token_usage_by_category
-            .get(&category),
-        Some(&9)
-    );
-    assert_eq!(custom_usage.warp_tokens, 0);
-    assert_eq!(
-        custom_usage.custom_endpoint_config_key.as_deref(),
-        Some("missing-config-key")
-    );
+        let model_usage =
+            app.read(|ctx| footer_model_token_usage(&usage_metadata, LLMPreferences::as_ref(ctx)));
+        let custom_usage = model_usage
+            .iter()
+            .find(|usage| usage.model_id == "Custom endpoint")
+            .expect("fallback custom endpoint usage should be present");
+
+        assert_eq!(model_usage.len(), 1);
+        assert_eq!(custom_usage.custom_endpoint_tokens, 9);
+        assert_eq!(custom_usage.byok_tokens, 0);
+        assert_eq!(
+            custom_usage
+                .custom_endpoint_token_usage_by_category
+                .get(&category),
+            Some(&9)
+        );
+        assert_eq!(custom_usage.warp_tokens, 0);
+    });
 }
 
 #[test]

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -238,9 +238,16 @@ fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
             .iter()
             .find(|usage| usage.model_id == "Friendly alias")
             .expect("custom endpoint alias should resolve into footer usage");
-        assert_eq!(usage.byok_tokens, 6);
         assert_eq!(
-            usage.byok_token_usage_by_category.get("primary_agent"),
+            usage.custom_endpoint_config_key.as_deref(),
+            Some("config-key")
+        );
+        assert_eq!(usage.custom_endpoint_tokens, 6);
+        assert_eq!(usage.byok_tokens, 0);
+        assert_eq!(
+            usage
+                .custom_endpoint_token_usage_by_category
+                .get("primary_agent"),
             Some(&6)
         );
     });
@@ -270,9 +277,16 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
             .iter()
             .find(|usage| usage.model_id == "Custom endpoint")
             .expect("unknown custom endpoint usage should use the fallback label");
-        assert_eq!(usage.byok_tokens, 9);
         assert_eq!(
-            usage.byok_token_usage_by_category.get("primary_agent"),
+            usage.custom_endpoint_config_key.as_deref(),
+            Some("missing-config-key")
+        );
+        assert_eq!(usage.custom_endpoint_tokens, 9);
+        assert_eq!(usage.byok_tokens, 0);
+        assert_eq!(
+            usage
+                .custom_endpoint_token_usage_by_category
+                .get("primary_agent"),
             Some(&9)
         );
     });
@@ -316,7 +330,7 @@ fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_label
         .expect("existing model usage should be present");
     let custom_usage = model_usage
         .iter()
-        .find(|usage| usage.model_id == "Resolved custom" && usage.byok_tokens == 6)
+        .find(|usage| usage.model_id == "Resolved custom" && usage.custom_endpoint_tokens == 6)
         .expect("custom endpoint usage should remain distinct");
 
     assert_eq!(model_usage.len(), 2);
@@ -325,11 +339,18 @@ fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_label
         Some(&4)
     );
     assert_eq!(
-        custom_usage.byok_token_usage_by_category.get(&category),
+        custom_usage
+            .custom_endpoint_token_usage_by_category
+            .get(&category),
         Some(&6)
     );
     assert_eq!(byok_usage.warp_tokens, 0);
     assert_eq!(custom_usage.warp_tokens, 0);
+    assert_eq!(custom_usage.byok_tokens, 0);
+    assert_eq!(
+        custom_usage.custom_endpoint_config_key.as_deref(),
+        Some("config-key")
+    );
 }
 #[allow(deprecated)]
 #[test]
@@ -362,12 +383,19 @@ fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fall
         .expect("fallback custom endpoint usage should be present");
 
     assert_eq!(model_usage.len(), 1);
-    assert_eq!(custom_usage.byok_tokens, 9);
+    assert_eq!(custom_usage.custom_endpoint_tokens, 9);
+    assert_eq!(custom_usage.byok_tokens, 0);
     assert_eq!(
-        custom_usage.byok_token_usage_by_category.get(&category),
+        custom_usage
+            .custom_endpoint_token_usage_by_category
+            .get(&category),
         Some(&9)
     );
     assert_eq!(custom_usage.warp_tokens, 0);
+    assert_eq!(
+        custom_usage.custom_endpoint_config_key.as_deref(),
+        Some("missing-config-key")
+    );
 }
 
 #[test]

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -1,13 +1,22 @@
 use std::collections::HashMap;
+use ai::api_keys::ApiKeyManager;
 
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
+use warpui::{App, SingletonEntity};
 
 use super::{
-    artifact_from_fork_proto, AIConversation, AIConversationAutoexecuteMode, AIConversationId,
+    artifact_from_fork_proto, footer_model_token_usage, AIConversation,
+    AIConversationAutoexecuteMode, AIConversationId,
 };
 use crate::ai::artifacts::Artifact;
+use crate::ai::llms::LLMPreferences;
+use crate::auth::{auth_manager::AuthManager, AuthStateProvider};
+use crate::network::NetworkStatus;
 use crate::persistence::model::AgentConversationData;
+use crate::server::server_api::ServerApiProvider;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 
 fn restored_conversation(conversation_data: Option<AgentConversationData>) -> AIConversation {
     AIConversation::new_restored(
@@ -87,6 +96,41 @@ fn restored_conversation_with_queries(queries: &[&str]) -> AIConversation {
     .unwrap()
 }
 
+fn initialize_custom_endpoint_usage_test_app(app: &mut App) {
+    initialize_settings_for_tests(app);
+    app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+    app.add_singleton_model(|_| NetworkStatus::new());
+    app.add_singleton_model(UserWorkspaces::default_mock);
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(AuthManager::new_for_test);
+}
+
+#[allow(deprecated)]
+fn custom_endpoint_usage_metadata(
+    config_key: &str,
+    total_tokens: u32,
+) -> api::response_event::stream_finished::ConversationUsageMetadata {
+    let category = "primary_agent".to_string();
+    api::response_event::stream_finished::ConversationUsageMetadata {
+        context_window_usage: 0.0,
+        credits_spent: 0.0,
+        platform_credits_spent: 0.0,
+        summarized: false,
+        token_usage: vec![],
+        tool_usage_metadata: None,
+        warp_token_usage: HashMap::new(),
+        byok_token_usage: HashMap::new(),
+        custom_endpoint_token_usage: HashMap::from([(
+            config_key.to_string(),
+            api::response_event::stream_finished::ModelTokenUsage {
+                model_id: config_key.to_string(),
+                total_tokens,
+                token_usage_by_category: HashMap::from([(category, total_tokens)]),
+            },
+        )]),
+    }
+}
+
 #[test]
 fn latest_user_query_returns_latest_non_empty_user_query() {
     let conversation =
@@ -155,6 +199,175 @@ fn child_conversation_detection_uses_parent_agent_id() {
 
     assert!(conversation.is_child_agent_conversation());
     assert_eq!(conversation.parent_conversation_id(), None);
+}
+
+#[test]
+fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
+    App::test((), |mut app| async move {
+        initialize_custom_endpoint_usage_test_app(&mut app);
+        ApiKeyManager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.add_custom_endpoint(
+                "Endpoint".to_string(),
+                "https://custom.example".to_string(),
+                "key".to_string(),
+                vec![(
+                    "raw-model".to_string(),
+                    Some("Friendly alias".to_string()),
+                    Some("config-key".to_string()),
+                )],
+                ctx,
+            );
+        });
+        app.add_singleton_model(LLMPreferences::new);
+
+        let mut conversation = AIConversation::new(false, false);
+        app.read(|ctx| {
+            conversation
+                .update_cost_and_usage_for_request(
+                    None,
+                    vec![],
+                    Some(custom_endpoint_usage_metadata("config-key", 6)),
+                    false,
+                    ctx,
+                )
+                .expect("custom endpoint usage should update");
+        });
+
+        let usage = conversation
+            .token_usage()
+            .iter()
+            .find(|usage| usage.model_id == "Friendly alias")
+            .expect("custom endpoint alias should resolve into footer usage");
+        assert_eq!(usage.byok_tokens, 6);
+        assert_eq!(
+            usage.byok_token_usage_by_category.get("primary_agent"),
+            Some(&6)
+        );
+    });
+}
+
+#[test]
+fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
+    App::test((), |mut app| async move {
+        initialize_custom_endpoint_usage_test_app(&mut app);
+        app.add_singleton_model(LLMPreferences::new);
+
+        let mut conversation = AIConversation::new(false, false);
+        app.read(|ctx| {
+            conversation
+                .update_cost_and_usage_for_request(
+                    None,
+                    vec![],
+                    Some(custom_endpoint_usage_metadata("missing-config-key", 9)),
+                    false,
+                    ctx,
+                )
+                .expect("fallback custom endpoint usage should update");
+        });
+
+        let usage = conversation
+            .token_usage()
+            .iter()
+            .find(|usage| usage.model_id == "Custom endpoint")
+            .expect("unknown custom endpoint usage should use the fallback label");
+        assert_eq!(usage.byok_tokens, 9);
+        assert_eq!(
+            usage.byok_token_usage_by_category.get("primary_agent"),
+            Some(&9)
+        );
+    });
+}
+
+#[allow(deprecated)]
+#[test]
+fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_labeled_models() {
+    let category = "primary_agent".to_string();
+    let usage_metadata = api::response_event::stream_finished::ConversationUsageMetadata {
+        context_window_usage: 0.0,
+        credits_spent: 0.0,
+        platform_credits_spent: 0.0,
+        summarized: false,
+        #[allow(deprecated)]
+        token_usage: vec![],
+        tool_usage_metadata: None,
+        warp_token_usage: HashMap::new(),
+        byok_token_usage: HashMap::from([(
+            "Resolved custom".to_string(),
+            api::response_event::stream_finished::ModelTokenUsage {
+                model_id: "Resolved custom".to_string(),
+                total_tokens: 4,
+                token_usage_by_category: HashMap::from([(category.clone(), 4)]),
+            },
+        )]),
+        custom_endpoint_token_usage: HashMap::from([(
+            "config-key".to_string(),
+            api::response_event::stream_finished::ModelTokenUsage {
+                model_id: "config-key".to_string(),
+                total_tokens: 6,
+                token_usage_by_category: HashMap::from([(category.clone(), 6)]),
+            },
+        )]),
+    };
+
+    let model_usage = footer_model_token_usage(&usage_metadata, |_| "Resolved custom".to_string());
+    let byok_usage = model_usage
+        .iter()
+        .find(|usage| usage.model_id == "Resolved custom" && usage.byok_tokens == 4)
+        .expect("existing model usage should be present");
+    let custom_usage = model_usage
+        .iter()
+        .find(|usage| usage.model_id == "Resolved custom" && usage.byok_tokens == 6)
+        .expect("custom endpoint usage should remain distinct");
+
+    assert_eq!(model_usage.len(), 2);
+    assert_eq!(
+        byok_usage.byok_token_usage_by_category.get(&category),
+        Some(&4)
+    );
+    assert_eq!(
+        custom_usage.byok_token_usage_by_category.get(&category),
+        Some(&6)
+    );
+    assert_eq!(byok_usage.warp_tokens, 0);
+    assert_eq!(custom_usage.warp_tokens, 0);
+}
+#[allow(deprecated)]
+#[test]
+fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fallback_label() {
+    let category = "primary_agent".to_string();
+    let usage_metadata = api::response_event::stream_finished::ConversationUsageMetadata {
+        context_window_usage: 0.0,
+        credits_spent: 0.0,
+        platform_credits_spent: 0.0,
+        summarized: false,
+        #[allow(deprecated)]
+        token_usage: vec![],
+        tool_usage_metadata: None,
+        warp_token_usage: HashMap::new(),
+        byok_token_usage: HashMap::new(),
+        custom_endpoint_token_usage: HashMap::from([(
+            "missing-config-key".to_string(),
+            api::response_event::stream_finished::ModelTokenUsage {
+                model_id: "missing-config-key".to_string(),
+                total_tokens: 9,
+                token_usage_by_category: HashMap::from([(category.clone(), 9)]),
+            },
+        )]),
+    };
+
+    let model_usage = footer_model_token_usage(&usage_metadata, |_| "Custom endpoint".to_string());
+    let custom_usage = model_usage
+        .iter()
+        .find(|usage| usage.model_id == "Custom endpoint")
+        .expect("fallback custom endpoint usage should be present");
+
+    assert_eq!(model_usage.len(), 1);
+    assert_eq!(custom_usage.byok_tokens, 9);
+    assert_eq!(
+        custom_usage.byok_token_usage_by_category.get(&category),
+        Some(&9)
+    );
+    assert_eq!(custom_usage.warp_tokens, 0);
 }
 
 #[test]

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -519,7 +519,11 @@ impl BlocklistAIController {
                         .iter()
                         .filter_map(|u| u.to_proto_byok_usage())
                         .collect(),
-                    custom_endpoint_token_usage: Default::default(),
+                    custom_endpoint_token_usage: conversation
+                        .token_usage()
+                        .iter()
+                        .filter_map(|u| u.to_proto_custom_endpoint_usage())
+                        .collect(),
                 })
         });
 

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -500,6 +500,7 @@ impl BlocklistAIController {
                 .map(|conversation| stream_finished::ConversationUsageMetadata {
                     context_window_usage: conversation.context_window_usage(),
                     credits_spent: conversation.credits_spent(),
+                    platform_credits_spent: 0.0,
                     summarized: conversation.was_summarized(),
                     #[allow(deprecated)]
                     token_usage: conversation
@@ -518,6 +519,7 @@ impl BlocklistAIController {
                         .iter()
                         .filter_map(|u| u.to_proto_byok_usage())
                         .collect(),
+                    custom_endpoint_token_usage: Default::default(),
                 })
         });
 

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1584,6 +1584,7 @@ impl BlocklistAIHistoryModel {
                 token_usage,
                 usage_metadata,
                 was_user_initiated_request,
+                ctx,
             ) {
                 log::warn!(
                     "Failed to update request cost for conversation {conversation_id}: {e:#}"

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -215,8 +215,8 @@ impl ConversationUsageView {
     }
 
     /// Helper to collect models grouped by category.
-    /// Returns a HashMap mapping category name to list of (model_id, is_byok) tuples.
-    /// Handles both category-based fields and legacy warp_tokens/byok_tokens fields.
+    /// Returns a HashMap mapping category name to list of (model_id, shows_key_icon) tuples.
+    /// Handles category-based fields plus legacy token-total fallbacks.
     fn collect_models_by_category(&self) -> HashMap<String, Vec<(String, bool)>> {
         let mut entries_by_category: HashMap<String, Vec<(String, bool)>> = HashMap::new();
 
@@ -238,6 +238,14 @@ impl ConversationUsageView {
                         .push((model.model_id.clone(), true));
                 }
             }
+            for (category, &tokens) in &model.custom_endpoint_token_usage_by_category {
+                if tokens > 0 {
+                    entries_by_category
+                        .entry(category.clone())
+                        .or_default()
+                        .push((model.model_id.clone(), true));
+                }
+            }
         }
 
         // Fallback to legacy fields for backwards compatibility
@@ -250,6 +258,12 @@ impl ConversationUsageView {
                         .push((model.model_id.clone(), false));
                 }
                 if model.byok_tokens > 0 {
+                    entries_by_category
+                        .entry(PRIMARY_AGENT_CATEGORY.to_string())
+                        .or_default()
+                        .push((model.model_id.clone(), true));
+                }
+                if model.custom_endpoint_tokens > 0 {
                     entries_by_category
                         .entry(PRIMARY_AGENT_CATEGORY.to_string())
                         .or_default()
@@ -374,7 +388,7 @@ impl ConversationUsageView {
                 labels.push(render_label_text(&label_text, appearance));
             }
 
-            // Build comma-separated list of models, with BYOK indicator using Icon::Key
+            // Build comma-separated list of models, with external-key indicator using Icon::Key
             let mut model_elements: Vec<Box<dyn Element>> = vec![];
             let mut sorted_models: Vec<_> = models.iter().collect();
             sorted_models.sort_by(|a, b| a.0.cmp(&b.0));

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -22,11 +22,13 @@
 //! framework's render path (which needs `Appearance` / theme singletons
 //! that aren't relevant to the handler's correctness).
 
+use std::collections::HashMap;
 use warp_core::ui::appearance::Appearance;
 use warpui::platform::WindowStyle;
 use warpui::App;
 
 use super::*;
+use crate::persistence::model::{ModelTokenUsage, PRIMARY_AGENT_CATEGORY};
 
 fn placeholder_usage_info() -> ConversationUsageInfo {
     ConversationUsageInfo {
@@ -118,6 +120,33 @@ fn toggle_details_expanded_flips_state_and_resets_show_all_on_collapse() {
             );
         });
     });
+}
+
+#[test]
+fn custom_endpoint_models_use_the_external_key_icon_bucket() {
+    let view = ConversationUsageView::new(
+        ConversationUsageInfo {
+            models: vec![ModelTokenUsage {
+                model_id: "Friendly alias".to_string(),
+                custom_endpoint_tokens: 6,
+                custom_endpoint_token_usage_by_category: HashMap::from([(
+                    PRIMARY_AGENT_CATEGORY.to_string(),
+                    6,
+                )]),
+                ..Default::default()
+            }],
+            ..placeholder_usage_info()
+        },
+        DisplayMode::Footer,
+        None,
+        MouseStateHandle::default(),
+    );
+
+    assert_eq!(
+        view.collect_models_by_category()
+            .get(PRIMARY_AGENT_CATEGORY),
+        Some(&vec![("Friendly alias".to_string(), true)])
+    );
 }
 
 #[test]

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -38,6 +38,7 @@ pub fn is_using_api_key_for_provider(provider: &LLMProvider, app: &AppContext) -
 /// Note: this key used to store a single [`AvailableLLMs`]
 /// but was migrated to store a full [`ModelsByFeature`].
 pub const MODELS_BY_FEATURE_CACHE_KEY: &str = "AvailableLLMs";
+const CUSTOM_ENDPOINT_USAGE_FALLBACK_LABEL: &str = "Custom endpoint";
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct LLMUsageMetadata {
@@ -809,6 +810,17 @@ impl LLMPreferences {
     /// Returns `None` if the id isn't a known custom model `config_key`.
     pub fn custom_llm_info_for_id(&self, id: &LLMId) -> Option<&LLMInfo> {
         self.custom_llms.iter().find(|info| info.id == *id)
+    }
+
+    /// Footer label for custom endpoint usage keyed by the request config_key.
+    /// The synthetic custom LLMInfo already owns alias-or-name display semantics.
+    pub fn custom_endpoint_usage_display_label(&self, config_key: &str) -> String {
+        let config_key = LLMId::from(config_key);
+        self.custom_llm_info_for_id(&config_key)
+            .map(|info| info.display_name.as_str())
+            .filter(|display_name| !display_name.contains('~'))
+            .map(str::to_string)
+            .unwrap_or_else(|| CUSTOM_ENDPOINT_USAGE_FALLBACK_LABEL.to_string())
     }
 
     fn custom_llm_info_for_id_if_enabled(&self, id: &LLMId, app: &AppContext) -> Option<&LLMInfo> {

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -818,7 +818,6 @@ impl LLMPreferences {
         let config_key = LLMId::from(config_key);
         self.custom_llm_info_for_id(&config_key)
             .map(|info| info.display_name.as_str())
-            .filter(|display_name| !display_name.contains('~'))
             .map(str::to_string)
             .unwrap_or_else(|| CUSTOM_ENDPOINT_USAGE_FALLBACK_LABEL.to_string())
     }

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -204,6 +204,46 @@ fn custom_llm_display_name_falls_back_to_name_when_alias_missing() {
 }
 
 #[test]
+fn custom_endpoint_usage_display_label_resolves_alias_name_and_generic_fallback() {
+    let keys = ai::api_keys::ApiKeys {
+        custom_endpoints: vec![endpoint(
+            "ep",
+            "https://a.io",
+            "k",
+            vec![
+                model("raw-alias", Some("Alias"), "uuid-alias"),
+                model("raw-name", None, "uuid-name"),
+                model("raw~name", None, "uuid-delimited-name"),
+            ],
+        )],
+        ..Default::default()
+    };
+    let preferences = LLMPreferences {
+        models_by_feature: ModelsByFeature::default(),
+        last_update: None,
+        base_llm_for_terminal_view: HashMap::new(),
+        custom_llms: build_custom_llm_infos(&keys),
+    };
+
+    assert_eq!(
+        preferences.custom_endpoint_usage_display_label("uuid-alias"),
+        "Alias"
+    );
+    assert_eq!(
+        preferences.custom_endpoint_usage_display_label("uuid-name"),
+        "raw-name"
+    );
+    assert_eq!(
+        preferences.custom_endpoint_usage_display_label("uuid-delimited-name"),
+        CUSTOM_ENDPOINT_USAGE_FALLBACK_LABEL
+    );
+    assert_eq!(
+        preferences.custom_endpoint_usage_display_label("unknown"),
+        CUSTOM_ENDPOINT_USAGE_FALLBACK_LABEL
+    );
+}
+
+#[test]
 fn custom_llm_infos_skip_endpoints_with_empty_api_key() {
     let keys = ai::api_keys::ApiKeys {
         custom_endpoints: vec![

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -213,7 +213,7 @@ fn custom_endpoint_usage_display_label_resolves_alias_name_and_generic_fallback(
             vec![
                 model("raw-alias", Some("Alias"), "uuid-alias"),
                 model("raw-name", None, "uuid-name"),
-                model("raw~name", None, "uuid-delimited-name"),
+                model("raw~name", None, "uuid-tilde-name"),
             ],
         )],
         ..Default::default()
@@ -234,8 +234,8 @@ fn custom_endpoint_usage_display_label_resolves_alias_name_and_generic_fallback(
         "raw-name"
     );
     assert_eq!(
-        preferences.custom_endpoint_usage_display_label("uuid-delimited-name"),
-        CUSTOM_ENDPOINT_USAGE_FALLBACK_LABEL
+        preferences.custom_endpoint_usage_display_label("uuid-tilde-name"),
+        "raw~name"
     );
     assert_eq!(
         preferences.custom_endpoint_usage_display_label("unknown"),

--- a/app/src/terminal/shared_session/replay_agent_conversations.rs
+++ b/app/src/terminal/shared_session/replay_agent_conversations.rs
@@ -178,7 +178,11 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
                 .iter()
                 .filter_map(|u| u.to_proto_byok_usage())
                 .collect(),
-            custom_endpoint_token_usage: Default::default(),
+            custom_endpoint_token_usage: conversation
+                .token_usage()
+                .iter()
+                .filter_map(|u| u.to_proto_custom_endpoint_usage())
+                .collect(),
         },
     );
 

--- a/app/src/terminal/shared_session/replay_agent_conversations.rs
+++ b/app/src/terminal/shared_session/replay_agent_conversations.rs
@@ -159,6 +159,7 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
         api_response_event::stream_finished::ConversationUsageMetadata {
             context_window_usage: conversation.context_window_usage(),
             credits_spent: conversation.credits_spent(),
+            platform_credits_spent: 0.0,
             summarized: conversation.was_summarized(),
             #[allow(deprecated)]
             token_usage: conversation
@@ -177,6 +178,7 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
                 .iter()
                 .filter_map(|u| u.to_proto_byok_usage())
                 .collect(),
+            custom_endpoint_token_usage: Default::default(),
         },
     );
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1091,15 +1091,22 @@ pub fn token_usage_category_display_name(category: &str) -> String {
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ModelTokenUsage {
     pub model_id: String,
+    /// Server-side custom endpoint config key used to faithfully replay usage metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_endpoint_config_key: Option<String>,
     /// Alias for backward compat: old persisted data used `total_tokens` for warp usage.
     #[serde(default, alias = "total_tokens")]
     pub warp_tokens: u32,
     #[serde(default)]
     pub byok_tokens: u32,
     #[serde(default)]
+    pub custom_endpoint_tokens: u32,
+    #[serde(default)]
     pub warp_token_usage_by_category: HashMap<TokenUsageCategory, u32>,
     #[serde(default)]
     pub byok_token_usage_by_category: HashMap<TokenUsageCategory, u32>,
+    #[serde(default)]
+    pub custom_endpoint_token_usage_by_category: HashMap<TokenUsageCategory, u32>,
 }
 
 impl ModelTokenUsage {
@@ -1132,16 +1139,38 @@ impl ModelTokenUsage {
     pub fn to_proto_byok_usage(&self) -> Option<(String, stream_finished::ModelTokenUsage)> {
         self.to_proto_usage(self.byok_tokens, &self.byok_token_usage_by_category)
     }
+    #[allow(deprecated)]
+    pub fn to_proto_custom_endpoint_usage(
+        &self,
+    ) -> Option<(String, stream_finished::ModelTokenUsage)> {
+        let config_key = self.custom_endpoint_config_key.clone()?;
+        if self.custom_endpoint_tokens == 0 {
+            return None;
+        }
+        Some((
+            config_key.clone(),
+            stream_finished::ModelTokenUsage {
+                model_id: config_key,
+                total_tokens: self.custom_endpoint_tokens,
+                token_usage_by_category: self
+                    .custom_endpoint_token_usage_by_category
+                    .iter()
+                    .map(|(cat, tokens)| (cat.clone(), *tokens))
+                    .collect(),
+            },
+        ))
+    }
 
     #[allow(deprecated)]
     pub fn to_proto_combined(&self) -> stream_finished::ModelTokenUsage {
         stream_finished::ModelTokenUsage {
             model_id: self.model_id.clone(),
-            total_tokens: self.warp_tokens + self.byok_tokens,
+            total_tokens: self.warp_tokens + self.byok_tokens + self.custom_endpoint_tokens,
             token_usage_by_category: self
                 .warp_token_usage_by_category
                 .iter()
                 .chain(self.byok_token_usage_by_category.iter())
+                .chain(self.custom_endpoint_token_usage_by_category.iter())
                 .fold(HashMap::new(), |mut acc, (cat, tokens)| {
                     *acc.entry(cat.clone()).or_insert(0) += tokens;
                     acc
@@ -1357,7 +1386,9 @@ pub struct NewMCPServerInstallation {
 
 #[cfg(test)]
 mod tests {
-    use super::AgentConversationData;
+    use std::collections::HashMap;
+
+    use super::{AgentConversationData, ModelTokenUsage};
 
     #[test]
     fn agent_conversation_data_roundtrips_last_event_sequence() {
@@ -1538,6 +1569,30 @@ mod tests {
         let data: AgentConversationData =
             serde_json::from_str(legacy_json).expect("legacy rows must deserialize");
         assert!(!data.pinned);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn model_token_usage_replays_custom_endpoint_usage_by_config_key() {
+        let usage = ModelTokenUsage {
+            model_id: "Friendly alias".to_string(),
+            custom_endpoint_config_key: Some("config-key".to_string()),
+            custom_endpoint_tokens: 6,
+            custom_endpoint_token_usage_by_category: HashMap::from([(
+                "primary_agent".to_string(),
+                6,
+            )]),
+            ..Default::default()
+        };
+
+        let (config_key, proto) = usage
+            .to_proto_custom_endpoint_usage()
+            .expect("custom endpoint usage should serialize for replay");
+
+        assert_eq!(config_key, "config-key");
+        assert_eq!(proto.model_id, "config-key");
+        assert_eq!(proto.total_tokens, 6);
+        assert_eq!(proto.token_usage_by_category.get("primary_agent"), Some(&6));
     }
 }
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1090,10 +1090,11 @@ pub fn token_usage_category_display_name(category: &str) -> String {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ModelTokenUsage {
+    /// Identifier used for both display and replay. For warp/byok rows this is the
+    /// server-known model id; for custom endpoint rows this is the resolved alias
+    /// (or fallback label) — the upstream `config_key` is translated into this
+    /// label once at ingestion time and is not retained separately.
     pub model_id: String,
-    /// Server-side custom endpoint config key used to faithfully replay usage metadata.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_endpoint_config_key: Option<String>,
     /// Alias for backward compat: old persisted data used `total_tokens` for warp usage.
     #[serde(default, alias = "total_tokens")]
     pub warp_tokens: u32,
@@ -1143,14 +1144,13 @@ impl ModelTokenUsage {
     pub fn to_proto_custom_endpoint_usage(
         &self,
     ) -> Option<(String, stream_finished::ModelTokenUsage)> {
-        let config_key = self.custom_endpoint_config_key.clone()?;
         if self.custom_endpoint_tokens == 0 {
             return None;
         }
         Some((
-            config_key.clone(),
+            self.model_id.clone(),
             stream_finished::ModelTokenUsage {
-                model_id: config_key,
+                model_id: self.model_id.clone(),
                 total_tokens: self.custom_endpoint_tokens,
                 token_usage_by_category: self
                     .custom_endpoint_token_usage_by_category
@@ -1573,10 +1573,9 @@ mod tests {
 
     #[allow(deprecated)]
     #[test]
-    fn model_token_usage_replays_custom_endpoint_usage_by_config_key() {
+    fn model_token_usage_replays_custom_endpoint_usage_by_model_id() {
         let usage = ModelTokenUsage {
             model_id: "Friendly alias".to_string(),
-            custom_endpoint_config_key: Some("config-key".to_string()),
             custom_endpoint_tokens: 6,
             custom_endpoint_token_usage_by_category: HashMap::from([(
                 "primary_agent".to_string(),
@@ -1585,14 +1584,25 @@ mod tests {
             ..Default::default()
         };
 
-        let (config_key, proto) = usage
+        let (key, proto) = usage
             .to_proto_custom_endpoint_usage()
             .expect("custom endpoint usage should serialize for replay");
 
-        assert_eq!(config_key, "config-key");
-        assert_eq!(proto.model_id, "config-key");
+        assert_eq!(key, "Friendly alias");
+        assert_eq!(proto.model_id, "Friendly alias");
         assert_eq!(proto.total_tokens, 6);
         assert_eq!(proto.token_usage_by_category.get("primary_agent"), Some(&6));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn model_token_usage_replay_skips_non_custom_endpoint_entries() {
+        let warp_only = ModelTokenUsage {
+            model_id: "warp-model".to_string(),
+            warp_tokens: 4,
+            ..Default::default()
+        };
+        assert!(warp_only.to_proto_custom_endpoint_usage().is_none());
     }
 }
 


### PR DESCRIPTION
## Description

Enables the CustomInferenceEndpoints feature flag in stable builds and adds proper token usage tracking for custom endpoints with alias display.

### Changes
- Enable CustomInferenceEndpoints feature flag in stable builds
- Add custom endpoint token usage aggregation in conversation footer
- Display custom endpoint aliases in usage views instead of raw config keys
- Add unit tests for custom endpoint usage metadata parsing and display
- Wire up custom endpoint usage in shared session replay

### Testing
- Added unit tests in conversation_tests.rs for custom endpoint usage metadata
- Added llms_tests.rs for custom endpoint display label resolution
- Added conversation_usage_view_tests.rs for UI display formatting

<img width="974" height="674" alt="Screenshot 2026-05-20 at 8 12 35 PM" src="https://github.com/user-attachments/assets/521d8c0d-2620-4987-955e-eb8be982d3ec" />

<img width="1081" height="653" alt="Screenshot 2026-05-21 at 3 53 18 PM" src="https://github.com/user-attachments/assets/cd260e9c-9f65-4a3d-9558-a59f0805bbd1" />

CHANGELOG-IMPROVEMENT: Custom inference endpoints now show token usage with friendly alias names in Agent Mode.

Co-Authored-By: Warp <agent@warp.dev>