### PR TITLE
[APP-4589] Avoid AI history scans while typing

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -297,6 +297,14 @@ impl BlocklistAIHistoryModel {
             })
     }
 
+    pub fn has_live_conversation_with_initial_user_query(
+        &self,
+        terminal_view_id: EntityId,
+    ) -> bool {
+        self.all_live_conversations_for_terminal_view(terminal_view_id)
+            .any(|conversation| conversation.initial_user_query().is_some())
+    }
+
     /// Returns a flattened and ordered (oldest first) list of exchanges from live conversations (not cleared)
     /// in the given terminal view ID.
     /// This works for terminal views that have been closed.

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -2539,3 +2539,68 @@ fn test_fork_conversation_title_override_replaces_prefix() {
         });
     });
 }
+
+#[test]
+fn has_live_conversation_with_initial_user_query_tracks_live_history() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let terminal_view_id = EntityId::new();
+        let other_terminal_view_id = EntityId::new();
+
+        assert!(!history_model.read(&app, |model, _| {
+            model.has_live_conversation_with_initial_user_query(terminal_view_id)
+        }));
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        assert!(!history_model.read(&app, |model, _| {
+            model.has_live_conversation_with_initial_user_query(terminal_view_id)
+        }));
+
+        history_model.update(&mut app, |model, ctx| {
+            let exchange = create_exchange_with_query("live query", Local::now(), None);
+            let task_id = model
+                .conversation(&conversation_id)
+                .expect("conversation should exist")
+                .get_root_task_id()
+                .clone();
+            model
+                .update_conversation_for_new_request_input(
+                    RequestInput {
+                        conversation_id,
+                        input_messages: HashMap::from([(task_id, exchange.input)]),
+                        working_directory: exchange.working_directory,
+                        model_id: exchange.model_id,
+                        coding_model_id: exchange.coding_model_id,
+                        cli_agent_model_id: exchange.cli_agent_model_id,
+                        computer_use_model_id: exchange.computer_use_model_id,
+                        shared_session_response_initiator: exchange.response_initiator,
+                        request_start_ts: exchange.start_time,
+                        supported_tools_override: None,
+                    },
+                    ResponseStreamId::new_for_test(),
+                    terminal_view_id,
+                    ctx,
+                )
+                .expect("request input should update conversation");
+        });
+
+        assert!(history_model.read(&app, |model, _| {
+            model.has_live_conversation_with_initial_user_query(terminal_view_id)
+        }));
+        assert!(!history_model.read(&app, |model, _| {
+            model.has_live_conversation_with_initial_user_query(other_terminal_view_id)
+        }));
+
+        history_model.update(&mut app, |model, ctx| {
+            model.clear_conversations_in_terminal_view(terminal_view_id, ctx);
+        });
+
+        assert!(!history_model.read(&app, |model, _| {
+            model.has_live_conversation_with_initial_user_query(terminal_view_id)
+        }));
+    });
+}

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1668,6 +1668,11 @@ pub struct Input {
     /// of using this flag.
     is_editor_empty_on_last_edit: bool,
 
+    /// Cached keymap state for whether this terminal has live AI conversations
+    /// with a user query. Keep this off the per-keystroke keymap path because
+    /// large AI history stacks make repeated HashMap lookups visible while typing.
+    has_live_ai_conversation_history: bool,
+
     /// Weak handle to this input view for drop target data
     weak_view_handle: WeakViewHandle<Input>,
 
@@ -3096,7 +3101,7 @@ impl Input {
         // vertical tab progress indicators in sync.
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
-            move |me, _, event, ctx| {
+            move |me, history_model, event, ctx| {
                 let affects_hint = matches!(
                     event,
                     BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
@@ -3110,14 +3115,38 @@ impl Input {
                         | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
                         | BlocklistAIHistoryEvent::RestoredConversations { .. }
                 );
-                if !affects_hint {
-                    return;
-                }
                 if event.terminal_view_id() != Some(terminal_view_id) {
                     return;
                 }
-                me.set_zero_state_hint_text(ctx);
-                ctx.notify();
+
+                let mut should_notify = false;
+                let affects_history_keymap = matches!(
+                    event,
+                    BlocklistAIHistoryEvent::StartedNewConversation { .. }
+                        | BlocklistAIHistoryEvent::AppendedExchange { .. }
+                        | BlocklistAIHistoryEvent::ReassignedExchange { .. }
+                        | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
+                        | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+                        | BlocklistAIHistoryEvent::SplitConversation { .. }
+                        | BlocklistAIHistoryEvent::RemoveConversation { .. }
+                        | BlocklistAIHistoryEvent::DeletedConversation { .. }
+                        | BlocklistAIHistoryEvent::RestoredConversations { .. }
+                );
+                if affects_history_keymap {
+                    me.has_live_ai_conversation_history = history_model
+                        .as_ref(ctx)
+                        .has_live_conversation_with_initial_user_query(terminal_view_id);
+                    should_notify = true;
+                }
+
+                if affects_hint {
+                    me.set_zero_state_hint_text(ctx);
+                    should_notify = true;
+                }
+
+                if should_notify {
+                    ctx.notify();
+                }
             },
         );
 
@@ -3490,6 +3519,8 @@ impl Input {
         let completions_menu_height = *input_settings.completions_menu_height.value();
 
         let is_editor_empty = editor.as_ref(ctx).is_empty(ctx);
+        let has_live_ai_conversation_history = BlocklistAIHistoryModel::as_ref(ctx)
+            .has_live_conversation_with_initial_user_query(terminal_view_id);
         let mut input = Self {
             input_suggestions,
             suggestions_mode_model,
@@ -3567,6 +3598,7 @@ impl Input {
             inline_terminal_menu_positioner,
             cached_agent_mode_hint_text: None,
             is_editor_empty_on_last_edit: is_editor_empty,
+            has_live_ai_conversation_history,
             weak_view_handle: ctx.handle(),
             buy_credits_banner,
             agent_status_view,
@@ -15091,10 +15123,7 @@ impl View for Input {
             ctx.set.insert("PromptChipMenuOpen");
         }
 
-        if BlocklistAIHistoryModel::as_ref(app)
-            .all_live_conversations_for_terminal_view(self.terminal_view_id)
-            .any(|conversation| conversation.initial_user_query().is_some())
-        {
+        if self.has_live_ai_conversation_history {
             ctx.set.insert("ActiveAIConversationHasHistory");
         }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5332,27 +5332,29 @@ impl TerminalView {
         history_model: &BlocklistAIHistoryModel,
         event: &BlocklistAIHistoryEvent,
     ) -> Option<EntityId> {
+        if let Some(terminal_view_id) = event.terminal_view_id() {
+            return Some(terminal_view_id);
+        }
+
         match event {
-            BlocklistAIHistoryEvent::AppendedExchange {
+            BlocklistAIHistoryEvent::UpdatedConversationMetadata {
                 conversation_id, ..
             }
-            | BlocklistAIHistoryEvent::UpdatedStreamingExchange {
+            | BlocklistAIHistoryEvent::NewConversationRequestComplete {
                 conversation_id, ..
             }
-            | BlocklistAIHistoryEvent::UpdatedConversationStatus {
+            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
                 conversation_id, ..
             }
-            | BlocklistAIHistoryEvent::UpdatedConversationMetadata {
-                conversation_id, ..
-            }
-            | BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
+            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated {
                 conversation_id, ..
             } => history_model.terminal_view_id_for_conversation(conversation_id),
-            BlocklistAIHistoryEvent::ReassignedExchange {
-                new_conversation_id,
-                ..
-            } => history_model.terminal_view_id_for_conversation(new_conversation_id),
-            BlocklistAIHistoryEvent::StartedNewConversation { .. }
+            BlocklistAIHistoryEvent::AppendedExchange { .. }
+            | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. }
+            | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
+            | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
+            | BlocklistAIHistoryEvent::ReassignedExchange { .. }
+            | BlocklistAIHistoryEvent::StartedNewConversation { .. }
             | BlocklistAIHistoryEvent::CreatedSubtask { .. }
             | BlocklistAIHistoryEvent::UpgradedTask { .. }
             | BlocklistAIHistoryEvent::SetActiveConversation { .. }
@@ -5365,10 +5367,7 @@ impl TerminalView {
             | BlocklistAIHistoryEvent::DeletedConversation { .. }
             | BlocklistAIHistoryEvent::RestoredConversations { .. }
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
-            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
-            | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
-            | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
-            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => None,
+            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. } => None,
         }
     }
 


### PR DESCRIPTION
## Description
Fixes APP-4589 by removing two AI history/blocklist main-thread hot spots that line up with the sampled beachball stack:

- Cache the terminal input keymap flag for whether live AI conversations contain user-query history, instead of walking live conversations and doing repeated HashMap lookups during keymap context generation while typing.
- Route hot `BlocklistAIHistoryEvent`s by their embedded `terminal_view_id` before falling back to the global conversation-owner lookup for conversation-scoped events that do not carry a terminal id.

This looks separate from APP-4525's file-context restoration/passive-suggestion memory spike: the mitigation here targets typing/event-routing work in the AI history/blocklist path, not FileContext restoration.

## Linked Issue
APP-4589

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] `cargo test -p warp has_live_conversation_with_initial_user_query_tracks_live_history` passed before merging latest `origin/master`.
- [x] `CARGO_BUILD_JOBS=1 cargo check -p warp --lib` passed after merging latest `origin/master`.
- [ ] I have manually tested my changes locally with `./script/run`

Note: after merging latest `origin/master`, rerunning the full targeted test binary build was killed by the sandbox with `SIGKILL`, likely due to the hard memory limit while linking the large `warp` test binary. The lower-memory library check passed afterward.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a typing-time performance issue where large AI conversation histories could cause expensive main-thread history scans.

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._