### PR TITLE
Fix cargo build --release panic when CARGO_FULL_PROFILE is unset

### DIFF
--- a/app/build.rs
+++ b/app/build.rs
@@ -128,8 +128,11 @@ fn main() -> Result<()> {
         // Ideally we could access `CARGO_TARGET_DIR` but this doesn't exist at build time.
         // See https://github.com/rust-lang/cargo/issues/9661.
         //
-        // Cargo defaults to the `debug` profile.
-        let cargo_full_profile = env::var("CARGO_FULL_PROFILE").unwrap_or(String::from("debug"));
+        // Cargo defaults to the `debug` profile. Fall back to the built-in PROFILE env var
+        // (always set by Cargo for build scripts) before defaulting to "debug".
+        let cargo_full_profile = env::var("CARGO_FULL_PROFILE")
+            .or_else(|_| env::var("PROFILE"))
+            .unwrap_or_else(|_| String::from("debug"));
         let target_dir =
             app_target_dir(&cargo_full_profile).expect("Could not get app target directory");
         copy_windows_assets(&target_dir);


### PR DESCRIPTION
## Summary
- Falls back to Cargo's built-in `PROFILE` env var before defaulting to `"debug"` when `CARGO_FULL_PROFILE` is unset
- Prevents panic when running `cargo build --release` on Windows without the custom env var set
- The panic occurred because the build script tried to copy assets into `target/debug/` which doesn't exist during a release-only build

Fixes #11315

## Test plan
- [ ] Run `cargo build --release` on Windows without setting `CARGO_FULL_PROFILE` — should no longer panic
- [ ] Run `cargo build` (debug) — should still work as before (PROFILE=debug)
- [ ] Run with `CARGO_FULL_PROFILE=release` explicitly — should still take precedence