### PR TITLE
Prevent WASM blocklist local image loads

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -1787,6 +1787,9 @@ fn load_renderable_image_asset(
 
     #[cfg(not(feature = "local_fs"))]
     let asset_source = blocklist_image_asset_source(&image.source, current_working_directory)?;
+    if !should_load_blocklist_image_asset(&asset_source) {
+        return None;
+    }
     let asset_state = AssetCache::as_ref(app).load_asset::<ImageType>(asset_source.clone());
     if matches!(asset_state, AssetState::FailedToLoad(_)) {
         return None;
@@ -1811,6 +1814,16 @@ fn can_render_blocklist_image(
         app,
     )
     .is_some()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn should_load_blocklist_image_asset(asset_source: &AssetSource) -> bool {
+    !matches!(asset_source, AssetSource::LocalFile { .. })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn should_load_blocklist_image_asset(_: &AssetSource) -> bool {
+    true
 }
 
 fn render_image_section<A: Action>(


### PR DESCRIPTION
## Description
Prevents the web/WASM transcript renderer from trying to load block-list Markdown images that resolve to local filesystem asset sources. In WASM, those local paths can point at files from a cloud-agent filesystem (for example `/tmp/...png`) that are not available in the browser, so this now falls back to the existing Markdown/alt-text rendering path instead.

Native local image rendering remains unchanged, and Mermaid rendering is unaffected.

## Linked Issue
No linked issue. Investigated from Slack report about a staging conversation crash.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --target wasm32-unknown-unknown`
- `cargo fmt --manifest-path /workspace/warp/app/Cargo.toml -- --check`
- `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml --no-fail-fast --workspace is_supported_blocklist_image_source_covers_common_local_formats`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — targeted crash-prevention guard validated by native and WASM typechecks.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/a39f3b30-0a84-48c3-a17d-cfa68d924d37_
_Run: https://oz.staging.warp.dev/runs/019e4ce4-20f7-7cca-8771-d3807ca7dff4_
_This PR was generated with [Oz](https://warp.dev/oz)._
