### PR TITLE
Handle create+delete same path as file replacement

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/request_file_edits/diff_application.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_file_edits/diff_application.rs
@@ -355,6 +355,10 @@ where
     let v4a_files: HashSet<String> = v4a_deltas.keys().cloned().collect();
     let new_file_paths: HashSet<String> = new_files.keys().cloned().collect();
     let deleted_file_paths: HashSet<String> = deleted_files.iter().cloned().collect();
+    let replacement_file_paths: HashSet<String> = new_file_paths
+        .intersection(&deleted_file_paths)
+        .cloned()
+        .collect();
 
     for (file_path, deltas) in search_replace_deltas {
         // If a file is also being explicitly created/deleted, skip applying edits to avoid
@@ -391,12 +395,18 @@ where
             result
                 .errors
                 .push(DiffApplicationError::MultipleFileCreation { file });
+        } else if replacement_file_paths.contains(&file) {
+            apply_replace_file(file, content, session_context, read_file, &mut result).await;
         } else {
             apply_create_file(file, content, session_context, read_file, &mut result).await;
         }
     }
 
     for file in deleted_files {
+        if replacement_file_paths.contains(&file) {
+            continue;
+        }
+
         if new_file_paths.contains(&file)
             || search_replace_files.contains(&file)
             || v4a_files.contains(&file)
@@ -411,6 +421,62 @@ where
     }
 
     result
+}
+
+async fn apply_replace_file<F, Fut>(
+    file_path: String,
+    content: String,
+    session_context: &SessionContext,
+    read_file: &F,
+    result: &mut DiffResult,
+) where
+    F: Fn(String) -> Fut,
+    Fut: Future<Output = FileReadResult>,
+{
+    let absolute_path = host_native_absolute_path(
+        &file_path,
+        session_context.shell(),
+        session_context.current_working_directory(),
+    );
+
+    match read_file(absolute_path.clone()).await {
+        FileReadResult::Found(file_content) => {
+            let num_lines = file_content.lines().count();
+            let replacement_line_range = if num_lines == 0 {
+                0..0
+            } else {
+                1..num_lines.saturating_add(1)
+            };
+
+            result.diffs.push(AIRequestedCodeDiff {
+                file_name: file_path,
+                diff_type: DiffType::update(
+                    vec![DiffDelta {
+                        replacement_line_range,
+                        insertion: content,
+                    }],
+                    None,
+                ),
+                failures: None,
+                original_content: file_content,
+            });
+        }
+        FileReadResult::NotFound => {
+            result
+                .errors
+                .push(DiffApplicationError::MissingFile { file: file_path });
+        }
+        FileReadResult::ReadError(err) => {
+            safe_warn!(
+                safe: ("Unable to read file for Agent Code: {err}"),
+                full: ("Unable to read file {absolute_path:?} for Agent Code: {err}")
+            );
+            result.errors.push(DiffApplicationError::ReadFailed {
+                file: file_path,
+                message: err,
+            });
+        }
+    }
 }
 
 /// Converts a file-creation request into a diff.

--- a/app/src/ai/blocklist/action_model/execute/request_file_edits/diff_application_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_file_edits/diff_application_tests.rs
@@ -468,6 +468,124 @@ fn test_mixed_create_and_edit_for_same_path() {
 }
 
 #[test]
+fn test_delete_and_create_same_path_replaces_existing_file() {
+    App::test((), |app| async move {
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file");
+        let file_path = temp_file.path().to_string_lossy().to_string();
+        writeln!(&mut temp_file, "Old line one\nOld line two").unwrap();
+
+        let delete_edit = FileEdit::Delete {
+            file: Some(file_path.clone()),
+        };
+        let create_edit = FileEdit::Create {
+            file: Some(file_path.clone()),
+            content: Some("New file content".to_string()),
+        };
+
+        let result = apply_edits(
+            vec![delete_edit, create_edit],
+            &SessionContext::new_for_test(),
+            &AIIdentifiers::default(),
+            app.background_executor(),
+            Arc::new(AuthState::new_for_test()),
+            false,
+            |path| async move { FileReadResult::from(std::fs::read_to_string(path)) },
+        )
+        .await;
+
+        assert!(result.is_ok(), "Expected Ok result but got: {result:?}");
+        let diffs = result.unwrap();
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].file_name, file_path);
+        assert_eq!(diffs[0].original_content, "Old line one\nOld line two\n");
+
+        let deltas = update_deltas(&diffs[0]);
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].replacement_line_range, 1..3);
+        assert_eq!(deltas[0].insertion, "New file content");
+    });
+}
+
+#[test]
+fn test_create_then_delete_same_path_replaces_existing_file() {
+    App::test((), |app| async move {
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file");
+        let file_path = temp_file.path().to_string_lossy().to_string();
+        writeln!(&mut temp_file, "Old line one\nOld line two").unwrap();
+
+        let create_edit = FileEdit::Create {
+            file: Some(file_path.clone()),
+            content: Some("New file content".to_string()),
+        };
+        let delete_edit = FileEdit::Delete {
+            file: Some(file_path.clone()),
+        };
+
+        let result = apply_edits(
+            vec![create_edit, delete_edit],
+            &SessionContext::new_for_test(),
+            &AIIdentifiers::default(),
+            app.background_executor(),
+            Arc::new(AuthState::new_for_test()),
+            false,
+            |path| async move { FileReadResult::from(std::fs::read_to_string(path)) },
+        )
+        .await;
+
+        assert!(result.is_ok(), "Expected Ok result but got: {result:?}");
+        let diffs = result.unwrap();
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].file_name, file_path);
+
+        let deltas = update_deltas(&diffs[0]);
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].replacement_line_range, 1..3);
+        assert_eq!(deltas[0].insertion, "New file content");
+    });
+}
+
+#[test]
+fn test_delete_create_and_edit_same_path_still_fails() {
+    App::test((), |app| async move {
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file");
+        let file_path = temp_file.path().to_string_lossy().to_string();
+        writeln!(&mut temp_file, "Existing content").unwrap();
+
+        let delete_edit = FileEdit::Delete {
+            file: Some(file_path.clone()),
+        };
+        let create_edit = FileEdit::Create {
+            file: Some(file_path.clone()),
+            content: Some("New file content".to_string()),
+        };
+        let edit_diff = ParsedDiff::StrReplaceEdit {
+            file: Some(file_path.clone()),
+            search: Some("1|Existing content".to_string()),
+            replace: Some("Modified content".to_string()),
+        };
+
+        let result = apply_edits(
+            vec![delete_edit, create_edit, FileEdit::Edit(edit_diff)],
+            &SessionContext::new_for_test(),
+            &AIIdentifiers::default(),
+            app.background_executor(),
+            Arc::new(AuthState::new_for_test()),
+            false,
+            |path| async move { FileReadResult::from(std::fs::read_to_string(path)) },
+        )
+        .await;
+
+        let errors = result.expect_err("Expected an error due to create/edit/delete same path");
+        match &errors[..] {
+            [DiffApplicationError::MultipleFileCreation { file }] => {
+                assert_eq!(*file, file_path);
+            }
+            other => panic!("Expected a single MultipleFileCreation error, got {other:?}"),
+        }
+    });
+}
+
+#[test]
 fn test_create_edit_for_existing_file() {
     App::test((), |app| async move {
         // Create a temporary file that already exists


### PR DESCRIPTION
## Description
This updates file-diff application logic so when `Create` and `Delete` target the same path in one request, we treat it as a file replacement instead of conflicting operations.


Before:
<img width="1264" height="140" alt="Screenshot 2026-05-21 at 5 08 36 PM" src="https://github.com/user-attachments/assets/aa7aafbc-5135-4a69-bf5e-b23ba819df17" />
[Debug Link
](https://staging.warp.dev/debug/maa/d81186e2-5fe5-4ecc-9b2e-e111a7ee510b?request=84ee6eaf-6855-4863-aae3-c7e83b064483)
After:

<img width="1248" height="526" alt="Screenshot 2026-05-21 at 5 08 52 PM" src="https://github.com/user-attachments/assets/dd0e17e6-375e-4335-b439-2e770c20053e" />

[Debug Link](https://staging.warp.dev/debug/maa/cdbfe098-e251-406a-b3f8-6f83157c86c1)



## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added unit tests for delete+create replacement behavior, create+delete replacement behavior, and mixed delete/create/edit conflict behavior.
- `cargo fmt --all -- --check` passed.
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` was not completed locally; CI will validate.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix file edit diff application when create and delete target the same path.

Co-Authored-By: Oz <oz-agent@warp.dev>
