### PR TITLE
Add warpctrl product and tech specs

### DIFF
--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -152,7 +152,7 @@ Non-goals:
    - Result data or structured error data.
 29. The protocol is versioned. Clients must be able to determine whether a running Warp process supports the protocol version and action they intend to call.
 30. Multiple running Warp processes are a supported normal case, not an error state. A local stable build and local dev build, or multiple supported local app instances, can coexist; the CLI provides deterministic discovery and addressing rather than assuming one global server.
-31. Requests should be scoped to local-user control of the running app. A command that fails authentication or local authorization reports that condition explicitly and does not degrade into a less-specific request.
+31. Requests should be scoped to local-user control of the running app, with separate enforcement for actions that require a true logged-in Warp user. A command that fails local authentication, local authorization, execution-context checks, or authenticated-user checks reports that condition explicitly and does not degrade into a less-specific request.
 32. If a selected action is valid in general but impossible in the current UI state, the CLI reports a state-specific failure. Examples include:
    - Splitting a pane that no longer exists.
    - Running a session-scoped command against a non-terminal pane.
@@ -167,47 +167,72 @@ Non-goals:
 34. Follow-up PRs should fill out the remaining catalog in parallelizable groups once the protocol, discovery model, target resolution, error model, `tab.create` action path, and standalone `warpctrl` packaging shape have been validated by the first slice.
 35. The protocol transport should be designed so that the default target is localhost but the CLI can be extended in the future to target remote URLs (e.g., a Warp instance on another machine or a hosted control endpoint). This is not in scope for the first implementation but should not be precluded by the architecture.
 ## Action classification and permission model
-Agents (Oz cloud agents, local agent mode, and third-party automation) are expected to be major consumers of the warpctrl CLI alongside human developers. The action catalog must support differentiated permission policies for human callers versus agent callers, and must clearly classify every action by its risk profile so that Warp can enforce appropriate guardrails at both the protocol and product level.
+Agents, scripts, and human developers are expected to be major consumers of `warpctrl`. The action catalog must therefore classify every action by both risk tier and authenticated-user requirement so Warp can enforce local-control permissions in the app bridge.
+Every action definition must include:
+- a stable action name and namespace;
+- a risk tier;
+- whether a true logged-in Warp user is required;
+- whether the action may run from external clients, verified Warp-terminal clients, or both;
+- the required local-control permission category;
+- any target-scope restrictions.
+By default, new actions require an authenticated Warp user. An action may be marked logged-out-safe only after deliberate review confirms it does not touch Warp Drive, AI conversation traces, synced settings, team/account data, cloud-backed user state, terminal content, or other user-sensitive data.
 ### Classification tiers
 Every action in the catalog belongs to exactly one of the following tiers, from least to most sensitive:
-1. **Read-only / metadata.** Actions that return app-level structural information without exposing terminal content. These are safe for any caller and should never require elevated permission.
+1. **Read-only / metadata.** Actions that return local app structure or configuration without exposing terminal content or user-authenticated data.
    - Instance discovery and health: `instance list`, `app active`, `app version`, `app ping`.
    - Layout enumeration: `window list`, `tab list`, `pane list`, `session list`.
-   - Appearance/settings reads that return configuration values but not user data: `theme list`, `setting list`, `setting get`.
-2. **Read-only / terminal data.** Actions that return content from a user's terminal sessions, command history, pane output buffers, or input editor state. These expose potentially sensitive user data and must be gated separately from structural metadata reads.
-   - Reading pane output or scrollback content (when implemented).
+   - Appearance reads that return local configuration values but not user data: `theme list`, selected `setting get` actions for logged-out-safe local settings.
+   These are the primary default actions for external clients.
+2. **Read-only / terminal data.** Actions that return content from terminal sessions, command history, pane output buffers, input editor state, session replay, or terminal-derived traces.
+   - Reading pane output or scrollback content.
    - Reading the current input buffer contents.
    - Reading command history or session replay data.
-   Even though these are read-only, they cross a privacy boundary that metadata reads do not. An agent that can enumerate tabs should not automatically be able to read terminal output.
-3. **Mutating / non-destructive.** Actions that change app state in ways that are visible but reversible or low-risk. They do not destroy user data or execute arbitrary commands.
+   Even though these are read-only, they cross a privacy boundary that metadata reads do not.
+3. **Mutating / non-destructive.** Actions that change app state in visible, reversible, or low-risk ways without executing terminal content or destroying user state.
    - Layout mutations: `tab create`, `tab activate`, `tab move`, `tab rename`, `window create`, `window focus`, `pane split`, `pane focus`, `pane navigate`, `pane maximize`, `pane resize`.
    - Appearance mutations: `theme set`, `font-size increase/decrease/reset`, `zoom increase/decrease/reset`.
-   - Settings writes for allowlisted non-destructive settings: `setting set`, `setting toggle`.
-   - Panel/surface toggles: settings open, command palette, Warp Drive toggle, AI assistant toggle, etc.
-4. **Mutating / destructive or high-risk.** Actions that destroy user state, close active work, or execute arbitrary content in a terminal session. These require the strongest permission gates and explicit review before agent use.
+   - Settings writes for allowlisted non-destructive local settings.
+   - Panel/surface toggles where they do not expose authenticated user data.
+4. **Mutating / destructive or high-risk.** Actions that destroy user state, close active work, inject terminal input, execute commands, or execute user-authored content.
    - Closing targets: `tab close`, `window close`, `pane close`.
    - Terminal input injection: `input insert`, `input replace`, `input clear`.
-   - Command execution in a session (when implemented).
+   - Command execution in a session.
    - Input mode switching between terminal and agent modes.
-   Any action that can cause data loss (closing an unsaved session) or execute arbitrary code (injecting and running a shell command) belongs here regardless of how simple the API looks.
-### Permission policies
-The protocol and product should support per-caller permission policies keyed to these tiers:
-- **Human interactive use** defaults to full access across all tiers, gated only by local authentication (the bearer token).
-- **Agent use** should default to read-only metadata access and require explicit opt-in for each higher tier. The product should support:
-  - A baseline "read-only metadata" grant that lets agents discover and enumerate without accessing terminal content or mutating state.
-  - A "read terminal data" grant that additionally permits reading pane output, input buffers, and session content.
-  - A "mutate non-destructive" grant that additionally permits layout and appearance changes.
-  - A "mutate destructive" grant that additionally permits closing targets, injecting input, and executing commands.
-- The permission model should be expressible in the protocol (e.g., a capability or scope field in the authentication material) so that the app bridge can enforce it server-side, not just client-side.
-- When an agent attempts an action above its granted tier, the bridge should return a structured `insufficient_permissions` error that identifies the required tier, rather than silently downgrading or returning a generic failure.
-### Scoped credentials and caller identity
-The local discovery bearer token is not sufficient for differentiated human vs. agent permissions. If the same full-access token is readable by both humans and agents, the server cannot enforce agent-specific read-only defaults. Before agent-facing read/write or destructive actions ship, the product must introduce scoped credentials.
-- The discovery record may expose a human CLI credential for same-user interactive use, but agent runtimes should not receive that full-access credential by default.
-- Agent callers should receive a separate scoped credential minted by Warp or by a trusted local broker. The credential must identify the caller class (`human`, `local_agent`, `cloud_agent`, `third_party_automation`) and granted permission tiers.
-- Scoped credentials should be bound to a specific Warp instance, protocol version, issued-at time, optional expiry time, and allowed action tiers. The bridge must validate those fields before action dispatch.
-- The bridge, not the CLI frontend, enforces permission tiers by mapping every `ActionKind` to a required tier and comparing that tier to the credential's grants.
-- If a process presents the human discovery credential, the bridge treats it as human interactive use. If a process presents an agent credential, the bridge applies the agent policy even if the process runs under the same local user account.
-- The first implementation slice may ship a same-user human credential only because it implements discovery and `tab create`; any slice that exposes terminal data, input mutation, command execution, or other agent-consumable automation must add scoped credential issuance first.
+   - Executing Warp Drive workflows or notebooks in a terminal session.
+   Any action that can cause data loss or execute arbitrary code belongs here regardless of how simple the API looks.
+### Authenticated-user requirement
+An authenticated user means a true logged-in Warp user in the selected Warp app, not merely the local OS user or a `warpctrl` process authenticated to localhost.
+The allowlist must clearly indicate `requires_authenticated_user` for every action:
+- `false` only for logged-out-safe actions that operate on local app structure, local appearance metadata, or local-only settings that do not expose user-sensitive data.
+- `true` for actions that read or mutate Warp Drive, AI conversation traces, synced settings, team/account data, user identity data, or any cloud-backed Warp state.
+- `true` for actions that execute user-authored Warp Drive content, even if the execution target is a local terminal session.
+If an authenticated-user action is invoked while the selected app has no logged-in user, the CLI reports a structured authenticated-user error. It must not silently return partial logged-out data as success.
+### Execution context policy
+`warpctrl` should distinguish verified invocations from inside Warp-managed terminal sessions from external invocations.
+- **External invocation:** a `warpctrl` process started outside Warp's terminal. By default, it can receive only the smaller logged-out-safe local action set that does not touch user-authenticated data. Higher tiers require explicit local-control settings or approvals.
+- **Verified Warp-terminal invocation:** a `warpctrl` process started inside a Warp-managed terminal session and able to present an app-issued execution-context proof. When the selected app has a logged-in Warp user, this context can receive authenticated-user grants if the user enabled that permission.
+- The app must not trust a caller-declared label. Environment variables may help discover the context, but the broker must verify a session-bound capability or equivalent proof before issuing in-Warp-only grants.
+### Granular local-control permissions
+The product settings surface should expose granular permissions under the default-off local-control setting. Recommended controls:
+- Allow local read-only metadata.
+- Allow terminal data reads.
+- Allow non-destructive local mutations.
+- Allow destructive or execution actions.
+- Allow authenticated-user actions from verified Warp terminals.
+- Allow authenticated-user actions from external clients, default off and separate from the in-Warp permission.
+These settings define the maximum grants the broker may issue. The app bridge still enforces the action's risk tier, authenticated-user requirement, execution-context requirement, and target scope for every request.
+### Scoped credentials
+The local discovery record must not expose a reusable full-access credential. `warpctrl` should request scoped credentials from an app-owned broker or equivalent trusted path.
+Scoped credentials should include:
+- the selected Warp instance;
+- granted risk tiers;
+- allowed action families;
+- verified execution context;
+- whether authenticated-user access is granted and for which logged-in user subject;
+- optional target scopes;
+- issuance and expiry metadata;
+- revocation/audit identity.
+The bridge, not the CLI frontend, enforces these grants. If a request exceeds its credential, the bridge returns `insufficient_permissions`, `authenticated_user_required`, `authenticated_user_unavailable`, or `execution_context_not_allowed` as appropriate.
 ### Future entity extensibility: files and Warp Drive objects
 The selector and action model should be designed to accommodate entity types beyond the current window/tab/pane/session hierarchy. Two important future entity families are **local files** and **Warp Drive objects** (workflows, notebooks, environment variables, prompts). Neither is in scope for the first implementation, but the protocol should not preclude them.
 **Files.** Warp already supports file opening via deep links and the built-in editor. A future `file` namespace could support:
@@ -224,12 +249,12 @@ Drive object selectors should support both opaque IDs (for automation stability)
 **Design constraints for both:**
 - File and Drive selectors are orthogonal to the window/tab/pane hierarchy — a file open action targets an instance (which window to open in), not a specific pane. A Drive workflow execution targets a session (which pane to run in).
 - The `TargetSelector` type in the protocol should be extensible with optional fields for these new selector families without breaking existing requests that omit them.
-- The action classification tiers apply: listing Drive objects is tier 1 (metadata), reading Drive object content is tier 1 or 2 depending on whether it contains user data, executing a Drive workflow is tier 4 (destructive/high-risk).
+- The action classification tiers apply, and Drive actions require authenticated-user grants by default: listing Drive objects is tier 1 metadata plus authenticated user, reading Drive object content is tier 1 or 2 depending on whether it contains user data plus authenticated user, and executing a Drive workflow is tier 4 plus authenticated user.
 ### Settings: protocol-first
 Settings reads and writes should go through the local-control protocol like other actions, not bypass it via direct file manipulation.
 - `warpctrl setting get <key>`, `warpctrl setting set <key> <value>`, and `warpctrl setting toggle <key>` send requests to the running Warp instance through the standard authenticated control endpoint.
 - The app bridge validates the key against the allowlist and the value against the expected type before applying the change.
-- This keeps authorization enforcement consistent: the same permission tier checks and caller-type policies apply to settings mutations as to any other action, rather than creating a second unguarded path through the filesystem.
+- This keeps authorization enforcement consistent: the same permission tier, execution-context, and authenticated-user policies apply to settings mutations as to any other action, rather than creating a second unguarded path through the filesystem.
 - The app owns the write to the settings file and any side effects (e.g., theme reload, layout reflow) as a single atomic operation, avoiding races between a CLI file write and the app's file watcher.
 - If a future need arises for offline settings manipulation (no running Warp process), a separate file-based path can be added later with its own validation, but it should not be the default.
 - The action classification still applies: settings reads are tier 1 (metadata), settings writes are tier 3 (non-destructive mutation).

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -53,7 +53,14 @@ Non-goals:
    - Active tab in the selected window.
    - Active pane in the selected tab.
    - Active session in the selected pane.
-10. Every selector family supports explicit opaque IDs returned by introspection. Tabs may also support index selectors where index-based workflows are already user-visible, but IDs remain the preferred automation surface.
+10. Every selector family supports explicit opaque IDs returned by introspection. Selector families may also support scoped indices, titles/names, or paths where those concepts are already user-visible, but IDs remain the preferred automation surface.
+   - Window selectors support `active`, opaque window IDs, window indices from `window list`, and exact window titles for interactive use.
+   - Tab selectors support `active`, opaque tab IDs, tab indices scoped to the resolved window, and exact tab titles for interactive use.
+   - Pane selectors support `active`, opaque pane IDs, and pane indices scoped to the resolved tab or pane group.
+   - Session selectors support `active`, opaque session IDs, and session indices scoped to the resolved pane when sessions are user-visible as an ordered list.
+   - Block selectors use opaque block IDs from block/session introspection.
+   - File selectors use paths, plus optional line/column coordinates where the command supports opening or reading a location.
+   - Warp Drive selectors use opaque object IDs, with optional type-scoped exact name/path lookups for interactive use.
 11. “Active session” means the currently selected terminal session for the resolved pane/window context. If the selected target does not contain a terminal session, session-scoped actions fail rather than silently redirecting elsewhere.
 12. When a command omits lower-level selectors, it resolves them from the chosen higher-level context using active defaults. Example: a pane split command with only `--instance` uses that instance’s active window, active tab, and active pane.
 13. When an explicitly supplied target disappears between discovery and execution, the request fails with a stale-target error. The CLI must not silently choose a different tab, pane, or session.
@@ -136,8 +143,13 @@ Non-goals:
    - `warpctrl instance list`
    - `warpctrl app active`
    - `warpctrl tab create`
+   - `warpctrl tab rename --window-id <window_id> --tab-id <tab_id> "Build logs"`
+   - `warpctrl tab rename --window active --tab-index 0 "Build logs"`
+   - `warpctrl window close --window-title "Scratch"`
    - `warpctrl pane split --direction right`
    - `warpctrl pane split --instance <id> --window active --pane active --direction right`
+   - `warpctrl input replace --session-id <session_id> "cargo check"`
+   - `warpctrl block output --pane-id <pane_id> --block-id <block_id> --plain`
    - `warpctrl theme set "Warp Dark"`
    - `warpctrl setting set appearance.themes.system_theme true`
    - `warpctrl input insert "cargo check" --replace`
@@ -177,15 +189,22 @@ The product surface must distinguish what kind of state a command touches. This 
 - **Underlying data mutations** can change user data or cause external side effects: executing terminal commands, writing/creating/deleting files, running workflows that execute commands, CRUD operations on Warp Drive objects, mutating AI conversation history, and any action that can modify data outside transient app UI state.
 A command that touches multiple categories must require the strongest applicable permission. For example, `file open` is an app-state mutation, while `file write` is an underlying data mutation; `input insert` is an app-state mutation, while `input run` is an underlying data mutation because it executes a command in the target session.
 ### Targeting flags
-All commands that address a running app target accept the same selector flags where meaningful:
+All commands that address a running app target accept the same selector flags where meaningful. Generic `--window`, `--tab`, `--pane`, and `--session` flags accept the selector grammar below; explicit typed aliases are provided so scripts can avoid string parsing ambiguity:
 - `--instance <instance_id>` selects a running Warp process from `warpctrl instance list`.
 - `--pid <pid>` is a convenience instance selector and conflicts with `--instance`.
-- `--window <active|id|index|title>` selects a window inside the instance.
-- `--tab <active|id|index|title>` selects a tab inside the window.
-- `--pane <active|id|index>` selects a pane inside the tab or pane-group context.
-- `--session <active|id>` selects a terminal or agent session inside the pane when the command is session-scoped.
+- `--window <active|id:<id>|index:<n>|title:<title>>` selects a window inside the instance.
+- `--window-id <id>`, `--window-index <n>`, and `--window-title <title>` are exact aliases for the corresponding `--window ...` forms.
+- `--tab <active|id:<id>|index:<n>|title:<title>>` selects a tab inside the resolved window.
+- `--tab-id <id>`, `--tab-index <n>`, and `--tab-title <title>` are exact aliases for the corresponding `--tab ...` forms.
+- `--pane <active|id:<id>|index:<n>>` selects a pane inside the resolved tab or pane-group context.
+- `--pane-id <id>` and `--pane-index <n>` are exact aliases for the corresponding `--pane ...` forms.
+- `--session <active|id:<id>|index:<n>>` selects a terminal or agent session inside the resolved pane when the command is session-scoped.
+- `--session-id <id>` and `--session-index <n>` are exact aliases for the corresponding `--session ...` forms.
+- `--block-id <id>` selects a terminal block for block-scoped read commands.
+- File commands use path arguments or `--path <path>` where the path is the selected file entity; `--line <n>` and `--column <n>` refine the location when supported.
+- Drive commands use object ID arguments or `--drive-id <id>` where the ID is the selected Warp Drive entity; name/path lookup must be type-scoped when supported.
 - `--output-format <pretty|json|ndjson|text>` controls output shape and remains globally available.
-Omitted lower-level selectors use active defaults only when that active target is unambiguous. Explicit IDs must resolve exactly or fail with `stale_target`.
+Within a selector family, specifying more than one form is invalid. For example, `--tab-id` conflicts with `--tab-index`, `--tab-title`, and `--tab`. Omitted lower-level selectors use active defaults only when that active target is unambiguous. Explicit IDs must resolve exactly or fail with `stale_target`; index/title/name/path selectors that match zero targets fail with `missing_target`, and selectors that match multiple targets fail with `ambiguous_target`.
 ### Read-only command set
 The read-only branch `zach/warp-cli-readonly` should implement the following commands before mutating catalog expansion begins. Read-only does not mean one permission: metadata reads and underlying data reads are separate grant categories.
 Metadata and capability reads:

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -1,13 +1,13 @@
 # Summary
-Warp should ship an allowlisted standalone local control CLI binary, provisionally named `warpctrl`, that lets developers script the same classes of user-visible actions they can already perform inside the running app: manipulating windows, tabs, panes, sessions, appearance, settings, and selected UI surfaces. The CLI should operate against one or more already-running local Warp app processes through a stable machine protocol, with deterministic target selection and clear errors when a process or target is ambiguous.
+Warp should ship an allowlisted standalone local control CLI binary, provisionally named `warpctrl`, that lets developers script the same classes of user-visible actions they can already perform inside the running app: manipulating windows, tabs, panes, sessions, terminal blocks, appearance, settings, Warp Drive views, and selected UI surfaces. The CLI should operate against one or more already-running local Warp app processes through a stable machine protocol, with deterministic target selection and clear errors when a process or target is ambiguous.
 ## Problem
-Warp already has rich interactive actions, but they are primarily reachable through UI, keybindings, menus, or deeplinks. Developers cannot reliably compose those same actions into shell scripts, demos, automation, or agent workflows, and there is no general local protocol for addressing a specific running Warp instance, window, pane, or session.
+Warp already has rich interactive actions, but they are primarily reachable through UI, keybindings, menus, or deeplinks. Developers cannot reliably compose those same actions into shell scripts, demos, automation, or agent workflows, and there is no general local protocol for addressing a specific running Warp instance, window, pane, session, terminal block, Warp Drive object, or other uniquely named Warp entity.
 ## Goals / Non-goals
 Goals:
 - Provide a first-class, scriptable standalone `warpctrl` binary for controlling running Warp app processes.
 - Keep CLI startup lightweight by avoiding GUI-app startup or full terminal initialization for routine control commands.
 - Keep the surface allowlisted and finite instead of exposing arbitrary internal actions.
-- Make targeting explicit and deterministic across multiple Warp processes, windows, tabs, panes, and sessions.
+- Make targeting explicit and deterministic across multiple Warp processes, windows, tabs, panes, terminal sessions, terminal blocks, Warp Drive objects, files, projects/workspaces, command surfaces, and other uniquely addressable Warp nouns.
 - Support both ergonomic active-target defaults and precise selectors for automation.
 - Define a complete protocol/catalog up front, while shipping the implementation incrementally.
 Non-goals:
@@ -21,7 +21,7 @@ Non-goals:
 2. The CLI exposes only explicitly allowlisted actions. Unknown action names, unsupported parameter combinations, or requests for non-allowlisted capabilities fail with structured errors; they are never forwarded to arbitrary internal dispatch.
 3. Every successful mutating request identifies:
    - The Warp process instance that executed it.
-   - The resolved target, when the action addresses a window, tab, pane, or session.
+   - The resolved target, when the action addresses a window, tab, pane, terminal session, terminal block, file, project/workspace, Warp Drive object, surface, or other targetable noun.
    - A success payload suitable for JSON output.
 4. Every failure identifies:
    - A stable machine-readable error code.
@@ -39,6 +39,8 @@ Non-goals:
    - `warpctrl tab list`
    - `warpctrl pane list`
    - `warpctrl session list`
+   - `warpctrl block list`
+   - `warpctrl drive list`
    - `warpctrl app active`
    These commands return opaque protocol-facing IDs and enough metadata for subsequent commands without requiring knowledge of internal Warp identifiers.
 8. The target selector model is hierarchical:
@@ -47,25 +49,29 @@ Non-goals:
    - Tab selector resolves within the window.
    - Pane selector resolves within the tab or active pane group context.
    - Session selector resolves within the pane when the pane hosts terminal session state.
+   - Block selector resolves within the terminal session when the command is block-scoped.
+   Non-hierarchical selectors such as file paths, projects/workspaces, Warp Drive objects, and global app surfaces still resolve inside the selected instance and must not silently borrow lower-level pane/session defaults unless the action definition explicitly requires that scope.
 9. Every selector family supports an ergonomic `active` form when that concept exists:
    - Active instance, if unambiguous.
    - Active window in the selected instance.
    - Active tab in the selected window.
    - Active pane in the selected tab.
    - Active session in the selected pane.
+   - Active or selected terminal block in the selected session when a current block is unambiguous.
 10. Every selector family supports explicit opaque IDs returned by introspection. Selector families may also support scoped indices, titles/names, or paths where those concepts are already user-visible, but IDs remain the preferred automation surface.
    - Window selectors support `active`, opaque window IDs, window indices from `window list`, and exact window titles for interactive use.
    - Tab selectors support `active`, opaque tab IDs, tab indices scoped to the resolved window, and exact tab titles for interactive use.
    - Pane selectors support `active`, opaque pane IDs, and pane indices scoped to the resolved tab or pane group.
    - Session selectors support `active`, opaque session IDs, and session indices scoped to the resolved pane when sessions are user-visible as an ordered list.
-   - Block selectors use opaque block IDs from block/session introspection.
+   - Block selectors support `active`, opaque block IDs, and block indices scoped to the resolved terminal session when blocks are user-visible as an ordered list. A block command may also support read-only filters such as command text, status, time range, or “last completed” for interactive lookup, but those filters must fail on ambiguity and resolve to concrete block IDs before reading output.
    - File selectors use paths, plus optional line/column coordinates where the command supports opening or reading a location.
-   - Warp Drive selectors use opaque object IDs, with optional type-scoped exact name/path lookups for interactive use.
+   - Project/workspace selectors use paths, opaque project/workspace IDs when exposed by introspection, and exact names only as interactive convenience selectors.
+   - Warp Drive selectors use opaque object IDs, with optional type-scoped exact name/path lookups for interactive use. Type scopes must include the user-facing object families Warp exposes today: spaces, folders, notebooks, workflows, agent-mode workflows/prompts, environment variable collections, AI facts/rules, MCP servers, MCP server collections, and trash entries when trash operations are supported.
 11. “Active session” means the currently selected terminal session for the resolved pane/window context. If the selected target does not contain a terminal session, session-scoped actions fail rather than silently redirecting elsewhere.
 12. When a command omits lower-level selectors, it resolves them from the chosen higher-level context using active defaults. Example: a pane split command with only `--instance` uses that instance’s active window, active tab, and active pane.
 13. When an explicitly supplied target disappears between discovery and execution, the request fails with a stale-target error. The CLI must not silently choose a different tab, pane, or session.
 14. The protocol is command-oriented, not open-ended state mutation. Each action has a named command, validated parameters, and defined target scope.
-15. The complete allowlisted action catalog should be organized into these namespaces.
+15. The complete allowlisted action catalog should be organized around stable public nouns rather than internal view/action names. The target taxonomy includes instances, windows, tabs, panes, terminal sessions, terminal blocks, input buffers, command history entries, files, projects/workspaces, Warp Drive spaces, folders, notebooks, workflows, agent-mode workflows/prompts, environment variable collections, AI facts/rules, MCP servers, MCP server collections, settings, themes, keybindings, command surfaces such as the command palette and command search, panels/surfaces such as Warp Drive, resource center, AI assistant, code review, left/right panels, and vertical tabs, plus action/capability metadata. The initial implementation may expose only a subset, but new command families should extend this noun taxonomy instead of inventing unrelated selector conventions.
 16. Discovery and read-only state actions:
    - List instances.
    - Get protocol/app version information for one instance.
@@ -98,9 +104,8 @@ Non-goals:
    - Insert text into the active input without executing it.
    - Replace the active input buffer.
    - Clear the active input buffer where that matches existing user behavior.
-   - Run a command in the target session where the app already supports user-triggered command execution.
    - Switch input mode between terminal and agent modes only where that mode switch is already user-visible and valid for the selected target.
-   These commands are part of the protocol catalog, but command execution should be treated as a higher-risk mutating action with explicit confirmation in spec/review before rollout.
+   The initial public version must not submit terminal input, press Enter, run terminal commands, accept suggested commands, launch workflows into a terminal, or submit agent prompts. At most, it may stage text into an active input buffer for the user to review and confirm manually. Command execution and agent-prompt submission may be reserved as future protocol concepts only after a separate product/security review.
 21. Appearance actions:
    - List available themes.
    - Set the current fixed theme.
@@ -139,6 +144,7 @@ Non-goals:
    - Arbitrary cloud object mutation or broad Warp Drive CRUD.
    - Arbitrary internal view dispatch by string.
    - Arbitrary setting names outside the allowlist.
+   - Terminal command execution, workflow execution, accepted-command submission, and agent-prompt submission in the initial public version.
 27. CLI command names should be noun-oriented and discoverable. During the provisional standalone-binary phase, the control CLI should expose a `warpctrl ...` command surface:
    - `warpctrl instance list`
    - `warpctrl app active`
@@ -167,7 +173,7 @@ Non-goals:
 31. Requests should be scoped to local-user control of the running app, with separate enforcement for actions that require a true logged-in Warp user. A command that fails local authentication, local authorization, execution-context checks, or authenticated-user checks reports that condition explicitly and does not degrade into a less-specific request.
 32. If a selected action is valid in general but impossible in the current UI state, the CLI reports a state-specific failure. Examples include:
    - Splitting a pane that no longer exists.
-   - Running a session-scoped command against a non-terminal pane.
+   - Issuing a session-scoped action against a non-terminal pane.
    - Focusing a window that has closed.
    - Setting a theme that is not available in that instance.
 33. The first `warpctrl` implementation slice should ship the smallest end-to-end vertical slice that proves:
@@ -186,10 +192,10 @@ The product surface must distinguish what kind of state a command touches. This 
 - **Underlying data reads** expose user content or data-bearing state without changing it: terminal output, block contents, command history, input buffer contents, file contents, Warp Drive object contents, AI conversation content, and any other content that could contain user data or secrets.
 - **App-state mutations** change visible local Warp UI state without directly changing user data: opening or focusing windows, creating or closing tabs, splitting panes, focusing panes, opening panels, opening command surfaces, opening files in Warp, and editing the input buffer without submitting it.
 - **Metadata/configuration mutations** change persistent configuration or metadata, but not primary user content: changing themes, font size, zoom, allowlisted settings, keybindings, tab names, pane names, and tab colors.
-- **Underlying data mutations** can change user data or cause external side effects: executing terminal commands, writing/creating/deleting files, running workflows that execute commands, CRUD operations on Warp Drive objects, mutating AI conversation history, and any action that can modify data outside transient app UI state.
-A command that touches multiple categories must require the strongest applicable permission. For example, `file open` is an app-state mutation, while `file write` is an underlying data mutation; `input insert` is an app-state mutation, while `input run` is an underlying data mutation because it executes a command in the target session.
+- **Underlying data mutations** can change user data or cause external side effects: writing/creating/deleting files, CRUD operations on Warp Drive objects, mutating AI conversation history, and future execution actions such as running terminal commands, running workflows that execute commands, accepting suggested commands, or submitting agent prompts.
+A command that touches multiple categories must require the strongest applicable permission. For example, `file open` is an app-state mutation, while `file write` is an underlying data mutation; `input insert` is an app-state mutation, while a future `input run` action would be an underlying data mutation because it executes a command in the target session.
 ### Targeting flags
-All commands that address a running app target accept the same selector flags where meaningful. Generic `--window`, `--tab`, `--pane`, and `--session` flags accept the selector grammar below; explicit typed aliases are provided so scripts can avoid string parsing ambiguity:
+All commands that address a running app target accept the same selector flags where meaningful. Generic `--window`, `--tab`, `--pane`, `--session`, and `--block` flags accept the selector grammar below; explicit typed aliases are provided so scripts can avoid string parsing ambiguity:
 - `--instance <instance_id>` selects a running Warp process from `warpctrl instance list`.
 - `--pid <pid>` is a convenience instance selector and conflicts with `--instance`.
 - `--window <active|id:<id>|index:<n>|title:<title>>` selects a window inside the instance.
@@ -200,7 +206,8 @@ All commands that address a running app target accept the same selector flags wh
 - `--pane-id <id>` and `--pane-index <n>` are exact aliases for the corresponding `--pane ...` forms.
 - `--session <active|id:<id>|index:<n>>` selects a terminal or agent session inside the resolved pane when the command is session-scoped.
 - `--session-id <id>` and `--session-index <n>` are exact aliases for the corresponding `--session ...` forms.
-- `--block-id <id>` selects a terminal block for block-scoped read commands.
+- `--block <active|id:<id>|index:<n>>` selects a terminal block inside the resolved terminal session when the command is block-scoped.
+- `--block-id <id>` and `--block-index <n>` are exact aliases for the corresponding `--block ...` forms.
 - File commands use path arguments or `--path <path>` where the path is the selected file entity; `--line <n>` and `--column <n>` refine the location when supported.
 - Drive commands use object ID arguments or `--drive-id <id>` where the ID is the selected Warp Drive entity; name/path lookup must be type-scoped when supported.
 - `--output-format <pretty|json|ndjson|text>` controls output shape and remains globally available.
@@ -225,9 +232,9 @@ Window, tab, pane, and session reads:
 - `warpctrl session list [--pane <selector>] [selectors]`
 - `warpctrl session inspect [--session <selector>] [selectors]`
 Underlying data reads, gated separately from structural metadata reads:
-- `warpctrl block list [--pane <selector>] [--limit <n>] [selectors]`
-- `warpctrl block inspect <block_id> [selectors]`
-- `warpctrl block output <block_id> [--plain|--ansi|--json] [selectors]`
+- `warpctrl block list [--session <selector>|--pane <selector>] [--limit <n>] [selectors]`
+- `warpctrl block inspect --block <selector> [selectors]`
+- `warpctrl block output --block <selector> [--plain|--ansi|--json] [selectors]`
 - `warpctrl input get [--session <selector>] [selectors]`
 - `warpctrl history list [--session <selector>] [--limit <n>] [selectors]`
 Appearance, settings, and command-surface reads:
@@ -245,7 +252,7 @@ Local file and project reads that expose only app/editor state, not arbitrary fi
 - `warpctrl project active [selectors]`
 - `warpctrl project list [selectors]`
 Authenticated read-only Warp Drive metadata and data reads, enabled only when the selected app has a logged-in Warp user and the grant allows authenticated reads. Listing is metadata; inspecting object content is an underlying data read:
-- `warpctrl drive list --type <workflow|notebook|env-var-collection|prompt|folder> [selectors]`
+- `warpctrl drive list --type <workflow|notebook|env-var-collection|prompt|folder|ai-fact|mcp-server|space|trash> [selectors]`
 - `warpctrl drive inspect <id> [selectors]`
 ### Mutating command set
 The stacked branch `zach/warp-cli-read-write` should build on `zach/warp-cli-readonly` and implement the following mutating commands. Mutating commands are split by what they mutate: app-state, metadata/configuration, or underlying data. Underlying data mutations require a separate and stronger permission than app-state or metadata/configuration mutations.
@@ -301,8 +308,7 @@ App-state mutations for sessions and input buffers:
 - `warpctrl input replace <text> [--session <selector>] [selectors]`
 - `warpctrl input clear [--session <selector>] [selectors]`
 - `warpctrl input mode set <terminal|agent> [--session <selector>] [selectors]`
-Underlying data mutations for terminal execution:
-- `warpctrl input run <command> [--session <selector>] [selectors]`
+These input-buffer commands only stage or edit text. The initial public implementation must not include a command that submits the buffer, executes a terminal command, accepts a suggested command, or sends an agent prompt.
 Metadata/configuration mutations for appearance and settings:
 - `warpctrl theme set <theme_name> [selectors]`
 - `warpctrl theme system set <true|false> [selectors]`
@@ -327,15 +333,36 @@ Underlying data mutations for files and authenticated Warp Drive objects:
 - `warpctrl file write <path> --content <text> [selectors]`
 - `warpctrl file append <path> --content <text> [selectors]`
 - `warpctrl file delete <path> [selectors]`
-- `warpctrl drive workflow run <id> [--arg <name=value>...] [selectors]`
 - `warpctrl drive object create --type <workflow|notebook|env-var-collection|prompt|folder> [selectors]`
 - `warpctrl drive object update <id> [selectors]`
 - `warpctrl drive object trash <id> [selectors]`
 - `warpctrl drive object restore <id> [selectors]`
+Future execution actions explicitly excluded from the initial public implementation:
+- `warpctrl input run <command> [--session <selector>] [selectors]`
+- `warpctrl agent prompt submit <prompt> [--session <selector>] [selectors]`
+- `warpctrl drive workflow run <id> [--arg <name=value>...] [selectors]`
+These are underlying-data mutations because they can execute code, trigger external side effects, or send user-authored prompts. They require a separate product/security review before being added to any public allowlist.
 ### Excluded from the public command surface
 The command surface must continue to exclude debug-only, crash-only, auth-token, heap-dump, and arbitrary internal dispatch actions even when those actions are available in command palette or keybinding registries. Examples that remain excluded are app crash/panic helpers, access-token copy helpers, heap profile dumps, debug reset actions, raw view-tree debugging, and broad internal action-by-string execution.
+## Branch stacking and delivery model
+The Warp Control CLI work should ship as a raw-git branch stack so specs, core scaffolding, read-only expansion, and mutating expansion remain reviewable independently:
+- `zach/warp-cli-specs` is the spec-only branch. It owns `specs/warp-control-cli/PRODUCT.md`, `TECH.md`, `SECURITY.md`, and supporting docs, and should not contain implementation changes.
+- `zach/warp-cli` stacks on the specs branch and owns the first implementation slice: shared protocol, discovery/auth scaffolding, Settings > Scripting, local-control bridge/server, standalone `warpctrl` binary, packaging hooks, and the smallest safe end-to-end action.
+- `zach/warp-cli-readonly` stacks on `zach/warp-cli` and fills in the read-only command set, including structural metadata reads and separately gated underlying-data reads such as terminal block output.
+- `zach/warp-cli-read-write` stacks on `zach/warp-cli-readonly` and fills in approved mutating command families while preserving the initial prohibition on terminal command execution and agent-prompt submission.
+Spec changes originate on `zach/warp-cli-specs` and are propagated upward through the stack with raw git so all implementation branches reflect the same product/security contract. Graphite is not part of this stack. If a lower branch merges first, higher branches should rebase onto the merged successor while preserving the approved spec content.
 ## Built-in Warp Agent skill
 Warp should include a built-in Agent skill for `warpctrl`, analogous to the bundled `oz-platform` skill. The skill should teach Warp Agent when to use `warpctrl`, how to discover and target running instances, how to prefer read-only commands before mutating commands, how to request explicit user approval for underlying data mutations, and how to interpret structured errors. The skill should document the stable command hierarchy above, include concise recipes for common automation tasks, and avoid instructing agents to bypass the CLI by calling local-control HTTP endpoints directly.
+## CLI implementation and documentation conventions
+`warpctrl` should feel consistent with the Oz CLI from a developer's perspective and use the same CLI libraries and conventions:
+- Argument parsing, subcommand structure, help text, and shell-completion generation should use the same `clap`/`clap_complete` patterns used by the Oz CLI.
+- JSON serialization and machine-readable output should use the same `serde`/`serde_json` conventions and the same output-format vocabulary used by the Oz CLI.
+- Human-readable help, examples, errors, and generated completions should follow Oz CLI conventions unless Warp Control has a documented product reason to differ.
+CLI documentation should be generated from the command catalog instead of maintained by hand in multiple places:
+- The typed action catalog is the source of truth for command names, selector flags, parameters, output formats, state/data category, required permission, authenticated-user requirement, support status, and examples.
+- `warpctrl help`, shell completions, markdown reference docs, the built-in Warp Agent skill, and the operator README should be generated or checked from that catalog so they cannot drift silently.
+- Generated documentation must distinguish implemented commands from planned catalog entries. A command may appear in specs as planned, but public operator docs must not imply it is usable until the selected app build advertises support for it.
+- CI or presubmit checks should fail when CLI parser/help output, generated reference docs, completions, or the built-in skill are stale relative to the command catalog.
 ## Action classification and permission model
 Agents, scripts, and human developers are expected to be major consumers of `warpctrl`. The action catalog must therefore classify every action by risk posture, state/data category, permission category, and authenticated-user requirement so Warp can enforce local-control permissions in the app bridge.
 Every action definition must include:
@@ -365,8 +392,9 @@ Every action in the catalog belongs to exactly one of the following permission c
 4. **Mutating / metadata or configuration.** Actions that change persistent metadata or configuration but do not directly mutate primary user data.
    - Tab and pane names, tab colors, themes, system-theme settings, font size, zoom, allowlisted app settings, and keybindings.
    Metadata/configuration writes need a stronger permission than app-state-only changes because they persist beyond the current UI interaction, but they are still distinct from data writes.
-5. **Mutating / underlying data.** Actions that can change user data, execute code, or cause external side effects.
-   - Terminal execution: `input run`, workflow execution in a terminal session, and any command execution path.
+5. **Mutating / underlying data.** Actions that can change user data, execute code, submit prompts, or cause external side effects.
+   - Future terminal execution: `input run`, workflow execution in a terminal session, and any command execution path. These are explicitly excluded from the initial public implementation.
+   - Future agent execution: submitting an agent prompt, accepting an agent-proposed command, or otherwise causing an agent to act. These are explicitly excluded from the initial public implementation.
    - File writes: create, write, append, delete, rename, or otherwise modify local files.
    - Warp Drive CRUD: create, update, trash, restore, permanently delete, or otherwise mutate workflows, notebooks, prompts, env-var collections, folders, or other Drive objects.
    - AI conversation history mutation and any action that modifies cloud-backed user content.
@@ -378,6 +406,15 @@ The allowlist must clearly indicate `requires_authenticated_user` for every acti
 - `true` for actions that read or mutate Warp Drive, AI conversation traces, synced settings, team/account data, user identity data, or any cloud-backed Warp state.
 - `true` for actions that execute user-authored Warp Drive content, even if the execution target is a local terminal session.
 If an authenticated-user action is invoked while the selected app has no logged-in user, the CLI reports a structured authenticated-user error. It must not silently return partial logged-out data as success.
+### Warp Control login protocol
+`warpctrl` must not maintain an independent cloud login that can drift from the Warp process it controls. For authenticated-user actions, the logged-in user is the user currently authenticated in the selected Warp app instance.
+The CLI should expose a small auth/status flow for actions that require a logged-in Warp user:
+- `warpctrl auth status [selectors]` reports whether the selected Warp app is logged in and returns a stable, non-secret user subject/identity summary when the caller has the required local-control grant.
+- `warpctrl auth login [selectors]` does not collect credentials in the CLI or mint a separate CLI account session. It focuses or opens the selected Warp app's normal sign-in UI and waits, or exits with instructions, until the user completes sign-in in that app.
+- After login completes, the app-side credential broker may mint an authenticated-user grant only for the same user subject that is currently logged in to the selected app.
+- Authenticated-user credentials are bound to the selected app instance and user subject. If the app logs out, switches users, loses auth state, or the grant's subject no longer matches the selected app's logged-in subject, authenticated-user actions fail with a structured authenticated-user error rather than using stale authority.
+- Raw Firebase, server, OAuth, or cloud API tokens are never exported to `warpctrl`, shell scripts, generated docs, logs, or JSON output.
+This login protocol applies only to actions whose allowlist entry requires a true logged-in Warp user. Logged-out-safe local actions continue to use local-control credentials without requiring Warp account login.
 ### Execution context policy
 `warpctrl` should distinguish verified invocations from inside Warp-managed terminal sessions from external invocations.
 - **Verified Warp-terminal invocation:** a `warpctrl` process started inside a Warp-managed terminal session and able to present an app-issued execution-context proof. The top-level setting for this context should default to on. When the selected app has a logged-in Warp user, this context can receive authenticated-user grants if the user's Scripting permissions allow that grant.
@@ -410,8 +447,9 @@ Scoped credentials should include:
 - issuance and expiry metadata;
 - revocation/audit identity.
 The bridge, not the CLI frontend, enforces these grants. If a request exceeds its credential, the bridge returns `insufficient_permissions`, `authenticated_user_required`, `authenticated_user_unavailable`, or `execution_context_not_allowed` as appropriate.
-### Future entity extensibility: files and Warp Drive objects
-The selector and action model should be designed to accommodate entity types beyond the current window/tab/pane/session hierarchy. Two important future entity families are **local files** and **Warp Drive objects** (workflows, notebooks, environment variables, prompts). Neither is in scope for the first implementation, but the protocol should not preclude them.
+### Future entity extensibility: files, blocks, and Warp Drive objects
+The selector and action model should be designed to accommodate entity types beyond the current window/tab/pane/session hierarchy. Important entity families are **terminal blocks**, **local files**, **projects/workspaces**, and **Warp Drive objects**. Neither broad file/Drive mutation nor command/agent execution is in scope for the first implementation, but the protocol should not preclude future reviewed additions.
+**Terminal blocks.** Blocks are first-class targetable terminal entities, not just data hanging off a session. Block selectors should support the same addressing primitives as terminal sessions where meaningful: active/current block, opaque block ID, and block index scoped to the resolved session. Block reads can expose command text, output, status, timing, exit code, and metadata, so block content reads are underlying-data reads while block listing that returns only IDs/status/timestamps may be metadata reads. Stale, missing, or ambiguous block selectors must fail rather than selecting a neighboring block.
 **Files.** Warp already supports file opening via deep links and the built-in editor. A future `file` namespace could support:
 - `warpctrl file open <path>` — app-state mutation that opens a file in a Warp editor tab, equivalent to clicking a file link.
 - `warpctrl file open <path> --line <n>` — app-state mutation that opens at a specific line.
@@ -419,14 +457,14 @@ The selector and action model should be designed to accommodate entity types bey
 - `warpctrl file read <path>` — underlying data read that returns file contents.
 - `warpctrl file create|write|append|delete <path>` — underlying data mutations that modify the filesystem.
 File selectors would use filesystem paths (absolute or relative to the working directory of the target pane/session). Unlike window/tab/pane selectors, file selectors are not opaque IDs — they are user-visible paths. The protocol should support a `file` field in the target selector that accepts a path string, distinct from the opaque ID selectors used for windows, tabs, and panes.
-**Warp Drive objects.** Warp Drive stores typed objects (workflows, notebooks, environment variable sets, prompts) that users can reference, execute, and share. A future `drive` namespace could support:
+**Warp Drive objects.** Warp Drive stores typed objects that users can reference, execute, edit, and share. The object taxonomy should include, at minimum, spaces, folders, notebooks, workflows, agent-mode workflows/prompts, environment variable collections, AI facts/rules, MCP servers, MCP server collections, and trash entries where trash operations are exposed. A future `drive` namespace could support:
 - `warpctrl drive list --type workflow` — authenticated metadata read that lists Warp Drive objects by type.
 - `warpctrl drive inspect <id>` — authenticated underlying data read when it returns object content.
-- `warpctrl drive workflow run <workflow-id>` — authenticated underlying data mutation that executes a workflow in a target session.
+- `warpctrl drive workflow run <workflow-id>` — future authenticated underlying data mutation that executes a workflow in a target session, excluded from the initial public implementation.
 - `warpctrl drive object create|update|trash|restore <id>` — authenticated underlying data mutations that change cloud-backed user content.
 - `warpctrl drive notebook open <notebook-id>` — app-state mutation that opens a view of an existing notebook without modifying it.
-Drive object selectors should support both opaque IDs (for automation stability) and human-friendly name/path lookups (for interactive use). The type field (`workflow`, `notebook`, `env_var`, `prompt`) acts as a namespace filter. Drive actions that execute content in a terminal session (e.g., running a workflow) inherit the underlying-data-mutation permission from the action classification model.
-**Design constraints for both:**
+Drive object selectors should support both opaque IDs (for automation stability) and human-friendly name/path lookups (for interactive use). The type field (`workflow`, `notebook`, `env_var_collection`, `prompt`, `folder`, `ai_fact`, `mcp_server`, etc.) acts as a namespace filter. Drive actions that execute content in a terminal session (e.g., running a workflow) inherit the underlying-data-mutation permission from the action classification model and remain unavailable until the execution prohibition is lifted by a later spec/review.
+**Design constraints for these future entity families:**
 - File and Drive selectors are orthogonal to the window/tab/pane hierarchy — a file open action targets an instance (which window to open in), not a specific pane. A Drive workflow execution targets a session (which pane to run in).
 - The `TargetSelector` type in the protocol should be extensible with optional fields for these new selector families without breaking existing requests that omit them.
 - The action classification categories apply, and Drive actions require authenticated-user grants by default: listing Drive objects is metadata plus authenticated user, reading Drive object content is underlying-data-read plus authenticated user, opening an existing Drive object in the app is app-state mutation plus authenticated user, and executing or changing a Drive object is underlying-data-mutation plus authenticated user.

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -200,6 +200,14 @@ The protocol and product should support per-caller permission policies keyed to 
   - A "mutate destructive" grant that additionally permits closing targets, injecting input, and executing commands.
 - The permission model should be expressible in the protocol (e.g., a capability or scope field in the authentication material) so that the app bridge can enforce it server-side, not just client-side.
 - When an agent attempts an action above its granted tier, the bridge should return a structured `insufficient_permissions` error that identifies the required tier, rather than silently downgrading or returning a generic failure.
+### Scoped credentials and caller identity
+The local discovery bearer token is not sufficient for differentiated human vs. agent permissions. If the same full-access token is readable by both humans and agents, the server cannot enforce agent-specific read-only defaults. Before agent-facing read/write or destructive actions ship, the product must introduce scoped credentials.
+- The discovery record may expose a human CLI credential for same-user interactive use, but agent runtimes should not receive that full-access credential by default.
+- Agent callers should receive a separate scoped credential minted by Warp or by a trusted local broker. The credential must identify the caller class (`human`, `local_agent`, `cloud_agent`, `third_party_automation`) and granted permission tiers.
+- Scoped credentials should be bound to a specific Warp instance, protocol version, issued-at time, optional expiry time, and allowed action tiers. The bridge must validate those fields before action dispatch.
+- The bridge, not the CLI frontend, enforces permission tiers by mapping every `ActionKind` to a required tier and comparing that tier to the credential's grants.
+- If a process presents the human discovery credential, the bridge treats it as human interactive use. If a process presents an agent credential, the bridge applies the agent policy even if the process runs under the same local user account.
+- The first implementation slice may ship a same-user human credential only because it implements discovery and `tab create`; any slice that exposes terminal data, input mutation, command execution, or other agent-consumable automation must add scoped credential issuance first.
 ### Future entity extensibility: files and Warp Drive objects
 The selector and action model should be designed to accommodate entity types beyond the current window/tab/pane/session hierarchy. Two important future entity families are **local files** and **Warp Drive objects** (workflows, notebooks, environment variables, prompts). Neither is in scope for the first implementation, but the protocol should not preclude them.
 **Files.** Warp already supports file opening via deep links and the built-in editor. A future `file` namespace could support:

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -173,6 +173,7 @@ Every action definition must include:
 - a risk tier;
 - whether a true logged-in Warp user is required;
 - whether the action may run from external clients, verified Warp-terminal clients, or both;
+- whether inside-Warp and outside-Warp scripting settings can enable the action;
 - the required local-control permission category;
 - any target-scope restrictions.
 By default, new actions require an authenticated Warp user. An action may be marked logged-out-safe only after deliberate review confirms it does not touch Warp Drive, AI conversation traces, synced settings, team/account data, cloud-backed user state, terminal content, or other user-sensitive data.
@@ -182,7 +183,7 @@ Every action in the catalog belongs to exactly one of the following tiers, from 
    - Instance discovery and health: `instance list`, `app active`, `app version`, `app ping`.
    - Layout enumeration: `window list`, `tab list`, `pane list`, `session list`.
    - Appearance reads that return local configuration values but not user data: `theme list`, selected `setting get` actions for logged-out-safe local settings.
-   These are the primary default actions for external clients.
+   These are the primary initial actions for external clients after outside-Warp control is explicitly enabled.
 2. **Read-only / terminal data.** Actions that return content from terminal sessions, command history, pane output buffers, input editor state, session replay, or terminal-derived traces.
    - Reading pane output or scrollback content.
    - Reading the current input buffer contents.
@@ -209,11 +210,16 @@ The allowlist must clearly indicate `requires_authenticated_user` for every acti
 If an authenticated-user action is invoked while the selected app has no logged-in user, the CLI reports a structured authenticated-user error. It must not silently return partial logged-out data as success.
 ### Execution context policy
 `warpctrl` should distinguish verified invocations from inside Warp-managed terminal sessions from external invocations.
-- **External invocation:** a `warpctrl` process started outside Warp's terminal. By default, it can receive only the smaller logged-out-safe local action set that does not touch user-authenticated data. Higher tiers require explicit local-control settings or approvals.
-- **Verified Warp-terminal invocation:** a `warpctrl` process started inside a Warp-managed terminal session and able to present an app-issued execution-context proof. When the selected app has a logged-in Warp user, this context can receive authenticated-user grants if the user enabled that permission.
+- **Verified Warp-terminal invocation:** a `warpctrl` process started inside a Warp-managed terminal session and able to present an app-issued execution-context proof. The top-level setting for this context should default to on. When the selected app has a logged-in Warp user, this context can receive authenticated-user grants if the user's Scripting permissions allow that grant.
+- **External invocation:** a `warpctrl` process started outside Warp's terminal, such as from another terminal app, launch agent, IDE, or background script. The top-level setting for this context must default to off. When disabled, external invocations receive no local-control credentials, including logged-out-safe metadata credentials.
 - The app must not trust a caller-declared label. Environment variables may help discover the context, but the broker must verify a session-bound capability or equivalent proof before issuing in-Warp-only grants.
+### Settings surface
+Warp should add a new top-level Settings pane page named **Scripting**. This page should own settings for local scripting and automation surfaces, including Warp control. For Warp control, it should include two top-level toggles:
+- **Allow Warp control from inside Warp:** default on. Controls `warpctrl` invocations from verified Warp-managed terminal sessions.
+- **Allow Warp control from outside Warp:** default off. Controls `warpctrl` invocations from external terminals, scripts, IDEs, launch agents, and other same-user processes.
+The Scripting page should explain that inside-Warp control is scoped to commands launched from Warp-managed terminals, while outside-Warp control allows other local apps and scripts to talk to Warp's control plane. Disabling either top-level toggle should invalidate credentials for that invocation context.
 ### Granular local-control permissions
-The product settings surface should expose granular permissions under the default-off local-control setting. Recommended controls:
+The Scripting settings page should expose granular permissions beneath the inside-Warp and outside-Warp toggles. Recommended controls:
 - Allow local read-only metadata.
 - Allow terminal data reads.
 - Allow non-destructive local mutations.

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -166,41 +166,192 @@ Non-goals:
    The first slice should include the minimum health/introspection commands needed to discover a running instance and exercise `tab.create`.
 34. Follow-up PRs should fill out the remaining catalog in parallelizable groups once the protocol, discovery model, target resolution, error model, `tab.create` action path, and standalone `warpctrl` packaging shape have been validated by the first slice.
 35. The protocol transport should be designed so that the default target is localhost but the CLI can be extended in the future to target remote URLs (e.g., a Warp instance on another machine or a hosted control endpoint). This is not in scope for the first implementation but should not be precluded by the architecture.
+## API command surface
+The public `warpctrl` API is organized around nouns that map to stable user-facing entities. Command names are intentionally not a dump of every internal `WorkspaceAction`, `TerminalAction`, keybinding, or command-palette binding. Internal actions inform the catalog, but a command is added only when it has a stable user-facing behavior, typed parameters, deterministic target resolution, and an explicit risk classification.
+### State and data taxonomy
+The product surface must distinguish what kind of state a command touches. This distinction is part of the public API and the permission model, not just an implementation detail.
+- **Metadata reads** inspect app structure or configuration metadata without exposing user content: instances, windows, tabs, panes, sessions, capability metadata, action metadata, keybinding metadata, theme names, setting keys, current project identity, and other structural state.
+- **Underlying data reads** expose user content or data-bearing state without changing it: terminal output, block contents, command history, input buffer contents, file contents, Warp Drive object contents, AI conversation content, and any other content that could contain user data or secrets.
+- **App-state mutations** change visible local Warp UI state without directly changing user data: opening or focusing windows, creating or closing tabs, splitting panes, focusing panes, opening panels, opening command surfaces, opening files in Warp, and editing the input buffer without submitting it.
+- **Metadata/configuration mutations** change persistent configuration or metadata, but not primary user content: changing themes, font size, zoom, allowlisted settings, keybindings, tab names, pane names, and tab colors.
+- **Underlying data mutations** can change user data or cause external side effects: executing terminal commands, writing/creating/deleting files, running workflows that execute commands, CRUD operations on Warp Drive objects, mutating AI conversation history, and any action that can modify data outside transient app UI state.
+A command that touches multiple categories must require the strongest applicable permission. For example, `file open` is an app-state mutation, while `file write` is an underlying data mutation; `input insert` is an app-state mutation, while `input run` is an underlying data mutation because it executes a command in the target session.
+### Targeting flags
+All commands that address a running app target accept the same selector flags where meaningful:
+- `--instance <instance_id>` selects a running Warp process from `warpctrl instance list`.
+- `--pid <pid>` is a convenience instance selector and conflicts with `--instance`.
+- `--window <active|id|index|title>` selects a window inside the instance.
+- `--tab <active|id|index|title>` selects a tab inside the window.
+- `--pane <active|id|index>` selects a pane inside the tab or pane-group context.
+- `--session <active|id>` selects a terminal or agent session inside the pane when the command is session-scoped.
+- `--output-format <pretty|json|ndjson|text>` controls output shape and remains globally available.
+Omitted lower-level selectors use active defaults only when that active target is unambiguous. Explicit IDs must resolve exactly or fail with `stale_target`.
+### Read-only command set
+The read-only branch `zach/warp-cli-readonly` should implement the following commands before mutating catalog expansion begins. Read-only does not mean one permission: metadata reads and underlying data reads are separate grant categories.
+Metadata and capability reads:
+- `warpctrl instance list`
+- `warpctrl instance inspect [--instance <id>|--pid <pid>]`
+- `warpctrl app ping [selectors]`
+- `warpctrl app version [selectors]`
+- `warpctrl app active [selectors]`
+- `warpctrl capability list [selectors]`
+- `warpctrl capability inspect <action> [selectors]`
+Window, tab, pane, and session reads:
+- `warpctrl window list [selectors]`
+- `warpctrl window inspect [--window <selector>] [selectors]`
+- `warpctrl tab list [--window <selector>] [selectors]`
+- `warpctrl tab inspect [--tab <selector>] [selectors]`
+- `warpctrl pane list [--tab <selector>] [selectors]`
+- `warpctrl pane inspect [--pane <selector>] [selectors]`
+- `warpctrl session list [--pane <selector>] [selectors]`
+- `warpctrl session inspect [--session <selector>] [selectors]`
+Underlying data reads, gated separately from structural metadata reads:
+- `warpctrl block list [--pane <selector>] [--limit <n>] [selectors]`
+- `warpctrl block inspect <block_id> [selectors]`
+- `warpctrl block output <block_id> [--plain|--ansi|--json] [selectors]`
+- `warpctrl input get [--session <selector>] [selectors]`
+- `warpctrl history list [--session <selector>] [--limit <n>] [selectors]`
+Appearance, settings, and command-surface reads:
+- `warpctrl theme list [selectors]`
+- `warpctrl theme get [selectors]`
+- `warpctrl appearance get [selectors]`
+- `warpctrl setting list [--namespace <namespace>] [selectors]`
+- `warpctrl setting get <key> [selectors]`
+- `warpctrl keybinding list [selectors]`
+- `warpctrl keybinding get <binding_name> [selectors]`
+- `warpctrl action list [selectors]`
+- `warpctrl action inspect <action> [selectors]`
+Local file and project reads that expose only app/editor state, not arbitrary filesystem traversal:
+- `warpctrl file list [selectors]`
+- `warpctrl project active [selectors]`
+- `warpctrl project list [selectors]`
+Authenticated read-only Warp Drive metadata and data reads, enabled only when the selected app has a logged-in Warp user and the grant allows authenticated reads. Listing is metadata; inspecting object content is an underlying data read:
+- `warpctrl drive list --type <workflow|notebook|env-var-collection|prompt|folder> [selectors]`
+- `warpctrl drive inspect <id> [selectors]`
+### Mutating command set
+The stacked branch `zach/warp-cli-read-write` should build on `zach/warp-cli-readonly` and implement the following mutating commands. Mutating commands are split by what they mutate: app-state, metadata/configuration, or underlying data. Underlying data mutations require a separate and stronger permission than app-state or metadata/configuration mutations.
+App-state mutations for app, window, and surfaces:
+- `warpctrl app focus [selectors]`
+- `warpctrl window create [--shell <name>] [selectors]`
+- `warpctrl window focus --window <selector> [selectors]`
+- `warpctrl window close --window <selector> [selectors]`
+- `warpctrl surface settings open [--page <page>] [--query <query>] [selectors]`
+- `warpctrl surface command-palette open [--query <query>] [selectors]`
+- `warpctrl surface command-search open [--query <query>] [selectors]`
+- `warpctrl surface warp-drive open [selectors]`
+- `warpctrl surface warp-drive toggle [selectors]`
+- `warpctrl surface resource-center toggle [selectors]`
+- `warpctrl surface ai-assistant toggle [selectors]`
+- `warpctrl surface code-review toggle [selectors]`
+- `warpctrl surface left-panel toggle [selectors]`
+- `warpctrl surface right-panel toggle [selectors]`
+- `warpctrl surface vertical-tabs toggle [selectors]`
+App-state mutations for tabs:
+- `warpctrl tab create [--type terminal|agent|cloud-agent|default] [--shell <name>] [selectors]`
+- `warpctrl tab activate --tab <selector> [selectors]`
+- `warpctrl tab activate --previous [selectors]`
+- `warpctrl tab activate --next [selectors]`
+- `warpctrl tab activate --last [selectors]`
+- `warpctrl tab move --tab <selector> --direction <left|right> [selectors]`
+- `warpctrl tab close --tab <selector> [selectors]`
+- `warpctrl tab close --active [selectors]`
+- `warpctrl tab close --others --tab <selector> [selectors]`
+- `warpctrl tab close --right-of --tab <selector> [selectors]`
+Metadata mutations for tabs:
+- `warpctrl tab rename --tab <selector> <title> [selectors]`
+- `warpctrl tab reset-name --tab <selector> [selectors]`
+- `warpctrl tab color set --tab <selector> <color> [selectors]`
+- `warpctrl tab color clear --tab <selector> [selectors]`
+App-state mutations for panes:
+- `warpctrl pane split --direction <left|right|up|down> [--shell <name>] [selectors]`
+- `warpctrl pane focus --pane <selector> [selectors]`
+- `warpctrl pane navigate --direction <left|right|up|down|previous|next> [selectors]`
+- `warpctrl pane resize --direction <left|right|up|down> [--amount <cells>] [selectors]`
+- `warpctrl pane maximize [--pane <selector>] [selectors]`
+- `warpctrl pane unmaximize [selectors]`
+- `warpctrl pane close --pane <selector> [selectors]`
+Metadata mutations for panes:
+- `warpctrl pane rename --pane <selector> <title> [selectors]`
+- `warpctrl pane reset-name --pane <selector> [selectors]`
+App-state mutations for sessions and input buffers:
+- `warpctrl session activate --session <selector> [selectors]`
+- `warpctrl session previous [selectors]`
+- `warpctrl session next [selectors]`
+- `warpctrl session reopen-closed [selectors]`
+- `warpctrl input insert <text> [--session <selector>] [selectors]`
+- `warpctrl input replace <text> [--session <selector>] [selectors]`
+- `warpctrl input clear [--session <selector>] [selectors]`
+- `warpctrl input mode set <terminal|agent> [--session <selector>] [selectors]`
+Underlying data mutations for terminal execution:
+- `warpctrl input run <command> [--session <selector>] [selectors]`
+Metadata/configuration mutations for appearance and settings:
+- `warpctrl theme set <theme_name> [selectors]`
+- `warpctrl theme system set <true|false> [selectors]`
+- `warpctrl theme light set <theme_name> [selectors]`
+- `warpctrl theme dark set <theme_name> [selectors]`
+- `warpctrl appearance font-size increase [selectors]`
+- `warpctrl appearance font-size decrease [selectors]`
+- `warpctrl appearance font-size reset [selectors]`
+- `warpctrl appearance zoom increase [selectors]`
+- `warpctrl appearance zoom decrease [selectors]`
+- `warpctrl appearance zoom reset [selectors]`
+- `warpctrl setting set <key> <value> [selectors]`
+- `warpctrl setting toggle <key> [selectors]`
+App-state mutations for files, projects, and Warp Drive views:
+- `warpctrl file open <path> [--line <line>] [--column <column>] [--new-tab] [selectors]`
+- `warpctrl project open <path> [selectors]`
+- `warpctrl drive open <id> [selectors]`
+- `warpctrl drive notebook open <id> [selectors]`
+- `warpctrl drive env-var-collection open <id> [selectors]`
+Underlying data mutations for files and authenticated Warp Drive objects:
+- `warpctrl file create <path> [--content <text>] [selectors]`
+- `warpctrl file write <path> --content <text> [selectors]`
+- `warpctrl file append <path> --content <text> [selectors]`
+- `warpctrl file delete <path> [selectors]`
+- `warpctrl drive workflow run <id> [--arg <name=value>...] [selectors]`
+- `warpctrl drive object create --type <workflow|notebook|env-var-collection|prompt|folder> [selectors]`
+- `warpctrl drive object update <id> [selectors]`
+- `warpctrl drive object trash <id> [selectors]`
+- `warpctrl drive object restore <id> [selectors]`
+### Excluded from the public command surface
+The command surface must continue to exclude debug-only, crash-only, auth-token, heap-dump, and arbitrary internal dispatch actions even when those actions are available in command palette or keybinding registries. Examples that remain excluded are app crash/panic helpers, access-token copy helpers, heap profile dumps, debug reset actions, raw view-tree debugging, and broad internal action-by-string execution.
+## Built-in Warp Agent skill
+Warp should include a built-in Agent skill for `warpctrl`, analogous to the bundled `oz-platform` skill. The skill should teach Warp Agent when to use `warpctrl`, how to discover and target running instances, how to prefer read-only commands before mutating commands, how to request explicit user approval for underlying data mutations, and how to interpret structured errors. The skill should document the stable command hierarchy above, include concise recipes for common automation tasks, and avoid instructing agents to bypass the CLI by calling local-control HTTP endpoints directly.
 ## Action classification and permission model
-Agents, scripts, and human developers are expected to be major consumers of `warpctrl`. The action catalog must therefore classify every action by both risk tier and authenticated-user requirement so Warp can enforce local-control permissions in the app bridge.
+Agents, scripts, and human developers are expected to be major consumers of `warpctrl`. The action catalog must therefore classify every action by risk posture, state/data category, permission category, and authenticated-user requirement so Warp can enforce local-control permissions in the app bridge.
 Every action definition must include:
 - a stable action name and namespace;
-- a risk tier;
+- a risk posture;
+- a state/data category: metadata read, underlying data read, app-state mutation, metadata/configuration mutation, or underlying data mutation;
 - whether a true logged-in Warp user is required;
 - whether the action may run from external clients, verified Warp-terminal clients, or both;
 - whether inside-Warp and outside-Warp scripting settings can enable the action;
 - the required local-control permission category;
 - any target-scope restrictions.
 By default, new actions require an authenticated Warp user. An action may be marked logged-out-safe only after deliberate review confirms it does not touch Warp Drive, AI conversation traces, synced settings, team/account data, cloud-backed user state, terminal content, or other user-sensitive data.
-### Classification tiers
-Every action in the catalog belongs to exactly one of the following tiers, from least to most sensitive:
-1. **Read-only / metadata.** Actions that return local app structure or configuration without exposing terminal content or user-authenticated data.
+### Permission categories
+Every action in the catalog belongs to exactly one of the following permission categories, from least to most sensitive:
+1. **Read-only / metadata.** Actions that return local app structure, app state, or configuration metadata without exposing terminal content, file content, Warp Drive object content, AI conversation content, or other user data.
    - Instance discovery and health: `instance list`, `app active`, `app version`, `app ping`.
    - Layout enumeration: `window list`, `tab list`, `pane list`, `session list`.
-   - Appearance reads that return local configuration values but not user data: `theme list`, selected `setting get` actions for logged-out-safe local settings.
-   These are the primary initial actions for external clients after outside-Warp control is explicitly enabled.
-2. **Read-only / terminal data.** Actions that return content from terminal sessions, command history, pane output buffers, input editor state, session replay, or terminal-derived traces.
-   - Reading pane output or scrollback content.
-   - Reading the current input buffer contents.
-   - Reading command history or session replay data.
-   Even though these are read-only, they cross a privacy boundary that metadata reads do not.
-3. **Mutating / non-destructive.** Actions that change app state in visible, reversible, or low-risk ways without executing terminal content or destroying user state.
-   - Layout mutations: `tab create`, `tab activate`, `tab move`, `tab rename`, `window create`, `window focus`, `pane split`, `pane focus`, `pane navigate`, `pane maximize`, `pane resize`.
-   - Appearance mutations: `theme set`, `font-size increase/decrease/reset`, `zoom increase/decrease/reset`.
-   - Settings writes for allowlisted non-destructive local settings.
-   - Panel/surface toggles where they do not expose authenticated user data.
-4. **Mutating / destructive or high-risk.** Actions that destroy user state, close active work, inject terminal input, execute commands, or execute user-authored content.
-   - Closing targets: `tab close`, `window close`, `pane close`.
-   - Terminal input injection: `input insert`, `input replace`, `input clear`.
-   - Command execution in a session.
-   - Input mode switching between terminal and agent modes.
-   - Executing Warp Drive workflows or notebooks in a terminal session.
-   Any action that can cause data loss or execute arbitrary code belongs here regardless of how simple the API looks.
+   - Metadata reads: `theme list`, `setting list`, `keybinding list`, `action list`, `project active`, and Drive object listing that returns object IDs/names/types but not content.
+2. **Read-only / underlying data.** Actions that return user content or data-bearing state without changing it.
+   - Terminal reads: block output, scrollback, command history, input editor contents, session replay, or terminal-derived traces.
+   - File reads, Warp Drive object content reads, AI conversation reads, and any authenticated-user data read.
+   This category is separate from metadata because read-only content can contain secrets, source code, customer data, command output, or other sensitive data.
+3. **Mutating / app state.** Actions that change visible local Warp UI state without directly changing underlying user data.
+   - Layout and focus: `window create`, `window focus`, `tab create`, `tab activate`, `tab move`, `window close`, `tab close`, `pane split`, `pane focus`, `pane navigate`, `pane maximize`, `pane resize`, and panel/surface toggles.
+   - Input-buffer staging: `input insert`, `input replace`, and `input clear` as long as they do not submit or execute the buffer.
+   - Opening views: opening settings, command palette, command search, Warp Drive, code review, files, projects, notebooks, and env-var collections.
+4. **Mutating / metadata or configuration.** Actions that change persistent metadata or configuration but do not directly mutate primary user data.
+   - Tab and pane names, tab colors, themes, system-theme settings, font size, zoom, allowlisted app settings, and keybindings.
+   Metadata/configuration writes need a stronger permission than app-state-only changes because they persist beyond the current UI interaction, but they are still distinct from data writes.
+5. **Mutating / underlying data.** Actions that can change user data, execute code, or cause external side effects.
+   - Terminal execution: `input run`, workflow execution in a terminal session, and any command execution path.
+   - File writes: create, write, append, delete, rename, or otherwise modify local files.
+   - Warp Drive CRUD: create, update, trash, restore, permanently delete, or otherwise mutate workflows, notebooks, prompts, env-var collections, folders, or other Drive objects.
+   - AI conversation history mutation and any action that modifies cloud-backed user content.
+   This category must be explicitly separate from app-state mutation. A client allowed to open or focus Warp UI must not automatically be allowed to execute commands, write files, or mutate Warp Drive content.
 ### Authenticated-user requirement
 An authenticated user means a true logged-in Warp user in the selected Warp app, not merely the local OS user or a `warpctrl` process authenticated to localhost.
 The allowlist must clearly indicate `requires_authenticated_user` for every action:
@@ -220,18 +371,19 @@ Warp should add a new top-level Settings pane page named **Scripting**. This pag
 The Scripting page should explain that inside-Warp control is scoped to commands launched from Warp-managed terminals, while outside-Warp control allows other local apps and scripts to talk to Warp's control plane. Disabling either top-level toggle should invalidate credentials for that invocation context.
 ### Granular local-control permissions
 The Scripting settings page should expose granular permissions beneath the inside-Warp and outside-Warp toggles. Recommended controls:
-- Allow local read-only metadata.
-- Allow terminal data reads.
-- Allow non-destructive local mutations.
-- Allow destructive or execution actions.
+- Allow metadata reads.
+- Allow underlying data reads.
+- Allow app-state mutations.
+- Allow metadata/configuration mutations.
+- Allow underlying data mutations.
 - Allow authenticated-user actions from verified Warp terminals.
 - Allow authenticated-user actions from external clients, default off and separate from the in-Warp permission.
-These settings define the maximum grants the broker may issue. The app bridge still enforces the action's risk tier, authenticated-user requirement, execution-context requirement, and target scope for every request.
+These settings define the maximum grants the broker may issue. The app bridge still enforces the action's risk posture, state/data category, authenticated-user requirement, execution-context requirement, and target scope for every request. Enabling app-state mutation must not imply permission to mutate underlying data.
 ### Scoped credentials
 The local discovery record must not expose a reusable full-access credential. `warpctrl` should request scoped credentials from an app-owned broker or equivalent trusted path.
 Scoped credentials should include:
 - the selected Warp instance;
-- granted risk tiers;
+- granted permission categories;
 - allowed action families;
 - verified execution context;
 - whether authenticated-user access is granted and for which logged-in user subject;
@@ -242,25 +394,28 @@ The bridge, not the CLI frontend, enforces these grants. If a request exceeds it
 ### Future entity extensibility: files and Warp Drive objects
 The selector and action model should be designed to accommodate entity types beyond the current window/tab/pane/session hierarchy. Two important future entity families are **local files** and **Warp Drive objects** (workflows, notebooks, environment variables, prompts). Neither is in scope for the first implementation, but the protocol should not preclude them.
 **Files.** Warp already supports file opening via deep links and the built-in editor. A future `file` namespace could support:
-- `warpctrl file open <path>` — open a file in a Warp editor tab, equivalent to clicking a file link.
-- `warpctrl file open <path> --line <n>` — open at a specific line.
-- `warpctrl file list` — list files currently open in editor tabs across the instance.
+- `warpctrl file open <path>` — app-state mutation that opens a file in a Warp editor tab, equivalent to clicking a file link.
+- `warpctrl file open <path> --line <n>` — app-state mutation that opens at a specific line.
+- `warpctrl file list` — metadata read that lists files currently open in editor tabs across the instance.
+- `warpctrl file read <path>` — underlying data read that returns file contents.
+- `warpctrl file create|write|append|delete <path>` — underlying data mutations that modify the filesystem.
 File selectors would use filesystem paths (absolute or relative to the working directory of the target pane/session). Unlike window/tab/pane selectors, file selectors are not opaque IDs — they are user-visible paths. The protocol should support a `file` field in the target selector that accepts a path string, distinct from the opaque ID selectors used for windows, tabs, and panes.
 **Warp Drive objects.** Warp Drive stores typed objects (workflows, notebooks, environment variable sets, prompts) that users can reference, execute, and share. A future `drive` namespace could support:
-- `warpctrl drive list --type workflow` — list Warp Drive objects by type.
-- `warpctrl drive get <id>` — retrieve a specific Drive object by its opaque ID or by name/path.
-- `warpctrl drive run <workflow-id>` — execute a workflow in a target session, equivalent to invoking it from the command palette.
-- `warpctrl drive insert <notebook-id>` — insert a notebook's runnable commands into the active input.
-Drive object selectors should support both opaque IDs (for automation stability) and human-friendly name/path lookups (for interactive use). The type field (`workflow`, `notebook`, `env_var`, `prompt`) acts as a namespace filter. Drive actions that execute content in a terminal session (e.g., running a workflow) inherit the destructive/high-risk tier from the action classification model.
+- `warpctrl drive list --type workflow` — authenticated metadata read that lists Warp Drive objects by type.
+- `warpctrl drive inspect <id>` — authenticated underlying data read when it returns object content.
+- `warpctrl drive workflow run <workflow-id>` — authenticated underlying data mutation that executes a workflow in a target session.
+- `warpctrl drive object create|update|trash|restore <id>` — authenticated underlying data mutations that change cloud-backed user content.
+- `warpctrl drive notebook open <notebook-id>` — app-state mutation that opens a view of an existing notebook without modifying it.
+Drive object selectors should support both opaque IDs (for automation stability) and human-friendly name/path lookups (for interactive use). The type field (`workflow`, `notebook`, `env_var`, `prompt`) acts as a namespace filter. Drive actions that execute content in a terminal session (e.g., running a workflow) inherit the underlying-data-mutation permission from the action classification model.
 **Design constraints for both:**
 - File and Drive selectors are orthogonal to the window/tab/pane hierarchy — a file open action targets an instance (which window to open in), not a specific pane. A Drive workflow execution targets a session (which pane to run in).
 - The `TargetSelector` type in the protocol should be extensible with optional fields for these new selector families without breaking existing requests that omit them.
-- The action classification tiers apply, and Drive actions require authenticated-user grants by default: listing Drive objects is tier 1 metadata plus authenticated user, reading Drive object content is tier 1 or 2 depending on whether it contains user data plus authenticated user, and executing a Drive workflow is tier 4 plus authenticated user.
+- The action classification categories apply, and Drive actions require authenticated-user grants by default: listing Drive objects is metadata plus authenticated user, reading Drive object content is underlying-data-read plus authenticated user, opening an existing Drive object in the app is app-state mutation plus authenticated user, and executing or changing a Drive object is underlying-data-mutation plus authenticated user.
 ### Settings: protocol-first
 Settings reads and writes should go through the local-control protocol like other actions, not bypass it via direct file manipulation.
 - `warpctrl setting get <key>`, `warpctrl setting set <key> <value>`, and `warpctrl setting toggle <key>` send requests to the running Warp instance through the standard authenticated control endpoint.
 - The app bridge validates the key against the allowlist and the value against the expected type before applying the change.
-- This keeps authorization enforcement consistent: the same permission tier, execution-context, and authenticated-user policies apply to settings mutations as to any other action, rather than creating a second unguarded path through the filesystem.
+- This keeps authorization enforcement consistent: the same permission category, execution-context, and authenticated-user policies apply to settings mutations as to any other action, rather than creating a second unguarded path through the filesystem.
 - The app owns the write to the settings file and any side effects (e.g., theme reload, layout reflow) as a single atomic operation, avoiding races between a CLI file write and the app's file watcher.
 - If a future need arises for offline settings manipulation (no running Warp process), a separate file-based path can be added later with its own validation, but it should not be the default.
-- The action classification still applies: settings reads are tier 1 (metadata), settings writes are tier 3 (non-destructive mutation).
+- The action classification still applies: settings reads are metadata reads, and settings writes are metadata/configuration mutations. Settings writes must not be authorized by app-state mutation permission alone.

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -1,0 +1,227 @@
+# Summary
+Warp should ship an allowlisted standalone local control CLI binary, provisionally named `warpctrl`, that lets developers script the same classes of user-visible actions they can already perform inside the running app: manipulating windows, tabs, panes, sessions, appearance, settings, and selected UI surfaces. The CLI should operate against one or more already-running local Warp app processes through a stable machine protocol, with deterministic target selection and clear errors when a process or target is ambiguous.
+## Problem
+Warp already has rich interactive actions, but they are primarily reachable through UI, keybindings, menus, or deeplinks. Developers cannot reliably compose those same actions into shell scripts, demos, automation, or agent workflows, and there is no general local protocol for addressing a specific running Warp instance, window, pane, or session.
+## Goals / Non-goals
+Goals:
+- Provide a first-class, scriptable standalone `warpctrl` binary for controlling running Warp app processes.
+- Keep CLI startup lightweight by avoiding GUI-app startup or full terminal initialization for routine control commands.
+- Keep the surface allowlisted and finite instead of exposing arbitrary internal actions.
+- Make targeting explicit and deterministic across multiple Warp processes, windows, tabs, panes, and sessions.
+- Support both ergonomic active-target defaults and precise selectors for automation.
+- Define a complete protocol/catalog up front, while shipping the implementation incrementally.
+Non-goals:
+- Replacing the Oz CLI or mixing cloud-agent management into this CLI.
+- Exposing every internal app action, debug action, developer-only helper, or privileged state mutation.
+- Treating the CLI as a general RPC escape hatch into Warp internals.
+- Requiring developers or automation to spawn the Warp GUI executable in CLI mode for ordinary control commands.
+- Requiring the first implementation slice to ship every action in the catalog.
+## Behavior
+1. The Warp control CLI operates only on running local Warp app processes. If no compatible Warp process is available, the CLI exits non-zero with a clear “no running Warp instance found” error.
+2. The CLI exposes only explicitly allowlisted actions. Unknown action names, unsupported parameter combinations, or requests for non-allowlisted capabilities fail with structured errors; they are never forwarded to arbitrary internal dispatch.
+3. Every successful mutating request identifies:
+   - The Warp process instance that executed it.
+   - The resolved target, when the action addresses a window, tab, pane, or session.
+   - A success payload suitable for JSON output.
+4. Every failure identifies:
+   - A stable machine-readable error code.
+   - A human-readable explanation.
+   - Any selector that was ambiguous, missing, stale, unsupported, or invalid.
+5. The CLI supports human-readable output by default and JSON output for scripts. JSON output has stable field names and is available for discovery commands, read commands, successful mutations, and failures.
+6. The CLI supports process discovery and instance selection:
+   - `warpctrl instance list` returns all reachable local Warp app processes that support the protocol.
+   - Each process has an opaque `instance_id`, a channel/build identity, and enough display metadata for a developer to choose it.
+   - If exactly one compatible process is available, commands may target it implicitly.
+   - If multiple compatible processes are available, the CLI may select a single clearly active/frontmost instance when that state is unambiguous; otherwise it fails and asks the developer to pass an explicit instance selector.
+   - Developers can explicitly choose an instance by opaque instance ID. Channel or PID filters may be offered as convenience filters, but opaque instance ID is the canonical selector.
+7. The CLI supports introspection for target discovery:
+   - `warpctrl window list`
+   - `warpctrl tab list`
+   - `warpctrl pane list`
+   - `warpctrl session list`
+   - `warpctrl app active`
+   These commands return opaque protocol-facing IDs and enough metadata for subsequent commands without requiring knowledge of internal Warp identifiers.
+8. The target selector model is hierarchical:
+   - Instance selector resolves a running Warp process.
+   - Window selector resolves within the instance.
+   - Tab selector resolves within the window.
+   - Pane selector resolves within the tab or active pane group context.
+   - Session selector resolves within the pane when the pane hosts terminal session state.
+9. Every selector family supports an ergonomic `active` form when that concept exists:
+   - Active instance, if unambiguous.
+   - Active window in the selected instance.
+   - Active tab in the selected window.
+   - Active pane in the selected tab.
+   - Active session in the selected pane.
+10. Every selector family supports explicit opaque IDs returned by introspection. Tabs may also support index selectors where index-based workflows are already user-visible, but IDs remain the preferred automation surface.
+11. “Active session” means the currently selected terminal session for the resolved pane/window context. If the selected target does not contain a terminal session, session-scoped actions fail rather than silently redirecting elsewhere.
+12. When a command omits lower-level selectors, it resolves them from the chosen higher-level context using active defaults. Example: a pane split command with only `--instance` uses that instance’s active window, active tab, and active pane.
+13. When an explicitly supplied target disappears between discovery and execution, the request fails with a stale-target error. The CLI must not silently choose a different tab, pane, or session.
+14. The protocol is command-oriented, not open-ended state mutation. Each action has a named command, validated parameters, and defined target scope.
+15. The complete allowlisted action catalog should be organized into these namespaces.
+16. Discovery and read-only state actions:
+   - List instances.
+   - Get protocol/app version information for one instance.
+   - List windows, tabs, panes, and sessions.
+   - Get the currently active instance/window/tab/pane/session chain when available.
+   - Inspect enough target metadata to let a script decide what to address next.
+17. Window actions:
+   - Create a new window.
+   - Focus a target window.
+   - Close a target window.
+18. Tab actions:
+   - Create a new terminal tab.
+   - Create a new agent tab where that is already a user-visible app capability.
+   - Activate a target tab.
+   - Activate previous, next, or last tab.
+   - Move a target tab left or right.
+   - Rename or reset a tab title.
+   - Set or clear active-tab color where that is already supported in the UI.
+   - Close the active tab, a target tab, other tabs, or tabs to the right of a target tab.
+19. Pane actions:
+   - Split a target pane left, right, up, or down.
+   - Optionally choose the shell/session profile for split operations when that already maps to user-facing behavior.
+   - Focus a target pane.
+   - Navigate focus left, right, up, or down among panes.
+   - Close a target pane.
+   - Toggle maximize for a target pane.
+   - Resize pane dividers left, right, up, or down when that is supported by the app.
+20. Session and terminal-input actions:
+   - Cycle to the previous or next session where the app exposes session cycling.
+   - Insert text into the active input without executing it.
+   - Replace the active input buffer.
+   - Clear the active input buffer where that matches existing user behavior.
+   - Run a command in the target session where the app already supports user-triggered command execution.
+   - Switch input mode between terminal and agent modes only where that mode switch is already user-visible and valid for the selected target.
+   These commands are part of the protocol catalog, but command execution should be treated as a higher-risk mutating action with explicit confirmation in spec/review before rollout.
+21. Appearance actions:
+   - List available themes.
+   - Set the current fixed theme.
+   - Toggle or set “follow system theme.”
+   - Set the light and dark themes used when following the system theme.
+   - Increase, decrease, or reset font size.
+   - Increase, decrease, or reset UI zoom.
+   - Set other allowlisted appearance controls only when they correspond to stable user-facing controls.
+22. Settings actions:
+   - Read allowlisted user-facing settings.
+   - Set allowlisted settings to validated values.
+   - Toggle allowlisted boolean settings.
+   - Reject attempts to mutate private, debug-only, unsafe, derived, or unsupported settings.
+   - Return a stable error when a named setting exists internally but is not part of the public local-control allowlist.
+23. The settings allowlist should initially cover settings families that are already plainly user-facing and valuable for scripting:
+   - Theme/system-theme configuration.
+   - Font/zoom-related controls.
+   - Notifications.
+   - Syntax highlighting and error-underlining toggles.
+   - Accessibility verbosity where exposed to users.
+   - Selected panel/layout toggles when the user-facing behavior is already stable.
+   Additional settings families can be added only by extending the allowlist.
+24. Panel and surface actions:
+   - Open the general settings surface.
+   - Open a specific settings page or settings search result.
+   - Open or toggle the command palette with an optional initial query where the app already supports query seeding.
+   - Open or toggle command search where that is already user-visible.
+   - Toggle or open the left panel, Warp Drive surface, right panel, resource center, AI assistant panel, code review panel, and vertical tabs panel where valid.
+25. File/path intent actions may be included when they already mirror existing user-visible deep-link behavior:
+   - Open a path in a new tab or window.
+   - Open a repository picker or repo path flow where the current app already supports it.
+   These should remain allowlisted intent actions rather than arbitrary filesystem RPCs.
+26. The following categories are explicitly excluded from the initial public allowlist even if there are internal actions for them:
+   - Crash, panic, heap-dump, token-copying, debug-reset, and similar developer/debug helpers.
+   - Arbitrary auth manipulation.
+   - Arbitrary cloud object mutation or broad Warp Drive CRUD.
+   - Arbitrary internal view dispatch by string.
+   - Arbitrary setting names outside the allowlist.
+27. CLI command names should be noun-oriented and discoverable. During the provisional standalone-binary phase, the control CLI should expose a `warpctrl ...` command surface:
+   - `warpctrl instance list`
+   - `warpctrl app active`
+   - `warpctrl tab create`
+   - `warpctrl pane split --direction right`
+   - `warpctrl pane split --instance <id> --window active --pane active --direction right`
+   - `warpctrl theme set "Warp Dark"`
+   - `warpctrl setting set appearance.themes.system_theme true`
+   - `warpctrl input insert "cargo check" --replace`
+   Channelized install names or aliases may vary during packaging. If the product later converges on `warp ...`, update packaging, shell completions, and operator docs together.
+28. The wire protocol mirrors the CLI model. A mutating request contains:
+   - An action name from the allowlist.
+   - A structured target selector.
+   - Validated parameters.
+   A response contains:
+   - Success/failure status.
+   - Resolved instance and target metadata.
+   - Result data or structured error data.
+29. The protocol is versioned. Clients must be able to determine whether a running Warp process supports the protocol version and action they intend to call.
+30. Multiple running Warp processes are a supported normal case, not an error state. A local stable build and local dev build, or multiple supported local app instances, can coexist; the CLI provides deterministic discovery and addressing rather than assuming one global server.
+31. Requests should be scoped to local-user control of the running app. A command that fails authentication or local authorization reports that condition explicitly and does not degrade into a less-specific request.
+32. If a selected action is valid in general but impossible in the current UI state, the CLI reports a state-specific failure. Examples include:
+   - Splitting a pane that no longer exists.
+   - Running a session-scoped command against a non-terminal pane.
+   - Focusing a window that has closed.
+   - Setting a theme that is not available in that instance.
+33. The first `warpctrl` implementation slice should ship the smallest end-to-end vertical slice that proves:
+   - Process discovery and target resolution work.
+   - A standalone CLI binary can reach a running local Warp process without launching or initializing the GUI app.
+   - `warpctrl tab create` creates a new terminal tab in the selected running instance.
+   - The command returns a structured success or failure payload suitable for human-readable and JSON output.
+   The first slice should include the minimum health/introspection commands needed to discover a running instance and exercise `tab.create`.
+34. Follow-up PRs should fill out the remaining catalog in parallelizable groups once the protocol, discovery model, target resolution, error model, `tab.create` action path, and standalone `warpctrl` packaging shape have been validated by the first slice.
+35. The protocol transport should be designed so that the default target is localhost but the CLI can be extended in the future to target remote URLs (e.g., a Warp instance on another machine or a hosted control endpoint). This is not in scope for the first implementation but should not be precluded by the architecture.
+## Action classification and permission model
+Agents (Oz cloud agents, local agent mode, and third-party automation) are expected to be major consumers of the warpctrl CLI alongside human developers. The action catalog must support differentiated permission policies for human callers versus agent callers, and must clearly classify every action by its risk profile so that Warp can enforce appropriate guardrails at both the protocol and product level.
+### Classification tiers
+Every action in the catalog belongs to exactly one of the following tiers, from least to most sensitive:
+1. **Read-only / metadata.** Actions that return app-level structural information without exposing terminal content. These are safe for any caller and should never require elevated permission.
+   - Instance discovery and health: `instance list`, `app active`, `app version`, `app ping`.
+   - Layout enumeration: `window list`, `tab list`, `pane list`, `session list`.
+   - Appearance/settings reads that return configuration values but not user data: `theme list`, `setting list`, `setting get`.
+2. **Read-only / terminal data.** Actions that return content from a user's terminal sessions, command history, pane output buffers, or input editor state. These expose potentially sensitive user data and must be gated separately from structural metadata reads.
+   - Reading pane output or scrollback content (when implemented).
+   - Reading the current input buffer contents.
+   - Reading command history or session replay data.
+   Even though these are read-only, they cross a privacy boundary that metadata reads do not. An agent that can enumerate tabs should not automatically be able to read terminal output.
+3. **Mutating / non-destructive.** Actions that change app state in ways that are visible but reversible or low-risk. They do not destroy user data or execute arbitrary commands.
+   - Layout mutations: `tab create`, `tab activate`, `tab move`, `tab rename`, `window create`, `window focus`, `pane split`, `pane focus`, `pane navigate`, `pane maximize`, `pane resize`.
+   - Appearance mutations: `theme set`, `font-size increase/decrease/reset`, `zoom increase/decrease/reset`.
+   - Settings writes for allowlisted non-destructive settings: `setting set`, `setting toggle`.
+   - Panel/surface toggles: settings open, command palette, Warp Drive toggle, AI assistant toggle, etc.
+4. **Mutating / destructive or high-risk.** Actions that destroy user state, close active work, or execute arbitrary content in a terminal session. These require the strongest permission gates and explicit review before agent use.
+   - Closing targets: `tab close`, `window close`, `pane close`.
+   - Terminal input injection: `input insert`, `input replace`, `input clear`.
+   - Command execution in a session (when implemented).
+   - Input mode switching between terminal and agent modes.
+   Any action that can cause data loss (closing an unsaved session) or execute arbitrary code (injecting and running a shell command) belongs here regardless of how simple the API looks.
+### Permission policies
+The protocol and product should support per-caller permission policies keyed to these tiers:
+- **Human interactive use** defaults to full access across all tiers, gated only by local authentication (the bearer token).
+- **Agent use** should default to read-only metadata access and require explicit opt-in for each higher tier. The product should support:
+  - A baseline "read-only metadata" grant that lets agents discover and enumerate without accessing terminal content or mutating state.
+  - A "read terminal data" grant that additionally permits reading pane output, input buffers, and session content.
+  - A "mutate non-destructive" grant that additionally permits layout and appearance changes.
+  - A "mutate destructive" grant that additionally permits closing targets, injecting input, and executing commands.
+- The permission model should be expressible in the protocol (e.g., a capability or scope field in the authentication material) so that the app bridge can enforce it server-side, not just client-side.
+- When an agent attempts an action above its granted tier, the bridge should return a structured `insufficient_permissions` error that identifies the required tier, rather than silently downgrading or returning a generic failure.
+### Future entity extensibility: files and Warp Drive objects
+The selector and action model should be designed to accommodate entity types beyond the current window/tab/pane/session hierarchy. Two important future entity families are **local files** and **Warp Drive objects** (workflows, notebooks, environment variables, prompts). Neither is in scope for the first implementation, but the protocol should not preclude them.
+**Files.** Warp already supports file opening via deep links and the built-in editor. A future `file` namespace could support:
+- `warpctrl file open <path>` — open a file in a Warp editor tab, equivalent to clicking a file link.
+- `warpctrl file open <path> --line <n>` — open at a specific line.
+- `warpctrl file list` — list files currently open in editor tabs across the instance.
+File selectors would use filesystem paths (absolute or relative to the working directory of the target pane/session). Unlike window/tab/pane selectors, file selectors are not opaque IDs — they are user-visible paths. The protocol should support a `file` field in the target selector that accepts a path string, distinct from the opaque ID selectors used for windows, tabs, and panes.
+**Warp Drive objects.** Warp Drive stores typed objects (workflows, notebooks, environment variable sets, prompts) that users can reference, execute, and share. A future `drive` namespace could support:
+- `warpctrl drive list --type workflow` — list Warp Drive objects by type.
+- `warpctrl drive get <id>` — retrieve a specific Drive object by its opaque ID or by name/path.
+- `warpctrl drive run <workflow-id>` — execute a workflow in a target session, equivalent to invoking it from the command palette.
+- `warpctrl drive insert <notebook-id>` — insert a notebook's runnable commands into the active input.
+Drive object selectors should support both opaque IDs (for automation stability) and human-friendly name/path lookups (for interactive use). The type field (`workflow`, `notebook`, `env_var`, `prompt`) acts as a namespace filter. Drive actions that execute content in a terminal session (e.g., running a workflow) inherit the destructive/high-risk tier from the action classification model.
+**Design constraints for both:**
+- File and Drive selectors are orthogonal to the window/tab/pane hierarchy — a file open action targets an instance (which window to open in), not a specific pane. A Drive workflow execution targets a session (which pane to run in).
+- The `TargetSelector` type in the protocol should be extensible with optional fields for these new selector families without breaking existing requests that omit them.
+- The action classification tiers apply: listing Drive objects is tier 1 (metadata), reading Drive object content is tier 1 or 2 depending on whether it contains user data, executing a Drive workflow is tier 4 (destructive/high-risk).
+### Settings: protocol-first
+Settings reads and writes should go through the local-control protocol like other actions, not bypass it via direct file manipulation.
+- `warpctrl setting get <key>`, `warpctrl setting set <key> <value>`, and `warpctrl setting toggle <key>` send requests to the running Warp instance through the standard authenticated control endpoint.
+- The app bridge validates the key against the allowlist and the value against the expected type before applying the change.
+- This keeps authorization enforcement consistent: the same permission tier checks and caller-type policies apply to settings mutations as to any other action, rather than creating a second unguarded path through the filesystem.
+- The app owns the write to the settings file and any side effects (e.g., theme reload, layout reflow) as a single atomic operation, avoiding races between a CLI file write and the app's file watcher.
+- If a future need arises for offline settings manipulation (no running Warp process), a separate file-based path can be added later with its own validation, but it should not be the default.
+- The action classification still applies: settings reads are tier 1 (metadata), settings writes are tier 3 (non-destructive mutation).

--- a/specs/warp-control-cli/README.md
+++ b/specs/warp-control-cli/README.md
@@ -45,7 +45,7 @@ Use matching app and CLI bits from the same branch or release artifact so the pr
    warpctrl tab create --instance <instance_id>
    ```
 5. Verify the running app receives focus for the selected instance and a new terminal tab appears according to Warp's normal new-tab placement behavior.
-6. Optionally inspect state before and after the mutation:
+6. In a future slice that implements `tab list`, inspect state before and after the mutation:
    ```bash
    warpctrl tab list --instance <instance_id>
    ```
@@ -58,7 +58,7 @@ Expected failures:
 The local-control protocol is designed for same-user scripting, not cross-user or network access. The trust boundary is the local user account.
 - **Loopback-only listener.** Each Warp process binds its control server to `127.0.0.1` on an ephemeral port. The listener is not reachable from the network.
 - **Per-instance bearer token.** A random token is generated at startup and written into the discovery record. Every control request must present this token in the `Authorization` header; missing or invalid tokens are rejected with HTTP 401.
-- **File-permission-gated discovery.** Discovery records are stored in `~/.warp/local-control/` with `0600` permissions (owner read/write only). Any process that can read the file can authenticate, so the security boundary is the same as `~/.ssh/` or macOS Keychain — same-user process isolation.
+- **File-permission-gated discovery.** Discovery records are stored in a per-user local-control directory. On POSIX platforms, files must be created with `0600` permissions (owner read/write only). On Windows, records must be stored under the current user's app data directory with an ACL that grants access only to the current user, Administrators, and SYSTEM. Any same-user process that can read the credential can authenticate, so the baseline security boundary is same-user process isolation.
 - **Stale-record pruning.** On each `instance list` or implicit discovery call, records whose PID is no longer alive are deleted automatically, preventing stale tokens from lingering on disk.
 - **No CORS.** The control endpoints do not set permissive CORS headers, so browser-origin JavaScript cannot read responses even if it guesses the port. The bearer token requirement provides a second layer since browsers cannot read the discovery file.
 ```mermaid
@@ -68,7 +68,7 @@ sequenceDiagram
     participant HTTP as Warp loopback server<br/>(127.0.0.1:ephemeral)
     participant Bridge as App bridge
 
-    CLI->>FS: Read discovery records (0600)
+    CLI->>FS: Read discovery records (user-only permissions / ACL)
     FS-->>CLI: instance_id, endpoint, auth_token
     CLI->>CLI: Prune stale PIDs, select instance
     CLI->>HTTP: POST /v1/control<br/>Authorization: Bearer <token>
@@ -84,6 +84,7 @@ sequenceDiagram
 **Known limitations and future hardening:**
 - The token is stored in plaintext in the discovery JSON file. Any compromised process running as the same user can extract it.
 - Tokens do not rotate or expire during a Warp session. A leaked token is valid until the process exits.
+- Windows local-control authentication is not complete until discovery-record ACL creation and validation are implemented.
 - Once higher-risk handlers land (e.g. `input.insert`, command execution), the same-user boundary becomes a code-execution trust boundary. Consider separating the token from the discovery metadata, adding per-request nonces, or switching to a Unix domain socket with `SO_PEERCRED` for kernel-verified caller identity.
 ## Documentation review notes
 - Treat `warpctrl` as provisional executable naming until packaging signs off on final artifact aliases.

--- a/specs/warp-control-cli/README.md
+++ b/specs/warp-control-cli/README.md
@@ -1,0 +1,92 @@
+# warpctrl operator README
+`warpctrl` is the provisional standalone CLI for controlling an already-running local Warp app instance. It is intended for scripts, demos, agent workflows, and developer automation that need to perform allowlisted Warp UI actions without launching the GUI executable in CLI mode.
+The first implementation slice is intentionally narrow:
+- discover compatible running Warp instances;
+- select one instance implicitly when unambiguous or explicitly with `--instance`;
+- send authenticated local-control requests through the per-instance discovery record;
+- create a new terminal tab with `warpctrl tab create`.
+The local-control protocol and catalog are broader than this slice, but commands outside the implemented capability set should fail with structured unsupported-action errors until their handlers land.
+## Packaging model
+`warpctrl` should be packaged as a separate CLI artifact from the Warp GUI app while reusing shared repository code:
+- `crates/local_control` owns discovery records, local authentication material, client transport, protocol envelopes, action names, and error types.
+- `crates/warp_cli` owns command parsing conventions for local-control subcommands.
+- the app-side bridge owns the per-process loopback listener and dispatches supported actions onto the live Warp UI context.
+The binary should initialize only CLI parsing, instance discovery, local authentication loading, request serialization, HTTP transport, and output formatting. It should not initialize GUI state, terminal models, rendering, workspaces, or main-app startup paths.
+During the provisional naming period, release artifacts and helper names may be channelized, but operator docs and examples should use `warpctrl` unless an integration branch explicitly documents a channel-specific alias.
+This branch wires the standalone binary target and the macOS/Linux bundle-script artifact selectors:
+- `cargo build -p warp --bin warpctrl`
+- `script/macos/bundle --artifact warpctrl ...`
+- `script/linux/bundle --artifact warpctrl ...`
+Windows has the native Rust binary target, but installer/release helper exposure remains follow-up packaging work.
+## Install and invocation guidance
+### macOS
+Build locally with `cargo build -p warp --bin warpctrl`, then run `target/debug/warpctrl` or copy/symlink that binary onto `PATH`.
+For distributable standalone artifact checks, use `script/macos/bundle --artifact warpctrl` with the desired channel/signing flags. The bundle script writes a standalone `warpctrl` binary into its macOS artifact output directory instead of embedding it in the GUI app bundle.
+### Linux
+Build locally with `cargo build -p warp --bin warpctrl`, then run `target/debug/warpctrl` or copy/symlink that binary onto `PATH`.
+For distributable standalone artifact checks, use `script/linux/bundle --artifact warpctrl` with the desired channel/package selection. The Linux bundle script routes packaging through the standalone control-binary artifact path; downstream package installation should place the emitted `warpctrl` binary according to that package format.
+Run `warpctrl --version` after installation to confirm the shell is resolving the expected build.
+### Windows
+Build locally with `cargo build -p warp --bin warpctrl`, then run `target\debug\warpctrl.exe` or copy that binary onto `PATH`.
+The Windows-native binary target exists in this slice. Installer helper creation and release-artifact wiring still need a later packaging change before docs can promise an installer-provided `warpctrl` command.
+## End-to-end local test flow
+Use matching app and CLI bits from the same branch or release artifact so the protocol version and action catalog agree.
+1. Start Warp and leave at least one window open.
+2. Confirm that the local-control server registered the running process:
+   ```bash
+   warpctrl instance list
+   ```
+3. If exactly one compatible instance is listed, create a new terminal tab:
+   ```bash
+   warpctrl tab create
+   ```
+4. If multiple compatible instances are listed, copy the desired `instance_id` and target it explicitly:
+   ```bash
+   warpctrl tab create --instance <instance_id>
+   ```
+5. Verify the running app receives focus for the selected instance and a new terminal tab appears according to Warp's normal new-tab placement behavior.
+6. Optionally inspect state before and after the mutation:
+   ```bash
+   warpctrl tab list --instance <instance_id>
+   ```
+Expected failures:
+- no running compatible app: exits non-zero with a no-instance error;
+- multiple ambiguous instances: exits non-zero and asks for `--instance`;
+- unsupported app build or stale discovery record: exits non-zero with a protocol, stale-target, or transport error;
+- `tab.create` not yet implemented by the running app bridge: exits non-zero with an unsupported-action error.
+## Security model
+The local-control protocol is designed for same-user scripting, not cross-user or network access. The trust boundary is the local user account.
+- **Loopback-only listener.** Each Warp process binds its control server to `127.0.0.1` on an ephemeral port. The listener is not reachable from the network.
+- **Per-instance bearer token.** A random token is generated at startup and written into the discovery record. Every control request must present this token in the `Authorization` header; missing or invalid tokens are rejected with HTTP 401.
+- **File-permission-gated discovery.** Discovery records are stored in `~/.warp/local-control/` with `0600` permissions (owner read/write only). Any process that can read the file can authenticate, so the security boundary is the same as `~/.ssh/` or macOS Keychain — same-user process isolation.
+- **Stale-record pruning.** On each `instance list` or implicit discovery call, records whose PID is no longer alive are deleted automatically, preventing stale tokens from lingering on disk.
+- **No CORS.** The control endpoints do not set permissive CORS headers, so browser-origin JavaScript cannot read responses even if it guesses the port. The bearer token requirement provides a second layer since browsers cannot read the discovery file.
+```mermaid
+sequenceDiagram
+    participant CLI as warpctrl
+    participant FS as ~/.warp/local-control/
+    participant HTTP as Warp loopback server<br/>(127.0.0.1:ephemeral)
+    participant Bridge as App bridge
+
+    CLI->>FS: Read discovery records (0600)
+    FS-->>CLI: instance_id, endpoint, auth_token
+    CLI->>CLI: Prune stale PIDs, select instance
+    CLI->>HTTP: POST /v1/control<br/>Authorization: Bearer <token>
+    HTTP->>HTTP: Verify token matches instance
+    alt Invalid or missing token
+        HTTP-->>CLI: 401 Unauthorized
+    else Valid token
+        HTTP->>Bridge: Dispatch action to app context
+        Bridge-->>HTTP: Structured result or error
+        HTTP-->>CLI: JSON response envelope
+    end
+```
+**Known limitations and future hardening:**
+- The token is stored in plaintext in the discovery JSON file. Any compromised process running as the same user can extract it.
+- Tokens do not rotate or expire during a Warp session. A leaked token is valid until the process exits.
+- Once higher-risk handlers land (e.g. `input.insert`, command execution), the same-user boundary becomes a code-execution trust boundary. Consider separating the token from the discovery metadata, adding per-request nonces, or switching to a Unix domain socket with `SO_PEERCRED` for kernel-verified caller identity.
+## Documentation review notes
+- Treat `warpctrl` as provisional executable naming until packaging signs off on final artifact aliases.
+- Keep examples scoped to discovery and `tab create` until additional app-side handlers are implemented.
+- Do not document catalog commands as usable just because they exist in protocol enums or parser scaffolding; operator docs should distinguish implemented commands from planned allowlist entries.
+- Windows packaging may initially follow the existing helper-wrapper pattern rather than shipping a native standalone executable. Update this README when that decision is final.

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -9,6 +9,8 @@ The action-tier model is primarily a safety and intent mechanism, not a hard sec
 - Prevent browser-origin JavaScript from becoming an ambient localhost control client.
 - Support multiple running Warp processes without a shared global mutating port or global credential.
 - Separate discovery metadata from control authority so enumerating an instance does not automatically grant full control.
+- Require explicit in-app user enablement before local control scripting can issue credentials or accept control requests.
+- Store the authoritative enablement state in protected local storage so external apps cannot enable local control by editing ordinary settings.
 - Keep raw credential material out of plaintext discovery records and protect it with platform secure storage where available.
 - Support least-privilege safety modes for automation and interactive use without relying on an unenforceable identity label.
 - Classify every action by risk tier and enforce the required tier in the local app bridge, not in the CLI frontend.
@@ -16,6 +18,86 @@ The action-tier model is primarily a safety and intent mechanism, not a hard sec
 - Preserve deterministic targeting so a request never silently mutates or reads the wrong window, tab, pane, session, file, or Warp Drive object.
 - Keep the action surface allowlisted and typed rather than exposing arbitrary internal app dispatch.
 - Make high-risk operations auditable and configurable without logging sensitive terminal contents or credentials.
+## Meaningful security boundaries
+The most important security boundary is preventing control from places that should have no ambient authority over the user's Warp instance:
+- arbitrary web apps running in a browser;
+- other OS users on the same machine;
+- unauthenticated clients that discover or guess the localhost control port;
+- stale discovery records from exited Warp processes;
+- malformed or unallowlisted direct protocol calls.
+The local-control design can provide meaningful protection for those cases by binding only to loopback, avoiding permissive CORS, requiring local credentials, keeping credentials out of browser-readable and world-readable locations, pruning stale records, and validating every request in the local Warp app process.
+The boundary is much weaker for a different local app running as the same OS user. Same-user local apps may already have access to user-owned files such as logs, may be able to observe the screen or UI through OS permissions such as Accessibility or Screen Recording, and can often invoke user-installed command-line tools. `warpctrl` should not imply strong isolation from such software.
+For same-user local apps, the realistic goal is narrower:
+- do not leave a raw bearer token in plaintext discovery records;
+- prevent arbitrary direct HTTP calls to the localhost control listener by requiring a credential those apps cannot simply read;
+- use platform secure storage, such as macOS Keychain, so raw credentials are accessible only to Warp-owned signed code where practical;
+- make high-risk operations go through `warpctrl` or a Warp-owned helper where user approval, configured policy, and safety grants can be applied;
+- avoid giving `warpctrl` ambient non-interactive full-control authority.
+In other words, the security model can make arbitrary direct localhost protocol calls fail, and it can make direct credential theft harder. It cannot make a same-user malicious app safe if that app can invoke `warpctrl`, automate the user's desktop, read other local state, or wait for the user to approve prompts.
+## Comparison with other local scripting models
+Other developer tools expose local automation through a few recurring patterns. The `warpctrl` design should borrow the parts that match Warp's needs while avoiding designs that assume localhost or same-user access is enough by itself.
+### VS Code
+VS Code's `code` command is primarily a launch and routing CLI: it opens files, folders, diffs, merge views, chat sessions, extension-management commands, and remote/tunnel workflows. It is not a general unauthenticated localhost API for arbitrary UI control of an already-running desktop app.
+VS Code's richer local automation runs through extension APIs and extension hosts. Extensions are installed into a trusted editor environment and run with broad access to the workspace or UI side depending on extension kind. Workspace Trust and remote extension placement help users reason about whether code should run locally, remotely, or in a browser sandbox, but they do not create a fine-grained same-user security boundary against arbitrary local software.
+Lessons for `warpctrl`:
+- a narrow, typed CLI command surface is safer to reason about than exposing arbitrary internal app commands;
+- agent and script workflows should request explicit capabilities instead of inheriting ambient full-control authority;
+- local UI control should remain distinct from remote/tunnel control because remote transports need stronger identity, approval, and network-security semantics.
+### Chrome DevTools Protocol
+Chrome DevTools Protocol is a powerful debugging and automation API. When Chrome is launched with remote debugging enabled, clients can discover targets over local HTTP endpoints and then control the browser over WebSocket. That protocol is intentionally high-power: it can inspect pages, navigate, execute JavaScript, observe network state, and interact with browser storage.
+Chrome's security history is a useful warning for `warpctrl`: a local debugging port is dangerous if it becomes reachable by unexpected clients. Recent Chrome versions restrict remote debugging against the default user data directory and recommend isolated user data directories for automation, because debugging a real browser profile can expose sensitive cookies and credentials. Chrome also distinguishes command-line remote debugging from user-confirmed debugging flows.
+Lessons for `warpctrl`:
+- loopback binding is necessary but not sufficient;
+- unauthenticated localhost endpoints should not expose powerful state or mutation;
+- browser-origin protections matter because web pages can attempt localhost requests;
+- high-power automation should prefer explicit, isolated, user-approved, or short-lived authority over a reusable full-profile control channel.
+### Ghostty and macOS AppleScript
+Ghostty exposes platform-native scripting on macOS through AppleScript. That model relies on macOS Automation/TCC prompts to decide whether one app may control another app, and Ghostty can disable AppleScript entirely with configuration. This is a good fit for macOS-native scripting, but it is platform-specific and inherits the limits of OS automation permission: once an app is allowed to automate another app, the boundary is not a per-action capability system.
+Ghostty also supports terminal-oriented features such as shell integration and command-line window creation flows. Those are useful local automation conveniences, but they are not a general cross-platform authenticated control protocol with scoped credentials.
+Lessons for `warpctrl`:
+- use platform security mechanisms where they exist, such as macOS Keychain and Automation prompts;
+- keep a user-visible kill switch or policy path for scripting/control surfaces;
+- do not rely only on platform automation permission if Warp needs cross-platform, action-scoped safety grants.
+### iTerm2 Python API
+iTerm2's Python API is a close comparison for terminal automation. The API is disabled by default. When enabled, iTerm2 listens on a Unix domain socket and requires authentication by default. Scripts launched by iTerm2 receive a random cookie in the environment, while external programs can request a cookie through AppleScript so macOS Automation permission mediates access. iTerm2 also documents an administrator-gated escape hatch to allow unauthenticated local apps.
+This model directly acknowledges that terminal contents are sensitive and that any local automation API can affect local and remote hosts connected through terminal sessions.
+Lessons for `warpctrl`:
+- default-off or policy-controlled high-power automation is reasonable for sensitive capabilities;
+- random local credentials are useful, but the path that grants or unwraps them is just as important as the token itself;
+- terminal-data reads and input/command execution should be treated as higher-risk than structural metadata reads;
+- macOS Automation can be part of the approval path, but Warp still needs local app-side enforcement because direct protocol clients can bypass the official CLI.
+### tmux
+tmux is a useful lower-level comparison because its clients and server communicate through local sockets. The default socket lives in a per-user directory under `/tmp`, and that directory must not be world readable, writable, or executable. tmux control mode then exposes a text protocol where clients can issue normal tmux commands and receive asynchronous pane/session notifications. Newer tmux versions also have explicit server-access controls for sharing across users.
+tmux's model is mostly an OS-user and socket-permission model. Once a client can access the socket with write authority, it can generally control the session. Read-only modes are useful operational guardrails but are not a reason to trust untrusted users or processes with the socket.
+Lessons for `warpctrl`:
+- per-user discovery directories and sockets protect meaningfully against other OS users;
+- structured control protocols are scriptable and durable, but broad socket access quickly becomes broad control access;
+- read-only and low-risk modes are valuable “do not accidentally interfere” controls, not a complete hostile-client sandbox.
+### Overall direction for `warpctrl`
+Compared with these systems, `warpctrl` should combine:
+- tmux-style local filesystem/socket hygiene for protecting against other OS users;
+- Chrome's lesson that local debugging/control endpoints need authentication and browser-origin hardening;
+- iTerm2's use of explicit local credentials and macOS Automation-style approval for external control;
+- Ghostty's use of platform-native scripting controls where available;
+- VS Code's preference for typed public commands and separate treatment of remote control.
+The resulting architecture should not claim to solve arbitrary same-user malicious-app isolation. Its real value is preventing web-origin and other-user access, preventing unauthenticated direct localhost calls, keeping raw credentials out of plaintext discovery, giving honest scripts and agents narrow safety grants, and routing high-risk operations through local Warp app validation and user/policy approval.
+## Authoritative enablement model
+Local control scripting must be explicitly enabled by the user inside the Warp app before `warpctrl` can control a running instance. The setting should be visible in Warp's settings UI as something like “Allow local control scripting,” and it should default to off.
+The visible UI setting is not enough by itself. The authoritative enablement state must be stored in protected local storage that ordinary same-user apps cannot update by writing a plist, settings database row, registry key, JSON file, or synced cloud preference. This avoids turning local control into a feature that any process can silently enable before invoking `warpctrl`.
+Enablement requirements:
+- The setting is local-only and must not sync through Settings Sync, Warp Drive, or server-backed user preferences.
+- Only the running Warp app, through an in-app user action, should be able to enable or disable the authoritative state.
+- `warpctrl`, shell scripts, config files, command-line flags, registry edits, defaults writes, and direct local-control protocol requests must not be able to enable the setting.
+- The app should require an intentional user gesture before enabling the setting, and the UI should explain that it allows local scripts and approved automation to control Warp.
+- The setting should be easy to disable from the same UI, and disabling it should revoke or invalidate active local-control credentials.
+- If enterprise or managed-device policy is added later, policy may force-disable local control or allow an administrator-controlled default, but policy should be separate from user-editable local settings.
+Disabled-state behavior:
+- Warp should not mint scoped local-control credentials while local control scripting is disabled.
+- The control listener should either not start or should reject all sensitive requests with a structured disabled-state error before authentication, selector resolution, or handler dispatch.
+- Discovery records should avoid publishing actionable endpoint or credential-reference metadata while disabled. If a minimal record is needed for UX, it should expose only non-sensitive status such as `local_control_enabled: false`.
+- `warpctrl` may detect the disabled state and print instructions to enable local control in Warp settings, but it must not offer a command that flips the setting.
+- Previously issued credentials must become unusable when local control is disabled, even if their original expiry has not elapsed.
+This enablement gate does not create perfect same-user malicious-app isolation. A hostile process with Accessibility or Screen Recording permission might still try to automate the Warp UI. The gate is still important because it closes the much easier paths where external apps silently edit local preferences, call a config CLI, or write synced settings to enable a powerful control surface.
 ## Trust boundaries
 `warpctrl` has several distinct trust boundaries.
 ### Operating-system user boundary
@@ -25,7 +107,7 @@ Same-user does not mean same authority. Interactive use and unattended automatio
 These scoped credentials are guardrails for well-behaved clients. They prevent accidental overreach and make user intent explicit, but they are not a defense against malicious same-user code that can automate the CLI, inspect the user's environment, or wait for user approvals.
 ### Application identity boundary
 On platforms with secure credential storage, especially macOS, the raw local-control credential should be readable only by Warp-owned, correctly signed code. On macOS this means storing raw credential material in Keychain with access constrained by Warp's signing identity, designated requirement, Keychain access group, or equivalent platform mechanism. This narrows token extraction from “any same-user process can read a file” to “only trusted Warp-signed code can unwrap the secret.”
-This boundary protects the credential from direct theft, but it does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary. That confused-deputy risk is handled by scoped credential issuance, action-tier policy, and local app-side bridge enforcement.
+This boundary protects the credential from direct theft and prevents arbitrary apps from making authenticated raw HTTP requests to the local-control listener. It also lets the authoritative enablement state be stored somewhere harder to modify than ordinary user preferences. It does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary or automate the Warp UI. That confused-deputy risk is reduced by explicit in-app enablement, scoped credential issuance, action-tier policy, and local app-side bridge enforcement, but it is not eliminated as a hard same-user security boundary.
 ### Action boundary
 Every action belongs to a risk tier. The bridge must map the requested action to a required tier and compare that tier to the presented credential before selector resolution or handler dispatch.
 ### Target boundary
@@ -48,18 +130,20 @@ A valid credential for one instance or target must not imply authority over anot
 - Kernel, hypervisor, or administrator-level compromise.
 - Security semantics for remote URL control endpoints. Remote control requires a separate transport and identity design before it can ship.
 ## Architecture overview
-The security model has six layers:
-1. **Discovery:** Find compatible live Warp instances without granting broad authority.
-2. **Secure credential storage:** Store raw secrets outside plaintext discovery records and restrict access to trusted Warp-owned code where the platform supports it.
-3. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes.
-4. **Transport authentication:** Reject unauthenticated requests before reading or mutating app state.
-5. **Safety policy:** Enforce requested action tiers and target scopes locally in the app bridge for well-behaved clients.
-6. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
+The security model has seven layers:
+1. **Protected enablement:** Require explicit in-app opt-in backed by protected local storage before local control is available.
+2. **Discovery:** Find compatible live Warp instances without granting broad authority.
+3. **Secure credential storage:** Store raw secrets outside plaintext discovery records and restrict access to trusted Warp-owned code where the platform supports it.
+4. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes only when local control is enabled.
+5. **Transport authentication:** Reject disabled or unauthenticated requests before reading or mutating app state.
+6. **Safety policy:** Enforce requested action tiers and target scopes locally in the app bridge for well-behaved clients.
+7. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
 ```mermaid
 sequenceDiagram
     participant Invoker as User / Automation
     participant CLI as warpctrl
     participant Registry as Per-user discovery registry
+    participant Enablement as Protected enablement state
     participant Broker as Credential broker
     participant Store as Secure credential storage
     participant HTTP as Warp control listener
@@ -69,7 +153,13 @@ sequenceDiagram
     Invoker->>CLI: Invoke allowlisted command
     CLI->>Registry: Read instance metadata
     Registry-->>CLI: instance_id, endpoint, protocol version, credential reference
+    CLI->>Enablement: Check local control enabled status
+    Enablement-->>CLI: Enabled or disabled
+    alt Disabled
+        CLI-->>Invoker: local control disabled; enable in Warp settings
+    else Enabled
     CLI->>Broker: Request scoped credential for action
+    Broker->>Enablement: Verify protected enablement state
     Broker->>Store: Load or unwrap raw secret with Warp-signed access
     Store-->>Broker: Raw secret or credential capability
     Broker-->>CLI: Scoped credential with grants, scopes, expiry
@@ -82,6 +172,7 @@ sequenceDiagram
         Bridge->>UI: Resolve target exactly and run allowlisted handler
         UI-->>Bridge: typed result or structured target error
         Bridge-->>CLI: response envelope
+    end
     end
 ```
 ## Discovery registry
@@ -97,6 +188,7 @@ Discovery rules:
 - Records must be readable only by the owning user.
 - POSIX records must use owner-only permissions such as `0600` for files and a non-world-readable directory.
 - Windows records must live under the current user's app data directory with ACLs limited to the current user, Administrators, and SYSTEM.
+- When local control scripting is disabled, records must not publish actionable control endpoints or credential references. A minimal disabled-status record is acceptable only if it contains no authority.
 - The CLI must prune or ignore stale records whose PID is gone or whose health/protocol check fails.
 - If multiple compatible instances are ambiguous, the CLI must require explicit `--instance` selection.
 - Discovery metadata must not expose terminal contents, environment variables, auth tokens for cloud services, raw local-control credentials, or mutating capability grants.
@@ -116,6 +208,7 @@ A control credential should encode or reference:
 ### Credential issuance
 Warp should issue credentials through an app-owned local broker or equivalent trusted path. The broker decides which grants to issue based on the requested action tier, target scope, user configuration, execution context, and any explicit user approval.
 Recommended defaults:
+- Credential issuance is unavailable unless the protected in-app enablement state says local control scripting is enabled.
 - Commands should start from least privilege and request only the grant needed for the requested action.
 - Unattended automation should default to read-only metadata unless policy or an explicit approval grants more.
 - Interactive use may receive broader local control only through an intentional approval or configured policy.
@@ -134,6 +227,7 @@ This model does not make untrusted same-user software safe. A malicious local pr
 ### Credential storage
 Credential storage should be platform-appropriate:
 - Local discovery may store a credential reference rather than the credential itself.
+- The authoritative local-control enablement state should use the same class of protected local storage as raw credential material, but it should be accessible to the Warp app for in-app settings UI and not writable by `warpctrl` or arbitrary external apps.
 - Raw long-lived credentials should prefer platform-secure storage such as macOS Keychain or Windows Credential Manager when practical.
 - On macOS, raw control secrets should be stored in Keychain and restricted to trusted Warp-signed code using a designated requirement, Keychain access group, trusted-application ACL, or equivalent code-signing based mechanism. Restricting by filesystem path alone is insufficient because paths can be replaced or wrapped.
 - Keychain item access should include the Warp app, the signed `warpctrl` binary, and any signed Warp-owned local broker/helper that needs to unwrap raw secrets. It should exclude arbitrary same-user applications.
@@ -150,11 +244,13 @@ Mitigations:
 - Bind issued credentials to the requested instance, action tier, optional action family, optional target scope, and short expiry.
 - Let `warpctrl` preflight and request credentials, but require the local app bridge to enforce scopes because direct protocol clients can bypass the CLI.
 - Make denials structured and non-fatal for automation so callers can request narrower or user-approved grants rather than falling back to unsafe behavior.
+These mitigations are about routing high-risk operations through intentional `warpctrl` flows rather than exposing a reusable localhost token to any process. They should not be documented as a guarantee that arbitrary same-user applications cannot cause Warp-visible actions.
 ## Transport authentication
 The default transport is an instance-local loopback listener bound to `127.0.0.1` on an ephemeral per-process port.
 Transport requirements:
 - Bind only to loopback for local control.
 - Do not set permissive CORS headers.
+- Reject control requests while local control scripting is disabled, even if the request presents an otherwise valid credential.
 - Authenticate every control request locally in the selected Warp app process before selector resolution or action dispatch.
 - Reject missing, malformed, expired, revoked, or invalid credentials with structured authentication errors.
 - Keep unauthenticated health metadata minimal and non-sensitive.
@@ -273,6 +369,7 @@ Error-level logs should be used only for conditions that need developer attentio
 ## Security- and safety-relevant errors
 Structured errors are part of the security contract.
 Important errors include:
+- `local_control_disabled` when the user has not enabled local control scripting in Warp settings or has disabled it after credentials were issued;
 - `unauthorized_local_client` for missing, malformed, expired, revoked, or invalid credentials;
 - `insufficient_permissions` for valid credentials that lack the requested safety tier or target scope;
 - `ambiguous_instance` when multiple compatible instances cannot be resolved safely;
@@ -286,6 +383,8 @@ Important errors include:
 The app must not downgrade these failures into broader default actions, and the CLI must preserve structured server errors in both human-readable and JSON output.
 ## Required controls before full catalog expansion
 Before shipping each action family, verify that these controls are implemented for that family:
+- Local control scripting must be explicitly enabled in Warp's app UI before the action family can run.
+- The authoritative enablement state is protected from external writes and is local-only rather than synced.
 - The action has a documented tier.
 - The bridge maps the action to that tier locally in the selected Warp app process.
 - The credential model can express the required grant.
@@ -299,12 +398,13 @@ Before shipping each action family, verify that these controls are implemented f
 ## Platform requirements
 ### macOS and Linux
 Discovery files must be stored in a per-user directory with owner-only permissions.
-On macOS, raw credential material should live in Keychain, not in the discovery record. Keychain access should be constrained to Warp-owned signed binaries or helpers using code-signing based access control. The discovery record should hold only metadata and a credential reference.
-On Linux, raw credentials should prefer platform-secure storage where available; otherwise short-lived scoped credentials may live in owner-only local state with strict file and directory permissions.
+On macOS, raw credential material and the authoritative local-control enablement state should live in Keychain, not in the discovery record or an ordinary preferences file. Keychain access should be constrained to Warp-owned signed binaries or helpers using code-signing based access control. The enablement state should be writable by the Warp app's in-app settings flow and not writable by `warpctrl`. The discovery record should hold only metadata and a credential reference when local control is enabled.
+On Linux, raw credentials and the authoritative enablement state should prefer platform-secure storage where available; otherwise short-lived scoped credentials may live in owner-only local state with strict file and directory permissions. If the enablement state falls back to owner-only local state, the weaker same-user protection should be documented.
 Unix domain sockets with peer credential checks may be considered for stronger same-machine identity than bearer tokens alone.
 ### Windows
 Discovery records and credential material must live under the current user's app data directory with ACLs restricted to the current user, Administrators, and SYSTEM.
-Windows support for authenticated local control should not be considered complete until the implementation creates, validates, and tests those ACLs.
+The authoritative enablement state should use Credential Manager, DPAPI-backed protected storage, or an equivalent app-controlled protected store rather than a normal registry setting that arbitrary same-user processes can write.
+Windows support for authenticated local control should not be considered complete until the implementation creates, validates, and tests those ACLs and the protected enablement-state behavior.
 ## Remote control is separate
 The local architecture intentionally assumes same-machine, same-user control over a loopback listener. Future remote URLs must use a different security design that includes:
 - transport encryption;

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -9,11 +9,12 @@ The action-tier model is primarily a safety and intent mechanism, not a hard sec
 - Prevent browser-origin JavaScript from becoming an ambient localhost control client.
 - Support multiple running Warp processes without a shared global mutating port or global credential.
 - Separate discovery metadata from control authority so enumerating an instance does not automatically grant full control.
-- Require explicit in-app user enablement before local control scripting can issue credentials or accept control requests.
-- Store the authoritative enablement state in protected local storage so external apps cannot enable local control by editing ordinary settings.
+- Require explicit in-app user enablement before local control scripting from outside Warp can issue credentials or accept control requests.
+- Allow local control scripting from verified Warp-managed terminal sessions by default, subject to granular permission settings.
+- Store the authoritative enablement states in protected local storage so external apps cannot enable outside-Warp control by editing ordinary settings.
 - Keep raw credential material out of plaintext discovery records and protect it with platform secure storage where available.
 - Distinguish verified `warpctrl` invocations that originate from a Warp-managed terminal session from external same-user invocations.
-- Allow external invocations by default only for a smaller local-only action set that does not touch user-authenticated data.
+- When outside-Warp control is enabled, allow external invocations only for a smaller local-only action set by default that does not touch user-authenticated data.
 - Allow in-Warp invocations to receive authenticated-user grants when the selected Warp app has a true logged-in user and the user's local-control settings permit that grant.
 - Support least-privilege safety modes for automation and interactive use without relying on an unenforceable identity label.
 - Classify every action by risk tier and enforce the required tier in the local app bridge, not in the CLI frontend.
@@ -86,32 +87,36 @@ Compared with these systems, `warpctrl` should combine:
 - VS Code's preference for typed public commands and separate treatment of remote control.
 The resulting architecture should not claim to solve arbitrary same-user malicious-app isolation. Its real value is preventing web-origin and other-user access, preventing unauthenticated direct localhost calls, keeping raw credentials out of plaintext discovery, giving honest scripts and agents narrow safety grants, and routing high-risk operations through local Warp app validation and user/policy approval.
 ## Authoritative enablement model
-Local control scripting must be explicitly enabled by the user inside the Warp app before `warpctrl` can control a running instance. The setting should be visible in Warp's settings UI as something like “Allow local control scripting,” and it should default to off.
-The visible UI setting is not enough by itself. The authoritative enablement state must be stored in protected local storage that ordinary same-user apps cannot update by writing a plist, settings database row, registry key, JSON file, or synced cloud preference. This avoids turning local control into a feature that any process can silently enable before invoking `warpctrl`.
+Warp control has two top-level enablement states based on invocation context:
+- **Allow scripting from inside Warp:** controls `warpctrl` invocations from verified Warp-managed terminal sessions. This should default to on so commands run inside Warp can use local control subject to granular permissions.
+- **Allow scripting from outside Warp:** controls `warpctrl` invocations from external terminals, scripts, launch agents, IDEs, or other same-user processes. This must default to off.
+Both controls should live in a new top-level Settings pane page named **Scripting**. The Scripting page owns the user-facing controls for local scripting surfaces, including Warp control, and should explain the difference between commands run inside Warp and commands run from other apps.
+The visible UI settings are not enough by themselves. The authoritative enablement states must be stored in protected local storage that ordinary same-user apps cannot update by writing a plist, settings database row, registry key, JSON file, or synced cloud preference. This avoids turning outside-Warp control into a feature that any process can silently enable before invoking `warpctrl`.
 Enablement requirements:
-- The setting is local-only and must not sync through Settings Sync, Warp Drive, or server-backed user preferences.
-- Only the running Warp app, through an in-app user action, should be able to enable or disable the authoritative state.
-- `warpctrl`, shell scripts, config files, command-line flags, registry edits, defaults writes, and direct local-control protocol requests must not be able to enable the setting.
-- The app should require an intentional user gesture before enabling the setting, and the UI should explain that it allows local scripts and approved automation to control Warp.
-- The UI should expose granular local-control permission settings rather than a single all-powerful switch.
-- The setting should be easy to disable from the same UI, and disabling it should revoke or invalidate active local-control credentials.
-- If enterprise or managed-device policy is added later, policy may force-disable local control or allow an administrator-controlled default, but policy should be separate from user-editable local settings.
+- The settings are local-only and must not sync through Settings Sync, Warp Drive, or server-backed user preferences.
+- Only the running Warp app, through the Settings > Scripting UI, should be able to enable or disable the authoritative states.
+- `warpctrl`, shell scripts, config files, command-line flags, registry edits, defaults writes, and direct local-control protocol requests must not be able to enable either setting.
+- The in-Warp setting may default to enabled, but turning it off should prevent verified Warp-terminal invocations from receiving local-control grants.
+- The outside-Warp setting defaults to disabled and should require an intentional user gesture before enabling; the UI should explain that it allows scripts and automation from other apps to control Warp.
+- The Scripting page should expose granular local-control permission settings rather than a single all-powerful switch.
+- Each setting should be easy to disable from the same UI, and disabling either setting should revoke or invalidate active local-control credentials for that invocation context.
+- If enterprise or managed-device policy is added later, policy may force-disable either setting or allow an administrator-controlled default, but policy should be separate from user-editable local settings.
 Disabled-state behavior:
-- Warp should not mint scoped local-control credentials while local control scripting is disabled.
-- The control listener should either not start or should reject all sensitive requests with a structured disabled-state error before authentication, selector resolution, or handler dispatch.
-- Discovery records should avoid publishing actionable endpoint or credential-reference metadata while disabled. If a minimal record is needed for UX, it should expose only non-sensitive status such as `local_control_enabled: false`.
-- `warpctrl` may detect the disabled state and print instructions to enable local control in Warp settings, but it must not offer a command that flips the setting.
-- Previously issued credentials must become unusable when local control is disabled, even if their original expiry has not elapsed.
-This enablement gate does not create perfect same-user malicious-app isolation. A hostile process with Accessibility or Screen Recording permission might still try to automate the Warp UI. The gate is still important because it closes the much easier paths where external apps silently edit local preferences, call a config CLI, or write synced settings to enable a powerful control surface.
+- Warp should not mint scoped local-control credentials for a request whose invocation context is disabled.
+- The control listener should reject requests from disabled contexts with a structured disabled-state error before authentication, selector resolution, or handler dispatch.
+- Discovery records should avoid publishing actionable endpoint or credential-reference metadata for disabled outside-Warp control. If a minimal record is needed for UX, it should expose only non-sensitive status such as `outside_warp_control_enabled: false`.
+- `warpctrl` may detect a disabled context and print instructions to enable it in Settings > Scripting, but it must not offer a command that flips the setting.
+- Previously issued credentials must become unusable when their invocation context is disabled, even if their original expiry has not elapsed.
+These enablement gates do not create perfect same-user malicious-app isolation. A hostile process with Accessibility or Screen Recording permission might still try to automate the Warp UI. The outside-Warp gate is still important because it closes the much easier paths where external apps silently edit local preferences, call a config CLI, or write synced settings to enable a powerful control surface.
 ### Granular permission settings
-Once local control scripting is enabled, users should control which categories of `warpctrl` authority can be granted. Recommended independent permissions:
+Once the relevant inside-Warp or outside-Warp enablement setting allows a request context, users should control which categories of `warpctrl` authority can be granted. These permissions should appear under Settings > Scripting. Recommended independent permissions:
 - **Local read-only metadata:** permit external and in-Warp clients to inspect non-sensitive local app structure such as instances, windows, tabs, panes, app version, and theme names.
 - **Terminal data reads:** permit reads of terminal output, scrollback, input buffers, command history, and session traces.
 - **Non-destructive local mutations:** permit reversible app-state changes such as creating tabs, focusing panes, changing theme, or opening panels.
 - **Destructive and execution actions:** permit closing targets, injecting input, running commands, executing workflows, or other high-risk operations.
 - **Authenticated-user actions from Warp terminals:** permit `warpctrl` invocations that originate from a verified Warp-managed terminal session to receive grants backed by the currently logged-in Warp user, enabling actions that read or mutate Warp Drive, AI conversation traces, synced settings, or other user-authenticated state.
 - **Authenticated-user actions from external clients:** default off. If supported, this must be a separate explicit permission from in-Warp authenticated actions because external same-user processes are a weaker context than a Warp-managed terminal session.
-Disabling any category should invalidate active credentials that include that category. The broker and app bridge must enforce these settings locally for every credential request and every presented credential.
+Granular permissions should be independently configurable for inside-Warp and outside-Warp contexts where the distinction matters. Disabling any category should invalidate active credentials that include that category. The broker and app bridge must enforce these settings locally for every credential request and every presented credential.
 ## Trust boundaries
 `warpctrl` has several distinct trust boundaries.
 ### Operating-system user boundary
@@ -155,11 +160,11 @@ A valid credential for one instance or target must not imply authority over anot
 - Security semantics for remote URL control endpoints. Remote control requires a separate transport and identity design before it can ship.
 ## Architecture overview
 The security model has eight layers:
-1. **Protected enablement:** Require explicit in-app opt-in backed by protected local storage before local control is available.
+1. **Protected enablement:** Use protected local storage for separate inside-Warp and outside-Warp enablement states, with inside-Warp on by default and outside-Warp off by default.
 2. **Discovery:** Find compatible live Warp instances without granting broad authority.
 3. **Secure credential storage:** Store raw secrets outside plaintext discovery records and restrict access to trusted Warp-owned code where the platform supports it.
 4. **Execution context verification:** Distinguish verified Warp-terminal invocations from external same-user invocations without trusting caller-declared labels.
-5. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes only when local control is enabled and the user's granular permissions allow the requested category.
+5. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes only when the request's invocation context is enabled and the user's granular permissions allow the requested category.
 6. **Transport authentication:** Reject disabled or unauthenticated requests before reading or mutating app state.
 7. **Safety and user-auth policy:** Enforce action tiers, target scopes, execution-context requirements, and authenticated-user requirements locally in the app bridge.
 8. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
@@ -180,10 +185,10 @@ sequenceDiagram
     Invoker->>CLI: Invoke allowlisted command
     CLI->>Registry: Read instance metadata
     Registry-->>CLI: instance_id, endpoint, protocol version, credential reference
-    CLI->>Enablement: Check local control enabled status
+    CLI->>Enablement: Check inside/outside context enablement
     Enablement-->>CLI: Enabled or disabled
     alt Disabled
-        CLI-->>Invoker: local control disabled; enable in Warp settings
+        CLI-->>Invoker: context disabled; enable in Settings > Scripting
     else Enabled
     CLI->>Broker: Request scoped credential for action
     Broker->>Enablement: Verify protected enablement state
@@ -220,7 +225,7 @@ Discovery rules:
 - Records must be readable only by the owning user.
 - POSIX records must use owner-only permissions such as `0600` for files and a non-world-readable directory.
 - Windows records must live under the current user's app data directory with ACLs limited to the current user, Administrators, and SYSTEM.
-- When local control scripting is disabled, records must not publish actionable control endpoints or credential references. A minimal disabled-status record is acceptable only if it contains no authority.
+- When outside-Warp control is disabled, records must not publish actionable control endpoints or credential references for external clients. A minimal disabled-status record is acceptable only if it contains no authority.
 - The CLI must prune or ignore stale records whose PID is gone or whose health/protocol check fails.
 - If multiple compatible instances are ambiguous, the CLI must require explicit `--instance` selection.
 - Discovery metadata must not expose terminal contents, environment variables, auth tokens for cloud services, raw local-control credentials, or mutating capability grants.
@@ -243,7 +248,7 @@ A control credential should encode or reference:
 ### Credential issuance
 Warp should issue credentials through an app-owned local broker or equivalent trusted path. The broker decides which grants to issue based on the requested action tier, target scope, user configuration, execution context, and any explicit user approval.
 Recommended defaults:
-- Credential issuance is unavailable unless the protected in-app enablement state says local control scripting is enabled.
+- Credential issuance is unavailable unless the protected enablement state allows the request's invocation context: inside Warp or outside Warp.
 - Commands should start from least privilege and request only the grant needed for the requested action.
 - External same-user invocations should default to the smaller logged-out-safe local action set unless policy or explicit approval grants more.
 - Verified Warp-terminal invocations may receive broader local-control grants when the user's granular settings allow them.
@@ -264,7 +269,7 @@ This model does not make untrusted same-user software safe. A malicious local pr
 ### Credential storage
 Credential storage should be platform-appropriate:
 - Local discovery may store a credential reference rather than the credential itself.
-- The authoritative local-control enablement state should use the same class of protected local storage as raw credential material, but it should be accessible to the Warp app for in-app settings UI and not writable by `warpctrl` or arbitrary external apps.
+- The authoritative local-control enablement states for inside-Warp and outside-Warp scripting should use the same class of protected local storage as raw credential material, but they should be accessible to the Warp app for the Settings > Scripting UI and not writable by `warpctrl` or arbitrary external apps.
 - Raw long-lived credentials should prefer platform-secure storage such as macOS Keychain or Windows Credential Manager when practical.
 - On macOS, raw control secrets should be stored in Keychain and restricted to trusted Warp-signed code using a designated requirement, Keychain access group, trusted-application ACL, or equivalent code-signing based mechanism. Restricting by filesystem path alone is insufficient because paths can be replaced or wrapped.
 - Keychain item access should include the Warp app, the signed `warpctrl` binary, and any signed Warp-owned local broker/helper that needs to unwrap raw secrets. It should exclude arbitrary same-user applications.
@@ -287,7 +292,7 @@ The default transport is an instance-local loopback listener bound to `127.0.0.1
 Transport requirements:
 - Bind only to loopback for local control.
 - Do not set permissive CORS headers.
-- Reject control requests while local control scripting is disabled, even if the request presents an otherwise valid credential.
+- Reject control requests when their inside-Warp or outside-Warp invocation context is disabled, even if the request presents an otherwise valid credential.
 - Authenticate every control request locally in the selected Warp app process before selector resolution or action dispatch.
 - Reject missing, malformed, expired, revoked, or invalid credentials with structured authentication errors.
 - Keep unauthenticated health metadata minimal and non-sensitive.
@@ -413,7 +418,7 @@ Error-level logs should be used only for conditions that need developer attentio
 ## Security- and safety-relevant errors
 Structured errors are part of the security contract.
 Important errors include:
-- `local_control_disabled` when the user has not enabled local control scripting in Warp settings or has disabled it after credentials were issued;
+- `local_control_disabled` when the relevant inside-Warp or outside-Warp scripting context is disabled in Settings > Scripting or has been disabled after credentials were issued;
 - `unauthorized_local_client` for missing, malformed, expired, revoked, or invalid credentials;
 - `insufficient_permissions` for valid credentials that lack the requested safety tier or target scope;
 - `authenticated_user_required` when an action requires a logged-in Warp user but the credential lacks an authenticated-user grant;
@@ -430,8 +435,8 @@ Important errors include:
 The app must not downgrade these failures into broader default actions, and the CLI must preserve structured server errors in both human-readable and JSON output.
 ## Required controls before full catalog expansion
 Before shipping each action family, verify that these controls are implemented for that family:
-- Local control scripting must be explicitly enabled in Warp's app UI before the action family can run.
-- The authoritative enablement state is protected from external writes and is local-only rather than synced.
+- Local control scripting must be enabled for the request's invocation context before the action family can run; inside-Warp control defaults on and outside-Warp control defaults off.
+- The authoritative enablement states live under Settings > Scripting, are protected from external writes, and are local-only rather than synced.
 - The action has a documented tier.
 - The action has a documented `requires_authenticated_user` value. New actions default to `true` unless explicitly reviewed as logged-out-safe.
 - The action documents allowed execution contexts and whether external clients may run it.
@@ -448,13 +453,13 @@ Before shipping each action family, verify that these controls are implemented f
 ## Platform requirements
 ### macOS and Linux
 Discovery files must be stored in a per-user directory with owner-only permissions.
-On macOS, raw credential material and the authoritative local-control enablement state should live in Keychain, not in the discovery record or an ordinary preferences file. Keychain access should be constrained to Warp-owned signed binaries or helpers using code-signing based access control. The enablement state should be writable by the Warp app's in-app settings flow and not writable by `warpctrl`. The discovery record should hold only metadata and a credential reference when local control is enabled.
-On Linux, raw credentials and the authoritative enablement state should prefer platform-secure storage where available; otherwise short-lived scoped credentials may live in owner-only local state with strict file and directory permissions. If the enablement state falls back to owner-only local state, the weaker same-user protection should be documented.
+On macOS, raw credential material and the authoritative local-control enablement states should live in Keychain, not in the discovery record or an ordinary preferences file. Keychain access should be constrained to Warp-owned signed binaries or helpers using code-signing based access control. The enablement states should be writable by the Warp app's Settings > Scripting flow and not writable by `warpctrl`. The discovery record should hold only metadata and a credential reference when the relevant inside-Warp or outside-Warp context is enabled.
+On Linux, raw credentials and the authoritative enablement states should prefer platform-secure storage where available; otherwise short-lived scoped credentials may live in owner-only local state with strict file and directory permissions. If an enablement state falls back to owner-only local state, the weaker same-user protection should be documented.
 Unix domain sockets with peer credential checks may be considered for stronger same-machine identity than bearer tokens alone.
 ### Windows
 Discovery records and credential material must live under the current user's app data directory with ACLs restricted to the current user, Administrators, and SYSTEM.
-The authoritative enablement state should use Credential Manager, DPAPI-backed protected storage, or an equivalent app-controlled protected store rather than a normal registry setting that arbitrary same-user processes can write.
-Windows support for authenticated local control should not be considered complete until the implementation creates, validates, and tests those ACLs and the protected enablement-state behavior.
+The authoritative enablement states should use Credential Manager, DPAPI-backed protected storage, or an equivalent app-controlled protected store rather than normal registry settings that arbitrary same-user processes can write.
+Windows support for authenticated local control should not be considered complete until the implementation creates, validates, and tests those ACLs and the protected enablement-state behavior for both inside-Warp and outside-Warp settings.
 ## Remote control is separate
 The local architecture intentionally assumes same-machine, same-user control over a loopback listener. Future remote URLs must use a different security design that includes:
 - transport encryption;

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -1,5 +1,5 @@
 # warpctrl security architecture
-`warpctrl` is a local-control CLI for an already-running Warp app instance. Its security architecture is designed to support the full control catalog: discovery, structural metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, underlying data mutations, input-buffer staging, command execution, file operations, and Warp Drive operations.
+`warpctrl` is a local-control CLI for an already-running Warp app instance. Its security architecture is designed to support the control catalog: discovery, structural metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, underlying data mutations, input-buffer staging, file operations, and Warp Drive operations. Terminal command execution, workflow execution, accepted-command submission, and agent-prompt submission are future high-risk capabilities and must not be included in the initial public implementation; the initial version may stage text in an active input buffer only for the user to review and confirm manually.
 The correct architecture is not a single shared localhost bearer token with client-side conventions. The CLI, app bridge, and protocol must treat security as a local app-enforced capability system: discovery finds compatible instances, secure storage protects raw credential material, broker-issued credentials identify the granted scopes, the running Warp app's local-control bridge enforces action categories before dispatch, and target resolution never silently retargets a request.
 The action-category model is primarily a safety and intent mechanism, not a hard security boundary against malicious same-user software. It lets a user, script, or agent intentionally request metadata-only, data-read, app-state mutation, metadata/configuration mutation, or underlying-data mutation access so it does not accidentally mutate state, expose sensitive content, or execute commands. It should not be described as strong access control against a process that can already run arbitrary commands as the user.
 `warpctrl` has two distinct authorization dimensions: local-control authority and Warp user authority. Local-control authority proves the request is allowed to control the local app. Warp user authority proves the selected Warp app has a real logged-in Warp user and the request is allowed to act on user-authenticated data such as Warp Drive objects, AI conversation traces, synced settings, or cloud-backed user state. Logged-out users should retain a smaller local-only control surface, but authenticated-user actions require a true logged-in Warp user in the selected app.
@@ -20,6 +20,7 @@ The action-category model is primarily a safety and intent mechanism, not a hard
 - Classify every action by state/data category and enforce the required permission category in the local app bridge, not in the CLI frontend.
 - Classify every action by whether it requires an authenticated Warp user. New actions should default to requiring an authenticated user unless they are deliberately reviewed as safe for logged-out or external use.
 - Prevent `warpctrl` from becoming an ambient full-power confused deputy that any same-user process can invoke for high-risk actions.
+- Prohibit terminal command execution, workflow execution, accepted-command submission, and agent-prompt submission in the initial public implementation; input-buffer actions may stage text only and must not submit it.
 - Preserve deterministic targeting so a request never silently mutates or reads the wrong window, tab, pane, session, file, or Warp Drive object.
 - Keep the action surface allowlisted and typed rather than exposing arbitrary internal app dispatch.
 - Make high-risk operations auditable and configurable without logging sensitive terminal contents or credentials.
@@ -114,7 +115,7 @@ Once the relevant inside-Warp or outside-Warp enablement setting allows a reques
 - **Underlying data reads:** permit reads of terminal output, scrollback, input buffers, command history, session traces, file contents, Warp Drive object contents, AI conversation content, and other content-bearing state.
 - **App-state mutations:** permit local UI/layout/focus changes such as opening windows, creating tabs, closing tabs, focusing panes, splitting panes, opening panels, opening files/projects/views, and staging text in the input buffer without executing it.
 - **Metadata/configuration mutations:** permit persistent metadata or configuration changes such as tab/pane names, tab colors, themes, font size, zoom, allowlisted settings, and keybindings.
-- **Underlying data mutations:** permit terminal command execution, file create/write/append/delete, Warp Drive workflow execution, Warp Drive object CRUD, AI conversation mutations, and any other action that can change user data or cause external side effects.
+- **Underlying data mutations:** permit file create/write/append/delete, Warp Drive object CRUD, AI conversation mutations, and any other action that can change user data or cause external side effects. Terminal command execution, Warp Drive workflow execution, accepted-command submission, and agent-prompt submission belong in this category if they are added later, but they are not allowed in the initial public implementation.
 - **Authenticated-user actions from Warp terminals:** permit `warpctrl` invocations that originate from a verified Warp-managed terminal session to receive grants backed by the currently logged-in Warp user, enabling actions that read or mutate Warp Drive, AI conversation traces, synced settings, or other user-authenticated state.
 - **Authenticated-user actions from external clients:** default off. If supported, this must be a separate explicit permission from in-Warp authenticated actions because external same-user processes are a weaker context than a Warp-managed terminal session.
 Granular permissions should be independently configurable for inside-Warp and outside-Warp contexts where the distinction matters. Disabling any category should invalidate active credentials that include that category. The broker and app bridge must enforce these settings locally for every credential request and every presented credential. App-state mutation permission must not imply metadata/configuration mutation or underlying data mutation permission.
@@ -130,9 +131,18 @@ These scoped credentials are guardrails for well-behaved clients. They prevent a
 Acceptable designs include a short-lived per-session capability, an app-owned broker handshake tied to the terminal session, or an equivalent proof that arbitrary external processes cannot mint by setting an environment variable. Plain environment variables may be used as handles or hints, but they must not be the sole authority for in-Warp privileges because external processes can spoof them.
 Verified in-Warp context can raise the maximum eligible grant set, especially for authenticated-user actions. It does not by itself bypass the user's granular local-control settings, action categories, target scopes, or logged-in-user requirements.
 ### Warp user authentication boundary
-Actions that touch user-authenticated Warp data require a true logged-in Warp user in the selected app. This includes Warp Drive object contents or mutation, AI conversation traces, cloud-backed user settings, team/account data, and any other surface whose normal app access depends on the user's Warp account.
+Actions that touch user-authenticated Warp data require a true logged-in Warp user in the selected app. This includes Warp Drive object contents or mutation, AI conversation traces, cloud-backed user settings, team/account data, and any other surface whose normal app access depends on the user's Warp account. Authenticated-user grants must be tied to the same logged-in Warp user that is active in the selected app instance; `warpctrl` must not maintain a separate cloud login that can drift from the controlled process.
 The app bridge should execute these actions on behalf of the logged-in app user through existing app auth state. `warpctrl` should receive a local-control credential that carries an `authenticated_user` grant, the verified user identity or stable subject reference, and the allowed authenticated action families. It should not need to export raw Firebase, server, or cloud API tokens to shell scripts.
 If the selected app has no logged-in user, authenticated-user actions must fail with a structured error rather than falling back to logged-out behavior. Logged-out users may still use the smaller local-only action set explicitly marked as not requiring an authenticated user.
+### Authenticated-user login protocol
+`warpctrl` should provide an auth/status flow for users and automation that need authenticated-user actions, but the CLI must not collect Warp credentials or own an independent Warp account session.
+Requirements:
+- `warpctrl auth status [selectors]` reports whether the selected app instance is logged in and may return a stable, non-secret user subject/identity summary when the caller has the required grant.
+- `warpctrl auth login [selectors]` focuses or opens the selected Warp app's normal sign-in UI and waits, or exits with actionable instructions, until the user signs in through Warp itself.
+- The credential broker may mint an authenticated-user grant only after confirming the selected app has a true logged-in Warp user and the requested authenticated-user setting is enabled for the verified invocation context.
+- Authenticated-user credentials are bound to the selected instance and logged-in user subject. If the app logs out, switches users, loses authenticated state, or the presented credential subject no longer matches the selected app's current user, authenticated-user actions fail with `authenticated_user_mismatch` or another structured authenticated-user error.
+- The app bridge executes authenticated-user actions through the selected app's existing auth state. Raw Firebase, server, OAuth, or cloud API tokens must not be exported to `warpctrl`, shell scripts, JSON output, generated docs, or logs.
+This protocol applies only to actions whose allowlist entry requires a logged-in Warp user. Logged-out-safe actions continue to use local-control credentials without requiring Warp account login.
 ### Application identity boundary
 On platforms with secure credential storage, especially macOS, the raw local-control credential should be readable only by Warp-owned, correctly signed code. On macOS this means storing raw credential material in Keychain with access constrained by Warp's signing identity, designated requirement, Keychain access group, or equivalent platform mechanism. This narrows token extraction from “any same-user process can read a file” to “only trusted Warp-signed code can unwrap the secret.”
 This boundary protects the credential from direct theft and prevents arbitrary apps from making authenticated raw HTTP requests to the local-control listener. It also lets the authoritative enablement state be stored somewhere harder to modify than ordinary user preferences. It does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary or automate the Warp UI. That confused-deputy risk is reduced by explicit in-app enablement, scoped credential issuance, action-category policy, and local app-side bridge enforcement, but it is not eliminated as a hard same-user security boundary.
@@ -309,7 +319,7 @@ Default rule for new actions:
 - New actions require an authenticated Warp user unless the implementer deliberately classifies them as logged-out-safe.
 - The logged-out-safe set should remain meaningfully smaller and limited to local app structure, local appearance metadata, and other surfaces that do not depend on the user's cloud-backed Warp identity.
 - Actions that read or mutate Warp Drive, AI conversation traces, synced settings, team/account data, or other user-authenticated state must require an authenticated user.
-- Actions that can execute user-authored cloud-backed content, such as running Warp Drive workflows or inserting notebook commands, require both the authenticated-user grant and the appropriate high-risk action category.
+- Future actions that can execute user-authored cloud-backed content, such as running Warp Drive workflows or submitting notebook commands, require both the authenticated-user grant and the appropriate high-risk action category. These execution actions are excluded from the initial public implementation.
 When an authenticated-user action is requested:
 - the selected app must have an active logged-in Warp user;
 - the presented local-control credential must include an `authenticated_user` grant for that user or stable subject;
@@ -362,14 +372,15 @@ Examples:
 - theme, font, zoom, keybinding, and allowlisted settings writes.
 This category should not authorize terminal command execution, file writes, or Warp Drive CRUD.
 ### Underlying data mutations
-Can change user data, execute code, or cause external side effects.
+Can change user data, execute code, submit prompts, or cause external side effects.
 Examples:
-- command execution in a session;
-- executing Warp Drive workflows or other user-authored runnable content;
+- future command execution in a session;
+- future agent prompt submission or acceptance of an agent-proposed command;
+- future execution of Warp Drive workflows or other user-authored runnable content;
 - file create/write/append/delete operations;
 - Warp Drive object create/update/trash/restore/permanent-delete operations;
 - AI conversation history mutation or other cloud-backed content mutation.
-This category should require explicit user or policy approval for unattended automation and integrations. It must remain separate from app-state mutation so a client that can open or focus Warp UI cannot automatically execute commands, write files, or mutate Warp Drive content.
+This category should require explicit user or policy approval for unattended automation and integrations. It must remain separate from app-state mutation so a client that can open or focus Warp UI cannot automatically execute commands, submit prompts, write files, or mutate Warp Drive content. Terminal command execution, workflow execution, accepted-command submission, and agent-prompt submission must remain unavailable in the initial public implementation even if the protocol has future reserved action names for them.
 ## Target scoping and deterministic resolution
 Targeting is part of security. The protocol must not convert ambiguous or stale selectors into best-effort mutations.
 Rules:
@@ -418,7 +429,8 @@ Recommended audit fields:
 Avoid logging:
 - bearer tokens or scoped credentials;
 - terminal output;
-- command text for command execution unless explicitly approved by policy;
+- command text for command execution unless explicitly approved by policy in a future version that supports execution;
+- agent prompt text;
 - input buffer contents;
 - Warp Drive object contents;
 - environment variable values.
@@ -431,6 +443,7 @@ Important errors include:
 - `insufficient_permissions` for valid credentials that lack the requested permission category or target scope;
 - `authenticated_user_required` when an action requires a logged-in Warp user but the credential lacks an authenticated-user grant;
 - `authenticated_user_unavailable` when the selected Warp app has no logged-in Warp user or cannot access the required authenticated user state;
+- `authenticated_user_mismatch` when an authenticated-user credential is bound to a different user subject than the user currently logged in to the selected Warp app;
 - `execution_context_not_allowed` when the action or requested grant is not allowed from the verified invocation context, such as an external client attempting an in-Warp-only authenticated-user action;
 - `ambiguous_instance` when multiple compatible instances cannot be resolved safely;
 - `invalid_selector` for malformed or unsupported selector syntax;
@@ -458,6 +471,7 @@ Before shipping each action family, verify that these controls are implemented f
 - Tests cover allowed, insufficient-permission, and denied credential paths.
 - Logs and errors do not expose credentials, terminal contents, command text, or sensitive settings.
 - Operator docs distinguish available commands from planned catalog entries.
+- Initial public action-family docs and tests prove terminal command execution, workflow execution, accepted-command submission, and agent-prompt submission are not allowlisted; input-buffer staging never submits the buffer.
 ## Platform requirements
 ### macOS and Linux
 Discovery files must be stored in a per-user directory with owner-only permissions.

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -1,7 +1,7 @@
 # warpctrl security architecture
-`warpctrl` is a local-control CLI for an already-running Warp app instance. Its security architecture is designed to support the full control catalog: discovery, structural reads, terminal-data reads, non-destructive mutations, settings changes, input manipulation, command execution, and destructive window/tab/pane operations.
-The correct architecture is not a single shared localhost bearer token with client-side conventions. The CLI, app bridge, and protocol must treat security as a local app-enforced capability system: discovery finds compatible instances, secure storage protects raw credential material, broker-issued credentials identify the granted scopes, the running Warp app's local-control bridge enforces action tiers before dispatch, and target resolution never silently retargets a request.
-The action-tier model is primarily a safety and intent mechanism, not a hard security boundary against malicious same-user software. It lets a user, script, or agent intentionally request read-only or low-risk access so it does not accidentally mutate state or execute commands. It should not be described as strong access control against a process that can already run arbitrary commands as the user.
+`warpctrl` is a local-control CLI for an already-running Warp app instance. Its security architecture is designed to support the full control catalog: discovery, structural metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, underlying data mutations, input-buffer staging, command execution, file operations, and Warp Drive operations.
+The correct architecture is not a single shared localhost bearer token with client-side conventions. The CLI, app bridge, and protocol must treat security as a local app-enforced capability system: discovery finds compatible instances, secure storage protects raw credential material, broker-issued credentials identify the granted scopes, the running Warp app's local-control bridge enforces action categories before dispatch, and target resolution never silently retargets a request.
+The action-category model is primarily a safety and intent mechanism, not a hard security boundary against malicious same-user software. It lets a user, script, or agent intentionally request metadata-only, data-read, app-state mutation, metadata/configuration mutation, or underlying-data mutation access so it does not accidentally mutate state, expose sensitive content, or execute commands. It should not be described as strong access control against a process that can already run arbitrary commands as the user.
 `warpctrl` has two distinct authorization dimensions: local-control authority and Warp user authority. Local-control authority proves the request is allowed to control the local app. Warp user authority proves the selected Warp app has a real logged-in Warp user and the request is allowed to act on user-authenticated data such as Warp Drive objects, AI conversation traces, synced settings, or cloud-backed user state. Logged-out users should retain a smaller local-only control surface, but authenticated-user actions require a true logged-in Warp user in the selected app.
 ## Security goals
 - Allow trusted local users and approved automation to control a running Warp instance through a stable, scriptable interface.
@@ -17,7 +17,7 @@ The action-tier model is primarily a safety and intent mechanism, not a hard sec
 - When outside-Warp control is enabled, allow external invocations only for a smaller local-only action set by default that does not touch user-authenticated data.
 - Allow in-Warp invocations to receive authenticated-user grants when the selected Warp app has a true logged-in user and the user's local-control settings permit that grant.
 - Support least-privilege safety modes for automation and interactive use without relying on an unenforceable identity label.
-- Classify every action by risk tier and enforce the required tier in the local app bridge, not in the CLI frontend.
+- Classify every action by state/data category and enforce the required permission category in the local app bridge, not in the CLI frontend.
 - Classify every action by whether it requires an authenticated Warp user. New actions should default to requiring an authenticated user unless they are deliberately reviewed as safe for logged-out or external use.
 - Prevent `warpctrl` from becoming an ambient full-power confused deputy that any same-user process can invoke for high-risk actions.
 - Preserve deterministic targeting so a request never silently mutates or reads the wrong window, tab, pane, session, file, or Warp Drive object.
@@ -69,7 +69,7 @@ This model directly acknowledges that terminal contents are sensitive and that a
 Lessons for `warpctrl`:
 - default-off or policy-controlled high-power automation is reasonable for sensitive capabilities;
 - random local credentials are useful, but the path that grants or unwraps them is just as important as the token itself;
-- terminal-data reads and input/command execution should be treated as higher-risk than structural metadata reads;
+- underlying data reads and input/command execution should be treated as higher-risk than structural metadata reads;
 - macOS Automation can be part of the approval path, but Warp still needs local app-side enforcement because direct protocol clients can bypass the official CLI.
 ### tmux
 tmux is a useful lower-level comparison because its clients and server communicate through local sockets. The default socket lives in a per-user directory under `/tmp`, and that directory must not be world readable, writable, or executable. tmux control mode then exposes a text protocol where clients can issue normal tmux commands and receive asynchronous pane/session notifications. Newer tmux versions also have explicit server-access controls for sharing across users.
@@ -110,13 +110,14 @@ Disabled-state behavior:
 These enablement gates do not create perfect same-user malicious-app isolation. A hostile process with Accessibility or Screen Recording permission might still try to automate the Warp UI. The outside-Warp gate is still important because it closes the much easier paths where external apps silently edit local preferences, call a config CLI, or write synced settings to enable a powerful control surface.
 ### Granular permission settings
 Once the relevant inside-Warp or outside-Warp enablement setting allows a request context, users should control which categories of `warpctrl` authority can be granted. These permissions should appear under Settings > Scripting. Recommended independent permissions:
-- **Local read-only metadata:** permit external and in-Warp clients to inspect non-sensitive local app structure such as instances, windows, tabs, panes, app version, and theme names.
-- **Terminal data reads:** permit reads of terminal output, scrollback, input buffers, command history, and session traces.
-- **Non-destructive local mutations:** permit reversible app-state changes such as creating tabs, focusing panes, changing theme, or opening panels.
-- **Destructive and execution actions:** permit closing targets, injecting input, running commands, executing workflows, or other high-risk operations.
+- **Metadata reads:** permit external and in-Warp clients to inspect non-sensitive local app structure and configuration metadata such as instances, windows, tabs, panes, app version, theme names, setting keys, action metadata, and Drive object IDs/names/types without content.
+- **Underlying data reads:** permit reads of terminal output, scrollback, input buffers, command history, session traces, file contents, Warp Drive object contents, AI conversation content, and other content-bearing state.
+- **App-state mutations:** permit local UI/layout/focus changes such as opening windows, creating tabs, closing tabs, focusing panes, splitting panes, opening panels, opening files/projects/views, and staging text in the input buffer without executing it.
+- **Metadata/configuration mutations:** permit persistent metadata or configuration changes such as tab/pane names, tab colors, themes, font size, zoom, allowlisted settings, and keybindings.
+- **Underlying data mutations:** permit terminal command execution, file create/write/append/delete, Warp Drive workflow execution, Warp Drive object CRUD, AI conversation mutations, and any other action that can change user data or cause external side effects.
 - **Authenticated-user actions from Warp terminals:** permit `warpctrl` invocations that originate from a verified Warp-managed terminal session to receive grants backed by the currently logged-in Warp user, enabling actions that read or mutate Warp Drive, AI conversation traces, synced settings, or other user-authenticated state.
 - **Authenticated-user actions from external clients:** default off. If supported, this must be a separate explicit permission from in-Warp authenticated actions because external same-user processes are a weaker context than a Warp-managed terminal session.
-Granular permissions should be independently configurable for inside-Warp and outside-Warp contexts where the distinction matters. Disabling any category should invalidate active credentials that include that category. The broker and app bridge must enforce these settings locally for every credential request and every presented credential.
+Granular permissions should be independently configurable for inside-Warp and outside-Warp contexts where the distinction matters. Disabling any category should invalidate active credentials that include that category. The broker and app bridge must enforce these settings locally for every credential request and every presented credential. App-state mutation permission must not imply metadata/configuration mutation or underlying data mutation permission.
 ## Trust boundaries
 `warpctrl` has several distinct trust boundaries.
 ### Operating-system user boundary
@@ -127,16 +128,16 @@ These scoped credentials are guardrails for well-behaved clients. They prevent a
 ### Warp-terminal execution context boundary
 `warpctrl` should be able to receive special grants when it is invoked from within a Warp-managed terminal session, but the bridge must not trust a caller-supplied string such as `caller_class=warp_terminal`. The app should issue a session-bound execution-context proof to Warp-managed terminal sessions and have the broker verify that proof before minting in-Warp-only grants.
 Acceptable designs include a short-lived per-session capability, an app-owned broker handshake tied to the terminal session, or an equivalent proof that arbitrary external processes cannot mint by setting an environment variable. Plain environment variables may be used as handles or hints, but they must not be the sole authority for in-Warp privileges because external processes can spoof them.
-Verified in-Warp context can raise the maximum eligible grant set, especially for authenticated-user actions. It does not by itself bypass the user's granular local-control settings, action risk tiers, target scopes, or logged-in-user requirements.
+Verified in-Warp context can raise the maximum eligible grant set, especially for authenticated-user actions. It does not by itself bypass the user's granular local-control settings, action categories, target scopes, or logged-in-user requirements.
 ### Warp user authentication boundary
 Actions that touch user-authenticated Warp data require a true logged-in Warp user in the selected app. This includes Warp Drive object contents or mutation, AI conversation traces, cloud-backed user settings, team/account data, and any other surface whose normal app access depends on the user's Warp account.
 The app bridge should execute these actions on behalf of the logged-in app user through existing app auth state. `warpctrl` should receive a local-control credential that carries an `authenticated_user` grant, the verified user identity or stable subject reference, and the allowed authenticated action families. It should not need to export raw Firebase, server, or cloud API tokens to shell scripts.
 If the selected app has no logged-in user, authenticated-user actions must fail with a structured error rather than falling back to logged-out behavior. Logged-out users may still use the smaller local-only action set explicitly marked as not requiring an authenticated user.
 ### Application identity boundary
 On platforms with secure credential storage, especially macOS, the raw local-control credential should be readable only by Warp-owned, correctly signed code. On macOS this means storing raw credential material in Keychain with access constrained by Warp's signing identity, designated requirement, Keychain access group, or equivalent platform mechanism. This narrows token extraction from “any same-user process can read a file” to “only trusted Warp-signed code can unwrap the secret.”
-This boundary protects the credential from direct theft and prevents arbitrary apps from making authenticated raw HTTP requests to the local-control listener. It also lets the authoritative enablement state be stored somewhere harder to modify than ordinary user preferences. It does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary or automate the Warp UI. That confused-deputy risk is reduced by explicit in-app enablement, scoped credential issuance, action-tier policy, and local app-side bridge enforcement, but it is not eliminated as a hard same-user security boundary.
+This boundary protects the credential from direct theft and prevents arbitrary apps from making authenticated raw HTTP requests to the local-control listener. It also lets the authoritative enablement state be stored somewhere harder to modify than ordinary user preferences. It does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary or automate the Warp UI. That confused-deputy risk is reduced by explicit in-app enablement, scoped credential issuance, action-category policy, and local app-side bridge enforcement, but it is not eliminated as a hard same-user security boundary.
 ### Action boundary
-Every action belongs to a risk tier. The bridge must map the requested action to a required tier and compare that tier to the presented credential before selector resolution or handler dispatch.
+Every action belongs to a state/data category. The bridge must map the requested action to a required permission category and compare that category to the presented credential before selector resolution or handler dispatch.
 ### Target boundary
 A valid credential for one instance or target must not imply authority over another. Credentials should be bound to the issuing Warp instance and may be further scoped to target families such as terminal sessions, files, or Warp Drive objects when those surfaces are exposed.
 ## Threat model
@@ -151,7 +152,7 @@ A valid credential for one instance or target must not imply authority over anot
 - Stale discovery records from exited Warp processes.
 - Multiple running Warp instances where ambiguous selection could target the wrong process.
 - Malformed clients attempting unknown, unsupported, unallowlisted, or invalid action payloads.
-- Valid clients attempting actions above their granted tier.
+- Valid clients attempting actions above their granted permission category.
 - Explicit target IDs that become stale between discovery and execution.
 - Future handlers that expose terminal data, settings writes, input mutation, command execution, file intents, or Warp Drive object operations.
 ### Out of scope
@@ -166,7 +167,7 @@ The security model has eight layers:
 4. **Execution context verification:** Distinguish verified Warp-terminal invocations from external same-user invocations without trusting caller-declared labels.
 5. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes only when the request's invocation context is enabled and the user's granular permissions allow the requested category.
 6. **Transport authentication:** Reject disabled or unauthenticated requests before reading or mutating app state.
-7. **Safety and user-auth policy:** Enforce action tiers, target scopes, execution-context requirements, and authenticated-user requirements locally in the app bridge.
+7. **Safety and user-auth policy:** Enforce permission categories, target scopes, execution-context requirements, and authenticated-user requirements locally in the app bridge.
 8. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
 ```mermaid
 sequenceDiagram
@@ -202,7 +203,7 @@ sequenceDiagram
     Broker-->>CLI: Scoped credential with grants, context, user scope, expiry
     CLI->>HTTP: Authenticated typed request
     HTTP->>Bridge: Verify credential and protocol envelope
-    Bridge->>Bridge: Check tier + context + authenticated-user + target scope
+    Bridge->>Bridge: Check permission category + context + authenticated-user + target scope
     alt Denied
         Bridge-->>CLI: structured safety-policy error
     else Allowed
@@ -230,12 +231,12 @@ Discovery rules:
 - If multiple compatible instances are ambiguous, the CLI must require explicit `--instance` selection.
 - Discovery metadata must not expose terminal contents, environment variables, auth tokens for cloud services, raw local-control credentials, or mutating capability grants.
 ## Credential model
-The full `warpctrl` catalog requires scoped credentials. A single shared full-power bearer token is not sufficient once automation, terminal data, command execution, and destructive actions are supported.
+The full `warpctrl` catalog requires scoped credentials. A single shared full-power bearer token is not sufficient once automation, underlying data reads, app-state mutations, metadata/configuration mutations, and underlying data mutations are supported.
 ### Credential properties
 A control credential should encode or reference:
 - issuing Warp instance;
 - protocol version or accepted version range;
-- granted action tiers;
+- granted permission categories;
 - verified execution context, such as external client or Warp-managed terminal session;
 - whether the credential may act on behalf of an authenticated Warp user;
 - authenticated Warp user subject or stable user reference when an authenticated-user grant is present;
@@ -246,26 +247,29 @@ A control credential should encode or reference:
 - unique credential ID for revocation and auditing;
 - integrity protection so callers cannot forge or widen grants.
 ### Credential issuance
-Warp should issue credentials through an app-owned local broker or equivalent trusted path. The broker decides which grants to issue based on the requested action tier, target scope, user configuration, execution context, and any explicit user approval.
+Warp should issue credentials through an app-owned local broker or equivalent trusted path. The broker decides which grants to issue based on the requested permission category, target scope, user configuration, execution context, and any explicit user approval.
 Recommended defaults:
 - Credential issuance is unavailable unless the protected enablement state allows the request's invocation context: inside Warp or outside Warp.
 - Commands should start from least privilege and request only the grant needed for the requested action.
 - External same-user invocations should default to the smaller logged-out-safe local action set unless policy or explicit approval grants more.
 - Verified Warp-terminal invocations may receive broader local-control grants when the user's granular settings allow them.
 - Authenticated-user grants are available only when the selected Warp app has a true logged-in Warp user and the requested execution context is allowed by local-control settings.
-- Terminal data reads require an explicit `read_terminal_data` grant.
-- Non-destructive mutations require an explicit `mutate_non_destructive` grant.
-- Destructive operations, input injection, and command execution require explicit high-risk grants.
-- User-authenticated data reads or mutations require an explicit `authenticated_user` grant and an allowed authenticated action family.
+- Metadata reads require an explicit `read_metadata` grant.
+- Underlying data reads require an explicit `read_underlying_data` grant.
+- App-state mutations require an explicit `mutate_app_state` grant.
+- Metadata/configuration mutations require an explicit `mutate_metadata` or `mutate_configuration` grant.
+- Underlying data mutations require an explicit `mutate_underlying_data` grant and should require approval or policy for unattended automation.
+- User-authenticated data reads or mutations require an explicit `authenticated_user` grant and an allowed authenticated action family in addition to the data-category grant.
 - Integrations should receive the narrowest grant needed for the configured workflow.
-The broker must not issue broad authority merely because the request came from the signed `warpctrl` binary. It should evaluate the requested action tier, target scope, configured policy, execution context, and whether user approval is required. The CLI must not mint its own authority. It can request, load, and present credentials, but the app bridge remains the enforcement point for these safety grants.
+The broker must not issue broad authority merely because the request came from the signed `warpctrl` binary. It should evaluate the requested permission category, target scope, configured policy, execution context, and whether user approval is required. The CLI must not mint its own authority. It can request, load, and present credentials, but the app bridge remains the enforcement point for these safety grants.
 ### Safety grants, not strong access control
-The tier system should be understood as a user-intent and accident-prevention mechanism:
-- A user can ask an agent or script to operate with read-only metadata grants so it can inspect structure but cannot accidentally mutate state.
-- A workflow can request terminal-data reads separately from structural metadata reads because terminal contents are more sensitive.
-- A script can request non-destructive mutation without also receiving command-execution capability.
-- Destructive actions and command execution can require an explicit approval or configured policy so surprising operations pause before they happen.
-This model does not make untrusted same-user software safe. A malicious local process may invoke `warpctrl`, simulate user workflows, or use other OS-level capabilities outside `warpctrl`. The tier model is still valuable because it lets honest clients, agents, and scripts constrain themselves and gives Warp a structured point to prompt, deny, or audit risky actions.
+The category system should be understood as a user-intent and accident-prevention mechanism:
+- A user can ask an agent or script to operate with metadata-read grants so it can inspect structure but cannot read terminal content or mutate state.
+- A workflow can request underlying-data reads separately from structural metadata reads because terminal output, files, Drive object content, and AI conversations can contain sensitive data.
+- A script can request app-state mutation without also receiving permission to change persistent settings, execute commands, write files, or mutate Warp Drive objects.
+- Metadata/configuration mutations can be allowed without granting underlying data mutation.
+- Underlying data mutations can require explicit approval or configured policy so surprising operations pause before they execute commands or change user data.
+This model does not make untrusted same-user software safe. A malicious local process may invoke `warpctrl`, simulate user workflows, or use other OS-level capabilities outside `warpctrl`. The category model is still valuable because it lets honest clients, agents, and scripts constrain themselves and gives Warp a structured point to prompt, deny, or audit risky actions.
 ### Credential storage
 Credential storage should be platform-appropriate:
 - Local discovery may store a credential reference rather than the credential itself.
@@ -281,9 +285,9 @@ For example, if `warpctrl` can silently unwrap a full-power credential and execu
 Mitigations:
 - Do not give `warpctrl` ambient non-interactive access to an unrestricted full-control credential.
 - Prefer action-scoped or session-scoped credentials minted just in time by the broker.
-- Require explicit user approval or preconfigured policy for Tier 4 actions and other sensitive grants.
+- Require explicit user approval or preconfigured policy for underlying data mutations and other sensitive grants.
 - Distinguish user-approved credential requests from ambient unattended invocations through explicit approval prompts, configured policy, terminal/session context, or narrow credential request flows.
-- Bind issued credentials to the requested instance, action tier, optional action family, optional target scope, and short expiry.
+- Bind issued credentials to the requested instance, permission category, optional action family, optional target scope, and short expiry.
 - Let `warpctrl` preflight and request credentials, but require the local app bridge to enforce scopes because direct protocol clients can bypass the CLI.
 - Make denials structured and non-fatal for automation so callers can request narrower or user-approved grants rather than falling back to unsafe behavior.
 These mitigations are about routing high-risk operations through intentional `warpctrl` flows rather than exposing a reusable localhost token to any process. They should not be documented as a guarantee that arbitrary same-user applications cannot cause Warp-visible actions.
@@ -305,7 +309,7 @@ Default rule for new actions:
 - New actions require an authenticated Warp user unless the implementer deliberately classifies them as logged-out-safe.
 - The logged-out-safe set should remain meaningfully smaller and limited to local app structure, local appearance metadata, and other surfaces that do not depend on the user's cloud-backed Warp identity.
 - Actions that read or mutate Warp Drive, AI conversation traces, synced settings, team/account data, or other user-authenticated state must require an authenticated user.
-- Actions that can execute user-authored cloud-backed content, such as running Warp Drive workflows or inserting notebook commands, require both the authenticated-user grant and the appropriate high-risk action tier.
+- Actions that can execute user-authored cloud-backed content, such as running Warp Drive workflows or inserting notebook commands, require both the authenticated-user grant and the appropriate high-risk action category.
 When an authenticated-user action is requested:
 - the selected app must have an active logged-in Warp user;
 - the presented local-control credential must include an `authenticated_user` grant for that user or stable subject;
@@ -318,50 +322,54 @@ The bridge must:
 1. Parse the typed request envelope.
 2. Verify protocol version compatibility.
 3. Authenticate the credential.
-4. Determine granted action tiers, execution context, target scopes, and authenticated-user grants.
-5. Map the requested action to a required tier, action family, execution-context requirement, and authenticated-user requirement.
+4. Determine granted permission categories, execution context, target scopes, and authenticated-user grants.
+5. Map the requested action to a required permission category, action family, execution-context requirement, and authenticated-user requirement.
 6. Check optional target-family restrictions.
 7. Reject requests that exceed the credential's grants with `insufficient_permissions`.
 8. Reject authenticated-user actions without a logged-in user or authenticated-user grant with a structured authenticated-user error.
 9. Only then resolve selectors and invoke the allowlisted handler.
 The CLI frontend may provide helpful preflight errors, but those checks are advisory. Local app-side bridge enforcement is mandatory because other tools can bypass the official CLI and speak the protocol directly.
-## Action risk tiers
-Every action belongs to exactly one tier. These tiers describe risk and intended safety prompts; they are not a sandbox or a complete OS-level access-control model.
-### Tier 1: read-only metadata
-Returns app structure or configuration without terminal contents or user data from sessions.
+## Action permission categories
+Every action belongs to exactly one state/data category for permission enforcement. These categories describe risk and intended safety prompts; they are not a sandbox or a complete OS-level access-control model.
+### Metadata reads
+Return app structure, app state, or configuration metadata without exposing terminal content, file content, Warp Drive object content, AI conversation content, or other user data.
 Examples:
 - `instance list`, `app active`, `app version`, `app ping`;
 - `window list`, `tab list`, `pane list`, `session list`;
-- `theme list`;
-- allowlisted settings reads that expose configuration but not terminal contents.
-Default unattended credentials may include this tier.
-### Tier 2: read-only terminal data
-Returns potentially sensitive terminal/session data without mutating state.
+- `theme list`, `setting list`, `keybinding list`, and action/capability metadata;
+- Drive object listing that returns object IDs, names, and types but not content.
+Default unattended credentials may include this category.
+### Underlying data reads
+Return user content or data-bearing state without mutating state.
 Examples:
-- pane output or scrollback reads;
-- current input buffer reads;
-- command history reads;
-- session replay or transcript reads.
-This tier is separate from metadata because terminal content often contains secrets, file paths, command output, customer data, and other sensitive information.
-### Tier 3: mutating non-destructive
-Changes visible app state in reversible or low-risk ways without executing terminal content or destroying user state.
+- pane output, scrollback, current input buffer, command history, session replay, or transcript reads;
+- file content reads;
+- Warp Drive object content reads;
+- AI conversation content reads.
+This category is separate from metadata because content often contains secrets, source code, file paths, command output, customer data, and other sensitive information.
+### App-state mutations
+Change visible local Warp UI state without directly changing underlying user data.
 Examples:
-- creating or activating tabs;
-- moving, renaming, or coloring tabs;
-- creating or focusing windows;
-- splitting, focusing, navigating, maximizing, or resizing panes;
-- theme, font, zoom, and allowlisted non-destructive settings changes;
-- opening panels, palettes, and user-facing surfaces.
-### Tier 4: mutating destructive or high-risk
-Can destroy active work, inject terminal input, execute commands, or run user-authored content.
+- creating, focusing, activating, moving, or closing windows, tabs, panes, or sessions;
+- splitting, navigating, maximizing, or resizing panes;
+- opening panels, palettes, files, projects, notebooks, and other user-facing surfaces;
+- inserting, replacing, or clearing staged input buffer text without submitting or executing it.
+### Metadata/configuration mutations
+Change persistent metadata or configuration without directly mutating primary user content.
 Examples:
-- closing windows, tabs, panes, or sessions;
-- clearing, replacing, or inserting terminal input;
+- renaming tabs or panes;
+- changing tab colors;
+- theme, font, zoom, keybinding, and allowlisted settings writes.
+This category should not authorize terminal command execution, file writes, or Warp Drive CRUD.
+### Underlying data mutations
+Can change user data, execute code, or cause external side effects.
+Examples:
 - command execution in a session;
-- switching input modes when it can change execution behavior;
-- executing Warp Drive workflows or notebooks in a terminal session;
-- broad Warp Drive object mutation.
-This tier should require explicit user or policy approval for unattended automation and integrations.
+- executing Warp Drive workflows or other user-authored runnable content;
+- file create/write/append/delete operations;
+- Warp Drive object create/update/trash/restore/permanent-delete operations;
+- AI conversation history mutation or other cloud-backed content mutation.
+This category should require explicit user or policy approval for unattended automation and integrations. It must remain separate from app-state mutation so a client that can open or focus Warp UI cannot automatically execute commands, write files, or mutate Warp Drive content.
 ## Target scoping and deterministic resolution
 Targeting is part of security. The protocol must not convert ambiguous or stale selectors into best-effort mutations.
 Rules:
@@ -380,14 +388,14 @@ Each supported command requires:
 - a typed protocol action;
 - typed parameters;
 - validation rules;
-- a documented risk tier;
+- a documented state/data category and permission category;
 - a documented `requires_authenticated_user` value;
 - a documented allowed execution context, including whether external clients can run it or whether it is limited to verified Warp-terminal invocations;
 - local app-side safety-grant checks;
 - deterministic target resolution;
 - a handler that reuses existing user-visible app behavior where possible;
 - typed success and error responses.
-Adding a new action should be additive and reviewable: extend the protocol enum, implement validation, map the action to a risk tier, declare whether it requires an authenticated user, declare its allowed execution contexts, add a handler, and add tests for authentication, safety-policy denial, authenticated-user denial, selector failure, and success behavior.
+Adding a new action should be additive and reviewable: extend the protocol enum, implement validation, map the action to a state/data category, declare whether it requires an authenticated user, declare its allowed execution contexts, add a handler, and add tests for authentication, safety-policy denial, authenticated-user denial, selector failure, and success behavior.
 ## Browser and localhost protections
 Loopback is not sufficient by itself because browsers can send requests to localhost.
 Required protections:
@@ -404,7 +412,7 @@ Recommended audit fields:
 - timestamp;
 - instance ID;
 - credential ID or grant profile;
-- action name and risk tier;
+- action name, state/data category, and permission category;
 - target type and opaque target ID when safe;
 - success or structured error code.
 Avoid logging:
@@ -420,7 +428,7 @@ Structured errors are part of the security contract.
 Important errors include:
 - `local_control_disabled` when the relevant inside-Warp or outside-Warp scripting context is disabled in Settings > Scripting or has been disabled after credentials were issued;
 - `unauthorized_local_client` for missing, malformed, expired, revoked, or invalid credentials;
-- `insufficient_permissions` for valid credentials that lack the requested safety tier or target scope;
+- `insufficient_permissions` for valid credentials that lack the requested permission category or target scope;
 - `authenticated_user_required` when an action requires a logged-in Warp user but the credential lacks an authenticated-user grant;
 - `authenticated_user_unavailable` when the selected Warp app has no logged-in Warp user or cannot access the required authenticated user state;
 - `execution_context_not_allowed` when the action or requested grant is not allowed from the verified invocation context, such as an external client attempting an in-Warp-only authenticated-user action;
@@ -437,10 +445,10 @@ The app must not downgrade these failures into broader default actions, and the 
 Before shipping each action family, verify that these controls are implemented for that family:
 - Local control scripting must be enabled for the request's invocation context before the action family can run; inside-Warp control defaults on and outside-Warp control defaults off.
 - The authoritative enablement states live under Settings > Scripting, are protected from external writes, and are local-only rather than synced.
-- The action has a documented tier.
+- The action has a documented state/data category and required permission category.
 - The action has a documented `requires_authenticated_user` value. New actions default to `true` unless explicitly reviewed as logged-out-safe.
 - The action documents allowed execution contexts and whether external clients may run it.
-- The bridge maps the action to that tier locally in the selected Warp app process.
+- The bridge maps the action to that permission category locally in the selected Warp app process.
 - The credential model can express the required grant.
 - The credential model can express authenticated-user grants and verified execution context requirements when needed.
 - The handler checks optional target restrictions where relevant.

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -2,7 +2,7 @@
 `warpctrl` is a local-control CLI for an already-running Warp app instance. Its security architecture is designed to support the full control catalog: discovery, structural reads, terminal-data reads, non-destructive mutations, settings changes, input manipulation, command execution, and destructive window/tab/pane operations.
 The correct architecture is not a single shared localhost bearer token with client-side conventions. The CLI, app bridge, and protocol must treat security as a local app-enforced capability system: discovery finds compatible instances, secure storage protects raw credential material, broker-issued credentials identify the granted scopes, the running Warp app's local-control bridge enforces action tiers before dispatch, and target resolution never silently retargets a request.
 The action-tier model is primarily a safety and intent mechanism, not a hard security boundary against malicious same-user software. It lets a user, script, or agent intentionally request read-only or low-risk access so it does not accidentally mutate state or execute commands. It should not be described as strong access control against a process that can already run arbitrary commands as the user.
-`warpctrl` must not require the selected Warp instance to be logged in to a Warp account. All request authentication, protocol validation, safety checks, and action dispatch happen locally inside the running app process. Warp cloud services, Firebase identity, team membership, and account login state are not part of the local-control trust model.
+`warpctrl` has two distinct authorization dimensions: local-control authority and Warp user authority. Local-control authority proves the request is allowed to control the local app. Warp user authority proves the selected Warp app has a real logged-in Warp user and the request is allowed to act on user-authenticated data such as Warp Drive objects, AI conversation traces, synced settings, or cloud-backed user state. Logged-out users should retain a smaller local-only control surface, but authenticated-user actions require a true logged-in Warp user in the selected app.
 ## Security goals
 - Allow trusted local users and approved automation to control a running Warp instance through a stable, scriptable interface.
 - Prevent unauthenticated localhost clients from invoking read or mutating control actions.
@@ -12,8 +12,12 @@ The action-tier model is primarily a safety and intent mechanism, not a hard sec
 - Require explicit in-app user enablement before local control scripting can issue credentials or accept control requests.
 - Store the authoritative enablement state in protected local storage so external apps cannot enable local control by editing ordinary settings.
 - Keep raw credential material out of plaintext discovery records and protect it with platform secure storage where available.
+- Distinguish verified `warpctrl` invocations that originate from a Warp-managed terminal session from external same-user invocations.
+- Allow external invocations by default only for a smaller local-only action set that does not touch user-authenticated data.
+- Allow in-Warp invocations to receive authenticated-user grants when the selected Warp app has a true logged-in user and the user's local-control settings permit that grant.
 - Support least-privilege safety modes for automation and interactive use without relying on an unenforceable identity label.
 - Classify every action by risk tier and enforce the required tier in the local app bridge, not in the CLI frontend.
+- Classify every action by whether it requires an authenticated Warp user. New actions should default to requiring an authenticated user unless they are deliberately reviewed as safe for logged-out or external use.
 - Prevent `warpctrl` from becoming an ambient full-power confused deputy that any same-user process can invoke for high-risk actions.
 - Preserve deterministic targeting so a request never silently mutates or reads the wrong window, tab, pane, session, file, or Warp Drive object.
 - Keep the action surface allowlisted and typed rather than exposing arbitrary internal app dispatch.
@@ -89,6 +93,7 @@ Enablement requirements:
 - Only the running Warp app, through an in-app user action, should be able to enable or disable the authoritative state.
 - `warpctrl`, shell scripts, config files, command-line flags, registry edits, defaults writes, and direct local-control protocol requests must not be able to enable the setting.
 - The app should require an intentional user gesture before enabling the setting, and the UI should explain that it allows local scripts and approved automation to control Warp.
+- The UI should expose granular local-control permission settings rather than a single all-powerful switch.
 - The setting should be easy to disable from the same UI, and disabling it should revoke or invalidate active local-control credentials.
 - If enterprise or managed-device policy is added later, policy may force-disable local control or allow an administrator-controlled default, but policy should be separate from user-editable local settings.
 Disabled-state behavior:
@@ -98,6 +103,15 @@ Disabled-state behavior:
 - `warpctrl` may detect the disabled state and print instructions to enable local control in Warp settings, but it must not offer a command that flips the setting.
 - Previously issued credentials must become unusable when local control is disabled, even if their original expiry has not elapsed.
 This enablement gate does not create perfect same-user malicious-app isolation. A hostile process with Accessibility or Screen Recording permission might still try to automate the Warp UI. The gate is still important because it closes the much easier paths where external apps silently edit local preferences, call a config CLI, or write synced settings to enable a powerful control surface.
+### Granular permission settings
+Once local control scripting is enabled, users should control which categories of `warpctrl` authority can be granted. Recommended independent permissions:
+- **Local read-only metadata:** permit external and in-Warp clients to inspect non-sensitive local app structure such as instances, windows, tabs, panes, app version, and theme names.
+- **Terminal data reads:** permit reads of terminal output, scrollback, input buffers, command history, and session traces.
+- **Non-destructive local mutations:** permit reversible app-state changes such as creating tabs, focusing panes, changing theme, or opening panels.
+- **Destructive and execution actions:** permit closing targets, injecting input, running commands, executing workflows, or other high-risk operations.
+- **Authenticated-user actions from Warp terminals:** permit `warpctrl` invocations that originate from a verified Warp-managed terminal session to receive grants backed by the currently logged-in Warp user, enabling actions that read or mutate Warp Drive, AI conversation traces, synced settings, or other user-authenticated state.
+- **Authenticated-user actions from external clients:** default off. If supported, this must be a separate explicit permission from in-Warp authenticated actions because external same-user processes are a weaker context than a Warp-managed terminal session.
+Disabling any category should invalidate active credentials that include that category. The broker and app bridge must enforce these settings locally for every credential request and every presented credential.
 ## Trust boundaries
 `warpctrl` has several distinct trust boundaries.
 ### Operating-system user boundary
@@ -105,6 +119,14 @@ The baseline local trust boundary is the OS user account. Discovery records and 
 ### Invocation boundary
 Same-user does not mean same authority. Interactive use and unattended automation may both run commands under the same user account, but they should be able to intentionally request narrower capabilities. The protocol needs scoped credentials that encode concrete grants, target scopes, and lifetimes rather than an abstract caller type that the bridge cannot reliably verify.
 These scoped credentials are guardrails for well-behaved clients. They prevent accidental overreach and make user intent explicit, but they are not a defense against malicious same-user code that can automate the CLI, inspect the user's environment, or wait for user approvals.
+### Warp-terminal execution context boundary
+`warpctrl` should be able to receive special grants when it is invoked from within a Warp-managed terminal session, but the bridge must not trust a caller-supplied string such as `caller_class=warp_terminal`. The app should issue a session-bound execution-context proof to Warp-managed terminal sessions and have the broker verify that proof before minting in-Warp-only grants.
+Acceptable designs include a short-lived per-session capability, an app-owned broker handshake tied to the terminal session, or an equivalent proof that arbitrary external processes cannot mint by setting an environment variable. Plain environment variables may be used as handles or hints, but they must not be the sole authority for in-Warp privileges because external processes can spoof them.
+Verified in-Warp context can raise the maximum eligible grant set, especially for authenticated-user actions. It does not by itself bypass the user's granular local-control settings, action risk tiers, target scopes, or logged-in-user requirements.
+### Warp user authentication boundary
+Actions that touch user-authenticated Warp data require a true logged-in Warp user in the selected app. This includes Warp Drive object contents or mutation, AI conversation traces, cloud-backed user settings, team/account data, and any other surface whose normal app access depends on the user's Warp account.
+The app bridge should execute these actions on behalf of the logged-in app user through existing app auth state. `warpctrl` should receive a local-control credential that carries an `authenticated_user` grant, the verified user identity or stable subject reference, and the allowed authenticated action families. It should not need to export raw Firebase, server, or cloud API tokens to shell scripts.
+If the selected app has no logged-in user, authenticated-user actions must fail with a structured error rather than falling back to logged-out behavior. Logged-out users may still use the smaller local-only action set explicitly marked as not requiring an authenticated user.
 ### Application identity boundary
 On platforms with secure credential storage, especially macOS, the raw local-control credential should be readable only by Warp-owned, correctly signed code. On macOS this means storing raw credential material in Keychain with access constrained by Warp's signing identity, designated requirement, Keychain access group, or equivalent platform mechanism. This narrows token extraction from “any same-user process can read a file” to “only trusted Warp-signed code can unwrap the secret.”
 This boundary protects the credential from direct theft and prevents arbitrary apps from making authenticated raw HTTP requests to the local-control listener. It also lets the authoritative enablement state be stored somewhere harder to modify than ordinary user preferences. It does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary or automate the Warp UI. That confused-deputy risk is reduced by explicit in-app enablement, scoped credential issuance, action-tier policy, and local app-side bridge enforcement, but it is not eliminated as a hard same-user security boundary.
@@ -119,6 +141,8 @@ A valid credential for one instance or target must not imply authority over anot
 - Same-user automation attempting actions without the required scoped grants.
 - Same-user processes attempting to extract plaintext credentials from local state.
 - Same-user processes invoking `warpctrl` as a confused deputy for actions the process could not authorize directly.
+- External same-user processes attempting authenticated-user actions that should be limited to verified Warp-terminal invocations.
+- Logged-out requests attempting actions that require a true logged-in Warp user.
 - Stale discovery records from exited Warp processes.
 - Multiple running Warp instances where ambiguous selection could target the wrong process.
 - Malformed clients attempting unknown, unsupported, unallowlisted, or invalid action payloads.
@@ -130,22 +154,25 @@ A valid credential for one instance or target must not imply authority over anot
 - Kernel, hypervisor, or administrator-level compromise.
 - Security semantics for remote URL control endpoints. Remote control requires a separate transport and identity design before it can ship.
 ## Architecture overview
-The security model has seven layers:
+The security model has eight layers:
 1. **Protected enablement:** Require explicit in-app opt-in backed by protected local storage before local control is available.
 2. **Discovery:** Find compatible live Warp instances without granting broad authority.
 3. **Secure credential storage:** Store raw secrets outside plaintext discovery records and restrict access to trusted Warp-owned code where the platform supports it.
-4. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes only when local control is enabled.
-5. **Transport authentication:** Reject disabled or unauthenticated requests before reading or mutating app state.
-6. **Safety policy:** Enforce requested action tiers and target scopes locally in the app bridge for well-behaved clients.
-7. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
+4. **Execution context verification:** Distinguish verified Warp-terminal invocations from external same-user invocations without trusting caller-declared labels.
+5. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes only when local control is enabled and the user's granular permissions allow the requested category.
+6. **Transport authentication:** Reject disabled or unauthenticated requests before reading or mutating app state.
+7. **Safety and user-auth policy:** Enforce action tiers, target scopes, execution-context requirements, and authenticated-user requirements locally in the app bridge.
+8. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
 ```mermaid
 sequenceDiagram
     participant Invoker as User / Automation
     participant CLI as warpctrl
     participant Registry as Per-user discovery registry
     participant Enablement as Protected enablement state
+    participant Context as Execution context proof
     participant Broker as Credential broker
     participant Store as Secure credential storage
+    participant Auth as App auth state
     participant HTTP as Warp control listener
     participant Bridge as App bridge + safety policy
     participant UI as Warp app state
@@ -160,12 +187,17 @@ sequenceDiagram
     else Enabled
     CLI->>Broker: Request scoped credential for action
     Broker->>Enablement: Verify protected enablement state
+    Broker->>Context: Verify external vs Warp-terminal context
+    opt Authenticated-user action
+        Broker->>Auth: Verify logged-in Warp user + setting
+        Auth-->>Broker: User subject or unavailable
+    end
     Broker->>Store: Load or unwrap raw secret with Warp-signed access
     Store-->>Broker: Raw secret or credential capability
-    Broker-->>CLI: Scoped credential with grants, scopes, expiry
+    Broker-->>CLI: Scoped credential with grants, context, user scope, expiry
     CLI->>HTTP: Authenticated typed request
     HTTP->>Bridge: Verify credential and protocol envelope
-    Bridge->>Bridge: Check action tier + target scope
+    Bridge->>Bridge: Check tier + context + authenticated-user + target scope
     alt Denied
         Bridge-->>CLI: structured safety-policy error
     else Allowed
@@ -199,6 +231,9 @@ A control credential should encode or reference:
 - issuing Warp instance;
 - protocol version or accepted version range;
 - granted action tiers;
+- verified execution context, such as external client or Warp-managed terminal session;
+- whether the credential may act on behalf of an authenticated Warp user;
+- authenticated Warp user subject or stable user reference when an authenticated-user grant is present;
 - optional allowed action families;
 - optional target restrictions, such as one session, one workspace, one file path, or one Warp Drive object type;
 - issued-at time;
@@ -210,11 +245,13 @@ Warp should issue credentials through an app-owned local broker or equivalent tr
 Recommended defaults:
 - Credential issuance is unavailable unless the protected in-app enablement state says local control scripting is enabled.
 - Commands should start from least privilege and request only the grant needed for the requested action.
-- Unattended automation should default to read-only metadata unless policy or an explicit approval grants more.
-- Interactive use may receive broader local control only through an intentional approval or configured policy.
+- External same-user invocations should default to the smaller logged-out-safe local action set unless policy or explicit approval grants more.
+- Verified Warp-terminal invocations may receive broader local-control grants when the user's granular settings allow them.
+- Authenticated-user grants are available only when the selected Warp app has a true logged-in Warp user and the requested execution context is allowed by local-control settings.
 - Terminal data reads require an explicit `read_terminal_data` grant.
 - Non-destructive mutations require an explicit `mutate_non_destructive` grant.
 - Destructive operations, input injection, and command execution require explicit high-risk grants.
+- User-authenticated data reads or mutations require an explicit `authenticated_user` grant and an allowed authenticated action family.
 - Integrations should receive the narrowest grant needed for the configured workflow.
 The broker must not issue broad authority merely because the request came from the signed `warpctrl` binary. It should evaluate the requested action tier, target scope, configured policy, execution context, and whether user approval is required. The CLI must not mint its own authority. It can request, load, and present credentials, but the app bridge remains the enforcement point for these safety grants.
 ### Safety grants, not strong access control
@@ -256,27 +293,32 @@ Transport requirements:
 - Keep unauthenticated health metadata minimal and non-sensitive.
 - Preserve structured error envelopes so the CLI does not collapse security failures into generic transport errors.
 Remote URL support is a separate future transport mode. It should not reuse the local same-user credential model without additional identity, encryption, replay protection, and remote approval/policy design.
-## Login independence
-Local-control validation is not tied to a logged-in Warp user. The selected Warp app process validates local-control requests using local protocol state:
-- discovery records;
-- secure local credential references;
-- scoped safety grants;
-- protocol version and request shape;
-- allowlisted actions and typed parameters;
-- deterministic target selectors.
-The app must not call Warp cloud services to decide whether a local `warpctrl` request is allowed, and it must not require Firebase authentication, team membership, or a non-anonymous Warp account. This keeps scripting and local automation available to logged-out users and offline-capable core terminal workflows.
-If a future action depends on cloud-backed state, such as a Warp Drive operation that requires network access, that action can return a state-specific error when unavailable. That should not turn the whole local-control protocol into a logged-in-user feature.
+## Logged-in user requirements
+Local-control validation always begins with local protocol state: discovery records, secure local credential references, scoped safety grants, execution-context proof, protocol version, request shape, allowlisted actions, typed parameters, and deterministic target selectors.
+Some actions additionally require a true logged-in Warp user in the selected app. The action allowlist must declare this explicitly with a `requires_authenticated_user` field.
+Default rule for new actions:
+- New actions require an authenticated Warp user unless the implementer deliberately classifies them as logged-out-safe.
+- The logged-out-safe set should remain meaningfully smaller and limited to local app structure, local appearance metadata, and other surfaces that do not depend on the user's cloud-backed Warp identity.
+- Actions that read or mutate Warp Drive, AI conversation traces, synced settings, team/account data, or other user-authenticated state must require an authenticated user.
+- Actions that can execute user-authored cloud-backed content, such as running Warp Drive workflows or inserting notebook commands, require both the authenticated-user grant and the appropriate high-risk action tier.
+When an authenticated-user action is requested:
+- the selected app must have an active logged-in Warp user;
+- the presented local-control credential must include an `authenticated_user` grant for that user or stable subject;
+- the user's granular settings must allow authenticated-user actions for the verified execution context;
+- the app bridge should execute through the app's existing authenticated state rather than exporting raw cloud auth credentials to `warpctrl`.
+If these conditions are not met, the app returns a structured error. It must not fall back to logged-out behavior or silently omit user-authenticated data from a result that claims success.
 ## Safety policy model
 Safety grants are enforced in the app bridge after transport authentication and before target resolution or handler dispatch. This provides consistent “do not accidentally do more than requested” behavior for honest clients, not a sandbox for hostile same-user code.
 The bridge must:
 1. Parse the typed request envelope.
 2. Verify protocol version compatibility.
 3. Authenticate the credential.
-4. Determine granted action tiers and target scopes.
-5. Map the requested action to a required tier and action family.
+4. Determine granted action tiers, execution context, target scopes, and authenticated-user grants.
+5. Map the requested action to a required tier, action family, execution-context requirement, and authenticated-user requirement.
 6. Check optional target-family restrictions.
 7. Reject requests that exceed the credential's grants with `insufficient_permissions`.
-8. Only then resolve selectors and invoke the allowlisted handler.
+8. Reject authenticated-user actions without a logged-in user or authenticated-user grant with a structured authenticated-user error.
+9. Only then resolve selectors and invoke the allowlisted handler.
 The CLI frontend may provide helpful preflight errors, but those checks are advisory. Local app-side bridge enforcement is mandatory because other tools can bypass the official CLI and speak the protocol directly.
 ## Action risk tiers
 Every action belongs to exactly one tier. These tiers describe risk and intended safety prompts; they are not a sandbox or a complete OS-level access-control model.
@@ -334,11 +376,13 @@ Each supported command requires:
 - typed parameters;
 - validation rules;
 - a documented risk tier;
+- a documented `requires_authenticated_user` value;
+- a documented allowed execution context, including whether external clients can run it or whether it is limited to verified Warp-terminal invocations;
 - local app-side safety-grant checks;
 - deterministic target resolution;
 - a handler that reuses existing user-visible app behavior where possible;
 - typed success and error responses.
-Adding a new action should be additive and reviewable: extend the protocol enum, implement validation, map the action to a risk tier, add a handler, and add tests for authentication, safety-policy denial, selector failure, and success behavior.
+Adding a new action should be additive and reviewable: extend the protocol enum, implement validation, map the action to a risk tier, declare whether it requires an authenticated user, declare its allowed execution contexts, add a handler, and add tests for authentication, safety-policy denial, authenticated-user denial, selector failure, and success behavior.
 ## Browser and localhost protections
 Loopback is not sufficient by itself because browsers can send requests to localhost.
 Required protections:
@@ -372,6 +416,9 @@ Important errors include:
 - `local_control_disabled` when the user has not enabled local control scripting in Warp settings or has disabled it after credentials were issued;
 - `unauthorized_local_client` for missing, malformed, expired, revoked, or invalid credentials;
 - `insufficient_permissions` for valid credentials that lack the requested safety tier or target scope;
+- `authenticated_user_required` when an action requires a logged-in Warp user but the credential lacks an authenticated-user grant;
+- `authenticated_user_unavailable` when the selected Warp app has no logged-in Warp user or cannot access the required authenticated user state;
+- `execution_context_not_allowed` when the action or requested grant is not allowed from the verified invocation context, such as an external client attempting an in-Warp-only authenticated-user action;
 - `ambiguous_instance` when multiple compatible instances cannot be resolved safely;
 - `invalid_selector` for malformed or unsupported selector syntax;
 - `missing_target` when an active/default target does not exist;
@@ -386,11 +433,14 @@ Before shipping each action family, verify that these controls are implemented f
 - Local control scripting must be explicitly enabled in Warp's app UI before the action family can run.
 - The authoritative enablement state is protected from external writes and is local-only rather than synced.
 - The action has a documented tier.
+- The action has a documented `requires_authenticated_user` value. New actions default to `true` unless explicitly reviewed as logged-out-safe.
+- The action documents allowed execution contexts and whether external clients may run it.
 - The bridge maps the action to that tier locally in the selected Warp app process.
 - The credential model can express the required grant.
+- The credential model can express authenticated-user grants and verified execution context requirements when needed.
 - The handler checks optional target restrictions where relevant.
 - Requests with invalid credentials or insufficient safety grants fail before selector resolution or mutation.
-- The action does not require a logged-in Warp account unless the action itself inherently depends on cloud-backed state.
+- Requests that require authenticated-user access fail unless the selected app has a true logged-in Warp user and the credential includes an authenticated-user grant.
 - Ambiguous, missing, and stale targets return structured errors.
 - Tests cover allowed, insufficient-permission, and denied credential paths.
 - Logs and errors do not expose credentials, terminal contents, command text, or sensitive settings.

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -1,0 +1,317 @@
+# warpctrl security architecture
+`warpctrl` is a local-control CLI for an already-running Warp app instance. Its security architecture is designed to support the full control catalog: discovery, structural reads, terminal-data reads, non-destructive mutations, settings changes, input manipulation, command execution, and destructive window/tab/pane operations.
+The correct architecture is not a single shared localhost bearer token with client-side conventions. The CLI, app bridge, and protocol must treat security as a local app-enforced capability system: discovery finds compatible instances, secure storage protects raw credential material, broker-issued credentials identify the granted scopes, the running Warp app's local-control bridge enforces action tiers before dispatch, and target resolution never silently retargets a request.
+The action-tier model is primarily a safety and intent mechanism, not a hard security boundary against malicious same-user software. It lets a user, script, or agent intentionally request read-only or low-risk access so it does not accidentally mutate state or execute commands. It should not be described as strong access control against a process that can already run arbitrary commands as the user.
+`warpctrl` must not require the selected Warp instance to be logged in to a Warp account. All request authentication, protocol validation, safety checks, and action dispatch happen locally inside the running app process. Warp cloud services, Firebase identity, team membership, and account login state are not part of the local-control trust model.
+## Security goals
+- Allow trusted local users and approved automation to control a running Warp instance through a stable, scriptable interface.
+- Prevent unauthenticated localhost clients from invoking read or mutating control actions.
+- Prevent browser-origin JavaScript from becoming an ambient localhost control client.
+- Support multiple running Warp processes without a shared global mutating port or global credential.
+- Separate discovery metadata from control authority so enumerating an instance does not automatically grant full control.
+- Keep raw credential material out of plaintext discovery records and protect it with platform secure storage where available.
+- Support least-privilege safety modes for automation and interactive use without relying on an unenforceable identity label.
+- Classify every action by risk tier and enforce the required tier in the local app bridge, not in the CLI frontend.
+- Prevent `warpctrl` from becoming an ambient full-power confused deputy that any same-user process can invoke for high-risk actions.
+- Preserve deterministic targeting so a request never silently mutates or reads the wrong window, tab, pane, session, file, or Warp Drive object.
+- Keep the action surface allowlisted and typed rather than exposing arbitrary internal app dispatch.
+- Make high-risk operations auditable and configurable without logging sensitive terminal contents or credentials.
+## Trust boundaries
+`warpctrl` has several distinct trust boundaries.
+### Operating-system user boundary
+The baseline local trust boundary is the OS user account. Discovery records and local credential material must be readable only by the owning user. This protects against other local users and network peers, but it does not protect against an already-compromised same-user process.
+### Invocation boundary
+Same-user does not mean same authority. Interactive use and unattended automation may both run commands under the same user account, but they should be able to intentionally request narrower capabilities. The protocol needs scoped credentials that encode concrete grants, target scopes, and lifetimes rather than an abstract caller type that the bridge cannot reliably verify.
+These scoped credentials are guardrails for well-behaved clients. They prevent accidental overreach and make user intent explicit, but they are not a defense against malicious same-user code that can automate the CLI, inspect the user's environment, or wait for user approvals.
+### Application identity boundary
+On platforms with secure credential storage, especially macOS, the raw local-control credential should be readable only by Warp-owned, correctly signed code. On macOS this means storing raw credential material in Keychain with access constrained by Warp's signing identity, designated requirement, Keychain access group, or equivalent platform mechanism. This narrows token extraction from “any same-user process can read a file” to “only trusted Warp-signed code can unwrap the secret.”
+This boundary protects the credential from direct theft, but it does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary. That confused-deputy risk is handled by scoped credential issuance, action-tier policy, and local app-side bridge enforcement.
+### Action boundary
+Every action belongs to a risk tier. The bridge must map the requested action to a required tier and compare that tier to the presented credential before selector resolution or handler dispatch.
+### Target boundary
+A valid credential for one instance or target must not imply authority over another. Credentials should be bound to the issuing Warp instance and may be further scoped to target families such as terminal sessions, files, or Warp Drive objects when those surfaces are exposed.
+## Threat model
+### In scope
+- Other local OS users attempting to control a Warp instance owned by the current user.
+- Browser-origin JavaScript attempting to call localhost control endpoints.
+- Same-user automation attempting actions without the required scoped grants.
+- Same-user processes attempting to extract plaintext credentials from local state.
+- Same-user processes invoking `warpctrl` as a confused deputy for actions the process could not authorize directly.
+- Stale discovery records from exited Warp processes.
+- Multiple running Warp instances where ambiguous selection could target the wrong process.
+- Malformed clients attempting unknown, unsupported, unallowlisted, or invalid action payloads.
+- Valid clients attempting actions above their granted tier.
+- Explicit target IDs that become stale between discovery and execution.
+- Future handlers that expose terminal data, settings writes, input mutation, command execution, file intents, or Warp Drive object operations.
+### Out of scope
+- A malicious process that already has arbitrary same-user filesystem and process access, except that scoped credentials should still reduce accidental over-granting to ordinary automation.
+- Kernel, hypervisor, or administrator-level compromise.
+- Security semantics for remote URL control endpoints. Remote control requires a separate transport and identity design before it can ship.
+## Architecture overview
+The security model has six layers:
+1. **Discovery:** Find compatible live Warp instances without granting broad authority.
+2. **Secure credential storage:** Store raw secrets outside plaintext discovery records and restrict access to trusted Warp-owned code where the platform supports it.
+3. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes.
+4. **Transport authentication:** Reject unauthenticated requests before reading or mutating app state.
+5. **Safety policy:** Enforce requested action tiers and target scopes locally in the app bridge for well-behaved clients.
+6. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
+```mermaid
+sequenceDiagram
+    participant Invoker as User / Automation
+    participant CLI as warpctrl
+    participant Registry as Per-user discovery registry
+    participant Broker as Credential broker
+    participant Store as Secure credential storage
+    participant HTTP as Warp control listener
+    participant Bridge as App bridge + safety policy
+    participant UI as Warp app state
+
+    Invoker->>CLI: Invoke allowlisted command
+    CLI->>Registry: Read instance metadata
+    Registry-->>CLI: instance_id, endpoint, protocol version, credential reference
+    CLI->>Broker: Request scoped credential for action
+    Broker->>Store: Load or unwrap raw secret with Warp-signed access
+    Store-->>Broker: Raw secret or credential capability
+    Broker-->>CLI: Scoped credential with grants, scopes, expiry
+    CLI->>HTTP: Authenticated typed request
+    HTTP->>Bridge: Verify credential and protocol envelope
+    Bridge->>Bridge: Check action tier + target scope
+    alt Denied
+        Bridge-->>CLI: structured safety-policy error
+    else Allowed
+        Bridge->>UI: Resolve target exactly and run allowlisted handler
+        UI-->>Bridge: typed result or structured target error
+        Bridge-->>CLI: response envelope
+    end
+```
+## Discovery registry
+Each participating Warp process writes a discovery record in a secure per-user local-control directory. Discovery records are metadata, not a full control-authority model.
+A discovery record should contain:
+- opaque `instance_id`;
+- PID and process start timestamp;
+- channel and build metadata;
+- protocol version and supported capability summary;
+- loopback endpoint for the instance-local control listener;
+- credential reference or bootstrap credential metadata, not necessarily the full control credential.
+Discovery rules:
+- Records must be readable only by the owning user.
+- POSIX records must use owner-only permissions such as `0600` for files and a non-world-readable directory.
+- Windows records must live under the current user's app data directory with ACLs limited to the current user, Administrators, and SYSTEM.
+- The CLI must prune or ignore stale records whose PID is gone or whose health/protocol check fails.
+- If multiple compatible instances are ambiguous, the CLI must require explicit `--instance` selection.
+- Discovery metadata must not expose terminal contents, environment variables, auth tokens for cloud services, raw local-control credentials, or mutating capability grants.
+## Credential model
+The full `warpctrl` catalog requires scoped credentials. A single shared full-power bearer token is not sufficient once automation, terminal data, command execution, and destructive actions are supported.
+### Credential properties
+A control credential should encode or reference:
+- issuing Warp instance;
+- protocol version or accepted version range;
+- granted action tiers;
+- optional allowed action families;
+- optional target restrictions, such as one session, one workspace, one file path, or one Warp Drive object type;
+- issued-at time;
+- expiry time or process-lifetime binding;
+- unique credential ID for revocation and auditing;
+- integrity protection so callers cannot forge or widen grants.
+### Credential issuance
+Warp should issue credentials through an app-owned local broker or equivalent trusted path. The broker decides which grants to issue based on the requested action tier, target scope, user configuration, execution context, and any explicit user approval.
+Recommended defaults:
+- Commands should start from least privilege and request only the grant needed for the requested action.
+- Unattended automation should default to read-only metadata unless policy or an explicit approval grants more.
+- Interactive use may receive broader local control only through an intentional approval or configured policy.
+- Terminal data reads require an explicit `read_terminal_data` grant.
+- Non-destructive mutations require an explicit `mutate_non_destructive` grant.
+- Destructive operations, input injection, and command execution require explicit high-risk grants.
+- Integrations should receive the narrowest grant needed for the configured workflow.
+The broker must not issue broad authority merely because the request came from the signed `warpctrl` binary. It should evaluate the requested action tier, target scope, configured policy, execution context, and whether user approval is required. The CLI must not mint its own authority. It can request, load, and present credentials, but the app bridge remains the enforcement point for these safety grants.
+### Safety grants, not strong access control
+The tier system should be understood as a user-intent and accident-prevention mechanism:
+- A user can ask an agent or script to operate with read-only metadata grants so it can inspect structure but cannot accidentally mutate state.
+- A workflow can request terminal-data reads separately from structural metadata reads because terminal contents are more sensitive.
+- A script can request non-destructive mutation without also receiving command-execution capability.
+- Destructive actions and command execution can require an explicit approval or configured policy so surprising operations pause before they happen.
+This model does not make untrusted same-user software safe. A malicious local process may invoke `warpctrl`, simulate user workflows, or use other OS-level capabilities outside `warpctrl`. The tier model is still valuable because it lets honest clients, agents, and scripts constrain themselves and gives Warp a structured point to prompt, deny, or audit risky actions.
+### Credential storage
+Credential storage should be platform-appropriate:
+- Local discovery may store a credential reference rather than the credential itself.
+- Raw long-lived credentials should prefer platform-secure storage such as macOS Keychain or Windows Credential Manager when practical.
+- On macOS, raw control secrets should be stored in Keychain and restricted to trusted Warp-signed code using a designated requirement, Keychain access group, trusted-application ACL, or equivalent code-signing based mechanism. Restricting by filesystem path alone is insufficient because paths can be replaced or wrapped.
+- Keychain item access should include the Warp app, the signed `warpctrl` binary, and any signed Warp-owned local broker/helper that needs to unwrap raw secrets. It should exclude arbitrary same-user applications.
+- Short-lived credentials may be stored in owner-only local state if their lifetime and scope are narrow.
+- Credentials must never be printed in human-readable output, JSON output, logs, errors, or shell completion data.
+### Confused-deputy mitigation
+Secure storage prevents arbitrary apps from reading the token; it does not prevent arbitrary apps from asking trusted Warp code to use the token on their behalf.
+For example, if `warpctrl` can silently unwrap a full-power credential and execute any action, another same-user process can invoke `warpctrl input run ...` without reading the credential directly. That makes `warpctrl` a confused deputy.
+Mitigations:
+- Do not give `warpctrl` ambient non-interactive access to an unrestricted full-control credential.
+- Prefer action-scoped or session-scoped credentials minted just in time by the broker.
+- Require explicit user approval or preconfigured policy for Tier 4 actions and other sensitive grants.
+- Distinguish user-approved credential requests from ambient unattended invocations through explicit approval prompts, configured policy, terminal/session context, or narrow credential request flows.
+- Bind issued credentials to the requested instance, action tier, optional action family, optional target scope, and short expiry.
+- Let `warpctrl` preflight and request credentials, but require the local app bridge to enforce scopes because direct protocol clients can bypass the CLI.
+- Make denials structured and non-fatal for automation so callers can request narrower or user-approved grants rather than falling back to unsafe behavior.
+## Transport authentication
+The default transport is an instance-local loopback listener bound to `127.0.0.1` on an ephemeral per-process port.
+Transport requirements:
+- Bind only to loopback for local control.
+- Do not set permissive CORS headers.
+- Authenticate every control request locally in the selected Warp app process before selector resolution or action dispatch.
+- Reject missing, malformed, expired, revoked, or invalid credentials with structured authentication errors.
+- Keep unauthenticated health metadata minimal and non-sensitive.
+- Preserve structured error envelopes so the CLI does not collapse security failures into generic transport errors.
+Remote URL support is a separate future transport mode. It should not reuse the local same-user credential model without additional identity, encryption, replay protection, and remote approval/policy design.
+## Login independence
+Local-control validation is not tied to a logged-in Warp user. The selected Warp app process validates local-control requests using local protocol state:
+- discovery records;
+- secure local credential references;
+- scoped safety grants;
+- protocol version and request shape;
+- allowlisted actions and typed parameters;
+- deterministic target selectors.
+The app must not call Warp cloud services to decide whether a local `warpctrl` request is allowed, and it must not require Firebase authentication, team membership, or a non-anonymous Warp account. This keeps scripting and local automation available to logged-out users and offline-capable core terminal workflows.
+If a future action depends on cloud-backed state, such as a Warp Drive operation that requires network access, that action can return a state-specific error when unavailable. That should not turn the whole local-control protocol into a logged-in-user feature.
+## Safety policy model
+Safety grants are enforced in the app bridge after transport authentication and before target resolution or handler dispatch. This provides consistent “do not accidentally do more than requested” behavior for honest clients, not a sandbox for hostile same-user code.
+The bridge must:
+1. Parse the typed request envelope.
+2. Verify protocol version compatibility.
+3. Authenticate the credential.
+4. Determine granted action tiers and target scopes.
+5. Map the requested action to a required tier and action family.
+6. Check optional target-family restrictions.
+7. Reject requests that exceed the credential's grants with `insufficient_permissions`.
+8. Only then resolve selectors and invoke the allowlisted handler.
+The CLI frontend may provide helpful preflight errors, but those checks are advisory. Local app-side bridge enforcement is mandatory because other tools can bypass the official CLI and speak the protocol directly.
+## Action risk tiers
+Every action belongs to exactly one tier. These tiers describe risk and intended safety prompts; they are not a sandbox or a complete OS-level access-control model.
+### Tier 1: read-only metadata
+Returns app structure or configuration without terminal contents or user data from sessions.
+Examples:
+- `instance list`, `app active`, `app version`, `app ping`;
+- `window list`, `tab list`, `pane list`, `session list`;
+- `theme list`;
+- allowlisted settings reads that expose configuration but not terminal contents.
+Default unattended credentials may include this tier.
+### Tier 2: read-only terminal data
+Returns potentially sensitive terminal/session data without mutating state.
+Examples:
+- pane output or scrollback reads;
+- current input buffer reads;
+- command history reads;
+- session replay or transcript reads.
+This tier is separate from metadata because terminal content often contains secrets, file paths, command output, customer data, and other sensitive information.
+### Tier 3: mutating non-destructive
+Changes visible app state in reversible or low-risk ways without executing terminal content or destroying user state.
+Examples:
+- creating or activating tabs;
+- moving, renaming, or coloring tabs;
+- creating or focusing windows;
+- splitting, focusing, navigating, maximizing, or resizing panes;
+- theme, font, zoom, and allowlisted non-destructive settings changes;
+- opening panels, palettes, and user-facing surfaces.
+### Tier 4: mutating destructive or high-risk
+Can destroy active work, inject terminal input, execute commands, or run user-authored content.
+Examples:
+- closing windows, tabs, panes, or sessions;
+- clearing, replacing, or inserting terminal input;
+- command execution in a session;
+- switching input modes when it can change execution behavior;
+- executing Warp Drive workflows or notebooks in a terminal session;
+- broad Warp Drive object mutation.
+This tier should require explicit user or policy approval for unattended automation and integrations.
+## Target scoping and deterministic resolution
+Targeting is part of security. The protocol must not convert ambiguous or stale selectors into best-effort mutations.
+Rules:
+- Instance selection happens before request dispatch and must be explicit when ambiguous.
+- `active` selectors may be ergonomic defaults only when the active target is unambiguous.
+- If no active target exists for a mutating request, return `missing_target` or `invalid_selector`.
+- Explicit opaque IDs must resolve exactly or return `stale_target`.
+- Index selectors must resolve to concrete IDs before execution and must not race into a different target silently.
+- Session-scoped requests against non-terminal panes return `target_state_conflict`.
+- File selectors use paths and must remain distinct from opaque UI IDs.
+- Warp Drive selectors must include object type and resolve by opaque ID for automation stability, with name/path lookup only as an interactive convenience.
+Target restrictions in credentials should be checked before invoking handlers. For example, a credential scoped to one session must not read another session's output even if the CLI can discover that session ID.
+## Allowlisted handlers
+The protocol must not expose arbitrary internal app actions by string.
+Each supported command requires:
+- a typed protocol action;
+- typed parameters;
+- validation rules;
+- a documented risk tier;
+- local app-side safety-grant checks;
+- deterministic target resolution;
+- a handler that reuses existing user-visible app behavior where possible;
+- typed success and error responses.
+Adding a new action should be additive and reviewable: extend the protocol enum, implement validation, map the action to a risk tier, add a handler, and add tests for authentication, safety-policy denial, selector failure, and success behavior.
+## Browser and localhost protections
+Loopback is not sufficient by itself because browsers can send requests to localhost.
+Required protections:
+- No permissive CORS on control endpoints.
+- No JSONP or browser-readable fallback formats.
+- Valid scoped credentials required for all sensitive endpoints.
+- Credentials stored outside browser-readable locations.
+- Preflight and error responses must not reveal credentials or sensitive target state.
+- The protocol should avoid GET endpoints for mutating actions.
+The control plane should assume a malicious webpage can guess common localhost ports and send blind requests. It should not be able to read discovery records or obtain credentials.
+## Auditing and logging
+High-risk action support should include auditability without leaking sensitive data.
+Recommended audit fields:
+- timestamp;
+- instance ID;
+- credential ID or grant profile;
+- action name and risk tier;
+- target type and opaque target ID when safe;
+- success or structured error code.
+Avoid logging:
+- bearer tokens or scoped credentials;
+- terminal output;
+- command text for command execution unless explicitly approved by policy;
+- input buffer contents;
+- Warp Drive object contents;
+- environment variable values.
+Error-level logs should be used only for conditions that need developer attention, not normal denied requests or user-caused selector failures.
+## Security- and safety-relevant errors
+Structured errors are part of the security contract.
+Important errors include:
+- `unauthorized_local_client` for missing, malformed, expired, revoked, or invalid credentials;
+- `insufficient_permissions` for valid credentials that lack the requested safety tier or target scope;
+- `ambiguous_instance` when multiple compatible instances cannot be resolved safely;
+- `invalid_selector` for malformed or unsupported selector syntax;
+- `missing_target` when an active/default target does not exist;
+- `stale_target` when an explicit target ID no longer exists;
+- `unsupported_action` for actions not implemented by the selected instance;
+- `not_allowlisted` for actions intentionally excluded from the public control surface;
+- `invalid_params` for malformed parameters;
+- `target_state_conflict` when the target exists but cannot support the requested action.
+The app must not downgrade these failures into broader default actions, and the CLI must preserve structured server errors in both human-readable and JSON output.
+## Required controls before full catalog expansion
+Before shipping each action family, verify that these controls are implemented for that family:
+- The action has a documented tier.
+- The bridge maps the action to that tier locally in the selected Warp app process.
+- The credential model can express the required grant.
+- The handler checks optional target restrictions where relevant.
+- Requests with invalid credentials or insufficient safety grants fail before selector resolution or mutation.
+- The action does not require a logged-in Warp account unless the action itself inherently depends on cloud-backed state.
+- Ambiguous, missing, and stale targets return structured errors.
+- Tests cover allowed, insufficient-permission, and denied credential paths.
+- Logs and errors do not expose credentials, terminal contents, command text, or sensitive settings.
+- Operator docs distinguish available commands from planned catalog entries.
+## Platform requirements
+### macOS and Linux
+Discovery files must be stored in a per-user directory with owner-only permissions.
+On macOS, raw credential material should live in Keychain, not in the discovery record. Keychain access should be constrained to Warp-owned signed binaries or helpers using code-signing based access control. The discovery record should hold only metadata and a credential reference.
+On Linux, raw credentials should prefer platform-secure storage where available; otherwise short-lived scoped credentials may live in owner-only local state with strict file and directory permissions.
+Unix domain sockets with peer credential checks may be considered for stronger same-machine identity than bearer tokens alone.
+### Windows
+Discovery records and credential material must live under the current user's app data directory with ACLs restricted to the current user, Administrators, and SYSTEM.
+Windows support for authenticated local control should not be considered complete until the implementation creates, validates, and tests those ACLs.
+## Remote control is separate
+The local architecture intentionally assumes same-machine, same-user control over a loopback listener. Future remote URLs must use a different security design that includes:
+- transport encryption;
+- remote identity and authentication;
+- replay protection;
+- explicit user or admin approval/policy;
+- network exposure review;
+- separate credential issuance from local discovery;
+- remote-safe auditing and revocation.
+Remote support should not be enabled by simply allowing `warpctrl` to point the existing local credential at an arbitrary URL.

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -242,6 +242,21 @@ Recommended modules/families:
 - Panels/surfaces:
   - settings/page/search, palettes, left/right panels, Drive, resource center, code review, vertical tabs, AI assistant.
 Do not use a generic “dispatch action by string” endpoint. Every handler should be reachable only through an explicit `ControlAction` variant.
+#### WarpCtrlBehavior review gate
+The public `ControlAction` catalog remains the source of truth for the wire protocol, CLI parser, permission metadata, generated documentation, and app bridge handlers. Internal app actions such as `WorkspaceAction`, `TerminalAction`, `PaneGroupAction`, settings actions, and future user-visible action enums must not become the public protocol directly because they can contain transient view locators, indices, debug-only variants, implementation-specific payloads, and unstable internal semantics.
+To prevent drift between user-visible Warp behavior and the `warpctrl` catalog, every user-visible app action enum should implement a `WarpCtrlBehavior` review mapping. The mapping is a code-level forcing function, not an automatic exposure mechanism. It answers whether each internal app action is:
+- `Exposed` through a specific public `ControlAction` kind.
+- `CoveredBy` an existing public `ControlAction` kind because several internal actions map to one stable CLI behavior.
+- `Excluded` with an explicit reason such as debug-only, unsafe/privileged, internal implementation detail, not user-visible, no deterministic targeting model, no stable public semantics, or prohibited in the initial public version.
+- `Deferred` with an explicit reason and tracking issue when the action might belong in `warpctrl` later but needs additional product, security, selector, or protocol design.
+`WarpCtrlBehavior` implementations must use exhaustive matches without wildcard arms. Adding a new variant to a reviewed action enum should fail compilation until the developer or agent deliberately classifies its relationship to `warpctrl`. This mirrors the existing exhaustive-action-review style used by app-state saving decisions and makes “should this exist in Warp Control?” part of the ordinary code path for adding new user-visible actions.
+Recommended shape:
+- Define a shared `WarpCtrlBehavior` trait in the local-control integration layer or another app-visible module that does not force the core `warpui::Action` blanket implementation to change.
+- Define review enums such as `WarpCtrlActionReview`, `WarpCtrlExclusionReason`, and `WarpCtrlDeferredReason`.
+- Implement `WarpCtrlBehavior` for the major user-visible action enums, starting with `WorkspaceAction` and `TerminalAction`.
+- Keep the mapping one-way from internal behavior to public catalog metadata. `WarpCtrlBehavior::Exposed(ControlActionKind::TabCreate)` means the action is represented by the public `tab.create` command; it does not mean raw `WorkspaceAction::AddTerminalTab` is serializable or dispatchable over the protocol.
+- Add tests that collect reviewed action kinds and verify every `ControlActionKind` has protocol metadata, permission metadata, CLI parser coverage, generated-doc coverage, and an app-side handler before it can be advertised as supported.
+The `warpui::Action` trait should not be extended for this purpose because it currently has a blanket implementation for any `Any + Debug + Send + Sync` type. The enforcement point is the concrete user-visible action enums and binding/action registration surfaces, where exhaustive review can be required without weakening the allowlisted protocol boundary.
 ### 7. First slice: prove discovery and `tab.create`
 The first `warpctrl` implementation slice should land the minimum cross-cutting architecture plus a single representative tab mutation:
 - Shared protocol types and error envelopes.
@@ -267,6 +282,7 @@ The PR should also introduce the shell-facing CLI command grammar that the remai
 ### 8. Follow-up slices: fill out the remaining protocol in parallel
 After the first slice validates discovery, auth, selector resolution, CLI syntax, and server-to-app execution, follow-up slices can add the remaining allowlisted catalog in parallelized action-family groups. The baseline code should make new action additions mostly additive:
 - Extend `ControlAction`.
+- Update the relevant `WarpCtrlBehavior` mappings for the internal app actions that implement, overlap with, exclude, or defer the behavior.
 - Add typed params/results.
 - Add a handler.
 - Add validation/tests.
@@ -437,7 +453,7 @@ Map tests directly to `PRODUCT.md` behavior.
   - Startup-path tests or focused checks confirming `warpctrl` dispatches commands without entering GUI-app launch code.
   - Shell completions/help output checks once final command naming is selected.
 ### Computer-use CLI verification
-Before any stacked PR is considered ready for review, run an end-to-end computer-use verification pass against a Claude-built validation artifact from that branch. The validation artifact is a Warp app build and standalone `warpctrl` binary built by the validation agent from the exact commit under review, with `warp_control_cli` compiled in and `FeatureFlag::WarpControlCli` enabled at runtime.
+Before any stacked PR is considered ready for review, run an end-to-end computer-use verification pass against a cloud built validation artifact from that branch. The validation artifact is a Warp app build and standalone `warpctrl` binary built by the validation agent from the exact commit under review, with `warp_control_cli` compiled in and `FeatureFlag::WarpControlCli` enabled at runtime.
 The verifier must launch the built Warp app, enable the Scripting settings needed for the command category under test, and capture screenshots or screen recordings that prove the user-visible result of each basic command family. Screenshots should be saved as durable artifacts and named by branch, invocation context, command family, and command name.
 The verifier must exercise both invocation contexts:
 - **Inside Warp terminal:** run `warpctrl` from a terminal session inside the feature-flag-enabled Warp app. This path must prove the app-issued Warp-terminal execution-context proof is accepted and that inside-Warp settings gate the command categories.
@@ -496,7 +512,7 @@ flowchart LR
 - Implementation drift from `SECURITY.md`:
   - Mitigation: treat `SECURITY.md` as normative for security behavior; update this technical plan before implementation when there is disagreement, and include tests for the security architecture in the first slice.
 - Action catalog drift from real UI behavior:
-  - Mitigation: each control action reuses or factors existing UI action paths rather than duplicating behavior.
+  - Mitigation: each control action reuses or factors existing UI action paths rather than duplicating behavior, and user-visible app action enums implement exhaustive `WarpCtrlBehavior` mappings so new internal actions cannot be added without an explicit expose/cover/exclude/defer decision.
 - Leaking internal unstable identifiers:
   - Mitigation: public protocol exposes opaque IDs and selectors; internal runtime IDs stay implementation details.
 - Over-broad settings mutation:

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -304,6 +304,7 @@ The intended stack is:
 2. `zach/warp-cli` — first implementation branch. This stays as the core scaffolding slice: protocol crate, discovery/auth scaffolding, Scripting settings surface, local-control server/bridge, standalone `warpctrl` binary, packaging hooks, and only the single `warpctrl tab create` mutation needed to prove the end-to-end path.
 3. `zach/warp-cli-readonly` — create this branch directly from `zach/warp-cli`. It implements the read-only command set from `PRODUCT.md` without adding additional mutations beyond the existing `tab create` proof command.
 4. `zach/warp-cli-read-write` — create this branch directly from `zach/warp-cli-readonly`. It implements the mutating command set from `PRODUCT.md` after the read-only branch has established selectors, metadata result shapes, and inspection APIs.
+Spec changes are an important part of the stacking strategy. All spec changes must originate on `zach/warp-cli-specs`, which is the authoritative source for `specs/warp-control-cli/PRODUCT.md`, `TECH.md`, `SECURITY.md`, and supporting docs. After a spec change lands there, propagate it upward through every stacked branch with raw git so the spec files stay synchronized across `zach/warp-cli`, `zach/warp-cli-readonly`, and `zach/warp-cli-read-write`. Do not make independent spec edits directly on the implementation branches except as part of resolving a propagation conflict in a way that preserves the authoritative specs-branch content.
 Recommended raw-git setup:
 ```bash
 git fetch origin

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -1,0 +1,322 @@
+# Context
+`PRODUCT.md` defines a standalone local Warp control CLI binary, provisionally named `warpctrl`, with an allowlisted action catalog, deterministic addressing across multiple running Warp app processes, and an incremental implementation plan.
+The existing app already has three relevant building blocks:
+- `crates/http_server/src/lib.rs (7-61)` runs a native-only loopback Axum server on fixed port `9277`.
+- `app/src/lib.rs (1993-2001)` registers that HTTP server in the native app and currently merges only installation-detection and profiling routers.
+- `crates/app-installation-detection/src/lib.rs (15-60)` and `app/src/profiling.rs (208-242)` show the current local HTTP routes. They are narrow endpoints, not a general control plane.
+Warp also already has the app-side behaviors the control API should reuse rather than reimplement:
+- `app/src/terminal/view/action.rs (193-196)` defines split-pane terminal actions.
+- `app/src/pane_group/mod.rs (4266-4360, 5377-5414)` shows pane creation/splitting semantics and how split events mutate pane layout.
+- `app/src/workspace/action.rs (153-156)` defines the existing tab creation actions, including default and terminal-tab variants.
+- `app/src/workspace/view.rs (21203-21244)` shows how user-visible default and terminal-tab actions are dispatched.
+- `app/src/settings/theme.rs (9-82)` defines persisted theme settings.
+- `app/src/themes/theme_chooser.rs (416-458)` shows persisted theme selection behavior.
+- `app/src/workspace/action.rs (95-776)` is the largest existing inventory of user-visible workspace actions and informs the allowlist catalog.
+- `app/src/workspace/util.rs (12-18)` defines `PaneViewLocator`, and `app/src/pane_group/pane/mod.rs (84-177)` defines serializable pane identifiers, both useful reference points for selector resolution.
+- `app/src/uri/mod.rs (822-1093, 1166-1364)` demonstrates external intents being resolved into active windows/workspaces and dispatched into running app state.
+The current Oz CLI build/distribution model is also directly relevant because the control CLI should follow the same standalone-artifact approach rather than relying on the Warp GUI executable to service ordinary shell invocations:
+- `crates/warp_cli/src/lib.rs (88-188, 316-418)` defines the existing CLI/parser conventions and channel-specific command naming support.
+- `app/src/lib.rs (631-746)` routes CLI invocations into CLI execution rather than GUI launch.
+- `script/macos/bundle (353-735)` and `script/linux/bundle (157-294)` build standalone CLI artifacts with the `standalone` feature.
+- `.github/workflows/create_release.yml (423-554, 660-858, 992-1276)` publishes macOS/Linux CLI artifacts.
+- `script/windows/windows-installer.iss (235-263)` shows the current Windows helper-wrapper pattern for CLI access.
+The most important constraint surfaced by this code is that the current fixed-port local HTTP server cannot be the entire solution for a multi-process control API. If multiple local Warp processes attempt to expose mutating routes through the same fixed port, only one can own it. The control design therefore needs explicit per-process discovery and addressing.
+## Proposed changes
+### 1. Protocol crate and stable envelope
+Create a small shared protocol crate or equivalent shared module used by both the app server and standalone CLI client. It should define:
+- Protocol version metadata.
+- Discovery/health response types.
+- Selector types:
+  - `InstanceSelector`
+  - `WindowSelector`
+  - `TabSelector`
+  - `PaneSelector`
+  - `SessionSelector`
+- Opaque protocol-facing ID newtypes for instance/window/tab/pane/session identifiers.
+- Allowlisted `ControlAction` variants and typed parameter payloads.
+- Success/error envelopes with stable machine-readable error codes.
+The protocol should treat target IDs as opaque. The app may encode existing runtime identifiers internally, but the public wire contract should not require callers to understand `EntityId`, `PaneId`, or other implementation types.
+Recommended top-level request shape for `tab.create`:
+```json
+{
+  "protocol_version": 1,
+  "request_id": "client-generated-id",
+  "action": "tab.create",
+  "target": {
+    "window": "active"
+  },
+  "params": {}
+}
+```
+Recommended response shape:
+```json
+{
+  "ok": true,
+  "protocol_version": 1,
+  "request_id": "client-generated-id",
+  "instance_id": "opaque-instance-id",
+  "resolved_target": {
+    "window_id": "opaque-window-id",
+    "tab_id": "opaque-tab-id"
+  },
+  "result": {}
+}
+```
+Error payloads should include a stable code such as `no_instance`, `ambiguous_instance`, `stale_target`, `invalid_selector`, `unsupported_action`, `not_allowlisted`, `invalid_params`, `target_state_conflict`, or `unauthorized_local_client`.
+### 2. Per-process discovery instead of fixed-port-only routing
+Keep the existing fixed-port HTTP behavior intact for installation detection/profiling compatibility. Add a separate local-control listener that follows the same native Axum/Tokio pattern but supports multiple local Warp app processes.
+Recommended design:
+- Each participating Warp process creates a random opaque `instance_id` at startup.
+- Each process binds a loopback control listener on an ephemeral port or an app-managed available port.
+- Each process writes a discovery record into a secure per-user Warp state directory. The record should contain:
+  - `instance_id`
+  - PID
+  - channel/build metadata
+  - control-listener endpoint
+  - protocol version
+  - start timestamp
+  - local-auth material reference or token metadata
+- The CLI loads discovery records, removes or ignores stale records after health checks, and chooses an instance using the product selector rules.
+- `warpctrl instance list` is a CLI-first projection of this discovery registry plus health responses.
+This design preserves the current `9277` behavior while avoiding cross-process port contention for the new control API.
+### 3. Local authentication boundary
+Mutating localhost routes should not copy the permissive CORS posture of `/install_detection`.
+Recommended local trust model:
+- No browser-readable CORS allowance on control endpoints.
+- Per-instance random bearer token or equivalent local credential stored in the discovery record or adjacent secure local state with user-only permissions.
+- CLI automatically loads and presents the credential.
+- The app rejects missing/invalid local credentials before action resolution.
+- Health metadata exposed without credentials, if needed for stale-record pruning, must not reveal mutating capabilities or sensitive target state.
+This keeps the protocol local and scriptable without creating an ambient browser-to-localhost control surface.
+### 4. App-side request bridge onto the UI/application context
+The HTTP handler runs on a Tokio runtime thread owned by the local-control server. It cannot directly access or mutate Warp's UI models, views, or app context because all WarpUI state is single-threaded and owned by the main app event loop. The bridge solves this by sending a closure from the Tokio handler thread to the main thread, executing it in the model's context, and returning the result to the waiting HTTP handler.
+#### Thread model
+- **Tokio runtime thread (HTTP handler):** Owns the Axum router, receives HTTP requests, authenticates, deserializes the `RequestEnvelope`. Cannot touch `AppContext`, views, or models.
+- **Main app thread:** Owns all WarpUI entities (`App`, `AppContext`, views, models). All UI state reads and mutations must happen here.
+- **Bridge:** Transfers a typed closure from the Tokio thread to the main thread, executes it with `&mut ModelContext`, and sends the return value back.
+#### Implementation: `ModelSpawner`
+The bridge uses WarpUI's `ModelSpawner<T>` mechanism, which is the standard way for background threads to schedule work on a model's main-thread context:
+1. During app initialization, a `LocalControlBridge` singleton model is created. The model's `ModelContext::spawner()` method returns a `ModelSpawner<LocalControlBridge>` — a cloneable, `Send` handle that can enqueue closures from any thread.
+2. The `ModelSpawner` is stored in the Axum router's shared state (`ControlServerState`), making it available to every HTTP handler.
+3. When an HTTP request arrives, the handler calls `spawner.spawn(|bridge, ctx| { ... }).await`:
+   - `spawn` sends a boxed `FnOnce(&mut LocalControlBridge, &mut ModelContext<LocalControlBridge>) -> R` closure through an `async_channel` to the main thread's task-callback loop.
+   - The main thread dequeues the closure, constructs a fresh `ModelContext` for the bridge model, and calls the closure.
+   - Inside the closure, the bridge has full access to `ModelContext`, which derefs to `AppContext`. This means it can call `ctx.windows()`, `ctx.views_of_type::<Workspace>(window_id)`, `workspace.update(ctx, ...)`, and any other main-thread API.
+   - The closure returns a typed result (e.g., `ResponseEnvelope`), which is sent back to the Tokio thread via a `oneshot` channel.
+4. The HTTP handler awaits the oneshot result and serializes it as the HTTP response.
+#### Concrete flow for `tab.create`
+```
+HTTP handler (Tokio thread)
+  │
+  ├─ verify auth token
+  ├─ deserialize RequestEnvelope
+  ├─ call bridge_spawner.spawn(move |bridge, ctx| {
+  │      bridge.handle_request(request, ctx)  // runs on main thread
+  │  }).await
+  │
+  └─ serialize ResponseEnvelope as JSON
+
+LocalControlBridge::handle_request (main thread)
+  │
+  ├─ match request.action.kind
+  │   └─ ActionKind::TabCreate
+  │       ├─ validate_tab_create_target(&request.target)
+  │       ├─ ctx.windows().active_window()
+  │       │   └─ fallback: ctx.windows().ordered_window_ids().first()
+  │       ├─ ctx.views_of_type::<Workspace>(window_id)
+  │       └─ workspace.update(ctx, |workspace, ctx| {
+  │             workspace.handle_action(
+  │                 &WorkspaceAction::AddTerminalTab { hide_homepage: false },
+  │                 ctx,
+  │             )
+  │           })
+  │
+  └─ return ResponseEnvelope::ok(request_id, json!({ ... }))
+```
+#### Why this pattern
+- **Thread safety.** WarpUI's entity/view system is not `Send` or `Sync`. The only safe way to interact with it from a background thread is through `ModelSpawner`, which serializes access through the main event loop.
+- **Synchronous result.** Unlike fire-and-forget patterns (e.g., URI intent dispatch in `app/src/uri/mod.rs`), the `spawn` call returns a concrete `Result<R, ModelDropped>`, so the HTTP handler can produce a structured success or error response.
+- **Reuses existing infrastructure.** `ModelSpawner` is already used throughout the codebase for background-to-main-thread communication (e.g., async file I/O results, network responses). No new concurrency primitive is needed.
+- **Action dispatch reuses existing app behavior.** The bridge calls `workspace.handle_action(&WorkspaceAction::AddTerminalTab { ... }, ctx)` — the exact same method the UI keybinding system uses. This ensures the control CLI produces identical behavior to the corresponding user action, including side effects like tab count updates, focus changes, and event emissions.
+#### Adding new action handlers
+To add a new action to the bridge:
+1. Add a variant to `ActionKind` in `crates/local_control/src/protocol.rs`.
+2. Add a match arm in `LocalControlBridge::handle_request` in `app/src/local_control/mod.rs`.
+3. Inside the match arm, use `ctx` (which is a `&mut ModelContext<LocalControlBridge>` that derefs to `&mut AppContext`) to resolve selectors and dispatch the action onto existing app types.
+4. Return a `ResponseEnvelope::ok(...)` or `ResponseEnvelope::error(...)` with the result.
+The bridge closure has access to the full `AppContext` API surface, including `ctx.windows()`, `ctx.window_ids()`, `ctx.views_of_type::<T>(window_id)`, `handle.update(ctx, ...)`, and `handle.read(ctx, ...)`. This makes it straightforward to wire new actions to existing UI behavior without introducing new concurrency concerns.
+### 5. Target resolution model
+Implement target resolution as a reusable component rather than scattering lookup logic across handlers.
+Recommended resolution order:
+1. Select instance in the CLI/discovery layer.
+2. Resolve window inside the target process.
+3. Resolve tab within the window.
+4. Resolve pane within the tab/pane-group context.
+5. Resolve session only for session-scoped commands.
+Selector behavior:
+- `active` resolves from current app focus/selection state.
+- Explicit opaque IDs must resolve exactly or return `stale_target`.
+- Index selectors are allowed only for user-visible indexed concepts such as tabs and should resolve to a concrete opaque ID before execution.
+- A session-scoped request against a non-terminal pane returns `target_state_conflict`.
+Implementation references:
+- Window-level active selection already exists inside the app through `WindowManager`.
+- Pane scoping can build on the conceptual model of `PaneViewLocator` in `app/src/workspace/util.rs (12-18)`.
+- Existing URI intent routing in `app/src/uri/mod.rs (895-1093)` shows how to locate workspaces/windows and avoid silently acting in the wrong place.
+### 6. Allowlisted handler families
+Use one handler module per action family. The protocol layer owns parsing/validation; handler modules own target resolution and delegation to existing app logic.
+Recommended modules/families:
+- Discovery/state:
+  - instances, version, active chain, windows/tabs/panes/sessions listings.
+- Window/tab:
+  - new, focus, close, activate, move, rename, color, close variants.
+- Pane:
+  - split, focus, navigate, close, maximize, resize.
+- Input/session:
+  - insert, replace, clear, run command, cycle session, mode switch where supported.
+- Appearance/settings:
+  - theme list/set, system-theme controls, font/zoom actions, allowlisted settings reads/writes/toggles.
+- Panels/surfaces:
+  - settings/page/search, palettes, left/right panels, Drive, resource center, code review, vertical tabs, AI assistant.
+Do not use a generic “dispatch action by string” endpoint. Every handler should be reachable only through an explicit `ControlAction` variant.
+### 7. First slice: prove discovery and `tab.create`
+The first `warpctrl` implementation slice should land the minimum cross-cutting architecture plus a single representative tab mutation:
+- Shared protocol types and error envelopes.
+- Discovery registry and CLI instance selection.
+- A standalone `warpctrl` binary or artifact path that runs control commands without starting the GUI app runtime.
+- Per-process authenticated local-control server.
+- App-side request bridge and selector resolver.
+- Read-only `ping/version` plus `warpctrl instance list` or equivalent minimal discovery command.
+- End-to-end `warpctrl tab create` for the selected instance, reusing the same app behavior as the user-visible new-terminal-tab action.
+Why `tab.create` first:
+- It proves a UI/layout action can be targeted and executed against live app state.
+- It exercises process discovery, local authentication, request bridging, selector defaults, app-context dispatch, and structured success/error output without introducing higher-risk terminal input execution.
+- It gives operators a concise end-to-end smoke test: discover a running instance, create a tab, and confirm the live app changed.
+The PR should also introduce the shell-facing CLI command grammar that the remainder of the protocol will reuse and establish a lightweight CLI startup path distinct from GUI startup.
+### 8. Follow-up slices: fill out the remaining protocol in parallel
+After the first slice validates discovery, auth, selector resolution, CLI syntax, and server-to-app execution, follow-up slices can add the remaining allowlisted catalog in parallelized action-family groups. The baseline code should make new action additions mostly additive:
+- Extend `ControlAction`.
+- Add typed params/results.
+- Add a handler.
+- Add validation/tests.
+- Add CLI surface/tests.
+### 9. CLI parsing and output libraries
+The `warpctrl` CLI must use the same argument parsing and output libraries as the existing Oz CLI so that conventions, derive patterns, and shell-completion generation remain consistent across both binaries.
+- **clap** (with the `derive` feature) for argument parsing, subcommand trees, and help generation. Both binaries share the `warp_cli` crate, so parser types defined there are reused directly.
+- **serde** / **serde_json** for JSON request/response serialization and for `--output-format json` output.
+- **clap_complete** for shell completion generation, reusing the same infrastructure the Oz CLI uses.
+- The `OutputFormat` enum (`Pretty`, `Json`, `Ndjson`, `Text`) is shared from `warp_cli::agent::OutputFormat` so human-readable vs. machine-readable output follows the same conventions.
+- New subcommand types for `warpctrl` live in `warp_cli::local_control` and follow the same `#[derive(Parser)]` / `#[derive(Subcommand)]` / `#[derive(Args)]` patterns used by the Oz CLI's top-level `Args` and `CliCommand` types.
+Do not introduce alternative parsing libraries (e.g., `structopt`, `argh`) or alternative serialization approaches. Keeping one set of libraries across both CLIs reduces dependency weight, ensures consistent `--help` formatting, and lets contributors move between the two surfaces without learning a different stack.
+### 10. CLI packaging and release shape
+The shipped product shape should be a separate bundled `warpctrl` CLI binary that reuses shared CLI/protocol crates but does not depend on launching the GUI binary in command mode. Follow the Oz CLI release model as closely as practical:
+- macOS:
+  - Add a standalone control CLI artifact path next to the existing Oz standalone CLI artifact flow.
+  - If the app bundle also exposes a wrapper/install flow, keep channelized naming consistent with the final product name decision.
+- Linux:
+  - Extend bundle/release scripts to emit control CLI standalone artifacts and packages in the same broad pattern as the current Oz CLI tarball/deb/rpm/Arch package flow.
+- Windows:
+  - Mirror the existing installer-generated helper-wrapper pattern first if that remains the canonical Oz behavior on Windows.
+  - If the product decision is to ship a true standalone Windows control CLI binary, add a dedicated release path in follow-up work rather than silently diverging from existing Oz precedent.
+Startup and dependency expectations:
+- The CLI process should initialize only command parsing, discovery, authentication material loading, protocol serialization, HTTP transport, and output formatting needed for the requested command.
+- The CLI should not initialize GUI state, rendering, terminal session models, app workspaces, or other main-app-only subsystems.
+- Startup cost should be treated as part of the product contract because control commands are expected to compose naturally in scripts and repeated interactive shell usage.
+Naming decision:
+- Product examples use provisional `warpctrl ...` command lines for the standalone local-control binary.
+- Final artifact filenames, channelized aliases, and installer exposure should be chosen before broad rollout to avoid churn in bundle scripts, docs, shell completions, and release workflow files.
+## End-to-end flow
+```mermaid
+sequenceDiagram
+    participant CLI as Warp control CLI
+    participant REG as Local discovery registry
+    participant PROC as Selected Warp process
+    participant HTTP as Local control listener
+    participant BRIDGE as App request bridge
+    participant RES as Target resolver
+    participant ACT as Allowlisted action handler
+    participant UI as Live Warp app state
+
+    CLI->>REG: Read local instance records
+    CLI->>PROC: Health/protocol check for candidates
+    PROC-->>CLI: Instance metadata + compatibility
+    CLI->>CLI: Resolve instance selector
+    CLI->>HTTP: Authenticated POST tab.create request
+    HTTP->>BRIDGE: Typed request + response channel
+    BRIDGE->>RES: Resolve window/tab/pane/session selectors
+    RES-->>BRIDGE: Concrete target handles or typed error
+    BRIDGE->>ACT: Execute allowlisted ControlAction
+    ACT->>UI: Reuse existing tab creation behavior
+    UI-->>ACT: Mutation/read result
+    ACT-->>BRIDGE: Typed result
+    BRIDGE-->>HTTP: Response envelope
+    HTTP-->>CLI: JSON success/error response
+    CLI-->>CLI: Pretty or JSON output
+```
+## Testing and validation
+Map tests directly to `PRODUCT.md` behavior.
+- Behavior 1-6, 29-31:
+  - Protocol version/unit tests.
+  - Discovery-registry tests with zero, one, multiple, stale, and incompatible instance records.
+  - Local-auth tests for missing/invalid/valid credentials.
+- Behavior 7-13:
+  - Selector-resolution unit tests for active, explicit ID, index, stale target, ambiguous target, and non-terminal session target.
+  - Tests that no lower-level selector silently retargets after an explicit stale selector fails.
+- Behavior 15-28:
+  - Parser/serde tests for every first-slice `ControlAction` variant.
+  - Router tests proving unknown/unallowlisted actions are rejected.
+  - CLI parse/output tests for pretty and JSON rendering.
+- Behavior 18 and 33:
+  - App-side tests for `tab.create` using existing workspace/tab helpers or a narrow extracted helper.
+  - Manual local verification that `warpctrl tab create` creates a terminal tab in a running app.
+- Behavior 30:
+  - Multi-process integration-style coverage using two synthetic discovery records and mock health responders, plus manual testing with multiple channel builds where practical.
+- Packaging:
+  - `--artifact cli`-style bundle smoke tests or script-level checks for each supported platform path touched by the first slice.
+  - Startup-path tests or focused checks confirming `warpctrl` dispatches commands without entering GUI-app launch code.
+  - Shell completions/help output checks once final command naming is selected.
+## Parallelization
+The first slice should stay mostly sequential because protocol envelope, discovery, authentication, selector resolution, and `tab.create` are tightly coupled and need one coherent architecture.
+The follow-up catalog expansion is a strong fit for remote Oz cloud-agent fan-out after the first slice lands. Proposed parallel workstreams:
+- `control-window-tab-pane` — remote agent owns window/tab/pane action expansion, including CLI syntax, protocol variants, app handlers, and tests. Branch suggestion: `zach/warp-control-cli-window-tab-pane`.
+- `control-settings-appearance` — remote agent owns settings/theme/font/zoom allowlist expansion and validation. Branch suggestion: `zach/warp-control-cli-settings-appearance`.
+- `control-input-surfaces` — remote agent owns session/input plus panel/palette/settings-surface commands, with extra care around command execution risk. Branch suggestion: `zach/warp-control-cli-input-surfaces`.
+- `control-introspection-packaging` — remote agent owns richer list/read commands, documentation/examples, and any follow-on bundle/release plumbing not completed in PR1. Branch suggestion: `zach/warp-control-cli-introspection-packaging`.
+Merge strategy:
+- Each remote agent works from the first slice’s merged baseline or a designated follow-up integration base.
+- Each returns a branch or compact patch plus validation notes.
+- A lead integrator folds accepted slices into one combined second PR so the public protocol remains coherent.
+```mermaid
+flowchart LR
+    P1["First slice merged<br/>protocol + discovery + bridge + tab.create"] --> Launch["Launch follow-up cloud agents"]
+    Launch --> A["control-window-tab-pane"]
+    Launch --> B["control-settings-appearance"]
+    Launch --> C["control-input-surfaces"]
+    Launch --> D["control-introspection-packaging"]
+    A --> Merge["Lead integrates protocol additions"]
+    B --> Merge
+    C --> Merge
+    D --> Merge
+    Merge --> Validate["Full validation + docs review"]
+    Validate --> P2["Single PR2 with remaining allowlist"]
+```
+## Risks and mitigations
+- Fixed-port server assumptions:
+  - Mitigation: leave current `9277` endpoints undisturbed and use a per-process control listener plus discovery registry.
+- Browser-to-localhost abuse:
+  - Mitigation: no permissive CORS, explicit local auth, and mutating routes gated before selector resolution.
+- Action catalog drift from real UI behavior:
+  - Mitigation: each control action reuses or factors existing UI action paths rather than duplicating behavior.
+- Leaking internal unstable identifiers:
+  - Mitigation: public protocol exposes opaque IDs and selectors; internal runtime IDs stay implementation details.
+- Over-broad settings mutation:
+  - Mitigation: allowlisted setting keys only, with private/debug/derived settings rejected.
+- Command execution risk:
+  - Mitigation: keep `input.run`/session execution in the catalog but require explicit follow-up product/review decision before broad rollout.
+- Packaging churn due to provisional executable naming:
+  - Mitigation: document `warpctrl` as provisional and settle final aliases before broad release workflow rollout.
+- Heavyweight CLI startup caused by sharing the GUI binary's launch path:
+  - Mitigation: ship a separate control CLI artifact with a narrow initialization path and keep GUI-only subsystems out of ordinary CLI command execution.
+## Follow-ups
+- Decide the final artifact filename/channel alias scheme around the provisional `warpctrl ...` public command surface.
+- Decide whether Windows should follow the current Oz wrapper pattern indefinitely or gain standalone control CLI artifacts.
+- Decide whether a future subscription/watch protocol is useful for scripts that want live state changes, rather than single request/response calls only.

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -55,10 +55,23 @@ Create a small shared protocol crate or equivalent shared module used by both th
   - `TabSelector`
   - `PaneSelector`
   - `SessionSelector`
+  - `BlockSelector`
+  - `FileSelector`
+  - `DriveObjectSelector`
 - Opaque protocol-facing ID newtypes for instance/window/tab/pane/session identifiers.
 - Allowlisted `ControlAction` variants and typed parameter payloads.
 - Success/error envelopes with stable machine-readable error codes.
 The protocol should treat target IDs as opaque. The app may encode existing runtime identifiers internally, but the public wire contract should not require callers to understand `EntityId`, `PaneId`, or other implementation types.
+Recommended selector variants:
+- `InstanceSelector`: `Active`, `Id(InstanceId)`, `Pid(u32)`.
+- `WindowSelector`: `Active`, `Id(WindowId)`, `Index(u32)`, `Title(String)`.
+- `TabSelector`: `Active`, `Id(TabId)`, `Index(u32)`, `Title(String)`.
+- `PaneSelector`: `Active`, `Id(PaneId)`, `Index(u32)`.
+- `SessionSelector`: `Active`, `Id(SessionId)`, `Index(u32)`.
+- `BlockSelector`: `Id(BlockId)`.
+- `FileSelector`: `Path { path, line, column }`.
+- `DriveObjectSelector`: `Id(DriveObjectId)` or `Lookup { object_type, name_or_path }`.
+Index selectors are resolved only within their parent selector context, so tab index resolution requires a resolved window and pane/session index resolution requires a resolved tab or pane. Title and name/path lookup selectors are ergonomic helpers for interactive use and must fail on ambiguity rather than choosing the first match.
 Recommended top-level request shape for `tab.create`:
 ```json
 {
@@ -85,7 +98,7 @@ Recommended response shape:
   "result": {}
 }
 ```
-Error payloads should include stable codes defined in `SECURITY.md`, including `local_control_disabled`, `unauthorized_local_client`, `insufficient_permissions`, `authenticated_user_required`, `authenticated_user_unavailable`, `execution_context_not_allowed`, `ambiguous_instance`, `stale_target`, `invalid_selector`, `unsupported_action`, `not_allowlisted`, `invalid_params`, `target_state_conflict`, `missing_target`, and `no_instance`.
+Error payloads should include stable codes defined in `SECURITY.md`, including `local_control_disabled`, `unauthorized_local_client`, `insufficient_permissions`, `authenticated_user_required`, `authenticated_user_unavailable`, `execution_context_not_allowed`, `ambiguous_instance`, `ambiguous_target`, `stale_target`, `invalid_selector`, `unsupported_action`, `not_allowlisted`, `invalid_params`, `target_state_conflict`, `missing_target`, and `no_instance`.
 ### 2. Per-process discovery instead of fixed-port-only routing
 Keep the existing fixed-port HTTP behavior intact for installation detection/profiling compatibility. Add a separate local-control listener that follows the same native Axum/Tokio pattern but supports multiple local Warp app processes.
 Recommended design:
@@ -192,16 +205,27 @@ Recommended resolution order:
 3. Resolve tab within the window.
 4. Resolve pane within the tab/pane-group context.
 5. Resolve session only for session-scoped commands.
+6. Resolve block/file/Drive selectors only for commands whose action metadata declares that target family.
 Selector behavior:
 - `active` resolves from current app focus/selection state.
 - Explicit opaque IDs must resolve exactly or return `stale_target`.
-- Index selectors are allowed only for user-visible indexed concepts such as tabs and should resolve to a concrete opaque ID before execution.
+- Index selectors are allowed only for user-visible indexed concepts and should resolve to a concrete opaque ID before execution.
+- Title, name, and path selectors are convenience selectors. They must be exact by default, document any future fuzzy behavior explicitly, and return `ambiguous_target` when more than one target matches.
 - A session-scoped request against a non-terminal pane returns `target_state_conflict`.
 Target resolution must happen after protected enablement, authentication, and safety-grant checks. This prevents denied requests from learning more target state than necessary and keeps enforcement centralized.
 Implementation references:
 - Window-level active selection already exists inside the app through `WindowManager`.
 - Pane scoping can build on the conceptual model of `PaneViewLocator` in `app/src/workspace/util.rs (12-18)`.
 - Existing URI intent routing in `app/src/uri/mod.rs (895-1093)` shows how to locate workspaces/windows and avoid silently acting in the wrong place.
+#### CLI selector grammar
+`crates/warp_cli/src/local_control.rs` should expose a shared selector argument group that is flattened into every command that accepts app targets. The parser must support:
+- Instance selectors: `--instance <instance_id>` and `--pid <pid>`, with clap conflicts.
+- Window selectors: `--window <active|id:<id>|index:<n>|title:<title>>`, `--window-id <id>`, `--window-index <n>`, and `--window-title <title>`, with one form allowed.
+- Tab selectors: `--tab <active|id:<id>|index:<n>|title:<title>>`, `--tab-id <id>`, `--tab-index <n>`, and `--tab-title <title>`, with one form allowed.
+- Pane selectors: `--pane <active|id:<id>|index:<n>>`, `--pane-id <id>`, and `--pane-index <n>`, with one form allowed.
+- Session selectors: `--session <active|id:<id>|index:<n>>`, `--session-id <id>`, and `--session-index <n>`, with one form allowed.
+- Block/file/Drive selectors only on commands that need them: `--block-id <id>`, path arguments or `--path <path>` plus `--line`/`--column`, and Drive object ID arguments or `--drive-id <id>`.
+The CLI converts these flags into the protocol `TargetSelector` before sending the request. It must not rely on positional entity IDs for commands like `window close 1`; target entities are selected through the shared selector flags so command arguments remain reserved for action parameters.
 ### 6. Allowlisted handler families
 Use one handler module per action family. The protocol layer owns parsing/validation; handler modules own target resolution and delegation to existing app logic.
 Recommended modules/families:
@@ -396,6 +420,8 @@ Map tests directly to `PRODUCT.md` behavior.
 - Behavior 7-13:
   - Selector-resolution unit tests for active, explicit ID, index, stale target, ambiguous target, and non-terminal session target.
   - Tests that no lower-level selector silently retargets after an explicit stale selector fails.
+  - CLI selector parsing tests for every generic and explicit alias form: `--window`, `--window-id`, `--window-index`, `--window-title`, `--tab`, `--tab-id`, `--tab-index`, `--tab-title`, `--pane`, `--pane-id`, `--pane-index`, `--session`, `--session-id`, and `--session-index`.
+  - CLI conflict tests proving only one selector form per entity family is accepted and that positional target IDs are rejected where the command expects selector flags.
 - Behavior 15-28:
   - Parser/serde tests for every first-slice `ControlAction` variant.
   - Router tests proving unknown/unallowlisted actions are rejected.

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -1,6 +1,6 @@
 # Context
 `PRODUCT.md` defines a standalone local Warp control CLI binary, provisionally named `warpctrl`, with an allowlisted action catalog, deterministic addressing across multiple running Warp app processes, and an incremental implementation plan.
-`SECURITY.md` is the normative security architecture for this feature. Implementation work must follow it for explicit in-app enablement, protected enablement storage, granular permissions, discovery metadata, credential storage, scoped safety grants, verified execution context, authenticated-user requirements, localhost/browser protections, action-tier enforcement, deterministic target resolution, and local app-side validation. If this technical plan and `SECURITY.md` disagree, update the plan before implementing rather than treating the security architecture as optional follow-up work.
+`SECURITY.md` is the normative security architecture for this feature. Implementation work must follow it for separate inside-Warp and outside-Warp enablement, the top-level Settings > Scripting surface, protected enablement storage, granular permissions, discovery metadata, credential storage, scoped safety grants, verified execution context, authenticated-user requirements, localhost/browser protections, action-tier enforcement, deterministic target resolution, and local app-side validation. If this technical plan and `SECURITY.md` disagree, update the plan before implementing rather than treating the security architecture as optional follow-up work.
 The existing app already has three relevant building blocks:
 - `crates/http_server/src/lib.rs (7-61)` runs a native-only loopback Axum server on fixed port `9277`.
 - `app/src/lib.rs (1993-2001)` registers that HTTP server in the native app and currently merges only installation-detection and profiling routers.
@@ -26,11 +26,12 @@ The most important constraint surfaced by this code is that the current fixed-po
 ### 0. Security architecture dependency
 Before implementing any local-control listener, CLI command, credential path, or action handler, the implementation must be checked against `SECURITY.md`.
 Required security gates:
-- Local control scripting is disabled by default and can only be enabled by an in-app Warp settings flow.
-- The authoritative enablement state is local-only, not Settings Sync'd, and stored in protected local storage rather than ordinary user-editable settings.
-- `warpctrl`, direct protocol requests, shell scripts, config files, registry/plist edits, and server-backed preferences must not be able to enable local control scripting.
-- Discovery records do not publish actionable endpoints or credential references while local control scripting is disabled.
-- Credential issuance is unavailable while local control scripting is disabled.
+- Local control scripting has separate inside-Warp and outside-Warp enablement states. Inside-Warp control for verified Warp-managed terminal sessions defaults on; outside-Warp control for external terminals, scripts, IDEs, launch agents, and other same-user processes defaults off.
+- Both controls live under a new top-level Settings pane page named **Scripting**.
+- The authoritative enablement states are local-only, not Settings Sync'd, and stored in protected local storage rather than ordinary user-editable settings.
+- `warpctrl`, direct protocol requests, shell scripts, config files, registry/plist edits, defaults writes, and server-backed preferences must not be able to enable either setting.
+- Discovery records do not publish actionable endpoints or credential references for disabled outside-Warp control.
+- Credential issuance is unavailable when the request's invocation context is disabled.
 - Raw credential material is kept out of plaintext discovery records and stored in platform secure storage where available.
 - The broker distinguishes verified Warp-terminal invocations from external invocations using an app-issued execution-context proof, not a caller-declared label.
 - External invocations default to a smaller logged-out-safe action set that does not touch user-authenticated data.
@@ -38,7 +39,7 @@ Required security gates:
 - The app rejects disabled, unauthenticated, expired, revoked, insufficient-scope, unsupported, malformed, ambiguous, missing-target, and stale-target requests with structured errors.
 - Every action has a documented risk tier and the app bridge enforces the required tier locally before selector resolution or handler dispatch.
 - Every action has a documented `requires_authenticated_user` value and allowed execution contexts. New actions default to requiring an authenticated user unless explicitly reviewed as logged-out-safe.
-- Granular local-control settings gate the maximum grants for metadata reads, terminal-data reads, non-destructive mutations, destructive/execution actions, authenticated-user actions from Warp terminals, and authenticated-user actions from external clients.
+- Granular local-control settings under Settings > Scripting gate the maximum grants for metadata reads, terminal-data reads, non-destructive mutations, destructive/execution actions, authenticated-user actions from Warp terminals, and authenticated-user actions from external clients.
 - Safety tiers are treated as user-intent and accident-prevention guardrails, not as strong same-user malicious-app isolation.
 - Remote control remains out of scope for the local same-machine credential model.
 The first implementation slice should include the protected enablement gate, credential issuance checks, and app-side tier enforcement even if the only mutating action initially implemented is `tab.create`. Shipping `tab.create` without the enablement and validation architecture would create the wrong foundation for the full catalog.
@@ -97,16 +98,16 @@ Recommended design:
   - control-listener endpoint
   - protocol version
   - start timestamp
-  - credential metadata or secure-storage references only when local control scripting is enabled
+  - credential metadata or secure-storage references only when the relevant inside-Warp or outside-Warp context is enabled
 - The CLI loads discovery records, removes or ignores stale records after health checks, and chooses an instance using the product selector rules.
 - `warpctrl instance list` is a CLI-first projection of this discovery registry plus health responses.
-When local control scripting is disabled, discovery must follow `SECURITY.md`: either publish no actionable local-control record or publish only a minimal disabled-status record with no endpoint authority or credential reference.
+When outside-Warp control is disabled, discovery must follow `SECURITY.md`: either publish no actionable local-control record for external clients or publish only a minimal disabled-status record with no endpoint authority or credential reference.
 This design preserves the current `9277` behavior while avoiding cross-process port contention for the new control API.
 ### 3. Local authentication, enablement, and safety boundary
 Mutating localhost routes should not copy the permissive CORS posture of `/install_detection`.
 Recommended local trust model:
 - No browser-readable CORS allowance on control endpoints.
-- Local control scripting must be explicitly enabled in the Warp app before credentials are minted or sensitive control requests are accepted.
+- The relevant inside-Warp or outside-Warp Scripting setting must allow the request context before credentials are minted or sensitive control requests are accepted.
 - The authoritative enablement bit must live in protected local storage and must not be writable by `warpctrl` or ordinary same-user preference/config edits.
 - Per-instance raw credential material must be kept out of plaintext discovery records and stored in platform secure storage where practical.
 - The CLI may load or request scoped credentials through an app-owned broker/helper, but it must not mint authority itself.
@@ -138,7 +139,7 @@ The bridge uses WarpUI's `ModelSpawner<T>` mechanism, which is the standard way 
 ```
 HTTP handler (Tokio thread)
   │
-  ├─ verify local control scripting is enabled
+  ├─ verify inside-Warp or outside-Warp context is enabled
   ├─ verify credential, execution context, safety grant, and authenticated-user grant
   ├─ deserialize RequestEnvelope
   ├─ call bridge_spawner.spawn(move |bridge, ctx| {
@@ -149,7 +150,7 @@ HTTP handler (Tokio thread)
 
 LocalControlBridge::handle_request (main thread)
   │
-  ├─ verify protected enablement state is still enabled
+  ├─ verify protected context-specific enablement state is still enabled
   ├─ map action to required risk tier
   ├─ map action to authenticated-user and execution-context requirements
   ├─ verify presented credential grants that tier, target family, execution context, and authenticated-user access
@@ -220,11 +221,12 @@ Do not use a generic “dispatch action by string” endpoint. Every handler sho
 ### 7. First slice: prove discovery and `tab.create`
 The first `warpctrl` implementation slice should land the minimum cross-cutting architecture plus a single representative tab mutation:
 - Shared protocol types and error envelopes.
-- Protected in-app enablement setting and protected local-only enablement storage.
-- Granular local-control permission storage for at least metadata, non-destructive local mutations, and authenticated-user-action categories.
+- New top-level Settings > Scripting page with separate protected inside-Warp and outside-Warp enablement states.
+- Protected local-only enablement storage where inside-Warp control defaults on and outside-Warp control defaults off.
+- Granular local-control permission storage under Settings > Scripting for at least metadata, non-destructive local mutations, and authenticated-user-action categories.
 - Discovery registry and CLI instance selection.
 - A standalone `warpctrl` binary or artifact path that runs control commands without starting the GUI app runtime.
-- Per-process authenticated local-control server that refuses sensitive work when local control scripting is disabled.
+- Per-process authenticated local-control server that refuses sensitive work when the request's inside-Warp or outside-Warp context is disabled.
 - Scoped credential issuance/storage with no raw credentials in plaintext discovery records, including execution-context fields and authenticated-user grant fields.
 - App-side request bridge and selector resolver.
 - Action-tier mapping and app-side safety-grant enforcement.
@@ -289,7 +291,7 @@ sequenceDiagram
     CLI->>BROKER: Request scoped credential for action + execution context
     BROKER-->>CLI: Grant or structured denial
     CLI->>HTTP: Authenticated POST tab.create request
-    HTTP->>HTTP: Verify enablement + credential + execution context
+    HTTP->>HTTP: Verify context-specific enablement + credential + execution context
     HTTP->>BRIDGE: Typed request + response channel
     BRIDGE->>BRIDGE: Recheck enablement + tier + auth-user policy
     BRIDGE->>RES: Resolve window/tab/pane/session selectors
@@ -305,13 +307,13 @@ sequenceDiagram
 ## Testing and validation
 Map tests directly to `PRODUCT.md` behavior.
 - Security architecture:
-  - Protected enablement tests proving disabled state rejects credential issuance, sensitive discovery, and mutating requests with `local_control_disabled`.
+  - Protected enablement tests proving inside-Warp control defaults on, outside-Warp control defaults off, and disabled contexts reject credential issuance, sensitive discovery, and mutating requests with `local_control_disabled`.
   - Tests proving discovery in disabled state exposes no actionable endpoint authority or credential reference.
   - Credential-storage tests proving raw credentials are not written into plaintext discovery records.
   - Execution-context tests proving external clients cannot receive grants reserved for verified Warp-terminal invocations.
   - Tier-enforcement tests proving insufficient grants fail with `insufficient_permissions` before selector resolution or handler dispatch.
   - Authenticated-user tests proving user-authenticated actions fail without a logged-in app user or authenticated-user grant.
-  - Granular-permission tests proving disabled categories invalidate credentials and prevent new grants.
+  - Settings > Scripting tests proving both top-level toggles and granular disabled categories invalidate credentials and prevent new grants.
   - Structured-error tests for disabled, unauthenticated, expired, revoked, insufficient-scope, execution-context-denied, authenticated-user-required, authenticated-user-unavailable, unsupported, malformed, ambiguous, missing-target, stale-target, and invalid-selector requests.
 - Behavior 1-6, 29-31:
   - Protocol version/unit tests.
@@ -363,8 +365,8 @@ flowchart LR
   - Mitigation: leave current `9277` endpoints undisturbed and use a per-process control listener plus discovery registry.
 - Browser-to-localhost abuse:
   - Mitigation: no permissive CORS, protected in-app enablement, explicit local auth, scoped grants, and mutating routes gated before selector resolution.
-- External apps silently enabling local control:
-  - Mitigation: authoritative enablement state lives in protected local storage, is local-only, is not Settings Sync'd, and is not writable through `warpctrl`, config files, registry/plist preference edits, or server-backed settings.
+- External apps silently enabling outside-Warp local control:
+  - Mitigation: the outside-Warp enablement state defaults off, lives in protected local storage behind Settings > Scripting, is local-only, is not Settings Sync'd, and is not writable through `warpctrl`, config files, registry/plist preference edits, defaults writes, or server-backed settings.
 - External apps obtaining in-Warp authenticated-user grants:
   - Mitigation: require an app-issued execution-context proof for Warp-terminal-only grants, do not trust caller-declared labels or plain environment variables as sole authority, and keep external authenticated-user grants behind a separate default-off permission.
 - Logged-out requests touching user-authenticated data:

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -409,6 +409,20 @@ Map tests directly to `PRODUCT.md` behavior.
   - `--artifact cli`-style bundle smoke tests or script-level checks for each supported platform path touched by the first slice.
   - Startup-path tests or focused checks confirming `warpctrl` dispatches commands without entering GUI-app launch code.
   - Shell completions/help output checks once final command naming is selected.
+### Computer-use CLI verification
+Before any stacked PR is considered ready for review, run an end-to-end computer-use verification pass against a Claude-built validation artifact from that branch. The validation artifact is a Warp app build and standalone `warpctrl` binary built by the validation agent from the exact commit under review, with `warp_control_cli` compiled in and `FeatureFlag::WarpControlCli` enabled at runtime.
+The verifier must launch the built Warp app, enable the Scripting settings needed for the command category under test, and capture screenshots or screen recordings that prove the user-visible result of each basic command family. Screenshots should be saved as durable artifacts and named by branch, invocation context, command family, and command name.
+The verifier must exercise both invocation contexts:
+- **Inside Warp terminal:** run `warpctrl` from a terminal session inside the feature-flag-enabled Warp app. This path must prove the app-issued Warp-terminal execution-context proof is accepted and that inside-Warp settings gate the command categories.
+- **Outside Warp terminal:** run the same `warpctrl` binary from an external terminal or automation shell outside the built Warp app. This path must prove outside-Warp control is default-off, then works only after enabling outside-Warp scripting and the required granular permissions in Settings > Scripting.
+The verification matrix should cover every implemented command in `PRODUCT.md` at least once in JSON output mode and, where there is a visible UI effect, with a screenshot after the command runs. At minimum:
+- read-only metadata commands show successful CLI output and, for active/focus/list commands, a visible target that matches the output;
+- underlying data read commands show successful CLI output only when the underlying-data-read permission is enabled and a denial screenshot/output when it is disabled;
+- app-state mutation commands show before/after screenshots proving the visible Warp UI changed;
+- metadata/configuration mutation commands show before/after screenshots proving the persisted setting or label changed;
+- underlying data mutation commands run only in a disposable test workspace/session with test files and test Warp Drive objects, show denial without the underlying-data-mutation permission, then show success with the permission enabled;
+- authenticated-user commands show both the logged-out or missing-grant denial path and the enabled authenticated path when a test account/environment is available.
+The verifier should produce a verification manifest checked into or attached to the PR artifacts. The manifest should list each command, branch under test, invocation context, required permission category, expected result, actual result, screenshot artifact path, and any skipped case with a reason. Missing screenshots for visible commands block review readiness.
 ## Parallelization
 The first slice on `zach/warp-cli` should stay mostly sequential because protocol envelope, discovery, authentication, feature-flag gating, selector resolution, and `tab.create` are tightly coupled and need one coherent architecture.
 The read-only and read-write follow-up branches are strong fits for Oz cloud-agent fan-out, but the fan-out should happen inside the stacked branch strategy from `## Implementation Plan`, not as unrelated sibling feature branches.

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -1,6 +1,6 @@
 # Context
 `PRODUCT.md` defines a standalone local Warp control CLI binary, provisionally named `warpctrl`, with an allowlisted action catalog, deterministic addressing across multiple running Warp app processes, and an incremental implementation plan.
-`SECURITY.md` is the normative security architecture for this feature. Implementation work must follow it for separate inside-Warp and outside-Warp enablement, the top-level Settings > Scripting surface, protected enablement storage, granular permissions, discovery metadata, credential storage, scoped safety grants, verified execution context, authenticated-user requirements, localhost/browser protections, action-tier enforcement, deterministic target resolution, and local app-side validation. If this technical plan and `SECURITY.md` disagree, update the plan before implementing rather than treating the security architecture as optional follow-up work.
+`SECURITY.md` is the normative security architecture for this feature. Implementation work must follow it for separate inside-Warp and outside-Warp enablement, the top-level Settings > Scripting surface, protected enablement storage, granular permissions, discovery metadata, credential storage, scoped safety grants, verified execution context, authenticated-user requirements, localhost/browser protections, permission-category enforcement, deterministic target resolution, and local app-side validation. If this technical plan and `SECURITY.md` disagree, update the plan before implementing rather than treating the security architecture as optional follow-up work.
 The existing app already has three relevant building blocks:
 - `crates/http_server/src/lib.rs (7-61)` runs a native-only loopback Axum server on fixed port `9277`.
 - `app/src/lib.rs (1993-2001)` registers that HTTP server in the native app and currently merges only installation-detection and profiling routers.
@@ -37,18 +37,18 @@ Required security gates:
 - External invocations default to a smaller logged-out-safe action set that does not touch user-authenticated data.
 - Verified Warp-terminal invocations may receive authenticated-user grants only when the selected app has a true logged-in Warp user and local-control settings allow authenticated-user actions from Warp terminals.
 - The app rejects disabled, unauthenticated, expired, revoked, insufficient-scope, unsupported, malformed, ambiguous, missing-target, and stale-target requests with structured errors.
-- Every action has a documented risk tier and the app bridge enforces the required tier locally before selector resolution or handler dispatch.
+- Every action has a documented state/data category and the app bridge enforces the required permission category locally before selector resolution or handler dispatch.
 - Every action has a documented `requires_authenticated_user` value and allowed execution contexts. New actions default to requiring an authenticated user unless explicitly reviewed as logged-out-safe.
-- Granular local-control settings under Settings > Scripting gate the maximum grants for metadata reads, terminal-data reads, non-destructive mutations, destructive/execution actions, authenticated-user actions from Warp terminals, and authenticated-user actions from external clients.
-- Safety tiers are treated as user-intent and accident-prevention guardrails, not as strong same-user malicious-app isolation.
+- Granular local-control settings under Settings > Scripting gate the maximum grants for metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, underlying data mutations, authenticated-user actions from Warp terminals, and authenticated-user actions from external clients.
+- Permission categories are treated as user-intent and accident-prevention guardrails, not as strong same-user malicious-app isolation.
 - Remote control remains out of scope for the local same-machine credential model.
-The first implementation slice should include the protected enablement gate, credential issuance checks, and app-side tier enforcement even if the only mutating action initially implemented is `tab.create`. Shipping `tab.create` without the enablement and validation architecture would create the wrong foundation for the full catalog.
+The first implementation slice should include the protected enablement gate, credential issuance checks, and app-side permission-category enforcement even if the only mutating action initially implemented is `tab.create`. Shipping `tab.create` without the enablement and validation architecture would create the wrong foundation for the full catalog.
 ### 1. Protocol crate and stable envelope
 Create a small shared protocol crate or equivalent shared module used by both the app server and standalone CLI client. It should define:
 - Protocol version metadata.
 - Discovery/health response types.
 - Execution-context proof/request types for verified Warp-terminal invocations versus external invocations.
-- Action metadata describing risk tier, required grant, `requires_authenticated_user`, allowed execution contexts, and target families.
+- Action metadata describing state/data category, required permission grant, `requires_authenticated_user`, allowed execution contexts, and target families.
 - Selector types:
   - `InstanceSelector`
   - `WindowSelector`
@@ -114,11 +114,11 @@ Recommended local trust model:
 - The broker verifies whether the invocation originated from a Warp-managed terminal session before issuing in-Warp-only grants.
 - The broker issues authenticated-user grants only when the selected app has a true logged-in Warp user and the relevant local-control permission is enabled.
 - The app rejects disabled-state, missing, malformed, invalid, expired, or revoked credentials before selector resolution or mutation.
-- The app maps every action to a risk tier and rejects insufficient grants before selector resolution or mutation.
+- The app maps every action to a state/data category and rejects insufficient grants before selector resolution or mutation.
 - The app maps every action to a `requires_authenticated_user` value and allowed execution contexts, rejecting mismatches before selector resolution or mutation.
 - Health metadata exposed without credentials, if needed for stale-record pruning, must not reveal mutating capabilities, credentials, or sensitive target state.
 This keeps the protocol local and scriptable without creating an ambient browser-to-localhost control surface.
-Do not ship the first slice as a plaintext discovery bearer token, even for same-user human CLI use. The first slice is the foundation for higher-risk terminal data, input injection, command execution, and destructive operations, so it must establish the protected enablement, credential storage, scoped grant, and app-side enforcement model from `SECURITY.md`.
+Do not ship the first slice as a plaintext discovery bearer token, even for same-user human CLI use. The first slice is the foundation for underlying data reads, app-state mutations, metadata/configuration mutations, and underlying data mutations, so it must establish the protected enablement, credential storage, scoped grant, and app-side enforcement model from `SECURITY.md`.
 ### 4. App-side request bridge onto the UI/application context
 The HTTP handler runs on a Tokio runtime thread owned by the local-control server. It cannot directly access or mutate Warp's UI models, views, or app context because all WarpUI state is single-threaded and owned by the main app event loop. The bridge solves this by sending a closure from the Tokio handler thread to the main thread, executing it in the model's context, and returning the result to the waiting HTTP handler.
 #### Thread model
@@ -151,9 +151,9 @@ HTTP handler (Tokio thread)
 LocalControlBridge::handle_request (main thread)
   │
   ├─ verify protected context-specific enablement state is still enabled
-  ├─ map action to required risk tier
+  ├─ map action to required permission category
   ├─ map action to authenticated-user and execution-context requirements
-  ├─ verify presented credential grants that tier, target family, execution context, and authenticated-user access
+  ├─ verify presented credential grants that category, target family, execution context, and authenticated-user access
   ├─ match request.action.kind
   │   └─ ActionKind::TabCreate
   │       ├─ validate_tab_create_target(&request.target)
@@ -178,9 +178,9 @@ LocalControlBridge::handle_request (main thread)
 #### Adding new action handlers
 To add a new action to the bridge:
 1. Add a variant to `ActionKind` in `crates/local_control/src/protocol.rs`.
-2. Document its `SECURITY.md` risk tier, required grant, `requires_authenticated_user` value, and allowed execution contexts.
+2. Document its `SECURITY.md` state/data category, required permission grant, `requires_authenticated_user` value, and allowed execution contexts.
 3. Add a match arm in `LocalControlBridge::handle_request` in `app/src/local_control/mod.rs`.
-4. Before selector resolution or dispatch, verify local control is enabled and the presented credential grants the action tier, target family, execution context, and authenticated-user access if required.
+4. Before selector resolution or dispatch, verify local control is enabled and the presented credential grants the action category, target family, execution context, and authenticated-user access if required.
 5. Inside the match arm, use `ctx` (which is a `&mut ModelContext<LocalControlBridge>` that derefs to `&mut AppContext`) to resolve selectors and dispatch the action onto existing app types.
 6. Return a `ResponseEnvelope::ok(...)` or `ResponseEnvelope::error(...)` with the result.
 The bridge closure has access to the full `AppContext` API surface, including `ctx.windows()`, `ctx.window_ids()`, `ctx.views_of_type::<T>(window_id)`, `handle.update(ctx, ...)`, and `handle.read(ctx, ...)`. This makes it straightforward to wire new actions to existing UI behavior without introducing new concurrency concerns.
@@ -221,16 +221,17 @@ Do not use a generic “dispatch action by string” endpoint. Every handler sho
 ### 7. First slice: prove discovery and `tab.create`
 The first `warpctrl` implementation slice should land the minimum cross-cutting architecture plus a single representative tab mutation:
 - Shared protocol types and error envelopes.
-- New top-level Settings > Scripting page with separate protected inside-Warp and outside-Warp enablement states.
+- `FeatureFlag::WarpControlCli` and Cargo feature `warp_control_cli`, with app-side runtime gating for settings, discovery, bridge registration, and local-control endpoints.
+- New top-level Settings > Scripting page with separate protected inside-Warp and outside-Warp enablement states, rendered only while `FeatureFlag::WarpControlCli` is enabled.
 - Protected local-only enablement storage where inside-Warp control defaults on and outside-Warp control defaults off.
-- Granular local-control permission storage under Settings > Scripting for at least metadata, non-destructive local mutations, and authenticated-user-action categories.
+- Granular local-control permission storage under Settings > Scripting for metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, underlying data mutations, and authenticated-user-action categories.
 - Discovery registry and CLI instance selection.
 - A standalone `warpctrl` binary or artifact path that runs control commands without starting the GUI app runtime.
 - Per-process authenticated local-control server that refuses sensitive work when the request's inside-Warp or outside-Warp context is disabled.
 - Scoped credential issuance/storage with no raw credentials in plaintext discovery records, including execution-context fields and authenticated-user grant fields.
 - App-side request bridge and selector resolver.
-- Action-tier mapping and app-side safety-grant enforcement.
-- Action metadata for `tab.create` that deliberately classifies it as a logged-out-safe non-destructive local mutation only when the user's granular local-control settings allow that category.
+- Action-category mapping and app-side safety-grant enforcement.
+- Action metadata for `tab.create` that deliberately classifies it as a logged-out-safe app-state mutation only when the user's granular local-control settings allow app-state mutation.
 - Read-only `ping/version` plus `warpctrl instance list` or equivalent minimal discovery command.
 - End-to-end `warpctrl tab create` for the selected instance, reusing the same app behavior as the user-visible new-terminal-tab action.
 Why `tab.create` first:
@@ -271,6 +272,79 @@ Startup and dependency expectations:
 Naming decision:
 - Product examples use provisional `warpctrl ...` command lines for the standalone local-control binary.
 - Final artifact filenames, channelized aliases, and installer exposure should be chosen before broad rollout to avoid churn in bundle scripts, docs, shell completions, and release workflow files.
+## Implementation Plan
+### Branch stack
+Use raw git for the stack; do not use Graphite for these branches.
+The intended stack is:
+1. `zach/warp-cli-specs` — spec-only branch. This branch owns `specs/warp-control-cli/PRODUCT.md`, `TECH.md`, `SECURITY.md`, and supporting docs. It should not contain implementation changes.
+2. `zach/warp-cli` — first implementation branch. This stays as the core scaffolding slice: protocol crate, discovery/auth scaffolding, Scripting settings surface, local-control server/bridge, standalone `warpctrl` binary, packaging hooks, and only the single `warpctrl tab create` mutation needed to prove the end-to-end path.
+3. `zach/warp-cli-readonly` — create this branch directly from `zach/warp-cli`. It implements the read-only command set from `PRODUCT.md` without adding additional mutations beyond the existing `tab create` proof command.
+4. `zach/warp-cli-read-write` — create this branch directly from `zach/warp-cli-readonly`. It implements the mutating command set from `PRODUCT.md` after the read-only branch has established selectors, metadata result shapes, and inspection APIs.
+Recommended raw-git setup:
+```bash
+git fetch origin
+git checkout zach/warp-cli
+git checkout -b zach/warp-cli-readonly
+git push -u origin zach/warp-cli-readonly
+git checkout -b zach/warp-cli-read-write
+git push -u origin zach/warp-cli-read-write
+```
+If `zach/warp-cli-readonly` changes after `zach/warp-cli-read-write` exists, rebase the read-write branch onto the updated read-only branch with raw git (`git checkout zach/warp-cli-read-write && git rebase zach/warp-cli-readonly`) and resolve conflicts by preserving both read-only API shape and mutating handlers.
+### Feature flag and rollout gate
+The entire feature should be gated behind a Warp feature flag, proposed as `FeatureFlag::WarpControlCli` with Cargo feature `warp_control_cli`.
+Implementation should follow the existing runtime feature-flag conventions:
+- Add `warp_control_cli = []` under `[features]` in `app/Cargo.toml`, not under the default feature set until launch.
+- Add `WarpControlCli` to the `FeatureFlag` enum in `crates/warp_features/src/lib.rs`.
+- Add the `#[cfg(feature = "warp_control_cli")] FeatureFlag::WarpControlCli` entry in `app/src/features.rs` so the compile-time feature initializes the runtime flag.
+- Enable the flag for dogfood or preview by adding it to `DOGFOOD_FLAGS` or `PREVIEW_FLAGS` only when the rollout plan calls for that exposure.
+- Prefer runtime checks with `FeatureFlag::WarpControlCli.is_enabled()` over broad `#[cfg]` gates except where code cannot compile without the Cargo feature.
+When `FeatureFlag::WarpControlCli` is disabled in the Warp app:
+- the Scripting settings page should not expose Warp control settings;
+- `LocalControlSettings` should not register user-visible controls for Warp control;
+- the app should not create `LocalControlBridge` or `LocalControlServer`;
+- no local-control discovery record should be written;
+- no `/v1/control` or `/v1/control/credentials` local server endpoints should be exposed;
+- command-palette/keybinding entries related specifically to installing, configuring, or using `warpctrl` should be hidden;
+- tests should cover both enabled and disabled flag states with the repo's normal feature-flag override helpers.
+The standalone `warpctrl` binary can still exist in a build where the app feature is disabled, but it should find no compatible enabled app instance and should return a structured no-instance or feature-disabled error rather than relying on hidden server state.
+### Read-only branch sharding with Oz cloud agents
+Use Oz cloud agents to shard `zach/warp-cli-readonly` by API family. Each agent should work from `zach/warp-cli-readonly` or a short-lived shard branch based on it, push a branch or return a patch, and report changed files plus validation results. A lead integrator merges/cherry-picks accepted shard work into `zach/warp-cli-readonly` using raw git.
+Suggested shards:
+- `readonly-protocol-cli` owns `crates/local_control` action variants, typed read-only params/results, CLI parser/output for read-only commands, and serde tests.
+- `readonly-app-targets` owns app-side handlers and target resolvers for `app`, `window`, `tab`, `pane`, and `session` structural metadata.
+- `readonly-underlying-data` owns read-only underlying-data commands such as block listing/output, input-buffer reads, history reads, file content reads if added, and Drive object content reads, with extra tests that content is denied without underlying-data-read permission.
+- `readonly-settings-appearance` owns theme, appearance, settings, keybinding, and action/capability inspection commands.
+- `readonly-files-drive-skill-docs` owns app-state file/project reads, authenticated Warp Drive read-only commands, operator docs, and the first version of the built-in `warpctrl` Agent skill.
+Read-only branch acceptance criteria:
+- all read-only commands in `PRODUCT.md` parse and serialize stable request envelopes;
+- structural metadata reads return opaque protocol IDs and do not expose terminal, file, Drive object, or AI conversation content;
+- underlying-data reads require the separate underlying-data-read grant;
+- authenticated Warp Drive metadata reads require a logged-in user and authenticated-user grant, and object-content reads additionally require the underlying-data-read grant;
+- disabled feature flag state exposes no settings, discovery records, or endpoints;
+- `cargo nextest run --no-fail-fast --workspace <relevant tests>` and targeted `cargo check` pass for the changed crates.
+### Read-write branch sharding with Oz cloud agents
+Start `zach/warp-cli-read-write` only after the read-only branch has a coherent target-resolution and result-shape baseline. Each mutating shard should add action metadata, typed params/results, CLI parser surface, app bridge handlers, permission checks, and tests for allowed and denied paths.
+Suggested shards:
+- `mutate-window-tab-pane` owns window creation/focus/close, tab create/activate/move/rename/color/close, and pane split/focus/navigate/resize/maximize/rename/close.
+- `mutate-input-session` owns session activation/cycling/reopen, input insert/replace/clear, and terminal-vs-agent input mode changes as app-state mutations. It may define `input run`, but execution must be classified as an underlying data mutation and can be handed to `mutate-underlying-data` if that keeps review cleaner.
+- `mutate-metadata-config` owns theme selection, system theme toggles, font/zoom controls, tab/pane metadata updates, and allowlisted setting set/toggle commands as metadata/configuration mutations.
+- `mutate-surfaces-files-drive` owns settings/palette/search/panel surface commands and file/project/Drive open commands as app-state mutations.
+- `mutate-underlying-data` owns terminal command execution, file create/write/append/delete commands, Warp Drive workflow execution, and Warp Drive object CRUD. This shard must require the underlying-data-mutation permission and authenticated-user grants where applicable.
+- `mutate-tests-docs-skill` owns cross-family integration tests, command help/shell completion checks, README updates, and updates to the built-in `warpctrl` Agent skill once the mutating command surface stabilizes.
+Read-write branch acceptance criteria:
+- every mutating command in `PRODUCT.md` has an explicit state/data category, required permission category, and authenticated-user classification;
+- app-state mutations, metadata/configuration mutations, and underlying-data mutations require distinct permissions;
+- command execution, file writes, Warp Drive CRUD, and other underlying-data mutations require the underlying-data-mutation permission, not merely read-write/app-state permission;
+- selector resolution happens after auth and permission checks and never silently retargets stale explicit selectors;
+- all mutating handlers reuse existing user-visible app behavior rather than duplicating business logic;
+- disabled feature flag state continues to hide settings and withhold endpoints;
+- the branch can be reviewed as a stacked PR whose base is `zach/warp-cli-readonly`.
+### Merge and review strategy
+Keep PR boundaries aligned with the stack:
+- PR1: `zach/warp-cli` into `master` for core scaffolding plus `tab create` only.
+- PR2: `zach/warp-cli-readonly` into `zach/warp-cli` or the merged successor of PR1 for read-only command expansion.
+- PR3: `zach/warp-cli-read-write` into `zach/warp-cli-readonly` or the merged successor of PR2 for mutating command expansion.
+If PR1 merges before PR2 is ready, rebase `zach/warp-cli-readonly` onto the new `master`. If PR2 merges before PR3 is ready, rebase `zach/warp-cli-read-write` onto the new `master` or onto the updated read-only branch, depending on the active review base. Use raw git for all rebases, conflict resolution, and pushes.
 ## End-to-end flow
 ```mermaid
 sequenceDiagram
@@ -293,7 +367,7 @@ sequenceDiagram
     CLI->>HTTP: Authenticated POST tab.create request
     HTTP->>HTTP: Verify context-specific enablement + credential + execution context
     HTTP->>BRIDGE: Typed request + response channel
-    BRIDGE->>BRIDGE: Recheck enablement + tier + auth-user policy
+    BRIDGE->>BRIDGE: Recheck enablement + permission + auth-user policy
     BRIDGE->>RES: Resolve window/tab/pane/session selectors
     RES-->>BRIDGE: Concrete target handles or typed error
     BRIDGE->>ACT: Execute allowlisted ControlAction
@@ -311,7 +385,7 @@ Map tests directly to `PRODUCT.md` behavior.
   - Tests proving discovery in disabled state exposes no actionable endpoint authority or credential reference.
   - Credential-storage tests proving raw credentials are not written into plaintext discovery records.
   - Execution-context tests proving external clients cannot receive grants reserved for verified Warp-terminal invocations.
-  - Tier-enforcement tests proving insufficient grants fail with `insufficient_permissions` before selector resolution or handler dispatch.
+  - Permission-category enforcement tests proving insufficient grants fail with `insufficient_permissions` before selector resolution or handler dispatch, including separate denial cases for app-state mutation, metadata/configuration mutation, and underlying-data mutation.
   - Authenticated-user tests proving user-authenticated actions fail without a logged-in app user or authenticated-user grant.
   - Settings > Scripting tests proving both top-level toggles and granular disabled categories invalidate credentials and prevent new grants.
   - Structured-error tests for disabled, unauthenticated, expired, revoked, insufficient-scope, execution-context-denied, authenticated-user-required, authenticated-user-unavailable, unsupported, malformed, ambiguous, missing-target, stale-target, and invalid-selector requests.
@@ -336,29 +410,36 @@ Map tests directly to `PRODUCT.md` behavior.
   - Startup-path tests or focused checks confirming `warpctrl` dispatches commands without entering GUI-app launch code.
   - Shell completions/help output checks once final command naming is selected.
 ## Parallelization
-The first slice should stay mostly sequential because protocol envelope, discovery, authentication, selector resolution, and `tab.create` are tightly coupled and need one coherent architecture.
-The follow-up catalog expansion is a strong fit for remote Oz cloud-agent fan-out after the first slice lands. Proposed parallel workstreams:
-- `control-window-tab-pane` — remote agent owns window/tab/pane action expansion, including CLI syntax, protocol variants, app handlers, and tests. Branch suggestion: `zach/warp-control-cli-window-tab-pane`.
-- `control-settings-appearance` — remote agent owns settings/theme/font/zoom allowlist expansion and validation. Branch suggestion: `zach/warp-control-cli-settings-appearance`.
-- `control-input-surfaces` — remote agent owns session/input plus panel/palette/settings-surface commands, with extra care around command execution risk. Branch suggestion: `zach/warp-control-cli-input-surfaces`.
-- `control-introspection-packaging` — remote agent owns richer list/read commands, documentation/examples, and any follow-on bundle/release plumbing not completed in PR1. Branch suggestion: `zach/warp-control-cli-introspection-packaging`.
+The first slice on `zach/warp-cli` should stay mostly sequential because protocol envelope, discovery, authentication, feature-flag gating, selector resolution, and `tab.create` are tightly coupled and need one coherent architecture.
+The read-only and read-write follow-up branches are strong fits for Oz cloud-agent fan-out, but the fan-out should happen inside the stacked branch strategy from `## Implementation Plan`, not as unrelated sibling feature branches.
+Read-only fan-out:
+- Launch agents against `zach/warp-cli-readonly` or short-lived shard branches based on it.
+- Use the shard names from `### Read-only branch sharding with Oz cloud agents`: `readonly-protocol-cli`, `readonly-app-targets`, `readonly-underlying-data`, `readonly-settings-appearance`, and `readonly-files-drive-skill-docs`.
+- The lead integrator merges accepted work into `zach/warp-cli-readonly` with raw git, then validates the full read-only API before the branch is used as the base for mutations.
+Read-write fan-out:
+- Launch agents against `zach/warp-cli-read-write` only after read-only target resolution and result shapes are stable.
+- Use the shard names from `### Read-write branch sharding with Oz cloud agents`: `mutate-window-tab-pane`, `mutate-input-session`, `mutate-metadata-config`, `mutate-surfaces-files-drive`, `mutate-underlying-data`, and `mutate-tests-docs-skill`.
+- The lead integrator merges accepted work into `zach/warp-cli-read-write` with raw git and keeps the branch rebased on the current read-only base.
 Merge strategy:
-- Each remote agent works from the first slice’s merged baseline or a designated follow-up integration base.
-- Each returns a branch or compact patch plus validation notes.
-- A lead integrator folds accepted slices into one combined second PR so the public protocol remains coherent.
+- One stacked PR per durable branch: `zach/warp-cli`, then `zach/warp-cli-readonly`, then `zach/warp-cli-read-write`.
+- Shard branches should not become independent long-lived PRs unless the lead intentionally splits review; their default purpose is to feed the durable stacked branch.
+- Use raw git for branch creation, merges, cherry-picks, rebases, conflict resolution, and pushes. Do not use Graphite commands.
 ```mermaid
 flowchart LR
-    P1["First slice merged<br/>protocol + discovery + bridge + tab.create"] --> Launch["Launch follow-up cloud agents"]
-    Launch --> A["control-window-tab-pane"]
-    Launch --> B["control-settings-appearance"]
-    Launch --> C["control-input-surfaces"]
-    Launch --> D["control-introspection-packaging"]
-    A --> Merge["Lead integrates protocol additions"]
-    B --> Merge
-    C --> Merge
-    D --> Merge
-    Merge --> Validate["Full validation + docs review"]
-    Validate --> P2["Single PR2 with remaining allowlist"]
+    Specs["zach/warp-cli-specs<br/>spec-only"] --> Core["zach/warp-cli<br/>core + tab.create"]
+    Core --> RO["zach/warp-cli-readonly<br/>read-only API"]
+    RO --> RW["zach/warp-cli-read-write<br/>mutating API"]
+    ROShardA["readonly-protocol-cli"] --> RO
+    ROShardB["readonly-app-targets"] --> RO
+    ROShardC["readonly-underlying-data"] --> RO
+    ROShardD["readonly-settings-appearance"] --> RO
+    ROShardE["readonly-files-drive-skill-docs"] --> RO
+    RWShardA["mutate-window-tab-pane"] --> RW
+    RWShardB["mutate-input-session"] --> RW
+    RWShardC["mutate-metadata-config"] --> RW
+    RWShardD["mutate-surfaces-files-drive"] --> RW
+    RWShardE["mutate-underlying-data"] --> RW
+    RWShardF["mutate-tests-docs-skill"] --> RW
 ```
 ## Risks and mitigations
 - Fixed-port server assumptions:

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -1,5 +1,6 @@
 # Context
 `PRODUCT.md` defines a standalone local Warp control CLI binary, provisionally named `warpctrl`, with an allowlisted action catalog, deterministic addressing across multiple running Warp app processes, and an incremental implementation plan.
+`SECURITY.md` is the normative security architecture for this feature. Implementation work must follow it for explicit in-app enablement, protected enablement storage, granular permissions, discovery metadata, credential storage, scoped safety grants, verified execution context, authenticated-user requirements, localhost/browser protections, action-tier enforcement, deterministic target resolution, and local app-side validation. If this technical plan and `SECURITY.md` disagree, update the plan before implementing rather than treating the security architecture as optional follow-up work.
 The existing app already has three relevant building blocks:
 - `crates/http_server/src/lib.rs (7-61)` runs a native-only loopback Axum server on fixed port `9277`.
 - `app/src/lib.rs (1993-2001)` registers that HTTP server in the native app and currently merges only installation-detection and profiling routers.
@@ -22,10 +23,31 @@ The current Oz CLI build/distribution model is also directly relevant because th
 - `script/windows/windows-installer.iss (235-263)` shows the current Windows helper-wrapper pattern for CLI access.
 The most important constraint surfaced by this code is that the current fixed-port local HTTP server cannot be the entire solution for a multi-process control API. If multiple local Warp processes attempt to expose mutating routes through the same fixed port, only one can own it. The control design therefore needs explicit per-process discovery and addressing.
 ## Proposed changes
+### 0. Security architecture dependency
+Before implementing any local-control listener, CLI command, credential path, or action handler, the implementation must be checked against `SECURITY.md`.
+Required security gates:
+- Local control scripting is disabled by default and can only be enabled by an in-app Warp settings flow.
+- The authoritative enablement state is local-only, not Settings Sync'd, and stored in protected local storage rather than ordinary user-editable settings.
+- `warpctrl`, direct protocol requests, shell scripts, config files, registry/plist edits, and server-backed preferences must not be able to enable local control scripting.
+- Discovery records do not publish actionable endpoints or credential references while local control scripting is disabled.
+- Credential issuance is unavailable while local control scripting is disabled.
+- Raw credential material is kept out of plaintext discovery records and stored in platform secure storage where available.
+- The broker distinguishes verified Warp-terminal invocations from external invocations using an app-issued execution-context proof, not a caller-declared label.
+- External invocations default to a smaller logged-out-safe action set that does not touch user-authenticated data.
+- Verified Warp-terminal invocations may receive authenticated-user grants only when the selected app has a true logged-in Warp user and local-control settings allow authenticated-user actions from Warp terminals.
+- The app rejects disabled, unauthenticated, expired, revoked, insufficient-scope, unsupported, malformed, ambiguous, missing-target, and stale-target requests with structured errors.
+- Every action has a documented risk tier and the app bridge enforces the required tier locally before selector resolution or handler dispatch.
+- Every action has a documented `requires_authenticated_user` value and allowed execution contexts. New actions default to requiring an authenticated user unless explicitly reviewed as logged-out-safe.
+- Granular local-control settings gate the maximum grants for metadata reads, terminal-data reads, non-destructive mutations, destructive/execution actions, authenticated-user actions from Warp terminals, and authenticated-user actions from external clients.
+- Safety tiers are treated as user-intent and accident-prevention guardrails, not as strong same-user malicious-app isolation.
+- Remote control remains out of scope for the local same-machine credential model.
+The first implementation slice should include the protected enablement gate, credential issuance checks, and app-side tier enforcement even if the only mutating action initially implemented is `tab.create`. Shipping `tab.create` without the enablement and validation architecture would create the wrong foundation for the full catalog.
 ### 1. Protocol crate and stable envelope
 Create a small shared protocol crate or equivalent shared module used by both the app server and standalone CLI client. It should define:
 - Protocol version metadata.
 - Discovery/health response types.
+- Execution-context proof/request types for verified Warp-terminal invocations versus external invocations.
+- Action metadata describing risk tier, required grant, `requires_authenticated_user`, allowed execution contexts, and target families.
 - Selector types:
   - `InstanceSelector`
   - `WindowSelector`
@@ -62,7 +84,7 @@ Recommended response shape:
   "result": {}
 }
 ```
-Error payloads should include a stable code such as `no_instance`, `ambiguous_instance`, `stale_target`, `invalid_selector`, `unsupported_action`, `not_allowlisted`, `invalid_params`, `target_state_conflict`, or `unauthorized_local_client`.
+Error payloads should include stable codes defined in `SECURITY.md`, including `local_control_disabled`, `unauthorized_local_client`, `insufficient_permissions`, `authenticated_user_required`, `authenticated_user_unavailable`, `execution_context_not_allowed`, `ambiguous_instance`, `stale_target`, `invalid_selector`, `unsupported_action`, `not_allowlisted`, `invalid_params`, `target_state_conflict`, `missing_target`, and `no_instance`.
 ### 2. Per-process discovery instead of fixed-port-only routing
 Keep the existing fixed-port HTTP behavior intact for installation detection/profiling compatibility. Add a separate local-control listener that follows the same native Axum/Tokio pattern but supports multiple local Warp app processes.
 Recommended design:
@@ -75,20 +97,27 @@ Recommended design:
   - control-listener endpoint
   - protocol version
   - start timestamp
-  - local-auth material reference or token metadata
+  - credential metadata or secure-storage references only when local control scripting is enabled
 - The CLI loads discovery records, removes or ignores stale records after health checks, and chooses an instance using the product selector rules.
 - `warpctrl instance list` is a CLI-first projection of this discovery registry plus health responses.
+When local control scripting is disabled, discovery must follow `SECURITY.md`: either publish no actionable local-control record or publish only a minimal disabled-status record with no endpoint authority or credential reference.
 This design preserves the current `9277` behavior while avoiding cross-process port contention for the new control API.
-### 3. Local authentication boundary
+### 3. Local authentication, enablement, and safety boundary
 Mutating localhost routes should not copy the permissive CORS posture of `/install_detection`.
 Recommended local trust model:
 - No browser-readable CORS allowance on control endpoints.
-- Per-instance random bearer token or equivalent local credential stored in the discovery record or adjacent secure local state with user-only permissions.
-- CLI automatically loads and presents the credential.
-- The app rejects missing/invalid local credentials before action resolution.
-- Health metadata exposed without credentials, if needed for stale-record pruning, must not reveal mutating capabilities or sensitive target state.
+- Local control scripting must be explicitly enabled in the Warp app before credentials are minted or sensitive control requests are accepted.
+- The authoritative enablement bit must live in protected local storage and must not be writable by `warpctrl` or ordinary same-user preference/config edits.
+- Per-instance raw credential material must be kept out of plaintext discovery records and stored in platform secure storage where practical.
+- The CLI may load or request scoped credentials through an app-owned broker/helper, but it must not mint authority itself.
+- The broker verifies whether the invocation originated from a Warp-managed terminal session before issuing in-Warp-only grants.
+- The broker issues authenticated-user grants only when the selected app has a true logged-in Warp user and the relevant local-control permission is enabled.
+- The app rejects disabled-state, missing, malformed, invalid, expired, or revoked credentials before selector resolution or mutation.
+- The app maps every action to a risk tier and rejects insufficient grants before selector resolution or mutation.
+- The app maps every action to a `requires_authenticated_user` value and allowed execution contexts, rejecting mismatches before selector resolution or mutation.
+- Health metadata exposed without credentials, if needed for stale-record pruning, must not reveal mutating capabilities, credentials, or sensitive target state.
 This keeps the protocol local and scriptable without creating an ambient browser-to-localhost control surface.
-For agent-facing permissions, local authentication must evolve from a single bearer token into scoped credentials before higher-risk surfaces ship. A scoped credential should encode caller class, instance binding, granted permission tiers, issue time, and optional expiry. The app bridge must authenticate the credential and enforce the required action tier server-side before selector resolution or mutation. The first slice can use the discovery bearer token for human same-user CLI use only because it is limited to discovery and `tab.create`.
+Do not ship the first slice as a plaintext discovery bearer token, even for same-user human CLI use. The first slice is the foundation for higher-risk terminal data, input injection, command execution, and destructive operations, so it must establish the protected enablement, credential storage, scoped grant, and app-side enforcement model from `SECURITY.md`.
 ### 4. App-side request bridge onto the UI/application context
 The HTTP handler runs on a Tokio runtime thread owned by the local-control server. It cannot directly access or mutate Warp's UI models, views, or app context because all WarpUI state is single-threaded and owned by the main app event loop. The bridge solves this by sending a closure from the Tokio handler thread to the main thread, executing it in the model's context, and returning the result to the waiting HTTP handler.
 #### Thread model
@@ -109,7 +138,8 @@ The bridge uses WarpUI's `ModelSpawner<T>` mechanism, which is the standard way 
 ```
 HTTP handler (Tokio thread)
   │
-  ├─ verify auth token
+  ├─ verify local control scripting is enabled
+  ├─ verify credential, execution context, safety grant, and authenticated-user grant
   ├─ deserialize RequestEnvelope
   ├─ call bridge_spawner.spawn(move |bridge, ctx| {
   │      bridge.handle_request(request, ctx)  // runs on main thread
@@ -119,6 +149,10 @@ HTTP handler (Tokio thread)
 
 LocalControlBridge::handle_request (main thread)
   │
+  ├─ verify protected enablement state is still enabled
+  ├─ map action to required risk tier
+  ├─ map action to authenticated-user and execution-context requirements
+  ├─ verify presented credential grants that tier, target family, execution context, and authenticated-user access
   ├─ match request.action.kind
   │   └─ ActionKind::TabCreate
   │       ├─ validate_tab_create_target(&request.target)
@@ -143,9 +177,11 @@ LocalControlBridge::handle_request (main thread)
 #### Adding new action handlers
 To add a new action to the bridge:
 1. Add a variant to `ActionKind` in `crates/local_control/src/protocol.rs`.
-2. Add a match arm in `LocalControlBridge::handle_request` in `app/src/local_control/mod.rs`.
-3. Inside the match arm, use `ctx` (which is a `&mut ModelContext<LocalControlBridge>` that derefs to `&mut AppContext`) to resolve selectors and dispatch the action onto existing app types.
-4. Return a `ResponseEnvelope::ok(...)` or `ResponseEnvelope::error(...)` with the result.
+2. Document its `SECURITY.md` risk tier, required grant, `requires_authenticated_user` value, and allowed execution contexts.
+3. Add a match arm in `LocalControlBridge::handle_request` in `app/src/local_control/mod.rs`.
+4. Before selector resolution or dispatch, verify local control is enabled and the presented credential grants the action tier, target family, execution context, and authenticated-user access if required.
+5. Inside the match arm, use `ctx` (which is a `&mut ModelContext<LocalControlBridge>` that derefs to `&mut AppContext`) to resolve selectors and dispatch the action onto existing app types.
+6. Return a `ResponseEnvelope::ok(...)` or `ResponseEnvelope::error(...)` with the result.
 The bridge closure has access to the full `AppContext` API surface, including `ctx.windows()`, `ctx.window_ids()`, `ctx.views_of_type::<T>(window_id)`, `handle.update(ctx, ...)`, and `handle.read(ctx, ...)`. This makes it straightforward to wire new actions to existing UI behavior without introducing new concurrency concerns.
 ### 5. Target resolution model
 Implement target resolution as a reusable component rather than scattering lookup logic across handlers.
@@ -160,6 +196,7 @@ Selector behavior:
 - Explicit opaque IDs must resolve exactly or return `stale_target`.
 - Index selectors are allowed only for user-visible indexed concepts such as tabs and should resolve to a concrete opaque ID before execution.
 - A session-scoped request against a non-terminal pane returns `target_state_conflict`.
+Target resolution must happen after protected enablement, authentication, and safety-grant checks. This prevents denied requests from learning more target state than necessary and keeps enforcement centralized.
 Implementation references:
 - Window-level active selection already exists inside the app through `WindowManager`.
 - Pane scoping can build on the conceptual model of `PaneViewLocator` in `app/src/workspace/util.rs (12-18)`.
@@ -183,15 +220,21 @@ Do not use a generic “dispatch action by string” endpoint. Every handler sho
 ### 7. First slice: prove discovery and `tab.create`
 The first `warpctrl` implementation slice should land the minimum cross-cutting architecture plus a single representative tab mutation:
 - Shared protocol types and error envelopes.
+- Protected in-app enablement setting and protected local-only enablement storage.
+- Granular local-control permission storage for at least metadata, non-destructive local mutations, and authenticated-user-action categories.
 - Discovery registry and CLI instance selection.
 - A standalone `warpctrl` binary or artifact path that runs control commands without starting the GUI app runtime.
-- Per-process authenticated local-control server.
+- Per-process authenticated local-control server that refuses sensitive work when local control scripting is disabled.
+- Scoped credential issuance/storage with no raw credentials in plaintext discovery records, including execution-context fields and authenticated-user grant fields.
 - App-side request bridge and selector resolver.
+- Action-tier mapping and app-side safety-grant enforcement.
+- Action metadata for `tab.create` that deliberately classifies it as a logged-out-safe non-destructive local mutation only when the user's granular local-control settings allow that category.
 - Read-only `ping/version` plus `warpctrl instance list` or equivalent minimal discovery command.
 - End-to-end `warpctrl tab create` for the selected instance, reusing the same app behavior as the user-visible new-terminal-tab action.
 Why `tab.create` first:
 - It proves a UI/layout action can be targeted and executed against live app state.
 - It exercises process discovery, local authentication, request bridging, selector defaults, app-context dispatch, and structured success/error output without introducing higher-risk terminal input execution.
+- It exercises the protected enablement and scoped-grant model before higher-risk action families depend on it.
 - It gives operators a concise end-to-end smoke test: discover a running instance, create a tab, and confirm the live app changed.
 The PR should also introduce the shell-facing CLI command grammar that the remainder of the protocol will reuse and establish a lightweight CLI startup path distinct from GUI startup.
 ### 8. Follow-up slices: fill out the remaining protocol in parallel
@@ -232,6 +275,7 @@ sequenceDiagram
     participant CLI as Warp control CLI
     participant REG as Local discovery registry
     participant PROC as Selected Warp process
+    participant BROKER as Credential broker
     participant HTTP as Local control listener
     participant BRIDGE as App request bridge
     participant RES as Target resolver
@@ -242,8 +286,12 @@ sequenceDiagram
     CLI->>PROC: Health/protocol check for candidates
     PROC-->>CLI: Instance metadata + compatibility
     CLI->>CLI: Resolve instance selector
+    CLI->>BROKER: Request scoped credential for action + execution context
+    BROKER-->>CLI: Grant or structured denial
     CLI->>HTTP: Authenticated POST tab.create request
+    HTTP->>HTTP: Verify enablement + credential + execution context
     HTTP->>BRIDGE: Typed request + response channel
+    BRIDGE->>BRIDGE: Recheck enablement + tier + auth-user policy
     BRIDGE->>RES: Resolve window/tab/pane/session selectors
     RES-->>BRIDGE: Concrete target handles or typed error
     BRIDGE->>ACT: Execute allowlisted ControlAction
@@ -256,10 +304,19 @@ sequenceDiagram
 ```
 ## Testing and validation
 Map tests directly to `PRODUCT.md` behavior.
+- Security architecture:
+  - Protected enablement tests proving disabled state rejects credential issuance, sensitive discovery, and mutating requests with `local_control_disabled`.
+  - Tests proving discovery in disabled state exposes no actionable endpoint authority or credential reference.
+  - Credential-storage tests proving raw credentials are not written into plaintext discovery records.
+  - Execution-context tests proving external clients cannot receive grants reserved for verified Warp-terminal invocations.
+  - Tier-enforcement tests proving insufficient grants fail with `insufficient_permissions` before selector resolution or handler dispatch.
+  - Authenticated-user tests proving user-authenticated actions fail without a logged-in app user or authenticated-user grant.
+  - Granular-permission tests proving disabled categories invalidate credentials and prevent new grants.
+  - Structured-error tests for disabled, unauthenticated, expired, revoked, insufficient-scope, execution-context-denied, authenticated-user-required, authenticated-user-unavailable, unsupported, malformed, ambiguous, missing-target, stale-target, and invalid-selector requests.
 - Behavior 1-6, 29-31:
   - Protocol version/unit tests.
   - Discovery-registry tests with zero, one, multiple, stale, and incompatible instance records.
-  - Local-auth tests for missing/invalid/valid credentials.
+  - Local-auth tests for missing, invalid, expired, revoked, and valid credentials.
 - Behavior 7-13:
   - Selector-resolution unit tests for active, explicit ID, index, stale target, ambiguous target, and non-terminal session target.
   - Tests that no lower-level selector silently retargets after an explicit stale selector fails.
@@ -305,7 +362,15 @@ flowchart LR
 - Fixed-port server assumptions:
   - Mitigation: leave current `9277` endpoints undisturbed and use a per-process control listener plus discovery registry.
 - Browser-to-localhost abuse:
-  - Mitigation: no permissive CORS, explicit local auth, and mutating routes gated before selector resolution.
+  - Mitigation: no permissive CORS, protected in-app enablement, explicit local auth, scoped grants, and mutating routes gated before selector resolution.
+- External apps silently enabling local control:
+  - Mitigation: authoritative enablement state lives in protected local storage, is local-only, is not Settings Sync'd, and is not writable through `warpctrl`, config files, registry/plist preference edits, or server-backed settings.
+- External apps obtaining in-Warp authenticated-user grants:
+  - Mitigation: require an app-issued execution-context proof for Warp-terminal-only grants, do not trust caller-declared labels or plain environment variables as sole authority, and keep external authenticated-user grants behind a separate default-off permission.
+- Logged-out requests touching user-authenticated data:
+  - Mitigation: every action declares `requires_authenticated_user`, new actions default to true, and the bridge returns authenticated-user errors before selector resolution or dispatch.
+- Implementation drift from `SECURITY.md`:
+  - Mitigation: treat `SECURITY.md` as normative for security behavior; update this technical plan before implementation when there is disagreement, and include tests for the security architecture in the first slice.
 - Action catalog drift from real UI behavior:
   - Mitigation: each control action reuses or factors existing UI action paths rather than duplicating behavior.
 - Leaking internal unstable identifiers:

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -88,6 +88,7 @@ Recommended local trust model:
 - The app rejects missing/invalid local credentials before action resolution.
 - Health metadata exposed without credentials, if needed for stale-record pruning, must not reveal mutating capabilities or sensitive target state.
 This keeps the protocol local and scriptable without creating an ambient browser-to-localhost control surface.
+For agent-facing permissions, local authentication must evolve from a single bearer token into scoped credentials before higher-risk surfaces ship. A scoped credential should encode caller class, instance binding, granted permission tiers, issue time, and optional expiry. The app bridge must authenticate the credential and enforce the required action tier server-side before selector resolution or mutation. The first slice can use the discovery bearer token for human same-user CLI use only because it is limited to discovery and `tab.create`.
 ### 4. App-side request bridge onto the UI/application context
 The HTTP handler runs on a Tokio runtime thread owned by the local-control server. It cannot directly access or mutate Warp's UI models, views, or app context because all WarpUI state is single-threaded and owned by the main app event loop. The bridge solves this by sending a closure from the Tokio handler thread to the main thread, executing it in the model's context, and returning the result to the waiting HTTP handler.
 #### Thread model
@@ -122,7 +123,7 @@ LocalControlBridge::handle_request (main thread)
   │   └─ ActionKind::TabCreate
   │       ├─ validate_tab_create_target(&request.target)
   │       ├─ ctx.windows().active_window()
-  │       │   └─ fallback: ctx.windows().ordered_window_ids().first()
+  │       │   └─ if none: return invalid_selector / missing_target
   │       ├─ ctx.views_of_type::<Workspace>(window_id)
   │       └─ workspace.update(ctx, |workspace, ctx| {
   │             workspace.handle_action(
@@ -138,6 +139,7 @@ LocalControlBridge::handle_request (main thread)
 - **Synchronous result.** Unlike fire-and-forget patterns (e.g., URI intent dispatch in `app/src/uri/mod.rs`), the `spawn` call returns a concrete `Result<R, ModelDropped>`, so the HTTP handler can produce a structured success or error response.
 - **Reuses existing infrastructure.** `ModelSpawner` is already used throughout the codebase for background-to-main-thread communication (e.g., async file I/O results, network responses). No new concurrency primitive is needed.
 - **Action dispatch reuses existing app behavior.** The bridge calls `workspace.handle_action(&WorkspaceAction::AddTerminalTab { ... }, ctx)` — the exact same method the UI keybinding system uses. This ensures the control CLI produces identical behavior to the corresponding user action, including side effects like tab count updates, focus changes, and event emissions.
+- **Deterministic targeting.** The bridge must not silently fall back from the active window to an arbitrary ordered window for mutating actions. If the caller relies on the default active selector and no active window exists, return a structured missing-target or invalid-selector error. If future command forms allow explicit window IDs, resolve the explicit ID exactly or return `stale_target`.
 #### Adding new action handlers
 To add a new action to the bridge:
 1. Add a variant to `ActionKind` in `crates/local_control/src/protocol.rs`.


### PR DESCRIPTION
## Description
Product and tech specs for `warpctrl`, a standalone local-control CLI for scripting Warp UI actions against running app instances.

**PRODUCT.md** defines:
- Allowlisted action catalog organized by namespace (discovery, window, tab, pane, session, input, appearance, settings, panels)
- Hierarchical target selector model (instance → window → tab → pane → session)
- 4-tier action classification: read-only/metadata, read-only/terminal data, mutating/non-destructive, mutating/destructive
- Differentiated permission policies for human vs agent callers (agents are expected to be major consumers)
- Protocol-first settings (reads/writes go through the authenticated control endpoint, not direct file manipulation)
- Future entity extensibility for files and Warp Drive objects
- Future remote URL transport extensibility (out of scope for first slice)

**TECH.md** covers:
- Protocol crate design with stable envelopes, opaque IDs, and versioning
- Per-process discovery via ephemeral-port loopback listeners and filesystem discovery records
- Local authentication boundary (bearer token, file permissions, no CORS)
- App-side request bridge using `ModelSpawner` to safely dispatch from Tokio HTTP threads to the main UI thread
- Target resolution model
- CLI library constraints (clap/serde/clap_complete matching the Oz CLI)
- Packaging and release shape following the Oz CLI artifact model

**README.md** documents:
- Build/install/invocation for macOS, Linux, Windows
- End-to-end test flow
- Security model with authenticated request flow diagram

This is a specs-only PR for review. Implementation is on `zach/warp-cli` stacked on top of this branch.

[Warp conversation](https://staging.warp.dev/conversation/8312e25c-fb94-45c7-957c-531dbbca580f)

## Linked Issue
- Related: #11545

## Testing
- Specs only, no code changes to test.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

