### PR TITLE
Add remote SSH sidebar file uploads

### DIFF
--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -7,6 +7,10 @@ use editing::sort_entries_for_file_tree;
 use itertools::Itertools;
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
+use remote_upload::{
+    build_local_upload_manifest, upload_manifest, FileTreeLocalFileDropTarget, LocalUploadManifest,
+    RemoteUploadTarget,
+};
 use render::RenderState;
 use repo_metadata::file_tree_store::{
     FileTreeDirectoryEntryState, FileTreeEntryState, FileTreeFileMetadata,
@@ -20,6 +24,7 @@ use warp_core::ui::theme::Fill;
 use warp_core::{send_telemetry_from_ctx, HostId};
 use warp_util::path::LineAndColumnArg;
 use warp_util::standardized_path::StandardizedPath;
+use warpui::actions::StandardAction;
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
     AcceptedByDropTarget, Align, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container,
@@ -31,6 +36,7 @@ use warpui::elements::{
 };
 use warpui::fonts::{Properties, Style, Weight};
 use warpui::keymap::FixedBinding;
+use warpui::modals::{AlertDialogWithCallbacks, ModalButton};
 use warpui::platform::Cursor;
 use warpui::text_layout::TextAlignment;
 use warpui::{
@@ -51,6 +57,7 @@ use crate::terminal::input::InputDropTargetData;
 use crate::terminal::view::{TerminalDropTargetData, TerminalView};
 use crate::ui_components::icons::Icon;
 use crate::ui_components::item_highlight::{ImageOrIcon, ItemHighlightState};
+use crate::util::bindings::CustomAction;
 #[cfg(feature = "local_fs")]
 use crate::util::file::external_editor::EditorSettings;
 use crate::util::openable_file_type::{
@@ -64,6 +71,7 @@ use crate::view_components::DismissibleToast;
 use crate::workspace::ToastStack;
 
 mod editing;
+mod remote_upload;
 mod render;
 
 const REMOTE_TEXT: &str = "The Project Explorer requires access to your local workspace, which isn’t supported in remote sessions.";
@@ -139,6 +147,15 @@ pub enum FileTreeAction {
         id: FileTreeIdentifier,
         terminal_view: WeakViewHandle<TerminalView>,
     },
+    PasteLocalFiles,
+    LocalFilesDragged {
+        id: FileTreeIdentifier,
+    },
+    LocalFileDragExited,
+    LocalFilesDropped {
+        id: FileTreeIdentifier,
+        paths: Vec<String>,
+    },
 }
 
 pub fn init(app: &mut AppContext) {
@@ -166,6 +183,24 @@ pub fn init(app: &mut AppContext) {
         FixedBinding::new(
             "enter",
             FileTreeAction::ExecuteSelectedItem,
+            id!(FileTreeView::ui_name()),
+        ),
+        FixedBinding::custom(
+            CustomAction::Paste,
+            FileTreeAction::PasteLocalFiles,
+            "Paste",
+            id!(FileTreeView::ui_name()),
+        ),
+        FixedBinding::standard(
+            StandardAction::Paste,
+            FileTreeAction::PasteLocalFiles,
+            id!(FileTreeView::ui_name()),
+        ),
+        #[cfg(windows)]
+        FixedBinding::custom(
+            CustomAction::WindowsPaste,
+            FileTreeAction::PasteLocalFiles,
+            "Paste",
             id!(FileTreeView::ui_name()),
         ),
     ]);
@@ -288,6 +323,8 @@ pub struct FileTreeView {
     /// the target is selected by the user or when the target root stops
     /// being displayed.
     pending_focus_target: Option<PendingFocusTarget>,
+    /// Remote file-tree item currently highlighted as a local OS file drop target.
+    local_file_drop_target: Option<FileTreeIdentifier>,
 }
 
 /// Directory the file tree wants to focus once its entry becomes available.
@@ -703,6 +740,7 @@ impl FileTreeView {
             #[cfg(feature = "local_fs")]
             registered_lazy_loaded_paths: HashSet::new(),
             pending_focus_target: None,
+            local_file_drop_target: None,
         };
 
         picker
@@ -1179,7 +1217,7 @@ impl FileTreeView {
             self.pending_focus_target = None;
             return false;
         }
-        let Some(id) = self.find_directory_header_id(&target.root, &target.path) else {
+        let Some(id) = self.find_item_id_by_path(&target.root, &target.path) else {
             return false;
         };
         self.selected_item = Some(id.clone());
@@ -1236,18 +1274,17 @@ impl FileTreeView {
         }
     }
 
-    /// Finds the `FileTreeIdentifier` for the directory header at
-    /// `directory_path` inside `root`, if it exists in the root's
-    /// flattened items.
-    fn find_directory_header_id(
+    fn find_item_id_by_path(
         &self,
         root: &StandardizedPath,
-        directory_path: &StandardizedPath,
+        path: &StandardizedPath,
     ) -> Option<FileTreeIdentifier> {
         let root_dir = self.root_directories.get(root)?;
-        let (index, _) = root_dir.items.iter().enumerate().find(|(_, item)| {
-            matches!(item, FileTreeItem::DirectoryHeader { .. }) && item.path() == directory_path
-        })?;
+        let (index, _) = root_dir
+            .items
+            .iter()
+            .enumerate()
+            .find(|(_, item)| item.path() == path)?;
         Some(FileTreeIdentifier {
             root: root.clone(),
             index,
@@ -1977,7 +2014,8 @@ impl FileTreeView {
             return Empty::new().finish();
         };
 
-        let is_selected = self.selected_item.as_ref() == Some(id);
+        let is_drop_target = self.local_file_drop_target.as_ref() == Some(id);
+        let is_selected = self.selected_item.as_ref() == Some(id) || is_drop_target;
         let is_expanded = self.is_item_expanded(&id.root, item);
         let render_state = item.to_render_state(is_expanded, appearance);
 
@@ -1999,7 +2037,11 @@ impl FileTreeView {
         let id_for_drop = id.clone();
         let id_for_drag = id.clone();
         let hoverable = Hoverable::new(render_state.mouse_state.clone(), move |mouse_state| {
-            let item_highlight_state = ItemHighlightState::new(is_selected, mouse_state);
+            let item_highlight_state = if is_drop_target {
+                ItemHighlightState::Selected
+            } else {
+                ItemHighlightState::new(is_selected, mouse_state)
+            };
             Self::render_item_with_hover(
                 render_state,
                 appearance,
@@ -2078,7 +2120,13 @@ impl FileTreeView {
             .with_keep_original_visible(true)
             .finish();
 
-        SavePosition::new(draggable, item_position_id.as_str()).finish()
+        let local_file_drop_target = Box::new(FileTreeLocalFileDropTarget::new(
+            draggable,
+            id.clone(),
+            self.is_remote_upload_drop_candidate(id),
+        ));
+
+        SavePosition::new(local_file_drop_target, item_position_id.as_str()).finish()
     }
 
     fn selected_item_std_path(&self) -> Option<StandardizedPath> {
@@ -2097,6 +2145,277 @@ impl FileTreeView {
         item.path()
             .strip_prefix(&repository_root)
             .map(PathBuf::from)
+    }
+
+    fn remote_upload_target_directory_for_id(
+        &self,
+        id: &FileTreeIdentifier,
+    ) -> Option<StandardizedPath> {
+        let root_dir = self.root_directories.get(&id.root)?;
+        if !root_dir.is_remote() {
+            return None;
+        }
+        let item = root_dir.items.get(id.index)?;
+        match item {
+            FileTreeItem::DirectoryHeader { directory, .. } => Some((*directory.path).clone()),
+            FileTreeItem::File { metadata, .. } => metadata.path.parent(),
+        }
+    }
+
+    fn is_remote_upload_drop_candidate(&self, id: &FileTreeIdentifier) -> bool {
+        FeatureFlag::SshRemoteServer.is_enabled()
+            && self.remote_upload_target_directory_for_id(id).is_some()
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn remote_upload_target_for_id(
+        &self,
+        id: &FileTreeIdentifier,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<RemoteUploadTarget> {
+        use crate::remote_server::manager::RemoteServerManager;
+
+        if !FeatureFlag::SshRemoteServer.is_enabled() {
+            return None;
+        }
+
+        let root_dir = self.root_directories.get(&id.root)?;
+        let host_id = root_dir.remote_host_id.clone()?;
+        let target_dir = self.remote_upload_target_directory_for_id(id)?;
+        let sessions = RemoteServerManager::as_ref(ctx).sessions_for_host(&host_id)?;
+        let session_id = *sessions.iter().next()?;
+
+        Some(RemoteUploadTarget {
+            host_id,
+            session_id,
+            root: id.root.clone(),
+            repo_root: root_dir.entry.root_directory().to_string(),
+            target_dir,
+        })
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn paste_local_files_to_remote(&mut self, ctx: &mut ViewContext<Self>) {
+        let paths = ctx.clipboard().read().paths.unwrap_or_default();
+        if paths.is_empty() {
+            return;
+        }
+
+        let Some(id) = self.selected_item.clone() else {
+            return;
+        };
+
+        self.begin_remote_upload_from_paths(id, paths, ctx);
+    }
+
+    #[cfg(not(feature = "local_fs"))]
+    fn paste_local_files_to_remote(&mut self, _ctx: &mut ViewContext<Self>) {}
+
+    #[cfg(feature = "local_fs")]
+    fn begin_remote_upload_from_paths(
+        &mut self,
+        id: FileTreeIdentifier,
+        paths: Vec<String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        use crate::remote_server::manager::RemoteServerManager;
+
+        let Some(target) = self.remote_upload_target_for_id(&id, ctx) else {
+            return;
+        };
+        let Some(client) = RemoteServerManager::as_ref(ctx)
+            .client_for_host(&target.host_id)
+            .cloned()
+        else {
+            Self::show_remote_upload_error_toast("Remote server is not connected.", ctx);
+            return;
+        };
+
+        self.select_id(&id, ctx);
+        let local_paths = paths.into_iter().map(PathBuf::from).collect::<Vec<_>>();
+        Self::show_remote_upload_status_toast("Preparing remote upload...", ctx);
+
+        let target_for_preflight = target.clone();
+        ctx.spawn(
+            async move {
+                let manifest = build_local_upload_manifest(local_paths)?;
+                let preflight = client
+                    .preflight_remote_upload(
+                        target_for_preflight.repo_root.clone(),
+                        target_for_preflight.target_dir.to_string(),
+                        manifest.proto_entries(),
+                    )
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok::<_, String>((client, target_for_preflight, manifest, preflight.conflicts))
+            },
+            move |view, result, ctx| match result {
+                Ok((client, target, manifest, conflicts)) if conflicts.is_empty() => {
+                    view.start_prepared_remote_upload(client, target, manifest, false, ctx);
+                }
+                Ok((client, target, manifest, conflicts)) => {
+                    view.confirm_remote_upload_replacement(
+                        client, target, manifest, conflicts, ctx,
+                    );
+                }
+                Err(message) => {
+                    Self::show_remote_upload_error_toast(&message, ctx);
+                }
+            },
+        );
+    }
+
+    #[cfg(not(feature = "local_fs"))]
+    fn begin_remote_upload_from_paths(
+        &mut self,
+        _id: FileTreeIdentifier,
+        _paths: Vec<String>,
+        _ctx: &mut ViewContext<Self>,
+    ) {
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn confirm_remote_upload_replacement(
+        &mut self,
+        client: Arc<remote_server::client::RemoteServerClient>,
+        target: RemoteUploadTarget,
+        manifest: LocalUploadManifest,
+        conflicts: Vec<String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let conflict_count = conflicts.len();
+        let sample = conflicts
+            .iter()
+            .take(5)
+            .map(|path| format!("• {path}"))
+            .join("\n");
+        let more = conflict_count
+            .checked_sub(5)
+            .filter(|count| *count > 0)
+            .map(|count| format!("\n…and {count} more"))
+            .unwrap_or_default();
+        let info_text = format!(
+            "{conflict_count} item(s) already exist in the remote folder. Replacing will overwrite matching files and merge directories.\n\n{sample}{more}"
+        );
+
+        ctx.show_native_platform_modal(AlertDialogWithCallbacks::for_view(
+            "Replace existing remote files?",
+            info_text,
+            vec![
+                ModalButton::for_view("Replace", move |view: &mut FileTreeView, ctx| {
+                    view.start_prepared_remote_upload(client, target, manifest, true, ctx);
+                }),
+                ModalButton::for_view("Cancel", |_view, _ctx| {}),
+            ],
+            |_view, _ctx| {},
+        ));
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn start_prepared_remote_upload(
+        &mut self,
+        client: Arc<remote_server::client::RemoteServerClient>,
+        target: RemoteUploadTarget,
+        manifest: LocalUploadManifest,
+        overwrite: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let upload_id = uuid::Uuid::new_v4().to_string();
+        let first_relative_path = manifest.first_relative_path().map(ToOwned::to_owned);
+        let file_count = manifest.file_count;
+        let directory_count = manifest.directory_count;
+        let total_bytes = manifest.total_bytes;
+        let failure_count = manifest.failure_count();
+        Self::show_remote_upload_status_toast(
+            &format!(
+                "Uploading {file_count} file(s), {directory_count} folder(s) ({})...",
+                format_upload_bytes(total_bytes)
+            ),
+            ctx,
+        );
+
+        let target_for_refresh = target.clone();
+        ctx.spawn(
+            async move { upload_manifest(client, upload_id, target, manifest, overwrite).await },
+            move |view, result, ctx| match result {
+                Ok(result) => {
+                    view.refresh_remote_upload_target(
+                        &target_for_refresh,
+                        first_relative_path.as_deref(),
+                        ctx,
+                    );
+                    Self::show_remote_upload_status_toast(
+                        &format!(
+                            "Uploaded {} file(s), {} folder(s) to the remote project.{}",
+                            result.file_count,
+                            result.directory_count,
+                            if failure_count == 0 {
+                                String::new()
+                            } else {
+                                format!(" {failure_count} item(s) could not be uploaded.")
+                            }
+                        ),
+                        ctx,
+                    );
+                }
+                Err(message) => {
+                    Self::show_remote_upload_error_toast(&message, ctx);
+                }
+            },
+        );
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn refresh_remote_upload_target(
+        &mut self,
+        target: &RemoteUploadTarget,
+        first_relative_path: Option<&str>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        use crate::remote_server::manager::RemoteServerManager;
+
+        if let Some(root_dir) = self.root_directories.get_mut(&target.root) {
+            root_dir.expanded_folders.insert(target.target_dir.clone());
+        }
+        if let Some(first_relative_path) = first_relative_path {
+            self.pending_focus_target = Some(PendingFocusTarget {
+                root: target.root.clone(),
+                path: target.target_dir.join(first_relative_path),
+                scrolled: false,
+            });
+        }
+
+        RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+            mgr.load_remote_repo_metadata_directory(
+                target.session_id,
+                target.repo_root.clone(),
+                target.target_dir.to_string(),
+                ctx,
+            );
+        });
+        ctx.notify();
+    }
+
+    fn show_remote_upload_status_toast(message: &str, ctx: &mut ViewContext<Self>) {
+        let window_id = ctx.window_id();
+        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            toast_stack.add_ephemeral_toast(
+                DismissibleToast::default(message.to_string()),
+                window_id,
+                ctx,
+            );
+        });
+    }
+
+    fn show_remote_upload_error_toast(message: &str, ctx: &mut ViewContext<Self>) {
+        let window_id = ctx.window_id();
+        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            toast_stack.add_ephemeral_toast(
+                DismissibleToast::error(message.to_string()),
+                window_id,
+                ctx,
+            );
+        });
     }
 
     /// Selects the first item if no item is selected.
@@ -3171,8 +3490,47 @@ impl TypedActionView for FileTreeView {
                     view.handle_file_tree_drop_on_active_command(&file_path, ctx);
                 });
             }
+            FileTreeAction::PasteLocalFiles => {
+                self.paste_local_files_to_remote(ctx);
+            }
+            FileTreeAction::LocalFilesDragged { id } => {
+                if self.is_remote_upload_drop_candidate(id) {
+                    self.local_file_drop_target = Some(id.clone());
+                    ctx.notify();
+                }
+            }
+            FileTreeAction::LocalFileDragExited => {
+                if self.local_file_drop_target.take().is_some() {
+                    ctx.notify();
+                }
+            }
+            FileTreeAction::LocalFilesDropped { id, paths } => {
+                self.local_file_drop_target = None;
+                self.begin_remote_upload_from_paths(id.clone(), paths.clone(), ctx);
+            }
         }
     }
 }
+
+fn format_upload_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.;
+    const MB: f64 = KB * 1024.;
+    const GB: f64 = MB * 1024.;
+
+    let bytes = bytes as f64;
+    if bytes >= GB {
+        let value = bytes / GB;
+        format!("{value:.1} GB")
+    } else if bytes >= MB {
+        let value = bytes / MB;
+        format!("{value:.1} MB")
+    } else if bytes >= KB {
+        let value = bytes / KB;
+        format!("{value:.1} KB")
+    } else {
+        format!("{bytes:.0} B")
+    }
+}
+
 #[cfg(test)]
 mod view_tests;

--- a/app/src/code/file_tree/view/remote_upload.rs
+++ b/app/src/code/file_tree/view/remote_upload.rs
@@ -1,0 +1,488 @@
+use std::any::Any;
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use futures::AsyncReadExt as _;
+use pathfinder_geometry::rect::RectF;
+use pathfinder_geometry::vector::Vector2F;
+use remote_server::client::RemoteServerClient;
+use remote_server::proto::{CompleteRemoteUploadSuccess, RemoteUploadManifestEntry};
+use warp_core::{HostId, SessionId};
+use warp_util::standardized_path::StandardizedPath;
+use warpui::event::DispatchedEvent;
+use warpui::{
+    elements::Point, AfterLayoutContext, AppContext, Element, Event, EventContext, LayoutContext,
+    PaintContext, SizeConstraint,
+};
+
+use super::{FileTreeAction, FileTreeIdentifier};
+
+pub const REMOTE_UPLOAD_CHUNK_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone)]
+pub struct RemoteUploadTarget {
+    pub host_id: HostId,
+    pub session_id: SessionId,
+    pub root: StandardizedPath,
+    pub repo_root: String,
+    pub target_dir: StandardizedPath,
+}
+
+#[derive(Clone, Debug)]
+pub struct LocalUploadManifest {
+    pub entries: Vec<LocalUploadEntry>,
+    pub file_count: u64,
+    pub directory_count: u64,
+    pub total_bytes: u64,
+    pub failures: Vec<String>,
+}
+
+impl LocalUploadManifest {
+    pub fn proto_entries(&self) -> Vec<RemoteUploadManifestEntry> {
+        self.entries
+            .iter()
+            .map(|entry| RemoteUploadManifestEntry {
+                relative_path: entry.relative_path.clone(),
+                is_directory: entry.is_directory,
+                size: entry.size,
+                unix_mode: entry.unix_mode,
+            })
+            .collect()
+    }
+
+    pub fn first_relative_path(&self) -> Option<&str> {
+        self.entries
+            .first()
+            .map(|entry| entry.relative_path.as_str())
+    }
+
+    pub fn failure_count(&self) -> usize {
+        self.failures.len()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LocalUploadEntry {
+    pub local_path: PathBuf,
+    pub relative_path: String,
+    pub is_directory: bool,
+    pub size: u64,
+    pub unix_mode: Option<u32>,
+}
+
+pub fn build_local_upload_manifest(paths: Vec<PathBuf>) -> Result<LocalUploadManifest, String> {
+    if paths.is_empty() {
+        return Err("No local files were provided for upload.".to_string());
+    }
+
+    let mut entries = Vec::new();
+    let mut failures = Vec::new();
+    let mut seen = HashSet::new();
+    for path in paths {
+        let Some(file_name) = path.file_name() else {
+            let path = path.display();
+            failures.push(format!("Skipped path without a file name: {path}"));
+            continue;
+        };
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            let path = path.display();
+            failures.push(format!("Skipped unreadable local path: {path}"));
+            continue;
+        };
+        let base = PathBuf::from(file_name);
+        collect_upload_entries(
+            &path,
+            &base,
+            metadata,
+            &mut seen,
+            &mut entries,
+            &mut failures,
+        )?;
+    }
+
+    if entries.is_empty() {
+        return Err(failures
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "No readable local files were provided for upload.".to_string()));
+    }
+
+    let mut file_count = 0;
+    let mut directory_count = 0;
+    let mut total_bytes = 0;
+    for entry in &entries {
+        if entry.is_directory {
+            directory_count += 1;
+        } else {
+            file_count += 1;
+            total_bytes += entry.size;
+        }
+    }
+
+    Ok(LocalUploadManifest {
+        entries,
+        file_count,
+        directory_count,
+        total_bytes,
+        failures,
+    })
+}
+
+fn collect_upload_entries(
+    local_path: &Path,
+    relative_path: &Path,
+    metadata: std::fs::Metadata,
+    seen: &mut HashSet<String>,
+    entries: &mut Vec<LocalUploadEntry>,
+    failures: &mut Vec<String>,
+) -> Result<(), String> {
+    let relative_path = normalize_relative_path(relative_path)?;
+    if !seen.insert(relative_path.clone()) {
+        return Err(format!("Duplicate local upload path: {relative_path}"));
+    }
+
+    let is_directory = metadata.is_dir();
+    entries.push(LocalUploadEntry {
+        local_path: local_path.to_path_buf(),
+        relative_path: relative_path.clone(),
+        is_directory,
+        size: if is_directory { 0 } else { metadata.len() },
+        unix_mode: unix_mode(&metadata),
+    });
+
+    if is_directory {
+        let Ok(read_dir) = std::fs::read_dir(local_path) else {
+            let path = local_path.display();
+            failures.push(format!(
+                "Skipped unreadable local directory contents: {path}"
+            ));
+            return Ok(());
+        };
+        let mut children = match read_dir.collect::<Result<Vec<_>, _>>() {
+            Ok(children) => children,
+            Err(_) => {
+                let path = local_path.display();
+                failures.push(format!(
+                    "Skipped unreadable local directory contents: {path}"
+                ));
+                return Ok(());
+            }
+        };
+        children.sort_by_key(|entry| entry.file_name());
+
+        for child in children {
+            let child_path = child.path();
+            let Ok(metadata) = std::fs::metadata(&child_path) else {
+                let path = child_path.display();
+                failures.push(format!("Skipped unreadable local path: {path}"));
+                continue;
+            };
+            collect_upload_entries(
+                &child_path,
+                &Path::new(&relative_path).join(child.file_name()),
+                metadata,
+                seen,
+                entries,
+                failures,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_relative_path(path: &Path) -> Result<String, String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let part = part
+                    .to_str()
+                    .ok_or_else(|| "Local upload path contains invalid UTF-8.".to_string())?;
+                parts.push(part.to_string());
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err("Local upload path cannot escape its source root.".to_string());
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        return Err("Local upload path is empty.".to_string());
+    }
+
+    Ok(parts.join("/"))
+}
+
+#[cfg(unix)]
+fn unix_mode(metadata: &std::fs::Metadata) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt as _;
+    Some(metadata.permissions().mode() & 0o777)
+}
+
+#[cfg(not(unix))]
+fn unix_mode(_metadata: &std::fs::Metadata) -> Option<u32> {
+    None
+}
+
+pub async fn upload_manifest(
+    client: Arc<RemoteServerClient>,
+    upload_id: String,
+    target: RemoteUploadTarget,
+    manifest: LocalUploadManifest,
+    overwrite: bool,
+) -> Result<CompleteRemoteUploadSuccess, String> {
+    client
+        .begin_remote_upload(
+            upload_id.clone(),
+            target.repo_root.clone(),
+            target.target_dir.to_string(),
+            manifest.proto_entries(),
+            overwrite,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    for entry in manifest.entries.iter().filter(|entry| !entry.is_directory) {
+        if let Err(message) = upload_file_entry(&client, &upload_id, entry).await {
+            let _ = client.complete_remote_upload(upload_id).await;
+            return Err(message);
+        }
+    }
+
+    client
+        .complete_remote_upload(upload_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn upload_file_entry(
+    client: &Arc<RemoteServerClient>,
+    upload_id: &str,
+    entry: &LocalUploadEntry,
+) -> Result<(), String> {
+    let mut file = async_fs::File::open(&entry.local_path)
+        .await
+        .map_err(|e| format!("Failed to open local file for upload: {e}"))?;
+    let mut buffer = vec![0; REMOTE_UPLOAD_CHUNK_BYTES];
+    let mut offset = 0;
+
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .await
+            .map_err(|e| format!("Failed to read local file for upload: {e}"))?;
+        if read == 0 {
+            break;
+        }
+        client
+            .upload_remote_file_chunk(
+                upload_id.to_string(),
+                entry.relative_path.clone(),
+                offset,
+                buffer[..read].to_vec(),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        offset += read as u64;
+    }
+
+    Ok(())
+}
+
+pub struct FileTreeLocalFileDropTarget {
+    child: Box<dyn Element>,
+    id: FileTreeIdentifier,
+    is_valid_target: bool,
+}
+
+impl FileTreeLocalFileDropTarget {
+    pub fn new(child: Box<dyn Element>, id: FileTreeIdentifier, is_valid_target: bool) -> Self {
+        Self {
+            child,
+            id,
+            is_valid_target,
+        }
+    }
+
+    fn mouse_position_is_in_bounds(&self, position: Vector2F) -> bool {
+        let Some(bounds) = self.bounds() else {
+            return false;
+        };
+
+        bounds.contains_point(position)
+    }
+}
+
+impl Element for FileTreeLocalFileDropTarget {
+    fn layout(
+        &mut self,
+        constraint: SizeConstraint,
+        ctx: &mut LayoutContext,
+        app: &AppContext,
+    ) -> Vector2F {
+        self.child.layout(constraint, ctx, app)
+    }
+
+    fn paint(&mut self, origin: Vector2F, ctx: &mut PaintContext, app: &AppContext) {
+        self.child.paint(origin, ctx, app)
+    }
+
+    fn after_layout(&mut self, ctx: &mut AfterLayoutContext, app: &AppContext) {
+        self.child.after_layout(ctx, app);
+    }
+
+    fn size(&self) -> Option<Vector2F> {
+        self.child.size()
+    }
+
+    fn origin(&self) -> Option<Point> {
+        self.child.origin()
+    }
+
+    fn bounds(&self) -> Option<RectF> {
+        self.child.bounds()
+    }
+
+    fn parent_data(&self) -> Option<&dyn Any> {
+        self.child.parent_data()
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &DispatchedEvent,
+        ctx: &mut EventContext,
+        app: &AppContext,
+    ) -> bool {
+        let handled_by_child = self.child.dispatch_event(event, ctx, app);
+        if handled_by_child {
+            return true;
+        }
+
+        let Some(z_index) = self.z_index() else {
+            return false;
+        };
+        let Some(event_at_z_index) = event.at_z_index(z_index, ctx) else {
+            return false;
+        };
+
+        match event_at_z_index {
+            Event::DragFiles { location } if self.mouse_position_is_in_bounds(*location) => {
+                if self.is_valid_target {
+                    ctx.dispatch_typed_action(FileTreeAction::LocalFilesDragged {
+                        id: self.id.clone(),
+                    });
+                } else {
+                    ctx.dispatch_typed_action(FileTreeAction::LocalFileDragExited);
+                }
+                true
+            }
+            Event::DragFileExit => {
+                ctx.dispatch_typed_action(FileTreeAction::LocalFileDragExited);
+                true
+            }
+            Event::DragAndDropFiles { paths, location }
+                if self.is_valid_target
+                    && self.mouse_position_is_in_bounds(*location)
+                    && !paths.is_empty() =>
+            {
+                ctx.dispatch_typed_action(FileTreeAction::LocalFilesDropped {
+                    id: self.id.clone(),
+                    paths: paths.clone(),
+                });
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_preserves_nested_directory_structure() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("assets");
+        std::fs::create_dir_all(root.join("nested")).unwrap();
+        std::fs::write(root.join("nested/icon.bin"), [0, 159, 146, 150]).unwrap();
+
+        let manifest = build_local_upload_manifest(vec![root.clone()]).unwrap();
+        let paths = manifest
+            .entries
+            .iter()
+            .map(|entry| (entry.relative_path.as_str(), entry.is_directory, entry.size))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                ("assets", true, 0),
+                ("assets/nested", true, 0),
+                ("assets/nested/icon.bin", false, 4),
+            ]
+        );
+        assert_eq!(manifest.file_count, 1);
+        assert_eq!(manifest.directory_count, 2);
+        assert_eq!(manifest.total_bytes, 4);
+    }
+
+    #[test]
+    fn manifest_rejects_duplicate_top_level_names() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("one");
+        let second_parent = temp.path().join("two");
+        let second = second_parent.join("shared.txt");
+        std::fs::create_dir_all(&second_parent).unwrap();
+        std::fs::write(&first, "first").unwrap();
+        std::fs::write(&second, "second").unwrap();
+
+        let first_as_shared = temp.path().join("shared.txt");
+        std::fs::rename(&first, &first_as_shared).unwrap();
+
+        let error = build_local_upload_manifest(vec![first_as_shared, second])
+            .expect_err("duplicate names should be rejected");
+        assert!(error.contains("Duplicate local upload path"));
+    }
+
+    #[test]
+    fn manifest_reports_unreadable_sources_without_aborting_valid_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let valid = temp.path().join("valid.bin");
+        let missing = temp.path().join("missing.bin");
+        std::fs::write(&valid, [1, 2, 3]).unwrap();
+
+        let manifest = build_local_upload_manifest(vec![missing, valid]).unwrap();
+
+        assert_eq!(manifest.file_count, 1);
+        assert_eq!(manifest.failure_count(), 1);
+        assert_eq!(manifest.entries[0].relative_path, "valid.bin");
+        assert!(manifest.failures[0].contains("Skipped unreadable local path"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn manifest_follows_valid_symlink_sources() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target.bin");
+        let link = temp.path().join("link.bin");
+        std::fs::write(&target, [1, 2, 3, 4]).unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let manifest = build_local_upload_manifest(vec![link]).unwrap();
+
+        assert_eq!(manifest.file_count, 1);
+        assert_eq!(manifest.entries[0].relative_path, "link.bin");
+        assert_eq!(manifest.entries[0].size, 4);
+    }
+
+    #[test]
+    fn normalize_relative_path_rejects_parent_escape() {
+        let error = normalize_relative_path(Path::new("../secret.txt"))
+            .expect_err("parent traversal should be rejected");
+        assert!(error.contains("cannot escape"));
+    }
+}

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -22,6 +22,8 @@ use crate::workspace::sync_inputs::SyncedInputState;
 use crate::workspace::ToastStack;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
+use super::RootDirectory;
+
 fn std_path(path: &std::path::Path) -> warp_util::standardized_path::StandardizedPath {
     warp_util::standardized_path::StandardizedPath::try_from_local(path).unwrap()
 }
@@ -111,6 +113,98 @@ fn build_repo_state_with_unloaded_directory(repo_root: &std::path::Path) -> File
         loaded: true,
     });
     FileTreeState::new(root, vec![], None)
+}
+
+fn install_remote_root(view: &mut FileTreeView, repo_root: &std::path::Path) {
+    let repo_root = std_path(repo_root);
+    let expanded_folders = [
+        repo_root.clone(),
+        repo_root.join("packages"),
+        repo_root.join("packages/app"),
+        repo_root.join("packages/app/src"),
+    ]
+    .into_iter()
+    .collect();
+    view.displayed_directories = vec![repo_root.clone()];
+    view.root_directories.insert(
+        repo_root.clone(),
+        RootDirectory {
+            entry: build_repo_state(&repo_root.to_local_path_lossy()).entry,
+            expanded_folders,
+            items: Vec::new(),
+            item_states: Default::default(),
+            remote_host_id: Some(warp_core::HostId::new("test-host".to_string())),
+        },
+    );
+    view.rebuild_flattened_items();
+}
+
+#[test]
+fn remote_upload_target_uses_directory_or_file_parent() {
+    VirtualFS::test("file_tree_remote_upload_targets", |dirs, mut vfs| {
+        vfs.mkdir("repo/packages/app/src")
+            .with_files(vec![Stub::FileWithContent(
+                "repo/packages/app/src/main.rs",
+                "fn main() {}\n",
+            )]);
+
+        let repo_root = dirs.tests().join("repo");
+        let src_dir = std_path(&repo_root.join("packages/app/src"));
+        let file_path = std_path(&repo_root.join("packages/app/src/main.rs"));
+
+        App::test((), |mut app| async move {
+            let _ = initialize_app(&mut app);
+            let (_, file_tree_view) = app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
+
+            file_tree_view.update(&mut app, |view, _ctx| {
+                install_remote_root(view, &repo_root);
+            });
+
+            file_tree_view.read(&app, |view, _ctx| {
+                let root = std_path(&repo_root);
+                let src_id = view.find_item_id_by_path(&root, &src_dir).unwrap();
+                let file_id = view.find_item_id_by_path(&root, &file_path).unwrap();
+
+                assert_eq!(
+                    view.remote_upload_target_directory_for_id(&src_id),
+                    Some(src_dir.clone())
+                );
+                assert_eq!(
+                    view.remote_upload_target_directory_for_id(&file_id),
+                    Some(src_dir)
+                );
+            });
+        });
+    });
+}
+
+#[test]
+fn local_roots_are_not_remote_upload_targets() {
+    VirtualFS::test("file_tree_local_upload_target_rejected", |dirs, mut vfs| {
+        vfs.mkdir("repo/packages/app/src")
+            .with_files(vec![Stub::FileWithContent(
+                "repo/packages/app/src/main.rs",
+                "fn main() {}\n",
+            )]);
+
+        let repo_root = dirs.tests().join("repo");
+
+        App::test((), |mut app| async move {
+            let _ = initialize_app(&mut app);
+            let (_, file_tree_view) = app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
+
+            file_tree_view.update(&mut app, |view, ctx| {
+                view.set_is_active(true, ctx);
+                view.set_root_directories(vec![repo_root.clone()], ctx);
+            });
+
+            file_tree_view.read(&app, |view, _ctx| {
+                let root = std_path(&repo_root);
+                let root_id = super::FileTreeIdentifier { root, index: 0 };
+                assert_eq!(view.remote_upload_target_directory_for_id(&root_id), None);
+            });
+        });
+    });
 }
 
 #[test]

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -10,6 +10,7 @@ use ::ai::index::full_source_code_embedding::manager::{
 use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
+use futures::AsyncWriteExt as _;
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
@@ -33,25 +34,30 @@ use super::diff_state_tracker::{
     DiffModelKey, DiffStateUpdate, RemoteDiffStateManager, SubscribeOutcome,
 };
 use super::proto::{
-    client_message, delete_file_response, discard_files_response, get_diff_state_response,
-    get_fragment_metadata_from_hash_response, resolve_conflict_response, run_command_response,
-    save_buffer_response, server_message, write_file_response, Abort, Authenticate, BranchInfo,
-    BufferEdit, BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexLimits,
-    CodebaseIndexStatus, CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot,
-    CodebaseResyncMode, DeleteFile, DeleteFileResponse, DeleteFileSuccess, DiscardFilesError,
-    DiscardFilesResponse, DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse,
-    FailedFileRead, FileContextProto, FileOperationError,
-    FragmentMetadata as ProtoFragmentMetadata,
+    begin_remote_upload_response, client_message, complete_remote_upload_response,
+    delete_file_response, discard_files_response, get_diff_state_response,
+    get_fragment_metadata_from_hash_response, preflight_remote_upload_response,
+    resolve_conflict_response, run_command_response, save_buffer_response, server_message,
+    upload_remote_file_chunk_response, write_file_response, Abort, Authenticate, BeginRemoteUpload,
+    BeginRemoteUploadResponse, BeginRemoteUploadSuccess, BranchInfo, BufferEdit, BufferUpdatedPush,
+    ClientMessage, CloseBuffer, CodebaseIndexLimits, CodebaseIndexStatus,
+    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, CodebaseResyncMode,
+    CompleteRemoteUpload, CompleteRemoteUploadResponse, CompleteRemoteUploadSuccess, DeleteFile,
+    DeleteFileResponse, DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse,
+    DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
+    FileContextProto, FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
     FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
     GetFragmentMetadataFromHashSuccess, IndexCodebase, Initialize, InitializeResponse,
     MissingFragmentMetadata, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
-    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
-    ResolveConflictSuccess, ResyncCodebase, RunCommandError, RunCommandErrorCode,
-    RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
-    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, UploadHandoffSnapshot,
-    WriteFile, WriteFileResponse, WriteFileSuccess,
+    OpenBufferResponse, PreflightRemoteUpload, PreflightRemoteUploadResponse,
+    PreflightRemoteUploadSuccess, ReadFileContextResponse, RemoteUploadManifestEntry,
+    ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, ResyncCodebase,
+    RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess,
+    SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped,
+    TextEdit, UploadHandoffSnapshot, UploadRemoteFileChunk, UploadRemoteFileChunkResponse,
+    UploadRemoteFileChunkSuccess, WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
@@ -189,6 +195,37 @@ impl PendingFileOps {
     }
 }
 
+#[derive(Clone)]
+struct RemoteUploadSession {
+    temp_dir: PathBuf,
+    entries: HashMap<String, RemoteUploadSessionEntry>,
+    overwrite: bool,
+}
+
+#[derive(Clone)]
+struct RemoteUploadSessionEntry {
+    final_path: PathBuf,
+    temp_path: Option<PathBuf>,
+    is_directory: bool,
+    size: u64,
+    unix_mode: Option<u32>,
+}
+
+#[derive(Debug)]
+struct RemoteUploadPreflightResult {
+    conflicts: Vec<String>,
+    file_count: u64,
+    directory_count: u64,
+    total_bytes: u64,
+}
+
+struct RemoteUploadCompleteResult {
+    written_paths: Vec<String>,
+    file_count: u64,
+    directory_count: u64,
+    total_bytes: u64,
+}
+
 /// The top-level server-side orchestrator model.
 ///
 /// Receives `ClientMessage`s from connected proxy sessions and routes
@@ -223,6 +260,8 @@ pub struct ServerModel {
     executors: HashMap<SessionId, Arc<LocalCommandExecutor>>,
     /// Tracks in-flight file write/delete operations and handles cleanup.
     pending_file_ops: PendingFileOps,
+    /// Tracks in-flight binary remote uploads staged under a target directory.
+    remote_upload_sessions: HashMap<String, RemoteUploadSession>,
     /// Daemon-wide auth credentials and user identity.
     auth_state: Arc<AuthState>,
     /// Tracks open buffers, per-buffer connection sets, and pending async
@@ -254,6 +293,7 @@ impl ServerModel {
             host_id,
             executors: HashMap::new(),
             pending_file_ops: PendingFileOps::new(),
+            remote_upload_sessions: HashMap::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
             buffers: ServerBufferTracker::new(),
             diff_states: ctx.add_model(|_| RemoteDiffStateManager::new()),
@@ -699,6 +739,18 @@ impl ServerModel {
             }
             Some(client_message::Message::WriteFile(msg)) => {
                 self.handle_write_file(msg, &request_id, conn_id, ctx)
+            }
+            Some(client_message::Message::PreflightRemoteUpload(msg)) => {
+                self.handle_preflight_remote_upload(msg, &request_id)
+            }
+            Some(client_message::Message::BeginRemoteUpload(msg)) => {
+                self.handle_begin_remote_upload(msg, &request_id, conn_id, ctx)
+            }
+            Some(client_message::Message::UploadRemoteFileChunk(msg)) => {
+                self.handle_upload_remote_file_chunk(msg, &request_id, conn_id, ctx)
+            }
+            Some(client_message::Message::CompleteRemoteUpload(msg)) => {
+                self.handle_complete_remote_upload(msg, &request_id, conn_id, ctx)
             }
             Some(client_message::Message::DeleteFile(msg)) => {
                 self.handle_delete_file(msg, &request_id, conn_id, ctx)
@@ -1890,6 +1942,189 @@ impl ServerModel {
         HandlerOutcome::Async(None)
     }
 
+    fn handle_preflight_remote_upload(
+        &self,
+        msg: PreflightRemoteUpload,
+        request_id: &RequestId,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling PreflightRemoteUpload entries={} (request_id={request_id})",
+            msg.entries.len()
+        );
+
+        match remote_upload_preflight(&msg.repo_path, &msg.target_dir, &msg.entries) {
+            Ok(result) => {
+                HandlerOutcome::Sync(server_message::Message::PreflightRemoteUploadResponse(
+                    PreflightRemoteUploadResponse {
+                        result: Some(preflight_remote_upload_response::Result::Success(
+                            PreflightRemoteUploadSuccess {
+                                conflicts: result.conflicts,
+                                file_count: result.file_count,
+                                directory_count: result.directory_count,
+                                total_bytes: result.total_bytes,
+                            },
+                        )),
+                    },
+                ))
+            }
+            Err(message) => {
+                HandlerOutcome::Sync(server_message::Message::PreflightRemoteUploadResponse(
+                    PreflightRemoteUploadResponse {
+                        result: Some(preflight_remote_upload_response::Result::Error(
+                            FileOperationError { message },
+                        )),
+                    },
+                ))
+            }
+        }
+    }
+
+    fn handle_begin_remote_upload(
+        &mut self,
+        msg: BeginRemoteUpload,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling BeginRemoteUpload entries={} overwrite={} (request_id={request_id})",
+            msg.entries.len(),
+            msg.overwrite
+        );
+
+        let request_id_for_response = request_id.clone();
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move { build_remote_upload_session(msg).await },
+            move |me, result, _ctx| {
+                let response = match result {
+                    Ok((upload_id, session)) => {
+                        me.remote_upload_sessions.insert(upload_id, session);
+                        BeginRemoteUploadResponse {
+                            result: Some(begin_remote_upload_response::Result::Success(
+                                BeginRemoteUploadSuccess {},
+                            )),
+                        }
+                    }
+                    Err(message) => BeginRemoteUploadResponse {
+                        result: Some(begin_remote_upload_response::Result::Error(
+                            FileOperationError { message },
+                        )),
+                    },
+                };
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::BeginRemoteUploadResponse(response),
+                );
+            },
+            ctx,
+        );
+
+        HandlerOutcome::Async(Some(handle))
+    }
+
+    fn handle_upload_remote_file_chunk(
+        &mut self,
+        msg: UploadRemoteFileChunk,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let Some(session) = self.remote_upload_sessions.get(&msg.upload_id).cloned() else {
+            return HandlerOutcome::Sync(server_message::Message::UploadRemoteFileChunkResponse(
+                UploadRemoteFileChunkResponse {
+                    result: Some(upload_remote_file_chunk_response::Result::Error(
+                        FileOperationError {
+                            message: "Upload session not found".to_string(),
+                        },
+                    )),
+                },
+            ));
+        };
+
+        let request_id_for_response = request_id.clone();
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move { append_remote_upload_chunk(session, msg).await },
+            move |me, result, _ctx| {
+                let response = match result {
+                    Ok(()) => UploadRemoteFileChunkResponse {
+                        result: Some(upload_remote_file_chunk_response::Result::Success(
+                            UploadRemoteFileChunkSuccess {},
+                        )),
+                    },
+                    Err(message) => UploadRemoteFileChunkResponse {
+                        result: Some(upload_remote_file_chunk_response::Result::Error(
+                            FileOperationError { message },
+                        )),
+                    },
+                };
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::UploadRemoteFileChunkResponse(response),
+                );
+            },
+            ctx,
+        );
+
+        HandlerOutcome::Async(Some(handle))
+    }
+
+    fn handle_complete_remote_upload(
+        &mut self,
+        msg: CompleteRemoteUpload,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let Some(session) = self.remote_upload_sessions.remove(&msg.upload_id) else {
+            return HandlerOutcome::Sync(server_message::Message::CompleteRemoteUploadResponse(
+                CompleteRemoteUploadResponse {
+                    result: Some(complete_remote_upload_response::Result::Error(
+                        FileOperationError {
+                            message: "Upload session not found".to_string(),
+                        },
+                    )),
+                },
+            ));
+        };
+
+        let request_id_for_response = request_id.clone();
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move { complete_remote_upload_session(session).await },
+            move |me, result, _ctx| {
+                let response = match result {
+                    Ok(result) => CompleteRemoteUploadResponse {
+                        result: Some(complete_remote_upload_response::Result::Success(
+                            CompleteRemoteUploadSuccess {
+                                written_paths: result.written_paths,
+                                file_count: result.file_count,
+                                directory_count: result.directory_count,
+                                total_bytes: result.total_bytes,
+                            },
+                        )),
+                    },
+                    Err(message) => CompleteRemoteUploadResponse {
+                        result: Some(complete_remote_upload_response::Result::Error(
+                            FileOperationError { message },
+                        )),
+                    },
+                };
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::CompleteRemoteUploadResponse(response),
+                );
+            },
+            ctx,
+        );
+
+        HandlerOutcome::Async(Some(handle))
+    }
+
     /// Handles `DeleteFile` by registering the path and triggering an async
     /// delete via `FileModel`. On a successful dispatch, returns
     /// `HandlerOutcome::Async(None)` — the response is sent later by the
@@ -2774,6 +3009,404 @@ fn fragment_metadata_to_proto(
         byte_start: metadata.location.byte_range.start.as_usize() as u64,
         byte_end: metadata.location.byte_range.end.as_usize() as u64,
     }
+}
+
+fn validate_upload_id(upload_id: &str) -> Result<(), String> {
+    if upload_id.is_empty()
+        || upload_id.contains('/')
+        || upload_id.contains('\\')
+        || upload_id.contains("..")
+    {
+        return Err("Invalid upload_id".to_string());
+    }
+    Ok(())
+}
+
+fn validate_upload_roots(
+    repo_path: &str,
+    target_dir: &str,
+) -> Result<(StandardizedPath, StandardizedPath), String> {
+    let repo_path = StandardizedPath::from_local_canonicalized(Path::new(repo_path))
+        .map_err(|e| format!("Invalid repo_path: {e}"))?;
+    let target_dir = StandardizedPath::from_local_canonicalized(Path::new(target_dir))
+        .map_err(|e| format!("Invalid target_dir: {e}"))?;
+
+    if !target_dir.starts_with(&repo_path) {
+        return Err(format!(
+            "target_dir {target_dir} is not a descendant of repo_path {repo_path}"
+        ));
+    }
+
+    Ok((repo_path, target_dir))
+}
+
+fn validate_relative_upload_path(relative_path: &str) -> Result<(), String> {
+    if relative_path.is_empty() {
+        return Err("Upload entry has an empty relative_path".to_string());
+    }
+
+    let path = Path::new(relative_path);
+    if path.is_absolute() {
+        return Err(format!(
+            "Upload entry must be relative, got {relative_path}"
+        ));
+    }
+
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(_) => {}
+            std::path::Component::CurDir => {
+                return Err(format!(
+                    "Upload entry must be normalized without current-directory segments: {relative_path}"
+                ));
+            }
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                return Err(format!(
+                    "Upload entry cannot escape the target directory: {relative_path}"
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_upload_destination(
+    target_dir: &StandardizedPath,
+    entry: &RemoteUploadManifestEntry,
+) -> Result<StandardizedPath, String> {
+    validate_relative_upload_path(&entry.relative_path)?;
+    let path = target_dir.join(&entry.relative_path);
+    if !path.starts_with(target_dir) {
+        return Err(format!(
+            "Upload entry cannot escape the target directory: {}",
+            entry.relative_path
+        ));
+    }
+    Ok(path)
+}
+
+fn remote_upload_preflight(
+    repo_path: &str,
+    target_dir: &str,
+    entries: &[RemoteUploadManifestEntry],
+) -> Result<RemoteUploadPreflightResult, String> {
+    if entries.is_empty() {
+        return Err("No files were provided for upload".to_string());
+    }
+
+    let (_repo_path, target_dir) = validate_upload_roots(repo_path, target_dir)?;
+    let mut seen = HashSet::new();
+    let mut conflicts = Vec::new();
+    let mut file_count = 0;
+    let mut directory_count = 0;
+    let mut total_bytes = 0;
+
+    for entry in entries {
+        if !seen.insert(entry.relative_path.clone()) {
+            let relative_path = &entry.relative_path;
+            return Err(format!("Duplicate upload entry: {relative_path}"));
+        }
+
+        let destination = resolve_upload_destination(&target_dir, entry)?;
+        let destination_path = PathBuf::from(destination.as_str());
+        if entry.is_directory {
+            directory_count += 1;
+            if destination_path.is_file() {
+                conflicts.push(entry.relative_path.clone());
+            }
+        } else {
+            file_count += 1;
+            total_bytes += entry.size;
+            if destination_path.is_dir() {
+                return Err(format!(
+                    "Cannot replace remote directory with a local file: {}",
+                    entry.relative_path
+                ));
+            }
+            if destination_path.exists() {
+                conflicts.push(entry.relative_path.clone());
+            }
+        }
+    }
+
+    Ok(RemoteUploadPreflightResult {
+        conflicts,
+        file_count,
+        directory_count,
+        total_bytes,
+    })
+}
+
+async fn build_remote_upload_session(
+    msg: BeginRemoteUpload,
+) -> Result<(String, RemoteUploadSession), String> {
+    validate_upload_id(&msg.upload_id)?;
+    let (_repo_path, target_dir) = validate_upload_roots(&msg.repo_path, &msg.target_dir)?;
+    let preflight = remote_upload_preflight(&msg.repo_path, &msg.target_dir, &msg.entries)?;
+    if !msg.overwrite && !preflight.conflicts.is_empty() {
+        return Err(format!(
+            "{} remote path(s) already exist",
+            preflight.conflicts.len()
+        ));
+    }
+
+    let upload_id = &msg.upload_id;
+    let temp_dir = PathBuf::from(
+        target_dir
+            .join(&format!(".warp-upload-{upload_id}"))
+            .as_str(),
+    );
+    if temp_dir.exists() {
+        let _ = async_fs::remove_dir_all(&temp_dir).await;
+    }
+    async_fs::create_dir_all(&temp_dir)
+        .await
+        .map_err(|e| format!("Failed to create upload staging directory: {e}"))?;
+
+    let entries = match build_remote_upload_session_entries(&target_dir, &temp_dir, msg.entries) {
+        Ok(entries) => entries,
+        Err(message) => {
+            let _ = async_fs::remove_dir_all(&temp_dir).await;
+            return Err(message);
+        }
+    };
+    if let Err(message) = create_empty_upload_staging_files(&entries).await {
+        let _ = async_fs::remove_dir_all(&temp_dir).await;
+        return Err(message);
+    }
+
+    Ok((
+        msg.upload_id,
+        RemoteUploadSession {
+            temp_dir,
+            entries,
+            overwrite: msg.overwrite,
+        },
+    ))
+}
+
+fn build_remote_upload_session_entries(
+    target_dir: &StandardizedPath,
+    temp_dir: &Path,
+    entries: Vec<RemoteUploadManifestEntry>,
+) -> Result<HashMap<String, RemoteUploadSessionEntry>, String> {
+    let mut session_entries = HashMap::new();
+    for entry in entries {
+        let final_std = resolve_upload_destination(target_dir, &entry)?;
+        let final_path = PathBuf::from(final_std.as_str());
+        let temp_path = if entry.is_directory {
+            None
+        } else {
+            Some(temp_dir.join(Path::new(&entry.relative_path)))
+        };
+
+        session_entries.insert(
+            entry.relative_path,
+            RemoteUploadSessionEntry {
+                final_path,
+                temp_path,
+                is_directory: entry.is_directory,
+                size: entry.size,
+                unix_mode: entry.unix_mode,
+            },
+        );
+    }
+    Ok(session_entries)
+}
+
+async fn create_empty_upload_staging_files(
+    entries: &HashMap<String, RemoteUploadSessionEntry>,
+) -> Result<(), String> {
+    for entry in entries
+        .values()
+        .filter(|entry| !entry.is_directory && entry.size == 0)
+    {
+        let Some(temp_path) = entry.temp_path.as_ref() else {
+            continue;
+        };
+        if let Some(parent) = temp_path.parent() {
+            async_fs::create_dir_all(parent)
+                .await
+                .map_err(|e| format!("Failed to create upload staging parent: {e}"))?;
+        }
+        async_fs::File::create(temp_path)
+            .await
+            .map_err(|e| format!("Failed to create upload staging file: {e}"))?;
+    }
+    Ok(())
+}
+
+async fn append_remote_upload_chunk(
+    session: RemoteUploadSession,
+    msg: UploadRemoteFileChunk,
+) -> Result<(), String> {
+    let Some(entry) = session.entries.get(&msg.relative_path) else {
+        let relative_path = &msg.relative_path;
+        return Err(format!("Upload entry not found: {relative_path}"));
+    };
+    if entry.is_directory {
+        return Err(format!(
+            "Cannot upload file bytes for directory entry: {}",
+            msg.relative_path
+        ));
+    }
+    let Some(temp_path) = entry.temp_path.as_ref() else {
+        return Err(format!(
+            "Upload entry has no staging file: {}",
+            msg.relative_path
+        ));
+    };
+    if let Some(parent) = temp_path.parent() {
+        async_fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create upload staging parent: {e}"))?;
+    }
+
+    let current_len = match async_fs::metadata(temp_path).await {
+        Ok(metadata) => metadata.len(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(e) => return Err(format!("Failed to inspect upload staging file: {e}")),
+    };
+    if current_len != msg.offset {
+        return Err(format!(
+            "Upload chunk offset mismatch for {}: expected {current_len}, got {}",
+            msg.relative_path, msg.offset
+        ));
+    }
+    if msg.offset + msg.data.len() as u64 > entry.size {
+        return Err(format!(
+            "Upload chunk exceeds expected file size for {}",
+            msg.relative_path
+        ));
+    }
+
+    let mut file = async_fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(temp_path)
+        .await
+        .map_err(|e| format!("Failed to open upload staging file: {e}"))?;
+    file.write_all(&msg.data)
+        .await
+        .map_err(|e| format!("Failed to write upload chunk: {e}"))?;
+    file.flush()
+        .await
+        .map_err(|e| format!("Failed to flush upload chunk: {e}"))?;
+    Ok(())
+}
+
+async fn complete_remote_upload_session(
+    session: RemoteUploadSession,
+) -> Result<RemoteUploadCompleteResult, String> {
+    let result = commit_remote_upload_session(&session).await;
+    let cleanup_result = async_fs::remove_dir_all(&session.temp_dir).await;
+    if let Err(error) = cleanup_result {
+        log::warn!("Failed to clean upload staging directory: {error}");
+    }
+    result
+}
+
+async fn commit_remote_upload_session(
+    session: &RemoteUploadSession,
+) -> Result<RemoteUploadCompleteResult, String> {
+    let mut written_paths = Vec::new();
+    let mut file_count = 0;
+    let mut directory_count = 0;
+    let mut total_bytes = 0;
+
+    let mut directory_entries = session
+        .entries
+        .iter()
+        .filter(|(_, entry)| entry.is_directory)
+        .collect::<Vec<_>>();
+    directory_entries.sort_by_key(|(relative_path, _)| relative_path.len());
+    for (relative_path, entry) in directory_entries {
+        if entry.final_path.is_file() {
+            if session.overwrite {
+                async_fs::remove_file(&entry.final_path)
+                    .await
+                    .map_err(|e| format!("Failed to replace remote file: {e}"))?;
+            } else {
+                return Err(format!("Remote file already exists: {relative_path}"));
+            }
+        }
+        async_fs::create_dir_all(&entry.final_path)
+            .await
+            .map_err(|e| format!("Failed to create remote directory: {e}"))?;
+        directory_count += 1;
+        written_paths.push(entry.final_path.to_string_lossy().to_string());
+    }
+
+    let mut file_entries = session
+        .entries
+        .iter()
+        .filter(|(_, entry)| !entry.is_directory)
+        .collect::<Vec<_>>();
+    file_entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    for (relative_path, entry) in file_entries {
+        let Some(temp_path) = entry.temp_path.as_ref() else {
+            return Err(format!("Upload entry has no staging file: {relative_path}"));
+        };
+        let staged_len = async_fs::metadata(temp_path)
+            .await
+            .map_err(|e| format!("Failed to inspect staged upload file: {e}"))?
+            .len();
+        if staged_len != entry.size {
+            return Err(format!(
+                "Upload size mismatch for {relative_path}: expected {}, got {staged_len}",
+                entry.size
+            ));
+        }
+        if entry.final_path.exists() {
+            if entry.final_path.is_dir() {
+                return Err(format!(
+                    "Cannot replace remote directory with uploaded file: {relative_path}"
+                ));
+            }
+            if session.overwrite {
+                async_fs::remove_file(&entry.final_path)
+                    .await
+                    .map_err(|e| format!("Failed to replace remote file: {e}"))?;
+            } else {
+                return Err(format!("Remote file already exists: {relative_path}"));
+            }
+        }
+        if let Some(parent) = entry.final_path.parent() {
+            async_fs::create_dir_all(parent)
+                .await
+                .map_err(|e| format!("Failed to create remote parent directory: {e}"))?;
+        }
+        async_fs::rename(temp_path, &entry.final_path)
+            .await
+            .map_err(|e| format!("Failed to commit uploaded file: {e}"))?;
+
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mut permissions = async_fs::metadata(&entry.final_path)
+                .await
+                .map_err(|e| format!("Failed to inspect uploaded file permissions: {e}"))?
+                .permissions();
+            permissions.set_mode((permissions.mode() & !0o111) | (mode & 0o111));
+            async_fs::set_permissions(&entry.final_path, permissions)
+                .await
+                .map_err(|e| format!("Failed to set uploaded file permissions: {e}"))?;
+        }
+
+        file_count += 1;
+        total_bytes += entry.size;
+        written_paths.push(entry.final_path.to_string_lossy().to_string());
+    }
+
+    Ok(RemoteUploadCompleteResult {
+        written_paths,
+        file_count,
+        directory_count,
+        total_bytes,
+    })
 }
 
 /// Converts a [`ReadFileContextResult`] into its protobuf equivalent.

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -5,9 +5,14 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
 use super::super::diff_state_tracker::RemoteDiffStateManager;
-use super::super::proto::{Authenticate, Initialize};
+use super::super::proto::{
+    Authenticate, BeginRemoteUpload, Initialize, RemoteUploadManifestEntry, UploadRemoteFileChunk,
+};
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{PendingFileOps, ServerModel};
+use super::{
+    append_remote_upload_chunk, build_remote_upload_session, complete_remote_upload_session,
+    remote_upload_preflight, PendingFileOps, ServerModel,
+};
 use crate::auth::auth_state::AuthState;
 use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
@@ -21,6 +26,7 @@ fn test_model(app: &mut App) -> ServerModel {
         host_id: "test-host-id".to_string(),
         executors: HashMap::new(),
         pending_file_ops: PendingFileOps::new(),
+        remote_upload_sessions: HashMap::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
         buffers: ServerBufferTracker::new(),
         diff_states: app.add_model(|_| RemoteDiffStateManager::new()),
@@ -183,4 +189,180 @@ fn diff_states_starts_empty() {
         });
         assert!(empty);
     });
+}
+
+#[test]
+fn remote_upload_preflight_reports_file_conflicts() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let target = repo.join("src");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join("main.bin"), [1, 2, 3]).unwrap();
+
+    let result = remote_upload_preflight(
+        repo.to_str().unwrap(),
+        target.to_str().unwrap(),
+        &[RemoteUploadManifestEntry {
+            relative_path: "main.bin".to_string(),
+            is_directory: false,
+            size: 4,
+            unix_mode: None,
+        }],
+    )
+    .unwrap();
+
+    assert_eq!(result.conflicts, vec!["main.bin"]);
+    assert_eq!(result.file_count, 1);
+    assert_eq!(result.total_bytes, 4);
+}
+
+#[test]
+fn remote_upload_preflight_rejects_path_traversal() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+
+    let error = remote_upload_preflight(
+        repo.to_str().unwrap(),
+        repo.to_str().unwrap(),
+        &[RemoteUploadManifestEntry {
+            relative_path: "../outside.bin".to_string(),
+            is_directory: false,
+            size: 1,
+            unix_mode: None,
+        }],
+    )
+    .expect_err("path traversal should be rejected");
+
+    assert!(error.contains("cannot escape"));
+}
+
+#[tokio::test]
+async fn remote_upload_writes_binary_chunks_and_cleans_staging_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let target = repo.join("src");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let upload_id = "upload-test".to_string();
+    let (_upload_id, session) = build_remote_upload_session(BeginRemoteUpload {
+        upload_id: upload_id.clone(),
+        repo_path: repo.to_str().unwrap().to_string(),
+        target_dir: target.to_str().unwrap().to_string(),
+        entries: vec![RemoteUploadManifestEntry {
+            relative_path: "nested/main.bin".to_string(),
+            is_directory: false,
+            size: 4,
+            unix_mode: None,
+        }],
+        overwrite: false,
+    })
+    .await
+    .unwrap();
+
+    let temp_dir = session.temp_dir.clone();
+    append_remote_upload_chunk(
+        session.clone(),
+        UploadRemoteFileChunk {
+            upload_id,
+            relative_path: "nested/main.bin".to_string(),
+            offset: 0,
+            data: vec![0, 159],
+        },
+    )
+    .await
+    .unwrap();
+    append_remote_upload_chunk(
+        session.clone(),
+        UploadRemoteFileChunk {
+            upload_id: "upload-test".to_string(),
+            relative_path: "nested/main.bin".to_string(),
+            offset: 2,
+            data: vec![146, 150],
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = complete_remote_upload_session(session).await.unwrap();
+
+    assert_eq!(result.file_count, 1);
+    assert_eq!(
+        std::fs::read(target.join("nested/main.bin")).unwrap(),
+        vec![0, 159, 146, 150]
+    );
+    assert!(!temp_dir.exists());
+}
+
+#[tokio::test]
+async fn remote_upload_replace_flow_overwrites_existing_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let target = repo.join("src");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join("main.bin"), [9]).unwrap();
+
+    let upload_id = "replace-test".to_string();
+    let (_upload_id, session) = build_remote_upload_session(BeginRemoteUpload {
+        upload_id: upload_id.clone(),
+        repo_path: repo.to_str().unwrap().to_string(),
+        target_dir: target.to_str().unwrap().to_string(),
+        entries: vec![RemoteUploadManifestEntry {
+            relative_path: "main.bin".to_string(),
+            is_directory: false,
+            size: 1,
+            unix_mode: None,
+        }],
+        overwrite: true,
+    })
+    .await
+    .unwrap();
+
+    append_remote_upload_chunk(
+        session.clone(),
+        UploadRemoteFileChunk {
+            upload_id,
+            relative_path: "main.bin".to_string(),
+            offset: 0,
+            data: vec![7],
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = complete_remote_upload_session(session).await.unwrap();
+
+    assert_eq!(result.file_count, 1);
+    assert_eq!(std::fs::read(target.join("main.bin")).unwrap(), vec![7]);
+}
+
+#[tokio::test]
+async fn remote_upload_creates_empty_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    let target = repo.join("src");
+    std::fs::create_dir_all(&target).unwrap();
+
+    let (_upload_id, session) = build_remote_upload_session(BeginRemoteUpload {
+        upload_id: "empty-file-test".to_string(),
+        repo_path: repo.to_str().unwrap().to_string(),
+        target_dir: target.to_str().unwrap().to_string(),
+        entries: vec![RemoteUploadManifestEntry {
+            relative_path: "empty.bin".to_string(),
+            is_directory: false,
+            size: 0,
+            unix_mode: None,
+        }],
+        overwrite: false,
+    })
+    .await
+    .unwrap();
+
+    let result = complete_remote_upload_session(session).await.unwrap();
+
+    assert_eq!(result.file_count, 1);
+    assert_eq!(
+        std::fs::read(target.join("empty.bin")).unwrap(),
+        Vec::<u8>::new()
+    );
 }

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -40,6 +40,10 @@ message ClientMessage {
     GetBranches get_branches = 24;
     ResyncCodebase resync_codebase = 25;
     UploadHandoffSnapshot upload_handoff_snapshot = 26;
+    PreflightRemoteUpload preflight_remote_upload = 27;
+    BeginRemoteUpload begin_remote_upload = 28;
+    UploadRemoteFileChunk upload_remote_file_chunk = 29;
+    CompleteRemoteUpload complete_remote_upload = 30;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -73,6 +77,10 @@ message ServerMessage {
     GetFragmentMetadataFromHashResponse get_fragment_metadata_from_hash_response = 24;
     GetBranchesResponse get_branches_response = 25;
     UploadHandoffSnapshotResponse upload_handoff_snapshot_response = 26;
+    PreflightRemoteUploadResponse preflight_remote_upload_response = 27;
+    BeginRemoteUploadResponse begin_remote_upload_response = 28;
+    UploadRemoteFileChunkResponse upload_remote_file_chunk_response = 29;
+    CompleteRemoteUploadResponse complete_remote_upload_response = 30;
   }
 }
 
@@ -281,6 +289,92 @@ message WriteFileResponse {
 }
 
 message WriteFileSuccess {}
+
+// A local file or directory entry the client intends to upload under a target
+// remote directory. `relative_path` is always relative to that target.
+message RemoteUploadManifestEntry {
+  string relative_path = 1;
+  bool is_directory = 2;
+  uint64 size = 3;
+  optional uint32 unix_mode = 4;
+}
+
+// Client → server: validate the upload destination and report paths that would
+// be replaced or merged before transferring file contents.
+message PreflightRemoteUpload {
+  string repo_path = 1;
+  string target_dir = 2;
+  repeated RemoteUploadManifestEntry entries = 3;
+}
+
+message PreflightRemoteUploadSuccess {
+  repeated string conflicts = 1;
+  uint64 file_count = 2;
+  uint64 directory_count = 3;
+  uint64 total_bytes = 4;
+}
+
+message PreflightRemoteUploadResponse {
+  oneof result {
+    PreflightRemoteUploadSuccess success = 1;
+    FileOperationError error = 2;
+  }
+}
+
+// Client → server: start a binary-safe upload session. File contents follow in
+// `UploadRemoteFileChunk` requests, then are committed by `CompleteRemoteUpload`.
+message BeginRemoteUpload {
+  string upload_id = 1;
+  string repo_path = 2;
+  string target_dir = 3;
+  repeated RemoteUploadManifestEntry entries = 4;
+  bool overwrite = 5;
+}
+
+message BeginRemoteUploadResponse {
+  oneof result {
+    BeginRemoteUploadSuccess success = 1;
+    FileOperationError error = 2;
+  }
+}
+
+message BeginRemoteUploadSuccess {}
+
+// Client → server: append one bounded byte chunk to a file in the active upload.
+message UploadRemoteFileChunk {
+  string upload_id = 1;
+  string relative_path = 2;
+  uint64 offset = 3;
+  bytes data = 4;
+}
+
+message UploadRemoteFileChunkResponse {
+  oneof result {
+    UploadRemoteFileChunkSuccess success = 1;
+    FileOperationError error = 2;
+  }
+}
+
+message UploadRemoteFileChunkSuccess {}
+
+// Client → server: atomically commit uploaded temp files into their final paths.
+message CompleteRemoteUpload {
+  string upload_id = 1;
+}
+
+message CompleteRemoteUploadSuccess {
+  repeated string written_paths = 1;
+  uint64 file_count = 2;
+  uint64 directory_count = 3;
+  uint64 total_bytes = 4;
+}
+
+message CompleteRemoteUploadResponse {
+  oneof result {
+    CompleteRemoteUploadSuccess success = 1;
+    FileOperationError error = 2;
+  }
+}
 
 // Client → server: delete a file.
 message DeleteFile {
@@ -577,4 +671,3 @@ message ResolveConflictSuccess {}
 message BufferConflictDetected {
   string path = 1;
 }
-

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -15,16 +15,18 @@ use crate::codebase_index_proto::{
 };
 use crate::proto::{
     client_message, get_branches_response, get_fragment_metadata_from_hash_response,
-    server_message, Abort, Authenticate, BranchInfo, BufferEdit, ClientMessage, CloseBuffer,
-    CodebaseIndexLimits, CodebaseResyncMode, DeleteFile, DiffMode, DiffStateFileDelta,
+    server_message, Abort, Authenticate, BeginRemoteUpload, BeginRemoteUploadSuccess, BranchInfo,
+    BufferEdit, ClientMessage, CloseBuffer, CodebaseIndexLimits, CodebaseResyncMode,
+    CompleteRemoteUpload, CompleteRemoteUploadSuccess, DeleteFile, DiffMode, DiffStateFileDelta,
     DiffStateMetadataUpdate, DiffStateSnapshot, DiscardFilesRequest, DropCodebaseIndex, ErrorCode,
     FileStatusInfo, FragmentMetadataLookupErrorCode, GetBranches, GetDiffState,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashSuccess,
     IndexCodebase, Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
-    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextRequest,
-    ReadFileContextResponse, ResyncCodebase, RunCommandRequest, RunCommandResponse, SaveBuffer,
+    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, PreflightRemoteUpload,
+    PreflightRemoteUploadSuccess, ReadFileContextRequest, ReadFileContextResponse,
+    RemoteUploadManifestEntry, ResyncCodebase, RunCommandRequest, RunCommandResponse, SaveBuffer,
     ServerMessage, SessionBootstrapped, TextEdit, UnsubscribeDiffState, UploadHandoffSnapshot,
-    UploadHandoffSnapshotResponse, WriteFile,
+    UploadHandoffSnapshotResponse, UploadRemoteFileChunk, UploadRemoteFileChunkSuccess, WriteFile,
 };
 use crate::repo_metadata_proto::{proto_snapshot_to_update, proto_to_repo_metadata_update};
 
@@ -657,6 +659,192 @@ impl RemoteServerClient {
                 safe_error!(
                     safe: ("Remote server unexpected response for WriteFile"),
                     full: ("Remote server unexpected response for WriteFile: response={other:?}")
+                );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Checks whether a remote upload would replace existing files.
+    pub async fn preflight_remote_upload(
+        &self,
+        repo_path: String,
+        target_dir: String,
+        entries: Vec<RemoteUploadManifestEntry>,
+    ) -> Result<PreflightRemoteUploadSuccess, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::PreflightRemoteUpload(
+                PreflightRemoteUpload {
+                    repo_path,
+                    target_dir,
+                    entries,
+                },
+            )),
+        };
+        let response = self
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::RemoteUpload,
+            )
+            .await?;
+        match response.message {
+            Some(server_message::Message::PreflightRemoteUploadResponse(resp)) => {
+                match resp.result {
+                    Some(crate::proto::preflight_remote_upload_response::Result::Success(
+                        success,
+                    )) => Ok(success),
+                    Some(crate::proto::preflight_remote_upload_response::Result::Error(e)) => {
+                        Err(ClientError::FileOperationFailed(e.message))
+                    }
+                    None => Err(ClientError::UnexpectedResponse),
+                }
+            }
+            other => {
+                safe_error!(
+                    safe: ("Remote server unexpected response for PreflightRemoteUpload"),
+                    full: ("Remote server unexpected response for PreflightRemoteUpload: response={other:?}")
+                );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Starts a binary-safe remote upload session.
+    pub async fn begin_remote_upload(
+        &self,
+        upload_id: String,
+        repo_path: String,
+        target_dir: String,
+        entries: Vec<RemoteUploadManifestEntry>,
+        overwrite: bool,
+    ) -> Result<BeginRemoteUploadSuccess, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::BeginRemoteUpload(
+                BeginRemoteUpload {
+                    upload_id,
+                    repo_path,
+                    target_dir,
+                    entries,
+                    overwrite,
+                },
+            )),
+        };
+        let response = self
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::RemoteUpload,
+            )
+            .await?;
+        match response.message {
+            Some(server_message::Message::BeginRemoteUploadResponse(resp)) => match resp.result {
+                Some(crate::proto::begin_remote_upload_response::Result::Success(success)) => {
+                    Ok(success)
+                }
+                Some(crate::proto::begin_remote_upload_response::Result::Error(e)) => {
+                    Err(ClientError::FileOperationFailed(e.message))
+                }
+                None => Err(ClientError::UnexpectedResponse),
+            },
+            other => {
+                safe_error!(
+                    safe: ("Remote server unexpected response for BeginRemoteUpload"),
+                    full: ("Remote server unexpected response for BeginRemoteUpload: response={other:?}")
+                );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Appends one byte chunk to an active remote upload.
+    pub async fn upload_remote_file_chunk(
+        &self,
+        upload_id: String,
+        relative_path: String,
+        offset: u64,
+        data: Vec<u8>,
+    ) -> Result<UploadRemoteFileChunkSuccess, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::UploadRemoteFileChunk(
+                UploadRemoteFileChunk {
+                    upload_id,
+                    relative_path,
+                    offset,
+                    data,
+                },
+            )),
+        };
+        let response = self
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::RemoteUpload,
+            )
+            .await?;
+        match response.message {
+            Some(server_message::Message::UploadRemoteFileChunkResponse(resp)) => {
+                match resp.result {
+                    Some(crate::proto::upload_remote_file_chunk_response::Result::Success(
+                        success,
+                    )) => Ok(success),
+                    Some(crate::proto::upload_remote_file_chunk_response::Result::Error(e)) => {
+                        Err(ClientError::FileOperationFailed(e.message))
+                    }
+                    None => Err(ClientError::UnexpectedResponse),
+                }
+            }
+            other => {
+                safe_error!(
+                    safe: ("Remote server unexpected response for UploadRemoteFileChunk"),
+                    full: ("Remote server unexpected response for UploadRemoteFileChunk: response={other:?}")
+                );
+                Err(ClientError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Commits an active remote upload into final destination paths.
+    pub async fn complete_remote_upload(
+        &self,
+        upload_id: String,
+    ) -> Result<CompleteRemoteUploadSuccess, ClientError> {
+        let request_id = RequestId::new();
+        let msg = ClientMessage {
+            request_id: request_id.to_string(),
+            message: Some(client_message::Message::CompleteRemoteUpload(
+                CompleteRemoteUpload { upload_id },
+            )),
+        };
+        let response = self
+            .send_request(
+                request_id,
+                msg,
+                crate::manager::RemoteServerOperation::RemoteUpload,
+            )
+            .await?;
+        match response.message {
+            Some(server_message::Message::CompleteRemoteUploadResponse(resp)) => {
+                match resp.result {
+                    Some(crate::proto::complete_remote_upload_response::Result::Success(
+                        success,
+                    )) => Ok(success),
+                    Some(crate::proto::complete_remote_upload_response::Result::Error(e)) => {
+                        Err(ClientError::FileOperationFailed(e.message))
+                    }
+                    None => Err(ClientError::UnexpectedResponse),
+                }
+            }
+            other => {
+                safe_error!(
+                    safe: ("Remote server unexpected response for CompleteRemoteUpload"),
+                    full: ("Remote server unexpected response for CompleteRemoteUpload: response={other:?}")
                 );
                 Err(ClientError::UnexpectedResponse)
             }

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -118,6 +118,7 @@ pub enum RemoteServerOperation {
     OpenBuffer,
     SaveBuffer,
     WriteFile,
+    RemoteUpload,
     ReadFileContext,
     DeleteFile,
     RunCommand,


### PR DESCRIPTION
## Description

Adds v1 upload support for remote-server-backed SSH project folders in the Project Explorer/sidebar.

This includes:
- Binary-safe remote upload RPCs for preflight, begin, chunk append, and completion.
- Remote-server staging under temporary paths, bounded binary chunk writes, nested directory creation, atomic file commits, staging cleanup, traversal rejection, conflict reporting, and executable-bit preservation where available.
- Sidebar drag/drop and filesystem-path paste support for local OS files and folders onto remote-server-backed file tree targets.
- Conflict confirmation, upload progress/status toasts, metadata refresh, destination expansion, and reveal/select of uploaded results.

Scope note: this v1 intentionally targets remote-server-backed Project Explorer/sidebar roots. Legacy SSH sessions without remote project-tree metadata and terminal-current-directory upload behavior remain out of scope.

## Linked Issue

Related to #6195.

#6195 is the closest matching request, but it currently has no `ready-to-spec` or `ready-to-implement` label and asks about terminal drag/drop into the current remote directory. This PR is opened as a draft pending maintainer readiness/scope confirmation.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] `cargo test -p warp remote_upload --lib`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p remote_server -p warp --lib --tests -- -D warnings`
- [x] Manual remote-server-backed SSH test:
  - Built a local `WarpLocal.app` from this branch without `standalone`.
  - Installed the branch-built remote binary to `~/.warp-local/remote-server/oz-local` on `devmac@devmac.sammyk.in`.
  - Launched the local app, connected to the remote-server-backed SSH project tree, and verified dropping/pasting local files into a remote sidebar folder uploads successfully.
  - Verified the sidebar refreshes and the uploaded files appear in the remote project tree.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Manual test proof is available from the local smoke test above; a short recording/screenshot can be attached before marking this PR ready.

https://github.com/user-attachments/assets/146f8d18-0ebc-4618-83d5-4922f50fd8a8


## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add drag-and-drop and paste upload support for remote-server-backed SSH project folders.
