### PR TITLE
Set cloud agent task context before setup

### DIFF
--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -611,6 +611,7 @@ impl AgentDriverRunner {
         // Local CLI-created runs may not have a task yet, so those setup events explicitly no-op.
         let mut task_id: Option<AmbientAgentTaskId> =
             args.task_id.as_deref().and_then(|s| s.parse().ok());
+        Self::set_ambient_agent_task_id(&foreground, task_id).await?;
         let background = foreground.spawn(|_, ctx| ctx.background_executor()).await?;
         let setup_events = match task_id {
             Some(task_id) => SetupClientEventReporter::new(task_id, server_api.clone(), background),
@@ -798,6 +799,21 @@ impl AgentDriverRunner {
             .await?
             .await
             .map_err(|_| AgentDriverError::TeamMetadataRefreshTimeout)
+    }
+
+    async fn set_ambient_agent_task_id(
+        foreground: &ModelSpawner<Self>,
+        task_id: Option<AmbientAgentTaskId>,
+    ) -> Result<(), AgentDriverError> {
+        foreground
+            .spawn(move |_, ctx| {
+                ServerApiProvider::handle(ctx)
+                    .as_ref(ctx)
+                    .get()
+                    .set_ambient_agent_task_id(task_id);
+            })
+            .await?;
+        Ok(())
     }
 
     /// Resolve the skill spec from args, if one was provided.
@@ -1010,15 +1026,8 @@ impl AgentDriverRunner {
             }
         };
 
-        foreground
-            .spawn(move |_, ctx| {
-                // Set the task ID on the ServerApi so it's sent with all subsequent requests.
-                ServerApiProvider::handle(ctx)
-                    .as_ref(ctx)
-                    .get()
-                    .set_ambient_agent_task_id(task_id);
-            })
-            .await?;
+        // Set the task ID on the ServerApi so it's sent with all subsequent requests.
+        Self::set_ambient_agent_task_id(foreground, task_id).await?;
         driver_options.task_id = task_id;
 
         Ok(())
@@ -1060,6 +1069,9 @@ impl AgentDriverRunner {
                 None
             }
         };
+        // Set the task ID on the ServerApi before any task-scoped server calls below, so failures
+        // during setup can still be reported with cloud-agent context.
+        Self::set_ambient_agent_task_id(foreground, parsed_task_id).await?;
 
         // Fetch secrets, task metadata, regular attachments, and handoff snapshot
         // attachments in parallel. The handoff snapshot fetch is independent of the
@@ -1239,16 +1251,6 @@ impl AgentDriverRunner {
                 task_harness,
             )?;
         }
-
-        // Set the task ID on the ServerApi so it's sent with all subsequent requests.
-        foreground
-            .spawn(move |_, ctx| {
-                ServerApiProvider::handle(ctx)
-                    .as_ref(ctx)
-                    .get()
-                    .set_ambient_agent_task_id(parsed_task_id);
-            })
-            .await?;
 
         driver_options.task_id = parsed_task_id;
         driver_options.parent_run_id = parent_run_id;


### PR DESCRIPTION
## Summary
- Set `ServerApi`'s ambient agent task ID immediately when `agent run --task-id` starts, before Warp Drive sync, metadata refresh, secrets/attachment fetches, cloud provider setup, or driver error reporting can fail.
- Reuse the same helper when a local CLI run creates a task and when existing task setup parses the task ID.
- Keep GraphQL request handling unchanged; once `ServerApi` has the task ID, existing header injection adds the cloud agent context automatically.

This should fix a regression where early setup failures couldn't be reported to the server, since they didn't include cloud agent request metadata.

## Validation
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib` passed with existing warnings.
- `rustfmt --edition 2021 --config-path /workspace/warp/.rustfmt.toml --check /workspace/warp/app/src/ai/agent_sdk/mod.rs` passed.
- `git -C /workspace/warp --no-pager diff --check` passed.
- `cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp -E 'test(ambient_agent_headers_for_task_overrides_existing_cloud_agent_header)'` was attempted but the test build was killed with SIGKILL; retrying with `CARGO_BUILD_JOBS=1` stalled near the end of compiling `warp(test)` and was interrupted.

_Conversation: https://staging.warp.dev/conversation/231ac3b7-4202-44a7-9e0d-68370eebdde0_
_Run: https://oz.staging.warp.dev/runs/019e4f84-9b90-78ff-992c-c292c42dc194_
_This PR was generated with [Oz](https://warp.dev/oz)._
