### PR TITLE
Show current zoom level in a transient HUD when zooming

### DIFF
--- a/app/src/view_components/mod.rs
+++ b/app/src/view_components/mod.rs
@@ -17,6 +17,7 @@ pub mod find;
 mod markdown_toggle_view;
 mod submittable_text_input;
 mod warning_box;
+pub mod zoom_level_hud;
 
 pub use agent_toast::*;
 pub use alert::Alert;

--- a/app/src/view_components/zoom_level_hud.rs
+++ b/app/src/view_components/zoom_level_hud.rs
@@ -1,0 +1,133 @@
+//! A small, transient HUD that briefly displays the current UI zoom percentage
+//! after a user-initiated zoom action. It is intentionally not built on top of
+//! `DismissibleToastStack` so it stays single-state, has no close affordance,
+//! and uses a shorter timeout than general toasts.
+
+use std::time::Duration;
+
+use pathfinder_color::ColorU;
+use warpui::elements::{
+    Border, Container, CornerRadius, CrossAxisAlignment, Element, Flex, MainAxisAlignment,
+    MainAxisSize, ParentElement, Radius, Text,
+};
+use warpui::r#async::{SpawnedFutureHandle, Timer};
+use warpui::{AppContext, Entity, SingletonEntity, View, ViewContext};
+
+use crate::appearance::Appearance;
+use crate::themes::theme::Fill as ThemeFill;
+
+/// Time the HUD remains visible after the most recent zoom action.
+pub const ZOOM_LEVEL_HUD_TIMEOUT: Duration = Duration::from_millis(1000);
+
+const HORIZONTAL_PADDING: f32 = 14.;
+const VERTICAL_PADDING: f32 = 8.;
+const CORNER_RADIUS: f32 = 6.;
+const FONT_SIZE_MULTIPLIER: f32 = 1.4;
+
+/// View that renders a single transient zoom-percentage indicator in the workspace.
+///
+/// Calling [`ZoomLevelHud::show_zoom_level`] sets the visible value and (re)starts
+/// a one-shot timer. When the timer fires, the value is cleared and the view
+/// renders nothing. Calling `show_zoom_level` again before the timer fires
+/// replaces the value and restarts the timer instead of stacking.
+pub struct ZoomLevelHud {
+    visible_zoom_level: Option<u16>,
+    dismiss_handle: Option<SpawnedFutureHandle>,
+    timeout: Duration,
+}
+
+impl ZoomLevelHud {
+    pub fn new() -> Self {
+        Self {
+            visible_zoom_level: None,
+            dismiss_handle: None,
+            timeout: ZOOM_LEVEL_HUD_TIMEOUT,
+        }
+    }
+
+    /// The currently displayed zoom level, if any. Used in tests and assertions.
+    #[cfg(test)]
+    pub fn visible_zoom_level(&self) -> Option<u16> {
+        self.visible_zoom_level
+    }
+
+    /// Show the given zoom percentage in the HUD and (re)start the dismissal timer.
+    pub fn show_zoom_level(&mut self, zoom_level: u16, ctx: &mut ViewContext<Self>) {
+        self.visible_zoom_level = Some(zoom_level);
+
+        if let Some(previous) = self.dismiss_handle.take() {
+            previous.abort();
+        }
+
+        let abort_handle = ctx.spawn_abortable(
+            Timer::after(self.timeout),
+            |view, _, ctx| {
+                view.dismiss_handle = None;
+                view.visible_zoom_level = None;
+                ctx.notify();
+            },
+            |_, _| {},
+        );
+        self.dismiss_handle = Some(abort_handle);
+
+        ctx.notify();
+    }
+
+    fn render_pill(&self, zoom_level: u16, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let background = theme.surface_3();
+        let text_color: ColorU = theme.main_text_color(background).into();
+        let border_fill: ThemeFill = theme.outline();
+        let font_size = appearance.ui_font_size() * FONT_SIZE_MULTIPLIER;
+
+        let percentage = Text::new(
+            format!("{zoom_level}%"),
+            appearance.ui_font_family(),
+            font_size,
+        )
+        .with_color(text_color)
+        .finish();
+
+        let row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_main_axis_alignment(MainAxisAlignment::Center)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(percentage)
+            .finish();
+
+        Container::new(row)
+            .with_horizontal_padding(HORIZONTAL_PADDING)
+            .with_vertical_padding(VERTICAL_PADDING)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(CORNER_RADIUS)))
+            .with_border(Border::all(1.).with_border_fill(border_fill))
+            .with_background(background)
+            .finish()
+    }
+}
+
+impl Default for ZoomLevelHud {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Entity for ZoomLevelHud {
+    type Event = ();
+}
+
+impl View for ZoomLevelHud {
+    fn ui_name() -> &'static str {
+        "ZoomLevelHud"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        match self.visible_zoom_level {
+            Some(zoom_level) => self.render_pill(zoom_level, app),
+            None => Flex::row()
+                .with_main_axis_size(MainAxisSize::Min)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .finish(),
+        }
+    }
+}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -350,6 +350,7 @@ use crate::view_components::action_button::ActionButton;
 use crate::view_components::callout_bubble::{
     render_callout_bubble, CalloutArrowDirection, CalloutArrowPosition, CalloutBubbleConfig,
 };
+use crate::view_components::zoom_level_hud::ZoomLevelHud;
 use crate::view_components::{
     AgentToast, AgentToastStack, DismissibleToast, DismissibleToastStack, ToastLink,
 };
@@ -978,6 +979,7 @@ pub struct Workspace {
     toast_stack: ViewHandle<DismissibleToastStack<WorkspaceAction>>,
     agent_toast_stack: ViewHandle<AgentToastStack>,
     update_toast_stack: ViewHandle<DismissibleToastStack<WorkspaceAction>>,
+    zoom_level_hud: ViewHandle<ZoomLevelHud>,
     /// We need to render some dynamic keybindings for our tooltips. These cannot be looked up in the
     /// render method, so look them up when the view is constructed and cache them here. Note that they
     /// need to be kept in sync as the keybindings change.
@@ -2888,6 +2890,8 @@ impl Workspace {
         let update_toast_stack =
             ctx.add_typed_action_view(|_| DismissibleToastStack::new(Duration::from_secs(4)));
 
+        let zoom_level_hud = ctx.add_view(|_| ZoomLevelHud::new());
+
         #[cfg(target_family = "wasm")]
         let wasm_nux_dialog = Self::build_wasm_nux_dialog(ctx);
 
@@ -3102,6 +3106,7 @@ impl Workspace {
             toast_stack,
             agent_toast_stack,
             update_toast_stack,
+            zoom_level_hud,
             cached_keybindings,
             prompt_editor_modal,
             agent_toolbar_editor_modal,
@@ -15665,11 +15670,11 @@ impl Workspace {
     }
 
     fn reset_zoom(&mut self, ctx: &mut ViewContext<Self>) {
+        let default_zoom = ZoomLevel::default_value();
         WindowSettings::handle(ctx).update(ctx, |window_settings, ctx| {
-            report_if_error!(window_settings
-                .zoom_level
-                .set_value(ZoomLevel::default_value(), ctx));
+            report_if_error!(window_settings.zoom_level.set_value(default_zoom, ctx));
         });
+        self.show_zoom_level_hud(default_zoom, ctx);
     }
 
     fn adjust_zoom(&mut self, increase: bool, ctx: &mut ViewContext<Self>) {
@@ -15687,10 +15692,17 @@ impl Workspace {
             current_index.saturating_sub(1)
         };
 
+        let next_zoom = crate::window_settings::ZoomLevel::VALUES[next_index];
+
         WindowSettings::handle(ctx).update(ctx, |window_settings, ctx| {
-            report_if_error!(window_settings
-                .zoom_level
-                .set_value(crate::window_settings::ZoomLevel::VALUES[next_index], ctx));
+            report_if_error!(window_settings.zoom_level.set_value(next_zoom, ctx));
+        });
+        self.show_zoom_level_hud(next_zoom, ctx);
+    }
+
+    fn show_zoom_level_hud(&mut self, zoom_level: u16, ctx: &mut ViewContext<Self>) {
+        self.zoom_level_hud.update(ctx, |hud, ctx| {
+            hud.show_zoom_level(zoom_level, ctx);
         });
     }
 
@@ -19053,6 +19065,17 @@ impl Workspace {
         OffsetPositioning::offset_from_save_position_element(
             TAB_CONTENT_POSITION_ID,
             vec2f(0., 16.),
+            PositionedElementOffsetBounds::WindowByPosition,
+            PositionedElementAnchor::TopMiddle,
+            ChildAnchor::TopMiddle,
+        )
+    }
+
+    /// Offset positioning for the transient zoom-level HUD.
+    fn zoom_level_hud_positioning(&self) -> OffsetPositioning {
+        OffsetPositioning::offset_from_save_position_element(
+            TAB_CONTENT_POSITION_ID,
+            vec2f(0., 24.),
             PositionedElementOffsetBounds::WindowByPosition,
             PositionedElementAnchor::TopMiddle,
             ChildAnchor::TopMiddle,
@@ -22882,6 +22905,13 @@ impl View for Workspace {
             ChildView::new(&self.toast_stack).finish(),
             self.global_toast_positioning(),
         );
+
+        if FeatureFlag::UIZoom.is_enabled() {
+            stack.add_positioned_overlay_child(
+                ChildView::new(&self.zoom_level_hud).finish(),
+                self.zoom_level_hud_positioning(),
+            );
+        }
 
         // Render agent toast stack (for agent-related notifications) if popup is not open
         if FeatureFlag::HOANotifications.is_enabled()

--- a/app/src/workspace/view_test.rs
+++ b/app/src/workspace/view_test.rs
@@ -3013,3 +3013,156 @@ fn test_open_cloud_agent_setup_guide_action_opens_management_view_and_is_idempot
         });
     });
 }
+
+fn set_zoom_level(value: u16, ctx: &mut ViewContext<Workspace>) {
+    WindowSettings::handle(ctx).update(ctx, |window_settings, ctx| {
+        window_settings
+            .zoom_level
+            .set_value(value, ctx)
+            .expect("Failed to update zoom_level setting");
+    });
+}
+
+fn current_zoom_level(ctx: &AppContext) -> u16 {
+    *WindowSettings::as_ref(ctx).zoom_level.value()
+}
+
+fn visible_hud_zoom_level(workspace: &Workspace, ctx: &AppContext) -> Option<u16> {
+    workspace
+        .zoom_level_hud
+        .read(ctx, |hud, _| hud.visible_zoom_level())
+}
+
+#[test]
+fn test_increase_zoom_action_updates_setting_and_hud() {
+    let _zoom_guard = FeatureFlag::UIZoom.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            set_zoom_level(100, ctx);
+
+            workspace.handle_action(&WorkspaceAction::IncreaseZoom, ctx);
+
+            assert_eq!(current_zoom_level(ctx), 110);
+            assert_eq!(visible_hud_zoom_level(workspace, ctx), Some(110));
+        });
+    });
+}
+
+#[test]
+fn test_decrease_zoom_action_updates_setting_and_hud() {
+    let _zoom_guard = FeatureFlag::UIZoom.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            set_zoom_level(100, ctx);
+
+            workspace.handle_action(&WorkspaceAction::DecreaseZoom, ctx);
+
+            assert_eq!(current_zoom_level(ctx), 90);
+            assert_eq!(visible_hud_zoom_level(workspace, ctx), Some(90));
+        });
+    });
+}
+
+#[test]
+fn test_reset_zoom_action_shows_default_in_hud() {
+    let _zoom_guard = FeatureFlag::UIZoom.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            set_zoom_level(150, ctx);
+
+            workspace.handle_action(&WorkspaceAction::ResetZoom, ctx);
+
+            assert_eq!(
+                current_zoom_level(ctx),
+                crate::window_settings::ZoomLevel::default_value()
+            );
+            assert_eq!(
+                visible_hud_zoom_level(workspace, ctx),
+                Some(crate::window_settings::ZoomLevel::default_value())
+            );
+        });
+    });
+}
+
+#[test]
+fn test_zoom_in_at_max_shows_clamped_value_in_hud() {
+    let _zoom_guard = FeatureFlag::UIZoom.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        let max_zoom = *crate::window_settings::ZoomLevel::VALUES.last().unwrap();
+
+        workspace.update(&mut app, |workspace, ctx| {
+            set_zoom_level(max_zoom, ctx);
+
+            workspace.handle_action(&WorkspaceAction::IncreaseZoom, ctx);
+
+            assert_eq!(current_zoom_level(ctx), max_zoom);
+            assert_eq!(visible_hud_zoom_level(workspace, ctx), Some(max_zoom));
+        });
+    });
+}
+
+#[test]
+fn test_zoom_out_at_min_shows_clamped_value_in_hud() {
+    let _zoom_guard = FeatureFlag::UIZoom.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        let min_zoom = *crate::window_settings::ZoomLevel::VALUES.first().unwrap();
+
+        workspace.update(&mut app, |workspace, ctx| {
+            set_zoom_level(min_zoom, ctx);
+
+            workspace.handle_action(&WorkspaceAction::DecreaseZoom, ctx);
+
+            assert_eq!(current_zoom_level(ctx), min_zoom);
+            assert_eq!(visible_hud_zoom_level(workspace, ctx), Some(min_zoom));
+        });
+    });
+}
+
+#[test]
+fn test_repeated_zoom_actions_replace_hud_value() {
+    let _zoom_guard = FeatureFlag::UIZoom.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            set_zoom_level(100, ctx);
+
+            workspace.handle_action(&WorkspaceAction::IncreaseZoom, ctx);
+            assert_eq!(visible_hud_zoom_level(workspace, ctx), Some(110));
+
+            workspace.handle_action(&WorkspaceAction::IncreaseZoom, ctx);
+            assert_eq!(visible_hud_zoom_level(workspace, ctx), Some(125));
+
+            workspace.handle_action(&WorkspaceAction::DecreaseZoom, ctx);
+            assert_eq!(visible_hud_zoom_level(workspace, ctx), Some(110));
+        });
+    });
+}

--- a/specs/GH9576/tech.md
+++ b/specs/GH9576/tech.md
@@ -38,7 +38,7 @@ Workspace already has general toast infrastructure, but it is optimized for mess
 
 ### 1. Add a dedicated zoom HUD view
 
-Introduce a small view component under the workspace or shared view-components area, for example `app/src/workspace/zoom_level_hud.rs` or `app/src/view_components/zoom_level_hud.rs`. Keep it focused on this feature rather than extending `DismissibleToastStack`.
+Introduce a small view component under the shared view-components area at `app/src/view_components/zoom_level_hud.rs`. Keep it focused on this feature rather than extending `DismissibleToastStack`.
 
 Suggested shape:
 
@@ -112,7 +112,7 @@ Do not change:
 - `FeatureFlag::UIZoom` gating
 - the font-size fallback path used when `UIZoom` is disabled
 
-The HUD should only be reachable from zoom actions that are registered when `FeatureFlag::UIZoom` is enabled.
+The HUD should only be reachable from zoom actions that are registered when `FeatureFlag::UIZoom` is enabled. As an extra defensive layer, also gate the HUD's `add_positioned_overlay_child` call in `Workspace::render` on `FeatureFlag::UIZoom.is_enabled()` so the overlay never participates in layout when UI zoom is disabled, even if the helper is called by some unexpected path.
 
 ## End-to-end flow
 


### PR DESCRIPTION
## Description

Adds a transient zoom-level HUD that briefly displays the current UI zoom percentage after a user-initiated zoom action.

**What:** A new `ZoomLevelHud` view component shows a small, top-centered pill (e.g. `110%`) for ~1 second whenever the user increases, decreases, or resets the UI zoom. Repeated zoom actions replace the value in place and restart the dismissal timer rather than stacking.

**Why:** Implements GH9576 — Warp already has stepped UI zoom values and actions, but no visible feedback of the resulting zoom level when zooming.

**How:**
- New `ZoomLevelHud` (`app/src/view_components/zoom_level_hud.rs`): a dedicated single-state HUD rather than an extension of `DismissibleToastStack`, with abort-and-replace dismissal timer logic and theme-aware colors from `Appearance`.
- `Workspace` owns a `ViewHandle<ZoomLevelHud>` and renders it as a positioned top-centered overlay, gated on `FeatureFlag::UIZoom`.
- `reset_zoom`/`adjust_zoom` show the resulting (clamped) zoom value via a `show_zoom_level_hud` helper.

This PR targets the `oz-agent/spec-issue-9576` spec branch and contains the implementation for the spec landed there (`specs/GH9576/product.md`, `specs/GH9576/tech.md`); `tech.md` is updated here to reflect implementation decisions.

## Linked Issue

https://github.com/warpdotdev/warp/issues/9576

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Screenshots / Videos

https://github.com/user-attachments/assets/607e2f14-9a19-4f13-b74d-c741f0419403


## Testing

Added unit coverage in `app/src/workspace/view_test.rs`:
- `IncreaseZoom` / `DecreaseZoom` update both the `WindowSettings::zoom_level` and the HUD state.
- `ResetZoom` shows the default zoom value in the HUD.
- Zoom in at max / zoom out at min show the clamped value.
- Repeated zoom actions replace the HUD value rather than stacking.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
