### PR TITLE
Guard cloud child launches missing harness auth

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -12,8 +12,8 @@ use ai::agent::action_result::{
 };
 use ai::agent::orchestration_config::OrchestrationConfig;
 use ai::skills::SkillReference;
-use futures::future::BoxFuture;
 use futures::FutureExt;
+use futures::future::BoxFuture;
 use settings::Setting;
 use warp_cli::agent::Harness;
 use warp_core::execution_mode::AppExecutionMode;
@@ -366,29 +366,32 @@ fn prepare_request_for_execution(
     parent_conversation_id: AIConversationId,
     terminal_view_id: EntityId,
     ctx: &ModelContext<RunAgentsExecutor>,
-) -> Option<&'static str> {
+) -> Option<String> {
     let status = resolve_request_from_approved_config(request, parent_conversation_id, ctx);
     populate_default_auth_secret_for_execution(request, ctx);
 
     if AppExecutionMode::as_ref(ctx).is_autonomous() {
+        if !can_execute_with_auth_secret(request, ctx) {
+            return Some(missing_auth_secret_message(request));
+        }
         return None;
     }
 
     if status.is_some_and(|status| status.is_disapproved()) {
-        return Some("Orchestration config was disapproved");
+        return Some("Orchestration config was disapproved".to_string());
     }
 
     if BlocklistAIPermissions::as_ref(ctx)
         .get_run_agents_setting(ctx, Some(terminal_view_id))
         .is_never_allow()
     {
-        return Some("Running child agents is disabled by the active execution profile.");
+        return Some(
+            "Running child agents is disabled by the active execution profile.".to_string(),
+        );
     }
 
     if !can_execute_with_auth_secret(request, ctx) {
-        return Some(
-            "Cloud child agents using this harness require an API key before they can run.",
-        );
+        return Some(missing_auth_secret_message(request));
     }
 
     None
@@ -418,7 +421,28 @@ fn can_execute_with_auth_secret(
     {
         return true;
     }
+    if inherit_auth_secret_chosen_for_harness(&request.harness_type, ctx) {
+        return true;
+    }
     default_auth_secret_name_for_harness(&request.harness_type, ctx).is_some()
+}
+
+fn missing_auth_secret_message(request: &RunAgentsRequest) -> String {
+    let harness_name = Harness::parse_orchestration_harness(&request.harness_type)
+        .map(|harness| harness.display_name().to_string())
+        .unwrap_or_else(|| {
+            let trimmed = request.harness_type.trim();
+            if trimmed.is_empty() {
+                "this".to_string()
+            } else {
+                trimmed.to_string()
+            }
+        });
+    format!(
+        "Cloud child agents using the {harness_name} harness require an API-key secret before \
+         they can run. Select a managed auth secret, choose Inherit key from environment for a \
+         configured environment, or use the Warp Agent harness."
+    )
 }
 
 fn default_auth_secret_name_for_harness(
@@ -435,6 +459,24 @@ fn default_auth_secret_name_for_harness(
         .get(harness.config_name())
         .cloned()
         .filter(|name| !name.trim().is_empty())
+}
+
+fn inherit_auth_secret_chosen_for_harness(
+    harness_type: &str,
+    ctx: &ModelContext<RunAgentsExecutor>,
+) -> bool {
+    let Some(harness) = Harness::parse_orchestration_harness(harness_type) else {
+        return false;
+    };
+    if harness == Harness::Oz {
+        return false;
+    }
+    CloudAgentSettings::as_ref(ctx)
+        .inherit_auth_secret_harnesses
+        .value()
+        .get(harness.config_name())
+        .copied()
+        .unwrap_or(false)
 }
 
 fn populate_default_auth_secret_for_execution(

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -13,8 +13,8 @@ use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::task::TaskId;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
-use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::execution_profiles::RunAgentsPermission;
+use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::model::persistence::CloudModel;
@@ -154,6 +154,24 @@ fn persist_default_auth_secret(app: &mut App, harness_config_name: &str, secret_
     });
 }
 
+fn persist_inherit_auth_secret(app: &mut App, harness_config_name: &str) {
+    CloudAgentSettings::handle(app).update(app, |settings, ctx| {
+        let mut secrets = settings.last_selected_auth_secret.value().clone();
+        secrets.remove(harness_config_name);
+        settings
+            .last_selected_auth_secret
+            .set_value(secrets, ctx)
+            .unwrap();
+
+        let mut inherit = settings.inherit_auth_secret_harnesses.value().clone();
+        inherit.insert(harness_config_name.to_string(), true);
+        settings
+            .inherit_auth_secret_harnesses
+            .set_value(inherit, ctx)
+            .unwrap();
+    });
+}
+
 #[test]
 fn should_autoexecute_when_plan_has_approved_orchestration_config() {
     App::test((), |mut app| async move {
@@ -274,7 +292,7 @@ fn execute_denies_never_allow_profile_setting() {
 }
 
 #[test]
-fn autonomous_mode_autoexecutes_and_does_not_deny_missing_api_key() {
+fn autonomous_mode_autoexecutes_but_denies_missing_remote_harness_api_key() {
     App::test((), |mut app| async move {
         let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
         set_run_agents_permission(&mut app, RunAgentsPermission::NeverAllow);
@@ -302,7 +320,16 @@ fn autonomous_mode_autoexecutes_and_does_not_deny_missing_api_key() {
                 )
                 .into()
         });
-        assert!(matches!(execution, AnyActionExecution::Async { .. }));
+        let AnyActionExecution::Sync(AIAgentActionResultType::RunAgents(RunAgentsResult::Denied {
+            reason,
+        })) = execution
+        else {
+            panic!("expected synchronous run_agents denial");
+        };
+        assert_eq!(
+            reason,
+            "Cloud child agents using the Codex harness require an API-key secret before they can run. Select a managed auth secret, choose Inherit key from environment for a configured environment, or use the Warp Agent harness."
+        );
     });
 }
 
@@ -359,7 +386,7 @@ fn execute_denies_remote_non_warp_harness_without_default_auth_secret() {
         };
         assert_eq!(
             reason,
-            "Cloud child agents using this harness require an API key before they can run."
+            "Cloud child agents using the Codex harness require an API-key secret before they can run. Select a managed auth secret, choose Inherit key from environment for a configured environment, or use the Warp Agent harness."
         );
     });
 }
@@ -391,6 +418,28 @@ fn should_autoexecute_remote_non_warp_harness_with_default_auth_secret() {
         let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
         set_run_agents_permission(&mut app, RunAgentsPermission::AlwaysAllow);
         persist_default_auth_secret(&mut app, "codex", "default-openai-key");
+        let action = remote_run_agents_action("codex");
+
+        let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {
+            executor.should_autoexecute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: state.conversation_id,
+                },
+                ctx,
+            )
+        });
+
+        assert!(should_autoexecute);
+    });
+}
+
+#[test]
+fn should_autoexecute_remote_non_warp_harness_with_explicit_inherit_auth_secret() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        set_run_agents_permission(&mut app, RunAgentsPermission::AlwaysAllow);
+        persist_inherit_auth_secret(&mut app, "codex");
         let action = remote_run_agents_action("codex");
 
         let should_autoexecute = state.executor.update(&mut app, |executor, ctx| {


### PR DESCRIPTION
## Summary
- Deny remote third-party child-agent launches without a managed auth secret or explicit environment inheritance, including autonomous local-agent sessions.
- Preserve explicit "Inherit key from environment" as an allowed auth choice.
- Add regression coverage for autonomous missing-auth denial and explicit inherit behavior.

## Tests
- cargo test -p warp run_agents --lib

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
