### PR TITLE
Add spacing before code review branch picker

### DIFF
--- a/app/src/code_review/code_review_header/mod.rs
+++ b/app/src/code_review/code_review_header/mod.rs
@@ -19,6 +19,7 @@ use crate::code_review::code_review_view::{
     get_discard_button_disabled_tooltip, CodeReviewAction, CodeReviewHeaderFields, CodeReviewView,
     LoadedState, CONTENT_TOP_MARGIN,
 };
+use crate::code_review::diff_selector::DiffSelector;
 use crate::code_review::diff_state::DiffStateModel;
 use crate::menu::Menu;
 use crate::ui_components::icons::Icon;
@@ -33,6 +34,8 @@ pub(crate) const HEADER_BUTTON_PADDING: Coords = Coords {
     left: 6.,
     right: 6.,
 };
+
+const BRANCH_PICKER_LEFT_MARGIN: f32 = 8.;
 
 #[derive(Default)]
 struct StateHandles {
@@ -114,7 +117,9 @@ impl CodeReviewHeader {
         let mut right_section_wide = Flex::row()
             .with_main_axis_alignment(MainAxisAlignment::End)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(ChildView::new(&code_review_header_fields.diff_selector).finish());
+            .with_child(Self::render_branch_picker(
+                &code_review_header_fields.diff_selector,
+            ));
 
         let has_no_changes = state.to_diff_stats().has_no_changes();
 
@@ -291,6 +296,12 @@ impl CodeReviewHeader {
             ChildAnchor::TopLeft,
             vec2f(0., 4.),
         )
+    }
+
+    fn render_branch_picker(diff_selector: &ViewHandle<DiffSelector>) -> Box<dyn Element> {
+        Container::new(ChildView::new(diff_selector).finish())
+            .with_margin_left(BRANCH_PICKER_LEFT_MARGIN)
+            .finish()
     }
 
     fn create_discard_button(


### PR DESCRIPTION
## Description
Adds external left spacing to the legacy code review branch picker in the wide header row so it does not crowd the diff stat.

The diff stat already has a right margin, and the branch picker already has internal horizontal button padding. This keeps the picker’s internal padding and hover target unchanged, and adds a small left margin to the picker wrapper instead.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Slack request: feedback-app message 1779472497.944709

## Testing
- [x] `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- [ ] I have manually tested my changes locally with `./script/run`

Manual UI testing was not run in this sandboxed environment. `rustfmt` was also unavailable in the sandbox toolchain (`rustfmt` is not installed for stable-x86_64-unknown-linux-gnu), so I reviewed the small diff manually.

### Screenshots / Videos
Not captured; change is a targeted spacing adjustment based on the attached Slack screenshot.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/d3a1cb82-a4f7-40d2-8684-8e206cb4e449_
_Run: https://oz.staging.warp.dev/runs/019e50d3-85ac-7d71-a8fd-d8e477444ba7_
_This PR was generated with [Oz](https://warp.dev/oz)._
