### PR TITLE
Enable async find on dogfood, add toggle for Preview/Stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -654,6 +654,7 @@ default = [
     "custom_inference_endpoints",
     "billing_and_usage_page_v2",
     "remote_code_review",
+    "async_find",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -654,7 +654,6 @@ default = [
     "custom_inference_endpoints",
     "billing_and_usage_page_v2",
     "remote_code_review",
-    "async_find",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -43,7 +43,8 @@ use super::settings_page::{
     HEADER_PADDING, TOGGLE_BUTTON_RIGHT_PADDING,
 };
 use super::{
-    features, flags, DisplayCount, SettingsAction, SettingsSection, ToggleSettingActionPair,
+    features, flags, render_beta_chip, DisplayCount, SettingsAction, SettingsSection,
+    ToggleSettingActionPair,
 };
 use crate::appearance::Appearance;
 use crate::default_terminal::DefaultTerminal;
@@ -7284,10 +7285,12 @@ impl SettingsWidget for AsyncFindWidget {
     type View = FeaturesPageView;
 
     fn search_terms(&self) -> &str {
-        "async asynchronous find search terminal ai background"
+        "async asynchronous fast find search"
     }
 
     fn should_render(&self, _app: &AppContext) -> bool {
+        // Here, the feature flag being enabled means the feature is force-enabled,
+        // so we don't need to render the toggle.
         !FeatureFlag::AsyncFind.is_enabled()
     }
 
@@ -7336,26 +7339,9 @@ impl SettingsWidget for AsyncFindWidget {
             switch,
             appearance,
             Some(
-                "Run find on a background thread to keep the UI responsive on large outputs."
+                "Use an improved implementation of find to keep the UI responsive while searching for matches on large outputs."
                     .into(),
             ),
         )
     }
-}
-
-/// Small inline pill rendered next to a settings label to mark a feature as beta.
-fn render_beta_chip(appearance: &Appearance) -> Box<dyn Element> {
-    let theme = appearance.theme();
-    let chip_color = theme.sub_text_color(theme.surface_3()).into_solid();
-    Container::new(
-        Text::new_inline("BETA", appearance.ui_font_family(), 10.)
-            .with_color(chip_color)
-            .finish(),
-    )
-    .with_background(theme.surface_3())
-    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(3.)))
-    .with_horizontal_padding(4.)
-    .with_vertical_padding(1.)
-    .with_margin_left(8.)
-    .finish()
 }

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -36,10 +36,11 @@ use super::keybindings::KeyBindingModifyingState;
 #[cfg(feature = "local_tty")]
 use super::settings_page::render_sub_sub_header;
 use super::settings_page::{
-    add_setting, build_reset_button, render_body_item, render_body_item_label,
-    render_dropdown_item, render_dropdown_item_label, render_local_only_icon, AdditionalInfo,
-    Category, LocalOnlyIconState, MatchData, PageType, SettingsPageMeta, SettingsPageViewHandle,
-    SettingsWidget, ToggleState, CONTENT_FONT_SIZE, HEADER_PADDING, TOGGLE_BUTTON_RIGHT_PADDING,
+    add_setting, build_reset_button, build_toggle_element, render_body_item,
+    render_body_item_label, render_dropdown_item, render_dropdown_item_label,
+    render_local_only_icon, AdditionalInfo, Category, LocalOnlyIconState, MatchData, PageType,
+    SettingsPageMeta, SettingsPageViewHandle, SettingsWidget, ToggleState, CONTENT_FONT_SIZE,
+    HEADER_PADDING, TOGGLE_BUTTON_RIGHT_PADDING,
 };
 use super::{
     features, flags, DisplayCount, SettingsAction, SettingsSection, ToggleSettingActionPair,
@@ -2521,12 +2522,10 @@ impl FeaturesPageView {
             general_widgets.push(Box::new(DefaultTerminalWidget::default()));
         }
 
-        // Gated behind the `AsyncFind` feature flag. The widget itself reads from
-        // `TerminalSettings::async_find_enabled`; both the flag and the setting must
-        // be on for async find to actually run (see `TerminalSettings::is_async_find_enabled`).
-        if FeatureFlag::AsyncFind.is_enabled() {
-            general_widgets.push(Box::new(AsyncFindWidget::default()));
-        }
+        // The widget is the opt-in surface for channels where `FeatureFlag::AsyncFind`
+        // is off. Channels with the flag on force the feature on and hide the toggle
+        // entirely; see `TerminalSettings::is_async_find_enabled`.
+        general_widgets.push(Box::new(AsyncFindWidget::default()));
 
         let app_editor_settings = AppEditorSettings::as_ref(ctx);
 
@@ -7289,7 +7288,7 @@ impl SettingsWidget for AsyncFindWidget {
     }
 
     fn should_render(&self, _app: &AppContext) -> bool {
-        FeatureFlag::AsyncFind.is_enabled()
+        !FeatureFlag::AsyncFind.is_enabled()
     }
 
     fn render(
@@ -7299,8 +7298,10 @@ impl SettingsWidget for AsyncFindWidget {
         app: &AppContext,
     ) -> Box<dyn Element> {
         let ui_builder = appearance.ui_builder();
-        render_body_item::<FeaturesPageAction>(
+
+        let label = render_body_item_label::<FeaturesPageAction>(
             "Asynchronous find".into(),
+            None,
             None,
             LocalOnlyIconState::for_setting(
                 AsyncFindEnabled::storage_key(),
@@ -7313,18 +7314,48 @@ impl SettingsWidget for AsyncFindWidget {
             ),
             ToggleState::Enabled,
             appearance,
-            ui_builder
-                .switch(self.switch_state.clone())
-                .check(*TerminalSettings::as_ref(app).async_find_enabled)
-                .build()
-                .on_click(move |ctx, _, _| {
-                    ctx.dispatch_typed_action(FeaturesPageAction::ToggleAsyncFind);
-                })
-                .finish(),
+        );
+
+        let label_with_chip = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(label)
+            .with_child(render_beta_chip(appearance))
+            .finish();
+
+        let switch = ui_builder
+            .switch(self.switch_state.clone())
+            .check(*TerminalSettings::as_ref(app).async_find_enabled)
+            .build()
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(FeaturesPageAction::ToggleAsyncFind);
+            })
+            .finish();
+
+        build_toggle_element(
+            label_with_chip,
+            switch,
+            appearance,
             Some(
                 "Run find on a background thread to keep the UI responsive on large outputs."
                     .into(),
             ),
         )
     }
+}
+
+/// Small inline pill rendered next to a settings label to mark a feature as beta.
+fn render_beta_chip(appearance: &Appearance) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let chip_color = theme.sub_text_color(theme.surface_3()).into_solid();
+    Container::new(
+        Text::new_inline("BETA", appearance.ui_font_family(), 10.)
+            .with_color(chip_color)
+            .finish(),
+    )
+    .with_background(theme.surface_3())
+    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(3.)))
+    .with_horizontal_padding(4.)
+    .with_vertical_padding(1.)
+    .with_margin_left(8.)
+    .finish()
 }

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -94,8 +94,8 @@ use crate::terminal::session_settings::{
     SessionSettingsChangedEvent, ShouldConfirmCloseSession,
 };
 use crate::terminal::settings::{
-    MaximumGridSize, ShowTerminalZeroStateBlock, TerminalSettings, TerminalSettingsChangedEvent,
-    UseAudibleBell,
+    AsyncFindEnabled, MaximumGridSize, ShowTerminalZeroStateBlock, TerminalSettings,
+    TerminalSettingsChangedEvent, UseAudibleBell,
 };
 use crate::terminal::{BlockListSettings, SnackbarEnabled};
 use crate::undo_close::UndoCloseSettings;
@@ -559,6 +559,7 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
 #[derive(Clone, Debug)]
 pub enum FeaturesPageAction {
     ToggleCopyOnSelect,
+    ToggleAsyncFind,
     ToggleNotifications,
     ToggleRestoreSession,
     ToggleAutocompleteSymbols,
@@ -1149,6 +1150,10 @@ impl FeaturesPageAction {
             Self::ToggleAgentInAppNotifications => TelemetryEvent::FeaturesPageAction {
                 action: "ToggleAgentInAppNotifications".to_string(),
                 value: to_string(*AISettings::as_ref(ctx).show_agent_notifications),
+            },
+            Self::ToggleAsyncFind => TelemetryEvent::FeaturesPageAction {
+                action: "ToggleAsyncFind".to_string(),
+                value: to_string(*TerminalSettings::as_ref(ctx).async_find_enabled),
             },
         }
     }
@@ -1905,6 +1910,13 @@ impl TypedActionView for FeaturesPageView {
                     default_terminal.make_warp_default(ctx);
                 });
             }
+            ToggleAsyncFind => {
+                TerminalSettings::handle(ctx).update(ctx, |terminal_settings, ctx| {
+                    report_if_error!(terminal_settings
+                        .async_find_enabled
+                        .toggle_and_save_value(ctx));
+                });
+            }
         }
 
         send_telemetry_from_ctx!(action.telemetry_event(ctx), ctx);
@@ -2507,6 +2519,13 @@ impl FeaturesPageView {
 
         if DefaultTerminal::can_warp_become_default() {
             general_widgets.push(Box::new(DefaultTerminalWidget::default()));
+        }
+
+        // Gated behind the `AsyncFind` feature flag. The widget itself reads from
+        // `TerminalSettings::async_find_enabled`; both the flag and the setting must
+        // be on for async find to actually run (see `TerminalSettings::is_async_find_enabled`).
+        if FeatureFlag::AsyncFind.is_enabled() {
+            general_widgets.push(Box::new(AsyncFindWidget::default()));
         }
 
         let app_editor_settings = AppEditorSettings::as_ref(ctx);
@@ -7254,5 +7273,58 @@ impl SettingsWidget for GraphicsBackendWidget {
             );
         }
         col.finish()
+    }
+}
+
+#[derive(Default)]
+struct AsyncFindWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for AsyncFindWidget {
+    type View = FeaturesPageView;
+
+    fn search_terms(&self) -> &str {
+        "async asynchronous find search terminal ai background"
+    }
+
+    fn should_render(&self, _app: &AppContext) -> bool {
+        FeatureFlag::AsyncFind.is_enabled()
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let ui_builder = appearance.ui_builder();
+        render_body_item::<FeaturesPageAction>(
+            "Asynchronous find".into(),
+            None,
+            LocalOnlyIconState::for_setting(
+                AsyncFindEnabled::storage_key(),
+                AsyncFindEnabled::sync_to_cloud(),
+                &mut view
+                    .button_mouse_states
+                    .local_only_icon_tooltip_states
+                    .borrow_mut(),
+                app,
+            ),
+            ToggleState::Enabled,
+            appearance,
+            ui_builder
+                .switch(self.switch_state.clone())
+                .check(*TerminalSettings::as_ref(app).async_find_enabled)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(FeaturesPageAction::ToggleAsyncFind);
+                })
+                .finish(),
+            Some(
+                "Run find on a background thread to keep the UI responsive on large outputs."
+                    .into(),
+            ),
+        )
     }
 }

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -162,6 +162,24 @@ pub(super) fn editor_text_colors(appearance: &Appearance) -> TextColors {
     }
 }
 
+/// Small inline pill rendered next to a settings label to mark a feature as beta.
+/// Used for experimental features (i.e. AsyncFind) that are enabled for Friends of Warp (i.e. Dogfood/Preview) and toggleable by others.
+pub(super) fn render_beta_chip(appearance: &Appearance) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let chip_color = theme.sub_text_color(theme.surface_3()).into_solid();
+    Container::new(
+        Text::new_inline("BETA", appearance.ui_font_family(), 10.)
+            .with_color(chip_color)
+            .finish(),
+    )
+    .with_background(theme.surface_3())
+    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(3.)))
+    .with_horizontal_padding(4.)
+    .with_vertical_padding(1.)
+    .with_margin_left(8.)
+    .finish()
+}
+
 /// Renders a horizontal row of pill-shaped chips for model labels.
 /// Used by custom inference endpoint cards and the remove confirmation dialog.
 pub(super) fn render_model_chips(

--- a/app/src/terminal/find/model.rs
+++ b/app/src/terminal/find/model.rs
@@ -18,7 +18,6 @@ use parking_lot::FairMutex;
 use rich_content::FindableRichContentHandle;
 pub use rich_content::{FindableRichContentView, RichContentMatchId};
 use settings::Setting as _;
-use warp_core::features::FeatureFlag;
 use warpui::{AppContext, Entity, EntityId, ModelContext, SingletonEntity, ViewHandle};
 
 use crate::settings::InputModeSettings;
@@ -28,6 +27,7 @@ use crate::terminal::model::grid::grid_handler::GridHandler;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::terminal_model::BlockIndex;
 use crate::terminal::model::TerminalModel;
+use crate::terminal::settings::TerminalSettings;
 use crate::view_components::find::{FindDirection, FindEvent, FindModel};
 
 /// Pre-computed find data for rendering a single block.
@@ -188,7 +188,7 @@ pub struct TerminalFindModel {
     /// `true` if the find bar is open.
     is_find_bar_open: bool,
 
-    /// Controller for async find operations (used when AsyncFind feature flag is enabled).
+    /// Controller for async find operations.
     pub(crate) async_find_controller: Option<AsyncFindController>,
 }
 
@@ -237,8 +237,8 @@ impl FindModel for TerminalFindModel {
 }
 
 impl TerminalFindModel {
-    pub fn new(terminal_model: Arc<FairMutex<TerminalModel>>) -> Self {
-        let async_find_controller = if FeatureFlag::AsyncFind.is_enabled() {
+    pub fn new(terminal_model: Arc<FairMutex<TerminalModel>>, ctx: &AppContext) -> Self {
+        let async_find_controller = if TerminalSettings::as_ref(ctx).is_async_find_enabled() {
             Some(AsyncFindController::new(terminal_model.clone()))
         } else {
             None

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -19,8 +19,8 @@ use crate::terminal::model::grid::grid_handler::AbsolutePoint;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::terminal_model::{BlockIndex, BlockSortDirection};
 use crate::terminal::model::TerminalModel;
-use crate::view_components::find::FindDirection;
 use crate::test_util::settings::initialize_settings_for_tests;
+use crate::view_components::find::FindDirection;
 
 /// Helper to create an AbsoluteMatch at a given row with default column span.
 fn make_match(row: u64) -> AbsoluteMatch {

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -20,6 +20,7 @@ use crate::terminal::model::index::Point;
 use crate::terminal::model::terminal_model::{BlockIndex, BlockSortDirection};
 use crate::terminal::model::TerminalModel;
 use crate::view_components::find::FindDirection;
+use crate::test_util::settings::initialize_settings_for_tests;
 
 /// Helper to create an AbsoluteMatch at a given row with default column span.
 fn make_match(row: u64) -> AbsoluteMatch {
@@ -43,6 +44,8 @@ fn make_match_at(row: u64, start_col: usize, end_col: usize) -> AbsoluteMatch {
 #[test]
 fn test_async_find_produces_same_results_as_sync_find() {
     App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
         let mut mock_terminal_model = TerminalModel::mock(None, None);
         mock_terminal_model.simulate_block("foobar", "foo\r\nbar\r\n");
         mock_terminal_model.simulate_block("barbaz", "bar baz\r\n");
@@ -66,8 +69,8 @@ fn test_async_find_produces_same_results_as_sync_find() {
         });
 
         // Run async find using TerminalFindModel.
-        let test_model = app.add_model(|_| {
-            let mut model = TerminalFindModel::new(terminal_model.clone());
+        let test_model = app.add_model(|ctx| {
+            let mut model = TerminalFindModel::new(terminal_model.clone(), ctx);
             if model.async_find_controller.is_none() {
                 model.async_find_controller =
                     Some(AsyncFindController::new(terminal_model.clone()));
@@ -170,14 +173,16 @@ fn test_async_find_produces_same_results_as_sync_find() {
 #[test]
 fn test_async_find_cancellation() {
     App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
         let mut mock_terminal_model = TerminalModel::mock(None, None);
         // Create some blocks with content.
         mock_terminal_model.simulate_block("cmd1", "line1\r\nline2\r\n");
         mock_terminal_model.simulate_block("cmd2", "line3\r\nline4\r\n");
 
         let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
-        let test_model = app.add_model(|_| {
-            let mut model = TerminalFindModel::new(terminal_model.clone());
+        let test_model = app.add_model(|ctx| {
+            let mut model = TerminalFindModel::new(terminal_model.clone(), ctx);
             if model.async_find_controller.is_none() {
                 model.async_find_controller =
                     Some(AsyncFindController::new(terminal_model.clone()));
@@ -250,11 +255,13 @@ fn test_async_find_cancellation() {
 #[test]
 fn test_message_processing_updates_state() {
     App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
         let mock_terminal_model = TerminalModel::mock(None, None);
         let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
 
-        let test_model = app.add_model(|_| {
-            let mut model = TerminalFindModel::new(terminal_model.clone());
+        let test_model = app.add_model(|ctx| {
+            let mut model = TerminalFindModel::new(terminal_model.clone(), ctx);
             let mut controller = AsyncFindController::new(terminal_model);
             // Manually set up state as if a find is in progress.
             controller.set_test_status(AsyncFindStatus::Scanning);
@@ -651,6 +658,8 @@ fn test_update_dirty_matches_clear_range() {
 
 fn assert_async_focused_order_matches_sync(block_sort_direction: BlockSortDirection) {
     App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
         let mut mock_terminal_model = TerminalModel::mock(None, None);
         mock_terminal_model.simulate_block(
             "ordtok command old ordtok",
@@ -690,8 +699,8 @@ fn assert_async_focused_order_matches_sync(block_sort_direction: BlockSortDirect
             .collect::<Vec<_>>()
         });
 
-        let test_model = app.add_model(|_| {
-            let mut model = TerminalFindModel::new(terminal_model.clone());
+        let test_model = app.add_model(|ctx| {
+            let mut model = TerminalFindModel::new(terminal_model.clone(), ctx);
             if model.async_find_controller.is_none() {
                 model.async_find_controller =
                     Some(AsyncFindController::new(terminal_model.clone()));

--- a/app/src/terminal/settings.rs
+++ b/app/src/terminal/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use settings::macros::define_settings_group;
 use settings::{RespectUserSyncSetting, SupportedPlatforms, SyncToCloud};
+use warp_core::channel::ChannelState;
 use warp_core::features::FeatureFlag;
 use warpui::units::Pixels;
 use warpui::{AppContext, SingletonEntity};
@@ -134,12 +135,13 @@ define_settings_group!(TerminalSettings, settings: [
         toml_path: "terminal.show_terminal_zero_state_block",
         description: "Whether to show the AI zero-state block in new terminal sessions.",
     },
-    // Opt-in toggle for running terminal find on a background thread. Gated behind
-    // `FeatureFlag::AsyncFind`; use `is_async_find_enabled()` rather than reading this
-    // field directly so the feature flag is always considered.
+    // Toggle for running terminal find on a background thread. Defaults to true on
+    // dogfood channels (Local/Dev) and false on all other channels. Gated behind
+    // `FeatureFlag::AsyncFind`; use `is_async_find_enabled()` rather than reading
+    // this field directly so the feature flag is always considered.
     async_find_enabled: AsyncFindEnabled {
         type: bool,
-        default: false,
+        default: ChannelState::channel().is_dogfood(),
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: false,

--- a/app/src/terminal/settings.rs
+++ b/app/src/terminal/settings.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use settings::macros::define_settings_group;
 use settings::{RespectUserSyncSetting, SupportedPlatforms, SyncToCloud};
-use warp_core::channel::ChannelState;
 use warp_core::features::FeatureFlag;
 use warpui::units::Pixels;
 use warpui::{AppContext, SingletonEntity};
@@ -135,13 +134,12 @@ define_settings_group!(TerminalSettings, settings: [
         toml_path: "terminal.show_terminal_zero_state_block",
         description: "Whether to show the AI zero-state block in new terminal sessions.",
     },
-    // Toggle for running terminal find on a background thread. Defaults to true on
-    // dogfood channels (Local/Dev) and false on all other channels. Gated behind
-    // `FeatureFlag::AsyncFind`; use `is_async_find_enabled()` rather than reading
-    // this field directly so the feature flag is always considered.
+    // Opt-in toggle for running terminal find on a background thread. Only consulted on
+    // channels where `FeatureFlag::AsyncFind` is off; channels with the flag on force the
+    // feature on and hide this toggle. See `is_async_find_enabled` for the composite check.
     async_find_enabled: AsyncFindEnabled {
         type: bool,
-        default: ChannelState::channel().is_dogfood(),
+        default: false,
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: false,
@@ -165,11 +163,11 @@ impl TerminalSettings {
         *self.show_terminal_zero_state_block && AISettings::as_ref(ctx).is_any_ai_enabled(ctx)
     }
 
-    /// Whether asynchronous terminal find should be used. Combines the `AsyncFind`
-    /// feature flag (compile/runtime gate) with the user-facing toggle, so callers
-    /// don't need to remember both checks.
+    /// Whether asynchronous terminal find should be used. On channels where
+    /// `FeatureFlag::AsyncFind` is on, the feature is force-enabled (no toggle shown).
+    /// On other channels, users opt in via the `async_find_enabled` setting.
     pub fn is_async_find_enabled(&self) -> bool {
-        FeatureFlag::AsyncFind.is_enabled() && *self.async_find_enabled
+        FeatureFlag::AsyncFind.is_enabled() || *self.async_find_enabled
     }
 
     /// Spacing for the input box.

--- a/app/src/terminal/settings.rs
+++ b/app/src/terminal/settings.rs
@@ -143,8 +143,8 @@ define_settings_group!(TerminalSettings, settings: [
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: false,
-        toml_path: "terminal.async_find_enabled",
-        description: "Whether terminal find runs asynchronously on a background thread.",
+        toml_path: "experimental.async_find_enabled",
+        description: "Use an improved implementation of find to keep the UI responsive while searching for matches on large outputs.",
     },
 ]);
 

--- a/app/src/terminal/settings.rs
+++ b/app/src/terminal/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use settings::macros::define_settings_group;
 use settings::{RespectUserSyncSetting, SupportedPlatforms, SyncToCloud};
+use warp_core::features::FeatureFlag;
 use warpui::units::Pixels;
 use warpui::{AppContext, SingletonEntity};
 
@@ -133,6 +134,18 @@ define_settings_group!(TerminalSettings, settings: [
         toml_path: "terminal.show_terminal_zero_state_block",
         description: "Whether to show the AI zero-state block in new terminal sessions.",
     },
+    // Opt-in toggle for running terminal find on a background thread. Gated behind
+    // `FeatureFlag::AsyncFind`; use `is_async_find_enabled()` rather than reading this
+    // field directly so the feature flag is always considered.
+    async_find_enabled: AsyncFindEnabled {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "terminal.async_find_enabled",
+        description: "Whether terminal find runs asynchronously on a background thread.",
+    },
 ]);
 
 impl TerminalSettings {
@@ -148,6 +161,13 @@ impl TerminalSettings {
     /// Checks both the user setting and the global AI enablement.
     pub fn should_show_zero_state_block(&self, ctx: &AppContext) -> bool {
         *self.show_terminal_zero_state_block && AISettings::as_ref(ctx).is_any_ai_enabled(ctx)
+    }
+
+    /// Whether asynchronous terminal find should be used. Combines the `AsyncFind`
+    /// feature flag (compile/runtime gate) with the user-facing toggle, so callers
+    /// don't need to remember both checks.
+    pub fn is_async_find_enabled(&self) -> bool {
+        FeatureFlag::AsyncFind.is_enabled() && *self.async_find_enabled
     }
 
     /// Spacing for the input box.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3487,7 +3487,7 @@ impl TerminalView {
             legacy: legacy_passive_suggestions_model,
         };
 
-        let find_model = ctx.add_model(|_| TerminalFindModel::new(model.clone()));
+        let find_model = ctx.add_model(|ctx| TerminalFindModel::new(model.clone(), ctx));
 
         ctx.subscribe_to_model(
             &TerminalSettings::handle(ctx),

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -944,6 +944,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::DragTabsToWindows,
     FeatureFlag::RemoteCodebaseIndexing,
     FeatureFlag::GroupedTabs,
+    FeatureFlag::AsyncFind,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

Surfaces an "Asynchronous find" toggle on the Features settings page so non-dogfood users can opt into this experimental feature, while keeping it force-enabled (no toggle) on dogfood channels.

Behavior by channel:

- **Dogfood (Local/Dev)**: `FeatureFlag::AsyncFind` is in `DOGFOOD_FLAGS`, so the feature is force-enabled and no toggle is shown.
- **Preview/Stable**: the flag is off, so the toggle appears on the Features page with `default: false`. Users opt in via the toggle.

The feature flag itself is the discriminator between these two modes — there's no separate channel-aware default baked into the setting. Promoting the feature through the normal flag-promotion ladder (add to `PREVIEW_FLAGS`, then `RELEASE_FLAGS`) automatically hides the toggle and force-enables the feature; no code changes here required.

On channels where the toggle is visible, a small "BETA" chip is rendered next to the title to signal the experimental nature of the feature, styled to match the `TitleChip` pattern used elsewhere (e.g. MCP server cards).

Concrete changes:

- `crates/warp_features/src/lib.rs`: add `FeatureFlag::AsyncFind` to `DOGFOOD_FLAGS` so the feature is force-on for Local/Dev.
- `app/src/terminal/settings.rs`: add the `async_find_enabled` setting (`terminal.async_find_enabled`) with `default: false`, and a `TerminalSettings::is_async_find_enabled()` helper that returns `FeatureFlag::AsyncFind.is_enabled() || *self.async_find_enabled`.
- `app/src/terminal/find/model.rs`: route the async-find init through `TerminalSettings::is_async_find_enabled()` so callers don't need to track both the flag and the setting.
- `app/src/settings_view/features_page.rs`: add the `AsyncFindWidget` to the Features page, gated by `!FeatureFlag::AsyncFind.is_enabled()` so it only renders on channels where the user can meaningfully toggle. Adds a free `render_beta_chip` helper for the inline "BETA" pill.

## Testing

Confirmed via manual testing on Preview/Stable-like builds (flag off, toggle visible) and dogfood-like builds (flag on, toggle hidden, feature force-enabled).

- [x] I have manually tested my changes locally with `./script/run` — toggle appears with the BETA chip on the Features page when the flag is off, is hidden when the flag is on, and async find engages/disengages with the setting.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: A new, faster implementation of find is now available as an opt-in setting under Features → Asynchronous find. This will help keep the UI responsive on large outputs.