### PR TITLE
Skip run command request when disconnected

### DIFF
--- a/app/src/terminal/model/session/command_executor/remote_server_executor.rs
+++ b/app/src/terminal/model/session/command_executor/remote_server_executor.rs
@@ -23,13 +23,13 @@ use crate::terminal::shell::Shell;
 /// the same underlying channels and transitively keeps them alive as long
 /// as the `Session` is alive.
 ///
-/// If the underlying SSH connection is torn down mid-session,
-/// [`RemoteServerClient::run_command`] will fail naturally and
-/// [`execute_command`] surfaces that as an `Err`. We deliberately do *not*
-/// silently synthesize an empty `Ok(CommandOutput)` for the disconnected
-/// case, because callers (notably the completions/syntax-highlighting
-/// pipeline) treat `Ok(empty)` as "there are zero top-level commands" and
-/// produce incorrect results.
+/// If the underlying SSH connection is torn down mid-session, we short-circuit
+/// so we don't send a `RunCommand` request that is guaranteed to fail.
+///
+/// We deliberately do *not* silently synthesize an empty `Ok(CommandOutput)`
+/// for the disconnected case, because callers (notably the completions /
+/// syntax-highlighting pipeline) treat `Ok(empty)` as "there are zero
+/// top-level commands" and produce incorrect results.
 pub struct RemoteServerCommandExecutor {
     session_id: SessionId,
     client: Arc<RemoteServerClient>,
@@ -61,6 +61,14 @@ impl CommandExecutor for RemoteServerCommandExecutor {
         environment_variables: Option<HashMap<String, String>>,
         _execute_command_options: ExecuteCommandOptions,
     ) -> Result<CommandOutput> {
+        // Short-circuit if client is disconnected.
+        if self.client.is_disconnected() {
+            return Err(anyhow!(
+                "Remote command skipped: client is disconnected (session={:?})",
+                self.session_id
+            ));
+        }
+
         let response = self
             .client
             .run_command(

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -282,6 +282,20 @@ impl RemoteServerClient {
         )
     }
 
+    /// Returns `true` once the reader task has detected that the underlying
+    /// connection is gone (EOF or fatal error). The flag is one-way: a
+    /// client never transitions back to connected, since reconnection
+    /// produces a brand-new client instance.
+    ///
+    /// Callers can use this as a cheap, non-blocking gate to skip work
+    /// that would otherwise fail with [`ClientError::Disconnected`] and
+    /// fire a `RequestFailed` telemetry event. Returning `false` does
+    /// not guarantee the next request will succeed — it just means the
+    /// reader task has not yet observed a disconnect.
+    pub fn is_disconnected(&self) -> bool {
+        self.disconnected.load(Ordering::Acquire)
+    }
+
     /// Sends an `Initialize` request and awaits the `InitializeResponse`.
     pub async fn initialize(
         &self,

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -406,6 +406,24 @@ async fn disconnected_on_closed_stream() {
     // The reader task should detect EOF and emit a Disconnected event.
     let event = disconnect_rx.recv().await.unwrap();
     assert!(matches!(event, ClientEvent::Disconnected));
+
+    // After the Disconnected event has been observed, the reader task has
+    // already stored `true` into the atomic flag (it does the store before
+    // sending the event), so callers can rely on `is_disconnected()` to
+    // short-circuit further requests.
+    assert!(client.is_disconnected());
+}
+
+#[tokio::test]
+async fn is_disconnected_starts_false() {
+    let (client, _disconnect_rx, _executor) = setup_mock_client(|_| {
+        server_message::Message::InitializeResponse(InitializeResponse {
+            server_version: "test-0.1.0".to_string(),
+            host_id: "test-host-id".to_string(),
+        })
+    });
+
+    assert!(!client.is_disconnected());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description
* Context: https://warpdev.slack.com/archives/C0AMRA82ZKL/p1779143889865059
* We're getting a lot of client error related to the run command request failing when the session is disconnected - this pr ensures that we're not sending any run command requests unless the remote server client is actually connected (we reuse the disconnected flag) 

## Testing
Tested manually that the request is not sent + verified the tests pass
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode