### PR TITLE
Style pane header overflow menu

### DIFF
--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -677,6 +677,11 @@ impl<A: Action + Clone> MenuItemFields<A> {
         } else {
             "Maximize pane"
         })
+        .with_icon(if is_maximized {
+            icons::Icon::Minimize
+        } else {
+            icons::Icon::Maximize
+        })
     }
 
     /// Creates a [`MenuItemFields`] where the `on_select_action` is of a

--- a/app/src/pane_group/pane/view/header/mod.rs
+++ b/app/src/pane_group/pane/view/header/mod.rs
@@ -137,7 +137,7 @@ impl<P: BackingView> PaneHeader<P> {
         pane_configuration: ModelHandle<PaneConfiguration>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let overflow_menu = ctx.add_typed_action_view(|_| Menu::new());
+        let overflow_menu = ctx.add_typed_action_view(|_| Menu::new().with_drop_shadow());
         ctx.subscribe_to_view(&overflow_menu, move |me, _, event, ctx| {
             me.handle_overflow_menu_action(event, ctx);
         });

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -677,6 +677,7 @@ impl BackingView for TerminalView {
             if !is_ambient_agent {
                 items.push(
                     MenuItemFields::new("Copy link")
+                        .with_icon(icons::Icon::Link)
                         .with_on_select_action(TerminalAction::CopySharedSessionLink { source })
                         .into_item(),
                 );
@@ -685,6 +686,7 @@ impl BackingView for TerminalView {
             if shared_session_status.is_sharer() {
                 items.push(
                     MenuItemFields::new("Stop sharing session")
+                        .with_icon(icons::Icon::Stop)
                         .with_on_select_action(TerminalAction::StopSharingCurrentSession { source })
                         .into_item(),
                 );
@@ -697,6 +699,7 @@ impl BackingView for TerminalView {
             {
                 items.push(
                     MenuItemFields::new("Open on Desktop")
+                        .with_icon(icons::Icon::Laptop)
                         .with_on_select_action(TerminalAction::OpenSharedSessionOnDesktop {
                             source,
                         })
@@ -708,6 +711,7 @@ impl BackingView for TerminalView {
         {
             items.push(
                 MenuItemFields::new("Share session")
+                    .with_icon(icons::Icon::Share)
                     .with_on_select_action(TerminalAction::OpenShareSessionModal { source })
                     .into_item(),
             );


### PR DESCRIPTION
## Description
- Add the shared menu drop shadow to pane header overflow menus so they match other floating kebab menus.
- Add representative leading icons to pane header overflow actions, including share/link/desktop/stop sharing and maximize/minimize.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `cargo fmt -p warp`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --lib -- -D warnings`
- Computer use launched the local app with `cargo run -- --api-key $STAGING_USER_WARP_API_KEY`, created a split pane, and verified the pane header menu renders leading icons, a separator, dark floating menu styling, hover accent, rounded corners, and a visible drop shadow.
- Note: `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --all-targets --all-features --tests -- -D warnings` was attempted, but failed before checking this change because generated channel config files were missing from `OUT_DIR` (`stable_config.json`, `dev_config.json`, `local_config.json`, `preview_config.json`).

### Screenshots / Videos
Computer-use visual verification completed; no artifact screenshot attached.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/2af1863b-b6a9-4d61-85a9-dccc5304acb0_
_Run: https://oz.staging.warp.dev/runs/019e50f0-01c7-7111-bc1e-e502b9b9a81e_
_This PR was generated with [Oz](https://warp.dev/oz)._
