### PR TITLE
Fix Shift+Backspace deleting a word instead of a character

### DIFF
--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -247,6 +247,7 @@ impl<T: ModeProvider> ToEscapeSequence<T> for KeystrokeWithDetails<'_> {
             .or_else(|| keystroke_to_c0_control_code(keystroke, mode_provider))
             .or_else(|| cursor_movement_keystroke_to_escape_sequence(keystroke, mode_provider))
             .or_else(|| meta_keystroke_to_escape_sequence(keystroke, mode_provider))
+            .or_else(|| special_key_keystroke_to_escape_sequence(keystroke))
     }
 }
 
@@ -590,6 +591,19 @@ fn meta_keystroke_to_escape_sequence(
         Some([&[C0::ESC], bytes].concat())
     } else {
         Some([&[C0::ESC], key.as_bytes()].concat())
+    }
+}
+
+/// Returns the byte sequence for special keys not handled by the encoders above.
+/// Guards against winit on Windows reporting `\x08` (Ctrl+H) for Shift+Backspace,
+/// which readline-style TUIs interpret as `backward-kill-word`. See GH#11342.
+fn special_key_keystroke_to_escape_sequence(keystroke: &Keystroke) -> Option<Vec<u8>> {
+    if keystroke.ctrl || keystroke.alt || keystroke.meta || keystroke.cmd {
+        return None;
+    }
+    match keystroke.key.as_str() {
+        "backspace" => Some(vec![C0::DEL]),
+        _ => None,
     }
 }
 

--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -247,7 +247,7 @@ impl<T: ModeProvider> ToEscapeSequence<T> for KeystrokeWithDetails<'_> {
             .or_else(|| keystroke_to_c0_control_code(keystroke, mode_provider))
             .or_else(|| cursor_movement_keystroke_to_escape_sequence(keystroke, mode_provider))
             .or_else(|| meta_keystroke_to_escape_sequence(keystroke, mode_provider))
-            .or_else(|| special_key_keystroke_to_escape_sequence(keystroke))
+            .or_else(|| backspace_keystroke_to_escape_sequence(keystroke))
     }
 }
 
@@ -594,10 +594,10 @@ fn meta_keystroke_to_escape_sequence(
     }
 }
 
-/// Returns the byte sequence for special keys not handled by the encoders above.
+/// Returns DEL (0x7f) for an unmodified or Shift-only Backspace.
 /// Guards against winit on Windows reporting `\x08` (Ctrl+H) for Shift+Backspace,
 /// which readline-style TUIs interpret as `backward-kill-word`. See GH#11342.
-fn special_key_keystroke_to_escape_sequence(keystroke: &Keystroke) -> Option<Vec<u8>> {
+fn backspace_keystroke_to_escape_sequence(keystroke: &Keystroke) -> Option<Vec<u8>> {
     if keystroke.ctrl || keystroke.alt || keystroke.meta || keystroke.cmd {
         return None;
     }

--- a/crates/warp_terminal/src/model/escape_sequences_tests.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_tests.rs
@@ -58,6 +58,19 @@ fn test_keystroke_to_c0_control_code() {
 }
 
 #[test]
+fn test_shift_backspace_emits_del_sequence() {
+    // Regression test: Shift+Backspace must emit DEL (0x7f), not BS (0x08).
+    // 0x08 is Ctrl+H, which readline-style TUIs interpret as backward-kill-word.
+    let test_cases: &[(Keystroke, Vec<u8>)] = &[
+        (Keystroke::parse("backspace").unwrap(), vec![C0::DEL]),
+        (Keystroke::parse("shift-backspace").unwrap(), vec![C0::DEL]),
+    ];
+
+    let terminal_model_mock = TerminalModelMock::new();
+    validate_keystroke_test_cases(test_cases, &terminal_model_mock);
+}
+
+#[test]
 fn test_mouse_actions_to_escape_sequence() {
     // Validating we produce the correct escape sequences.
     let test_cases: &[(MouseState, Vec<u8>)] = &[


### PR DESCRIPTION
## Description

On Windows, Shift+Backspace in TUIs running inside Warp (Claude Code, fish, ipython, psql, etc.) deletes an entire word instead of a single character. Root cause: `winit`'s `text_with_all_modifiers()` returns `0x08` (Ctrl+H) for Shift+Backspace on Windows, which readline-style line editors universally bind to `backward-kill-word`. Every other terminal tested on Windows (WezTerm, Windows Terminal, vanilla PowerShell, bash) emits `0x7f` (DEL) for both plain and Shift+Backspace.

Fix adds a fallback to `to_escape_sequence` in `crates/warp_terminal/src/model/escape_sequences.rs` that emits DEL for `backspace` when no earlier branch in the chain claims it. Guarded to unmodified or shift-only keystrokes so Ctrl/Alt/Cmd+Backspace continue to flow through their existing paths untouched.

## Linked Issue

Fixes #11342

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots are included below.

## Testing

Added regression test `test_shift_backspace_emits_del_sequence` in `escape_sequences_tests.rs` asserting both `backspace` and `shift-backspace` keystrokes produce `vec![C0::DEL]` via `to_escape_sequence`. Before the fix, both fail (the chain returns `None` and the caller falls back to OS-provided chars, which is `0x08` for Shift+Backspace on Windows). After the fix, both pass.

Byte-level evidence captured before opening this PR (script + outputs in #11342):

- Warp before fix: Backspace → `0x7f`, Shift+Backspace → `0x08`
- Warp after fix: Backspace → `0x7f`, Shift+Backspace → `0x7f`
- WezTerm (same machine, same OS): `0x7f` for both, matching the new Warp behavior

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

**Before the fix:**

<img width="1194" height="803" alt="warp-bugtest-bug-01" src="https://github.com/user-attachments/assets/21fe940a-4445-4e7d-8a81-3875bed569f8" />

**Holding shift and pressing backspace:**
<img width="1192" height="803" alt="warp-bugtest-bug-01 1" src="https://github.com/user-attachments/assets/ccf068be-6e97-434d-b01f-7bbaa2a2b92c" />


**After the fix:**
<img width="1282" height="800" alt="warp-bugtest-01-fix" src="https://github.com/user-attachments/assets/24a43eea-9a37-4e2c-9b0f-1793de8c44f1" />

**Holding shift and pressing backspace:**
<img width="1280" height="798" alt="warp-bugtest-01 1-fix" src="https://github.com/user-attachments/assets/dc1beec5-bbc4-4a28-9227-0c1da3de765d" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix Shift+Backspace deleting a whole word instead of one character on Windows
