### PR TITLE
Banner for remote server disconnect

### DIFF
--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -2456,9 +2456,10 @@ pub fn render_unsaved_changes_banner(
 
 /// Renders a banner indicating that the remote SSH session is disconnected
 /// and save / auto-reload are unavailable.
-fn render_remote_disconnected_banner(appearance: &Appearance) -> Box<dyn Element> {
+pub fn render_remote_disconnected_banner(appearance: &Appearance) -> Box<dyn Element> {
     let row = Flex::row()
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_main_axis_size(MainAxisSize::Max)
         .with_child(
             Container::new(
                 ConstrainedBox::new(
@@ -2477,7 +2478,7 @@ fn render_remote_disconnected_banner(appearance: &Appearance) -> Box<dyn Element
             Shrinkable::new(
                 1.,
                 Text::new(
-                    "Remote session disconnected. Save and auto-reload are unavailable.",
+                    "Remote host disconnected. You will not be able to see updates and save changes.",
                     appearance.ui_font_family(),
                     appearance.ui_font_size(),
                 )
@@ -2491,8 +2492,8 @@ fn render_remote_disconnected_banner(appearance: &Appearance) -> Box<dyn Element
 
     Container::new(row)
         .with_background(appearance.theme().text_selection_as_context_color())
-        .with_padding_top(4.)
-        .with_padding_bottom(4.)
+        .with_padding_top(8.)
+        .with_padding_bottom(8.)
         .with_padding_left(12.)
         .with_padding_right(12.)
         .finish()

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -2149,41 +2149,44 @@ impl View for LocalCodeEditorView {
 
     fn render(&self, app: &AppContext) -> Box<dyn warpui::Element> {
         // Rendering the remote disconnection banner or version conflict banner.
-        let base: Box<dyn Element> = if self.is_remote_disconnected(app) {
-            let appearance = Appearance::as_ref(app);
-            let banner = render_remote_disconnected_banner(appearance);
-            let mut col = Flex::column().with_child(banner);
+        // Only show the disconnection banner if the file was successfully loaded;
+        // if it never loaded, the error/loading state handles that.
+        let base: Box<dyn Element> =
+            if self.base_content_version.is_some() && self.is_remote_disconnected(app) {
+                let appearance = Appearance::as_ref(app);
+                let banner = render_remote_disconnected_banner(appearance);
+                let mut col = Flex::column().with_child(banner);
 
-            let editor_view = ChildView::new(&self.editor).finish();
-            if self.editor.as_ref(app).needs_vertical_constraint() {
-                col.add_child(Shrinkable::new(1., editor_view).finish());
-            } else {
-                col.add_child(editor_view);
-            }
-            col.finish()
-        } else if self.has_version_conflicts(app) {
-            let appearance = Appearance::as_ref(app);
-            let banner = render_unsaved_changes_banner(
-                appearance,
-                self.conflict_banner_mouse_states
-                    .discard_mouse_state
-                    .clone(),
-                self.conflict_banner_mouse_states
-                    .overwrite_mouse_state
-                    .clone(),
-            );
-            let mut col = Flex::column().with_child(banner);
+                let editor_view = ChildView::new(&self.editor).finish();
+                if self.editor.as_ref(app).needs_vertical_constraint() {
+                    col.add_child(Shrinkable::new(1., editor_view).finish());
+                } else {
+                    col.add_child(editor_view);
+                }
+                col.finish()
+            } else if self.has_version_conflicts(app) {
+                let appearance = Appearance::as_ref(app);
+                let banner = render_unsaved_changes_banner(
+                    appearance,
+                    self.conflict_banner_mouse_states
+                        .discard_mouse_state
+                        .clone(),
+                    self.conflict_banner_mouse_states
+                        .overwrite_mouse_state
+                        .clone(),
+                );
+                let mut col = Flex::column().with_child(banner);
 
-            let editor_view = ChildView::new(&self.editor).finish();
-            if self.editor.as_ref(app).needs_vertical_constraint() {
-                col.add_child(Shrinkable::new(1., editor_view).finish());
+                let editor_view = ChildView::new(&self.editor).finish();
+                if self.editor.as_ref(app).needs_vertical_constraint() {
+                    col.add_child(Shrinkable::new(1., editor_view).finish());
+                } else {
+                    col.add_child(editor_view);
+                }
+                col.finish()
             } else {
-                col.add_child(editor_view);
-            }
-            col.finish()
-        } else {
-            ChildView::new(&self.editor).finish()
-        };
+                ChildView::new(&self.editor).finish()
+            };
 
         let base_with_handler =
             Hoverable::new(self.context_menu_state.mouse_state.clone(), |_| base)

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -56,6 +56,8 @@ use warpui::{
     ViewHandle, WindowId,
 };
 
+use remote_server::manager::RemoteServerManager;
+
 use crate::ai::persisted_workspace::{PersistedWorkspace, PersistedWorkspaceEvent};
 use crate::code::buffer_location::LocalOrRemotePath as BufferFileLocation;
 use crate::code::editor::model::HoverableLink;
@@ -1580,10 +1582,28 @@ impl LocalCodeEditorView {
         self.has_unsaved_changes(app)
             && self.base_content_version != GlobalBufferModel::as_ref(app).base_version(file_id)
     }
+
+    /// Returns `true` when this editor is backed by a remote file whose
+    /// host no longer has any connected session. Derived on-the-fly from
+    /// `RemoteServerManager` so it is always in sync with actual
+    /// connection state.
+    pub fn is_remote_disconnected(&self, app: &AppContext) -> bool {
+        let Some(BufferFileLocation::Remote(remote_path)) = self.file_location() else {
+            return false;
+        };
+        RemoteServerManager::as_ref(app)
+            .client_for_host(&remote_path.host_id)
+            .is_none()
+    }
+
     /// Save the file to the local file system (or remotely via the remote server).
     /// This will only return an error immediately if there is a failure in the sync part of the call.
     /// Other errors could be returned asynchronously via the FileModelEvent::FailedToSave event.
     pub fn save_local(&mut self, ctx: &mut ViewContext<Self>) -> Result<(), ImmediateSaveError> {
+        if self.is_remote_disconnected(ctx) {
+            return Err(ImmediateSaveError::RemoteDisconnected);
+        }
+
         let Some(file_id) = self.file_id() else {
             return Err(ImmediateSaveError::NoFileId);
         };
@@ -2128,8 +2148,20 @@ impl View for LocalCodeEditorView {
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn warpui::Element> {
-        // Rendering the version conflict banner.
-        let base: Box<dyn Element> = if self.has_version_conflicts(app) {
+        // Rendering the remote disconnection banner or version conflict banner.
+        let base: Box<dyn Element> = if self.is_remote_disconnected(app) {
+            let appearance = Appearance::as_ref(app);
+            let banner = render_remote_disconnected_banner(appearance);
+            let mut col = Flex::column().with_child(banner);
+
+            let editor_view = ChildView::new(&self.editor).finish();
+            if self.editor.as_ref(app).needs_vertical_constraint() {
+                col.add_child(Shrinkable::new(1., editor_view).finish());
+            } else {
+                col.add_child(editor_view);
+            }
+            col.finish()
+        } else if self.has_version_conflicts(app) {
             let appearance = Appearance::as_ref(app);
             let banner = render_unsaved_changes_banner(
                 appearance,
@@ -2420,6 +2452,50 @@ pub fn render_unsaved_changes_banner(
     .with_padding_left(12.)
     .with_padding_right(12.)
     .finish()
+}
+
+/// Renders a banner indicating that the remote SSH session is disconnected
+/// and save / auto-reload are unavailable.
+fn render_remote_disconnected_banner(appearance: &Appearance) -> Box<dyn Element> {
+    let row = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(
+            Container::new(
+                ConstrainedBox::new(
+                    Icon::Warning
+                        .to_warpui_icon(appearance.theme().active_ui_text_color())
+                        .finish(),
+                )
+                .with_height(16.)
+                .with_width(16.)
+                .finish(),
+            )
+            .with_margin_right(8.)
+            .finish(),
+        )
+        .with_child(
+            Shrinkable::new(
+                1.,
+                Text::new(
+                    "Remote session disconnected. Save and auto-reload are unavailable.",
+                    appearance.ui_font_family(),
+                    appearance.ui_font_size(),
+                )
+                .with_color(appearance.theme().active_ui_text_color().into())
+                .soft_wrap(true)
+                .finish(),
+            )
+            .finish(),
+        )
+        .finish();
+
+    Container::new(row)
+        .with_background(appearance.theme().text_selection_as_context_color())
+        .with_padding_top(4.)
+        .with_padding_bottom(4.)
+        .with_padding_left(12.)
+        .with_padding_right(12.)
+        .finish()
 }
 
 /// Renders a small yellow circle with tooltip indicating unsaved changes

--- a/app/src/code/mod.rs
+++ b/app/src/code/mod.rs
@@ -37,6 +37,8 @@ pub enum ImmediateSaveError {
     FailedToSave(#[from] FileSaveError),
     #[error("There is no file tab currently selected")]
     NoActiveFileTab,
+    #[error("Remote session disconnected")]
+    RemoteDisconnected,
 }
 
 /// Trait to determine whether we should show the comment editor based on state held

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -935,15 +935,11 @@ impl CodeView {
         });
     }
 
-    fn display_remote_disconnected_save_failure(
-        window_id: WindowId,
-        ctx: &mut ViewContext<Self>,
-    ) {
+    fn display_remote_disconnected_save_failure(window_id: WindowId, ctx: &mut ViewContext<Self>) {
         ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-            let toast = DismissibleToast::error(String::from(
-                "Cannot save — remote session disconnected.",
-            ))
-            .with_object_id("failed_to_save_file_remote_disconnected".to_string());
+            let toast =
+                DismissibleToast::error(String::from("Cannot save — remote session disconnected."))
+                    .with_object_id("failed_to_save_file_remote_disconnected".to_string());
             toast_stack.add_ephemeral_toast(toast, window_id, ctx);
         });
     }

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -863,6 +863,14 @@ impl CodeView {
                 // If there's no file ID, this is a new file - trigger Save As
                 self.save_as(index, callback, ctx)
             }
+            Err(ImmediateSaveError::RemoteDisconnected) => {
+                log::warn!("Cannot save: remote session disconnected");
+                CodeView::display_remote_disconnected_save_failure(ctx.window_id(), ctx);
+                if let Some(callback) = callback {
+                    callback(SaveOutcome::Failed, self, ctx);
+                }
+                SaveStatus::Failed(ImmediateSaveError::RemoteDisconnected)
+            }
             Err(err) => {
                 log::warn!("Failed to save file. {err:?}");
                 CodeView::display_save_failure(ctx.window_id(), ctx);
@@ -923,6 +931,19 @@ impl CodeView {
         ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
             let toast = DismissibleToast::error(String::from("Failed to save file."))
                 .with_object_id("failed_to_save_file".to_string());
+            toast_stack.add_ephemeral_toast(toast, window_id, ctx);
+        });
+    }
+
+    fn display_remote_disconnected_save_failure(
+        window_id: WindowId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            let toast = DismissibleToast::error(String::from(
+                "Cannot save — remote session disconnected.",
+            ))
+            .with_object_id("failed_to_save_file_remote_disconnected".to_string());
             toast_stack.add_ephemeral_toast(toast, window_id, ctx);
         });
     }

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -29,6 +29,7 @@ use warpui::{
     ViewHandle,
 };
 
+#[cfg(not(target_family = "wasm"))]
 use remote_server::manager::RemoteServerManager;
 
 use super::context_menu::{show_rich_editor_context_menu, ContextMenuAction, ContextMenuState};

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -936,7 +936,7 @@ impl FileNotebookView {
             FileState::Loaded(_) => ChildView::new(&self.editor).finish(),
         };
 
-        if self.is_remote_disconnected(app) {
+        if matches!(self.file_state, FileState::Loaded(_)) && self.is_remote_disconnected(app) {
             let banner =
                 crate::code::local_code_editor::render_remote_disconnected_banner(appearance);
             let mut col = Flex::column();

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -952,16 +952,17 @@ impl FileNotebookView {
             FileState::Loaded(_) => ChildView::new(&self.editor).finish(),
         };
 
+        #[cfg(not(target_family = "wasm"))]
         if matches!(self.file_state, FileState::Loaded(_)) && self.is_remote_disconnected(app) {
             let banner =
                 crate::code::local_code_editor::render_remote_disconnected_banner(appearance);
             let mut col = Flex::column();
             col.add_child(banner);
             col.add_child(Shrinkable::new(1., styles::wrap_body(body)).finish());
-            col.finish()
-        } else {
-            styles::wrap_body(body)
+            return col.finish();
         }
+
+        styles::wrap_body(body)
     }
 }
 

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -935,6 +935,7 @@ impl FileNotebookView {
 
     /// Returns `true` when this notebook is backed by a remote file whose
     /// host no longer has any connected session.
+    #[cfg(not(target_family = "wasm"))]
     fn is_remote_disconnected(&self, app: &AppContext) -> bool {
         let Some(LocalOrRemotePath::Remote(remote_path)) = self.file_state.path() else {
             return false;
@@ -944,7 +945,7 @@ impl FileNotebookView {
             .is_none()
     }
 
-    fn render_body(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
+    fn render_body(&self, appearance: &Appearance, _app: &AppContext) -> Box<dyn Element> {
         let body = match &self.file_state {
             FileState::NoFile => self.render_no_file(appearance),
             FileState::Loading(source) => self.render_loading(source, appearance),
@@ -953,7 +954,7 @@ impl FileNotebookView {
         };
 
         #[cfg(not(target_family = "wasm"))]
-        if matches!(self.file_state, FileState::Loaded(_)) && self.is_remote_disconnected(app) {
+        if matches!(self.file_state, FileState::Loaded(_)) && self.is_remote_disconnected(_app) {
             let banner =
                 crate::code::local_code_editor::render_remote_disconnected_banner(appearance);
             let mut col = Flex::column();

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -591,6 +591,22 @@ impl FileNotebookView {
 
         let host_id = remote_path.host_id.clone();
         let manager = remote_server::manager::RemoteServerManager::handle(ctx);
+
+        // Subscribe to host connect/disconnect events so the disconnection
+        // banner appears/disappears when the remote session state changes.
+        let watched_host_id = host_id.clone();
+        ctx.subscribe_to_model(&manager, move |_me, _handle, event, ctx| {
+            use remote_server::manager::RemoteServerManagerEvent;
+            match event {
+                RemoteServerManagerEvent::HostDisconnected { host_id }
+                | RemoteServerManagerEvent::HostConnected { host_id }
+                    if *host_id == watched_host_id =>
+                {
+                    ctx.notify();
+                }
+                _ => {}
+            }
+        });
         let client = manager.as_ref(ctx).client_for_host(&host_id).cloned();
 
         let Some(client) = client else {

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -29,6 +29,8 @@ use warpui::{
     ViewHandle,
 };
 
+use remote_server::manager::RemoteServerManager;
+
 use super::context_menu::{show_rich_editor_context_menu, ContextMenuAction, ContextMenuState};
 use super::editor::view::{EditorViewEvent, RichTextEditorConfig, RichTextEditorView};
 use super::link::{NotebookLinks, SessionSource};
@@ -915,14 +917,35 @@ impl FileNotebookView {
         .finish()
     }
 
-    fn render_body(&self, appearance: &Appearance) -> Box<dyn Element> {
+    /// Returns `true` when this notebook is backed by a remote file whose
+    /// host no longer has any connected session.
+    fn is_remote_disconnected(&self, app: &AppContext) -> bool {
+        let Some(LocalOrRemotePath::Remote(remote_path)) = self.file_state.path() else {
+            return false;
+        };
+        RemoteServerManager::as_ref(app)
+            .client_for_host(&remote_path.host_id)
+            .is_none()
+    }
+
+    fn render_body(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let body = match &self.file_state {
             FileState::NoFile => self.render_no_file(appearance),
             FileState::Loading(source) => self.render_loading(source, appearance),
             FileState::Error(source) => self.render_error(source, appearance),
             FileState::Loaded(_) => ChildView::new(&self.editor).finish(),
         };
-        styles::wrap_body(body)
+
+        if self.is_remote_disconnected(app) {
+            let banner =
+                crate::code::local_code_editor::render_remote_disconnected_banner(appearance);
+            let mut col = Flex::column();
+            col.add_child(banner);
+            col.add_child(Shrinkable::new(1., styles::wrap_body(body)).finish());
+            col.finish()
+        } else {
+            styles::wrap_body(body)
+        }
     }
 }
 
@@ -948,7 +971,7 @@ impl View for FileNotebookView {
 
         let column = Flex::column().with_children([
             self.render_title(appearance, font_settings),
-            Shrinkable::new(1., self.render_body(appearance)).finish(),
+            Shrinkable::new(1., self.render_body(appearance, app)).finish(),
         ]);
 
         let mut stack = Stack::new().with_child(column.finish());


### PR DESCRIPTION
## Summary
When a remote SSH session disconnects while a code editor or file notebook pane is open, the pane silently becomes stale — save fails, auto-reload stops, and there is no visual indication. This PR adds a disconnection banner and save guard.

## Changes
- **Disconnection banner** — Shows "Remote host disconnected. You will not be able to see updates and save changes." above the editor/notebook content when the remote host loses connection. The banner auto-dismisses on reconnection.
- **Save guard** — `save_local()` immediately returns `ImmediateSaveError::RemoteDisconnected` when the host is disconnected, with a specific toast message ("Cannot save — remote session disconnected.").
- **On-the-fly state derivation** — No stored boolean; `is_remote_disconnected()` checks `RemoteServerManager::client_for_host()` each render, so it is always in sync.
- **File notebook support** — `FileNotebookView` subscribes to `HostDisconnected`/`HostConnected` events to trigger re-renders.
- **Loaded-only gating** — Banner only appears if the file was successfully loaded; error/loading states handle the "never loaded" case.

## Files Changed
- `app/src/code/mod.rs` — Added `ImmediateSaveError::RemoteDisconnected` variant
- `app/src/code/local_code_editor.rs` — `is_remote_disconnected()`, save guard, render banner, `render_remote_disconnected_banner()`
- `app/src/code/view.rs` — Specific toast + error handling for `RemoteDisconnected`
- `app/src/notebooks/file/mod.rs` — `is_remote_disconnected()`, render banner, subscribe to `RemoteServerManager` events

## Conversation
https://staging.warp.dev/conversation/bab4762c-633a-40a3-9258-4a0752b608e1

## Plan
https://staging.warp.dev/drive/notebook/VqsXi9GmQ7EW1TnCJ9jlOp

## Demo
https://www.loom.com/share/f0bab2f11c4047609bf1b318827af0ec