### PR TITLE
Daemon startup latency telemetry

### DIFF
--- a/app/src/remote_server/unix/mod.rs
+++ b/app/src/remote_server/unix/mod.rs
@@ -17,8 +17,10 @@ use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 
 use warpui::r#async::executor;
+use warpui::SingletonEntity;
 
 use super::server_model::{ConnectionId, ServerModel};
+use crate::{send_telemetry_from_app_ctx, TelemetryEvent};
 
 /// Run the `remote-server-daemon` subcommand.
 ///
@@ -68,6 +70,27 @@ pub(crate) fn launch_daemon(identity_key: &str, ctx: &mut warpui::AppContext) {
     let _ = std::fs::set_permissions(&socket_path, Permissions::from_mode(0o600));
     listener.set_nonblocking(true).ok();
     log::info!("Daemon bound to {}", socket_path.display());
+
+    // Flush the accumulated IntervalTimer data as telemetry now that the
+    // daemon is ready to accept connections. The timer was created in
+    // `run_internal` and carries intervals from the full startup path
+    // (logging, SQLite, singleton models, etc.).
+    //
+    // All telemetry dependencies are ready at this point:
+    // `AppTelemetryContextProvider` and `AuthStateProvider` are
+    // registered during `initialize_app` (before `launch` calls us),
+    // and `TelemetryCollector` is already running its periodic flush.
+    // The flush sends directly to Rudderstack using a baked-in write
+    // key — no user auth token is required.
+    let timing_data =
+        warp_core::interval_timer::IntervalTimer::handle(ctx).update(ctx, |timer, _| {
+            timer.mark_interval_end("DAEMON_SOCKET_BOUND");
+            timer.compute_stats()
+        });
+    send_telemetry_from_app_ctx!(
+        TelemetryEvent::RemoteServerDaemonStartup { timing_data },
+        ctx
+    );
 
     let _ = std::fs::write(&pid_path, std::process::id().to_string());
 

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -2879,6 +2879,14 @@ pub enum TelemetryEvent {
         remote_os: Option<String>,
         remote_arch: Option<String>,
     },
+    /// Emitted when the remote server daemon process finishes startup and
+    /// binds its Unix domain socket.  Reports the same `IntervalTimer`
+    /// data that `AppStartup` reports for the GUI, but from the headless
+    /// daemon process on the remote host.  Only emitted on success — if
+    /// the daemon crashes before binding, no event is sent.
+    RemoteServerDaemonStartup {
+        timing_data: Vec<warp_core::interval_timer::TimingDataPoint>,
+    },
     /// Emitted when all reconnection attempts are exhausted.
     RemoteServerReconnectExhausted {
         attempts: u32,
@@ -4320,6 +4328,9 @@ impl TelemetryEvent {
                 "remote_os": remote_os,
                 "remote_arch": remote_arch,
             })),
+            TelemetryEvent::RemoteServerDaemonStartup { timing_data } => {
+                Some(json!({ "timing_data": timing_data }))
+            }
             TelemetryEvent::RemoteServerSetupDuration {
                 duration_ms,
                 installed_binary,
@@ -5183,6 +5194,7 @@ impl TelemetryEvent {
             | TelemetryEvent::RemoteServerBinaryCheck { .. }
             | TelemetryEvent::RemoteServerInstallation { .. }
             | TelemetryEvent::RemoteServerInitialization { .. }
+            | TelemetryEvent::RemoteServerDaemonStartup { .. }
             | TelemetryEvent::RemoteServerDisconnection { .. }
             | TelemetryEvent::RemoteServerClientRequestError { .. }
             | TelemetryEvent::RemoteServerMessageDecodingError { .. }
@@ -5756,6 +5768,7 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::RemoteServerBinaryCheck
             | Self::RemoteServerInstallation
             | Self::RemoteServerInitialization
+            | Self::RemoteServerDaemonStartup
             | Self::RemoteServerDisconnection
             | Self::RemoteServerClientRequestError
             | Self::RemoteServerMessageDecodingError
@@ -6169,6 +6182,7 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::RemoteServerBinaryCheck => "RemoteServer.BinaryCheck",
             Self::RemoteServerInstallation => "RemoteServer.Installation",
             Self::RemoteServerInitialization => "RemoteServer.Initialization",
+            Self::RemoteServerDaemonStartup => "RemoteServer.DaemonStartup",
             Self::RemoteServerDisconnection => "RemoteServer.Disconnection",
             Self::RemoteServerClientRequestError => "RemoteServer.ClientRequestError",
             Self::RemoteServerMessageDecodingError => "RemoteServer.MessageDecodingError",
@@ -7213,6 +7227,9 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             }
             Self::RemoteServerInitialization => {
                 "Remote server connection and initialization completed (success or failure)"
+            }
+            Self::RemoteServerDaemonStartup => {
+                "Remote server daemon startup completed and socket bound"
             }
             Self::RemoteServerDisconnection => {
                 "An established remote server connection was dropped"


### PR DESCRIPTION
## Description

The remote server daemon goes through the full `run_internal` → `initialize_app` → `launch` path before binding its Unix socket. The `IntervalTimer` records interval markers (`LOG_FILE_SETUP_COMPLETE`, `SQLITE_INITIALIZED`, `SINGLETON_MODELS_REGISTERED`, etc.) throughout this path, but the timing data was **never emitted** — `AppStartup` is only sent inside `ctx.on_first_frame_drawn()`, which never fires for headless processes like the daemon.

This means we have zero visibility into whether daemon socket timeouts (the #1 remote server initialization error) are caused by slow cold starts, silent crashes, or NFS bind failures.

**Changes:**
- Add a `RemoteServerDaemonStartup` telemetry event that carries the same `IntervalTimer` timing data as `AppStartup`
- Emit it from `launch_daemon` after the Unix socket is successfully bound, with a final `DAEMON_SOCKET_BOUND` interval marker
- Telemetry sends directly to Rudderstack using the baked-in write key — no user auth token required

## Linked Issue
- Part of remote server initialization error triage

## Testing
- [x] `cargo fmt` passes
- [x] `cargo clippy -p warp --all-targets --all-features --tests -- -D warnings` passes
- Telemetry emission is on the existing `send_telemetry_from_app_ctx!` path used by all other remote server events — no new networking or auth code

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->