### PR TITLE
Skip SSE reconnect when watched run_id set is unchanged

### DIFF
--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -56,6 +56,9 @@ struct SseConnectionState {
     generation: u64,
     /// Abort handle for the spawned SSE driver task, used to cancel on teardown.
     abort_handle: futures::future::AbortHandle,
+    /// Snapshot of `watched_run_ids` at the time this connection was opened;
+    /// compared in `reevaluate_eligibility` to skip same-set reconnects.
+    connected_run_ids: HashSet<String>,
 }
 
 struct SseForwardingConsumer {
@@ -1038,10 +1041,12 @@ impl OrchestrationEventStreamer {
         match (eligible, connected) {
             (true, false) => self.start_sse_connection(conversation_id, ctx),
             (true, true) => {
-                // Already connected; reconnect with the current run_ids
-                // list (in case the parent role's contribution
-                // changed).
-                self.reconnect_sse(conversation_id, ctx);
+                // Status / metadata updates fire `reevaluate_eligibility` on
+                // every exchange transition; only reconnect when the run-id
+                // filter actually changed.
+                if self.watched_run_ids_differ_from_connected(conversation_id) {
+                    self.reconnect_sse(conversation_id, ctx);
+                }
             }
             (false, true) => self.teardown_sse(conversation_id, ctx),
             (false, false) => {}
@@ -1255,15 +1260,29 @@ impl OrchestrationEventStreamer {
             },
         );
 
+        let connected_run_ids: HashSet<String> = run_ids.iter().cloned().collect();
         let stream = self.streams.entry(conversation_id).or_default();
         stream.sse_connection = Some(SseConnectionState {
             event_receiver: rx,
             generation,
             abort_handle: handle.abort_handle(),
+            connected_run_ids,
         });
 
         // Start periodic event drain.
         self.start_sse_drain_timer(conversation_id, generation, ctx);
+    }
+
+    /// True iff the open SSE's recorded run-id set is stale relative to the
+    /// conversation's current `watched_run_ids`.
+    fn watched_run_ids_differ_from_connected(&self, conversation_id: AIConversationId) -> bool {
+        let Some(stream) = self.streams.get(&conversation_id) else {
+            return false;
+        };
+        let Some(connection) = stream.sse_connection.as_ref() else {
+            return false;
+        };
+        stream.watched_run_ids != connection.connected_run_ids
     }
 
     /// Periodically fires to drain buffered SSE events into the event

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -4,7 +4,7 @@ use mockall::predicate::eq;
 use warpui::App;
 
 use super::*;
-use crate::ai::agent::conversation::AIConversation;
+use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent_events::{
     agent_event_backoff, agent_event_failures_exceeded_threshold, AgentEventConsumerControlFlow,
     DEFAULT_AGENT_EVENT_RECONNECT_BACKOFF_STEPS,
@@ -1227,6 +1227,85 @@ fn on_conversation_removed_prunes_killed_child_run_id_from_parent_but_keeps_tomb
 }
 
 #[test]
+fn reevaluate_eligibility_does_not_reconnect_when_watched_run_ids_unchanged() {
+    App::test((), |mut app| async move {
+        let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440401";
+        let child_run_id = "550e8400-e29b-41d4-a716-446655440402";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+            model.update_conversation_status(
+                terminal_view_id,
+                conversation_id,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+        });
+
+        let mock = MockAIClient::new();
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+
+        let poller = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
+        });
+
+        // Open SSE (gen 0) with watched set == connected snapshot.
+        let (_, rx) = futures::channel::mpsc::unbounded::<SseStreamItem>();
+        let consumer_id = warpui::EntityId::new();
+        poller.update(&mut app, |me, _| {
+            let stream = me.streams.entry(conversation_id).or_default();
+            stream.event_cursor = 0;
+            stream.watched_run_ids.insert(own_run_id.to_string());
+            stream.watched_run_ids.insert(child_run_id.to_string());
+            stream.consumers.insert(consumer_id);
+            let (abort_handle, _) = futures::future::AbortHandle::new_pair();
+            let mut connected_run_ids = HashSet::new();
+            connected_run_ids.insert(own_run_id.to_string());
+            connected_run_ids.insert(child_run_id.to_string());
+            stream.sse_connection = Some(SseConnectionState {
+                event_receiver: rx,
+                generation: 0,
+                abort_handle,
+                connected_run_ids,
+            });
+            me.next_sse_generation = 1;
+        });
+
+        // Fire a status transition; should reach `reevaluate_eligibility`
+        // (true, true) without changing the run_id set.
+        history_model.update(&mut app, |model, ctx| {
+            model.update_conversation_status(
+                terminal_view_id,
+                conversation_id,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        poller.read(&app, |me, _| {
+            let generation = me
+                .streams
+                .get(&conversation_id)
+                .and_then(|s| s.sse_connection.as_ref())
+                .map(|c| c.generation);
+            assert_eq!(
+                generation,
+                Some(0),
+                "SSE must not reconnect when watched_run_ids is unchanged; got generation={generation:?}"
+            );
+        });
+    });
+}
+
+#[test]
 fn finish_restore_fetch_reconnects_sse_when_children_added_to_open_connection() {
     // When a status transition races with the restore fetch and opens SSE
     // before children are known, finish_restore_fetch must reconnect SSE
@@ -1282,10 +1361,13 @@ fn finish_restore_fetch_reconnects_sse_when_children_added_to_open_connection() 
             stream.watched_run_ids.insert(own_run_id.to_string());
             stream.consumers.insert(consumer_id);
             let (abort_handle, _) = futures::future::AbortHandle::new_pair();
+            let mut connected_run_ids = HashSet::new();
+            connected_run_ids.insert(own_run_id.to_string());
             stream.sse_connection = Some(SseConnectionState {
                 event_receiver: rx,
                 generation: 0,
                 abort_handle,
+                connected_run_ids,
             });
             me.next_sse_generation = 1;
         });


### PR DESCRIPTION
## Description
The orchestration SSE connection was being torn down and re-opened on every status transition (Idle → InProgress → Success/Cancelled/Error), even when the underlying run-id filter hadn't changed. This caused unnecessary connection churn on every exchange.

This change tracks the run-id set associated with each open SSE connection and only reconnects when that set actually changes.

## Testing
- Added a regression test asserting the SSE generation does not advance across a same-set re-evaluation.
- All \`orchestration_event_streamer\` tests pass.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Stop tearing down and re-opening the orchestration SSE connection on every exchange's status transitions.