### PR TITLE
Use new queued prompt panel for /compact-and and /fork-and-compact

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -49,7 +49,7 @@ use crate::ai::agent::linearization::compute_task_depths;
 use crate::ai::agent::todos::AIAgentTodoList;
 use crate::ai::agent::{
     AIAgentOutputMessage, AIAgentOutputMessageType, AIIdentifiers, CancellationReason,
-    MessageToAIAgentOutputMessageError,
+    MessageToAIAgentOutputMessageError, SummarizationType,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::artifacts::Artifact;
@@ -646,6 +646,26 @@ impl AIConversation {
 
     pub fn was_summarized(&self) -> bool {
         self.conversation_usage_metadata.was_summarized
+    }
+
+    /// Returns true if the conversation is currently being summarized.
+    pub fn is_summarizing(&self) -> bool {
+        let Some(exchange) = self.latest_visible_exchange() else {
+            return false;
+        };
+        let Some(output) = exchange.output_status.output() else {
+            return false;
+        };
+        output.get().messages.last().is_some_and(|m| {
+            matches!(
+                m.message,
+                AIAgentOutputMessageType::Summarization {
+                    finished_duration: None,
+                    summarization_type: SummarizationType::ConversationSummary,
+                    ..
+                }
+            )
+        })
     }
 
     pub fn context_window_usage(&self) -> f32 {

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -27,6 +27,12 @@ pub enum QueuedQueryOrigin {
     QueueSlashCommand,
     /// Filed via the auto-queue toggle in the warping indicator.
     AutoQueueToggle,
+    /// Filed as the follow-up prompt of a `/compact-and <prompt>` slash command, waiting for
+    /// the summarize to finish.
+    CompactAndSlashCommand,
+    /// Filed as the follow-up prompt of a `/fork-and-compact <prompt>` slash command on the
+    /// forked conversation, waiting for the fork's summarize to finish.
+    ForkAndCompactSlashCommand,
 }
 
 /// A single queued prompt.

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1191,6 +1191,8 @@ pub enum TelemetryQueuedQueryOrigin {
     InitialCloudMode,
     QueueSlashCommand,
     AutoQueueToggle,
+    CompactAndSlashCommand,
+    ForkAndCompactSlashCommand,
 }
 
 impl From<QueuedQueryOrigin> for TelemetryQueuedQueryOrigin {
@@ -1199,6 +1201,8 @@ impl From<QueuedQueryOrigin> for TelemetryQueuedQueryOrigin {
             QueuedQueryOrigin::InitialCloudMode => Self::InitialCloudMode,
             QueuedQueryOrigin::QueueSlashCommand => Self::QueueSlashCommand,
             QueuedQueryOrigin::AutoQueueToggle => Self::AutoQueueToggle,
+            QueuedQueryOrigin::CompactAndSlashCommand => Self::CompactAndSlashCommand,
+            QueuedQueryOrigin::ForkAndCompactSlashCommand => Self::ForkAndCompactSlashCommand,
         }
     }
 }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -13314,7 +13314,8 @@ impl Input {
 
     /// Checks whether the current input should be queued instead of executed.
     /// Returns true (and queues the prompt) when the active conversation is in progress
-    /// (or blocked) AND either the queue-next-prompt toggle is on or the conversation is summarizing.
+    /// (or blocked) AND either the queue-next-prompt toggle is on or (under
+    /// `QueuedPromptsV2`) the conversation is summarizing.
     /// Only queues when AI input is active — if the user is in shell mode the
     /// input is not queued (so e.g. `ls` still runs in the terminal).
     fn maybe_queue_input_for_in_progress_conversation(
@@ -13340,8 +13341,11 @@ impl Input {
         let is_summarizing = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
             .is_some_and(|c| c.is_summarizing());
+        // Summarization only routes a prompt into the queued-prompts panel under QueuedPromptsV2;
+        // with the flag off, only the auto-queue toggle queues (pre-V2 behavior).
+        let queue_for_summarize = is_summarizing && FeatureFlag::QueuedPromptsV2.is_enabled();
         if !QueuedQueryModel::as_ref(ctx).is_queue_next_prompt_enabled(conversation_id)
-            && !is_summarizing
+            && !queue_for_summarize
         {
             return false;
         }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -13313,8 +13313,8 @@ impl Input {
     }
 
     /// Checks whether the current input should be queued instead of executed.
-    /// Returns true (and queues the prompt) when the queue-next-prompt toggle is
-    /// on and the active conversation is still in progress.
+    /// Returns true (and queues the prompt) when the active conversation is in progress
+    /// (or blocked) AND either the queue-next-prompt toggle is on or the conversation is summarizing.
     /// Only queues when AI input is active — if the user is in shell mode the
     /// input is not queued (so e.g. `ls` still runs in the terminal).
     fn maybe_queue_input_for_in_progress_conversation(
@@ -13337,7 +13337,12 @@ impl Input {
             return false;
         };
 
-        if !QueuedQueryModel::as_ref(ctx).is_queue_next_prompt_enabled(conversation_id) {
+        let is_summarizing = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .is_some_and(|c| c.is_summarizing());
+        if !QueuedQueryModel::as_ref(ctx).is_queue_next_prompt_enabled(conversation_id)
+            && !is_summarizing
+        {
             return false;
         }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5219,6 +5219,30 @@ impl TerminalView {
         self.enqueue_prompt(prompt, QueuedQueryOrigin::InitialCloudMode, ctx)
     }
 
+    /// Files a follow-up prompt that will run after the next conversation finishes on
+    /// `conversation_id`. Used by `/compact-and` (targets the active conversation) and
+    /// `/fork-and-compact` (targets the newly forked conversation, which may differ from the
+    /// currently selected one). Falls back to the legacy pending-user-query block when
+    /// `QueuedPromptsV2` is disabled.
+    pub fn enqueue_followup_prompt(
+        &mut self,
+        prompt: String,
+        origin: QueuedQueryOrigin,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if FeatureFlag::QueuedPromptsV2.is_enabled() {
+            QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                model.append(conversation_id, QueuedQuery::new(prompt, origin), ctx);
+            });
+        } else {
+            self.send_user_query_after_next_conversation_finished(
+                prompt, /* show_close_button */ true, /* show_send_now_button */ false,
+                ctx,
+            );
+        }
+    }
+
     /// Drains one prompt from the queued-query singleton for `conversation_id` when that
     /// conversation finishes.
     fn drain_queued_prompts(

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -89,6 +89,17 @@ fn queue_texts(
     else {
         return Vec::new();
     };
+    queue_texts_for(view, conversation_id, ctx)
+}
+
+/// Returns the queue rows for an explicit `conversation_id`, looked up against the
+/// `QueuedQueryModel` singleton. Useful for tests that need to target a conversation other than
+/// the currently selected one (e.g. `/fork-and-compact`).
+fn queue_texts_for(
+    _view: &TerminalView,
+    conversation_id: AIConversationId,
+    ctx: &ViewContext<TerminalView>,
+) -> Vec<(String, QueuedQueryOrigin)> {
     QueuedQueryModel::as_ref(ctx)
         .queue(conversation_id)
         .iter()
@@ -542,6 +553,141 @@ fn error_or_cancel_drain_leaves_queue_intact_when_input_is_non_empty() {
         model.read(&app, |m, _| {
             assert_eq!(m.queue(conv).len(), 2);
             assert_eq!(m.queue(conv)[0].text(), "first");
+        });
+    });
+}
+
+#[test]
+fn enqueue_followup_prompt_appends_compact_and_row_when_v2_is_enabled() {
+    // /compact-and follow-ups land in the queue with the CompactAndSlashCommand origin under V2.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let _queued_prompts_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_cloud_setup_with_conversation(view, ctx);
+
+            view.enqueue_followup_prompt(
+                "follow up after summarize".to_owned(),
+                QueuedQueryOrigin::CompactAndSlashCommand,
+                conversation_id,
+                ctx,
+            );
+
+            assert_eq!(
+                queue_texts_for(view, conversation_id, ctx),
+                vec![(
+                    "follow up after summarize".to_owned(),
+                    QueuedQueryOrigin::CompactAndSlashCommand
+                )]
+            );
+            assert!(view.pending_user_query_view_id.is_none());
+        });
+    });
+}
+
+#[test]
+fn enqueue_followup_prompt_appends_fork_and_compact_row_when_v2_is_enabled() {
+    // /fork-and-compact follow-ups land in the queue with the ForkAndCompactSlashCommand origin.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let _queued_prompts_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_cloud_setup_with_conversation(view, ctx);
+
+            view.enqueue_followup_prompt(
+                "work on the forked branch".to_owned(),
+                QueuedQueryOrigin::ForkAndCompactSlashCommand,
+                conversation_id,
+                ctx,
+            );
+
+            assert_eq!(
+                queue_texts_for(view, conversation_id, ctx),
+                vec![(
+                    "work on the forked branch".to_owned(),
+                    QueuedQueryOrigin::ForkAndCompactSlashCommand
+                )]
+            );
+        });
+    });
+}
+
+#[test]
+fn enqueue_followup_prompt_uses_supplied_conversation_id_when_v2_is_enabled() {
+    // /fork-and-compact passes the newly forked conversation id directly, which can differ from
+    // the currently selected conversation. The helper must respect that explicit id.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let _queued_prompts_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        terminal.update(&mut app, |view, ctx| {
+            let selected_conversation_id = enter_cloud_setup_with_conversation(view, ctx);
+            let other_conversation_id = AIConversationId::new();
+            assert_ne!(selected_conversation_id, other_conversation_id);
+
+            view.enqueue_followup_prompt(
+                "goes to the forked id".to_owned(),
+                QueuedQueryOrigin::ForkAndCompactSlashCommand,
+                other_conversation_id,
+                ctx,
+            );
+
+            assert!(queue_texts_for(view, selected_conversation_id, ctx).is_empty());
+            assert_eq!(
+                queue_texts_for(view, other_conversation_id, ctx),
+                vec![(
+                    "goes to the forked id".to_owned(),
+                    QueuedQueryOrigin::ForkAndCompactSlashCommand
+                )]
+            );
+        });
+    });
+}
+
+#[test]
+fn enqueue_followup_prompt_falls_back_to_pending_block_when_v2_is_disabled() {
+    // With V2 off, the helper must call into the legacy send_user_query_after_next_conversation_finished
+    // path: no row gets appended to the queue model, and the queued_prompt_callback is armed so the
+    // pending-user-query block lifecycle continues to handle the follow-up exactly as today.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let _queued_prompts_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(false);
+        let _pending_user_query_indicator =
+            FeatureFlag::PendingUserQueryIndicator.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_cloud_setup_with_conversation(view, ctx);
+
+            view.enqueue_followup_prompt(
+                "legacy follow up".to_owned(),
+                QueuedQueryOrigin::CompactAndSlashCommand,
+                conversation_id,
+                ctx,
+            );
+
+            assert!(QueuedQueryModel::as_ref(ctx)
+                .queue(conversation_id)
+                .is_empty());
+            assert!(view.queued_prompt_callback.is_some());
+            assert!(view.pending_user_query_view_id.is_some());
         });
     });
 }

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -89,17 +89,6 @@ fn queue_texts(
     else {
         return Vec::new();
     };
-    queue_texts_for(view, conversation_id, ctx)
-}
-
-/// Returns the queue rows for an explicit `conversation_id`, looked up against the
-/// `QueuedQueryModel` singleton. Useful for tests that need to target a conversation other than
-/// the currently selected one (e.g. `/fork-and-compact`).
-fn queue_texts_for(
-    _view: &TerminalView,
-    conversation_id: AIConversationId,
-    ctx: &ViewContext<TerminalView>,
-) -> Vec<(String, QueuedQueryOrigin)> {
     QueuedQueryModel::as_ref(ctx)
         .queue(conversation_id)
         .iter()
@@ -579,7 +568,7 @@ fn enqueue_followup_prompt_appends_compact_and_row_when_v2_is_enabled() {
             );
 
             assert_eq!(
-                queue_texts_for(view, conversation_id, ctx),
+                queue_texts(view, ctx),
                 vec![(
                     "follow up after summarize".to_owned(),
                     QueuedQueryOrigin::CompactAndSlashCommand
@@ -612,7 +601,7 @@ fn enqueue_followup_prompt_appends_fork_and_compact_row_when_v2_is_enabled() {
             );
 
             assert_eq!(
-                queue_texts_for(view, conversation_id, ctx),
+                queue_texts(view, ctx),
                 vec![(
                     "work on the forked branch".to_owned(),
                     QueuedQueryOrigin::ForkAndCompactSlashCommand
@@ -646,13 +635,13 @@ fn enqueue_followup_prompt_uses_supplied_conversation_id_when_v2_is_enabled() {
                 ctx,
             );
 
-            assert!(queue_texts_for(view, selected_conversation_id, ctx).is_empty());
+            assert!(queue_texts(view, ctx).is_empty());
+            let other_queue = QueuedQueryModel::as_ref(ctx).queue(other_conversation_id);
+            assert_eq!(other_queue.len(), 1);
+            assert_eq!(other_queue[0].text(), "goes to the forked id");
             assert_eq!(
-                queue_texts_for(view, other_conversation_id, ctx),
-                vec![(
-                    "goes to the forked id".to_owned(),
-                    QueuedQueryOrigin::ForkAndCompactSlashCommand
-                )]
+                other_queue[0].origin(),
+                QueuedQueryOrigin::ForkAndCompactSlashCommand
             );
         });
     });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -186,8 +186,8 @@ use crate::ai::blocklist::suggested_rule_modal::{
     SuggestedRuleAndId, SuggestedRuleModal, SuggestedRuleModalEvent,
 };
 use crate::ai::blocklist::{
-    BlocklistAIHistoryEvent, PendingQueryState, SerializedBlockListItem, SlashCommandRequest,
-    FORK_PREFIX,
+    BlocklistAIHistoryEvent, PendingQueryState, QueuedQueryOrigin, SerializedBlockListItem,
+    SlashCommandRequest, FORK_PREFIX,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 #[cfg(target_family = "wasm")]
@@ -13071,7 +13071,7 @@ impl Workspace {
                 {
                     terminal.enqueue_followup_prompt(
                         prompt,
-                        crate::ai::blocklist::QueuedQueryOrigin::CompactAndSlashCommand,
+                        QueuedQueryOrigin::CompactAndSlashCommand,
                         conversation_id,
                         ctx,
                     );

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -12963,10 +12963,10 @@ impl Workspace {
                     });
 
                 if let Some(prompt) = initial_prompt {
-                    terminal_view.send_user_query_after_next_conversation_finished(
+                    terminal_view.enqueue_followup_prompt(
                         prompt,
-                        /* show_close_button */ true,
-                        /* show_send_now_button */ false,
+                        crate::ai::blocklist::QueuedQueryOrigin::ForkAndCompactSlashCommand,
+                        forked_conversation_id,
                         terminal_view_ctx,
                     );
                 }
@@ -13060,10 +13060,22 @@ impl Workspace {
             });
 
             if let Some(prompt) = initial_prompt {
-                terminal.send_user_query_after_next_conversation_finished(
-                    prompt, /* show_close_button */ true,
-                    /* show_send_now_button */ false, ctx,
-                );
+                // The slash-command handler at
+                // `app/src/terminal/input/slash_commands/mod.rs` for `/compact-and` short-circuits
+                // when there is no active conversation, so `selected_conversation_id` is set by the
+                // time we get here. Skip the follow-up if for some reason that invariant is broken.
+                if let Some(conversation_id) = terminal
+                    .ai_context_model()
+                    .as_ref(ctx)
+                    .selected_conversation_id(ctx)
+                {
+                    terminal.enqueue_followup_prompt(
+                        prompt,
+                        crate::ai::blocklist::QueuedQueryOrigin::CompactAndSlashCommand,
+                        conversation_id,
+                        ctx,
+                    );
+                }
             }
         });
     }

--- a/specs/APP-4594/TECH.md
+++ b/specs/APP-4594/TECH.md
@@ -1,0 +1,69 @@
+# Queued Prompts V2 for `/compact-and` and `/fork-and-compact` — Tech Spec
+Builds on the regular Agent Mode queued-prompts panel from `specs/REMOTE-1543/` and the Cloud Mode extension from `specs/APP-4562/`. This spec is the third (and final) step in moving every user-facing queued prompt surface onto the new panel UI behind `QueuedPromptsV2`.
+## Context
+Today `/compact-and <prompt>` and `/fork-and-compact <prompt>` still file their follow-up prompts through the legacy `PendingUserQueryBlock` path while a summarize (or fork-then-summarize) runs. The follow-up appears as a rich-content placeholder in the blocklist instead of as a row in the new queued-prompts panel.
+Both flows funnel into one helper:
+- `TerminalView::send_user_query_after_next_conversation_finished` (`app/src/terminal/view/pending_user_query.rs:185`) inserts a `PendingUserQueryKind::QueuedPrompt` block via `insert_pending_user_query_block` and stashes a `queued_prompt_callback` on `TerminalView` (`app/src/terminal/view.rs:4218`).
+- `TerminalView::handle_finished_conversation` (`app/src/terminal/view.rs:4788`) drains both the new queue (`drain_queued_prompts`) and the legacy callback. The callback submits via `Input::submit_queued_prompt` on `FinishReason::Complete` and restores the text into the input on the error/cancel reasons.
+The two callsites that reach this helper are:
+- `/compact-and`: dispatched as `WorkspaceAction::SummarizeAIConversation { initial_prompt, .. }`, which calls `Workspace::summarize_active_ai_conversation` (`app/src/workspace/view.rs:12173-12200`). The active terminal view sends `SlashCommandRequest::Summarize` and, if an `initial_prompt` is present, calls `send_user_query_after_next_conversation_finished(prompt, /*show_close*/ true, /*show_send_now*/ false, ctx)`.
+- `/fork-and-compact`: dispatched as `WorkspaceAction::ForkAIConversation { summarize_after_fork: true, initial_prompt, .. }`. After the fork is created and restored into the new pane, `Workspace::handle_forked_conversation_prompts` (`app/src/workspace/view.rs:12071-12117`) sends `SlashCommandRequest::Summarize` on the forked terminal view, then calls the same `send_user_query_after_next_conversation_finished` helper on that new terminal view. The forked conversation has already been restored via `restore_conversation_after_view_creation`, so `selected_conversation_id` on the new terminal view resolves to the forked id by the time the helper runs.
+Other `on_next_conversation_finished` callers (`app/src/terminal/view.rs:6744, 13597, 13656`) are internal init/project sequencing — they do not render user-visible queued prompts and stay on the existing path. A grep for `send_user_query_after_next_conversation_finished` confirms `/compact-and` and `/fork-and-compact` are the only remaining queued-prompt surfaces still on the legacy block.
+The new queued-prompts panel (`app/src/ai/blocklist/queued_prompts_panel.rs`) and its model `QueuedQueryModel` (`app/src/ai/blocklist/queued_query.rs`) already support exactly the surface this spec needs: append a row per origin, drain on `FinishReason::Complete` via `TerminalView::drain_queued_prompts` (`app/src/terminal/view.rs:5106`), and restore text to the input on error/cancel. For local Agent Mode, `drain_queued_prompts` submits via `Input::submit_queued_prompt_for_active_pane` (`app/src/terminal/input.rs:13145`), which falls back to `Input::submit_queued_prompt` (`app/src/terminal/input.rs:13062`) — the exact path the legacy callback already uses. No new submission plumbing is required.
+## Proposed changes
+### 1. Two new `QueuedQueryOrigin` variants for telemetry
+Extend `QueuedQueryOrigin` (`app/src/ai/blocklist/queued_query.rs:22`) with two variants matching the existing per-origin pattern:
+- `CompactAndSlashCommand`
+- `ForkAndCompactSlashCommand`
+Neither variant is locked (`QueuedQuery::is_locked` keeps `InitialCloudMode` as the only locked origin at `app/src/ai/blocklist/queued_query.rs:63`). These rows are user-managed: interactive drag, edit, and delete, exactly like `QueueSlashCommand` and `AutoQueueToggle` rows. The follow-up has not been sent anywhere yet at queue time; only the summarize is running.
+Mirror the new variants into `TelemetryQueuedQueryOrigin` (`app/src/server/telemetry/events.rs:1187`) and its `From<QueuedQueryOrigin>` impl. No new telemetry events are needed — the existing `QueuedPrompt.Edited` / `QueuedPrompt.Deleted` / `QueuedPrompt.Reordered` / `QueuedPrompt.PanelCollapseToggled` events already carry `origin` and gate on `FeatureFlag::QueueSlashCommand`, which is transitively enabled by `QueuedPromptsV2` per `app/Cargo.toml:942`.
+### 2. Single `TerminalView` helper hides the V2 gate from callers
+Add `TerminalView::enqueue_followup_prompt` (next to `enqueue_prompt` at `app/src/terminal/view.rs:5051`):
+```rust path=null start=null
+pub fn enqueue_followup_prompt(
+    &mut self,
+    prompt: String,
+    origin: QueuedQueryOrigin,
+    conversation_id: AIConversationId,
+    ctx: &mut ViewContext<Self>,
+) {
+    if FeatureFlag::QueuedPromptsV2.is_enabled() {
+        self.queued_query_model.update(ctx, |model, ctx| {
+            model.append(conversation_id, QueuedQuery::new(prompt, origin), ctx);
+        });
+    } else {
+        self.send_user_query_after_next_conversation_finished(
+            prompt,
+            /* show_close_button */ true,
+            /* show_send_now_button */ false,
+            ctx,
+        );
+    }
+}
+```
+The helper takes an explicit `conversation_id` so the `/fork-and-compact` caller can pass `forked_conversation_id` directly without depending on `selected_conversation_id` post-restoration ordering. The legacy branch ignores it, matching the existing helper which uses the input's selected conversation lazily inside the callback.
+The helper is the only place that names `FeatureFlag::QueuedPromptsV2` for this rollout; subsequent cleanup deletes the legacy branch and the helper collapses to a one-liner.
+### 3. Route both slash-command paths through the helper
+Replace the two `send_user_query_after_next_conversation_finished` callsites in `Workspace` so they delegate to the helper instead:
+- `Workspace::summarize_active_ai_conversation` (`app/src/workspace/view.rs:12194`): after sending `SlashCommandRequest::Summarize`, resolve the active conversation id via `terminal.ai_context_model().as_ref(ctx).selected_conversation_id(ctx)` and call `terminal.enqueue_followup_prompt(prompt, QueuedQueryOrigin::CompactAndSlashCommand, conversation_id, ctx)`. If `selected_conversation_id` is `None`, fall through with no follow-up (matches the legacy semantics — the slash-command handler at `app/src/terminal/input/slash_commands/mod.rs:1030-1048` already requires an active conversation to dispatch `/compact-and`).
+- `Workspace::handle_forked_conversation_prompts` (`app/src/workspace/view.rs:12097`): pass the already-known `forked_conversation_id` and use `QueuedQueryOrigin::ForkAndCompactSlashCommand`.
+Both callsites continue to send `SlashCommandRequest::Summarize` via `ai_controller` before enqueueing the follow-up, so the conversation transitions to `InProgress` before any drain hook can observe it.
+### 4. Legacy path is preserved when the flag is off
+When `QueuedPromptsV2` is off, the helper's `else` branch is the exact code that runs today: `send_user_query_after_next_conversation_finished` inserts a `PendingUserQueryKind::QueuedPrompt` block, sets `queued_prompt_callback`, and `handle_finished_conversation` drains it on completion. No other code paths change.
+`PendingUserQueryIndicator` continues to gate the block's visibility inside `send_user_query_after_next_conversation_finished` (`app/src/terminal/view/pending_user_query.rs:192`); this spec does not modify that gate.
+## Testing and validation
+Behavior maps to the existing regular-queue panel invariants in `specs/REMOTE-1543/PRODUCT.md` (12-30, 31-37). The new code is the helper plus two callsites; testing focuses on the helper's branching and on the routing changes:
+- **Helper branching**: Add unit tests next to the existing terminal view tests in `app/src/terminal/view/queued_prompts_test.rs` proving (a) with V2 on, `enqueue_followup_prompt` appends a row with the supplied origin and conversation id to `QueuedQueryModel`, and (b) with V2 off, it calls `send_user_query_after_next_conversation_finished`, which sets `pending_user_query_view_id` and `queued_prompt_callback`. Use the same `App::test`-style harness already used by sibling tests in that file.
+- **`/compact-and` integration**: Dispatch `WorkspaceAction::SummarizeAIConversation { initial_prompt: Some(...) }` on a terminal view with an active conversation. With V2 on, assert the queued-prompts panel contains exactly one row with origin `CompactAndSlashCommand`. With V2 off, assert a `PendingUserQueryKind::QueuedPrompt` rich content was inserted and the legacy callback is set.
+- **`/fork-and-compact` integration**: Drive `Workspace::handle_forked_conversation_prompts` with `summarize_after_fork: true` and an `initial_prompt`, then assert the **forked** terminal view's `QueuedQueryModel` contains exactly one row with origin `ForkAndCompactSlashCommand` keyed by the forked conversation id. Verify the source terminal view's queue is untouched.
+- **Drain semantics**: With V2 on, simulate `FinishReason::Complete` on the conversation and assert the row drains through `submit_queued_prompt_for_active_pane` → local fallback `submit_queued_prompt`. Simulate `FinishReason::Error` with an empty input and assert the row's text lands in the input editor (matches §35 of `specs/REMOTE-1543/PRODUCT.md`).
+- **Telemetry**: Add a serialization assertion for both new `TelemetryQueuedQueryOrigin` variants in the existing telemetry test pattern at `app/src/server/telemetry/events.rs`.
+- **Compile gating**: `cargo check -p warp` and `cargo check -p warp --features queued_prompts_v2` both pass; `cargo fmt` and `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` per the WARP.md PR workflow.
+Do not run the app to test.
+## Parallelization
+Single workstream. The helper, two callsite edits, origin enum changes, and telemetry mirror all sit in a tight ownership boundary (`TerminalView`, `Workspace`, `QueuedQueryModel`, telemetry events). Sub-agents would create merge churn on the same files without reducing wall-clock time.
+## Risks and mitigations
+- **`selected_conversation_id` not yet resolving to the forked id on `CurrentPane` forks**: the helper takes an explicit `conversation_id` from the caller, and the `/fork-and-compact` path already has `forked_conversation_id` in scope at `handle_forked_conversation_prompts`. The `/compact-and` path uses the selected conversation id resolved at dispatch time on the active terminal view, which is guaranteed to be set because the slash-command handler short-circuits when none exists.
+- **Double drain on the legacy path**: `handle_finished_conversation` calls both `drain_queued_prompts` and the legacy `queued_prompt_callback`. With V2 off, only the legacy callback fires (no row was appended). With V2 on, only the V2 row is present (no callback was set). The helper's branching guarantees the two paths are mutually exclusive.
+- **Telemetry origin drift between core and telemetry enums**: extending `QueuedQueryOrigin` without mirroring `TelemetryQueuedQueryOrigin` would compile but ship payloads without telemetry for the new origins. The exhaustive `match` in the `From` impl catches that at compile time, per the WARP.md "Exhaustive Matching" guideline.
+- **Removing the legacy block UI prematurely**: this spec deliberately keeps `send_user_query_after_next_conversation_finished` and `PendingUserQueryBlock` intact for the V2-off case. Cleanup happens when `QueuedPromptsV2` is removed in a later pass.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

WISOTT. These were the last two things using the old queued block UI, and this PR slots in the new UI (behind a feature flag)

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/80431f33636547119639e464c5e29ec1

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode