### PR TITLE
Gate Warp Control CLI phase 1

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -731,6 +731,7 @@ ligatures = []
 trim_trailing_blank_lines = []
 cli_agent_rich_input = []
 list_skills = []
+warp_control_cli = []
 # This feature is enabled in build.rs when compiling for platforms which
 # support having a local tty/shell session.  It can be used to conditionally
 # include dependencies that should only exist in such environments.

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -473,6 +473,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::GitOperationsInCodeReview,
         #[cfg(feature = "hoa_remote_control")]
         FeatureFlag::HOARemoteControl,
+        #[cfg(feature = "warp_control_cli")]
+        FeatureFlag::WarpControlCli,
         #[cfg(feature = "codex_notifications")]
         FeatureFlag::CodexNotifications,
         #[cfg(feature = "trim_trailing_blank_lines")]

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2004,7 +2004,8 @@ pub(crate) fn initialize_app(
     if matches!(
         launch_mode,
         LaunchMode::App { .. } | LaunchMode::Test { .. }
-    ) {
+    ) && FeatureFlag::WarpControlCli.is_enabled()
+    {
         ctx.add_singleton_model(local_control::LocalControlBridge::new);
         ctx.add_singleton_model(local_control::LocalControlServer::new);
     }

--- a/app/src/local_control/mod.rs
+++ b/app/src/local_control/mod.rs
@@ -6,7 +6,9 @@ use crate::settings::{
     LocalControlInvocationContext, LocalControlPermissionCategory, LocalControlSettings,
 };
 use ::local_control::auth::{CredentialGrant, CredentialRequest, ScopedCredential};
-use ::local_control::protocol::{PaneTarget, TabTarget, TargetSelector, WindowTarget};
+use ::local_control::protocol::{
+    ExecutionContextProof, PaneTarget, TabTarget, TargetSelector, WindowTarget,
+};
 use ::local_control::{
     ActionKind, AuthToken, ControlEndpoint, ControlError, ControlResponse, ErrorCode,
     ErrorResponseEnvelope, InstanceId, InstanceRecord, RegisteredInstance, RequestEnvelope,
@@ -22,6 +24,7 @@ use axum::{Json, Router};
 use chrono::Duration;
 use serde_json::json;
 use warp_core::channel::ChannelState;
+use warp_core::features::FeatureFlag;
 use warpui::{Entity, ModelContext, ModelSpawner, SingletonEntity, TypedActionView};
 
 use crate::workspace::{Workspace, WorkspaceAction};
@@ -46,6 +49,12 @@ impl SingletonEntity for LocalControlServer {}
 
 impl LocalControlServer {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        if !warp_control_cli_enabled() {
+            return Self {
+                _runtime: None,
+                _registered_instance: None,
+            };
+        }
         match Self::start(ctx) {
             Ok(server) => server,
             Err(error) => {
@@ -59,6 +68,9 @@ impl LocalControlServer {
     }
 
     fn start(ctx: &mut ModelContext<Self>) -> Result<Self, ControlError> {
+        if !warp_control_cli_enabled() {
+            return Err(warp_control_cli_disabled_error());
+        }
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .enable_io()
@@ -89,19 +101,26 @@ impl LocalControlServer {
                 err.to_string(),
             )
         })?;
-        let record = InstanceRecord::for_current_process(
-            ControlEndpoint::localhost(port.port()),
-            ChannelState::channel().to_string(),
-            ChannelState::app_id().to_string(),
-            ChannelState::app_version().map(str::to_owned),
-            ActionKind::implemented_metadata(),
-        );
-        let instance_id = record.instance_id.clone();
+        let endpoint = ControlEndpoint::localhost(port.port());
+        let outside_warp_enabled = LocalControlSettings::as_ref(ctx)
+            .is_context_enabled(LocalControlInvocationContext::OutsideWarp);
+        let (instance_id, registered_instance) = if outside_warp_enabled {
+            let record = InstanceRecord::for_current_process(
+                endpoint,
+                ChannelState::channel().to_string(),
+                ChannelState::app_id().to_string(),
+                ChannelState::app_version().map(str::to_owned),
+                ActionKind::implemented_metadata(),
+            );
+            let instance_id = record.instance_id.clone();
+            (instance_id, Some(RegisteredInstance::register(record)?))
+        } else {
+            (InstanceId::new(), None)
+        };
         let bridge_spawner = LocalControlBridge::handle(ctx).update(ctx, |bridge, ctx| {
             bridge.set_instance_id(instance_id.clone());
             ctx.spawner()
         });
-        let registered_instance = RegisteredInstance::register(record)?;
         let state = ControlServerState {
             bridge_spawner,
             instance_id,
@@ -118,7 +137,7 @@ impl LocalControlServer {
         });
         Ok(Self {
             _runtime: Some(runtime),
-            _registered_instance: Some(registered_instance),
+            _registered_instance: registered_instance,
         })
     }
 }
@@ -148,6 +167,9 @@ impl LocalControlBridge {
         grant: CredentialGrant,
         ctx: &mut ModelContext<Self>,
     ) -> ResponseEnvelope {
+        if !warp_control_cli_enabled() {
+            return ResponseEnvelope::error(request.request_id, warp_control_cli_disabled_error());
+        }
         if request.protocol_version != PROTOCOL_VERSION {
             return ResponseEnvelope::error(
                 request.request_id,
@@ -249,6 +271,13 @@ async fn handle_credential_request(
     State(state): State<ControlServerState>,
     payload: Result<Json<CredentialRequest>, JsonRejection>,
 ) -> Response {
+    if !warp_control_cli_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(warp_control_cli_disabled_error())),
+        )
+            .into_response();
+    }
     let request = match payload {
         Ok(Json(request)) => request,
         Err(err) => {
@@ -284,6 +313,13 @@ async fn handle_credential_request(
                     request.action.as_str()
                 ),
             ))),
+        )
+            .into_response();
+    }
+    if let Err(error) = verify_execution_context(&request) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(error)),
         )
             .into_response();
     }
@@ -364,6 +400,13 @@ async fn handle_control_request(
     headers: HeaderMap,
     payload: Result<Json<RequestEnvelope>, JsonRejection>,
 ) -> Response {
+    if !warp_control_cli_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(warp_control_cli_disabled_error())),
+        )
+            .into_response();
+    }
     let auth_header = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok());
@@ -461,23 +504,16 @@ fn validate_tab_create_target(target: &TargetSelector) -> Result<(), ControlErro
 fn target_window_id(
     ctx: &mut ModelContext<LocalControlBridge>,
 ) -> Result<warpui::WindowId, ControlError> {
-    preferred_window_id(
-        ctx.windows().active_window(),
-        ctx.windows().frontmost_window_id(),
-    )
-    .ok_or_else(|| {
+    preferred_window_id(ctx.windows().active_window()).ok_or_else(|| {
         ControlError::new(
             ErrorCode::MissingTarget,
-            "tab.create requires an active or previously active Warp window",
+            "tab.create requires an active Warp window",
         )
     })
 }
 
-fn preferred_window_id(
-    active_window: Option<warpui::WindowId>,
-    frontmost_window: Option<warpui::WindowId>,
-) -> Option<warpui::WindowId> {
-    active_window.or(frontmost_window)
+fn preferred_window_id(active_window: Option<warpui::WindowId>) -> Option<warpui::WindowId> {
+    active_window
 }
 
 #[cfg(test)]
@@ -488,17 +524,52 @@ fn capabilities() -> Vec<ActionKind> {
         .collect()
 }
 
+fn warp_control_cli_enabled() -> bool {
+    FeatureFlag::WarpControlCli.is_enabled()
+}
+
+fn warp_control_cli_disabled_error() -> ControlError {
+    ControlError::new(
+        ErrorCode::LocalControlDisabled,
+        "Warp Control CLI is disabled by feature flag",
+    )
+}
+
 fn local_invocation_context(context: InvocationContext) -> LocalControlInvocationContext {
     match context {
         InvocationContext::InsideWarp => LocalControlInvocationContext::InsideWarp,
         InvocationContext::OutsideWarp => LocalControlInvocationContext::OutsideWarp,
     }
 }
+fn verify_execution_context(request: &CredentialRequest) -> Result<(), ControlError> {
+    match request.invocation_context {
+        InvocationContext::InsideWarp => {
+            if matches!(
+                request.execution_context_proof,
+                Some(ExecutionContextProof::VerifiedWarpTerminal { .. })
+            ) {
+                Ok(())
+            } else {
+                Err(ControlError::new(
+                    ErrorCode::ExecutionContextNotAllowed,
+                    "inside-Warp credentials require a verified Warp terminal execution proof",
+                ))
+            }
+        }
+        InvocationContext::OutsideWarp => Ok(()),
+    }
+}
 
 fn local_permission(permission: LocalControlPermission) -> LocalControlPermissionCategory {
     match permission {
-        LocalControlPermission::ReadOnly => LocalControlPermissionCategory::ReadOnly,
-        LocalControlPermission::ReadWrite => LocalControlPermissionCategory::ReadWrite,
+        LocalControlPermission::MetadataRead | LocalControlPermission::UnderlyingDataRead => {
+            LocalControlPermissionCategory::ReadOnly
+        }
+        LocalControlPermission::AppStateMutation
+        | LocalControlPermission::MetadataConfigurationMutation
+        | LocalControlPermission::UnderlyingDataMutation => {
+            LocalControlPermissionCategory::ReadWrite
+        }
     }
 }
 

--- a/app/src/local_control/mod_tests.rs
+++ b/app/src/local_control/mod_tests.rs
@@ -1,10 +1,17 @@
 use ::local_control::protocol::{
-    PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector, WindowTarget,
+    ExecutionContextProof, InvocationContext, PaneSelector, PaneTarget, TabSelector, TabTarget,
+    TargetSelector, WindowSelector, WindowTarget,
 };
 
-use super::{capabilities, preferred_window_id, validate_tab_create_target};
+use super::{
+    capabilities, preferred_window_id, validate_tab_create_target, verify_execution_context,
+};
+use ::local_control::auth::CredentialRequest;
 use ::local_control::protocol::ActionKind;
 use ::local_control::ErrorCode;
+use warp_core::features::FeatureFlag;
+
+use super::warp_control_cli_enabled;
 
 #[test]
 fn tab_create_accepts_default_and_active_targets() {
@@ -57,19 +64,42 @@ fn capabilities_only_advertises_tab_create() {
 }
 
 #[test]
-fn tab_create_prefers_active_window() {
-    let active = warpui::WindowId::from_usize(1);
-    let frontmost = warpui::WindowId::from_usize(2);
+fn local_control_disabled_when_warp_control_cli_flag_is_disabled() {
+    let _guard = FeatureFlag::WarpControlCli.override_enabled(false);
 
-    assert_eq!(
-        preferred_window_id(Some(active), Some(frontmost)),
-        Some(active)
-    );
+    assert!(!warp_control_cli_enabled());
 }
 
 #[test]
-fn tab_create_falls_back_to_frontmost_window() {
-    let frontmost = warpui::WindowId::from_usize(2);
+fn local_control_enabled_when_warp_control_cli_flag_is_enabled() {
+    let _guard = FeatureFlag::WarpControlCli.override_enabled(true);
 
-    assert_eq!(preferred_window_id(None, Some(frontmost)), Some(frontmost));
+    assert!(warp_control_cli_enabled());
+}
+
+#[test]
+fn tab_create_prefers_active_window() {
+    let active = warpui::WindowId::from_usize(1);
+    assert_eq!(preferred_window_id(Some(active)), Some(active));
+}
+
+#[test]
+fn tab_create_requires_active_window() {
+    assert_eq!(preferred_window_id(None), None);
+}
+
+#[test]
+fn inside_warp_credentials_require_verified_execution_proof() {
+    let request = CredentialRequest::new(ActionKind::TabCreate, InvocationContext::InsideWarp);
+    let err = verify_execution_context(&request).expect_err("missing proof rejected");
+    assert_eq!(err.code, ErrorCode::ExecutionContextNotAllowed);
+}
+
+#[test]
+fn inside_warp_credentials_accept_verified_execution_proof() {
+    let mut request = CredentialRequest::new(ActionKind::TabCreate, InvocationContext::InsideWarp);
+    request.execution_context_proof = Some(ExecutionContextProof::VerifiedWarpTerminal {
+        proof_id: "proof".to_owned(),
+    });
+    verify_execution_context(&request).expect("verified proof accepted");
 }

--- a/app/src/settings/init.rs
+++ b/app/src/settings/init.rs
@@ -98,7 +98,9 @@ pub fn register_all_settings(ctx: &mut AppContext) {
     EmacsBindingsSettings::register(ctx);
     SameLinePromptBlockSettings::register(ctx);
     SemanticSelection::register(ctx);
-    LocalControlSettings::register(ctx);
+    if FeatureFlag::WarpControlCli.is_enabled() {
+        LocalControlSettings::register(ctx);
+    }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     super::LinuxAppConfiguration::register(ctx);

--- a/app/src/settings_view/scripting_page.rs
+++ b/app/src/settings_view/scripting_page.rs
@@ -15,8 +15,8 @@ use crate::settings::{
 use settings::{Setting as _, ToggleableSetting as _};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use warp_core::settings::SyncToCloud;
-use warpui::elements::{Container, Element, MouseStateHandle};
+use warp_core::{features::FeatureFlag, settings::SyncToCloud};
+use warpui::elements::{Container, Element, Empty, MouseStateHandle};
 use warpui::ui_components::components::UiComponent;
 use warpui::ui_components::switch::SwitchStateHandle;
 use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle};
@@ -125,6 +125,14 @@ impl ScriptingToggle {
     }
 }
 
+fn scripting_settings_enabled() -> bool {
+    cfg!(not(target_family = "wasm")) && FeatureFlag::WarpControlCli.is_enabled()
+}
+
+#[cfg(test)]
+#[path = "scripting_page_tests.rs"]
+mod tests;
+
 #[derive(Clone, Debug)]
 pub enum ScriptingSettingsPageAction {
     Toggle(ScriptingToggle),
@@ -137,9 +145,11 @@ pub struct ScriptingSettingsPageView {
 
 impl ScriptingSettingsPageView {
     pub fn new(ctx: &mut ViewContext<Self>) -> Self {
-        ctx.subscribe_to_model(&LocalControlSettings::handle(ctx), |_, _, _, ctx| {
-            ctx.notify();
-        });
+        if scripting_settings_enabled() {
+            ctx.subscribe_to_model(&LocalControlSettings::handle(ctx), |_, _, _, ctx| {
+                ctx.notify();
+            });
+        }
 
         Self {
             page: PageType::new_uncategorized(
@@ -225,6 +235,9 @@ impl View for ScriptingSettingsPageView {
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        if !scripting_settings_enabled() {
+            return Empty::new().finish();
+        }
         self.page.render(self, app)
     }
 }
@@ -235,10 +248,13 @@ impl SettingsPageMeta for ScriptingSettingsPageView {
     }
 
     fn should_render(&self, _ctx: &AppContext) -> bool {
-        cfg!(not(target_family = "wasm"))
+        scripting_settings_enabled()
     }
 
     fn update_filter(&mut self, query: &str, ctx: &mut ViewContext<Self>) -> MatchData {
+        if !scripting_settings_enabled() {
+            return false.into();
+        }
         self.page.update_filter(query, ctx)
     }
 
@@ -302,6 +318,9 @@ impl SettingsWidget for ScriptingToggleWidget {
     }
 
     fn should_render(&self, app: &AppContext) -> bool {
+        if !scripting_settings_enabled() {
+            return false;
+        }
         let settings = LocalControlSettings::as_ref(app);
         match self.toggle.parent_context() {
             Some(context) => settings.is_context_enabled(context),

--- a/app/src/settings_view/scripting_page_tests.rs
+++ b/app/src/settings_view/scripting_page_tests.rs
@@ -1,0 +1,17 @@
+use warp_core::features::FeatureFlag;
+
+use super::scripting_settings_enabled;
+
+#[test]
+fn scripting_settings_page_hidden_when_warp_control_cli_flag_is_disabled() {
+    let _guard = FeatureFlag::WarpControlCli.override_enabled(false);
+
+    assert!(!scripting_settings_enabled());
+}
+
+#[test]
+fn scripting_settings_page_visible_when_warp_control_cli_flag_is_enabled() {
+    let _guard = FeatureFlag::WarpControlCli.override_enabled(true);
+
+    assert!(scripting_settings_enabled());
+}

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -29,8 +29,11 @@ pub enum RiskTier {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LocalControlPermission {
-    ReadOnly,
-    ReadWrite,
+    MetadataRead,
+    UnderlyingDataRead,
+    AppStateMutation,
+    MetadataConfigurationMutation,
+    UnderlyingDataMutation,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -366,7 +369,7 @@ impl ActionKind {
                     InvocationContext::InsideWarp,
                     InvocationContext::OutsideWarp,
                 ],
-                permission: LocalControlPermission::ReadWrite,
+                permission: LocalControlPermission::AppStateMutation,
                 target_scope: TargetScope::Window,
             };
         }
@@ -453,10 +456,25 @@ impl ActionKind {
     fn default_permission(self) -> LocalControlPermission {
         match self.default_risk_tier() {
             RiskTier::ReadOnlyMetadata | RiskTier::ReadOnlyTerminalData => {
-                LocalControlPermission::ReadOnly
+                if matches!(self.default_risk_tier(), RiskTier::ReadOnlyTerminalData) {
+                    LocalControlPermission::UnderlyingDataRead
+                } else {
+                    LocalControlPermission::MetadataRead
+                }
             }
-            RiskTier::MutatingNonDestructive | RiskTier::MutatingDestructiveOrExecution => {
-                LocalControlPermission::ReadWrite
+            RiskTier::MutatingNonDestructive => match self.default_target_scope() {
+                TargetScope::Settings | TargetScope::Appearance => {
+                    LocalControlPermission::MetadataConfigurationMutation
+                }
+                TargetScope::Instance
+                | TargetScope::Window
+                | TargetScope::Tab
+                | TargetScope::Pane
+                | TargetScope::Session
+                | TargetScope::Surface => LocalControlPermission::AppStateMutation,
+            },
+            RiskTier::MutatingDestructiveOrExecution => {
+                LocalControlPermission::UnderlyingDataMutation
             }
         }
     }
@@ -667,7 +685,10 @@ mod tests {
         );
         assert_eq!(metadata.risk_tier, RiskTier::MutatingNonDestructive);
         assert!(!metadata.requires_authenticated_user);
-        assert_eq!(metadata.permission, LocalControlPermission::ReadWrite);
+        assert_eq!(
+            metadata.permission,
+            LocalControlPermission::AppStateMutation
+        );
         assert_eq!(
             metadata.allowed_invocation_contexts,
             vec![

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -826,6 +826,8 @@ pub enum FeatureFlag {
 
     /// Gates the remote control chip and `/remote-control` slash command in the CLI agent footer.
     HOARemoteControl,
+    /// Gates the standalone Warp Control CLI and its local app control plane.
+    WarpControlCli,
 
     /// Trims trailing blank rows from CLI agent block output so unused vertical
     /// space is not rendered while the agent is running.


### PR DESCRIPTION
Summary:
- Add the WarpControlCli runtime flag and cargo feature wiring.
- Gate Settings > Scripting visibility, local-control settings registration, app bridge/server registration, server start, and HTTP handlers when the flag is disabled.
- Preserve the five local-control permission categories and classify tab.create as an app-state mutation.
- Tighten Phase 1 security behavior for verified inside-Warp credentials, outside-Warp discovery, and active-window targeting.

Validation:
- cargo fmt
- cargo check -p local_control && cargo check -p warp_features && cargo check -p warp_cli && cargo check -p warp --features warp_control_cli && cargo check -p warp
- cargo nextest run --no-fail-fast --workspace warp_control_cli
- cargo nextest run --no-fail-fast --workspace local_control

Notes:
- This branch overlaps with the bridge/selectors shard in app/src/lib.rs, app/src/local_control/mod.rs, app/src/settings_view/scripting_page.rs, app/src/features.rs, crates/warp_features/src/lib.rs, and app/Cargo.toml.

_Conversation: https://staging.warp.dev/conversation/ebedad5e-e241-475d-b068-89453f418970_
_Run: https://oz.staging.warp.dev/runs/019e5227-eb72-7d9c-930f-7ca5b93efb5a_

Co-Authored-By: Oz <oz-agent@warp.dev>
_This PR was generated with [Oz](https://warp.dev/oz)._
