### PR TITLE
Implement warpctrl core contract security

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2004,7 +2004,8 @@ pub(crate) fn initialize_app(
     if matches!(
         launch_mode,
         LaunchMode::App { .. } | LaunchMode::Test { .. }
-    ) {
+    ) && FeatureFlag::WarpControlCli.is_enabled()
+    {
         ctx.add_singleton_model(local_control::LocalControlBridge::new);
         ctx.add_singleton_model(local_control::LocalControlServer::new);
     }

--- a/app/src/local_control/mod.rs
+++ b/app/src/local_control/mod.rs
@@ -12,7 +12,7 @@ use ::local_control::{
     ErrorResponseEnvelope, InstanceId, InstanceRecord, RegisteredInstance, RequestEnvelope,
     ResponseEnvelope, PROTOCOL_VERSION,
 };
-use ::local_control::{InvocationContext, LocalControlPermission};
+use ::local_control::{InvocationContext, PermissionCategory};
 use axum::extract::rejection::JsonRejection;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
@@ -22,6 +22,7 @@ use axum::{Json, Router};
 use chrono::Duration;
 use serde_json::json;
 use warp_core::channel::ChannelState;
+use warp_core::features::FeatureFlag;
 use warpui::{Entity, ModelContext, ModelSpawner, SingletonEntity, TypedActionView};
 
 use crate::workspace::{Workspace, WorkspaceAction};
@@ -46,6 +47,12 @@ impl SingletonEntity for LocalControlServer {}
 
 impl LocalControlServer {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        if !FeatureFlag::WarpControlCli.is_enabled() {
+            return Self {
+                _runtime: None,
+                _registered_instance: None,
+            };
+        }
         match Self::start(ctx) {
             Ok(server) => server,
             Err(error) => {
@@ -89,8 +96,12 @@ impl LocalControlServer {
                 err.to_string(),
             )
         })?;
+        let outside_warp_control_enabled = LocalControlSettings::as_ref(ctx)
+            .is_context_enabled(LocalControlInvocationContext::OutsideWarp);
+        let endpoint =
+            outside_warp_control_enabled.then_some(ControlEndpoint::localhost(port.port()));
         let record = InstanceRecord::for_current_process(
-            ControlEndpoint::localhost(port.port()),
+            endpoint,
             ChannelState::channel().to_string(),
             ChannelState::app_id().to_string(),
             ChannelState::app_version().map(str::to_owned),
@@ -173,6 +184,30 @@ impl LocalControlBridge {
             );
         }
         match request.action.kind {
+            ActionKind::InstanceList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, self.instance_metadata())
+            }
+            ActionKind::AppPing => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, self.ping_metadata())
+            }
+            ActionKind::AppVersion => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, self.version_metadata())
+            }
             ActionKind::TabCreate => {
                 if let Err(error) =
                     ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
@@ -243,12 +278,55 @@ impl LocalControlBridge {
             },
         }))
     }
+
+    fn instance_metadata(&self) -> serde_json::Value {
+        json!({
+            "action": ActionKind::InstanceList.as_str(),
+            "instance_id": self.instance_id.as_ref().map(|id| id.0.as_str()),
+            "pid": std::process::id(),
+            "channel": ChannelState::channel().to_string(),
+            "app_id": ChannelState::app_id().to_string(),
+            "app_version": ChannelState::app_version(),
+            "protocol_version": PROTOCOL_VERSION,
+            "actions": ActionKind::implemented_metadata(),
+        })
+    }
+
+    fn ping_metadata(&self) -> serde_json::Value {
+        json!({
+            "action": ActionKind::AppPing.as_str(),
+            "ok": true,
+            "instance_id": self.instance_id.as_ref().map(|id| id.0.as_str()),
+            "protocol_version": PROTOCOL_VERSION,
+        })
+    }
+
+    fn version_metadata(&self) -> serde_json::Value {
+        json!({
+            "action": ActionKind::AppVersion.as_str(),
+            "instance_id": self.instance_id.as_ref().map(|id| id.0.as_str()),
+            "protocol_version": PROTOCOL_VERSION,
+            "channel": ChannelState::channel().to_string(),
+            "app_id": ChannelState::app_id().to_string(),
+            "app_version": ChannelState::app_version(),
+        })
+    }
 }
 
 async fn handle_credential_request(
     State(state): State<ControlServerState>,
     payload: Result<Json<CredentialRequest>, JsonRejection>,
 ) -> Response {
+    if !FeatureFlag::WarpControlCli.is_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(ControlError::new(
+                ErrorCode::LocalControlDisabled,
+                "local control is disabled by feature flag",
+            ))),
+        )
+            .into_response();
+    }
     let request = match payload {
         Ok(Json(request)) => request,
         Err(err) => {
@@ -300,6 +378,13 @@ async fn handle_credential_request(
                     request.action.as_str()
                 ),
             ))),
+        )
+            .into_response();
+    }
+    if let Err(error) = request.verify_execution_context_proof() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(error)),
         )
             .into_response();
     }
@@ -364,6 +449,16 @@ async fn handle_control_request(
     headers: HeaderMap,
     payload: Result<Json<RequestEnvelope>, JsonRejection>,
 ) -> Response {
+    if !FeatureFlag::WarpControlCli.is_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(ControlError::new(
+                ErrorCode::LocalControlDisabled,
+                "local control is disabled by feature flag",
+            ))),
+        )
+            .into_response();
+    }
     let auth_header = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok());
@@ -461,23 +556,16 @@ fn validate_tab_create_target(target: &TargetSelector) -> Result<(), ControlErro
 fn target_window_id(
     ctx: &mut ModelContext<LocalControlBridge>,
 ) -> Result<warpui::WindowId, ControlError> {
-    preferred_window_id(
-        ctx.windows().active_window(),
-        ctx.windows().frontmost_window_id(),
-    )
-    .ok_or_else(|| {
+    active_window_id(ctx.windows().active_window()).ok_or_else(|| {
         ControlError::new(
             ErrorCode::MissingTarget,
-            "tab.create requires an active or previously active Warp window",
+            "tab.create requires an active Warp window",
         )
     })
 }
 
-fn preferred_window_id(
-    active_window: Option<warpui::WindowId>,
-    frontmost_window: Option<warpui::WindowId>,
-) -> Option<warpui::WindowId> {
-    active_window.or(frontmost_window)
+fn active_window_id(active_window: Option<warpui::WindowId>) -> Option<warpui::WindowId> {
+    active_window
 }
 
 #[cfg(test)]
@@ -495,10 +583,19 @@ fn local_invocation_context(context: InvocationContext) -> LocalControlInvocatio
     }
 }
 
-fn local_permission(permission: LocalControlPermission) -> LocalControlPermissionCategory {
+fn local_permission(permission: PermissionCategory) -> LocalControlPermissionCategory {
     match permission {
-        LocalControlPermission::ReadOnly => LocalControlPermissionCategory::ReadOnly,
-        LocalControlPermission::ReadWrite => LocalControlPermissionCategory::ReadWrite,
+        PermissionCategory::ReadMetadata => LocalControlPermissionCategory::MetadataReads,
+        PermissionCategory::ReadUnderlyingData => {
+            LocalControlPermissionCategory::UnderlyingDataReads
+        }
+        PermissionCategory::MutateAppState => LocalControlPermissionCategory::AppStateMutations,
+        PermissionCategory::MutateMetadataConfiguration => {
+            LocalControlPermissionCategory::MetadataConfigurationMutations
+        }
+        PermissionCategory::MutateUnderlyingData => {
+            LocalControlPermissionCategory::UnderlyingDataMutations
+        }
     }
 }
 
@@ -515,7 +612,7 @@ fn ensure_action_allowed(
             "local control is disabled for this invocation context",
         ));
     }
-    let permission = local_permission(action.metadata().permission);
+    let permission = local_permission(action.metadata().permission_category);
     if !settings.is_permission_enabled(context, permission) {
         return Err(ControlError::new(
             ErrorCode::InsufficientPermissions,

--- a/app/src/local_control/mod_tests.rs
+++ b/app/src/local_control/mod_tests.rs
@@ -2,7 +2,7 @@ use ::local_control::protocol::{
     PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector, WindowTarget,
 };
 
-use super::{capabilities, preferred_window_id, validate_tab_create_target};
+use super::{active_window_id, capabilities, validate_tab_create_target};
 use ::local_control::protocol::ActionKind;
 use ::local_control::ErrorCode;
 
@@ -52,24 +52,26 @@ fn tab_create_rejects_concrete_targets() {
 }
 
 #[test]
-fn capabilities_only_advertises_tab_create() {
-    assert_eq!(capabilities(), vec![ActionKind::TabCreate]);
+fn capabilities_advertises_only_first_slice_core_actions() {
+    assert_eq!(
+        capabilities(),
+        vec![
+            ActionKind::InstanceList,
+            ActionKind::AppPing,
+            ActionKind::AppVersion,
+            ActionKind::TabCreate,
+        ]
+    );
 }
 
 #[test]
 fn tab_create_prefers_active_window() {
     let active = warpui::WindowId::from_usize(1);
-    let frontmost = warpui::WindowId::from_usize(2);
 
-    assert_eq!(
-        preferred_window_id(Some(active), Some(frontmost)),
-        Some(active)
-    );
+    assert_eq!(active_window_id(Some(active)), Some(active));
 }
 
 #[test]
-fn tab_create_falls_back_to_frontmost_window() {
-    let frontmost = warpui::WindowId::from_usize(2);
-
-    assert_eq!(preferred_window_id(None, Some(frontmost)), Some(frontmost));
+fn tab_create_does_not_fall_back_without_active_window() {
+    assert_eq!(active_window_id(None), None);
 }

--- a/app/src/settings/local_control.rs
+++ b/app/src/settings/local_control.rs
@@ -8,8 +8,11 @@ pub enum LocalControlInvocationContext {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LocalControlPermissionCategory {
-    ReadOnly,
-    ReadWrite,
+    MetadataReads,
+    UnderlyingDataReads,
+    AppStateMutations,
+    MetadataConfigurationMutations,
+    UnderlyingDataMutations,
 }
 
 define_settings_group!(LocalControlSettings, settings: [
@@ -85,19 +88,25 @@ impl LocalControlSettings {
         match (context, permission) {
             (
                 LocalControlInvocationContext::InsideWarp,
-                LocalControlPermissionCategory::ReadOnly,
+                LocalControlPermissionCategory::MetadataReads
+                | LocalControlPermissionCategory::UnderlyingDataReads,
             ) => *self.allow_inside_warp_read_only,
             (
                 LocalControlInvocationContext::OutsideWarp,
-                LocalControlPermissionCategory::ReadOnly,
+                LocalControlPermissionCategory::MetadataReads
+                | LocalControlPermissionCategory::UnderlyingDataReads,
             ) => *self.allow_outside_warp_read_only,
             (
                 LocalControlInvocationContext::InsideWarp,
-                LocalControlPermissionCategory::ReadWrite,
+                LocalControlPermissionCategory::AppStateMutations
+                | LocalControlPermissionCategory::MetadataConfigurationMutations
+                | LocalControlPermissionCategory::UnderlyingDataMutations,
             ) => *self.allow_inside_warp_read_write,
             (
                 LocalControlInvocationContext::OutsideWarp,
-                LocalControlPermissionCategory::ReadWrite,
+                LocalControlPermissionCategory::AppStateMutations
+                | LocalControlPermissionCategory::MetadataConfigurationMutations
+                | LocalControlPermissionCategory::UnderlyingDataMutations,
             ) => *self.allow_outside_warp_read_write,
         }
     }

--- a/app/src/settings/local_control_tests.rs
+++ b/app/src/settings/local_control_tests.rs
@@ -30,19 +30,31 @@ fn defaults_allow_inside_warp_permissions_only() {
 
     assert!(settings.allows(
         LocalControlInvocationContext::InsideWarp,
-        LocalControlPermissionCategory::ReadOnly
+        LocalControlPermissionCategory::MetadataReads
     ));
     assert!(settings.allows(
         LocalControlInvocationContext::InsideWarp,
-        LocalControlPermissionCategory::ReadWrite
+        LocalControlPermissionCategory::UnderlyingDataReads
+    ));
+    assert!(settings.allows(
+        LocalControlInvocationContext::InsideWarp,
+        LocalControlPermissionCategory::AppStateMutations
+    ));
+    assert!(settings.allows(
+        LocalControlInvocationContext::InsideWarp,
+        LocalControlPermissionCategory::MetadataConfigurationMutations
+    ));
+    assert!(settings.allows(
+        LocalControlInvocationContext::InsideWarp,
+        LocalControlPermissionCategory::UnderlyingDataMutations
     ));
     assert!(!settings.allows(
         LocalControlInvocationContext::OutsideWarp,
-        LocalControlPermissionCategory::ReadOnly
+        LocalControlPermissionCategory::MetadataReads
     ));
     assert!(!settings.allows(
         LocalControlInvocationContext::OutsideWarp,
-        LocalControlPermissionCategory::ReadWrite
+        LocalControlPermissionCategory::AppStateMutations
     ));
 }
 
@@ -73,10 +85,10 @@ fn disabled_context_blocks_enabled_granular_permissions() {
 
     assert!(!settings.allows(
         LocalControlInvocationContext::InsideWarp,
-        LocalControlPermissionCategory::ReadWrite
+        LocalControlPermissionCategory::AppStateMutations
     ));
     assert!(!settings.allows(
         LocalControlInvocationContext::OutsideWarp,
-        LocalControlPermissionCategory::ReadOnly
+        LocalControlPermissionCategory::MetadataReads
     ));
 }

--- a/app/src/settings_view/scripting_page.rs
+++ b/app/src/settings_view/scripting_page.rs
@@ -15,6 +15,7 @@ use crate::settings::{
 use settings::{Setting as _, ToggleableSetting as _};
 use std::cell::RefCell;
 use std::collections::HashMap;
+use warp_core::features::FeatureFlag;
 use warp_core::settings::SyncToCloud;
 use warpui::elements::{Container, Element, MouseStateHandle};
 use warpui::ui_components::components::UiComponent;
@@ -235,7 +236,7 @@ impl SettingsPageMeta for ScriptingSettingsPageView {
     }
 
     fn should_render(&self, _ctx: &AppContext) -> bool {
-        cfg!(not(target_family = "wasm"))
+        cfg!(not(target_family = "wasm")) && FeatureFlag::WarpControlCli.is_enabled()
     }
 
     fn update_filter(&mut self, query: &str, ctx: &mut ViewContext<Self>) -> MatchData {

--- a/crates/local_control/src/auth.rs
+++ b/crates/local_control/src/auth.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 
 use crate::discovery::InstanceId;
 use crate::protocol::{
-    ActionKind, ControlError, ErrorCode, ExecutionContextProof, InvocationContext, RiskTier,
+    ActionKind, ControlError, ErrorCode, ExecutionContextProof, InvocationContext,
+    PermissionCategory, RiskTier, StateDataCategory,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,6 +80,26 @@ impl CredentialRequest {
             execution_context_proof: None,
         }
     }
+
+    pub fn verify_execution_context_proof(&self) -> Result<(), ControlError> {
+        match (&self.invocation_context, &self.execution_context_proof) {
+            (InvocationContext::InsideWarp, _) => Err(ControlError::new(
+                ErrorCode::ExecutionContextNotAllowed,
+                "inside-Warp credentials require an app-issued verified Warp terminal proof",
+            )),
+            (
+                InvocationContext::OutsideWarp,
+                None | Some(ExecutionContextProof::ExternalClient),
+            ) => Ok(()),
+            (
+                InvocationContext::OutsideWarp,
+                Some(ExecutionContextProof::VerifiedWarpTerminal { .. }),
+            ) => Err(ControlError::new(
+                ErrorCode::ExecutionContextNotAllowed,
+                "external clients cannot use a Warp terminal execution proof",
+            )),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -99,10 +120,17 @@ pub struct CredentialGrant {
     pub instance_id: InstanceId,
     pub action: ActionKind,
     pub risk_tier: RiskTier,
+    pub state_data_category: StateDataCategory,
+    pub permission_category: PermissionCategory,
     pub invocation_context: InvocationContext,
-    pub authenticated_user_subject: Option<String>,
+    pub authenticated_user: AuthenticatedUserGrant,
     pub issued_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticatedUserGrant {
+    pub required: bool,
+    pub subject: Option<String>,
 }
 
 impl CredentialGrant {
@@ -113,13 +141,19 @@ impl CredentialGrant {
         ttl: Duration,
     ) -> Self {
         let issued_at = Utc::now();
+        let metadata = action.metadata();
         Self {
             credential_id: format!("cred_{}", Uuid::new_v4().simple()),
             instance_id,
             action,
-            risk_tier: action.metadata().risk_tier,
+            risk_tier: metadata.risk_tier,
+            state_data_category: metadata.state_data_category,
+            permission_category: metadata.permission_category,
             invocation_context,
-            authenticated_user_subject: None,
+            authenticated_user: AuthenticatedUserGrant {
+                required: metadata.authenticated_user.required,
+                subject: None,
+            },
             issued_at,
             expires_at: issued_at + ttl,
         }
@@ -143,7 +177,19 @@ impl CredentialGrant {
             ));
         }
         let metadata = action.metadata();
-        if metadata.requires_authenticated_user && self.authenticated_user_subject.is_none() {
+        if self.risk_tier != metadata.risk_tier
+            || self.state_data_category != metadata.state_data_category
+            || self.permission_category != metadata.permission_category
+        {
+            return Err(ControlError::new(
+                ErrorCode::InsufficientPermissions,
+                format!(
+                    "credential grant metadata does not satisfy {}",
+                    action.as_str()
+                ),
+            ));
+        }
+        if metadata.requires_authenticated_user && self.authenticated_user.subject.is_none() {
             return Err(ControlError::new(
                 ErrorCode::AuthenticatedUserRequired,
                 format!("{} requires an authenticated Warp user", action.as_str()),
@@ -166,49 +212,5 @@ impl CredentialGrant {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rejects_missing_authorization_header() {
-        let token = AuthToken::from_secret("secret");
-        let err = token
-            .verify_authorization_header(None)
-            .expect_err("rejected");
-        assert_eq!(err.code, ErrorCode::UnauthorizedLocalClient);
-    }
-
-    #[test]
-    fn rejects_wrong_bearer_token() {
-        let token = AuthToken::from_secret("secret");
-        let err = token
-            .verify_authorization_header(Some("Bearer wrong"))
-            .expect_err("rejected");
-        assert_eq!(err.code, ErrorCode::UnauthorizedLocalClient);
-    }
-
-    #[test]
-    fn accepts_matching_bearer_token() {
-        let token = AuthToken::from_secret("secret");
-        token
-            .verify_authorization_header(Some("Bearer secret"))
-            .expect("accepted");
-    }
-
-    #[test]
-    fn scoped_credential_allows_only_granted_action() {
-        let grant = CredentialGrant::new(
-            InstanceId("inst_test".to_owned()),
-            ActionKind::TabCreate,
-            InvocationContext::OutsideWarp,
-            Duration::minutes(5),
-        );
-        grant
-            .verify_for_action(ActionKind::TabCreate)
-            .expect("tab.create grant is accepted");
-        let err = grant
-            .verify_for_action(ActionKind::WindowCreate)
-            .expect_err("other actions are rejected");
-        assert_eq!(err.code, ErrorCode::InsufficientPermissions);
-    }
-}
+#[path = "auth_tests.rs"]
+mod tests;

--- a/crates/local_control/src/auth_tests.rs
+++ b/crates/local_control/src/auth_tests.rs
@@ -1,0 +1,105 @@
+use chrono::Duration;
+
+use super::*;
+use crate::discovery::InstanceId;
+use crate::protocol::{PermissionCategory, StateDataCategory};
+
+#[test]
+fn rejects_missing_authorization_header() {
+    let token = AuthToken::from_secret("secret");
+    let err = token
+        .verify_authorization_header(None)
+        .expect_err("rejected");
+    assert_eq!(err.code, ErrorCode::UnauthorizedLocalClient);
+}
+
+#[test]
+fn rejects_wrong_bearer_token() {
+    let token = AuthToken::from_secret("secret");
+    let err = token
+        .verify_authorization_header(Some("Bearer wrong"))
+        .expect_err("rejected");
+    assert_eq!(err.code, ErrorCode::UnauthorizedLocalClient);
+}
+
+#[test]
+fn accepts_matching_bearer_token() {
+    let token = AuthToken::from_secret("secret");
+    token
+        .verify_authorization_header(Some("Bearer secret"))
+        .expect("accepted");
+}
+
+#[test]
+fn scoped_credential_allows_only_granted_action() {
+    let grant = CredentialGrant::new(
+        InstanceId("inst_test".to_owned()),
+        ActionKind::TabCreate,
+        InvocationContext::OutsideWarp,
+        Duration::minutes(5),
+    );
+    grant
+        .verify_for_action(ActionKind::TabCreate)
+        .expect("tab.create grant is accepted");
+    let err = grant
+        .verify_for_action(ActionKind::WindowCreate)
+        .expect_err("other actions are rejected");
+    assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+}
+
+#[test]
+fn scoped_credential_carries_permission_and_authenticated_user_metadata() {
+    let grant = CredentialGrant::new(
+        InstanceId("inst_test".to_owned()),
+        ActionKind::TabCreate,
+        InvocationContext::InsideWarp,
+        Duration::minutes(5),
+    );
+    assert_eq!(grant.risk_tier, RiskTier::MutatingNonDestructive);
+    assert_eq!(
+        grant.state_data_category,
+        StateDataCategory::AppStateMutation
+    );
+    assert_eq!(
+        grant.permission_category,
+        PermissionCategory::MutateAppState
+    );
+    assert!(!grant.authenticated_user.required);
+    assert!(grant.authenticated_user.subject.is_none());
+}
+
+#[test]
+fn mismatched_permission_metadata_is_rejected() {
+    let mut grant = CredentialGrant::new(
+        InstanceId("inst_test".to_owned()),
+        ActionKind::TabCreate,
+        InvocationContext::InsideWarp,
+        Duration::minutes(5),
+    );
+    grant.permission_category = PermissionCategory::ReadMetadata;
+    let err = grant
+        .verify_for_action(ActionKind::TabCreate)
+        .expect_err("metadata mismatch is rejected");
+    assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+}
+
+#[test]
+fn credential_request_rejects_unverified_inside_warp_context() {
+    let request = CredentialRequest::new(ActionKind::TabCreate, InvocationContext::InsideWarp);
+    let err = request
+        .verify_execution_context_proof()
+        .expect_err("missing proof is rejected");
+    assert_eq!(err.code, ErrorCode::ExecutionContextNotAllowed);
+}
+
+#[test]
+fn credential_request_rejects_terminal_proof_for_external_client() {
+    let mut request = CredentialRequest::new(ActionKind::TabCreate, InvocationContext::OutsideWarp);
+    request.execution_context_proof = Some(ExecutionContextProof::VerifiedWarpTerminal {
+        proof_id: "proof".to_owned(),
+    });
+    let err = request
+        .verify_execution_context_proof()
+        .expect_err("terminal proof is rejected for external context");
+    assert_eq!(err.code, ErrorCode::ExecutionContextNotAllowed);
+}

--- a/crates/local_control/src/client.rs
+++ b/crates/local_control/src/client.rs
@@ -14,9 +14,15 @@ pub fn send_request(
         request.action.kind,
         InvocationContext::OutsideWarp,
     )?;
+    let endpoint = instance.endpoint.as_ref().ok_or_else(|| {
+        ControlError::new(
+            ErrorCode::LocalControlDisabled,
+            "outside-Warp local control endpoint is disabled for this instance",
+        )
+    })?;
     let client = reqwest::blocking::Client::new();
     let response = client
-        .post(instance.endpoint.url())
+        .post(endpoint.url())
         .header("Authorization", credential.authorization_value())
         .json(request)
         .send()
@@ -56,10 +62,16 @@ pub fn request_credential(
     action: crate::protocol::ActionKind,
     invocation_context: InvocationContext,
 ) -> Result<ScopedCredential, ControlError> {
+    let credential_broker = instance.credential_broker.as_ref().ok_or_else(|| {
+        ControlError::new(
+            ErrorCode::LocalControlDisabled,
+            "outside-Warp local control credential broker is disabled for this instance",
+        )
+    })?;
     let client = reqwest::blocking::Client::new();
     let request = CredentialRequest::new(action, invocation_context);
     let response = client
-        .post(instance.credential_broker.endpoint.credential_url())
+        .post(credential_broker.endpoint.credential_url())
         .json(&request)
         .send()
         .map_err(|err| {

--- a/crates/local_control/src/discovery.rs
+++ b/crates/local_control/src/discovery.rs
@@ -62,19 +62,23 @@ pub struct InstanceRecord {
     pub app_version: Option<String>,
     pub started_at: DateTime<Utc>,
     pub executable_path: Option<PathBuf>,
-    pub endpoint: ControlEndpoint,
-    pub credential_broker: CredentialBrokerReference,
+    pub endpoint: Option<ControlEndpoint>,
+    pub credential_broker: Option<CredentialBrokerReference>,
+    pub outside_warp_control_enabled: bool,
     pub actions: Vec<ActionMetadata>,
 }
 
 impl InstanceRecord {
     pub fn for_current_process(
-        endpoint: ControlEndpoint,
+        endpoint: Option<ControlEndpoint>,
         channel: impl Into<String>,
         app_id: impl Into<String>,
         app_version: Option<String>,
         actions: Vec<ActionMetadata>,
     ) -> Self {
+        let credential_broker = endpoint
+            .clone()
+            .map(|endpoint| CredentialBrokerReference { endpoint });
         Self {
             protocol_version: PROTOCOL_VERSION,
             instance_id: InstanceId::new(),
@@ -84,9 +88,8 @@ impl InstanceRecord {
             app_version,
             started_at: Utc::now(),
             executable_path: std::env::current_exe().ok(),
-            credential_broker: CredentialBrokerReference {
-                endpoint: endpoint.clone(),
-            },
+            outside_warp_control_enabled: endpoint.is_some(),
+            credential_broker,
             endpoint,
             actions,
         }
@@ -221,7 +224,7 @@ mod tests {
     fn registered_instance_round_trips_discovery_record() {
         let dir = tempfile::tempdir().expect("temp dir");
         let record = InstanceRecord::for_current_process(
-            ControlEndpoint::localhost(4000),
+            Some(ControlEndpoint::localhost(4000)),
             "local",
             "dev.warp.WarpLocal",
             Some("test".to_owned()),
@@ -237,7 +240,7 @@ mod tests {
     fn serialized_discovery_record_does_not_contain_raw_credential_material() {
         let raw_secret = "raw-secret-token-material";
         let record = InstanceRecord::for_current_process(
-            ControlEndpoint::localhost(4000),
+            Some(ControlEndpoint::localhost(4000)),
             "local",
             "dev.warp.WarpLocal",
             Some("test".to_owned()),
@@ -247,6 +250,20 @@ mod tests {
         assert!(!serialized.contains(raw_secret));
         assert!(!serialized.contains("auth_token"));
         assert!(!serialized.contains("bearer_token"));
+    }
+
+    #[test]
+    fn disabled_outside_warp_record_does_not_expose_actionable_authority() {
+        let record = InstanceRecord::for_current_process(
+            None,
+            "local",
+            "dev.warp.WarpLocal",
+            Some("test".to_owned()),
+            crate::protocol::ActionKind::implemented_metadata(),
+        );
+        assert!(!record.outside_warp_control_enabled);
+        assert!(record.endpoint.is_none());
+        assert!(record.credential_broker.is_none());
     }
 
     impl RegisteredInstance {

--- a/crates/local_control/src/lib.rs
+++ b/crates/local_control/src/lib.rs
@@ -4,14 +4,17 @@ pub mod discovery;
 pub mod protocol;
 pub mod selection;
 
-pub use auth::{AuthToken, CredentialGrant, CredentialRequest, ScopedCredential};
+pub use auth::{
+    AuthToken, AuthenticatedUserGrant, CredentialGrant, CredentialRequest, ScopedCredential,
+};
 pub use discovery::{
     ControlEndpoint, CredentialBrokerReference, InstanceId, InstanceRecord, RegisteredInstance,
     discovery_dir,
 };
 pub use protocol::{
-    Action, ActionImplementationStatus, ActionKind, ActionMetadata, ControlError, ControlResponse,
-    ErrorCode, ErrorResponseEnvelope, ExecutionContextProof, InvocationContext,
-    LocalControlPermission, PROTOCOL_VERSION, PaneSelector, RequestEnvelope, ResponseEnvelope,
-    RiskTier, TabSelector, TargetScope, TargetSelector, WindowSelector,
+    Action, ActionImplementationStatus, ActionKind, ActionMetadata, AuthenticatedUserRequirement,
+    ControlError, ControlResponse, ErrorCode, ErrorResponseEnvelope, ExecutionContextProof,
+    InvocationContext, PROTOCOL_VERSION, PaneSelector, PermissionCategory, RequestEnvelope,
+    ResponseEnvelope, RiskTier, StateDataCategory, TabSelector, TargetScope, TargetSelector,
+    WindowSelector,
 };

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -28,9 +28,27 @@ pub enum RiskTier {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum LocalControlPermission {
-    ReadOnly,
-    ReadWrite,
+pub enum StateDataCategory {
+    MetadataRead,
+    UnderlyingDataRead,
+    AppStateMutation,
+    MetadataConfigurationMutation,
+    UnderlyingDataMutation,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionCategory {
+    ReadMetadata,
+    ReadUnderlyingData,
+    MutateAppState,
+    MutateMetadataConfiguration,
+    MutateUnderlyingData,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticatedUserRequirement {
+    pub required: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -59,9 +77,11 @@ pub struct ActionMetadata {
     pub name: String,
     pub implementation_status: ActionImplementationStatus,
     pub risk_tier: RiskTier,
+    pub state_data_category: StateDataCategory,
     pub requires_authenticated_user: bool,
+    pub authenticated_user: AuthenticatedUserRequirement,
     pub allowed_invocation_contexts: Vec<InvocationContext>,
-    pub permission: LocalControlPermission,
+    pub permission_category: PermissionCategory,
     pub target_scope: TargetScope,
 }
 
@@ -152,6 +172,8 @@ impl Action {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ActionKind {
+    #[serde(rename = "instance.list")]
+    InstanceList,
     #[serde(rename = "app.ping")]
     AppPing,
     #[serde(rename = "app.inspect")]
@@ -252,6 +274,7 @@ pub enum ActionKind {
 
 impl ActionKind {
     pub const ALL: &[Self] = &[
+        Self::InstanceList,
         Self::AppPing,
         Self::AppInspect,
         Self::AppVersion,
@@ -303,6 +326,7 @@ impl ActionKind {
     ];
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::InstanceList => "instance.list",
             Self::AppPing => "app.ping",
             Self::AppInspect => "app.inspect",
             Self::AppVersion => "app.version",
@@ -355,29 +379,30 @@ impl ActionKind {
     }
 
     pub fn metadata(self) -> ActionMetadata {
-        if self == Self::TabCreate {
-            return ActionMetadata {
-                kind: self,
-                name: self.as_str().to_owned(),
-                implementation_status: ActionImplementationStatus::Implemented,
-                risk_tier: RiskTier::MutatingNonDestructive,
-                requires_authenticated_user: false,
-                allowed_invocation_contexts: vec![
-                    InvocationContext::InsideWarp,
-                    InvocationContext::OutsideWarp,
-                ],
-                permission: LocalControlPermission::ReadWrite,
-                target_scope: TargetScope::Window,
+        let (implementation_status, requires_authenticated_user, allowed_invocation_contexts) =
+            match self {
+                Self::InstanceList | Self::AppPing | Self::AppVersion | Self::TabCreate => (
+                    ActionImplementationStatus::Implemented,
+                    false,
+                    vec![
+                        InvocationContext::InsideWarp,
+                        InvocationContext::OutsideWarp,
+                    ],
+                ),
+                _ => (ActionImplementationStatus::Stub, true, Vec::new()),
             };
-        }
         ActionMetadata {
             kind: self,
             name: self.as_str().to_owned(),
-            implementation_status: ActionImplementationStatus::Stub,
+            implementation_status,
             risk_tier: self.default_risk_tier(),
-            requires_authenticated_user: true,
-            allowed_invocation_contexts: Vec::new(),
-            permission: self.default_permission(),
+            state_data_category: self.default_state_data_category(),
+            requires_authenticated_user,
+            authenticated_user: AuthenticatedUserRequirement {
+                required: requires_authenticated_user,
+            },
+            allowed_invocation_contexts,
+            permission_category: self.default_permission_category(),
             target_scope: self.default_target_scope(),
         }
     }
@@ -399,7 +424,8 @@ impl ActionKind {
 
     fn default_risk_tier(self) -> RiskTier {
         match self {
-            Self::AppPing
+            Self::InstanceList
+            | Self::AppPing
             | Self::AppInspect
             | Self::AppVersion
             | Self::AppActive
@@ -450,17 +476,70 @@ impl ActionKind {
         }
     }
 
-    fn default_permission(self) -> LocalControlPermission {
-        match self.default_risk_tier() {
-            RiskTier::ReadOnlyMetadata | RiskTier::ReadOnlyTerminalData => {
-                LocalControlPermission::ReadOnly
+    fn default_state_data_category(self) -> StateDataCategory {
+        match self {
+            Self::InstanceList
+            | Self::AppPing
+            | Self::AppInspect
+            | Self::AppVersion
+            | Self::AppActive
+            | Self::WindowList
+            | Self::TabList
+            | Self::PaneList
+            | Self::SessionList
+            | Self::ThemeList
+            | Self::AppearanceGet
+            | Self::SettingGet
+            | Self::SettingList => StateDataCategory::MetadataRead,
+            Self::SettingSet
+            | Self::SettingToggle
+            | Self::ThemeSet
+            | Self::AppearanceSet
+            | Self::AppearanceFontSize
+            | Self::AppearanceZoom => StateDataCategory::MetadataConfigurationMutation,
+            Self::InputInsert | Self::InputReplace | Self::InputClear | Self::InputModeSet => {
+                StateDataCategory::UnderlyingDataMutation
             }
-            RiskTier::MutatingNonDestructive | RiskTier::MutatingDestructiveOrExecution => {
-                LocalControlPermission::ReadWrite
-            }
+            Self::AppFocus
+            | Self::AppSettingsOpen
+            | Self::AppCommandPaletteOpen
+            | Self::AppCommandSearchOpen
+            | Self::AppWarpDriveOpen
+            | Self::AppWarpDriveToggle
+            | Self::AppResourceCenterToggle
+            | Self::AppAiAssistantToggle
+            | Self::AppCodeReviewToggle
+            | Self::AppVerticalTabsToggle
+            | Self::WindowCreate
+            | Self::WindowFocus
+            | Self::WindowClose
+            | Self::TabCreate
+            | Self::TabActivate
+            | Self::TabMove
+            | Self::TabRename
+            | Self::TabClose
+            | Self::PaneSplit
+            | Self::PaneFocus
+            | Self::PaneNavigate
+            | Self::PaneClose
+            | Self::PaneMaximize
+            | Self::PaneResize
+            | Self::PaneSessionPrevious
+            | Self::PaneSessionNext => StateDataCategory::AppStateMutation,
         }
     }
 
+    fn default_permission_category(self) -> PermissionCategory {
+        match self.default_state_data_category() {
+            StateDataCategory::MetadataRead => PermissionCategory::ReadMetadata,
+            StateDataCategory::UnderlyingDataRead => PermissionCategory::ReadUnderlyingData,
+            StateDataCategory::AppStateMutation => PermissionCategory::MutateAppState,
+            StateDataCategory::MetadataConfigurationMutation => {
+                PermissionCategory::MutateMetadataConfiguration
+            }
+            StateDataCategory::UnderlyingDataMutation => PermissionCategory::MutateUnderlyingData,
+        }
+    }
     fn default_target_scope(self) -> TargetScope {
         match self {
             Self::WindowList | Self::WindowCreate | Self::WindowFocus | Self::WindowClose => {
@@ -504,7 +583,8 @@ impl ActionKind {
             | Self::AppAiAssistantToggle
             | Self::AppCodeReviewToggle
             | Self::AppVerticalTabsToggle => TargetScope::Surface,
-            Self::AppPing
+            Self::InstanceList
+            | Self::AppPing
             | Self::AppInspect
             | Self::AppVersion
             | Self::AppActive
@@ -627,67 +707,5 @@ impl std::fmt::Display for ErrorCode {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn request_envelope_serializes_stable_action_names() {
-        let request = RequestEnvelope::new(Action::new(ActionKind::WindowFocus));
-        let value = serde_json::to_value(&request).expect("request serializes");
-        assert_eq!(value["protocol_version"], PROTOCOL_VERSION);
-        assert_eq!(value["action"]["kind"], "window.focus");
-    }
-
-    #[test]
-    fn response_error_serializes_machine_code() {
-        let response = ResponseEnvelope::error(
-            Uuid::nil(),
-            ControlError::new(ErrorCode::UnauthorizedLocalClient, "bad token"),
-        );
-        let value = serde_json::to_value(&response).expect("response serializes");
-        assert_eq!(value["response"]["status"], "error");
-        assert_eq!(
-            value["response"]["error"]["code"],
-            "unauthorized_local_client"
-        );
-    }
-
-    #[test]
-    fn input_run_is_not_in_the_allowlisted_catalog() {
-        let action = serde_json::from_value::<ActionKind>(serde_json::json!("input.run"));
-        assert!(action.is_err());
-    }
-
-    #[test]
-    fn tab_create_metadata_is_first_slice_logged_out_safe_mutation() {
-        let metadata = ActionKind::TabCreate.metadata();
-        assert_eq!(
-            metadata.implementation_status,
-            ActionImplementationStatus::Implemented
-        );
-        assert_eq!(metadata.risk_tier, RiskTier::MutatingNonDestructive);
-        assert!(!metadata.requires_authenticated_user);
-        assert_eq!(metadata.permission, LocalControlPermission::ReadWrite);
-        assert_eq!(
-            metadata.allowed_invocation_contexts,
-            vec![
-                InvocationContext::InsideWarp,
-                InvocationContext::OutsideWarp
-            ]
-        );
-    }
-
-    #[test]
-    fn non_first_slice_actions_are_catalog_stubs() {
-        let metadata = ActionKind::WindowCreate.metadata();
-        assert_eq!(
-            metadata.implementation_status,
-            ActionImplementationStatus::Stub
-        );
-        assert!(
-            !metadata
-                .allowed_invocation_contexts
-                .contains(&InvocationContext::OutsideWarp)
-        );
-    }
-}
+#[path = "protocol_tests.rs"]
+mod tests;

--- a/crates/local_control/src/protocol_tests.rs
+++ b/crates/local_control/src/protocol_tests.rs
@@ -1,0 +1,109 @@
+use super::*;
+
+#[test]
+fn request_envelope_serializes_stable_action_names() {
+    let request = RequestEnvelope::new(Action::new(ActionKind::WindowFocus));
+    let value = serde_json::to_value(&request).expect("request serializes");
+    assert_eq!(value["protocol_version"], PROTOCOL_VERSION);
+    assert_eq!(value["action"]["kind"], "window.focus");
+}
+
+#[test]
+fn response_error_serializes_machine_code() {
+    let response = ResponseEnvelope::error(
+        Uuid::nil(),
+        ControlError::new(ErrorCode::UnauthorizedLocalClient, "bad token"),
+    );
+    let value = serde_json::to_value(&response).expect("response serializes");
+    assert_eq!(value["response"]["status"], "error");
+    assert_eq!(
+        value["response"]["error"]["code"],
+        "unauthorized_local_client"
+    );
+}
+
+#[test]
+fn input_run_is_not_in_the_allowlisted_catalog() {
+    let action = serde_json::from_value::<ActionKind>(serde_json::json!("input.run"));
+    assert!(action.is_err());
+}
+
+#[test]
+fn tab_create_metadata_is_first_slice_logged_out_safe_mutation() {
+    let metadata = ActionKind::TabCreate.metadata();
+    assert_eq!(
+        metadata.implementation_status,
+        ActionImplementationStatus::Implemented
+    );
+    assert_eq!(metadata.risk_tier, RiskTier::MutatingNonDestructive);
+    assert_eq!(
+        metadata.state_data_category,
+        StateDataCategory::AppStateMutation
+    );
+    assert!(!metadata.requires_authenticated_user);
+    assert!(!metadata.authenticated_user.required);
+    assert_eq!(
+        metadata.permission_category,
+        PermissionCategory::MutateAppState
+    );
+    assert_eq!(
+        metadata.allowed_invocation_contexts,
+        vec![
+            InvocationContext::InsideWarp,
+            InvocationContext::OutsideWarp
+        ]
+    );
+}
+
+#[test]
+fn core_smoke_metadata_has_explicit_read_metadata_category() {
+    for action in [
+        ActionKind::InstanceList,
+        ActionKind::AppPing,
+        ActionKind::AppVersion,
+    ] {
+        let metadata = action.metadata();
+        assert_eq!(
+            metadata.implementation_status,
+            ActionImplementationStatus::Implemented
+        );
+        assert_eq!(metadata.risk_tier, RiskTier::ReadOnlyMetadata);
+        assert_eq!(
+            metadata.state_data_category,
+            StateDataCategory::MetadataRead
+        );
+        assert_eq!(
+            metadata.permission_category,
+            PermissionCategory::ReadMetadata
+        );
+        assert!(!metadata.authenticated_user.required);
+        assert_eq!(metadata.target_scope, TargetScope::Instance);
+    }
+}
+
+#[test]
+fn action_metadata_serializes_security_categories() {
+    let metadata = ActionKind::TabCreate.metadata();
+    let value = serde_json::to_value(metadata).expect("metadata serializes");
+    assert_eq!(value["name"], "tab.create");
+    assert_eq!(value["state_data_category"], "app_state_mutation");
+    assert_eq!(value["permission_category"], "mutate_app_state");
+    assert_eq!(
+        value["authenticated_user"]["required"],
+        serde_json::json!(false)
+    );
+}
+
+#[test]
+fn non_first_slice_actions_are_catalog_stubs() {
+    let metadata = ActionKind::WindowCreate.metadata();
+    assert_eq!(
+        metadata.implementation_status,
+        ActionImplementationStatus::Stub
+    );
+    assert!(
+        !metadata
+            .allowed_invocation_contexts
+            .contains(&InvocationContext::OutsideWarp)
+    );
+}

--- a/crates/local_control/src/selection.rs
+++ b/crates/local_control/src/selection.rs
@@ -69,10 +69,11 @@ mod tests {
             app_version: None,
             started_at: Utc::now(),
             executable_path: None,
-            endpoint: ControlEndpoint::localhost(4000),
-            credential_broker: crate::discovery::CredentialBrokerReference {
+            endpoint: Some(ControlEndpoint::localhost(4000)),
+            credential_broker: Some(crate::discovery::CredentialBrokerReference {
                 endpoint: ControlEndpoint::localhost(4000),
-            },
+            }),
+            outside_warp_control_enabled: true,
             actions: vec![ActionKind::TabCreate.metadata()],
         }
     }

--- a/crates/warp_cli/src/local_control.rs
+++ b/crates/warp_cli/src/local_control.rs
@@ -2,7 +2,9 @@ use std::io::Write as _;
 
 use anyhow::Context as _;
 use clap::{Args, Parser, Subcommand};
-use local_control::protocol::{Action, ActionKind, ControlResponse, RequestEnvelope};
+use local_control::protocol::{
+    Action, ActionKind, ActionMetadata, ControlResponse, RequestEnvelope,
+};
 use local_control::selection::{InstanceSelector, select_instance};
 use serde::Serialize;
 use serde_json::json;
@@ -35,6 +37,9 @@ pub enum ControlCommand {
     /// Inspect local Warp app instances.
     #[command(subcommand)]
     Instance(InstanceCommand),
+    /// Inspect a selected local Warp app.
+    #[command(subcommand)]
+    App(AppCommand),
 
     /// Control local Warp tabs.
     #[command(subcommand)]
@@ -45,6 +50,15 @@ pub enum ControlCommand {
 pub enum InstanceCommand {
     /// List locally discoverable Warp instances.
     List,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AppCommand {
+    /// Check that the selected local Warp app responds.
+    Ping(TargetArgs),
+
+    /// Print protocol and app version metadata for the selected local Warp app.
+    Version(TargetArgs),
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -72,8 +86,9 @@ struct InstanceSummary {
     app_id: String,
     app_version: Option<String>,
     started_at: String,
-    endpoint: local_control::discovery::ControlEndpoint,
-    actions: Vec<String>,
+    endpoint: Option<local_control::discovery::ControlEndpoint>,
+    outside_warp_control_enabled: bool,
+    actions: Vec<ActionMetadata>,
 }
 
 impl From<local_control::discovery::InstanceRecord> for InstanceSummary {
@@ -86,11 +101,8 @@ impl From<local_control::discovery::InstanceRecord> for InstanceSummary {
             app_version: record.app_version,
             started_at: record.started_at.to_rfc3339(),
             endpoint: record.endpoint,
-            actions: record
-                .actions
-                .into_iter()
-                .map(|metadata| metadata.name)
-                .collect(),
+            outside_warp_control_enabled: record.outside_warp_control_enabled,
+            actions: record.actions,
         }
     }
 }
@@ -99,6 +111,7 @@ pub fn run(args: ControlArgs) -> anyhow::Result<()> {
     let output_format = args.output_format;
     match args.command {
         ControlCommand::Instance(command) => run_instance_command(command, output_format),
+        ControlCommand::App(command) => run_app_command(command, output_format),
         ControlCommand::Tab(command) => run_tab_command(command, output_format),
     }
 }
@@ -123,18 +136,28 @@ fn run_instance_command(
                 }
                 OutputFormat::Pretty | OutputFormat::Text => {
                     for summary in summaries {
+                        let endpoint = summary
+                            .endpoint
+                            .as_ref()
+                            .map(|endpoint| format!("{}:{}", endpoint.host, endpoint.port))
+                            .unwrap_or_else(|| "outside_warp_disabled".to_owned());
                         println!(
-                            "{}\tpid={}\t{}\t{}:{}",
-                            summary.instance_id,
-                            summary.pid,
-                            summary.channel,
-                            summary.endpoint.host,
-                            summary.endpoint.port
+                            "{}\tpid={}\t{}\t{}",
+                            summary.instance_id, summary.pid, summary.channel, endpoint
                         );
                     }
                     Ok(())
                 }
             }
+        }
+    }
+}
+
+fn run_app_command(command: AppCommand, output_format: OutputFormat) -> anyhow::Result<()> {
+    match command {
+        AppCommand::Ping(args) => run_action(args, ActionKind::AppPing, json!({}), output_format),
+        AppCommand::Version(args) => {
+            run_action(args, ActionKind::AppVersion, json!({}), output_format)
         }
     }
 }
@@ -199,37 +222,5 @@ fn write_json_line(value: &impl Serialize) -> anyhow::Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use clap::Parser as _;
-
-    use super::*;
-
-    #[test]
-    fn parses_first_slice_tab_create() {
-        let args =
-            ControlArgs::try_parse_from(["warpctrl", "tab", "create", "--instance", "inst_123"])
-                .expect("tab create parses");
-        let ControlCommand::Tab(TabCommand::Create(target)) = args.command else {
-            panic!("expected tab create command");
-        };
-        assert_eq!(target.instance.as_deref(), Some("inst_123"));
-    }
-
-    #[test]
-    fn parses_first_slice_instance_list() {
-        let args = ControlArgs::try_parse_from(["warpctrl", "instance", "list"])
-            .expect("instance list parses");
-        assert!(matches!(
-            args.command,
-            ControlCommand::Instance(InstanceCommand::List)
-        ));
-    }
-
-    #[test]
-    fn rejects_future_catalog_commands_not_in_first_slice() {
-        assert!(ControlArgs::try_parse_from(["warpctrl", "window", "list"]).is_err());
-        assert!(ControlArgs::try_parse_from(["warpctrl", "app", "ping"]).is_err());
-        assert!(ControlArgs::try_parse_from(["warpctrl", "tab", "list"]).is_err());
-        assert!(ControlArgs::try_parse_from(["warpctrl", "setting", "list"]).is_err());
-    }
-}
+#[path = "local_control_tests.rs"]
+mod tests;

--- a/crates/warp_cli/src/local_control_tests.rs
+++ b/crates/warp_cli/src/local_control_tests.rs
@@ -1,0 +1,36 @@
+use clap::Parser as _;
+
+use super::*;
+
+#[test]
+fn parses_first_slice_tab_create() {
+    let args = ControlArgs::try_parse_from(["warpctrl", "tab", "create", "--instance", "inst_123"])
+        .expect("tab create parses");
+    let ControlCommand::Tab(TabCommand::Create(target)) = args.command else {
+        panic!("expected tab create command");
+    };
+    assert_eq!(target.instance.as_deref(), Some("inst_123"));
+}
+
+#[test]
+fn parses_first_slice_instance_list() {
+    let args = ControlArgs::try_parse_from(["warpctrl", "instance", "list"])
+        .expect("instance list parses");
+    assert!(matches!(
+        args.command,
+        ControlCommand::Instance(InstanceCommand::List)
+    ));
+}
+
+#[test]
+fn parses_first_slice_app_smoke_metadata_commands() {
+    assert!(ControlArgs::try_parse_from(["warpctrl", "app", "ping"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "app", "version"]).is_ok());
+}
+
+#[test]
+fn rejects_future_catalog_commands_not_in_first_slice() {
+    assert!(ControlArgs::try_parse_from(["warpctrl", "window", "list"]).is_err());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "tab", "list"]).is_err());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "setting", "list"]).is_err());
+}

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -817,6 +817,9 @@ pub enum FeatureFlag {
     /// Enables conversation retrieval via the CLI (oz run conversation get, oz run get --conversation).
     ConversationApi,
 
+    /// Gates the local Warp Control CLI (`warpctrl`) settings, discovery, and app bridge.
+    WarpControlCli,
+
     /// Guided onboarding flow for existing users introducing HOA features
     /// (vertical tabs, agent inbox, tab configs).
     HOAOnboardingFlow,
@@ -942,6 +945,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::DragTabsToWindows,
     FeatureFlag::RemoteCodebaseIndexing,
     FeatureFlag::RemoteCodeReview,
+    FeatureFlag::WarpControlCli,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Implements the Phase 1 `warpctrl` core contract/security shard on top of `zach/warp-cli`:

- Adds explicit action metadata for `instance.list`, `app.ping`, `app.version`, and `tab.create` including state/data category, five-category permission mapping, authenticated-user requirement, invocation contexts, risk, and target scope.
- Preserves the five permission categories in local-control settings/enforcement and maps them to the existing read-only/read-write UI controls.
- Gates local-control settings visibility, bridge/server registration, server startup, and credential/control endpoints behind `FeatureFlag::WarpControlCli`.
- Hides actionable discovery endpoint/broker authority unless outside-Warp control is enabled.
- Fails closed for unverified inside-Warp credential requests pending a real app-issued Warp-terminal proof verifier.
- Keeps `tab.create` scoped to the active window only and rejects concrete selectors instead of falling back to frontmost windows.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt`
- [x] `cargo check -p local_control -p warp_cli`
- [x] `cargo check -p warp`
- [x] `cargo nextest run --no-fail-fast -p local_control`
- [x] `cargo nextest run --no-fail-fast -p warp_cli local_control`
- [x] `cargo nextest run --no-fail-fast -p warp local_control`
- [x] `cargo clippy -p local_control -p warp_cli --all-targets -- -D warnings`
- [x] `cargo clippy -p warp --lib -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not applicable; core protocol/security scaffolding only.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/b53dd529-7361-495a-bdaf-90342cc51692_
_Run: https://oz.staging.warp.dev/runs/019e5227-eb5c-7844-99e5-471a1c4ec340_

_This PR was generated with [Oz](https://warp.dev/oz)._
