### PR TITLE
Harden warpctrl phase 1 negative paths

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2004,7 +2004,8 @@ pub(crate) fn initialize_app(
     if matches!(
         launch_mode,
         LaunchMode::App { .. } | LaunchMode::Test { .. }
-    ) {
+    ) && FeatureFlag::WarpControlCli.is_enabled()
+    {
         ctx.add_singleton_model(local_control::LocalControlBridge::new);
         ctx.add_singleton_model(local_control::LocalControlServer::new);
     }

--- a/app/src/local_control/mod.rs
+++ b/app/src/local_control/mod.rs
@@ -9,8 +9,8 @@ use ::local_control::auth::{CredentialGrant, CredentialRequest, ScopedCredential
 use ::local_control::protocol::{PaneTarget, TabTarget, TargetSelector, WindowTarget};
 use ::local_control::{
     ActionKind, AuthToken, ControlEndpoint, ControlError, ControlResponse, ErrorCode,
-    ErrorResponseEnvelope, InstanceId, InstanceRecord, RegisteredInstance, RequestEnvelope,
-    ResponseEnvelope, PROTOCOL_VERSION,
+    ErrorResponseEnvelope, ExecutionContextProof, InstanceId, InstanceRecord, RegisteredInstance,
+    RequestEnvelope, ResponseEnvelope, PROTOCOL_VERSION,
 };
 use ::local_control::{InvocationContext, LocalControlPermission};
 use axum::extract::rejection::JsonRejection;
@@ -22,6 +22,7 @@ use axum::{Json, Router};
 use chrono::Duration;
 use serde_json::json;
 use warp_core::channel::ChannelState;
+use warp_core::features::FeatureFlag;
 use warpui::{Entity, ModelContext, ModelSpawner, SingletonEntity, TypedActionView};
 
 use crate::workspace::{Workspace, WorkspaceAction};
@@ -46,6 +47,12 @@ impl SingletonEntity for LocalControlServer {}
 
 impl LocalControlServer {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        if !warp_control_cli_enabled() || !outside_warp_control_enabled(ctx) {
+            return Self {
+                _runtime: None,
+                _registered_instance: None,
+            };
+        }
         match Self::start(ctx) {
             Ok(server) => server,
             Err(error) => {
@@ -148,6 +155,9 @@ impl LocalControlBridge {
         grant: CredentialGrant,
         ctx: &mut ModelContext<Self>,
     ) -> ResponseEnvelope {
+        if let Err(error) = ensure_feature_enabled() {
+            return ResponseEnvelope::error(request.request_id, error);
+        }
         if request.protocol_version != PROTOCOL_VERSION {
             return ResponseEnvelope::error(
                 request.request_id,
@@ -156,9 +166,6 @@ impl LocalControlBridge {
                     format!("unsupported protocol version {}", request.protocol_version),
                 ),
             );
-        }
-        if let Err(error) = grant.verify_for_action(request.action.kind) {
-            return ResponseEnvelope::error(request.request_id, error);
         }
         if !request.action.kind.is_implemented() {
             return ResponseEnvelope::error(
@@ -171,6 +178,12 @@ impl LocalControlBridge {
                     ),
                 ),
             );
+        }
+        if let Err(error) = validate_action_params(&request.action) {
+            return ResponseEnvelope::error(request.request_id, error);
+        }
+        if let Err(error) = grant.verify_for_action(request.action.kind) {
+            return ResponseEnvelope::error(request.request_id, error);
         }
         match request.action.kind {
             ActionKind::TabCreate => {
@@ -249,6 +262,13 @@ async fn handle_credential_request(
     State(state): State<ControlServerState>,
     payload: Result<Json<CredentialRequest>, JsonRejection>,
 ) -> Response {
+    if let Err(error) = ensure_feature_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(error)),
+        )
+            .into_response();
+    }
     let request = match payload {
         Ok(Json(request)) => request,
         Err(err) => {
@@ -300,6 +320,15 @@ async fn handle_credential_request(
                     request.action.as_str()
                 ),
             ))),
+        )
+            .into_response();
+    }
+    if let Err(error) =
+        ensure_execution_context_proof(request.invocation_context, &request.execution_context_proof)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(error)),
         )
             .into_response();
     }
@@ -364,6 +393,13 @@ async fn handle_control_request(
     headers: HeaderMap,
     payload: Result<Json<RequestEnvelope>, JsonRejection>,
 ) -> Response {
+    if let Err(error) = ensure_feature_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponseEnvelope::new(error)),
+        )
+            .into_response();
+    }
     let auth_header = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok());
@@ -437,16 +473,34 @@ async fn handle_control_request(
 }
 
 fn validate_tab_create_target(target: &TargetSelector) -> Result<(), ControlError> {
+    if matches!(target.window.as_ref(), Some(WindowTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "tab.create cannot resolve the requested window id",
+        ));
+    }
     if !matches!(target.window.as_ref(), None | Some(WindowTarget::Active)) {
         return Err(ControlError::new(
             ErrorCode::InvalidSelector,
             "tab.create only supports the active window selector",
         ));
     }
+    if matches!(target.tab.as_ref(), Some(TabTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "tab.create cannot resolve the requested tab id",
+        ));
+    }
     if !matches!(target.tab.as_ref(), None | Some(TabTarget::Active)) {
         return Err(ControlError::new(
             ErrorCode::InvalidSelector,
             "tab.create does not accept a concrete tab selector",
+        ));
+    }
+    if matches!(target.pane.as_ref(), Some(PaneTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "tab.create cannot resolve the requested pane id",
         ));
     }
     if !matches!(target.pane.as_ref(), None | Some(PaneTarget::Active)) {
@@ -458,26 +512,78 @@ fn validate_tab_create_target(target: &TargetSelector) -> Result<(), ControlErro
     Ok(())
 }
 
+fn validate_action_params(action: &::local_control::Action) -> Result<(), ControlError> {
+    if action.kind != ActionKind::TabCreate {
+        return Ok(());
+    }
+    if action
+        .params
+        .as_object()
+        .is_some_and(serde_json::Map::is_empty)
+    {
+        return Ok(());
+    }
+    Err(ControlError::new(
+        ErrorCode::InvalidParams,
+        "tab.create does not accept parameters in the first implementation slice",
+    ))
+}
+
+fn warp_control_cli_enabled() -> bool {
+    FeatureFlag::WarpControlCli.is_enabled()
+}
+
+fn ensure_feature_enabled() -> Result<(), ControlError> {
+    if warp_control_cli_enabled() {
+        return Ok(());
+    }
+    Err(ControlError::new(
+        ErrorCode::LocalControlDisabled,
+        "Warp control CLI is disabled by feature flag",
+    ))
+}
+
+fn outside_warp_control_enabled(ctx: &ModelContext<LocalControlServer>) -> bool {
+    LocalControlSettings::as_ref(ctx).is_context_enabled(LocalControlInvocationContext::OutsideWarp)
+}
+
 fn target_window_id(
     ctx: &mut ModelContext<LocalControlBridge>,
 ) -> Result<warpui::WindowId, ControlError> {
-    preferred_window_id(
-        ctx.windows().active_window(),
-        ctx.windows().frontmost_window_id(),
-    )
-    .ok_or_else(|| {
+    require_active_window_id(ctx.windows().active_window())
+}
+
+fn require_active_window_id(
+    active_window: Option<warpui::WindowId>,
+) -> Result<warpui::WindowId, ControlError> {
+    active_window.ok_or_else(|| {
         ControlError::new(
             ErrorCode::MissingTarget,
-            "tab.create requires an active or previously active Warp window",
+            "tab.create requires an active Warp window",
         )
     })
 }
 
-fn preferred_window_id(
-    active_window: Option<warpui::WindowId>,
-    frontmost_window: Option<warpui::WindowId>,
-) -> Option<warpui::WindowId> {
-    active_window.or(frontmost_window)
+fn ensure_execution_context_proof(
+    context: InvocationContext,
+    proof: &Option<ExecutionContextProof>,
+) -> Result<(), ControlError> {
+    match context {
+        InvocationContext::InsideWarp => match proof {
+            Some(ExecutionContextProof::VerifiedWarpTerminal { proof_id })
+                if !proof_id.is_empty() =>
+            {
+                Ok(())
+            }
+            Some(ExecutionContextProof::VerifiedWarpTerminal { .. })
+            | Some(ExecutionContextProof::ExternalClient)
+            | None => Err(ControlError::new(
+                ErrorCode::ExecutionContextNotAllowed,
+                "inside-Warp local-control credentials require a verified Warp terminal proof",
+            )),
+        },
+        InvocationContext::OutsideWarp => Ok(()),
+    }
 }
 
 #[cfg(test)]
@@ -497,8 +603,14 @@ fn local_invocation_context(context: InvocationContext) -> LocalControlInvocatio
 
 fn local_permission(permission: LocalControlPermission) -> LocalControlPermissionCategory {
     match permission {
-        LocalControlPermission::ReadOnly => LocalControlPermissionCategory::ReadOnly,
-        LocalControlPermission::ReadWrite => LocalControlPermissionCategory::ReadWrite,
+        LocalControlPermission::MetadataReads | LocalControlPermission::UnderlyingDataReads => {
+            LocalControlPermissionCategory::ReadOnly
+        }
+        LocalControlPermission::AppStateMutations
+        | LocalControlPermission::MetadataConfigurationMutations
+        | LocalControlPermission::UnderlyingDataMutations => {
+            LocalControlPermissionCategory::ReadWrite
+        }
     }
 }
 
@@ -508,6 +620,14 @@ fn ensure_action_allowed(
     ctx: &mut ModelContext<LocalControlBridge>,
 ) -> Result<(), ControlError> {
     let settings = LocalControlSettings::as_ref(ctx);
+    ensure_settings_allow_action(settings, context, action)
+}
+
+fn ensure_settings_allow_action(
+    settings: &LocalControlSettings,
+    context: InvocationContext,
+    action: ActionKind,
+) -> Result<(), ControlError> {
     let context = local_invocation_context(context);
     if !settings.is_context_enabled(context) {
         return Err(ControlError::new(

--- a/app/src/local_control/mod_tests.rs
+++ b/app/src/local_control/mod_tests.rs
@@ -1,10 +1,41 @@
 use ::local_control::protocol::{
-    PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector, WindowTarget,
+    Action, ExecutionContextProof, PaneSelector, PaneTarget, TabSelector, TabTarget,
+    TargetSelector, WindowSelector, WindowTarget,
 };
 
-use super::{capabilities, preferred_window_id, validate_tab_create_target};
+use super::{
+    capabilities, ensure_execution_context_proof, ensure_feature_enabled,
+    ensure_settings_allow_action, require_active_window_id, validate_action_params,
+    validate_tab_create_target,
+};
+use crate::settings::{
+    AllowInsideWarpControl, AllowInsideWarpReadOnly, AllowInsideWarpReadWrite,
+    AllowOutsideWarpControl, AllowOutsideWarpReadOnly, AllowOutsideWarpReadWrite,
+    LocalControlSettings,
+};
 use ::local_control::protocol::ActionKind;
 use ::local_control::ErrorCode;
+use ::local_control::InvocationContext;
+use settings::Setting;
+use warp_core::features::FeatureFlag;
+
+fn settings_with_values(
+    inside_enabled: bool,
+    outside_enabled: bool,
+    inside_read_only: bool,
+    outside_read_only: bool,
+    inside_read_write: bool,
+    outside_read_write: bool,
+) -> LocalControlSettings {
+    LocalControlSettings {
+        allow_inside_warp_control: AllowInsideWarpControl::new(Some(inside_enabled)),
+        allow_outside_warp_control: AllowOutsideWarpControl::new(Some(outside_enabled)),
+        allow_inside_warp_read_only: AllowInsideWarpReadOnly::new(Some(inside_read_only)),
+        allow_outside_warp_read_only: AllowOutsideWarpReadOnly::new(Some(outside_read_only)),
+        allow_inside_warp_read_write: AllowInsideWarpReadWrite::new(Some(inside_read_write)),
+        allow_outside_warp_read_write: AllowOutsideWarpReadWrite::new(Some(outside_read_write)),
+    }
+}
 
 #[test]
 fn tab_create_accepts_default_and_active_targets() {
@@ -28,7 +59,7 @@ fn tab_create_rejects_concrete_targets() {
         pane: None,
     })
     .expect_err("concrete window target is rejected");
-    assert_eq!(err.code, ErrorCode::InvalidSelector);
+    assert_eq!(err.code, ErrorCode::StaleTarget);
 
     let err = validate_tab_create_target(&TargetSelector {
         window: None,
@@ -38,7 +69,7 @@ fn tab_create_rejects_concrete_targets() {
         pane: None,
     })
     .expect_err("concrete tab target is rejected");
-    assert_eq!(err.code, ErrorCode::InvalidSelector);
+    assert_eq!(err.code, ErrorCode::StaleTarget);
 
     let err = validate_tab_create_target(&TargetSelector {
         window: None,
@@ -48,6 +79,25 @@ fn tab_create_rejects_concrete_targets() {
         }),
     })
     .expect_err("concrete pane target is rejected");
+    assert_eq!(err.code, ErrorCode::StaleTarget);
+}
+
+#[test]
+fn tab_create_rejects_unsupported_selector_forms() {
+    let err = validate_tab_create_target(&TargetSelector {
+        window: Some(WindowTarget::Index { index: 0 }),
+        tab: None,
+        pane: None,
+    })
+    .expect_err("indexed window target is rejected");
+    assert_eq!(err.code, ErrorCode::InvalidSelector);
+
+    let err = validate_tab_create_target(&TargetSelector {
+        window: None,
+        tab: Some(TabTarget::Index { index: 0 }),
+        pane: None,
+    })
+    .expect_err("indexed tab target is rejected");
     assert_eq!(err.code, ErrorCode::InvalidSelector);
 }
 
@@ -57,19 +107,84 @@ fn capabilities_only_advertises_tab_create() {
 }
 
 #[test]
-fn tab_create_prefers_active_window() {
+fn tab_create_requires_active_window() {
     let active = warpui::WindowId::from_usize(1);
-    let frontmost = warpui::WindowId::from_usize(2);
 
     assert_eq!(
-        preferred_window_id(Some(active), Some(frontmost)),
-        Some(active)
+        require_active_window_id(Some(active)).expect("active"),
+        active
     );
+    let err = require_active_window_id(None).expect_err("missing active window");
+    assert_eq!(err.code, ErrorCode::MissingTarget);
 }
 
 #[test]
-fn tab_create_falls_back_to_frontmost_window() {
-    let frontmost = warpui::WindowId::from_usize(2);
+fn feature_flag_disabled_denies_local_control() {
+    let _flag = FeatureFlag::WarpControlCli.override_enabled(false);
+    let err = ensure_feature_enabled().expect_err("feature flag disabled");
+    assert_eq!(err.code, ErrorCode::LocalControlDisabled);
+}
 
-    assert_eq!(preferred_window_id(None, Some(frontmost)), Some(frontmost));
+#[test]
+fn disabled_context_denies_before_granular_permission() {
+    let settings = settings_with_values(false, true, true, true, true, true);
+
+    let err = ensure_settings_allow_action(
+        &settings,
+        InvocationContext::InsideWarp,
+        ActionKind::TabCreate,
+    )
+    .expect_err("inside-Warp parent context is disabled");
+    assert_eq!(err.code, ErrorCode::LocalControlDisabled);
+}
+
+#[test]
+fn disabled_granular_permission_denies_with_insufficient_permissions() {
+    let settings = settings_with_values(true, true, true, true, false, true);
+
+    let err = ensure_settings_allow_action(
+        &settings,
+        InvocationContext::InsideWarp,
+        ActionKind::TabCreate,
+    )
+    .expect_err("read-write permission is disabled");
+    assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+}
+
+#[test]
+fn tab_create_rejects_malformed_params() {
+    let err = validate_action_params(&Action {
+        kind: ActionKind::TabCreate,
+        params: serde_json::json!({ "unexpected": true }),
+    })
+    .expect_err("tab.create params must be empty");
+    assert_eq!(err.code, ErrorCode::InvalidParams);
+
+    validate_action_params(&Action {
+        kind: ActionKind::TabCreate,
+        params: serde_json::json!({}),
+    })
+    .expect("empty tab.create params are accepted");
+}
+
+#[test]
+fn inside_warp_credential_requires_verified_execution_context_proof() {
+    let err = ensure_execution_context_proof(InvocationContext::InsideWarp, &None)
+        .expect_err("inside-Warp proof is required");
+    assert_eq!(err.code, ErrorCode::ExecutionContextNotAllowed);
+
+    let err = ensure_execution_context_proof(
+        InvocationContext::InsideWarp,
+        &Some(ExecutionContextProof::ExternalClient),
+    )
+    .expect_err("external proof is not accepted for inside-Warp grants");
+    assert_eq!(err.code, ErrorCode::ExecutionContextNotAllowed);
+
+    ensure_execution_context_proof(
+        InvocationContext::InsideWarp,
+        &Some(ExecutionContextProof::VerifiedWarpTerminal {
+            proof_id: "proof".to_owned(),
+        }),
+    )
+    .expect("verified proof is accepted");
 }

--- a/app/src/settings/init.rs
+++ b/app/src/settings/init.rs
@@ -98,7 +98,9 @@ pub fn register_all_settings(ctx: &mut AppContext) {
     EmacsBindingsSettings::register(ctx);
     SameLinePromptBlockSettings::register(ctx);
     SemanticSelection::register(ctx);
-    LocalControlSettings::register(ctx);
+    if FeatureFlag::WarpControlCli.is_enabled() {
+        LocalControlSettings::register(ctx);
+    }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     super::LinuxAppConfiguration::register(ctx);

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -1159,7 +1159,11 @@ impl SettingsView {
         ctx.subscribe_to_view(&referrals_page_handle, |me, _, event, ctx| {
             me.handle_referrals_page_event(event, ctx);
         });
-        let scripting_page_handle = ctx.add_typed_action_view(ScriptingSettingsPageView::new);
+        let scripting_page_handle = if FeatureFlag::WarpControlCli.is_enabled() {
+            Some(ctx.add_typed_action_view(ScriptingSettingsPageView::new))
+        } else {
+            None
+        };
 
         // Warp Drive page
         let warp_drive_page_handle =
@@ -1219,10 +1223,13 @@ impl SettingsView {
             SettingsPage::new(platform_page_handle),
             SettingsPage::new(warpify_page_handle),
             SettingsPage::new(referrals_page_handle),
-            SettingsPage::new(scripting_page_handle),
             SettingsPage::new(show_blocks_view_handle),
             SettingsPage::new(warp_drive_page_handle),
         ];
+
+        if let Some(scripting_page_handle) = scripting_page_handle {
+            settings_pages.push(SettingsPage::new(scripting_page_handle));
+        }
 
         settings_pages.extend(vec![
             SettingsPage::new(mcp_servers_page_handle),
@@ -1260,17 +1267,32 @@ impl SettingsView {
             SettingsNavItem::Page(SettingsSection::Keybindings),
             SettingsNavItem::Page(SettingsSection::Warpify),
             SettingsNavItem::Page(SettingsSection::Referrals),
-            SettingsNavItem::Page(SettingsSection::Scripting),
             SettingsNavItem::Page(SettingsSection::SharedBlocks),
             SettingsNavItem::Page(SettingsSection::WarpDrive),
             SettingsNavItem::Page(SettingsSection::Privacy),
             SettingsNavItem::Page(SettingsSection::About),
         ];
 
+        if FeatureFlag::WarpControlCli.is_enabled() {
+            let shared_blocks_index = nav_items
+                .iter()
+                .position(|item| {
+                    matches!(item, SettingsNavItem::Page(SettingsSection::SharedBlocks))
+                })
+                .unwrap_or(nav_items.len());
+            nav_items.insert(
+                shared_blocks_index,
+                SettingsNavItem::Page(SettingsSection::Scripting),
+            );
+        }
+
         // Resolve the initial page: map internal backing-page sections to their default subpage.
         let initial_page = match page {
             Some(SettingsSection::AI) => SettingsSection::WarpAgent,
             Some(SettingsSection::Code) => SettingsSection::CodeIndexing,
+            Some(SettingsSection::Scripting) if !FeatureFlag::WarpControlCli.is_enabled() => {
+                SettingsSection::Account
+            }
             Some(section) if section.is_subpage() => section,
             other => other.unwrap_or_default(),
         };

--- a/app/src/settings_view/scripting_page.rs
+++ b/app/src/settings_view/scripting_page.rs
@@ -15,6 +15,7 @@ use crate::settings::{
 use settings::{Setting as _, ToggleableSetting as _};
 use std::cell::RefCell;
 use std::collections::HashMap;
+use warp_core::features::FeatureFlag;
 use warp_core::settings::SyncToCloud;
 use warpui::elements::{Container, Element, MouseStateHandle};
 use warpui::ui_components::components::UiComponent;
@@ -235,7 +236,7 @@ impl SettingsPageMeta for ScriptingSettingsPageView {
     }
 
     fn should_render(&self, _ctx: &AppContext) -> bool {
-        cfg!(not(target_family = "wasm"))
+        cfg!(not(target_family = "wasm")) && FeatureFlag::WarpControlCli.is_enabled()
     }
 
     fn update_filter(&mut self, query: &str, ctx: &mut ViewContext<Self>) -> MatchData {

--- a/app/src/test_util/settings.rs
+++ b/app/src/test_util/settings.rs
@@ -32,9 +32,9 @@ pub fn initialize_settings_for_tests_with_mode(
             manager::SettingsManager, AISettings, AccessibilitySettings, AliasExpansionSettings,
             AppEditorSettings, BlockVisibilitySettings, ChangelogSettings,
             CloudPreferencesSettings, CodeSettings, DebugSettings, EmacsBindingsSettings,
-            FontSettings, GPUSettings, InputModeSettings, InputSettings, NativePreferenceSettings,
-            PaneSettings, SameLinePromptBlockSettings, ScrollSettings, SelectionSettings,
-            SshSettings, ThemeSettings, VimBannerSettings,
+            FontSettings, GPUSettings, InputModeSettings, InputSettings, LocalControlSettings,
+            NativePreferenceSettings, PaneSettings, SameLinePromptBlockSettings, ScrollSettings,
+            SelectionSettings, SshSettings, ThemeSettings, VimBannerSettings,
         },
         terminal::{
             general_settings::GeneralSettings, keys_settings::KeysSettings,
@@ -81,6 +81,9 @@ pub fn initialize_settings_for_tests_with_mode(
     InputSettings::register(app);
     KeysSettings::register(app);
     LigatureSettings::register(app);
+    if warp_core::features::FeatureFlag::WarpControlCli.is_enabled() {
+        LocalControlSettings::register(app);
+    }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     {

--- a/crates/local_control/src/auth.rs
+++ b/crates/local_control/src/auth.rs
@@ -179,6 +179,15 @@ mod tests {
     }
 
     #[test]
+    fn rejects_malformed_authorization_header() {
+        let token = AuthToken::from_secret("secret");
+        let err = token
+            .verify_authorization_header(Some("Basic secret"))
+            .expect_err("rejected");
+        assert_eq!(err.code, ErrorCode::UnauthorizedLocalClient);
+    }
+
+    #[test]
     fn rejects_wrong_bearer_token() {
         let token = AuthToken::from_secret("secret");
         let err = token

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -29,8 +29,11 @@ pub enum RiskTier {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LocalControlPermission {
-    ReadOnly,
-    ReadWrite,
+    MetadataReads,
+    UnderlyingDataReads,
+    AppStateMutations,
+    MetadataConfigurationMutations,
+    UnderlyingDataMutations,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -366,7 +369,7 @@ impl ActionKind {
                     InvocationContext::InsideWarp,
                     InvocationContext::OutsideWarp,
                 ],
-                permission: LocalControlPermission::ReadWrite,
+                permission: LocalControlPermission::AppStateMutations,
                 target_scope: TargetScope::Window,
             };
         }
@@ -451,13 +454,55 @@ impl ActionKind {
     }
 
     fn default_permission(self) -> LocalControlPermission {
-        match self.default_risk_tier() {
-            RiskTier::ReadOnlyMetadata | RiskTier::ReadOnlyTerminalData => {
-                LocalControlPermission::ReadOnly
-            }
-            RiskTier::MutatingNonDestructive | RiskTier::MutatingDestructiveOrExecution => {
-                LocalControlPermission::ReadWrite
-            }
+        match self {
+            Self::AppPing
+            | Self::AppInspect
+            | Self::AppVersion
+            | Self::AppActive
+            | Self::WindowList
+            | Self::TabList
+            | Self::PaneList
+            | Self::SessionList
+            | Self::ThemeList
+            | Self::AppearanceGet
+            | Self::SettingGet
+            | Self::SettingList => LocalControlPermission::MetadataReads,
+            Self::InputInsert
+            | Self::InputReplace
+            | Self::InputClear
+            | Self::InputModeSet
+            | Self::WindowClose
+            | Self::TabClose
+            | Self::PaneClose => LocalControlPermission::UnderlyingDataMutations,
+            Self::ThemeSet
+            | Self::AppearanceSet
+            | Self::AppearanceFontSize
+            | Self::AppearanceZoom
+            | Self::SettingSet
+            | Self::SettingToggle => LocalControlPermission::MetadataConfigurationMutations,
+            Self::AppFocus
+            | Self::AppSettingsOpen
+            | Self::AppCommandPaletteOpen
+            | Self::AppCommandSearchOpen
+            | Self::AppWarpDriveOpen
+            | Self::AppWarpDriveToggle
+            | Self::AppResourceCenterToggle
+            | Self::AppAiAssistantToggle
+            | Self::AppCodeReviewToggle
+            | Self::AppVerticalTabsToggle
+            | Self::WindowCreate
+            | Self::WindowFocus
+            | Self::TabCreate
+            | Self::TabActivate
+            | Self::TabMove
+            | Self::TabRename
+            | Self::PaneSplit
+            | Self::PaneFocus
+            | Self::PaneNavigate
+            | Self::PaneMaximize
+            | Self::PaneResize
+            | Self::PaneSessionPrevious
+            | Self::PaneSessionNext => LocalControlPermission::AppStateMutations,
         }
     }
 
@@ -659,6 +704,24 @@ mod tests {
     }
 
     #[test]
+    fn malformed_action_name_is_not_deserialized() {
+        let request = serde_json::json!({
+            "protocol_version": PROTOCOL_VERSION,
+            "request_id": Uuid::nil(),
+            "target": {},
+            "action": {
+                "kind": "tab.create.unexpected",
+                "params": {}
+            }
+        });
+        let err = serde_json::from_value::<RequestEnvelope>(request).expect_err("bad action name");
+        assert!(
+            err.to_string().contains("unknown variant"),
+            "expected unknown action variant error, got: {err}"
+        );
+    }
+
+    #[test]
     fn tab_create_metadata_is_first_slice_logged_out_safe_mutation() {
         let metadata = ActionKind::TabCreate.metadata();
         assert_eq!(
@@ -667,7 +730,10 @@ mod tests {
         );
         assert_eq!(metadata.risk_tier, RiskTier::MutatingNonDestructive);
         assert!(!metadata.requires_authenticated_user);
-        assert_eq!(metadata.permission, LocalControlPermission::ReadWrite);
+        assert_eq!(
+            metadata.permission,
+            LocalControlPermission::AppStateMutations
+        );
         assert_eq!(
             metadata.allowed_invocation_contexts,
             vec![
@@ -688,6 +754,26 @@ mod tests {
             !metadata
                 .allowed_invocation_contexts
                 .contains(&InvocationContext::OutsideWarp)
+        );
+    }
+
+    #[test]
+    fn default_permissions_preserve_security_categories() {
+        assert_eq!(
+            ActionKind::WindowList.metadata().permission,
+            LocalControlPermission::MetadataReads
+        );
+        assert_eq!(
+            ActionKind::InputInsert.metadata().permission,
+            LocalControlPermission::UnderlyingDataMutations
+        );
+        assert_eq!(
+            ActionKind::SettingSet.metadata().permission,
+            LocalControlPermission::MetadataConfigurationMutations
+        );
+        assert_eq!(
+            ActionKind::PaneSplit.metadata().permission,
+            LocalControlPermission::AppStateMutations
         );
     }
 }

--- a/crates/local_control/src/selection.rs
+++ b/crates/local_control/src/selection.rs
@@ -91,4 +91,10 @@ mod tests {
         let err = select_instance(&records, &InstanceSelector::Active).expect_err("ambiguous");
         assert_eq!(err.code, ErrorCode::AmbiguousInstance);
     }
+
+    #[test]
+    fn active_selector_rejects_no_instances() {
+        let err = select_instance(&[], &InstanceSelector::Active).expect_err("no instance");
+        assert_eq!(err.code, ErrorCode::NoInstance);
+    }
 }

--- a/crates/warp_cli/src/local_control.rs
+++ b/crates/warp_cli/src/local_control.rs
@@ -201,8 +201,22 @@ fn write_json_line(value: &impl Serialize) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use clap::Parser as _;
+    use serial_test::serial;
 
     use super::*;
+
+    fn set_discovery_dir(path: &std::path::Path) -> Option<std::ffi::OsString> {
+        let previous = std::env::var_os("WARP_LOCAL_CONTROL_DISCOVERY_DIR");
+        unsafe { std::env::set_var("WARP_LOCAL_CONTROL_DISCOVERY_DIR", path) };
+        previous
+    }
+
+    fn restore_discovery_dir(previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => unsafe { std::env::set_var("WARP_LOCAL_CONTROL_DISCOVERY_DIR", value) },
+            None => unsafe { std::env::remove_var("WARP_LOCAL_CONTROL_DISCOVERY_DIR") },
+        }
+    }
 
     #[test]
     fn parses_first_slice_tab_create() {
@@ -231,5 +245,26 @@ mod tests {
         assert!(ControlArgs::try_parse_from(["warpctrl", "app", "ping"]).is_err());
         assert!(ControlArgs::try_parse_from(["warpctrl", "tab", "list"]).is_err());
         assert!(ControlArgs::try_parse_from(["warpctrl", "setting", "list"]).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn tab_create_reports_no_instance_when_discovery_is_empty() {
+        let dir = std::env::temp_dir().join(format!(
+            "warpctrl-empty-discovery-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&dir).expect("create discovery dir");
+        let previous = set_discovery_dir(&dir);
+        let result = run(ControlArgs {
+            output_format: OutputFormat::Json,
+            command: ControlCommand::Tab(TabCommand::Create(TargetArgs::default())),
+        });
+        restore_discovery_dir(previous);
+        let err = result.expect_err("missing instance is reported");
+        assert!(
+            err.to_string().contains("no_instance"),
+            "expected no_instance error, got: {err}"
+        );
     }
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -826,6 +826,8 @@ pub enum FeatureFlag {
 
     /// Gates the remote control chip and `/remote-control` slash command in the CLI agent footer.
     HOARemoteControl,
+    /// Gates the first-slice Warp control CLI protocol, settings, discovery, and app bridge.
+    WarpControlCli,
 
     /// Trims trailing blank rows from CLI agent block output so unused vertical
     /// space is not rendered while the agent is running.


### PR DESCRIPTION
Summary:
- Harden warpctrl Phase 1 negative paths around feature gating, permissions, credential proof checks, selector handling, and malformed inputs.
- Expand local-control protocol permissions to the five SECURITY.md categories while mapping them to existing read-only/read-write settings enforcement.
- Gate settings registration, Scripting settings page visibility/construction, bridge/server registration, and local-control endpoints behind `FeatureFlag::WarpControlCli`.

Validation:
- `cargo fmt`
- `CARGO_BUILD_JOBS=1 cargo nextest run --no-fail-fast --workspace local_control`
- `CARGO_BUILD_JOBS=1 cargo nextest run --no-fail-fast --workspace rejects_malformed_authorization_header`
- `CARGO_BUILD_JOBS=1 cargo nextest run --no-fail-fast --workspace malformed_action_name_is_not_deserialized`
- `CARGO_BUILD_JOBS=1 cargo nextest run --no-fail-fast --workspace active_selector_rejects_no_instances`
- `CARGO_BUILD_JOBS=1 cargo check -p local_control -p warp_cli -p warp`
- `CARGO_BUILD_JOBS=1 cargo clippy -p local_control -p warp_cli --all-targets --all-features --tests -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p warp --lib --tests --all-features -- -D warnings`

Known validation limitation:
- Broader `CARGO_BUILD_JOBS=1 cargo clippy -p local_control -p warp_cli -p warp --all-targets --all-features --tests -- -D warnings` fails on a generated artifact issue in `app/src/bin/channel_config.rs` because `target/debug/build/warp-28df828b794f8e13/out/dev_config.json` is missing for the `dev` bin test target.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/cbf4c05f-4f4d-43da-b53e-b452b95ce271_
_Run: https://oz.staging.warp.dev/runs/019e5227-eb9f-7295-872e-57a82578fd07_
_This PR was generated with [Oz](https://warp.dev/oz)._
