### PR TITLE
Fix line-editing shortcuts in alt-screen TUIs

### DIFF
--- a/app/src/terminal/view/init.rs
+++ b/app/src/terminal/view/init.rs
@@ -500,14 +500,18 @@ pub fn init(app: &mut AppContext) {
         // We already have bindings for home/end (the keybindings for this on Linux and Mac) that
         // send the correct control sequence to the PTY.
         .with_mac_key_binding("cmd-left")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal") & !id!("IMEOpen") & (id!("LongRunningCommand") | id!("AltScreen")),
+        ),
         EditableBinding::new(
             "terminal:executing_command_move_cursor_end",
             "Move cursor end within an executing command",
             TerminalAction::ControlSequence(vec![escape_sequences::C0::ENQ]),
         )
         .with_mac_key_binding("cmd-right")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal") & !id!("IMEOpen") & (id!("LongRunningCommand") | id!("AltScreen")),
+        ),
         EditableBinding::new(
             "terminal:executing_command_delete_word_left",
             "Delete word left within an executing command",
@@ -515,13 +519,17 @@ pub fn init(app: &mut AppContext) {
         )
         .with_mac_key_binding("alt-backspace")
         .with_linux_or_windows_key_binding("ctrl-backspace")
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand")),
+        .with_context_predicate(
+            id!("Terminal") & !id!("IMEOpen") & (id!("LongRunningCommand") | id!("AltScreen")),
+        ),
         EditableBinding::new(
             "terminal:executing_command_delete_line_start",
             "Delete to line start within an executing command",
             TerminalAction::ControlSequence(vec![escape_sequences::C0::NAK]),
         )
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand"))
+        .with_context_predicate(
+            id!("Terminal") & !id!("IMEOpen") & (id!("LongRunningCommand") | id!("AltScreen")),
+        )
         // Set this for mac-only. The default binding for this on Linux / Windows is `ctrl-y`, which
         // we can't hijack because it is already reserved for the PTY.
         .with_mac_key_binding("cmd-backspace"),
@@ -530,7 +538,9 @@ pub fn init(app: &mut AppContext) {
             "Delete to line end within an executing command",
             TerminalAction::ControlSequence(vec![escape_sequences::C0::VT]),
         )
-        .with_context_predicate(id!("Terminal") & !id!("IMEOpen") & id!("LongRunningCommand"))
+        .with_context_predicate(
+            id!("Terminal") & !id!("IMEOpen") & (id!("LongRunningCommand") | id!("AltScreen")),
+        )
         // Set this for mac-only since the corresponding editor action is also Mac-only.
         .with_mac_key_binding("cmd-delete"),
         EditableBinding::new(


### PR DESCRIPTION
## Description

When a readline-style TUI runs in alt-screen mode (Claude Code fullscreen, opencode, vim insert mode, etc.), `cmd+Left` / `cmd+Right` / `cmd+Backspace` / `cmd+Delete` / `alt+Backspace` no longer perform their line-editing actions on macOS — they fall through to plain bytes.

**Root cause:** the `EditableBinding`s in `view/init.rs` were gated on `LongRunningCommand`, which is mutually exclusive with `AltScreen` (`view.rs:27201-27209`). The fallback encoder wildcards the `cmd` modifier (`escape_sequences.rs:301-340`), so `cmd` was silently dropped.

**Fix:** extend the predicate on five bindings to `(LongRunningCommand | AltScreen)` — same pattern already used by `shift-tab` at `init.rs:545`.

`alt-left` / `alt-right` predicates are intentionally unchanged, so the encoder path keeps emitting `ESC[1;3D` / `ESC[1;3C` for vim, helix, and KKP-aware TUIs (no behavior change for those users).

## Linked Issue

Fixes #807 (open since 2022, labeled `ready-to-implement`)
Refs #2686, #9159

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Verified inside Claude Code `/tui fullscreen`:

| Key | Before | After |
|---|---|---|
| `cmd+Left` | `ESC[D` (1 char left) | `0x01` (jump to start) |
| `cmd+Right` | `ESC[C` (1 char right) | `0x05` (jump to end) |
| `cmd+Backspace` | `0x7f` (delete 1) | `0x15` (delete to line start) |

`alt+Left` / `alt+Right` bytes unchanged.

https://github.com/user-attachments/assets/8657e489-4126-44eb-847c-143e5f81d4a6

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed macOS line-editing shortcuts (cmd+arrows, cmd+backspace, cmd+delete, alt+backspace) not working inside fullscreen TUIs like Claude Code and opencode.