### PR TITLE
Implement warpctrl readonly metadata shard

### DIFF
--- a/app/src/local_control/bridge.rs
+++ b/app/src/local_control/bridge.rs
@@ -89,6 +89,88 @@ impl LocalControlBridge {
                 }
                 ResponseEnvelope::ok(request.request_id, metadata::version(&self.instance_id))
             }
+            ActionKind::AppActive => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, metadata::active(&self.instance_id, ctx))
+            }
+            ActionKind::AppInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(
+                    request.request_id,
+                    metadata::inspect(&self.instance_id, ctx),
+                )
+            }
+            ActionKind::ActionList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, metadata::action_list())
+            }
+            ActionKind::ActionGet => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::action_get(&request.action) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::WindowList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::window_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::TabList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::tab_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::PaneList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::pane_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::SessionList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::session_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
             ActionKind::TabCreate => {
                 if let Err(error) =
                     ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)

--- a/app/src/local_control/handlers/metadata.rs
+++ b/app/src/local_control/handlers/metadata.rs
@@ -1,6 +1,31 @@
-use ::local_control::{ActionKind, InstanceId, PROTOCOL_VERSION};
+use ::local_control::protocol::{
+    ActionGetParams, ActiveTargetChain, PaneTarget, SessionTarget, TabTarget, TargetSelector,
+    WindowTarget,
+};
+use ::local_control::{ActionKind, ControlError, ErrorCode, InstanceId, PROTOCOL_VERSION};
 use serde_json::json;
 use warp_core::channel::ChannelState;
+use warpui::{ModelContext, ViewHandle, WindowId};
+
+use crate::local_control::LocalControlBridge;
+use crate::pane_group::{PaneGroup, PaneId};
+use crate::workspace::Workspace;
+
+#[derive(Clone)]
+struct TabEntry {
+    window_id: WindowId,
+    index: usize,
+    workspace_active_tab_index: usize,
+    pane_group: ViewHandle<PaneGroup>,
+}
+
+#[derive(Clone)]
+struct PaneEntry {
+    tab_id: String,
+    index: usize,
+    pane_group: ViewHandle<PaneGroup>,
+    pane_id: PaneId,
+}
 
 pub(crate) fn instance(instance_id: &Option<InstanceId>) -> serde_json::Value {
     json!({
@@ -32,5 +57,544 @@ pub(crate) fn version(instance_id: &Option<InstanceId>) -> serde_json::Value {
         "channel": ChannelState::channel().to_string(),
         "app_id": ChannelState::app_id().to_string(),
         "app_version": ChannelState::app_version(),
+    })
+}
+
+pub(crate) fn active(
+    instance_id: &Option<InstanceId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> serde_json::Value {
+    json!({
+        "action": ActionKind::AppActive.as_str(),
+        "active": active_chain(instance_id, ctx),
+    })
+}
+
+pub(crate) fn inspect(
+    instance_id: &Option<InstanceId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> serde_json::Value {
+    json!({
+        "action": ActionKind::AppInspect.as_str(),
+        "instance_id": instance_id.as_ref().map(|id| id.0.as_str()),
+        "version": {
+            "protocol_version": PROTOCOL_VERSION,
+            "channel": ChannelState::channel().to_string(),
+            "app_id": ChannelState::app_id().to_string(),
+            "app_version": ChannelState::app_version(),
+        },
+        "active": active_chain(instance_id, ctx),
+        "actions": ActionKind::implemented_metadata(),
+    })
+}
+
+pub(crate) fn action_list() -> serde_json::Value {
+    json!({
+        "action": ActionKind::ActionList.as_str(),
+        "actions": ActionKind::implemented_metadata(),
+    })
+}
+
+pub(crate) fn action_get(
+    action: &::local_control::Action,
+) -> Result<serde_json::Value, ControlError> {
+    let params = action.params_as::<ActionGetParams>()?;
+    let metadata = action_metadata_for_name(&params.action)?;
+    Ok(json!({
+        "action": ActionKind::ActionGet.as_str(),
+        "requested_action": params.action,
+        "metadata": metadata,
+    }))
+}
+
+pub(crate) fn window_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let window_ids = select_window_ids(target, false, ActionKind::WindowList, ctx)?;
+    let active_window = ctx.windows().active_window();
+    let windows = window_ids
+        .into_iter()
+        .map(|window_id| {
+            let title = ctx
+                .views_of_type::<Workspace>(window_id)
+                .and_then(|workspaces| workspaces.into_iter().next())
+                .map(|workspace| {
+                    workspace.read(ctx, |workspace, ctx| {
+                        workspace
+                            .active_tab_pane_group()
+                            .as_ref(ctx)
+                            .display_title(ctx)
+                    })
+                });
+            json!({
+                "window_id": window_id.to_string(),
+                "is_active": Some(window_id) == active_window,
+                "title": title,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "action": ActionKind::WindowList.as_str(),
+        "windows": windows,
+    }))
+}
+
+pub(crate) fn tab_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    reject_target_families(
+        ActionKind::TabList,
+        target.pane.is_some() || target.session.is_some(),
+        "pane or session selectors",
+    )?;
+    let tabs = select_tab_entries(target, ActionKind::TabList, ctx)?
+        .into_iter()
+        .map(|entry| {
+            let title = entry
+                .pane_group
+                .read(ctx, |pane_group, ctx| pane_group.display_title(ctx));
+            json!({
+                "tab_id": entry.pane_group.id().to_string(),
+                "window_id": entry.window_id.to_string(),
+                "index": entry.index as u32,
+                "is_active": entry.index == entry.workspace_active_tab_index,
+                "title": title,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "action": ActionKind::TabList.as_str(),
+        "tabs": tabs,
+    }))
+}
+
+pub(crate) fn pane_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    reject_target_families(
+        ActionKind::PaneList,
+        target.session.is_some(),
+        "session selectors",
+    )?;
+    let panes = select_pane_entries(target, ActionKind::PaneList, ctx)?
+        .into_iter()
+        .map(|entry| {
+            let (is_active, has_terminal_session) =
+                entry.pane_group.read(ctx, |pane_group, ctx| {
+                    (
+                        pane_group.focused_pane_id(ctx) == entry.pane_id,
+                        pane_group
+                            .terminal_view_from_pane_id(entry.pane_id, ctx)
+                            .is_some(),
+                    )
+                });
+            json!({
+                "pane_id": entry.pane_id.to_string(),
+                "tab_id": entry.tab_id,
+                "index": entry.index as u32,
+                "is_active": is_active,
+                "has_terminal_session": has_terminal_session,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "action": ActionKind::PaneList.as_str(),
+        "panes": panes,
+    }))
+}
+
+pub(crate) fn session_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let session_target = target.session.as_ref();
+    let session_id_filter = matches!(session_target, Some(SessionTarget::Id { .. }));
+    let sessions = select_pane_entries(target, ActionKind::SessionList, ctx)?
+        .into_iter()
+        .filter_map(|entry| {
+            let (is_active, has_terminal_session) =
+                entry.pane_group.read(ctx, |pane_group, ctx| {
+                    (
+                        pane_group.active_session_id(ctx).map(PaneId::from) == Some(entry.pane_id),
+                        pane_group
+                            .terminal_view_from_pane_id(entry.pane_id, ctx)
+                            .is_some(),
+                    )
+                });
+            if !has_terminal_session {
+                return None;
+            }
+            let session_id = entry.pane_id.to_string();
+            let matches_session = match session_target {
+                None => true,
+                Some(SessionTarget::Active) => is_active,
+                Some(SessionTarget::Id { id }) => id.0 == session_id,
+            };
+            matches_session.then(|| {
+                json!({
+                    "session_id": session_id,
+                    "pane_id": entry.pane_id.to_string(),
+                    "is_active": is_active,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    if session_id_filter && sessions.is_empty() {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "session.list cannot resolve the requested session id",
+        ));
+    }
+    Ok(json!({
+        "action": ActionKind::SessionList.as_str(),
+        "sessions": sessions,
+    }))
+}
+
+pub(crate) fn action_metadata_for_name(
+    action_name: &str,
+) -> Result<::local_control::ActionMetadata, ControlError> {
+    ActionKind::ALL
+        .iter()
+        .copied()
+        .find(|kind| kind.as_str() == action_name)
+        .map(ActionKind::metadata)
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::NotAllowlisted,
+                format!("{action_name} is not an allowlisted local-control action"),
+            )
+        })
+}
+
+fn active_chain(
+    instance_id: &Option<InstanceId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> ActiveTargetChain {
+    let instance_id = instance_id.as_ref().map(|id| id.0.clone());
+    let active_window = ctx.windows().active_window();
+    let Some(window_id) = active_window else {
+        return ActiveTargetChain {
+            instance_id,
+            window_id: None,
+            tab_id: None,
+            pane_id: None,
+            session_id: None,
+        };
+    };
+    let window_id_string = window_id.to_string();
+    let workspace = ctx
+        .views_of_type::<Workspace>(window_id)
+        .and_then(|workspaces| workspaces.into_iter().next());
+    let Some(workspace) = workspace else {
+        return ActiveTargetChain {
+            instance_id,
+            window_id: Some(window_id_string),
+            tab_id: None,
+            pane_id: None,
+            session_id: None,
+        };
+    };
+    let (tab_id, pane_id, session_id) = workspace.read(ctx, |workspace, ctx| {
+        let pane_group = workspace.active_tab_pane_group();
+        let pane_group_ref = pane_group.as_ref(ctx);
+        let pane_id = pane_group_ref.focused_pane_id(ctx);
+        let session_id = pane_group_ref
+            .active_session_id(ctx)
+            .map(|session_id| PaneId::from(session_id).to_string());
+        (
+            Some(pane_group.id().to_string()),
+            Some(pane_id.to_string()),
+            session_id,
+        )
+    });
+    ActiveTargetChain {
+        instance_id,
+        window_id: Some(window_id_string),
+        tab_id,
+        pane_id,
+        session_id,
+    }
+}
+
+fn reject_target_families(
+    action: ActionKind,
+    rejected: bool,
+    families: &str,
+) -> Result<(), ControlError> {
+    if rejected {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!("{} does not accept {families}", action.as_str()),
+        ));
+    }
+    Ok(())
+}
+
+fn select_window_ids(
+    target: &TargetSelector,
+    force_active_default: bool,
+    action: ActionKind,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<Vec<WindowId>, ControlError> {
+    if action == ActionKind::WindowList {
+        reject_target_families(
+            action,
+            target.tab.is_some() || target.pane.is_some() || target.session.is_some(),
+            "tab, pane, or session selectors",
+        )?;
+    }
+    match target.window.as_ref() {
+        None if force_active_default => {
+            let window_id =
+                require_active_window_id_for_action(ctx.windows().active_window(), action)?;
+            Ok(vec![window_id])
+        }
+        None => Ok(ctx.window_ids().collect()),
+        Some(WindowTarget::Active) => {
+            let window_id =
+                require_active_window_id_for_action(ctx.windows().active_window(), action)?;
+            Ok(vec![window_id])
+        }
+        Some(WindowTarget::Id { id }) => ctx
+            .window_ids()
+            .find(|window_id| window_id.to_string() == id.0)
+            .map(|window_id| vec![window_id])
+            .ok_or_else(|| {
+                ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested window id", action.as_str()),
+                )
+            }),
+        Some(WindowTarget::Index { .. } | WindowTarget::Title { .. }) => Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!(
+                "{} only supports active and opaque window id selectors",
+                action.as_str()
+            ),
+        )),
+    }
+}
+
+fn select_tab_entries(
+    target: &TargetSelector,
+    action: ActionKind,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<Vec<TabEntry>, ControlError> {
+    let force_active_window = matches!(
+        target.tab,
+        Some(TabTarget::Active | TabTarget::Index { .. })
+    ) || matches!(
+        target.pane,
+        Some(PaneTarget::Active | PaneTarget::Index { .. })
+    ) || matches!(target.session, Some(SessionTarget::Active));
+    let window_ids = select_window_ids(target, force_active_window, action, ctx)?;
+    let all_entries = tab_entries_for_windows(window_ids, ctx);
+    let requires_active_tab_default = matches!(
+        target.pane,
+        Some(PaneTarget::Active | PaneTarget::Index { .. })
+    ) || matches!(target.session, Some(SessionTarget::Active));
+    match target.tab.as_ref() {
+        None if requires_active_tab_default => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index == entry.workspace_active_tab_index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active tab", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        None => Ok(all_entries),
+        Some(TabTarget::Active) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index == entry.workspace_active_tab_index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active tab", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(TabTarget::Id { id }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.pane_group.id().to_string() == id.0)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested tab id", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(TabTarget::Index { index }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index as u32 == *index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested tab index", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(TabTarget::Title { .. }) => Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!(
+                "{} only supports active, opaque tab id, and tab index selectors",
+                action.as_str()
+            ),
+        )),
+    }
+}
+
+fn tab_entries_for_windows(
+    window_ids: Vec<WindowId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Vec<TabEntry> {
+    window_ids
+        .into_iter()
+        .filter_map(|window_id| {
+            let workspace = ctx
+                .views_of_type::<Workspace>(window_id)
+                .and_then(|workspaces| workspaces.into_iter().next())?;
+            Some(workspace.read(ctx, |workspace, _| {
+                workspace
+                    .tab_views()
+                    .enumerate()
+                    .map(|(index, pane_group)| TabEntry {
+                        window_id,
+                        index,
+                        workspace_active_tab_index: workspace.active_tab_index(),
+                        pane_group: pane_group.clone(),
+                    })
+                    .collect::<Vec<_>>()
+            }))
+        })
+        .flatten()
+        .collect()
+}
+
+fn select_pane_entries(
+    target: &TargetSelector,
+    action: ActionKind,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<Vec<PaneEntry>, ControlError> {
+    let tab_entries = select_tab_entries(target, action, ctx)?;
+    let all_entries = pane_entries_for_tabs(tab_entries, ctx);
+    match target.pane.as_ref() {
+        None if matches!(target.session, Some(SessionTarget::Active)) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| {
+                    entry.pane_group.read(ctx, |pane_group, ctx| {
+                        pane_group.active_session_id(ctx).map(PaneId::from) == Some(entry.pane_id)
+                    })
+                })
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active terminal session", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        None => Ok(all_entries),
+        Some(PaneTarget::Active) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| {
+                    entry.pane_group.read(ctx, |pane_group, ctx| {
+                        pane_group.focused_pane_id(ctx) == entry.pane_id
+                    })
+                })
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active pane", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(PaneTarget::Id { id }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.pane_id.to_string() == id.0)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested pane id", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(PaneTarget::Index { index }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index as u32 == *index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!(
+                        "{} cannot resolve the requested pane index",
+                        action.as_str()
+                    ),
+                ));
+            }
+            Ok(entries)
+        }
+    }
+}
+
+fn pane_entries_for_tabs(
+    tab_entries: Vec<TabEntry>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Vec<PaneEntry> {
+    tab_entries
+        .into_iter()
+        .flat_map(|entry| {
+            let tab_id = entry.pane_group.id().to_string();
+            let pane_group = entry.pane_group.clone();
+            entry
+                .pane_group
+                .read(ctx, |pane_group, _| pane_group.visible_pane_ids())
+                .into_iter()
+                .enumerate()
+                .map(move |(index, pane_id)| PaneEntry {
+                    tab_id: tab_id.clone(),
+                    index,
+                    pane_group: pane_group.clone(),
+                    pane_id,
+                })
+        })
+        .collect()
+}
+
+pub(crate) fn require_active_window_id_for_action(
+    active_window: Option<WindowId>,
+    action: ActionKind,
+) -> Result<WindowId, ControlError> {
+    active_window.ok_or_else(|| {
+        ControlError::new(
+            ErrorCode::MissingTarget,
+            format!("{} requires an active Warp window", action.as_str()),
+        )
     })
 }

--- a/app/src/local_control/mod.rs
+++ b/app/src/local_control/mod.rs
@@ -386,6 +386,8 @@ async fn handle_control_request(
 }
 
 #[cfg(test)]
+pub(crate) use handlers::metadata::action_metadata_for_name;
+#[cfg(test)]
 pub(crate) use permissions::{
     capabilities, ensure_settings_allow_action, outside_warp_action_enabled_for_settings,
 };

--- a/app/src/local_control/mod_tests.rs
+++ b/app/src/local_control/mod_tests.rs
@@ -1,16 +1,21 @@
+use ::local_control::auth::CredentialGrant;
 use ::local_control::protocol::ActionKind;
 use ::local_control::protocol::{
-    Action, PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector,
-    WindowTarget,
+    Action, ControlResponse, PaneSelector, PaneTarget, SessionSelector, SessionTarget, TabSelector,
+    TabTarget, TargetSelector, WindowSelector, WindowTarget,
 };
-use ::local_control::{ErrorCode, InvocationContext};
+use ::local_control::{
+    ErrorCode, InstanceId, InvocationContext, PermissionCategory, RequestEnvelope,
+};
+use chrono::Duration;
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
+use warpui::App;
 
 use super::{
-    capabilities, ensure_feature_enabled, ensure_settings_allow_action,
+    action_metadata_for_name, capabilities, ensure_feature_enabled, ensure_settings_allow_action,
     outside_warp_action_enabled_for_settings, require_active_window_id, validate_action_params,
-    validate_tab_create_target,
+    validate_tab_create_target, LocalControlBridge,
 };
 use crate::settings::{
     AllowInsideWarpAppStateMutations, AllowInsideWarpControl,
@@ -21,6 +26,7 @@ use crate::settings::{
     AllowOutsideWarpUnderlyingDataMutations, AllowOutsideWarpUnderlyingDataReads,
     LocalControlSettings,
 };
+use crate::test_util::settings::initialize_settings_for_tests;
 
 fn settings_with_values(
     inside_enabled: bool,
@@ -78,6 +84,28 @@ fn settings_with_outside_warp(
     )
 }
 
+fn grant_for(action: ActionKind) -> CredentialGrant {
+    CredentialGrant::new(
+        InstanceId("test-instance".to_owned()),
+        action,
+        InvocationContext::InsideWarp,
+        Duration::minutes(5),
+    )
+}
+
+fn request_with_target(action: ActionKind, target: TargetSelector) -> RequestEnvelope {
+    let mut request = RequestEnvelope::new(Action::new(action));
+    request.target = target;
+    request
+}
+
+fn response_error_code(response: ::local_control::ResponseEnvelope) -> ErrorCode {
+    match response.response {
+        ControlResponse::Error { error } => error.code,
+        ControlResponse::Ok { data } => panic!("expected error response, got {data:?}"),
+    }
+}
+
 #[test]
 fn tab_create_accepts_default_and_active_targets() {
     validate_tab_create_target(&TargetSelector::default()).expect("default target is accepted");
@@ -86,6 +114,7 @@ fn tab_create_accepts_default_and_active_targets() {
         window: Some(WindowTarget::Active),
         tab: Some(TabTarget::Active),
         pane: Some(PaneTarget::Active),
+        session: Some(SessionTarget::Active),
     })
     .expect("active target is accepted");
 }
@@ -96,30 +125,36 @@ fn tab_create_rejects_concrete_targets() {
         window: Some(WindowTarget::Id {
             id: WindowSelector("window".to_owned()),
         }),
-        tab: None,
-        pane: None,
+        ..TargetSelector::default()
     })
     .expect_err("concrete window target is rejected");
     assert_eq!(err.code, ErrorCode::StaleTarget);
 
     let err = validate_tab_create_target(&TargetSelector {
-        window: None,
         tab: Some(TabTarget::Id {
             id: TabSelector("tab".to_owned()),
         }),
-        pane: None,
+        ..TargetSelector::default()
     })
     .expect_err("concrete tab target is rejected");
     assert_eq!(err.code, ErrorCode::StaleTarget);
 
     let err = validate_tab_create_target(&TargetSelector {
-        window: None,
-        tab: None,
         pane: Some(PaneTarget::Id {
             id: PaneSelector("pane".to_owned()),
         }),
+        ..TargetSelector::default()
     })
     .expect_err("concrete pane target is rejected");
+    assert_eq!(err.code, ErrorCode::StaleTarget);
+
+    let err = validate_tab_create_target(&TargetSelector {
+        session: Some(SessionTarget::Id {
+            id: SessionSelector("session".to_owned()),
+        }),
+        ..TargetSelector::default()
+    })
+    .expect_err("concrete session target is rejected");
     assert_eq!(err.code, ErrorCode::StaleTarget);
 }
 
@@ -127,30 +162,36 @@ fn tab_create_rejects_concrete_targets() {
 fn tab_create_rejects_unsupported_selector_forms() {
     let err = validate_tab_create_target(&TargetSelector {
         window: Some(WindowTarget::Index { index: 0 }),
-        tab: None,
-        pane: None,
+        ..TargetSelector::default()
     })
     .expect_err("indexed window target is rejected");
     assert_eq!(err.code, ErrorCode::InvalidSelector);
 
     let err = validate_tab_create_target(&TargetSelector {
-        window: None,
         tab: Some(TabTarget::Index { index: 0 }),
-        pane: None,
+        ..TargetSelector::default()
     })
     .expect_err("indexed tab target is rejected");
     assert_eq!(err.code, ErrorCode::InvalidSelector);
 }
 
 #[test]
-fn capabilities_advertises_only_first_slice_core_actions() {
+fn capabilities_advertises_core_and_metadata_slice_actions() {
     assert_eq!(
         capabilities(),
         vec![
             ActionKind::InstanceList,
             ActionKind::AppPing,
+            ActionKind::AppInspect,
             ActionKind::AppVersion,
+            ActionKind::AppActive,
+            ActionKind::ActionList,
+            ActionKind::ActionGet,
+            ActionKind::WindowList,
+            ActionKind::TabList,
             ActionKind::TabCreate,
+            ActionKind::PaneList,
+            ActionKind::SessionList,
         ]
     );
 }
@@ -168,6 +209,14 @@ fn outside_warp_discovery_requires_context_and_action_permission() {
     assert!(outside_warp_action_enabled_for_settings(
         &settings_with_outside_warp(true, true),
         ActionKind::TabCreate
+    ));
+    assert!(!outside_warp_action_enabled_for_settings(
+        &settings_with_values(true, true, true, false, true, true),
+        ActionKind::WindowList
+    ));
+    assert!(outside_warp_action_enabled_for_settings(
+        &settings_with_values(true, true, true, true, true, false),
+        ActionKind::WindowList
     ));
 }
 
@@ -230,4 +279,206 @@ fn tab_create_rejects_malformed_params() {
         params: serde_json::json!({}),
     })
     .expect("empty tab.create params are accepted");
+}
+
+#[test]
+fn metadata_handlers_return_successful_empty_metadata_without_windows() {
+    let _flag = FeatureFlag::WarpControlCli.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let bridge = app.add_model(LocalControlBridge::new);
+
+        for action in [
+            ActionKind::AppActive,
+            ActionKind::AppInspect,
+            ActionKind::AppVersion,
+            ActionKind::ActionList,
+            ActionKind::WindowList,
+            ActionKind::TabList,
+            ActionKind::PaneList,
+            ActionKind::SessionList,
+        ] {
+            let response = bridge.update(&mut app, |bridge, ctx| {
+                bridge.handle_request(
+                    RequestEnvelope::new(Action::new(action)),
+                    grant_for(action),
+                    ctx,
+                )
+            });
+            match response.response {
+                ControlResponse::Ok { data } => {
+                    assert_eq!(data["action"], action.as_str());
+                }
+                ControlResponse::Error { error } => {
+                    panic!("{} returned {error}", action.as_str());
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn metadata_list_handlers_reject_stale_and_unsupported_selectors() {
+    let _flag = FeatureFlag::WarpControlCli.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let bridge = app.add_model(LocalControlBridge::new);
+
+        let cases = [
+            (
+                ActionKind::WindowList,
+                TargetSelector {
+                    tab: Some(TabTarget::Active),
+                    ..TargetSelector::default()
+                },
+                ErrorCode::InvalidSelector,
+            ),
+            (
+                ActionKind::WindowList,
+                TargetSelector {
+                    window: Some(WindowTarget::Id {
+                        id: WindowSelector("stale-window".to_owned()),
+                    }),
+                    ..TargetSelector::default()
+                },
+                ErrorCode::StaleTarget,
+            ),
+            (
+                ActionKind::TabList,
+                TargetSelector {
+                    tab: Some(TabTarget::Title {
+                        title: "unsupported".to_owned(),
+                    }),
+                    ..TargetSelector::default()
+                },
+                ErrorCode::InvalidSelector,
+            ),
+            (
+                ActionKind::PaneList,
+                TargetSelector {
+                    pane: Some(PaneTarget::Id {
+                        id: PaneSelector("stale-pane".to_owned()),
+                    }),
+                    ..TargetSelector::default()
+                },
+                ErrorCode::StaleTarget,
+            ),
+            (
+                ActionKind::SessionList,
+                TargetSelector {
+                    session: Some(SessionTarget::Id {
+                        id: SessionSelector("stale-session".to_owned()),
+                    }),
+                    ..TargetSelector::default()
+                },
+                ErrorCode::StaleTarget,
+            ),
+        ];
+
+        for (action, target, code) in cases {
+            let response = bridge.update(&mut app, |bridge, ctx| {
+                bridge.handle_request(request_with_target(action, target), grant_for(action), ctx)
+            });
+            assert_eq!(response_error_code(response), code);
+        }
+    });
+}
+
+#[test]
+fn metadata_actions_require_metadata_permission_not_app_state_mutation_permission() {
+    let metadata_without_mutation = settings_with_values(true, true, true, true, false, false);
+    let mutation_without_metadata = settings_with_values(true, true, false, false, true, true);
+
+    for action in [
+        ActionKind::InstanceList,
+        ActionKind::AppPing,
+        ActionKind::AppInspect,
+        ActionKind::AppVersion,
+        ActionKind::AppActive,
+        ActionKind::ActionList,
+        ActionKind::ActionGet,
+        ActionKind::WindowList,
+        ActionKind::TabList,
+        ActionKind::PaneList,
+        ActionKind::SessionList,
+    ] {
+        assert_eq!(
+            action.metadata().permission_category,
+            PermissionCategory::ReadMetadata
+        );
+        ensure_settings_allow_action(
+            &metadata_without_mutation,
+            InvocationContext::InsideWarp,
+            action,
+        )
+        .expect("metadata read permission allows metadata action");
+        let err = ensure_settings_allow_action(
+            &mutation_without_metadata,
+            InvocationContext::InsideWarp,
+            action,
+        )
+        .expect_err("metadata action is denied without metadata read permission");
+        assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+    }
+
+    assert_eq!(
+        ActionKind::TabCreate.metadata().permission_category,
+        PermissionCategory::MutateAppState
+    );
+    ensure_settings_allow_action(
+        &mutation_without_metadata,
+        InvocationContext::InsideWarp,
+        ActionKind::TabCreate,
+    )
+    .expect("app-state mutation permission allows tab.create");
+}
+
+#[test]
+fn action_get_rejects_unallowlisted_action_names() {
+    let err = validate_action_params(&Action {
+        kind: ActionKind::ActionGet,
+        params: serde_json::json!({ "action": "input.run" }),
+    })
+    .expect_err("unallowlisted action is rejected");
+    assert_eq!(err.code, ErrorCode::NotAllowlisted);
+}
+
+#[test]
+fn action_metadata_lookup_reports_stub_status_for_allowlisted_future_actions() {
+    let metadata = action_metadata_for_name("window.create").expect("allowlisted action");
+
+    assert_eq!(metadata.kind, ActionKind::WindowCreate);
+    assert_eq!(
+        metadata.implementation_status,
+        ::local_control::ActionImplementationStatus::Stub
+    );
+}
+
+#[test]
+fn app_target_metadata_reads_reject_malformed_params() {
+    for action in [
+        ActionKind::AppVersion,
+        ActionKind::AppActive,
+        ActionKind::AppInspect,
+        ActionKind::ActionList,
+        ActionKind::WindowList,
+        ActionKind::TabList,
+        ActionKind::PaneList,
+        ActionKind::SessionList,
+    ] {
+        let err = validate_action_params(&Action {
+            kind: action,
+            params: serde_json::json!({ "unexpected": true }),
+        })
+        .expect_err("app target metadata read params must be empty");
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+
+        validate_action_params(&Action {
+            kind: action,
+            params: serde_json::json!({}),
+        })
+        .expect("empty app target metadata read params are accepted");
+    }
 }

--- a/app/src/local_control/resolver.rs
+++ b/app/src/local_control/resolver.rs
@@ -1,4 +1,7 @@
-use ::local_control::protocol::{PaneTarget, TabTarget, TargetSelector, WindowTarget};
+use crate::local_control::handlers::metadata::action_metadata_for_name;
+use ::local_control::protocol::{
+    ActionGetParams, PaneTarget, SessionTarget, TabTarget, TargetSelector, WindowTarget,
+};
 use ::local_control::{ActionKind, ControlError, ErrorCode};
 use warpui::ModelContext;
 
@@ -41,13 +44,43 @@ pub(crate) fn validate_tab_create_target(target: &TargetSelector) -> Result<(), 
             "tab.create does not accept a concrete pane selector",
         ));
     }
+    if matches!(target.session.as_ref(), Some(SessionTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "tab.create cannot resolve the requested session id",
+        ));
+    }
+    if !matches!(target.session.as_ref(), None | Some(SessionTarget::Active)) {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            "tab.create does not accept a concrete session selector",
+        ));
+    }
     Ok(())
 }
 
 pub(crate) fn validate_action_params(action: &::local_control::Action) -> Result<(), ControlError> {
-    if action.kind != ActionKind::TabCreate {
-        return Ok(());
+    match action.kind {
+        ActionKind::ActionGet => {
+            let params = action.params_as::<ActionGetParams>()?;
+            action_metadata_for_name(&params.action)?;
+            Ok(())
+        }
+        ActionKind::AppPing
+        | ActionKind::AppInspect
+        | ActionKind::AppVersion
+        | ActionKind::AppActive
+        | ActionKind::ActionList
+        | ActionKind::WindowList
+        | ActionKind::TabList
+        | ActionKind::TabCreate
+        | ActionKind::PaneList
+        | ActionKind::SessionList => validate_empty_action_params(action),
+        _ => Ok(()),
     }
+}
+
+fn validate_empty_action_params(action: &::local_control::Action) -> Result<(), ControlError> {
     if action
         .params
         .as_object()
@@ -57,7 +90,7 @@ pub(crate) fn validate_action_params(action: &::local_control::Action) -> Result
     }
     Err(ControlError::new(
         ErrorCode::InvalidParams,
-        "tab.create does not accept parameters in the first implementation slice",
+        format!("{} does not accept parameters", action.kind.as_str()),
     ))
 }
 

--- a/crates/local_control/src/catalog.rs
+++ b/crates/local_control/src/catalog.rs
@@ -61,6 +61,7 @@ pub enum TargetScope {
     Settings,
     Appearance,
     Surface,
+    Action,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,6 +97,10 @@ pub enum ActionKind {
     AppVersion,
     #[serde(rename = "app.active")]
     AppActive,
+    #[serde(rename = "action.list")]
+    ActionList,
+    #[serde(rename = "action.get")]
+    ActionGet,
     #[serde(rename = "app.focus")]
     AppFocus,
     #[serde(rename = "app.settings.open")]
@@ -193,6 +198,8 @@ impl ActionKind {
         Self::AppInspect,
         Self::AppVersion,
         Self::AppActive,
+        Self::ActionList,
+        Self::ActionGet,
         Self::AppFocus,
         Self::AppSettingsOpen,
         Self::AppCommandPaletteOpen,
@@ -245,6 +252,8 @@ impl ActionKind {
             Self::AppInspect => "app.inspect",
             Self::AppVersion => "app.version",
             Self::AppActive => "app.active",
+            Self::ActionList => "action.list",
+            Self::ActionGet => "action.get",
             Self::AppFocus => "app.focus",
             Self::AppSettingsOpen => "app.settings.open",
             Self::AppCommandPaletteOpen => "app.command_palette.open",
@@ -293,17 +302,31 @@ impl ActionKind {
     }
 
     pub fn metadata(self) -> ActionMetadata {
-        let (implementation_status, requires_authenticated_user, allowed_invocation_contexts) =
-            match self {
-                Self::InstanceList | Self::AppPing | Self::AppVersion | Self::TabCreate => (
-                    ActionImplementationStatus::Implemented,
-                    false,
-                    vec![
-                        InvocationContext::InsideWarp,
-                        InvocationContext::OutsideWarp,
-                    ],
-                ),
-                _ => (ActionImplementationStatus::Stub, true, Vec::new()),
+        let implementation_status = match self {
+            Self::InstanceList
+            | Self::AppPing
+            | Self::AppInspect
+            | Self::AppVersion
+            | Self::AppActive
+            | Self::ActionList
+            | Self::ActionGet
+            | Self::WindowList
+            | Self::TabList
+            | Self::TabCreate
+            | Self::PaneList
+            | Self::SessionList => ActionImplementationStatus::Implemented,
+            _ => ActionImplementationStatus::Stub,
+        };
+        let requires_authenticated_user =
+            implementation_status != ActionImplementationStatus::Implemented;
+        let allowed_invocation_contexts =
+            if implementation_status == ActionImplementationStatus::Implemented {
+                vec![
+                    InvocationContext::InsideWarp,
+                    InvocationContext::OutsideWarp,
+                ]
+            } else {
+                Vec::new()
             };
         ActionMetadata {
             kind: self,
@@ -343,6 +366,8 @@ impl ActionKind {
             | Self::AppInspect
             | Self::AppVersion
             | Self::AppActive
+            | Self::ActionList
+            | Self::ActionGet
             | Self::WindowList
             | Self::TabList
             | Self::PaneList
@@ -397,6 +422,8 @@ impl ActionKind {
             | Self::AppInspect
             | Self::AppVersion
             | Self::AppActive
+            | Self::ActionList
+            | Self::ActionGet
             | Self::WindowList
             | Self::TabList
             | Self::PaneList
@@ -488,6 +515,7 @@ impl ActionKind {
             Self::SettingGet | Self::SettingList | Self::SettingSet | Self::SettingToggle => {
                 TargetScope::Settings
             }
+            Self::ActionList | Self::ActionGet => TargetScope::Action,
             Self::AppSettingsOpen
             | Self::AppCommandPaletteOpen
             | Self::AppCommandSearchOpen

--- a/crates/local_control/src/lib.rs
+++ b/crates/local_control/src/lib.rs
@@ -18,7 +18,11 @@ pub use discovery::{
     discovery_dir,
 };
 pub use protocol::{
-    Action, ControlError, ControlResponse, ErrorCode, ErrorResponseEnvelope, ExecutionContextProof,
-    PROTOCOL_VERSION, RequestEnvelope, ResponseEnvelope,
+    Action, ActionGetParams, ActionGetResult, ActionListParams, ActionListResult,
+    ActiveTargetChain, AppActiveParams, AppInspectParams, AppInspectResult, AppVersionResult,
+    ControlError, ControlResponse, EmptyParams, ErrorCode, ErrorResponseEnvelope,
+    ExecutionContextProof, PROTOCOL_VERSION, PaneListResult, PaneSummary, RequestEnvelope,
+    ResponseEnvelope, SessionListResult, SessionSummary, TabListResult, TabSummary,
+    WindowListResult, WindowSummary,
 };
-pub use selectors::{PaneSelector, TabSelector, TargetSelector, WindowSelector};
+pub use selectors::{PaneSelector, SessionSelector, TabSelector, TargetSelector, WindowSelector};

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -1,3 +1,4 @@
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -7,7 +8,8 @@ pub use crate::catalog::{
     StateDataCategory, TargetScope,
 };
 pub use crate::selectors::{
-    PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector, WindowTarget,
+    PaneSelector, PaneTarget, SessionSelector, SessionTarget, TabSelector, TabTarget,
+    TargetSelector, WindowSelector, WindowTarget,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -37,12 +39,145 @@ pub struct Action {
     pub params: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmptyParams {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionGetParams {
+    pub action: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionListParams {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppActiveParams {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppInspectParams {}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionListResult {
+    pub actions: Vec<ActionMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionGetResult {
+    pub action: ActionMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActiveTargetChain {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppVersionResult {
+    pub protocol_version: u32,
+    pub channel: String,
+    pub app_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AppInspectResult {
+    pub version: AppVersionResult,
+    pub active: ActiveTargetChain,
+    pub actions: Vec<ActionMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowSummary {
+    pub window_id: String,
+    pub is_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowListResult {
+    pub windows: Vec<WindowSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TabSummary {
+    pub tab_id: String,
+    pub window_id: String,
+    pub index: u32,
+    pub is_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TabListResult {
+    pub tabs: Vec<TabSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaneSummary {
+    pub pane_id: String,
+    pub tab_id: String,
+    pub index: u32,
+    pub is_active: bool,
+    pub has_terminal_session: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PaneListResult {
+    pub panes: Vec<PaneSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub pane_id: String,
+    pub is_active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionListResult {
+    pub sessions: Vec<SessionSummary>,
+}
 impl Action {
     pub fn new(kind: ActionKind) -> Self {
         Self {
             kind,
             params: serde_json::Value::Object(Default::default()),
         }
+    }
+
+    pub fn with_params<T: Serialize>(kind: ActionKind, params: T) -> Result<Self, ControlError> {
+        Ok(Self {
+            kind,
+            params: serde_json::to_value(params).map_err(|err| {
+                ControlError::with_details(
+                    ErrorCode::InvalidParams,
+                    format!("failed to serialize {} parameters", kind.as_str()),
+                    err.to_string(),
+                )
+            })?,
+        })
+    }
+
+    pub fn params_as<T: DeserializeOwned>(&self) -> Result<T, ControlError> {
+        serde_json::from_value(self.params.clone()).map_err(|err| {
+            ControlError::with_details(
+                ErrorCode::InvalidParams,
+                format!("failed to decode {} parameters", self.kind.as_str()),
+                err.to_string(),
+            )
+        })
     }
 }
 

--- a/crates/local_control/src/protocol_tests.rs
+++ b/crates/local_control/src/protocol_tests.rs
@@ -33,6 +33,7 @@ fn input_run_is_not_in_the_allowlisted_catalog() {
     let action = serde_json::from_value::<ActionKind>(serde_json::json!("input.run"));
     assert!(action.is_err());
 }
+
 #[test]
 fn malformed_action_name_is_not_deserialized() {
     let action = serde_json::from_value::<ActionKind>(serde_json::json!("tab.create.extra"));
@@ -67,11 +68,19 @@ fn tab_create_metadata_is_first_slice_logged_out_safe_mutation() {
 }
 
 #[test]
-fn core_smoke_metadata_has_explicit_read_metadata_category() {
+fn structural_metadata_actions_are_logged_out_safe_read_metadata() {
     for action in [
         ActionKind::InstanceList,
         ActionKind::AppPing,
+        ActionKind::AppInspect,
         ActionKind::AppVersion,
+        ActionKind::AppActive,
+        ActionKind::ActionList,
+        ActionKind::ActionGet,
+        ActionKind::WindowList,
+        ActionKind::TabList,
+        ActionKind::PaneList,
+        ActionKind::SessionList,
     ] {
         let metadata = action.metadata();
         assert_eq!(
@@ -87,9 +96,72 @@ fn core_smoke_metadata_has_explicit_read_metadata_category() {
             metadata.permission_category,
             PermissionCategory::ReadMetadata
         );
+        assert!(!metadata.requires_authenticated_user);
         assert!(!metadata.authenticated_user.required);
-        assert_eq!(metadata.target_scope, TargetScope::Instance);
+        assert_eq!(
+            metadata.allowed_invocation_contexts,
+            vec![
+                InvocationContext::InsideWarp,
+                InvocationContext::OutsideWarp
+            ]
+        );
     }
+}
+
+#[test]
+fn structural_metadata_actions_have_expected_target_scopes() {
+    for action in [
+        ActionKind::InstanceList,
+        ActionKind::AppPing,
+        ActionKind::AppInspect,
+        ActionKind::AppVersion,
+        ActionKind::AppActive,
+    ] {
+        assert_eq!(action.metadata().target_scope, TargetScope::Instance);
+    }
+
+    assert_eq!(
+        ActionKind::ActionList.metadata().target_scope,
+        TargetScope::Action
+    );
+    assert_eq!(
+        ActionKind::ActionGet.metadata().target_scope,
+        TargetScope::Action
+    );
+    assert_eq!(
+        ActionKind::WindowList.metadata().target_scope,
+        TargetScope::Window
+    );
+    assert_eq!(
+        ActionKind::TabList.metadata().target_scope,
+        TargetScope::Tab
+    );
+    assert_eq!(
+        ActionKind::PaneList.metadata().target_scope,
+        TargetScope::Pane
+    );
+    assert_eq!(
+        ActionKind::SessionList.metadata().target_scope,
+        TargetScope::Session
+    );
+}
+
+#[test]
+fn action_with_params_roundtrips_typed_action_get_params() {
+    let action = Action::with_params(
+        ActionKind::ActionGet,
+        ActionGetParams {
+            action: "tab.create".to_owned(),
+        },
+    )
+    .expect("params serialize");
+    assert_eq!(action.kind, ActionKind::ActionGet);
+    assert_eq!(action.params["action"], "tab.create");
+
+    let params = action
+        .params_as::<ActionGetParams>()
+        .expect("params deserialize");
+    assert_eq!(params.action, "tab.create");
 }
 
 #[test]
@@ -124,6 +196,7 @@ fn default_permissions_preserve_security_categories() {
         PermissionCategory::ReadMetadata
     );
 }
+
 #[test]
 fn non_first_slice_actions_are_catalog_stubs() {
     let metadata = ActionKind::WindowCreate.metadata();

--- a/crates/local_control/src/selectors.rs
+++ b/crates/local_control/src/selectors.rs
@@ -12,6 +12,10 @@ pub struct TabSelector(pub String);
 #[serde(transparent)]
 pub struct PaneSelector(pub String);
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SessionSelector(pub String);
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct TargetSelector {
@@ -21,6 +25,8 @@ pub struct TargetSelector {
     pub tab: Option<TabTarget>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane: Option<PaneTarget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<SessionTarget>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -47,4 +53,11 @@ pub enum PaneTarget {
     Active,
     Id { id: PaneSelector },
     Index { index: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionTarget {
+    Active,
+    Id { id: SessionSelector },
 }

--- a/crates/warp_cli/src/local_control/commands.rs
+++ b/crates/warp_cli/src/local_control/commands.rs
@@ -1,5 +1,6 @@
 use local_control::protocol::{
-    Action, ActionKind, ActionMetadata, ControlError, ErrorCode, RequestEnvelope,
+    Action, ActionGetParams, ActionKind, ActionMetadata, ControlError, EmptyParams, ErrorCode,
+    RequestEnvelope,
 };
 use local_control::selection::select_instance;
 use serde::Serialize;
@@ -8,7 +9,10 @@ use serde_json::json;
 use crate::agent::OutputFormat;
 use crate::local_control::output::{write_json, write_json_line};
 use crate::local_control::selectors::instance_selector;
-use crate::local_control::{AppCommand, InstanceCommand, TabCommand, TargetArgs};
+use crate::local_control::{
+    ActionCommand, AppCommand, InstanceCommand, PaneCommand, SessionCommand, TabCommand,
+    TargetArgs, WindowCommand,
+};
 
 #[derive(Serialize)]
 struct InstanceSummary {
@@ -85,6 +89,51 @@ pub(super) fn run_app_command(
         AppCommand::Version(args) => {
             run_action(args, ActionKind::AppVersion, json!({}), output_format)
         }
+        AppCommand::Active(args) => run_action_with_params(
+            args,
+            ActionKind::AppActive,
+            local_control::AppActiveParams::default(),
+            output_format,
+        ),
+        AppCommand::Inspect(args) => run_action_with_params(
+            args,
+            ActionKind::AppInspect,
+            local_control::AppInspectParams::default(),
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_action_command(
+    command: ActionCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        ActionCommand::List(args) => run_action_with_params(
+            args,
+            ActionKind::ActionList,
+            local_control::ActionListParams::default(),
+            output_format,
+        ),
+        ActionCommand::Get(args) => run_action_with_params(
+            args.target,
+            ActionKind::ActionGet,
+            ActionGetParams {
+                action: args.action,
+            },
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_window_command(
+    command: WindowCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        WindowCommand::List(args) => {
+            run_action_with_params(args, ActionKind::WindowList, EmptyParams {}, output_format)
+        }
     }
 }
 pub(super) fn run_tab_command(
@@ -92,8 +141,33 @@ pub(super) fn run_tab_command(
     output_format: OutputFormat,
 ) -> Result<(), ControlError> {
     match command {
+        TabCommand::List(args) => {
+            run_action_with_params(args, ActionKind::TabList, EmptyParams {}, output_format)
+        }
         TabCommand::Create(args) => {
             run_action(args, ActionKind::TabCreate, json!({}), output_format)
+        }
+    }
+}
+
+pub(super) fn run_pane_command(
+    command: PaneCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        PaneCommand::List(args) => {
+            run_action_with_params(args, ActionKind::PaneList, EmptyParams {}, output_format)
+        }
+    }
+}
+
+pub(super) fn run_session_command(
+    command: SessionCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        SessionCommand::List(args) => {
+            run_action_with_params(args, ActionKind::SessionList, EmptyParams {}, output_format)
         }
     }
 }
@@ -111,6 +185,30 @@ fn run_action(
         kind: action,
         params,
     });
+    let response = local_control::client::send_request(&instance, &request)?;
+    let local_control::protocol::ControlResponse::Ok { data } = response.response else {
+        return Err(ControlError::new(
+            ErrorCode::Internal,
+            "local-control request failed without an error payload",
+        ));
+    };
+    match output_format {
+        OutputFormat::Json => write_json(&data),
+        OutputFormat::Ndjson => write_json_line(&data),
+        OutputFormat::Pretty | OutputFormat::Text => write_json(&data),
+    }
+}
+
+fn run_action_with_params<T: Serialize>(
+    args: TargetArgs,
+    action: ActionKind,
+    params: T,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    let records = local_control::discovery::list_instances();
+    let selector = instance_selector(args);
+    let instance = select_instance(&records, &selector)?;
+    let request = RequestEnvelope::new(Action::with_params(action, params)?);
     let response = local_control::client::send_request(&instance, &request)?;
     let local_control::protocol::ControlResponse::Ok { data } = response.response else {
         return Err(ControlError::new(

--- a/crates/warp_cli/src/local_control/mod.rs
+++ b/crates/warp_cli/src/local_control/mod.rs
@@ -9,7 +9,10 @@ use crate::agent::OutputFormat;
 use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::aot::Shell;
 
-use commands::{run_app_command, run_instance_command, run_tab_command};
+use commands::{
+    run_action_command, run_app_command, run_instance_command, run_pane_command,
+    run_session_command, run_tab_command, run_window_command,
+};
 use completions::generate_completions_to_stdout;
 use output::write_control_error;
 
@@ -67,10 +70,24 @@ pub enum ControlCommand {
     /// Inspect a selected local Warp app.
     #[command(subcommand)]
     App(AppCommand),
+    /// Inspect the local-control action catalog.
+    #[command(subcommand)]
+    Action(ActionCommand),
+
+    /// Inspect local Warp windows.
+    #[command(subcommand)]
+    Window(WindowCommand),
 
     /// Control local Warp tabs.
     #[command(subcommand)]
     Tab(TabCommand),
+    /// Inspect local Warp panes.
+    #[command(subcommand)]
+    Pane(PaneCommand),
+
+    /// Inspect local Warp sessions.
+    #[command(subcommand)]
+    Session(SessionCommand),
 
     /// Generate shell completions for your shell to stdout.
     ///
@@ -108,12 +125,47 @@ pub enum AppCommand {
 
     /// Print protocol and app version metadata for the selected local Warp app.
     Version(TargetArgs),
+
+    /// Print the active window/tab/pane/session chain.
+    Active(TargetArgs),
+
+    /// Print app and protocol metadata.
+    Inspect(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ActionCommand {
+    /// List allowlisted local-control actions.
+    List(TargetArgs),
+
+    /// Inspect one allowlisted local-control action.
+    Get(ActionGetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum WindowCommand {
+    /// List windows in the selected local Warp app.
+    List(TargetArgs),
 }
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum TabCommand {
+    /// List tabs in the selected local Warp app.
+    List(TargetArgs),
     /// Create a new terminal tab in the active window.
     Create(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum PaneCommand {
+    /// List panes in the selected local Warp app.
+    List(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SessionCommand {
+    /// List sessions in the selected local Warp app.
+    List(TargetArgs),
 }
 
 #[derive(Debug, Clone, Args, Default)]
@@ -125,6 +177,15 @@ pub struct TargetArgs {
     /// Target a specific local Warp process id.
     #[arg(long = "pid", conflicts_with = "instance")]
     pub pid: Option<u32>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ActionGetArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Action name, such as tab.create or window.list.
+    pub action: String,
 }
 
 pub fn run(args: ControlArgs) -> ExitCode {
@@ -148,7 +209,11 @@ fn run_inner(args: ControlArgs) -> Result<(), local_control::protocol::ControlEr
     match args.command {
         ControlCommand::Instance(command) => run_instance_command(command, output_format),
         ControlCommand::App(command) => run_app_command(command, output_format),
+        ControlCommand::Action(command) => run_action_command(command, output_format),
+        ControlCommand::Window(command) => run_window_command(command, output_format),
         ControlCommand::Tab(command) => run_tab_command(command, output_format),
+        ControlCommand::Pane(command) => run_pane_command(command, output_format),
+        ControlCommand::Session(command) => run_session_command(command, output_format),
         ControlCommand::Completions { shell } => generate_completions_to_stdout(shell),
     }
 }

--- a/crates/warp_cli/src/local_control_tests.rs
+++ b/crates/warp_cli/src/local_control_tests.rs
@@ -22,8 +22,9 @@ fn restore_discovery_dir(previous: Option<OsString>) {
         None => unsafe { std::env::remove_var(DISCOVERY_DIR_ENV) },
     }
 }
+
 #[test]
-fn parses_first_slice_tab_create() {
+fn parses_tab_create() {
     let args = ControlArgs::try_parse_from(["warpctrl", "tab", "create", "--instance", "inst_123"])
         .expect("tab create parses");
     let ControlCommand::Tab(TabCommand::Create(target)) = args.command else {
@@ -33,7 +34,7 @@ fn parses_first_slice_tab_create() {
 }
 
 #[test]
-fn parses_first_slice_instance_list() {
+fn parses_instance_list() {
     let args = ControlArgs::try_parse_from(["warpctrl", "instance", "list"])
         .expect("instance list parses");
     assert!(matches!(
@@ -43,9 +44,64 @@ fn parses_first_slice_instance_list() {
 }
 
 #[test]
-fn parses_first_slice_app_smoke_metadata_commands() {
+fn parses_app_metadata_commands() {
     assert!(ControlArgs::try_parse_from(["warpctrl", "app", "ping"]).is_ok());
     assert!(ControlArgs::try_parse_from(["warpctrl", "app", "version"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "app", "active"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "app", "inspect"]).is_ok());
+}
+
+#[test]
+fn parses_action_metadata_commands() {
+    let args = ControlArgs::try_parse_from(["warpctrl", "action", "list", "--pid", "123"])
+        .expect("action list parses");
+    let ControlCommand::Action(ActionCommand::List(target)) = args.command else {
+        panic!("expected action list command");
+    };
+    assert_eq!(target.pid, Some(123));
+
+    let args = ControlArgs::try_parse_from([
+        "warpctrl",
+        "action",
+        "get",
+        "--instance",
+        "inst_123",
+        "window.list",
+    ])
+    .expect("action get parses");
+    let ControlCommand::Action(ActionCommand::Get(action)) = args.command else {
+        panic!("expected action get command");
+    };
+    assert_eq!(action.target.instance.as_deref(), Some("inst_123"));
+    assert_eq!(action.action, "window.list");
+}
+
+#[test]
+fn parses_structural_metadata_list_commands() {
+    assert!(matches!(
+        ControlArgs::try_parse_from(["warpctrl", "window", "list"])
+            .expect("window list parses")
+            .command,
+        ControlCommand::Window(WindowCommand::List(_))
+    ));
+    assert!(matches!(
+        ControlArgs::try_parse_from(["warpctrl", "tab", "list"])
+            .expect("tab list parses")
+            .command,
+        ControlCommand::Tab(TabCommand::List(_))
+    ));
+    assert!(matches!(
+        ControlArgs::try_parse_from(["warpctrl", "pane", "list"])
+            .expect("pane list parses")
+            .command,
+        ControlCommand::Pane(PaneCommand::List(_))
+    ));
+    assert!(matches!(
+        ControlArgs::try_parse_from(["warpctrl", "session", "list"])
+            .expect("session list parses")
+            .command,
+        ControlCommand::Session(SessionCommand::List(_))
+    ));
 }
 
 #[test]
@@ -61,18 +117,25 @@ fn parses_completion_generation_command() {
 }
 
 #[test]
-fn rejects_future_catalog_commands_not_in_first_slice() {
-    assert!(ControlArgs::try_parse_from(["warpctrl", "window", "list"]).is_err());
-    assert!(ControlArgs::try_parse_from(["warpctrl", "tab", "list"]).is_err());
+fn rejects_non_metadata_and_future_catalog_commands_not_in_this_shard() {
     assert!(ControlArgs::try_parse_from(["warpctrl", "setting", "list"]).is_err());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "input", "get"]).is_err());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "history", "list"]).is_err());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "block", "list"]).is_err());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "drive", "list"]).is_err());
 }
 
 #[test]
-fn generated_bash_completions_include_first_slice_commands() {
+fn generated_bash_completions_include_metadata_commands() {
     let completions =
         generate_completion_string(Shell::Bash).expect("bash completions render to UTF-8");
     assert!(completions.contains("instance"));
+    assert!(completions.contains("app"));
+    assert!(completions.contains("action"));
+    assert!(completions.contains("window"));
     assert!(completions.contains("tab"));
+    assert!(completions.contains("pane"));
+    assert!(completions.contains("session"));
     assert!(completions.contains("completions"));
 }
 


### PR DESCRIPTION
## Summary
- Adds metadata-only local-control protocol/catalog support for app active/inspect, action list/get, and window/tab/pane/session list actions.
- Wires app-side metadata handlers, target validation, permission checks, and CLI subcommands for the structural read-only shard.
- Adds focused protocol, CLI, and app local-control tests covering action metadata, permissions, selectors, and parser behavior.

## Validation
- cargo fmt --manifest-path /tmp/warpctrl-readonly-metadata/warp/Cargo.toml --all
- git -C /tmp/warpctrl-readonly-metadata/warp diff --check
- cargo check --manifest-path /tmp/warpctrl-readonly-metadata/warp/Cargo.toml -p local_control -p warp_cli
- cargo check --manifest-path /tmp/warpctrl-readonly-metadata/warp/Cargo.toml -p warp --features warp_control_cli
- cargo nextest run --manifest-path /tmp/warpctrl-readonly-metadata/warp/Cargo.toml -p local_control --no-fail-fast
- cargo nextest run --manifest-path /tmp/warpctrl-readonly-metadata/warp/Cargo.toml -p warp_cli --no-fail-fast local_control
- CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /tmp/warpctrl-readonly-metadata/warp/Cargo.toml -p warp --features warp_control_cli --no-fail-fast local_control

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/05fefcfe-b511-4529-93a3-f9eaf9f001f5_
_Run: https://oz.staging.warp.dev/runs/019e566e-96c6-7a85-a60b-41ee6f027572_
_This PR was generated with [Oz](https://warp.dev/oz)._
