### PR TITLE
Match offline tab bar icon color

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19275,12 +19275,13 @@ impl Workspace {
 
     fn render_offline_button(&self, appearance: &Appearance) -> Box<dyn Element> {
         let ui_builder = appearance.ui_builder().clone();
+        let theme = appearance.theme();
 
         let tool_tip_label_text = "Some features may be unavailable offline".to_string();
         let icon = ConstrainedBox::new(
             Container::new(
                 icons::Icon::CloudOffline
-                    .to_warpui_icon(appearance.theme().foreground())
+                    .to_warpui_icon(theme.sub_text_color(theme.background()))
                     .finish(),
             )
             .with_uniform_padding(3.)


### PR DESCRIPTION
## Description
Changes the tab bar offline/no-connection cloud icon to use the same inactive tab bar icon color token as the other toolbar icons.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

No linked issue.

## Testing
- [x] `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- [ ] `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --lib -- -D warnings` (fails on pre-existing lint errors in `crates/warpui_core`, unrelated to this change)
- [x] Computer-use verification: launched Warp, toggled debug network status offline, and observed the offline icon in the tab bar. The icon appeared in the right-side tab bar area with the same muted light-gray treatment as adjacent toolbar chrome and showed the expected tooltip.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/8afba71d-7166-4b93-aebf-9dc79ea532e0_
_Run: https://oz.staging.warp.dev/runs/019e5720-ffbb-7d2c-8b3f-a859b4339858_
_This PR was generated with [Oz](https://warp.dev/oz)._
