### PR TITLE
Fix shell injection in cd commands via proper path quoting

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13275,7 +13275,10 @@ impl TerminalView {
         }
 
         self.input.update(ctx, |input, ctx| {
-            input.try_execute_command(format!("cd \"{path}\"").as_str(), ctx);
+            input.try_execute_command(
+                &format!("cd {}", shell_words::quote(&path)),
+                ctx,
+            );
         });
 
         self.toggle_left_panel_file_tree(true, ctx);

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -291,7 +291,10 @@ impl TerminalView {
             RestorationDirState::NeedsCd { path } => {
                 let path_for_hint = path.clone();
                 let did_execute_cd = self.input.update(ctx, |input, ctx| {
-                    input.try_execute_command(&format!("cd \"{path}\""), ctx)
+                    input.try_execute_command(
+                        &format!("cd {}", shell_words::quote(&path)),
+                        ctx,
+                    )
                 });
                 if did_execute_cd {
                     self.on_next_block_completed(move |me, ctx| {


### PR DESCRIPTION
## Summary
- Replaced unsafe `format!("cd \"{path}\"")` with `shell_words::quote` in `open_repo_folder` and AI conversation restoration
- Double-quoted interpolation allows shell expansion of `$`, backticks, `\`, and `"` in directory paths — a path like `/tmp/my$(id)/project` would execute arbitrary commands
- Now uses `shell_words::quote` which is already used correctly elsewhere in the codebase for the same purpose (e.g. `workspace/view.rs:7437`)

## Test plan
- [ ] Open a repo folder whose path contains a `$` character (e.g. `/tmp/my$var/repo`) — verify `cd` executes without shell expansion
- [ ] Restore an AI conversation whose working directory contains special characters — verify correct `cd`
- [ ] Verify normal paths (no special chars) continue working as before