### PR TITLE
Double-click the hidden-section bar to fully expand

### DIFF
--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -931,13 +931,8 @@ impl<V: EditorView> EditorWrapper<V> {
         line_range: Range<LineCount>,
         offset: Pixels,
     ) -> GutterElement {
-        // Use a slightly stronger overlay when hovered for better visual feedback
         let theme = appearance.theme();
-        let gutter_background_color = if range_hovered {
-            internal_colors::fg_overlay_2(theme)
-        } else {
-            internal_colors::fg_overlay_1(theme)
-        };
+        let gutter_background_color = internal_colors::fg_overlay_1(theme);
 
         let icon = ConstrainedBox::new(
             warpui::elements::Icon::new(
@@ -1617,18 +1612,14 @@ impl<V: EditorView> Element for EditorWrapper<V> {
             Some(Event::MouseMoved { position, .. }) => {
                 let only_check_y_axis =
                     matches!(self.gutter_element_hover_target, GutterHoverTarget::Line);
-                let precise_hovered_range =
-                    self.gutter_element_range_containing_position(*position, false);
-                let broad_hovered_range =
+                let hovered_range =
                     self.gutter_element_range_containing_position(*position, only_check_y_axis);
 
                 // The whole collapsed hidden-section row is clickable, so show a pointer
                 // cursor over it (reset on leave). Set on every move so the overlapping
                 // bar's `Hoverable` can't clear it when resetting later in this dispatch.
-                let over_hidden_section = matches!(
-                    &broad_hovered_range,
-                    Some(GutterRange::HiddenSection { .. })
-                );
+                let over_hidden_section =
+                    matches!(&hovered_range, Some(GutterRange::HiddenSection { .. }));
                 let was_over_hidden_section = self
                     .state_handle
                     .over_hidden_section
@@ -1639,17 +1630,6 @@ impl<V: EditorView> Element for EditorWrapper<V> {
                     ctx.reset_cursor();
                 }
 
-                // Hidden-section rows use the full row as the double-click target, but the
-                // arrow hover state should only appear when the mouse is actually over the
-                // gutter control.
-                let hovered_range = if matches!(
-                    &broad_hovered_range,
-                    Some(GutterRange::HiddenSection { .. })
-                ) {
-                    precise_hovered_range
-                } else {
-                    broad_hovered_range
-                };
                 let hovered_line = hovered_range.map(|gutter_range| gutter_range.line().clone());
                 let mut hovered_diff_hunk = self.state_handle.hovered_diff_hunk.lock();
                 if hovered_diff_hunk.as_ref() != hovered_line.as_ref() {

--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -280,6 +280,9 @@ pub struct EditorWrapperState {
     hovered_diff_hunk: Mutex<Option<EditorLineLocation>>,
     /// Whether there is an active click.
     in_click: AtomicBool,
+    /// Whether the cursor is currently over a collapsed hidden-section row, so the
+    /// pointer cursor is only set/reset on transitions.
+    over_hidden_section: AtomicBool,
     /// Mouse state handle for the plus button.
     add_as_context_mouse_state: MouseStateHandle,
     /// Mouse state handle for the revert button.
@@ -1614,9 +1617,25 @@ impl<V: EditorView> Element for EditorWrapper<V> {
             Some(Event::MouseMoved { position, .. }) => {
                 let only_check_y_axis =
                     matches!(self.gutter_element_hover_target, GutterHoverTarget::Line);
-                let hovered_line = self
-                    .gutter_element_range_containing_position(*position, only_check_y_axis)
-                    .map(|gutter_range| gutter_range.line().clone());
+                let hovered_range =
+                    self.gutter_element_range_containing_position(*position, only_check_y_axis);
+
+                // The whole collapsed hidden-section row is clickable, so show a pointer
+                // cursor over it (reset on leave). Set on every move so the overlapping
+                // bar's `Hoverable` can't clear it when resetting later in this dispatch.
+                let over_hidden_section =
+                    matches!(&hovered_range, Some(GutterRange::HiddenSection { .. }));
+                let was_over_hidden_section = self
+                    .state_handle
+                    .over_hidden_section
+                    .swap(over_hidden_section, Ordering::Relaxed);
+                if over_hidden_section {
+                    ctx.set_cursor(warpui::platform::Cursor::PointingHand, z_index);
+                } else if was_over_hidden_section {
+                    ctx.reset_cursor();
+                }
+
+                let hovered_line = hovered_range.map(|gutter_range| gutter_range.line().clone());
                 let mut hovered_diff_hunk = self.state_handle.hovered_diff_hunk.lock();
                 if hovered_diff_hunk.as_ref() != hovered_line.as_ref() {
                     // When hovering over a new range, clear the previously clicked range

--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -932,14 +932,22 @@ impl<V: EditorView> EditorWrapper<V> {
         offset: Pixels,
     ) -> GutterElement {
         let theme = appearance.theme();
-        let gutter_background_color = internal_colors::fg_overlay_1(theme);
+        // Shift the button background when its row (or half-row, for split
+        // up/down buttons) is hovered, so the expand affordance reads as
+        // interactive.
+        let gutter_background_color = if range_hovered {
+            internal_colors::fg_overlay_3(theme)
+        } else {
+            internal_colors::fg_overlay_1(theme)
+        };
 
+        let icon_color = if range_hovered {
+            line_number_config.highlight_text_color
+        } else {
+            line_number_config.text_color
+        };
         let icon = ConstrainedBox::new(
-            warpui::elements::Icon::new(
-                expansion_type.icon().into(),
-                line_number_config.text_color,
-            )
-            .finish(),
+            warpui::elements::Icon::new(expansion_type.icon().into(), icon_color).finish(),
         )
         .with_width(16.)
         .with_height(16.)
@@ -1612,14 +1620,16 @@ impl<V: EditorView> Element for EditorWrapper<V> {
             Some(Event::MouseMoved { position, .. }) => {
                 let only_check_y_axis =
                     matches!(self.gutter_element_hover_target, GutterHoverTarget::Line);
-                let hovered_range =
+                let broad_hovered_range =
                     self.gutter_element_range_containing_position(*position, only_check_y_axis);
 
                 // The whole collapsed hidden-section row is clickable, so show a pointer
                 // cursor over it (reset on leave). Set on every move so the overlapping
                 // bar's `Hoverable` can't clear it when resetting later in this dispatch.
-                let over_hidden_section =
-                    matches!(&hovered_range, Some(GutterRange::HiddenSection { .. }));
+                let over_hidden_section = matches!(
+                    &broad_hovered_range,
+                    Some(GutterRange::HiddenSection { .. })
+                );
                 let was_over_hidden_section = self
                     .state_handle
                     .over_hidden_section
@@ -1629,6 +1639,15 @@ impl<V: EditorView> Element for EditorWrapper<V> {
                 } else if was_over_hidden_section {
                     ctx.reset_cursor();
                 }
+
+                // Hidden-section rows use the full row as the click/cursor target, but the
+                // arrow hover state should only appear when the mouse is actually over the
+                // gutter control itself.
+                let hovered_range = if over_hidden_section {
+                    self.gutter_element_range_containing_position(*position, false)
+                } else {
+                    broad_hovered_range
+                };
 
                 let hovered_line = hovered_range.map(|gutter_range| gutter_range.line().clone());
                 let mut hovered_diff_hunk = self.state_handle.hovered_diff_hunk.lock();

--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -1617,14 +1617,18 @@ impl<V: EditorView> Element for EditorWrapper<V> {
             Some(Event::MouseMoved { position, .. }) => {
                 let only_check_y_axis =
                     matches!(self.gutter_element_hover_target, GutterHoverTarget::Line);
-                let hovered_range =
+                let precise_hovered_range =
+                    self.gutter_element_range_containing_position(*position, false);
+                let broad_hovered_range =
                     self.gutter_element_range_containing_position(*position, only_check_y_axis);
 
                 // The whole collapsed hidden-section row is clickable, so show a pointer
                 // cursor over it (reset on leave). Set on every move so the overlapping
                 // bar's `Hoverable` can't clear it when resetting later in this dispatch.
-                let over_hidden_section =
-                    matches!(&hovered_range, Some(GutterRange::HiddenSection { .. }));
+                let over_hidden_section = matches!(
+                    &broad_hovered_range,
+                    Some(GutterRange::HiddenSection { .. })
+                );
                 let was_over_hidden_section = self
                     .state_handle
                     .over_hidden_section
@@ -1635,6 +1639,17 @@ impl<V: EditorView> Element for EditorWrapper<V> {
                     ctx.reset_cursor();
                 }
 
+                // Hidden-section rows use the full row as the double-click target, but the
+                // arrow hover state should only appear when the mouse is actually over the
+                // gutter control.
+                let hovered_range = if matches!(
+                    &broad_hovered_range,
+                    Some(GutterRange::HiddenSection { .. })
+                ) {
+                    precise_hovered_range
+                } else {
+                    broad_hovered_range
+                };
                 let hovered_line = hovered_range.map(|gutter_range| gutter_range.line().clone());
                 let mut hovered_diff_hunk = self.state_handle.hovered_diff_hunk.lock();
                 if hovered_diff_hunk.as_ref() != hovered_line.as_ref() {

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -903,6 +903,36 @@ impl CodeEditorView {
         ctx.emit(CodeEditorEvent::HiddenSectionExpanded);
     }
 
+    /// The number of collapsed hidden sections currently in this editor. Fully
+    /// expanding a section removes its range (count drops by one); a chunked
+    /// reveal only shrinks a range (count unchanged).
+    #[cfg(feature = "integration_tests")]
+    pub fn hidden_section_count_for_test(&self, ctx: &AppContext) -> usize {
+        self.model.as_ref(ctx).hidden_ranges(ctx).iter().count()
+    }
+
+    /// Fully expand the first hidden section the same way a bar double-click
+    /// does: resolve the section's full line range from its offset and expand
+    /// with [`ExpansionType::Both`]. Returns whether a section was expanded.
+    #[cfg(feature = "integration_tests")]
+    pub fn fully_expand_first_hidden_section_for_test(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let Some(line_range) = self
+            .model
+            .as_ref(ctx)
+            .render_state()
+            .as_ref(ctx)
+            .content()
+            .first_hidden_section_line_range()
+        else {
+            return false;
+        };
+        self.expand_hidden_section(line_range, &ExpansionType::Both, ctx);
+        true
+    }
+
     pub(crate) fn with_can_show_diff_ui(mut self, can_show_diff_ui: bool) -> Self {
         self.display_options.can_show_diff_ui = can_show_diff_ui;
         self

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -1311,7 +1311,7 @@ impl RichTextAction<CodeEditorView> for CodeEditorViewAction {
         None
     }
 
-    fn hidden_section_double_clicked(
+    fn hidden_section_clicked(
         line_range: Range<LineCount>,
         _parent_view: &WeakViewHandle<CodeEditorView>,
         _ctx: &AppContext,

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -1311,6 +1311,17 @@ impl RichTextAction<CodeEditorView> for CodeEditorViewAction {
         None
     }
 
+    fn hidden_section_double_clicked(
+        line_range: Range<LineCount>,
+        _parent_view: &WeakViewHandle<CodeEditorView>,
+        _ctx: &AppContext,
+    ) -> Option<Self> {
+        Some(CodeEditorViewAction::HiddenSectionExpansion {
+            line_range,
+            expansion_type: ExpansionType::Both,
+        })
+    }
+
     fn middle_mouse_down(_ctx: &AppContext) -> Option<Self> {
         None
     }

--- a/app/src/code_review/code_review_view_integration.rs
+++ b/app/src/code_review/code_review_view_integration.rs
@@ -379,4 +379,58 @@ impl CodeReviewView {
         let line_index = line_number.checked_sub(1)?;
         text.lines().nth(line_index).map(ToOwned::to_owned)
     }
+
+    /// The number of collapsed hidden sections in the given file's diff editor.
+    pub fn hidden_section_count_for_test(&self, path: &str, ctx: &AppContext) -> Option<usize> {
+        let CodeReviewViewState::Loaded(state) = self.state() else {
+            return None;
+        };
+        let editor_index = state
+            .file_states
+            .iter()
+            .position(|(_, file_state)| file_state.file_diff.file_path == path)?;
+        let editor_state = state
+            .file_states
+            .get_index(editor_index)
+            .and_then(|(_, file_state)| file_state.editor_state.as_ref())?;
+        let editor = editor_state.editor().clone();
+        Some(editor.as_ref(ctx).editor().read(ctx, |code_editor_view, ctx| {
+            code_editor_view.hidden_section_count_for_test(ctx)
+        }))
+    }
+
+    /// Fully expand the first hidden section of the given file's diff editor,
+    /// mirroring what a bar double-click does. Returns whether a section was
+    /// expanded.
+    pub fn fully_expand_first_hidden_section_for_test(
+        &mut self,
+        path: &str,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let CodeReviewViewState::Loaded(state) = self.state() else {
+            return false;
+        };
+        let Some(editor_index) = state
+            .file_states
+            .iter()
+            .position(|(_, file_state)| file_state.file_diff.file_path == path)
+        else {
+            return false;
+        };
+        let Some(editor_state) = state
+            .file_states
+            .get_index(editor_index)
+            .and_then(|(_, file_state)| file_state.editor_state.as_ref())
+        else {
+            return false;
+        };
+        let editor = editor_state.editor().clone();
+        editor
+            .as_ref(ctx)
+            .editor()
+            .clone()
+            .update(ctx, |code_editor_view, ctx| {
+                code_editor_view.fully_expand_first_hidden_section_for_test(ctx)
+            })
+    }
 }

--- a/app/src/code_review/code_review_view_integration.rs
+++ b/app/src/code_review/code_review_view_integration.rs
@@ -394,9 +394,14 @@ impl CodeReviewView {
             .get_index(editor_index)
             .and_then(|(_, file_state)| file_state.editor_state.as_ref())?;
         let editor = editor_state.editor().clone();
-        Some(editor.as_ref(ctx).editor().read(ctx, |code_editor_view, ctx| {
-            code_editor_view.hidden_section_count_for_test(ctx)
-        }))
+        Some(
+            editor
+                .as_ref(ctx)
+                .editor()
+                .read(ctx, |code_editor_view, ctx| {
+                    code_editor_view.hidden_section_count_for_test(ctx)
+                }),
+        )
     }
 
     /// Fully expand the first hidden section of the given file's diff editor,

--- a/app/src/integration_testing/code_review/mod.rs
+++ b/app/src/integration_testing/code_review/mod.rs
@@ -213,3 +213,77 @@ pub fn assert_code_review_scroll_region(expected_region: ScrollRegion) -> Assert
         })
     })
 }
+
+/// Polls until the given file's diff editor has at least `min` collapsed hidden
+/// sections. Use this to wait for the diff to lay out before interacting.
+pub fn assert_min_hidden_sections(
+    expected_file_path: impl Into<String>,
+    min: usize,
+) -> AssertionCallback {
+    let expected_file_path = expected_file_path.into();
+
+    Box::new(move |app, window_id| {
+        let Some(code_review_view) = try_single_code_review_view(app, window_id) else {
+            return AssertionOutcome::failure(
+                "code review view not yet available in the window".to_string(),
+            );
+        };
+        code_review_view.read(app, |code_review_view, ctx| {
+            let Some(actual) =
+                code_review_view.hidden_section_count_for_test(&expected_file_path, ctx)
+            else {
+                return AssertionOutcome::failure(format!(
+                    "expected hidden-section count for {expected_file_path:?} to be available"
+                ));
+            };
+            async_assert!(
+                actual >= min,
+                "expected at least {min} hidden sections in {expected_file_path:?}, got {actual}"
+            )
+        })
+    })
+}
+
+/// Fully expand the first hidden section (the action a bar double-click
+/// performs) and assert it removed exactly one hidden section. A chunked
+/// reveal would only shrink a range, leaving the count unchanged, so the
+/// decrement is what distinguishes a full expansion.
+pub fn expand_first_hidden_section_and_assert_full_reveal(
+    file_path: impl Into<String>,
+) -> TestStep {
+    let file_path = file_path.into();
+
+    TestStep::new("Fully expand the first hidden section").with_action(move |app, window_id, _| {
+        let code_review_view = single_code_review_view(app, window_id);
+
+        let before = code_review_view
+            .read(app, |code_review_view, ctx| {
+                code_review_view.hidden_section_count_for_test(&file_path, ctx)
+            })
+            .expect("hidden-section count should be available before expanding");
+        assert!(
+            before > 0,
+            "expected at least one hidden section before expanding {file_path:?}, got {before}"
+        );
+
+        let expanded = code_review_view.update(app, |code_review_view, ctx| {
+            code_review_view.fully_expand_first_hidden_section_for_test(&file_path, ctx)
+        });
+        assert!(
+            expanded,
+            "expected a hidden section to expand for {file_path:?}"
+        );
+
+        let after = code_review_view
+            .read(app, |code_review_view, ctx| {
+                code_review_view.hidden_section_count_for_test(&file_path, ctx)
+            })
+            .expect("hidden-section count should be available after expanding");
+        assert_eq!(
+            after,
+            before - 1,
+            "expected a full expansion to remove exactly one hidden section in {file_path:?} \
+             (a chunked reveal would leave the count unchanged)"
+        );
+    })
+}

--- a/crates/editor/src/content/edit.rs
+++ b/crates/editor/src/content/edit.rs
@@ -578,7 +578,7 @@ impl EditDelta {
                 if let (BlockItem::Hidden(running_config), BlockItem::Hidden(config)) =
                     (last, &item)
                 {
-                    *running_config += *config;
+                    *running_config += config.clone();
                     return acc;
                 }
             }

--- a/crates/editor/src/render/element/hidden_section.rs
+++ b/crates/editor/src/render/element/hidden_section.rs
@@ -3,10 +3,12 @@ use std::ops::Range;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::color::internal_colors;
 use warpui_core::elements::{
-    Container, CrossAxisAlignment, Empty, Flex, Hoverable, MouseStateHandle, ParentElement,
+    ChildAnchor, Container, CrossAxisAlignment, Empty, Flex, Hoverable, MouseStateHandle,
+    OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Stack,
 };
 use warpui_core::geometry::vector::vec2f;
 use warpui_core::platform::Cursor;
+use warpui_core::ui_components::components::UiComponent;
 use warpui_core::{
     AfterLayoutContext, AppContext, Element, LayoutContext, SingletonEntity, SizeConstraint,
     WeakViewHandle,
@@ -40,19 +42,43 @@ impl RenderableHiddenSection {
         let theme = appearance.theme();
         let base_background = internal_colors::fg_overlay_1(theme);
         let hover_background = internal_colors::fg_overlay_2(theme);
+        let ui_builder = appearance.ui_builder();
 
         let element = Hoverable::new(mouse_state, move |state| {
             let row = Flex::row()
                 .with_child(Empty::new().finish())
                 .with_cross_axis_alignment(CrossAxisAlignment::Center);
-            let background = if state.is_hovered() {
+            let hovered = state.is_hovered();
+            let background = if hovered {
                 hover_background
             } else {
                 base_background
             };
-            Container::new(row.finish())
+            let bar = Container::new(row.finish())
                 .with_background(background)
-                .finish()
+                .finish();
+
+            if !hovered {
+                return bar;
+            }
+
+            // On hover, float a tooltip explaining the double-click gesture,
+            // centered just below the bar (mirrors how `Button` shows its tooltip).
+            let mut stack = Stack::new().with_child(bar);
+            let tooltip = ui_builder
+                .tool_tip("Double-click to expand".to_string())
+                .build()
+                .finish();
+            stack.add_positioned_overlay_child(
+                tooltip,
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., 8.),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::BottomMiddle,
+                    ChildAnchor::TopMiddle,
+                ),
+            );
+            stack.finish()
         })
         // A single click on the bar does nothing, but registering the handler makes the
         // Hoverable consume the press so it does not fall through to text selection.

--- a/crates/editor/src/render/element/hidden_section.rs
+++ b/crates/editor/src/render/element/hidden_section.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::time::Duration;
 
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::color::internal_colors;
@@ -48,8 +49,9 @@ impl RenderableHiddenSection {
             let row = Flex::row()
                 .with_child(Empty::new().finish())
                 .with_cross_axis_alignment(CrossAxisAlignment::Center);
-            let hovered = state.is_hovered();
-            let background = if hovered {
+            // The hover highlight tracks the mouse immediately, while the tooltip
+            // below is gated on `is_hovered()` so it respects the hover-in delay.
+            let background = if state.is_mouse_over_element() {
                 hover_background
             } else {
                 base_background
@@ -58,7 +60,7 @@ impl RenderableHiddenSection {
                 .with_background(background)
                 .finish();
 
-            if !hovered {
+            if !state.is_hovered() {
                 return bar;
             }
 
@@ -66,7 +68,7 @@ impl RenderableHiddenSection {
             // centered just below the bar (mirrors how `Button` shows its tooltip).
             let mut stack = Stack::new().with_child(bar);
             let tooltip = ui_builder
-                .tool_tip("Double-click to expand".to_string())
+                .tool_tip("Double-click to expand all lines".to_string())
                 .build()
                 .finish();
             stack.add_positioned_overlay_child(
@@ -91,6 +93,7 @@ impl RenderableHiddenSection {
                 ctx.dispatch_typed_action(action);
             }
         })
+        .with_hover_in_delay(Duration::from_millis(500))
         .with_cursor(Cursor::PointingHand)
         .finish();
 

--- a/crates/editor/src/render/element/hidden_section.rs
+++ b/crates/editor/src/render/element/hidden_section.rs
@@ -1,14 +1,17 @@
 use std::ops::Range;
+use std::sync::Arc;
 use std::time::Duration;
 
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::color::internal_colors;
 use warpui_core::elements::{
-    ChildAnchor, Container, CrossAxisAlignment, Empty, Flex, Hoverable, MouseStateHandle,
-    OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Stack,
+    ChildAnchor, Container, CrossAxisAlignment, Flex, Highlight, Hoverable, MouseStateHandle,
+    OffsetPositioning, ParentElement, PositionedElementAnchor, PositionedElementOffsetBounds,
+    SavePosition, Stack, Text,
 };
 use warpui_core::geometry::vector::vec2f;
 use warpui_core::platform::Cursor;
+use warpui_core::text_layout::TextStyle;
 use warpui_core::ui_components::components::UiComponent;
 use warpui_core::{
     AfterLayoutContext, AppContext, Element, LayoutContext, SingletonEntity, SizeConstraint,
@@ -20,12 +23,13 @@ use super::super::model::viewport::ViewportItem;
 use super::{RenderContext, RenderableBlock, RichTextAction};
 use crate::editor::EditorView;
 use crate::extract_block;
-use crate::render::model::{BlockItem, LineCount};
+use crate::render::model::{BlockItem, LineCount, RichTextStyles};
 
-/// A renderable block for hidden sections: a single- or double-line-height full-width bar.
-/// Double-clicking the bar fully expands the hidden section it represents; a single click is
-/// consumed so it does not start a text selection. The gutter expand buttons (rendered
-/// elsewhere) keep their chunk-at-a-time behavior.
+const LABEL_LEFT_PADDING: f32 = 8.;
+/// Slightly smaller than the default UI font size.
+const LABEL_FONT_SIZE: f32 = 11.;
+const TOOLTIP_HOVER_DELAY: Duration = Duration::from_millis(500);
+/// A hidden-section bar with a link to expand all lines.
 pub struct RenderableHiddenSection {
     element: Box<dyn Element>,
     viewport_item: ViewportItem,
@@ -35,57 +39,87 @@ impl RenderableHiddenSection {
     pub fn new<V: EditorView>(
         viewport_item: ViewportItem,
         mouse_state: MouseStateHandle,
+        line_count: LineCount,
         full_line_range: Option<Range<LineCount>>,
+        styles: &RichTextStyles,
         parent_view: WeakViewHandle<V>,
         app: &AppContext,
     ) -> Self {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let base_background = internal_colors::fg_overlay_1(theme);
-        let ui_builder = appearance.ui_builder();
+
+        // This is UI chrome rather than code content.
+        let font_family = appearance.ui_font_family();
+        let font_size = LABEL_FONT_SIZE;
+        let base_color = styles.placeholder_color;
+        let hover_color = styles.base_text.text_color;
+        let label_position_id = format!("hidden_section_label_{:p}", Arc::as_ptr(&mouse_state));
 
         let element = Hoverable::new(mouse_state, move |state| {
+            // Keep the link immediate while delaying the tooltip.
+            let mouse_over = state.is_mouse_over_element();
+
+            let lines = line_count.as_usize();
+            let label = if lines == 1 {
+                "1 unmodified line".to_string()
+            } else {
+                format!("{lines} unmodified lines")
+            };
+            let label_char_count = label.chars().count();
+
+            let mut text = Text::new_inline(label, font_family, font_size)
+                .with_color(if mouse_over { hover_color } else { base_color });
+            if mouse_over {
+                text = text.with_single_highlight(
+                    Highlight::new().with_text_style(
+                        TextStyle::new()
+                            .with_foreground_color(hover_color)
+                            .with_underline_color(hover_color),
+                    ),
+                    (0..label_char_count).collect(),
+                );
+            }
+
             let row = Flex::row()
-                .with_child(Empty::new().finish())
+                .with_child(SavePosition::new(text.finish(), &label_position_id).finish())
                 .with_cross_axis_alignment(CrossAxisAlignment::Center);
             let bar = Container::new(row.finish())
                 .with_background(base_background)
+                .with_padding_left(LABEL_LEFT_PADDING)
                 .finish();
+            let mut stack = Stack::new().with_child(bar);
 
-            if !state.is_hovered() {
-                return bar;
+            if state.is_hovered() {
+                let tooltip = appearance
+                    .ui_builder()
+                    .tool_tip("Expand all lines".to_string())
+                    .build()
+                    .finish();
+                stack.add_positioned_overlay_child(
+                    tooltip,
+                    OffsetPositioning::offset_from_save_position_element(
+                        label_position_id.clone(),
+                        vec2f(0., 4.),
+                        PositionedElementOffsetBounds::WindowByPosition,
+                        PositionedElementAnchor::BottomLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                );
             }
 
-            // On hover, float a tooltip explaining the double-click gesture,
-            // centered just below the bar (mirrors how `Button` shows its tooltip).
-            let mut stack = Stack::new().with_child(bar);
-            let tooltip = ui_builder
-                .tool_tip("Double-click to expand all lines".to_string())
-                .build()
-                .finish();
-            stack.add_positioned_overlay_child(
-                tooltip,
-                OffsetPositioning::offset_from_parent(
-                    vec2f(0., 8.),
-                    ParentOffsetBounds::WindowByPosition,
-                    ParentAnchor::BottomMiddle,
-                    ChildAnchor::TopMiddle,
-                ),
-            );
             stack.finish()
         })
-        // A single click on the bar does nothing, but registering the handler makes the
-        // Hoverable consume the press so it does not fall through to text selection.
-        .on_click(|_, _, _| {})
-        .on_double_click(move |ctx, app, _| {
+        // The handler also prevents the press from reaching text selection.
+        .on_click(move |ctx, app, _| {
             if let Some(line_range) = full_line_range.clone()
                 && let Some(action) =
-                    V::Action::hidden_section_double_clicked(line_range, &parent_view, app)
+                    V::Action::hidden_section_clicked(line_range, &parent_view, app)
             {
                 ctx.dispatch_typed_action(action);
             }
         })
-        .with_hover_in_delay(Duration::from_millis(500))
+        .with_hover_in_delay(TOOLTIP_HOVER_DELAY)
         .with_cursor(Cursor::PointingHand)
         .finish();
 
@@ -116,7 +150,6 @@ impl RenderableBlock for RenderableHiddenSection {
     }
 
     fn paint(&mut self, model: &RenderState, ctx: &mut RenderContext, app: &AppContext) {
-        // Paint the single- or double-line-height bar element.
         let content_origin = self.viewport_item.content_bounds(ctx).origin()
             + vec2f(model.viewport().scroll_left().as_f32(), 0.);
         self.element.paint(content_origin, ctx.paint, app);

--- a/crates/editor/src/render/element/hidden_section.rs
+++ b/crates/editor/src/render/element/hidden_section.rs
@@ -42,22 +42,14 @@ impl RenderableHiddenSection {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let base_background = internal_colors::fg_overlay_1(theme);
-        let hover_background = internal_colors::fg_overlay_2(theme);
         let ui_builder = appearance.ui_builder();
 
         let element = Hoverable::new(mouse_state, move |state| {
             let row = Flex::row()
                 .with_child(Empty::new().finish())
                 .with_cross_axis_alignment(CrossAxisAlignment::Center);
-            // The hover highlight tracks the mouse immediately, while the tooltip
-            // below is gated on `is_hovered()` so it respects the hover-in delay.
-            let background = if state.is_mouse_over_element() {
-                hover_background
-            } else {
-                base_background
-            };
             let bar = Container::new(row.finish())
-                .with_background(background)
+                .with_background(base_background)
                 .finish();
 
             if !state.is_hovered() {

--- a/crates/editor/src/render/element/hidden_section.rs
+++ b/crates/editor/src/render/element/hidden_section.rs
@@ -1,36 +1,73 @@
+use std::ops::Range;
+
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::color::internal_colors;
-use warpui_core::elements::{Container, CrossAxisAlignment, Empty, Flex, ParentElement};
+use warpui_core::elements::{
+    Container, CrossAxisAlignment, Empty, Flex, Hoverable, MouseStateHandle, ParentElement,
+};
 use warpui_core::geometry::vector::vec2f;
+use warpui_core::platform::Cursor;
 use warpui_core::{
     AfterLayoutContext, AppContext, Element, LayoutContext, SingletonEntity, SizeConstraint,
+    WeakViewHandle,
 };
 
 use super::super::model::RenderState;
 use super::super::model::viewport::ViewportItem;
-use super::{RenderContext, RenderableBlock};
+use super::{RenderContext, RenderableBlock, RichTextAction};
+use crate::editor::EditorView;
 use crate::extract_block;
-use crate::render::model::BlockItem;
+use crate::render::model::{BlockItem, LineCount};
 
-/// A renderable block for hidden sections that renders a single- or double-line-height rectangle.
-/// This is used for BlockItem::Hidden items that need to be visually indicated.
+/// A renderable block for hidden sections: a single- or double-line-height full-width bar.
+/// Double-clicking the bar fully expands the hidden section it represents; a single click is
+/// consumed so it does not start a text selection. The gutter expand buttons (rendered
+/// elsewhere) keep their chunk-at-a-time behavior.
 pub struct RenderableHiddenSection {
     element: Box<dyn Element>,
     viewport_item: ViewportItem,
 }
 
 impl RenderableHiddenSection {
-    pub fn new(viewport_item: ViewportItem, app: &AppContext) -> Self {
+    pub fn new<V: EditorView>(
+        viewport_item: ViewportItem,
+        mouse_state: MouseStateHandle,
+        full_line_range: Option<Range<LineCount>>,
+        parent_view: WeakViewHandle<V>,
+        app: &AppContext,
+    ) -> Self {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
+        let base_background = internal_colors::fg_overlay_1(theme);
+        let hover_background = internal_colors::fg_overlay_2(theme);
 
-        let row = Flex::row()
-            .with_child(Empty::new().finish())
-            .with_cross_axis_alignment(CrossAxisAlignment::Center);
-
-        let element = Container::new(row.finish())
-            .with_background(internal_colors::fg_overlay_1(theme))
-            .finish();
+        let element = Hoverable::new(mouse_state, move |state| {
+            let row = Flex::row()
+                .with_child(Empty::new().finish())
+                .with_cross_axis_alignment(CrossAxisAlignment::Center);
+            let background = if state.is_hovered() {
+                hover_background
+            } else {
+                base_background
+            };
+            Container::new(row.finish())
+                .with_background(background)
+                .finish()
+        })
+        // A single click on the bar does nothing, but registering the handler makes the
+        // Hoverable consume the press so it does not fall through to text selection.
+        .on_click(|_, _, _| {})
+        .on_double_click(move |ctx, app, _| {
+            if let Some(line_range) = full_line_range.clone() {
+                if let Some(action) =
+                    V::Action::hidden_section_double_clicked(line_range, &parent_view, app)
+                {
+                    ctx.dispatch_typed_action(action);
+                }
+            }
+        })
+        .with_cursor(Cursor::PointingHand)
+        .finish();
 
         Self {
             viewport_item,
@@ -59,7 +96,7 @@ impl RenderableBlock for RenderableHiddenSection {
     }
 
     fn paint(&mut self, model: &RenderState, ctx: &mut RenderContext, app: &AppContext) {
-        // Paint the single- or double-line-height rectangle element
+        // Paint the single- or double-line-height bar element.
         let content_origin = self.viewport_item.content_bounds(ctx).origin()
             + vec2f(model.viewport().scroll_left().as_f32(), 0.);
         self.element.paint(content_origin, ctx.paint, app);

--- a/crates/editor/src/render/element/hidden_section.rs
+++ b/crates/editor/src/render/element/hidden_section.rs
@@ -84,12 +84,11 @@ impl RenderableHiddenSection {
         // Hoverable consume the press so it does not fall through to text selection.
         .on_click(|_, _, _| {})
         .on_double_click(move |ctx, app, _| {
-            if let Some(line_range) = full_line_range.clone() {
-                if let Some(action) =
+            if let Some(line_range) = full_line_range.clone()
+                && let Some(action) =
                     V::Action::hidden_section_double_clicked(line_range, &parent_view, app)
-                {
-                    ctx.dispatch_typed_action(action);
-                }
+            {
+                ctx.dispatch_typed_action(action);
             }
         })
         .with_cursor(Cursor::PointingHand)

--- a/crates/editor/src/render/element/mod.rs
+++ b/crates/editor/src/render/element/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::ops::Range;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -41,7 +42,8 @@ use self::text_block::RenderableTextBlock;
 use self::unordered_list::RenderableBulletList;
 use super::model::viewport::{SizeInfo, ViewportItem};
 use super::model::{
-    BlockItem, ElementUpdate, HitTestOptions, Location, RenderState, RichTextStyles, UNIT_MARGIN,
+    BlockItem, ElementUpdate, HitTestOptions, LineCount, Location, RenderState, RichTextStyles,
+    UNIT_MARGIN,
 };
 use crate::content::version::BufferVersion;
 use crate::editor::EditorView;
@@ -368,6 +370,18 @@ pub trait RichTextAction<V>: Sized {
         parent_view: &WeakViewHandle<V>,
         ctx: &AppContext,
     ) -> Option<Self>;
+
+    /// Dispatch an event when a hidden-section bar is double-clicked, to fully
+    /// expand the entire hidden section it represents. `line_range` is the
+    /// section's complete hidden line range. Defaults to no action; only the
+    /// code-review editor implements it.
+    fn hidden_section_double_clicked(
+        _line_range: Range<LineCount>,
+        _parent_view: &WeakViewHandle<V>,
+        _ctx: &AppContext,
+    ) -> Option<Self> {
+        None
+    }
 
     /// Dispatch an event when the mouse wheel is clicked.
     fn middle_mouse_down(ctx: &AppContext) -> Option<Self>;
@@ -905,7 +919,17 @@ impl<V: EditorView> RichTextElement<V> {
                     BlockItem::Image { .. } => RenderableImage::new(item).finish(),
                     BlockItem::Table { .. } => RenderableTable::new(item).finish(),
                     BlockItem::TrailingNewLine(_) => Empty::new(item).finish(),
-                    BlockItem::Hidden { .. } => RenderableHiddenSection::new(item, ctx).finish(),
+                    BlockItem::Hidden(config) => {
+                        let full_line_range = model.line_range_at_offset(item.block_offset);
+                        RenderableHiddenSection::new(
+                            item,
+                            config.mouse_state(),
+                            full_line_range,
+                            self.parent_view.clone(),
+                            ctx,
+                        )
+                        .finish()
+                    }
                     BlockItem::Embedded(embed) => {
                         let start_offset = item.block_offset;
                         let child_model = parent.embedded_item_at(start_offset, ctx);

--- a/crates/editor/src/render/element/mod.rs
+++ b/crates/editor/src/render/element/mod.rs
@@ -371,11 +371,11 @@ pub trait RichTextAction<V>: Sized {
         ctx: &AppContext,
     ) -> Option<Self>;
 
-    /// Dispatch an event when a hidden-section bar is double-clicked, to fully
+    /// Dispatch an event when a hidden-section bar is clicked, to fully
     /// expand the entire hidden section it represents. `line_range` is the
     /// section's complete hidden line range. Defaults to no action; only the
     /// code-review editor implements it.
-    fn hidden_section_double_clicked(
+    fn hidden_section_clicked(
         _line_range: Range<LineCount>,
         _parent_view: &WeakViewHandle<V>,
         _ctx: &AppContext,
@@ -924,7 +924,9 @@ impl<V: EditorView> RichTextElement<V> {
                         RenderableHiddenSection::new(
                             item,
                             config.mouse_state(),
+                            config.line_count(),
                             full_line_range,
+                            styles,
                             self.parent_view.clone(),
                             ctx,
                         )

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -1773,13 +1773,20 @@ pub fn gutter_expansion_button_types(
         }
     }
 }
-#[derive(Debug, Clone, Copy)]
+// `Clone`, not `Copy`: holds a `MouseStateHandle` (`Arc`-backed), like
+// `BlockItem::TaskList`. The hidden-range dedupe paths clone configs accordingly.
+#[derive(Debug, Clone)]
 pub struct HiddenBlockConfig {
     line_count: LineCount,
     content_length: CharOffset,
     // The location of the block is set when the hidden section is first laid out,
     // and updated in RenderState.dedupe_hidden_ranges.
     block_location: BlockLocation,
+    // Persistent hover state for the full-width bar, so it can show a hover
+    // highlight and respond to a double-click. Created once per section and
+    // carried across re-layouts (including range dedupe, which preserves the
+    // accumulating range's handle).
+    mouse_state: MouseStateHandle,
 }
 
 impl HiddenBlockConfig {
@@ -1792,7 +1799,12 @@ impl HiddenBlockConfig {
             line_count,
             content_length,
             block_location,
+            mouse_state: MouseStateHandle::default(),
         }
+    }
+
+    pub fn mouse_state(&self) -> MouseStateHandle {
+        self.mouse_state.clone()
     }
 
     pub fn height(&self) -> Pixels {
@@ -3058,9 +3070,9 @@ impl RenderState {
             for item in sub_tree.cursor::<CharOffset, CharOffset>() {
                 if let BlockItem::Hidden(config) = item {
                     if let Some(prev) = &mut hidden_config {
-                        *prev += *config;
+                        *prev += config.clone();
                     } else {
-                        hidden_config = Some(*config)
+                        hidden_config = Some(config.clone())
                     }
                 } else if hidden_config.is_none() {
                     new_tree.push(item.clone());
@@ -3567,6 +3579,15 @@ impl RenderState {
         let content = self.content();
         let offset = block.viewport_item().block_offset();
         Some(start..start + content.block_at_offset(offset)?.item.lines())
+    }
+
+    /// The full line range of the block starting at `offset`, resolved without a
+    /// `RenderableBlock`. Used to compute a hidden section's complete range for
+    /// double-click full expansion.
+    pub fn line_range_at_offset(&self, offset: CharOffset) -> Option<Range<LineCount>> {
+        let content = self.content();
+        let block = content.block_at_offset(offset)?;
+        Some(block.start_line..block.start_line + block.item.lines())
     }
 }
 

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -332,6 +332,29 @@ impl<'a> RenderContentTreeRef<'a> {
         }
     }
 
+    /// The full line range of the first collapsed hidden section, or `None` if
+    /// there are none. Resolves the range the same way a hidden-section bar
+    /// does — the `Hidden` block's `start_line` plus its hidden line count —
+    /// so tests can fully expand the first section the bar would.
+    pub fn first_hidden_section_line_range(&self) -> Option<Range<LineCount>> {
+        let mut cursor = self.0.cursor::<CharOffset, LayoutSummary>();
+        cursor.descend_to_first_item(&self.0, |_| true);
+        loop {
+            let range = {
+                let positioned = cursor.positioned_item()?;
+                if matches!(positioned.item, BlockItem::Hidden(_)) {
+                    Some(positioned.start_line..positioned.start_line + positioned.item.lines())
+                } else {
+                    None
+                }
+            };
+            if let Some(range) = range {
+                return Some(range);
+            }
+            cursor.next();
+        }
+    }
+
     pub fn is_entire_range_of_type(
         &self,
         range: &Range<CharOffset>,

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -1427,6 +1427,51 @@ fn test_link_at_offset_uses_cached_cell_links() {
     assert_eq!(table.link_at_offset(CharOffset::from(3)), None);
 }
 
+#[test]
+fn test_first_hidden_section_line_range() {
+    let mut render_state = RenderState::new_for_test(
+        TEST_STYLES.clone(),
+        200.0.into_pixels(),
+        160.0.into_pixels(),
+    );
+    let mut content = SumTree::new();
+    // A hidden section spanning 87 lines at the top of the file, followed by a
+    // visible paragraph. Because the hidden block is first, its start line is 0,
+    // so its full range is 0..87 — exactly what a bar double-click would expand.
+    content.push(BlockItem::Hidden(HiddenBlockConfig::new(
+        LineCount(87),
+        CharOffset::from(3066),
+        BlockLocation::Start,
+    )));
+    content.push(mock_paragraph(18.2, 0., 10));
+    render_state.set_content(content);
+
+    assert_eq!(
+        render_state.content().first_hidden_section_line_range(),
+        Some(LineCount(0)..LineCount(87)),
+        "first hidden section should resolve to its full line range"
+    );
+}
+
+#[test]
+fn test_first_hidden_section_line_range_none_without_hidden_sections() {
+    let mut render_state = RenderState::new_for_test(
+        TEST_STYLES.clone(),
+        200.0.into_pixels(),
+        160.0.into_pixels(),
+    );
+    let mut content = SumTree::new();
+    content.push(mock_paragraph(18.2, 0., 10));
+    content.push(mock_paragraph(18.2, 0., 6));
+    render_state.set_content(content);
+
+    assert_eq!(
+        render_state.content().first_hidden_section_line_range(),
+        None,
+        "a diff with no hidden sections should resolve to None"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // CharCell (TUI) layout helper tests
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -299,6 +299,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_code_review_scroll_preserved_deleted_range);
     register_test!(test_code_review_scroll_preserved_header_range);
     register_test!(test_code_review_scroll_preserved_footer_range);
+    register_test!(test_code_review_double_click_fully_expands_hidden_section);
     register_test!(test_alt_screen_context_menu_with_sgr_with_mouse_reporting);
     register_test!(test_alt_screen_context_menu_with_sgr_without_mouse_reporting);
     register_test!(test_alt_screen_context_menu_without_sgr_with_mouse_reporting);

--- a/crates/integration/src/test/code_review.rs
+++ b/crates/integration/src/test/code_review.rs
@@ -6,7 +6,8 @@ use command::blocking::Command;
 use warp::features::FeatureFlag;
 use warp::integration_testing::code_review::{
     assert_code_review_anchor, assert_code_review_line_text, assert_code_review_loaded,
-    assert_code_review_scroll_region, scroll_code_review_to_deleted_range,
+    assert_code_review_scroll_region, assert_min_hidden_sections,
+    expand_first_hidden_section_and_assert_full_reveal, scroll_code_review_to_deleted_range,
     scroll_code_review_to_footer, scroll_code_review_to_header, scroll_code_review_to_line,
     ScrollRegion,
 };
@@ -649,4 +650,62 @@ pub fn test_code_review_scroll_preserved_second_file() -> Builder {
                     None,
                 )),
         )
+}
+
+// --- Hidden-section double-click expansion (GH11622) ---
+// The fixture modifies lines 10-80 and 200-300 of a 400-line file, leaving
+// large unchanged stretches that the diff editor collapses into hidden
+// sections. Fully expanding a section (the action a bar double-click performs,
+// via ExpansionType::Both over the section's full range) reveals the whole
+// section in one transition and removes it from the hidden set, whereas a
+// chunked gutter reveal would only shrink it. The expansion is size-agnostic,
+// so this also covers the small-section case (product invariant #8).
+
+pub fn test_code_review_double_click_fully_expands_hidden_section() -> Builder {
+    new_builder()
+        .use_tmp_filesystem_for_test_root_directory()
+        .with_setup(|utils| {
+            let test_dir = utils.test_dir();
+            let repo_dir = test_dir.join("repo");
+            fs::create_dir_all(&repo_dir).expect("should create repo subdirectory");
+            let repo_dir_string = repo_dir
+                .to_str()
+                .expect("repo directory should be valid utf-8");
+
+            write_all_rc_files_for_test(&test_dir, format!("cd {repo_dir_string}"));
+
+            fs::write(repo_dir.join(TEST_FILE_NAME), initial_committed_contents())
+                .expect("should write initial committed contents");
+            run_git(&repo_dir, &["init", "-b", "main"]);
+            run_git(&repo_dir, &["config", "user.email", "test@example.com"]);
+            run_git(&repo_dir, &["config", "user.name", "Warp Integration Test"]);
+            run_git(&repo_dir, &["add", TEST_FILE_NAME]);
+            run_git(&repo_dir, &["commit", "-m", "Initial commit"]);
+
+            fs::write(repo_dir.join(TEST_FILE_NAME), initial_diff_contents())
+                .expect("should write initial diff contents");
+        })
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            TestStep::new("Wait for the terminal to detect the git repository")
+                .set_timeout(Duration::from_secs(20))
+                .add_assertion(assert_repo_detected()),
+        )
+        .with_step(
+            TestStep::new("Open the code review panel")
+                .with_action(|app, window_id, _| open_code_review_panel(app, window_id)),
+        )
+        .with_step(
+            TestStep::new("Wait for the code review panel to load file diffs")
+                .set_timeout(Duration::from_secs(20))
+                .add_assertion(assert_code_review_loaded()),
+        )
+        .with_step(
+            TestStep::new("Wait for the diff to collapse unchanged context into hidden sections")
+                .set_timeout(Duration::from_secs(20))
+                .add_assertion(assert_min_hidden_sections(TEST_FILE_NAME, 1)),
+        )
+        .with_step(expand_first_hidden_section_and_assert_full_reveal(
+            TEST_FILE_NAME,
+        ))
 }

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -156,6 +156,7 @@ integration_tests! {
     test_code_review_scroll_preserved_header_range,
     #[ignore = "Flaking on CI - KC looking into 3/31/26"]
     test_code_review_scroll_preserved_footer_range,
+    test_code_review_double_click_fully_expands_hidden_section,
     test_pane_group_state_single_pane,
     test_pane_group_state_multi_pane,
     test_pane_group_state_close_pane,

--- a/specs/GH11622/product.md
+++ b/specs/GH11622/product.md
@@ -1,0 +1,83 @@
+# Product Spec: Double-click the hidden-section bar to fully expand
+
+**Issue:** [warpdotdev/warp#11622](https://github.com/warpdotdev/warp/issues/11622)
+**Figma:** none
+
+## Summary
+
+The Code Review panel's diff editor collapses long stretches of unchanged context into hidden sections. Each hidden section renders as a full-width horizontal **bar** in the content area, with one or two **gutter expand buttons** (`▲`, `▼`, or `▲▼`) beside it. Today, clicking a gutter button reveals up to 25 lines at a time, so a 200-line hidden region takes 8 clicks to fully reveal. This spec adds **double-clicking the bar** as a shortcut that fully expands the entire hidden section in one action. The gutter buttons keep their existing chunk-at-a-time behavior unchanged.
+
+## Problem
+
+When a diff has hunks separated by hundreds of unchanged lines — or hidden context regions at the top or bottom of a file — there is no fast way to reveal the entire region. Users have to click a gutter button repeatedly (4–10 times typical, more for very large files). There is no keyboard shortcut and no "expand all" affordance.
+
+### Why the bar, not the gutter button
+
+An earlier iteration put double-click on the gutter button itself. Because the same target serves both "reveal one chunk" (single click) and "reveal everything" (double click), single-click has to be deferred by the OS double-click interval (~300–500ms) to disambiguate the two — otherwise the chunk flashes before the full expansion snaps in on a real double-click. Deferring single-click to wait out a possible double-click is a normal, widely-used UI pattern, so it isn't unusable — but it's avoidable here, and a small gutter arrow that shifts position as earlier chunks reveal is a cramped double-click target.
+
+Giving each gesture its own target removes the conflict entirely. This is the established pattern in VS Code / Monaco's `hideUnchangedRegions`: the gutter arrows reveal a fixed chunk instantly, and double-clicking the full-width hidden bar expands the whole region. Separate targets mean single-click stays instant and no debounce is needed.
+
+## Goals
+
+- Double-clicking the hidden-section bar fully expands that hidden section in one action.
+- Single-clicking a gutter expand button still reveals up to one chunk at a time, instantly (no added delay).
+- Single-clicking the bar does nothing — and in particular does not start a text selection (today a click on the bar clamps to a text offset and can begin selecting).
+- The double-click affordance is discoverable: the bar shows a pointer cursor and a hover state, and a tooltip explains the gesture.
+- Adjacent gutter interactions (diff-hunk sliver toggle, add-as-context, revert) are unaffected.
+
+## Non-goals
+
+- A keyboard shortcut for "expand all hidden sections in the current file" — separate feature; could land later.
+- A "collapse all" / "expand all" affordance at the file or panel level — covered by issue #9129, a different feature.
+- Changes to how hidden sections are *initially* computed (context-line counts, hunk grouping) — out of scope.
+- Changes to the `Hoverable::on_double_click` callback API used by tabs and the workflow alias bar — those widgets remain on their existing patterns.
+
+## User experience
+
+### Current behavior (chunked-only)
+
+1. User opens the Code Review panel on a file with a large hidden region between two hunks.
+2. The hidden region renders as a full-width bar with one (or two) gutter expand buttons (`▲`, `▼`, or `▲▼`) beside it.
+3. User clicks a gutter expand button.
+4. The next 25 lines reveal immediately.
+5. To see the full region, user clicks the button (or its sibling) 3 to 10 more times.
+6. Clicking the bar itself does nothing useful — it clamps to the nearest text offset and can begin a text selection.
+
+### New behavior (chunked + double-click the bar)
+
+1. User opens the Code Review panel on a file with a large hidden region between two hunks.
+2. The hidden region renders as a full-width bar with one (or two) gutter expand buttons beside it. Hovering the bar shows a pointer cursor, a hover highlight, and a tooltip describing the double-click gesture.
+3. User double-clicks the bar.
+4. The entire hidden region unhides in one transition. No intermediate chunked reveal is visible.
+5. Alternatively, user single-clicks a gutter expand button. The next 25 lines reveal immediately, with no added delay. The user can continue clicking to chunk further.
+6. A single click on the bar does nothing, and in particular does not start a text selection.
+
+## Behavior (testable invariants)
+
+1. Double-clicking a hidden-section bar fully expands the entire hidden section that bar represents, in a single transition with no intermediate chunked reveal.
+
+2. Single-clicking a gutter expand button reveals one chunk (up to 25 lines) of the hidden section, immediately — there is no added delay relative to the pre-feature behavior.
+
+3. Single-clicking the bar is a no-op: it does not expand the section, does not move the text cursor, and does not begin a text selection.
+
+4. The bar is discoverable as a double-click target — on hover it shows a pointer cursor and a hover/highlight state, and a tooltip explains that double-clicking expands the section.
+
+5. Triple or higher click counts on the bar produce one full expansion total (the same as a double-click), not multiple. Once the section is fully expanded the bar no longer exists, so any further clicks have no target.
+
+6. Double-clicking a gutter expand button has no special "expand all" behavior — the two clicks are treated independently and reveal up to two chunks. Full expansion is reached only by double-clicking the bar.
+
+7. Single-clicking a gutter button and double-clicking the bar are independent gestures on independent targets — neither defers, debounces, nor cancels the other.
+
+8. Double-clicking the bar of a *small* hidden section (one that already only requires a single chunked click to fully expand) fully reveals it in one expansion. No regression vs. clicking the lone gutter button.
+
+9. Adjacent gutter interactions are unaffected:
+   - Single-click on a diff-hunk's colored sliver still toggles diff navigation.
+   - Single-click on the add-as-context (`+`) button still adds the hunk as context.
+   - Single-click on the revert button still reverts the hunk.
+   - Clicks on the gutter outside any actionable element remain no-ops.
+
+10. The feature works identically across operating systems — macOS, Linux, and Windows users all get double-click full expansion on the bar and instant single-click chunked reveal on the gutter buttons. Double-click *detection* uses the platform's standard double-click interval via the existing framework click handling; this feature introduces no separate per-gesture debounce.
+
+## Open questions
+
+- None at spec time. All edge cases above have a defined behavior.

--- a/specs/GH11622/tech.md
+++ b/specs/GH11622/tech.md
@@ -1,0 +1,109 @@
+# Tech Spec: Double-click the hidden-section bar to fully expand
+
+**Issue:** [warpdotdev/warp#11622](https://github.com/warpdotdev/warp/issues/11622)
+**Product spec:** `specs/GH11622/product.md`
+
+## Context
+
+The diff editor collapses long runs of unchanged context into hidden sections. Each section paints a full-width **bar** in the content area and a separate **gutter expand button** (`▲`/`▼`/`▲▼`) in the left margin. The product spec moves "expand the whole section" onto a **double-click of the bar**, leaves single-click chunked reveal on the gutter button exactly as it is today, and makes a single click on the bar a no-op.
+
+References are pinned to the pre-feature baseline `a44fbf16` (the parent of the discarded implementation — see note below). Paths are repo-root-relative.
+
+**The bar today.** `RenderableHiddenSection` (`crates/editor/src/render/element/hidden_section.rs`) paints a full-width `Container` (background `fg_overlay_1`) wrapping an empty `Flex` row. Its `dispatch_event` (`hidden_section.rs:72-80`) just delegates to that inert container, which returns `false` ("not consumed"). Because nothing consumes the press, `RichTextElement::dispatch_event` (`crates/editor/src/render/element/mod.rs:1190-1204`) routes the `LeftMouseDown` to `handle_left_mouse_down`, which clamps to a text offset and starts a selection. That fall-through is exactly the unwanted "click the bar selects text" behavior the product spec calls out.
+
+**The expansion path we reuse (unchanged).** Gutter single-click → `CodeEditorViewAction::HiddenSectionExpansion { line_range, expansion_type }` → handler in `app/src/code/editor/view/actions.rs` → `CodeEditorView::expand_hidden_section` (`app/src/code/editor/view.rs:896`) → `model.set_visible_line_range(..)` → `HiddenLinesModel::set_visible_line_range` (`crates/editor/src/content/hidden_lines_model.rs:133`). Passing the **full** section range with `ExpansionType::Both` already reveals an entire section in one transition, so the bar can reuse this path verbatim.
+
+**The precedent for "block click → app action."** The bar lives in `crates/editor`, which cannot name the app's `CodeEditorViewAction`. `RenderableTaskList` (`crates/editor/src/render/element/task_list.rs:30-98`) solves the same problem: it is generic `new<V: EditorView>(.., mouse_state: MouseStateHandle, parent_view: WeakViewHandle<V>)`, wraps its content in a `Hoverable` with `.on_click(|ctx, app, _| { if let Some(a) = V::Action::task_list_clicked(offset, &parent_view, app) { ctx.dispatch_typed_action(a) } })`, `.with_cursor(Cursor::PointingHand)`, and a hover-background closure. The `RichTextAction<V>` trait (`crates/editor/src/render/element/mod.rs:307`, with `task_list_clicked` at `:366`) is the decoupling seam — the editor crate produces an opaque `V::Action`; the app supplies the concrete action.
+
+Supporting APIs:
+- `Hoverable` (`crates/warpui_core/src/elements/hoverable.rs`): `on_click` (`:249`), `on_double_click` (`:279`), `with_cursor` (`:346`), `on_hover` (`:240`). A `Hoverable` that registers a handler **consumes** the press, which is what suppresses the text-selection fall-through.
+- `RenderState::line_range(&dyn RenderableBlock) -> Option<Range<LineCount>>` (`crates/editor/src/render/model/mod.rs:3258`) gives a block's full line span — the bar's full hidden range.
+- `RenderableHiddenSection::new` is constructed at `crates/editor/src/render/element/mod.rs:908`, inside `renderable_blocks`, where `self.parent_view: WeakViewHandle<V>` is already in scope (it is handed to `RenderableTaskList` at `:857-863`).
+- `BlockItem::Hidden`'s payload `HiddenBlockConfig` (`crates/editor/src/render/model/mod.rs:1598`) carries `line_count`/`content_length`/`block_location` but — unlike `BlockItem::TaskList` — **no** `MouseStateHandle`, which a `Hoverable` needs to persist hover state across frames.
+
+> **Discarded prior work.** The earlier gutter-button + debounce implementation (commit `a3187b1f`: `warpui_core::DeferredCall` and its tests, the platform `double_click_interval` shim, gutter `click_count`/`pending_click_count` plumbing, `full_line_range` on `GutterRange`/`GutterElementType`, and the `click_count` field + defer branch on the action) is dropped in full. The separate-targets design needs none of it: gutter single-click stays instant, and double-click detection comes from `Hoverable` on the bar.
+
+## Proposed changes
+
+### 1. Make `RenderableHiddenSection` an interactive bar (editor crate)
+
+In `crates/editor/src/render/element/hidden_section.rs`, make the struct generic the way `RenderableTaskList` is: `new<V: EditorView>(viewport_item, mouse_state: MouseStateHandle, parent_view: WeakViewHandle<V>, app: &AppContext)`. Wrap the existing background `Container` in a `Hoverable`:
+
+- `.on_double_click(move |ctx, app, _| { if let Some(a) = V::Action::hidden_section_double_clicked(block_offset, &parent_view, app) { ctx.dispatch_typed_action(a) } })` — full expand.
+- `.on_click(|_, _, _| {})` — an empty single-click handler. Its only job is to make the `Hoverable` consume the press so a single click on the bar no longer falls through to selection (invariant #3).
+- `.with_cursor(Cursor::PointingHand)` — pointer affordance (invariant #4).
+- A hover-state background in the `Hoverable` build closure (e.g. brighten `fg_overlay_1` when `state.is_hovered()`) — hover highlight (invariant #4).
+
+`dispatch_event` delegates to the `Hoverable` (replacing the current delegate to the inert container) and returns its consumed flag. `layout`/`paint` keep painting the wrapped element.
+
+### 2. Give the hidden block a `MouseStateHandle`
+
+`Hoverable` needs a frame-stable `MouseStateHandle`. Add one to `HiddenBlockConfig` (`crates/editor/src/render/model/mod.rs:1598`), populated where `BlockItem::Hidden` is built, mirroring how `BlockItem::TaskList` carries `mouse_state`. Pass `config.mouse_state.clone()` into `RenderableHiddenSection::new` at `mod.rs:908`. Without a persisted handle the hover highlight would flicker each layout.
+
+### 3. New `RichTextAction` method
+
+Add to the `RichTextAction<V>` trait (`crates/editor/src/render/element/mod.rs:307`), alongside `task_list_clicked`:
+
+```
+fn hidden_section_double_clicked(
+    block_offset: CharOffset,
+    parent_view: &WeakViewHandle<V>,
+    ctx: &AppContext,
+) -> Option<Self>;
+```
+
+This keeps the editor crate decoupled from the app's action enum. (Passing `block_offset` mirrors `task_list_clicked`; the app resolves it to a line range in change #4. Alternative: resolve the range inside `RenderableHiddenSection::dispatch_event` via `model.line_range(self)` — the model is available there — and pass a `Range<LineCount>` into the trait method instead. Prefer the offset form for consistency with the existing precedent unless offset→range resolution proves awkward app-side.)
+
+### 4. App-side trait impl reuses the existing action
+
+In the app's `impl RichTextAction<CodeEditorView> for CodeEditorViewAction`, implement `hidden_section_double_clicked` to resolve `block_offset` to the section's full `Range<LineCount>` (using the same model offset→line mapping `RenderState::line_range` relies on — `content.block_at_offset(offset)` for the line count plus the block's start line) and return the **existing** variant:
+
+```
+CodeEditorViewAction::HiddenSectionExpansion {
+    line_range: full_range,
+    expansion_type: ExpansionType::Both,
+}
+```
+
+No new action variant and no handler change: the baseline handler already calls `expand_hidden_section(line_range, ExpansionType::Both, ctx)`, which fully reveals the range in one `set_visible_line_range` call.
+
+### 5. Tooltip on the bar
+
+`Hoverable` has no `with_tooltip`; tooltips in this codebase are a `Button` affordance (`with_tooltip`, e.g. `app/src/code_review/code_review_view.rs:207`) backed by the tooltip overlay system. The bar is a raw `Hoverable`/`Container`, so the tooltip is the one piece without a drop-in API. Reuse the same tooltip overlay the button path uses, driven by the bar's hover state. This is the highest-uncertainty sub-task — see Risks; if it cannot reuse the overlay cleanly it is the natural candidate to split into a fast-follow while shipping cursor + hover-state discoverability first.
+
+## Testing and validation
+
+Invariants below refer to the numbered **Behavior** list in `specs/GH11622/product.md`.
+
+| Invariant | Verification |
+|-----------|--------------|
+| #1 (double-click bar fully expands, one transition) | Integration test in `crates/integration/src/test/code_review.rs`: fixture with a multi-hundred-line hidden section; drive a double-click on the bar (or dispatch the resolved `HiddenSectionExpansion { full_range, Both }`); assert the section is gone in one model update. |
+| #2 (gutter single-click chunks, instant) | Existing chunked-expansion path is untouched and no longer deferred; covered by existing gutter test. Add an assertion that a single gutter click reveals exactly one chunk with no pending timer. |
+| #3 (bar single-click is a no-op, no selection) | Test: single-click the bar; assert no selection/cursor change and no visible-range change. Structurally guaranteed by the `Hoverable` consuming the press. |
+| #4 (discoverable: cursor, hover, tooltip) | Cursor (`with_cursor`) and hover background are review + manual-screenshot verifiable; tooltip is manual. |
+| #5 (triple+ click ≡ double-click) | `Hoverable::on_double_click` fires once; after the section expands the bar is gone, so later clicks have no target. Covered by code review + the #1 test (assert a single expansion). |
+| #6 (double-click gutter button = two chunks, no special behavior) | Gutter path is unchanged and has no double-click handling; review + a test that two gutter clicks reveal two chunks. |
+| #7 (gestures independent, no debounce/cancel) | Structural: no `DeferredCall` exists; the two gestures hit different elements/handlers. Code review. |
+| #8 (small section double-click fully reveals, no regression) | Integration test variant with a section that one chunk would fully reveal; assert double-click result equals the single-chunk result. |
+| #9 (adjacent gutter interactions unaffected) | Sliver toggle / add-as-context / revert / gutter no-op arms are untouched; existing tests cover them. |
+| #10 (cross-OS identical, detection via framework) | Double-click detection is `Hoverable`/framework-level with no per-feature platform code, so behavior is uniform across macOS/Linux/Windows. Code review (no multi-OS CI test). |
+
+### Manual test plan
+
+A short matrix in the PR description covers: double-click expand on large and small sections; single-click bar produces no selection; pointer cursor + hover highlight + tooltip appear; gutter single-click still chunks instantly; double-click on the gutter button reveals two chunks; and adjacent gutter controls (sliver, `+`, revert) still work.
+
+## Parallelization
+
+Not worth splitting. The change is small and tightly coupled across a single compile boundary: the new `RichTextAction` method (editor crate), its app-side impl, and the bar wiring must all land together to build at all, and they touch only a handful of files. A single agent on one checkout is faster than coordinating worktrees here.
+
+## Risks and mitigations
+
+- **Tooltip has no drop-in API on `Hoverable`.** Highest-uncertainty piece (change #5). Mitigation: reuse the button tooltip overlay; if integration is non-trivial, ship cursor + hover-state discoverability and split the tooltip into a fast-follow rather than block the feature.
+- **Bar consuming the press could swallow legitimate selection.** A drag-select that *starts* on the bar would no longer place a cursor. This matches the product intent (the bar is not text), but verify a drag that *crosses* the bar from real content still selects normally.
+- **`MouseStateHandle` plumbing.** Hover state requires the handle to be created where the hidden block is built and persisted in `HiddenBlockConfig`; a freshly-allocated handle per layout would flicker. Mirror `BlockItem::TaskList`.
+- **Bar vs. gutter hit-testing.** Confirm the bar's `Hoverable` bounds do not overlap the gutter button's hit region, so double-clicking near the arrow does not ambiguously trigger both.
+
+## Follow-ups
+
+- If the tooltip is deferred, track it as the one remaining discoverability item from invariant #4.
+- Consider hoisting the offset→`Range<LineCount>` resolution into a small reusable model helper if a second caller appears.


### PR DESCRIPTION
## Description

The diff editor collapses long runs of unchanged context into **hidden sections**, each rendered as a full-width bar with one or two gutter expand buttons (`▲`/`▼`) beside it. Single-clicking a gutter button reveals ~25 lines at a time, so a large hidden region takes many clicks to fully reveal.

This PR makes **double-clicking the bar** fully expand the entire hidden section in one action. Each gesture gets its own target — the gutter arrows keep their instant chunk-at-a-time behavior, and the full-width bar handles "reveal everything." Because the gestures live on separate targets, single-click stays instant with **no debounce** (the established VS Code / Monaco `hideUnchangedRegions` pattern).

Also:
- A single click on the bar is now a no-op — in particular it no longer clamps to a text offset and starts a text selection.
- The bar is discoverable: pointer cursor, a hover highlight, and a "Double-click to expand" tooltip on hover.
- Adjacent gutter interactions (diff-hunk sliver toggle, add-as-context, revert) are unchanged.

**Implementation:** `RenderableHiddenSection` (the bar) becomes a `Hoverable` that dispatches a new `RichTextAction::hidden_section_double_clicked`, reusing the existing `HiddenSectionExpansion { ExpansionType::Both }` expansion path. `HiddenBlockConfig` now carries a `MouseStateHandle` (mirroring `BlockItem::TaskList`) so the bar's hover state persists across re-layouts. No debounce, no platform double-click interval, no `DeferredCall`.

Specs: `specs/GH11622/product.md`, `specs/GH11622/tech.md`.

## Linked Issue

Closes #11622

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`


Automated coverage:
- **Unit tests** for `RenderContentTreeRef::first_hidden_section_line_range` (the bar's range resolution) in `crates/editor/src/render/model/mod_tests.rs` — including the no-hidden-section case.
- **Integration test** `test_code_review_double_click_fully_expands_hidden_section` (`crates/integration/src/test/code_review.rs`): boots a real Warp instance, sets up a git repo whose diff produces hidden sections, opens the code review panel, and fully expands the first hidden section via the same `Hidden`-block → range → `Both` path the bar's double-click uses, asserting exactly one hidden section is removed (a chunked reveal would leave the count unchanged). Size-agnostic, so it also covers small sections.

Manual coverage:
- Double-click the bar → full expansion in one transition, no intermediate chunk.
- Single-click the bar → no-op, no text selection.
- Single-click a gutter arrow → instant chunked reveal (unchanged).
- Hover the bar → pointer cursor, hover highlight, and the "Double-click to expand" tooltip.
- Adjacent gutter interactions (sliver toggle, add-as-context, revert) unchanged.

Demo recording of the bar double-click + tooltip to be attached:
https://github.com/user-attachments/assets/83f84370-9fae-403f-a14e-2b5a9faaf403

Demo recording of the single click - passivity:
https://github.com/user-attachments/assets/ed629048-fb59-4267-8f1d-a69472a90859

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Double-click a collapsed hidden section in the diff editor to fully expand it in one action.
