### PR TITLE
fix(ime): preserve Korean IME composition through split-commit and Backspace

### DIFF
--- a/app/src/editor/view/marked_text_tests.rs
+++ b/app/src/editor/view/marked_text_tests.rs
@@ -194,7 +194,7 @@ fn test_set_marked_text_vim_insert_mode() {
 
 #[test]
 fn test_korean_ime_backspace_clears_marked_syllable() {
-    // Regression test for the Korean IME Backspace flow:
+    // Regression test for the Korean IME Backspace flow (related to #3944):
     //
     //   buffer: "가나" + marked "ㄷ"   (i.e. the user just deleted the vowel
     //   from a previously-marked "다")
@@ -249,8 +249,8 @@ fn test_korean_ime_backspace_clears_marked_syllable() {
 
 #[test]
 fn test_split_commit_with_new_marked_text() {
-    // Regression test for the Korean (and other CJK) IME split-commit
-    // scenario: a single keystroke can both commit the previously-composed
+    // Regression test for #3944 — the Korean (and other CJK) IME
+    // split-commit scenario: a single keystroke can both commit the previously-composed
     // syllable AND start a new composition. Typing 'ㅏ' after '간', for
     // example, commits '가' and starts new marked '나' in the same keyDown.
     //

--- a/app/src/editor/view/marked_text_tests.rs
+++ b/app/src/editor/view/marked_text_tests.rs
@@ -191,3 +191,102 @@ fn test_set_marked_text_vim_insert_mode() {
         });
     });
 }
+
+#[test]
+fn test_korean_ime_backspace_clears_marked_syllable() {
+    // Regression test for the Korean IME Backspace flow:
+    //
+    //   buffer: "가나" + marked "ㄷ"   (i.e. the user just deleted the vowel
+    //   from a previously-marked "다")
+    //   → pressing Backspace should remove the remaining "ㄷ", leaving "가나".
+    //
+    // The macOS Korean IME asks for this via the following NSTextInputClient
+    // callback sequence inside a single -interpretKeyEvents: pass:
+    //   1. setMarkedText("ㄷ")                          // transient redraw
+    //   2. insertText("ㄷ")                             // queue the syllable as a commit
+    //   3. setMarkedText("")                            // clear marked selection
+    //   4. doCommandBySelector(deleteBackward:)         // "cancel that commit"
+    //
+    // host_view.m's keyDownImpl interprets (4) as "drop the queued commit"
+    // and emits only the marked-text changes plus a final unmarkText. Without
+    // that suppression the queued "ㄷ" would land as plain text after the
+    // marked-text clear, leaving a stray jamo in the buffer that the user
+    // would have to delete with an extra Backspace press.
+    //
+    // This test simulates the resulting editor-view event sequence (steps 1
+    // and 3, then an explicit clear, with the commit suppressed) and asserts
+    // that the marked jamo disappears with no stray plain-text leftover.
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let _guard = FeatureFlag::ImeMarkedText.override_enabled(true);
+
+        app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let mut editor = EditorView::new_with_base_text("가나", Default::default(), ctx);
+
+            editor
+                .select_ranges(vec![DisplayPoint::new(0, 2)..DisplayPoint::new(0, 2)], ctx)
+                .unwrap();
+
+            // Start a marked composition for the trailing "ㄷ".
+            editor.set_marked_text("ㄷ", &(1..1), ctx);
+            assert_eq!(editor.buffer_text(ctx), "가나ㄷ");
+            assert_eq!(editor.selected_text(ctx), "ㄷ");
+
+            // host_view.m emits SetMarkedText("") (step 3) and then unmarkText
+            // (translates to ClearMarkedText) after suppressing the IME's
+            // queued insertText commit on deleteBackward:.
+            editor.set_marked_text("", &(0..0), ctx);
+            editor.clear_marked_text(ctx);
+
+            // The marked jamo is gone — and no stray plain-text "ㄷ" was left
+            // behind by an unsuppressed commit.
+            assert_eq!(editor.buffer_text(ctx), "가나");
+
+            editor
+        });
+    });
+}
+
+#[test]
+fn test_split_commit_with_new_marked_text() {
+    // Regression test for the Korean (and other CJK) IME split-commit
+    // scenario: a single keystroke can both commit the previously-composed
+    // syllable AND start a new composition. Typing 'ㅏ' after '간', for
+    // example, commits '가' and starts new marked '나' in the same keyDown.
+    //
+    // Before the host_view.m fix this scenario emitted SetMarkedText('나')
+    // first, placing '나' as a buffer selection, and then dispatched
+    // TypedCharacters('가') — whose insert path replaces the current
+    // selection and so overwrote '나', losing the next character.
+    //
+    // The fix changes host_view.m to dispatch the workaround sequence
+    //   1. ClearMarkedText  (drop the stale marked selection from the buffer)
+    //   2. TypedCharacters  (insert the committed text into the now-empty selection)
+    //   3. SetMarkedText    (re-apply the new composition)
+    // so the buffer ends up as "<commit><new marked>". This test simulates
+    // that sequence at the editor view layer and asserts the resulting
+    // buffer and selection state.
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let _guard = FeatureFlag::ImeMarkedText.override_enabled(true);
+
+        app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let mut editor = EditorView::new_with_base_text("", Default::default(), ctx);
+
+            // Existing composition state: marked '간' held as a buffer selection.
+            editor.set_marked_text("간", &(1..1), ctx);
+            assert_eq!(editor.selected_text(ctx), "간");
+
+            // User types 'ㅏ'. host_view.m emits the workaround sequence.
+            editor.clear_marked_text(ctx);
+            editor.user_insert("가", ctx);
+            editor.set_marked_text("나", &(1..1), ctx);
+
+            // Buffer is "가" (committed) followed by "나" (marked, selected).
+            assert_eq!(editor.buffer_text(ctx), "가나");
+            assert_eq!(editor.selected_text(ctx), "나");
+
+            editor
+        });
+    });
+}

--- a/crates/warpui/src/platform/mac/objc/host_view.m
+++ b/crates/warpui/src/platform/mac/objc/host_view.m
@@ -63,6 +63,23 @@ void warp_marked_text_cleared(WarpHostView *);
     // new in-progress text) in the same keystroke. Without this, the trailing
     // unmarkText in keyDownImpl would clobber that new marked text.
     BOOL imeTouchedMarkedTextDuringInterpret;
+
+    // The selectedRange of the most recent setMarkedText: call. Kept so that
+    // when a split-commit keystroke both commits previous text and starts a
+    // new marked composition, we can re-emit the new marked-text event after
+    // the commit (see keyDownImpl:).
+    NSRange lastMarkedSelectedRange;
+
+    // True if the IME asked us via doCommandBySelector: to delete characters
+    // (deleteBackward: / deleteForward:) during the current interpretKeyEvents:.
+    // This is how Korean IMEs ask us to remove a marked syllable on Backspace:
+    // they call insertText: to commit the syllable, then immediately
+    // doCommandBySelector(deleteBackward:) to cancel that commit — the net
+    // effect should be that the marked text just disappears. Without acting
+    // on this flag the commit accumulates as plain text and the marked
+    // syllable appears to require an extra Backspace press to actually go
+    // away.
+    BOOL imeRequestedDeleteDuringInterpret;
 }
 
 - (BOOL)acceptsFirstResponder {
@@ -166,6 +183,7 @@ void warp_marked_text_cleared(WarpHostView *);
     BOOL wasComposing = [self hasMarkedText];
     [textToInsert setString:@""];
     imeTouchedMarkedTextDuringInterpret = NO;
+    imeRequestedDeleteDuringInterpret = NO;
 
     // Interpret the key events here so we could check whether user is composing
     // text within the IME and pass the state down to the KeyDown events.
@@ -194,13 +212,46 @@ void warp_marked_text_cleared(WarpHostView *);
 
     // Dispatch TypedCharacter event after KeyDown has been dispatched.
     if ([textToInsert length] > 0 && !handled) {
+        // If the IME asked us to delete (via doCommandBySelector:
+        // deleteBackward:/deleteForward:) during the same interpretKeyEvents
+        // pass, the commit is the IME's way of materializing a marked
+        // composition just so it can immediately delete it (Korean IME's
+        // Backspace flow for a marked syllable). The net intent is "remove
+        // the marked text"; we honor it by suppressing the commit entirely
+        // and ending the IME state.
+        if (imeRequestedDeleteDuringInterpret) {
+            [self unmarkText];
+            return handled;
+        }
+        // In a split-commit (the IME committed text AND started a new
+        // composition in the same keystroke — e.g. typing 'ㅏ' after '간'
+        // produces commit '가' + new marked '나'), setMarkedText: has
+        // already placed the new composition as a selection in the input
+        // field's buffer. If we now insert the committed text, the input
+        // field's insert path (which replaces selection contents) would
+        // overwrite the new marked text and lose the next character.
+        // Workaround: temporarily clear the marked text, dispatch the
+        // commit, and re-apply the marked text afterwards so the input
+        // field's buffer ends up with `<commit><new marked>`.
+        BOOL hasNewMarked = imeTouchedMarkedTextDuringInterpret && [self hasMarkedText];
+        if (hasNewMarked) {
+            warp_marked_text_cleared(self);
+            warp_update_ime_state(self, NO);
+        }
         warp_handle_insert_text(self, (NSString *)textToInsert);
-        // Only clear marked text if the IME did not touch it during this
-        // interpretKeyEvents pass. Otherwise we'd either fire a redundant
-        // ClearMarkedText (if IME already cleared) or, worse, wipe the new
-        // marked text the IME just set in a split-commit (e.g. Japanese IME
-        // committing a phrase and queuing the next character as marked text).
-        if (!imeTouchedMarkedTextDuringInterpret) {
+        if (hasNewMarked) {
+            warp_marked_text_updated(self, markedText.string, lastMarkedSelectedRange);
+            warp_update_ime_state(self, YES);
+        } else {
+            // Commit-only flow (no new composition starting after this commit).
+            // End IME state explicitly even when the IME touched markedText
+            // during interpretKeyEvents — that touch can be the IME clearing
+            // its own marked text as part of the commit (e.g. Korean IME
+            // committing a syllable when Backspace removes its last jamo).
+            // Without this, the stale marked-text state would leak into the
+            // next keyDown and break Backspace, requiring an extra press.
+            // The hasNewMarked branch above is what protects newly-started
+            // marked text from being wiped — split-commit is safe.
             [self unmarkText];
         }
     }
@@ -416,8 +467,15 @@ void warp_marked_text_cleared(WarpHostView *);
     return (NSUInteger)0;
 }
 
-// This is a no-op as we will be handling control characters in KeyDown events.
+// Most control-character commands are handled via KeyDown dispatch directly,
+// but a few selectors that the IME calls during interpretKeyEvents: must be
+// tracked here so keyDownImpl: can adjust its commit behavior (see
+// imeRequestedDeleteDuringInterpret).
 - (void)doCommandBySelector:(SEL)selector {
+    if (interpretingKeyEvents &&
+        (selector == @selector(deleteBackward:) || selector == @selector(deleteForward:))) {
+        imeRequestedDeleteDuringInterpret = YES;
+    }
 }
 
 - (NSRect)firstRectForCharacterRange:(NSRange)range
@@ -488,6 +546,8 @@ void warp_marked_text_cleared(WarpHostView *);
     if (interpretingKeyEvents) {
         imeTouchedMarkedTextDuringInterpret = YES;
     }
+
+    lastMarkedSelectedRange = selectedRange;
 
     [markedText release];
     if ([string isKindOfClass:[NSAttributedString class]])


### PR DESCRIPTION
## Description

Follow-up to #9730 (merged). That PR addressed the Japanese IME Enter-form-submit case, but two multi-byte IME flows on macOS still misbehave:

### 1. The in-progress jamo/character is invisible until the next keystroke (split-commit)

This is the bug tracked in #3944 — "Text input in multi-byte Japanese doesn't appear until confirmation". The same root cause affects Korean IME: typing "가나다" slowly, the `나` does not appear after `가`; it only shows up once `다` is typed and the buffer re-renders.

**Cause**: When typing `ㅏ` after `간`, the IME sends `setMarkedText('가') → insertText('가') → setMarkedText('') → setMarkedText('나')` within a single `interpretKeyEvents:` pass. The trailing `setMarkedText('나')` places `나` as a buffer-level selection in the input field. The queued commit `가` then dispatches through `user_insert`, whose selection-replacement semantics overwrite `나` with `가` — losing the new composing jamo until the next composition update.

#9730's `imeTouchedMarkedTextDuringInterpret` guard only makes `unmarkText` conditional. It preserves the `markedText` object inside `host_view.m`, but the Rust input field's buffer selection still gets clobbered by the commit.

### 2. Backspace requires two presses to delete a marked syllable

With a marked `ㄷ` on `가나ㄷ`, the user observes `가나다 → 가나ㄷ → 가나ㄷ (no change) → 가나` — the second Backspace is wasted.

**Cause**: macOS Korean IME implements Backspace on a marked syllable as:

    setMarkedText('ㄷ') + insertText('ㄷ') + setMarkedText('') + doCommandBySelector(deleteBackward:)

`doCommandBySelector:` is currently a no-op (`// no-op as we will be handling control characters in KeyDown events`), so the IME's `deleteBackward:` signal is ignored. Only the queued commit `ㄷ` is applied, leaving a stray plain-text `ㄷ` that the next Backspace then deletes.

## Changes (`crates/warpui/src/platform/mac/objc/host_view.m`)

- **Split-commit handling** — In `keyDownImpl:`'s commit branch, when a new marked text was started during the same `interpretKeyEvents:`, dispatch `ClearMarkedText → commit → SetMarkedText` instead of just the commit. This avoids the buffer-selection overwrite. New `lastMarkedSelectedRange` instance variable holds the most recent `selectedRange` for the re-dispatch.
- **deleteBackward handling** — `doCommandBySelector:` now tracks `deleteBackward:` / `deleteForward:` signaled by the IME during `interpretKeyEvents:` via a new `imeRequestedDeleteDuringInterpret` flag. When set, `keyDownImpl:` suppresses the queued commit so the marked text simply disappears, matching native macOS apps' behavior.
- **Always end IME state on commit-only flow** — Removed #9730's `!imeTouchedMarkedTextDuringInterpret` guard around the trailing `unmarkText`. The new split-commit branch above is what now protects newly-started marked text in split-commit cases, so the pre-#9730 invariant (commit ends IME state) can be restored — without it the stale marked-text state leaks into the next keystroke and breaks Backspace.

## Linked Issue

Fixes #3944. Also addresses the Korean-specific symptoms reported in #8919 (follow-up to #9730).

- [x] The linked issue (#3944) is labeled `ready-to-implement`.

## Screenshots / Videos

<!-- TODO -->

## Testing

### Manual (macOS, Apple Korean IME, `cargo run --features ime_marked_text`)

| Scenario | master (#9730) | This PR |
|----------|----------------|---------|
| "가나다" typed slowly | ❌ `나` missing until `다` is typed | ✅ each jamo visible immediately |
| "가나다" + Backspace × 3 | ❌ `가나다 → 가나ㄷ → 가나ㄷ → 가나` (one press wasted) | ✅ `가나다 → 가나ㄷ → 가나 → 가` |
| "안녕하세요" + Enter | ✅ | ✅ (no regression) |
| Dead key `⌥E + g` | ✅ `´g` | ✅ (no regression) |
| Plain English + shortcuts | ✅ | ✅ (no regression) |

### Automated (`app/src/editor/view/marked_text_tests.rs`)

Two regression tests added:
- `test_split_commit_with_new_marked_text` — verifies split-commit leaves the buffer as `<commit><new marked>`
- `test_korean_ime_backspace_clears_marked_syllable` — verifies Backspace cleanly removes the marked syllable with no stray plain-text leftover

```
cargo test --features ime_marked_text -p warp --lib marked_text
# 7 passed (5 existing + 2 new)
```

## Note on prior PR (#9713)

A previous attempt (#9713) added a `(!handled || wasComposing)` guard to dispatch committed text on handled key events. @abhishekp106 closed it in favor of #9730 citing concerns about double-handled events. This PR drops the `wasComposing` guard entirely — the Enter case is already covered by #9730 + the `deleteBackward:` handling here, so the guard isn't needed.

## Agent Mode

- [ ] Warp Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed Korean IME issues where composition characters were displayed late and Backspace required two presses
-->