### PR TITLE
fix(ai): make reasoning text selectable after streaming completes

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3572,8 +3572,9 @@ fn render_collapsible_text_block_section(
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
     let text_color = blended_colors::text_disabled(theme, theme.surface_2());
-    let selectable = false;
     let is_streaming = props.model.status(app).is_streaming();
+    // Allow text selection once streaming is complete so users can copy reasoning content.
+    let selectable = !is_streaming;
 
     let mut container = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
 


### PR DESCRIPTION
## Description

Agent thinking/reasoning traces were rendered with `selectable: false` inside `render_collapsible_text_block_section`, making it impossible for users to select or copy any part of the reasoning content—even after the response had fully streamed in.

The fix swaps the declaration order of `selectable` and `is_streaming` so selectability derives from stream state: when the agent is done streaming, `selectable = !is_streaming = true`. This matches the existing height logic in the same function, which already switches the collapsible viewport from 120 px (streaming) to 360 px (complete).

## Linked Issue

Closes #9702

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

Note: Issue #9702 is labeled `enhancement` / `triaged` (not yet `ready-to-implement`). The fix is a targeted 3-line change to a hardcoded `false` that the triage analysis identified as the root cause. Happy to hold off if the team prefers to label first.

## Testing

- `cargo fmt --check` — clean
- `cargo clippy -p warp --lib --tests --no-deps -- -D warnings` — clean (0 warnings, finished in ~2m 40s)

Manual smoke test requires the full app running (`./script/run`) which needs internal build deps not present on this machine. A maintainer should verify the behaviour end-to-end: open a completed agent response with "Always show" thinking enabled and confirm the reasoning text is now selectable/copyable.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Agent reasoning/thinking traces are now selectable and copyable once the response finishes streaming.