### PR TITLE
Add AWS Bedrock region selection support

### DIFF
--- a/app/src/ai/aws_credentials.rs
+++ b/app/src/ai/aws_credentials.rs
@@ -131,18 +131,30 @@ fn aws_credentials_state_for_error(err: LoadAwsCredentialsError) -> AwsCredentia
 /// # Arguments
 /// * `profile` - AWS profile name. If empty, uses the default AWS SDK behavior
 ///   (checks AWS_PROFILE env var, then uses "default").
+/// * `region_override` - Explicit region to use. If empty, the region is resolved
+///   from the AWS SDK default provider chain (AWS_REGION env var, ~/.aws/config, etc.).
 pub async fn load_aws_credentials_from_sdk(
     profile: &str,
+    region_override: &str,
 ) -> Result<AwsCredentials, LoadAwsCredentialsError> {
-    let region_provider = aws_config::meta::region::RegionProviderChain::default_provider();
-    let loader =
-        aws_config::defaults(aws_config::BehaviorVersion::latest()).region(region_provider);
+    let loader = if region_override.trim().is_empty() {
+        let region_provider = aws_config::meta::region::RegionProviderChain::default_provider();
+        aws_config::defaults(aws_config::BehaviorVersion::latest()).region(region_provider)
+    } else {
+        aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(region_override.trim().to_string()))
+    };
     let loader = if profile.trim().is_empty() {
         loader // Let AWS SDK use its default behavior
     } else {
         loader.profile_name(profile)
     };
     let config = loader.load().await;
+
+    let resolved_region = config
+        .region()
+        .map(|r| r.as_ref().to_string())
+        .unwrap_or_default();
 
     let provider = config
         .credentials_provider()
@@ -164,6 +176,7 @@ pub async fn load_aws_credentials_from_sdk(
         creds.secret_access_key().to_string(),
         creds.session_token().map(|s| s.to_string()),
         creds.expiry(),
+        resolved_region,
     ))
 }
 
@@ -225,6 +238,7 @@ impl AwsCredentialRefresher for ApiKeyManager {
             if matches!(
                 event,
                 AISettingsChangedEvent::AwsBedrockProfile { .. }
+                    | AISettingsChangedEvent::AwsBedrockRegion { .. }
                     | AISettingsChangedEvent::AwsBedrockAuthRefreshCommand { .. }
                     | AISettingsChangedEvent::AwsBedrockCredentialsEnabled { .. }
             ) {
@@ -267,13 +281,14 @@ fn refresh_aws_credentials_local_chain(
     }
 
     let profile = (*AISettings::as_ref(ctx).aws_bedrock_profile).clone();
+    let region = (*AISettings::as_ref(ctx).aws_bedrock_region).clone();
 
     manager.set_aws_credentials_state(AwsCredentialsState::Refreshing, ctx);
 
     let (tx, rx) = channel();
     // credential fetch from aws cli's disk cache
     let _ = ctx.spawn(
-        async move { load_aws_credentials_from_sdk(&profile).await },
+        async move { load_aws_credentials_from_sdk(&profile, &region).await },
         move |manager, result, ctx| {
             let (new_state, tx_result) = match result {
                 Ok(credentials) => (
@@ -375,6 +390,7 @@ fn refresh_aws_credentials_oidc(
                 credentials.secret_access_key().to_string(),
                 Some(credentials.session_token().to_string()),
                 SystemTime::try_from(*credentials.expiration()).ok(),
+                region.clone(),
             ))
         },
         move |manager, result, ctx| {

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1059,6 +1059,18 @@ define_settings_group!(AISettings, settings: [
         toml_path: "cloud_platform.third_party_api_keys.aws_bedrock_profile",
         description: "The AWS profile name to use for Bedrock credentials.",
     }
+    // AWS region to use for Bedrock API requests (e.g. us-east-1, us-west-2).
+    // If empty, the region is resolved from the AWS SDK default provider chain
+    // (AWS_REGION env var, ~/.aws/config, etc.).
+    aws_bedrock_region: AwsBedrockRegion {
+        type: String,
+        default: String::new(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "cloud_platform.third_party_api_keys.aws_bedrock_region",
+        description: "The AWS region for Bedrock requests (e.g. us-east-1). If empty, resolved from AWS config.",
+    }
     // Whether the AWS Bedrock login banner has been permanently dismissed.
     //
     // Not a user-visible setting - we model it as a setting so we can track state.

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -7874,6 +7874,7 @@ impl SettingsWidget for ApiKeysWidget {
 struct AwsBedrockWidget {
     aws_auth_refresh_command_editor: ViewHandle<EditorView>,
     aws_auth_refresh_profile_editor: ViewHandle<EditorView>,
+    aws_region_editor: ViewHandle<EditorView>,
     credentials_enabled_toggle: SwitchStateHandle,
     auto_login_toggle: SwitchStateHandle,
     refresh_credentials_button: ViewHandle<ActionButton>,
@@ -7886,6 +7887,7 @@ impl AwsBedrockWidget {
 
         let aws_auth_refresh_command = ai_settings.aws_bedrock_auth_refresh_command.value().clone();
         let aws_auth_refresh_profile = ai_settings.aws_bedrock_profile.value().clone();
+        let aws_region = ai_settings.aws_bedrock_region.value().clone();
         let is_usage_enabled = is_any_ai_enabled
             && UserWorkspaces::as_ref(ctx).is_aws_bedrock_credentials_enabled(ctx);
 
@@ -7983,6 +7985,41 @@ impl AwsBedrockWidget {
             }
         });
 
+        let aws_region_editor = ctx.add_typed_action_view(move |ctx| {
+            let appearance = Appearance::as_ref(ctx);
+            let options = SingleLineEditorOptions {
+                is_password: false,
+                text: TextOptions {
+                    font_size_override: Some(appearance.ui_font_size()),
+                    font_family_override: Some(appearance.monospace_font_family()),
+                    text_colors_override: Some(TextColors {
+                        default_color: appearance.theme().active_ui_text_color(),
+                        disabled_color: appearance.theme().disabled_ui_text_color(),
+                        hint_color: appearance.theme().disabled_ui_text_color(),
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let mut editor = EditorView::single_line(options, ctx);
+            editor.set_placeholder_text("us-east-1", ctx);
+            editor.set_buffer_text(&aws_region, ctx);
+            editor
+        });
+        AISettingsPageView::update_editor_interaction_state(
+            aws_region_editor.clone(),
+            is_usage_enabled,
+            ctx,
+        );
+        ctx.subscribe_to_view(&aws_region_editor, |_, editor, event, ctx| {
+            if matches!(event, EditorEvent::Blurred | EditorEvent::Enter) {
+                let value = editor.as_ref(ctx).buffer_text(ctx);
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    let _ = settings.aws_bedrock_region.set_value(value, ctx);
+                });
+            }
+        });
+
         let refresh_credentials_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("Refresh", SecondaryTheme)
                 .with_icon(Icon::RefreshCw04)
@@ -7998,6 +8035,7 @@ impl AwsBedrockWidget {
         // Keep enablement in sync with the Global AI toggle.
         let aws_auth_refresh_command_editor_clone = aws_auth_refresh_command_editor.clone();
         let aws_auth_refresh_profile_editor_clone = aws_auth_refresh_profile_editor.clone();
+        let aws_region_editor_clone = aws_region_editor.clone();
         let refresh_credentials_button_clone = refresh_credentials_button.clone();
         ctx.subscribe_to_model(&AISettings::handle(ctx), move |_, _, event, ctx| {
             if matches!(
@@ -8019,6 +8057,11 @@ impl AwsBedrockWidget {
                     is_usage_enabled,
                     ctx,
                 );
+                AISettingsPageView::update_editor_interaction_state(
+                    aws_region_editor_clone.clone(),
+                    is_usage_enabled,
+                    ctx,
+                );
                 refresh_credentials_button_clone.update(ctx, |button, ctx| {
                     button.set_disabled(!is_usage_enabled, ctx);
                 });
@@ -8029,6 +8072,7 @@ impl AwsBedrockWidget {
 
         let aws_auth_refresh_command_editor_clone = aws_auth_refresh_command_editor.clone();
         let aws_auth_refresh_profile_editor_clone = aws_auth_refresh_profile_editor.clone();
+        let aws_region_editor_clone = aws_region_editor.clone();
         let refresh_credentials_button_clone = refresh_credentials_button.clone();
         ctx.subscribe_to_model(
             &UserWorkspaces::handle(ctx),
@@ -8050,6 +8094,11 @@ impl AwsBedrockWidget {
                         is_usage_enabled,
                         ctx,
                     );
+                    AISettingsPageView::update_editor_interaction_state(
+                        aws_region_editor_clone.clone(),
+                        is_usage_enabled,
+                        ctx,
+                    );
                     refresh_credentials_button_clone.update(ctx, |button, ctx| {
                         button.set_disabled(!is_usage_enabled, ctx);
                     });
@@ -8062,6 +8111,7 @@ impl AwsBedrockWidget {
         Self {
             aws_auth_refresh_command_editor,
             aws_auth_refresh_profile_editor,
+            aws_region_editor,
             credentials_enabled_toggle: SwitchStateHandle::default(),
             auto_login_toggle: SwitchStateHandle::default(),
             refresh_credentials_button,
@@ -8240,6 +8290,13 @@ impl AwsBedrockWidget {
             is_usage_enabled,
             app,
         ));
+        column.add_child(render_input(
+            appearance,
+            "AWS Region",
+            self.aws_region_editor.clone(),
+            is_usage_enabled,
+            app,
+        ));
 
         let auto_login_enabled = *AISettings::as_ref(app).aws_bedrock_auto_login.value();
 
@@ -8272,7 +8329,7 @@ impl SettingsWidget for AwsBedrockWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "aws bedrock amazon credentials login profile"
+        "aws bedrock amazon credentials login profile region"
     }
 
     fn should_render(&self, app: &AppContext) -> bool {

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -334,3 +334,41 @@ fn api_keys_for_request_none_for_custom_endpoints_only() {
     });
     assert!(mgr.api_keys_for_request(true, false).is_none());
 }
+
+#[test]
+fn api_keys_for_request_includes_aws_credentials_with_region() {
+    let mut mgr = make_manager(ApiKeys::default());
+    mgr.aws_credentials_state = AwsCredentialsState::Loaded {
+        credentials: AwsCredentials::new(
+            "AKID".to_string(),
+            "secret".to_string(),
+            Some("token".to_string()),
+            None,
+            "us-west-2".to_string(),
+        ),
+        loaded_at: std::time::SystemTime::now(),
+    };
+    let result = mgr.api_keys_for_request(false, true).unwrap();
+    let aws = result.aws_credentials.unwrap();
+    assert_eq!(aws.access_key, "AKID");
+    assert_eq!(aws.secret_key, "secret");
+    assert_eq!(aws.session_token, "token");
+    assert_eq!(aws.region, "us-west-2");
+}
+
+#[test]
+fn api_keys_for_request_aws_credentials_none_when_disabled() {
+    let mut mgr = make_manager(ApiKeys::default());
+    mgr.aws_credentials_state = AwsCredentialsState::Loaded {
+        credentials: AwsCredentials::new(
+            "AKID".to_string(),
+            "secret".to_string(),
+            None,
+            None,
+            "us-east-1".to_string(),
+        ),
+        loaded_at: std::time::SystemTime::now(),
+    };
+    // include_aws_bedrock_credentials = false and no OIDC strategy
+    assert!(mgr.api_keys_for_request(false, false).is_none());
+}

--- a/crates/ai/src/aws_credentials.rs
+++ b/crates/ai/src/aws_credentials.rs
@@ -12,6 +12,7 @@ pub struct AwsCredentials {
     secret_key: String,
     session_token: Option<String>,
     expires_at: Option<SystemTime>,
+    region: String,
 }
 
 impl AwsCredentials {
@@ -20,17 +21,23 @@ impl AwsCredentials {
         secret_key: String,
         session_token: Option<String>,
         expires_at: Option<SystemTime>,
+        region: String,
     ) -> Self {
         Self {
             access_key,
             secret_key,
             session_token,
             expires_at,
+            region,
         }
     }
 
     pub fn expires_at(&self) -> Option<SystemTime> {
         self.expires_at
+    }
+
+    pub fn region(&self) -> &str {
+        &self.region
     }
 }
 
@@ -54,7 +61,7 @@ impl From<AwsCredentials> for api::request::settings::api_keys::AwsCredentials {
             access_key: creds.access_key,
             secret_key: creds.secret_key,
             session_token: creds.session_token.unwrap_or_default(),
-            region: String::new(),
+            region: creds.region,
         }
     }
 }
@@ -67,6 +74,10 @@ fn format_status_timestamp(time: SystemTime) -> String {
         datetime.format("%b %-d at %-I:%M %p").to_string()
     }
 }
+
+#[cfg(test)]
+#[path = "aws_credentials_tests.rs"]
+mod tests;
 
 impl AwsCredentialsState {
     pub fn user_facing_components(&self) -> (String, String, Icon) {
@@ -91,18 +102,27 @@ impl AwsCredentialsState {
             Self::Loaded {
                 credentials,
                 loaded_at,
-            } => (
-                "Credentials loaded".to_string(),
-                match credentials.expires_at() {
+            } => {
+                let region_suffix = if credentials.region.is_empty() {
+                    String::new()
+                } else {
+                    format!(" · Region: {}", credentials.region)
+                };
+                let detail = match credentials.expires_at() {
                     Some(expires_at) => format!(
-                        "Loaded at {}, expires {}",
+                        "Loaded at {}, expires {}{}",
                         format_status_timestamp(*loaded_at),
-                        format_status_timestamp(expires_at)
+                        format_status_timestamp(expires_at),
+                        region_suffix
                     ),
-                    None => format!("Loaded at {}", format_status_timestamp(*loaded_at)),
-                },
-                Icon::CheckCircleBroken,
-            ),
+                    None => format!(
+                        "Loaded at {}{}",
+                        format_status_timestamp(*loaded_at),
+                        region_suffix
+                    ),
+                };
+                ("Credentials loaded".to_string(), detail, Icon::CheckCircleBroken)
+            }
             Self::Failed { message } => (
                 "Unable to load credentials".to_string(),
                 message.clone(),

--- a/crates/ai/src/aws_credentials_tests.rs
+++ b/crates/ai/src/aws_credentials_tests.rs
@@ -1,0 +1,117 @@
+use std::time::{Duration, SystemTime};
+
+use warp_multi_agent_api as api;
+
+use super::*;
+
+#[test]
+fn new_credentials_stores_region() {
+    let creds = AwsCredentials::new(
+        "AKID".to_string(),
+        "secret".to_string(),
+        Some("token".to_string()),
+        None,
+        "us-west-2".to_string(),
+    );
+    assert_eq!(creds.region(), "us-west-2");
+}
+
+#[test]
+fn new_credentials_empty_region() {
+    let creds = AwsCredentials::new(
+        "AKID".to_string(),
+        "secret".to_string(),
+        None,
+        None,
+        String::new(),
+    );
+    assert_eq!(creds.region(), "");
+}
+
+#[test]
+fn from_credentials_passes_region_to_proto() {
+    let creds = AwsCredentials::new(
+        "AKID".to_string(),
+        "secret".to_string(),
+        Some("token".to_string()),
+        None,
+        "eu-west-1".to_string(),
+    );
+    let proto: api::request::settings::api_keys::AwsCredentials = creds.into();
+    assert_eq!(proto.region, "eu-west-1");
+    assert_eq!(proto.access_key, "AKID");
+    assert_eq!(proto.secret_key, "secret");
+    assert_eq!(proto.session_token, "token");
+}
+
+#[test]
+fn from_credentials_empty_session_token_defaults() {
+    let creds = AwsCredentials::new(
+        "AKID".to_string(),
+        "secret".to_string(),
+        None,
+        None,
+        "us-east-1".to_string(),
+    );
+    let proto: api::request::settings::api_keys::AwsCredentials = creds.into();
+    assert_eq!(proto.session_token, "");
+    assert_eq!(proto.region, "us-east-1");
+}
+
+#[test]
+fn user_facing_components_loaded_shows_region() {
+    let creds = AwsCredentials::new(
+        "AKID".to_string(),
+        "secret".to_string(),
+        None,
+        Some(SystemTime::now() + Duration::from_secs(3600)),
+        "us-east-1".to_string(),
+    );
+    let state = AwsCredentialsState::Loaded {
+        credentials: creds,
+        loaded_at: SystemTime::now(),
+    };
+    let (title, detail, _icon) = state.user_facing_components();
+    assert_eq!(title, "Credentials loaded");
+    assert!(detail.contains("Region: us-east-1"));
+}
+
+#[test]
+fn user_facing_components_loaded_no_region_when_empty() {
+    let creds = AwsCredentials::new(
+        "AKID".to_string(),
+        "secret".to_string(),
+        None,
+        None,
+        String::new(),
+    );
+    let state = AwsCredentialsState::Loaded {
+        credentials: creds,
+        loaded_at: SystemTime::now(),
+    };
+    let (title, detail, _icon) = state.user_facing_components();
+    assert_eq!(title, "Credentials loaded");
+    assert!(!detail.contains("Region"));
+}
+
+#[test]
+fn user_facing_components_missing_state() {
+    let (title, _, _) = AwsCredentialsState::Missing.user_facing_components();
+    assert_eq!(title, "AWS credentials not configured");
+}
+
+#[test]
+fn user_facing_components_disabled_state() {
+    let (title, _, _) = AwsCredentialsState::Disabled.user_facing_components();
+    assert_eq!(title, "AWS Bedrock Disabled");
+}
+
+#[test]
+fn user_facing_components_failed_state() {
+    let state = AwsCredentialsState::Failed {
+        message: "bad config".to_string(),
+    };
+    let (title, detail, _) = state.user_facing_components();
+    assert_eq!(title, "Unable to load credentials");
+    assert_eq!(detail, "bad config");
+}


### PR DESCRIPTION
## Summary

Closes #8506

Adds first-class AWS Bedrock region selection support. Users can now configure their preferred AWS region (e.g. `us-east-1`, `eu-west-1`) directly in Warp's AI settings, enabling Bedrock inference in any supported region.

## Changes

- **`crates/ai/src/aws_credentials.rs`** — Added `region` field to `AwsCredentials` struct, fixed proto conversion (was hardcoding empty string), enhanced status card to display active region
- **`crates/ai/src/aws_credentials_tests.rs`** — New test file: 9 unit tests covering region storage, proto conversion, and UI display
- **`crates/ai/src/api_keys_tests.rs`** — Added tests for AWS credentials in API key request flow
- **`app/src/settings/ai.rs`** — Added `aws_bedrock_region` setting with TOML persistence and cloud sync
- **`app/src/ai/aws_credentials.rs`** — Updated `load_aws_credentials_from_sdk()` to accept region override, resolves from SDK when not set, subscribes to region setting changes
- **`app/src/settings_view/ai_page.rs`** — Added "AWS Region" text input to the Bedrock settings widget

## How to use

1. Open **Settings → AI** (or press Cmd+,)
2. Scroll down to **AWS Bedrock** section (or search "bedrock")
3. Enable the **"Use AWS Bedrock credentials"** toggle
4. Set your **AWS Profile** (optional, leave blank for default)
5. Set your **AWS Region** (e.g. `us-east-1`, `us-west-2`, `eu-west-1`) — if left blank, the region is automatically resolved from your `~/.aws/config` or `AWS_REGION` environment variable
6. Configure a **Login Command** (e.g. `aws sso login`) for credential refresh
7. Click **Refresh** to load credentials

Once loaded, the status card shows: "Credentials loaded · Region: us-east-1"

### Region resolution priority:
1. Explicit value in the "AWS Region" field (highest priority)
2. `AWS_REGION` or `AWS_DEFAULT_REGION` environment variable
3. Region from `~/.aws/config` for the configured profile

<img width="854" height="496" alt="image" src="https://github.com/user-attachments/assets/756f54af-debb-457b-b2e4-889af3a50a21" />

## Test plan

- [x] Unit tests pass: `cargo nextest run -p ai` (37 tests)
- [x] Clippy clean on affected crates
- [x] Manual: AWS Bedrock section renders with new Region input field
- [x] Manual: Region field disabled when Bedrock toggle is off, enabled when on
- [ ] Manual: Set region, verify credentials load with correct region shown in status
- [ ] Manual: Leave region blank, verify SDK resolves from `~/.aws/config`

CHANGELOG-NEW-FEATURE: Added AWS region selection to Bedrock settings for choosing inference region