### PR TITLE
Restore set_ime_allowed(true) on Linux to fix IME input

### DIFF
--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -1481,6 +1481,11 @@ fn create_window(
         }
     }
 
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    if let Ok(window) = created_window.as_ref() {
+        window.set_ime_allowed(true);
+    }
+
     created_window
 }
 


### PR DESCRIPTION
## Description

Re-applies the fix from #9602 that was reverted in #11032. On Linux/Wayland (and X11 via XWayland), winit only sends `zwp_text_input_v3.enable()` to the compositor after `set_ime_allowed(true)` is called. Without this call, IME stays inactive and non-Latin input methods (CJK, Korean, etc.) are completely unusable in Warp.

The revert in #11032 re-introduced the regression for all Linux users relying on fcitx5 or other IME frameworks starting from `v0.2026.05.20.09.21.stable_03`.

### Fix

```rust
#[cfg(any(target_os = "linux", target_os = "freebsd"))]
if let Ok(window) = created_window.as_ref() {
    window.set_ime_allowed(true);
}
```

This mirrors the existing `set_ime_allowed(true)` call in the `#[cfg(windows)]` block and restores the behavior that #9602 originally provided.

## Linked Issues

Fixes #11593, #5279, #7971

## Context

- #9602 added `set_ime_allowed(true)` for Linux — merged and working
- #11032 reverted #9602 on 2026-05-15, causing IME to break for all Linux CJK/Korean users
- Multiple users confirmed the regression in #11593: fcitx5 stopped working after the `stable_03` update
- The issue reproduces even with `force_x11 = true` in Warp config
- Affected distros: Fedora 43/44, Arch Linux, Deepin (any Linux with fcitx5)

## Testing

- Verified locally on Deepin Linux with fcitx5: Chinese input works correctly after this fix
- Downgrading to `v0.2026.05.18.05.32.stable_02` (before the revert landed) confirms IME works

🤖 Generated with [Claude Code](https://claude.com/claude-code)