### PR TITLE
fix: Preserve custom models during LLM preference reconciliation

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -1180,7 +1180,10 @@ impl LLMPreferences {
                     let effective_base_model_usable = self
                         .models_by_feature
                         .agent_mode
-                        .usable_info_for_id(effective_base_model_id, ctx);
+                        .usable_info_for_id(effective_base_model_id, ctx)
+                        .or_else(|| {
+                            self.custom_llm_info_for_id_if_enabled(effective_base_model_id, ctx)
+                        });
                     let effective_base_model_unusable = effective_base_model_usable.is_none();
                     let effective_base_model_is_configurable = effective_base_model_usable
                         .is_some_and(|info| info.context_window.is_configurable);
@@ -1199,6 +1202,9 @@ impl LLMPreferences {
                             .models_by_feature
                             .coding
                             .usable_info_for_id(preferred_llm_id, ctx)
+                            .or_else(|| {
+                                self.custom_llm_info_for_id_if_enabled(preferred_llm_id, ctx)
+                            })
                             .is_none()
                         {
                             profiles.set_coding_model(profile_id, None, ctx);
@@ -1208,6 +1214,9 @@ impl LLMPreferences {
                         if self
                             .get_cli_agent_available()
                             .usable_info_for_id(preferred_llm_id, ctx)
+                            .or_else(|| {
+                                self.custom_llm_info_for_id_if_enabled(preferred_llm_id, ctx)
+                            })
                             .is_none()
                         {
                             profiles.set_cli_agent_model(profile_id, None, ctx);

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -1,5 +1,21 @@
 use super::*;
 
+use warpui::App;
+
+use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::mcp::TemplatableMCPServerManager;
+use crate::auth::auth_manager::AuthManager;
+use crate::auth::AuthStateProvider;
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::network::NetworkStatus;
+use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::server_api::ServerApiProvider;
+use crate::server::sync_queue::SyncQueue;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::workspaces::team_tester::TeamTesterStatus;
+use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::LaunchMode;
+
 // -- DisableReason::should_clear_preference tests --
 
 #[test]
@@ -302,4 +318,65 @@ fn removing_endpoint_purges_all_its_models_from_custom_llms() {
     let infos = build_custom_llm_infos(&after);
     assert_eq!(infos.len(), 1);
     assert_eq!(infos[0].id.as_str(), "uuid-k1");
+}
+
+#[test]
+fn reconcile_preserves_custom_models_saved_on_execution_profile() {
+    App::test((), |mut app| async move {
+        let _custom_inference_flag = FeatureFlag::CustomInferenceEndpoints.override_enabled(true);
+
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+
+        let profiles_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let llm_preferences = app.add_singleton_model(LLMPreferences::new);
+
+        let custom_model_id = LLMId::from("custom-model-config-key");
+        ApiKeyManager::handle(&app).update(&mut app, |api_key_manager, ctx| {
+            api_key_manager.add_custom_endpoint(
+                "local".to_string(),
+                "https://example.com/v1".to_string(),
+                "test-key".to_string(),
+                vec![(
+                    "custom-model".to_string(),
+                    Some("Custom Model".to_string()),
+                    Some(custom_model_id.to_string()),
+                )],
+                ctx,
+            );
+        });
+
+        let default_profile_id =
+            profiles_model.read(&app, |profiles, _| profiles.default_profile_id());
+        profiles_model.update(&mut app, |profiles, ctx| {
+            profiles.set_base_model(default_profile_id, Some(custom_model_id.clone()), ctx);
+            profiles.set_coding_model(default_profile_id, Some(custom_model_id.clone()), ctx);
+            profiles.set_cli_agent_model(default_profile_id, Some(custom_model_id.clone()), ctx);
+        });
+
+        llm_preferences.update(&mut app, |preferences, ctx| {
+            preferences.update_feature_model_choices(Ok(ModelsByFeature::default()), ctx);
+        });
+
+        profiles_model.read(&app, |profiles, ctx| {
+            let profile = profiles.default_profile(ctx);
+            assert_eq!(profile.data().base_model.as_ref(), Some(&custom_model_id));
+            assert_eq!(profile.data().coding_model.as_ref(), Some(&custom_model_id));
+            assert_eq!(
+                profile.data().cli_agent_model.as_ref(),
+                Some(&custom_model_id)
+            );
+        });
+    });
 }


### PR DESCRIPTION
## Description
With the current logic, only the built-in models are checked when preferences are updated/validated (such as on app startup). As a result, setting a custom model as the default will only persist until this preference update runs. This PR fixes this by extending that model check to also include custom models that the user defined. 

## Linked Issue
Closes https://github.com/warpdotdev/warp/issues/8562 and https://github.com/warpdotdev/warp/issues/11564

## Testing
I tested manually by adding a custom BYOK model and verifying that I could use it for a new agent session. Then I quit the app and re-opened to verify that my default model was still set to my custom BYOK model.

- [ x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

### Updated Profile With Custom Default Model

<img width="1834" height="1244" alt="image" src="https://github.com/user-attachments/assets/3d332a58-cd8b-439d-b8dd-8e0f76adaea2" />

<img width="1634" height="566" alt="image" src="https://github.com/user-attachments/assets/da381bf0-6ad6-4855-b383-986b63f6d5f7" />


### State After Quitting and Re-Opening

<img width="1620" height="942" alt="image" src="https://github.com/user-attachments/assets/320f48b2-8d68-4c72-96cd-a055e45f4e5b" />



<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.


CHANGELOG-BUG-FIX: fixes issue where the default profile's model settings would not be preserved when using a custom model
-->
