### PR TITLE
Preserve custom endpoint model selections in profiles

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -859,8 +859,6 @@ impl LLMPreferences {
             .map(|info| info.id.clone())
             .collect();
         let mut updated_agent_mode = false;
-        let mut updated_coding = false;
-        let mut updated_other = false;
 
         self.base_llm_for_terminal_view.retain(|_, id| {
             let keep = !custom_ids.contains(id);
@@ -868,58 +866,13 @@ impl LLMPreferences {
             keep
         });
 
-        AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles, ctx| {
-            for profile_id in profiles.get_all_profile_ids() {
-                let Some(profile) = profiles.get_profile_by_id(profile_id, ctx) else {
-                    continue;
-                };
-                let profile_data = profile.data();
-
-                if profile_data
-                    .base_model
-                    .as_ref()
-                    .is_some_and(|id| custom_ids.contains(id))
-                {
-                    profiles.set_base_model(profile_id, None, ctx);
-                    profiles.set_context_window_limit(profile_id, None, ctx);
-                    updated_agent_mode = true;
-                }
-                if profile_data
-                    .coding_model
-                    .as_ref()
-                    .is_some_and(|id| custom_ids.contains(id))
-                {
-                    profiles.set_coding_model(profile_id, None, ctx);
-                    updated_coding = true;
-                }
-                if profile_data
-                    .cli_agent_model
-                    .as_ref()
-                    .is_some_and(|id| custom_ids.contains(id))
-                {
-                    profiles.set_cli_agent_model(profile_id, None, ctx);
-                    updated_other = true;
-                }
-                if profile_data
-                    .computer_use_model
-                    .as_ref()
-                    .is_some_and(|id| custom_ids.contains(id))
-                {
-                    profiles.set_computer_use_model(profile_id, None, ctx);
-                    updated_other = true;
-                }
-            }
-        });
+        // Keep saved execution-profile model ids intact. `get_preferred_*_model` already falls
+        // back when custom inference is unavailable, and preserving the id lets profiles recover
+        // when workspace entitlements or custom endpoints finish loading again.
 
         if updated_agent_mode {
             self.trigger_snapshot_save(ctx);
             ctx.emit(LLMPreferencesEvent::UpdatedActiveAgentModeLLM);
-        }
-        if updated_coding {
-            ctx.emit(LLMPreferencesEvent::UpdatedActiveCodingLLM);
-        }
-        if updated_other {
-            ctx.emit(LLMPreferencesEvent::UpdatedAvailableLLMs);
         }
     }
 


### PR DESCRIPTION
## Summary
- keep saved execution-profile model ids when custom inference is temporarily unavailable
- continue clearing only transient pane-level custom model overrides in that state
- rely on existing runtime model resolution to fall back safely until custom models are available again

## Why
Custom endpoint model selections are stored in execution profiles as local custom model ids. During workspace/team updates, custom inference can temporarily appear unavailable while entitlements or endpoint data are still loading. The previous sanitizer wrote `None` into every profile field that referenced a custom model, permanently resetting the profile back to the default agent model, usually `auto`.

Preserving the profile value avoids losing the user's selection. The existing `get_preferred_*_model` paths already gate custom model resolution on custom inference availability, so unavailable custom models still fall back safely at runtime without mutating the saved profile.

## Test plan
- `cargo fmt --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo test -p warp ai::llms_tests`

Note: the first test attempt failed because local `xcode-select` points at missing `/Applications/Xcode-beta.app/Contents/Developer`; reran with installed `/Applications/Xcode.app/Contents/Developer`.