### PR TITLE
[REMOTE-1771] Fix public Oz shared session info panel

### DIFF
--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -15,10 +15,10 @@ use warp_core::ui::color::coloru_with_opacity;
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::new_scrollable::{NewScrollable, SingleAxisConfig};
 use warpui::elements::{
-    resizable_state_handle, Border, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container,
-    CornerRadius, CrossAxisAlignment, DragBarSide, Empty, Expanded, Flex, MainAxisAlignment,
-    MainAxisSize, MouseStateHandle, ParentElement, Radius, Resizable, ResizableStateHandle,
-    SelectableArea, SelectionHandle, Shrinkable, Text, Wrap,
+    Border, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container, CornerRadius,
+    CrossAxisAlignment, DragBarSide, Empty, Expanded, Flex, MainAxisAlignment, MainAxisSize,
+    MouseStateHandle, ParentElement, Radius, Resizable, ResizableStateHandle, SelectableArea,
+    SelectionHandle, Shrinkable, Text, Wrap, resizable_state_handle,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::keymap::FixedBinding;
@@ -39,7 +39,7 @@ use crate::ai::agent_management::details_action_buttons::{
 };
 use crate::ai::agent_management::telemetry::{AgentManagementTelemetryEvent, OpenedFrom};
 use crate::ai::ambient_agents::task::TaskPrincipalInfo;
-use crate::ai::ambient_agents::{cancel_task_with_toast, AmbientAgentTaskId};
+use crate::ai::ambient_agents::{AmbientAgentTaskId, cancel_task_with_toast};
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::cloud_environments::{AmbientAgentEnvironment, CloudAmbientAgentEnvironment};
@@ -47,7 +47,7 @@ use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::ai::harness_display;
 use crate::appearance::Appearance;
 use crate::auth::UserUid;
-use crate::cloud_object::CloudObjectLookup as _;
+use crate::cloud_object::{CloudObjectLookup as _, Owner, ServerPermissions};
 use crate::notebooks::NotebookId;
 use crate::send_telemetry_from_ctx;
 use crate::server::ids::{ServerId, SyncId};
@@ -60,13 +60,13 @@ use crate::ui_components::buttons::icon_button;
 use crate::ui_components::icons::Icon;
 use crate::util::bindings::CustomAction;
 use crate::util::time_format::{format_approx_duration_from_now, human_readable_precise_duration};
+use crate::view_components::DismissibleToast;
 #[cfg(not(target_family = "wasm"))]
 use crate::view_components::action_button::PrimaryTheme;
 use crate::view_components::action_button::{ActionButton, ButtonSize, SecondaryTheme};
 use crate::view_components::copyable_text_field::{
-    render_copyable_text_field, CopyableTextFieldConfig, COPY_FEEDBACK_DURATION,
+    COPY_FEEDBACK_DURATION, CopyableTextFieldConfig, render_copyable_text_field,
 };
-use crate::view_components::DismissibleToast;
 use crate::workspace::{ForkedConversationDestination, ToastStack, WorkspaceAction};
 use crate::workspaces::user_profiles::UserProfiles;
 
@@ -219,11 +219,24 @@ pub struct ConversationDetailsData {
     skill_spec: Option<SkillSpec>,
     /// Execution harness for this conversation/task.
     harness: Option<Harness>,
+    /// Link/object visibility for cloud-backed conversations.
+    visibility: Option<String>,
     /// Error message displayed when the API call to fetch run data failed.
     fetch_error: Option<String>,
 }
 
 impl ConversationDetailsData {
+    fn visibility_from_permissions(permissions: &ServerPermissions) -> String {
+        if permissions.anyone_link_sharing.is_some() {
+            return "Public".to_string();
+        }
+
+        match permissions.space {
+            Owner::Team { .. } => "Team".to_string(),
+            Owner::User { .. } => "Private".to_string(),
+        }
+    }
+
     fn directory_for_task(task: &AmbientAgentTask, app: &AppContext) -> Option<String> {
         let history_model = BlocklistAIHistoryModel::as_ref(app);
         let conversation_id = history_model
@@ -252,10 +265,17 @@ impl ConversationDetailsData {
     pub fn from_conversation(conversation: &AIConversation, app: &AppContext) -> Self {
         let mut directory = None;
         let mut conversation_id = None;
+        let mut task_id = None;
+        let mut visibility = None;
 
         // Server metadata (creator, timestamps)
         let mut creator = None;
         if let Some(server_metadata) = conversation.server_metadata() {
+            task_id = server_metadata.ambient_agent_task_id;
+            visibility = Some(Self::visibility_from_permissions(
+                &server_metadata.permissions,
+            ));
+
             if let Some(creator_uid_str) = &server_metadata.metadata.creator_uid {
                 let creator_uid = UserUid::new(creator_uid_str);
                 let user_profiles = UserProfiles::handle(app).as_ref(app);
@@ -309,13 +329,28 @@ impl ConversationDetailsData {
             .map(|m| Harness::from(m.harness))
             .or(Some(Harness::Oz));
 
-        ConversationDetailsData {
-            mode: PanelMode::Conversation {
+        let mode = if let Some(task_id) = task_id {
+            PanelMode::Task {
+                task_id: Some(task_id),
+                directory,
+                display_status: Some(AgentRunDisplayStatus::from_conversation_status(
+                    conversation.status(),
+                )),
+                error_message: None,
+                environment_id: None,
+                conversation_id,
+            }
+        } else {
+            PanelMode::Conversation {
                 directory,
                 server_conversation_id: conversation_id,
                 ai_conversation_id: None,
                 status: Some(conversation.status().clone()),
-            },
+            }
+        };
+
+        ConversationDetailsData {
+            mode,
             title: conversation
                 .title()
                 .unwrap_or_else(|| "Conversation".to_string()),
@@ -330,6 +365,7 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec: None,
             harness,
+            visibility,
             fetch_error: None,
         }
     }
@@ -394,6 +430,7 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec,
             harness,
+            visibility: None,
             fetch_error: None,
         }
     }
@@ -466,6 +503,7 @@ impl ConversationDetailsData {
                 copy_link_url,
                 skill_spec,
                 harness,
+                visibility: None,
                 fetch_error: None,
             };
         }
@@ -493,6 +531,7 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec: None,
             harness,
+            visibility: None,
             fetch_error: None,
         }
     }
@@ -521,6 +560,7 @@ impl ConversationDetailsData {
             copy_link_url: None,
             skill_spec: None,
             harness: None,
+            visibility: None,
             fetch_error,
         }
     }
@@ -563,6 +603,7 @@ impl ConversationDetailsData {
             copy_link_url,
             skill_spec: None,
             harness,
+            visibility: None,
             fetch_error: None,
         }
     }
@@ -1829,6 +1870,14 @@ impl View for ConversationDetailsPanel {
         if let Some(harness_section) = self.render_harness_section(appearance, app) {
             content.add_child(
                 Container::new(harness_section)
+                    .with_margin_bottom(FIELD_SPACING)
+                    .finish(),
+            );
+        }
+
+        if let Some(visibility) = &self.data.visibility {
+            content.add_child(
+                Container::new(self.render_simple_field("Visibility", visibility, appearance))
                     .with_margin_bottom(FIELD_SPACING)
                     .finish(),
             );

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -1,17 +1,23 @@
 use std::collections::HashMap;
 
 use chrono::{Local, Utc};
-use persistence::model::AgentConversationData;
+use persistence::model::{AgentConversationData, ConversationUsageMetadata};
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
+use warp_graphql::object_permissions::AccessLevel;
 use warp_multi_agent_api as api;
 use warpui::{App, EntityId, SingletonEntity};
 
 use super::{ConversationDetailsData, PanelMode};
-use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+use crate::ai::agent::api::ServerConversationToken;
+use crate::ai::agent::conversation::{
+    AIAgentHarness, AIConversation, AIConversationId, ServerAIConversationMetadata,
+};
 use crate::ai::ambient_agents::task::{AgentConfigSnapshot, HarnessConfig, TaskPrincipalInfo};
-use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
+use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
+use crate::cloud_object::{Owner, Revision, ServerLinkSharing, ServerMetadata, ServerPermissions};
+use crate::server::ids::ServerId;
 
 fn create_test_task(task_id: &str) -> AmbientAgentTask {
     let now = Utc::now();
@@ -105,6 +111,48 @@ fn create_restored_conversation(
 
     AIConversation::new_restored(conversation_id, vec![task], Some(conversation_data))
         .expect("restored conversation should build")
+}
+
+fn create_public_ambient_server_metadata(
+    server_token: &str,
+    task_id: AmbientAgentTaskId,
+) -> ServerAIConversationMetadata {
+    ServerAIConversationMetadata {
+        title: "Public Oz run".to_string(),
+        working_directory: Some("/tmp/public-oss".to_string()),
+        harness: AIAgentHarness::Oz,
+        usage: ConversationUsageMetadata {
+            was_summarized: false,
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            credits_spent_for_last_block: None,
+            token_usage: vec![],
+            tool_usage_metadata: Default::default(),
+        },
+        metadata: ServerMetadata {
+            uid: ServerId::default(),
+            revision: Revision::now(),
+            metadata_last_updated_ts: Utc::now().into(),
+            trashed_ts: None,
+            folder_id: None,
+            is_welcome_object: false,
+            creator_uid: None,
+            last_editor_uid: None,
+            current_editor_uid: None,
+        },
+        permissions: ServerPermissions {
+            space: Owner::mock_current_user(),
+            guests: Vec::new(),
+            anyone_link_sharing: Some(ServerLinkSharing {
+                access_level: AccessLevel::Viewer,
+                source: None,
+            }),
+            permissions_last_updated_ts: Utc::now().into(),
+        },
+        ambient_agent_task_id: Some(task_id),
+        server_conversation_token: ServerConversationToken::new(server_token.to_string()),
+        artifacts: Vec::new(),
+    }
 }
 
 #[test]
@@ -318,6 +366,62 @@ fn test_from_conversation_populates_local_conversation_fields() {
             assert_eq!(data.title, "test query");
             assert_eq!(data.source_prompt.as_deref(), Some("test query"));
             assert!(data.credits.is_some());
+        });
+    });
+}
+
+#[test]
+fn test_from_conversation_uses_run_mode_for_public_ambient_metadata() {
+    App::test((), |mut app| async move {
+        let _history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let conversation_id = AIConversationId::new();
+        let task_id: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-000000004040".parse().unwrap();
+        let server_token = "server-token-public";
+        let mut conversation = create_restored_conversation(
+            conversation_id,
+            "root-task",
+            "/tmp/public-oss",
+            AgentConversationData {
+                server_conversation_token: Some(server_token.to_string()),
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: None,
+                agent_name: None,
+                orchestration_harness_type: None,
+                parent_conversation_id: None,
+                is_remote_child: false,
+                root_task_is_optimistic: None,
+                run_id: Some(task_id.to_string()),
+                autoexecute_override: None,
+                last_event_sequence: None,
+                pinned: false,
+            },
+        );
+        conversation
+            .set_server_metadata(create_public_ambient_server_metadata(server_token, task_id));
+
+        app.update(|ctx| {
+            let data = ConversationDetailsData::from_conversation(&conversation, ctx);
+
+            match &data.mode {
+                PanelMode::Task {
+                    task_id: panel_task_id,
+                    conversation_id,
+                    ..
+                } => {
+                    assert_eq!(*panel_task_id, Some(task_id));
+                    assert_eq!(conversation_id.as_deref(), Some(server_token));
+                }
+                PanelMode::Conversation { .. } => {
+                    panic!("expected public ambient conversation to render as run details")
+                }
+            }
+
+            assert_eq!(data.harness, Some(Harness::Oz));
+            assert_eq!(data.visibility.as_deref(), Some("Public"));
         });
     });
 }


### PR DESCRIPTION
## Summary
- Render cloud conversations with ambient task metadata as run details in the info panel
- Surface public/team/private visibility from shared conversation permissions
- Add regression coverage for public Oz ambient session metadata

## Tests
- cargo test -p warp ai::conversation_details_panel::tests --lib

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._