### PR TITLE
Fix Sentry framework copy in `./script/run`.

### DIFF
--- a/script/macos/run
+++ b/script/macos/run
@@ -103,6 +103,7 @@ popd > /dev/null
 if [[ ",$FEATURES," =~ ",cocoa_sentry," ]]; then
   echo "Copying Sentry framework into app bundle..."
   SENTRY_FRAMEWORK="app/frameworks/dev/Sentry-Dynamic-WithARM64e.xcframework/macos-arm64_arm64e_x86_64/Sentry.framework"
+  mkdir -p "$WARP_APP_PATH/Contents/Frameworks"
   cp -a "$SENTRY_FRAMEWORK" "$WARP_APP_PATH/Contents/Frameworks/"
 fi
 echo "Adding rpath to support mac frameworks (e.g. Sentry)"


### PR DESCRIPTION
## Description
Fixes local macOS runs with `cocoa_sentry` enabled by ensuring the app bundle's `Contents/Frameworks` directory exists before copying `Sentry.framework` into it.

Without this, `cp` can create `Contents/Frameworks` as the copied framework directory itself, leaving framework internals directly under `Contents/Frameworks` and causing `codesign --deep` to reject the bundle.

## Linked Issue
None.

## Testing
Not run after the fix. This was diagnosed from a failed local run of:

`./script/run --features cocoa_sentry,crash_reporting`

That run reached the codesigning step and failed because the Sentry framework was copied into an invalid bundle layout.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
