### PR TITLE
force the default bracketed-paste widget in zsh bootstrap to workarou…

### DIFF
--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -1169,6 +1169,12 @@ esac
     fi
   fi
 
+  # Restore the built-in bracketed-paste widget. This works around a buggy interaction we observed
+  # with the bracketed-paste-magic plugin (included in oh-my-zsh by default), zsh's "allexport"
+  # option (set -a), and Warp's bootstrapping code.
+  # https://github.com/warpdotdev/warp/issues/11520
+  zle -A .bracketed-paste bracketed-paste
+
   precmd_functions+=(warp_precmd warp_update_prompt_vars)
   preexec_functions+=(warp_preexec)
 


### PR DESCRIPTION
…nd bug with oh-my-zsh and allexport option

## Description

This fixes a bootstrapping issue in zsh. To repro the bug:

1. Use zsh
2. Add oh-my-zsh (or simply the `bracketed-paste-magic` plugin, but oh-my-zsh includes that by default and that is probably the easiest way)
3. Either in the RC file or in an interactive session, run `set -a`.
4. Run any command and it will get duplicated in the shell's line editor, e.g. if you type `pwd` the shell will try to run `pwdpwd` and fail.

This PR fixes it by forcing the default `bracketed-paste` widget, undoing the custom `bracketed-paste-magic` widget which interacts with `set -a` and causes the bug with Warp's hooks.

This shouldn't impact any existing functionality for Warp users. `bracketed-paste-magic` won't actually have any effect since Warp is bypassing ZLE anyways with our own editor. For example, if you are using zsh in a vanilla terminal and you type `open ` and paste a URL, `bracketed-paste-magic` will recognize a URL was pasted and escape the special chars, e.g. `&` and such. If you use Warp and paste a URL, the paste is entirely handled by Warp and `bracketed-paste-magic` won't kick in when the URL is pasted. Warp will eventually send the whole command to ZLE on submission and that gets placed inside bracketed paste, but since the entire command is submitted all together it will not trigger `bracketed-paste-magic` to escape a URL.

## Linked Issue

Closes #11520

## Testing

Tested locally and this bug no longer occurs after `set -a`.


<!--
## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fix failures due to `set -a` in zsh sessions.
-->
