### PR TITLE
Implement warpctrl execution-underlying actions

### DIFF
--- a/app/src/local_control/bridge.rs
+++ b/app/src/local_control/bridge.rs
@@ -9,7 +9,7 @@ use ::local_control::{
 };
 use warpui::{Entity, ModelContext, SingletonEntity};
 
-use crate::local_control::handlers::{layout, metadata};
+use crate::local_control::handlers::{execution, layout, metadata};
 use crate::local_control::permissions::{ensure_action_allowed, ensure_feature_enabled};
 use crate::local_control::resolver::validate_action_params;
 
@@ -101,6 +101,47 @@ impl LocalControlBridge {
                     return ResponseEnvelope::error(request.request_id, error);
                 }
                 match layout::create_terminal_tab(&self.instance_id, &request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::InputRun | ActionKind::DriveWorkflowRun => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                let Some(authenticated_user_subject) = grant.authenticated_user.subject.as_deref()
+                else {
+                    return ResponseEnvelope::error(
+                        request.request_id,
+                        ControlError::new(
+                            ErrorCode::AuthenticatedUserRequired,
+                            format!(
+                                "{} requires an authenticated Warp user",
+                                request.action.kind.as_str()
+                            ),
+                        ),
+                    );
+                };
+                let result = match request.action.kind {
+                    ActionKind::InputRun => execution::run_input(
+                        &request,
+                        authenticated_user_subject,
+                    ),
+                    ActionKind::DriveWorkflowRun => execution::run_drive_workflow(
+                        &request,
+                        authenticated_user_subject,
+                    ),
+                    action => Err(ControlError::new(
+                        ErrorCode::UnsupportedAction,
+                        format!(
+                            "{} is not an execution-underlying action",
+                            action.as_str()
+                        ),
+                    )),
+                };
+                match result {
                     Ok(data) => ResponseEnvelope::ok(request.request_id, data),
                     Err(error) => ResponseEnvelope::error(request.request_id, error),
                 }

--- a/app/src/local_control/handlers.rs
+++ b/app/src/local_control/handlers.rs
@@ -1,3 +1,4 @@
 //! App-side action handlers invoked by the local-control bridge.
+pub(super) mod execution;
 pub(super) mod layout;
 pub(super) mod metadata;

--- a/app/src/local_control/handlers/execution.rs
+++ b/app/src/local_control/handlers/execution.rs
@@ -1,0 +1,102 @@
+//! Execution-underlying handlers for local-control actions.
+use ::local_control::protocol::{ActionParams, LocalControlAuditRecord, WorkflowRunParams};
+use ::local_control::{
+    ActionKind, ControlError, ErrorCode, PermissionCategory, RequestEnvelope,
+};
+
+pub(crate) fn run_input(
+    request: &RequestEnvelope,
+    authenticated_user_subject: &str,
+) -> Result<serde_json::Value, ControlError> {
+    let ActionParams::Text { text } = request.action.params_as::<ActionParams>()? else {
+        return Err(ControlError::new(
+            ErrorCode::InvalidParams,
+            "input.run requires text parameters",
+        ));
+    };
+    if text.trim().is_empty() {
+        return Err(ControlError::new(
+            ErrorCode::InvalidParams,
+            "input.run requires non-empty text",
+        ));
+    }
+    fail_closed_without_execution_policy(request.action.kind, authenticated_user_subject)
+}
+
+pub(crate) fn run_drive_workflow(
+    request: &RequestEnvelope,
+    authenticated_user_subject: &str,
+) -> Result<serde_json::Value, ControlError> {
+    let ActionParams::WorkflowRun(params) = request.action.params_as::<ActionParams>()? else {
+        return Err(ControlError::new(
+            ErrorCode::InvalidParams,
+            "drive.workflow.run requires workflow run parameters",
+        ));
+    };
+    validate_workflow_run_params(&params)?;
+    fail_closed_without_execution_policy(request.action.kind, authenticated_user_subject)
+}
+
+pub(crate) fn execution_audit_record(
+    action: ActionKind,
+    authenticated_user_subject: &str,
+) -> LocalControlAuditRecord {
+    LocalControlAuditRecord {
+        action: action.as_str().to_owned(),
+        target_scope: action.metadata().target_scope,
+        permission_category: PermissionCategory::MutateUnderlyingData,
+        authenticated_user_subject: authenticated_user_subject.to_owned(),
+    }
+}
+
+fn validate_workflow_run_params(params: &WorkflowRunParams) -> Result<(), ControlError> {
+    if params.id.0.trim().is_empty() {
+        return Err(ControlError::new(
+            ErrorCode::InvalidParams,
+            "drive.workflow.run requires a non-empty workflow id",
+        ));
+    }
+    for arg in &params.args {
+        if excluded_submission_argument_name(&arg.name) {
+            return Err(ControlError::new(
+                ErrorCode::UnsupportedAction,
+                "drive.workflow.run does not accept accepted-command or agent-prompt submissions",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn excluded_submission_argument_name(name: &str) -> bool {
+    matches!(
+        name,
+        "accepted_command"
+            | "accepted-command"
+            | "agent_prompt"
+            | "agent-prompt"
+            | "internal_dispatch"
+            | "internal-dispatch"
+    )
+}
+
+fn fail_closed_without_execution_policy(
+    action: ActionKind,
+    authenticated_user_subject: &str,
+) -> Result<serde_json::Value, ControlError> {
+    let audit = execution_audit_record(action, authenticated_user_subject);
+    let details = serde_json::to_string(&audit).map_err(|err| {
+        ControlError::with_details(
+            ErrorCode::Internal,
+            "failed to encode local-control execution audit record",
+            err.to_string(),
+        )
+    })?;
+    Err(ControlError::with_details(
+        ErrorCode::ExecutionContextNotAllowed,
+        format!(
+            "{} requires an explicit execution approval policy, but no approval is available",
+            action.as_str()
+        ),
+        details,
+    ))
+}

--- a/app/src/local_control/mod.rs
+++ b/app/src/local_control/mod.rs
@@ -50,7 +50,9 @@ use warp_core::channel::ChannelState;
 use warpui::{Entity, ModelContext, ModelSpawner, SingletonEntity};
 
 pub use bridge::LocalControlBridge;
-use permissions::{ensure_action_allowed, ensure_feature_enabled};
+use permissions::{
+    authenticated_user_subject_for_action, ensure_action_allowed, ensure_feature_enabled,
+};
 
 /// Shared state made available to Axum handlers for one localhost server
 /// running inside Warp.
@@ -300,13 +302,43 @@ async fn handle_credential_request(
                 .into_response();
         }
     }
+    let authenticated_user_subject = match state
+        .bridge_spawner
+        .spawn({
+            let action = request.action;
+            move |_, ctx| authenticated_user_subject_for_action(action, ctx)
+        })
+        .await
+    {
+        Ok(Ok(subject)) => subject,
+        Ok(Err(error)) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponseEnvelope::new(error)),
+            )
+                .into_response();
+        }
+        Err(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponseEnvelope::new(ControlError::new(
+                    ErrorCode::BridgeUnavailable,
+                    "local-control app bridge is unavailable",
+                ))),
+            )
+                .into_response();
+        }
+    };
     let auth_token = AuthToken::generate();
-    let grant = CredentialGrant::new(
+    let mut grant = CredentialGrant::new(
         state.instance_id.clone(),
         request.action,
         request.invocation_context,
         Duration::minutes(5),
     );
+    if let Some(subject) = authenticated_user_subject {
+        grant = grant.with_authenticated_user_subject(subject);
+    }
     let mut credentials = match state.credentials.lock() {
         Ok(credentials) => credentials,
         Err(_) => {

--- a/app/src/local_control/mod_tests.rs
+++ b/app/src/local_control/mod_tests.rs
@@ -1,9 +1,10 @@
 use ::local_control::protocol::ActionKind;
 use ::local_control::protocol::{
-    Action, PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector,
-    WindowTarget,
+    Action, ActionParams, DriveObjectId, PaneSelector, PaneTarget, TabSelector, TabTarget,
+    RequestEnvelope, TargetSelector, WindowSelector, WindowTarget, WorkflowArgument,
+    WorkflowRunParams,
 };
-use ::local_control::{ErrorCode, InvocationContext};
+use ::local_control::{ErrorCode, InvocationContext, PermissionCategory};
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
 
@@ -12,6 +13,7 @@ use super::{
     outside_warp_action_enabled_for_settings, require_active_window_id, validate_action_params,
     validate_tab_create_target,
 };
+use crate::local_control::handlers::execution;
 use crate::settings::{
     AllowOutsideWarpAppStateMutations, AllowOutsideWarpControl,
     AllowOutsideWarpMetadataConfigurationMutations, AllowOutsideWarpMetadataReads,
@@ -123,6 +125,8 @@ fn capabilities_advertises_only_first_slice_core_actions() {
             ActionKind::AppPing,
             ActionKind::AppVersion,
             ActionKind::TabCreate,
+            ActionKind::InputRun,
+            ActionKind::DriveWorkflowRun,
         ]
     );
 }
@@ -199,6 +203,106 @@ fn disabled_granular_permission_denies_with_insufficient_permissions() {
     )
     .expect_err("read-write permission is disabled");
     assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+}
+
+#[test]
+fn execution_underlying_actions_require_mutate_underlying_data_permission() {
+    let settings = settings_with_values(true, true, true);
+
+    for action in [ActionKind::InputRun, ActionKind::DriveWorkflowRun] {
+        assert_eq!(
+            action.metadata().permission_category,
+            PermissionCategory::MutateUnderlyingData
+        );
+        let err = ensure_settings_allow_action(&settings, InvocationContext::OutsideWarp, action)
+            .expect_err("underlying data mutation permission is disabled");
+        assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+    }
+}
+
+#[test]
+fn execution_mutations_reject_malformed_params() {
+    validate_action_params(
+        &Action::with_params(
+            ActionKind::InputRun,
+            ActionParams::Text {
+                text: "cargo check".to_owned(),
+            },
+        )
+        .expect("input.run params serialize"),
+    )
+    .expect("input.run accepts non-empty text");
+
+    let err = validate_action_params(
+        &Action::with_params(
+            ActionKind::InputRun,
+            ActionParams::Text {
+                text: "   ".to_owned(),
+            },
+        )
+        .expect("input.run params serialize"),
+    )
+    .expect_err("input.run requires non-empty text");
+    assert_eq!(err.code, ErrorCode::InvalidParams);
+
+    let err = validate_action_params(
+        &Action::with_params(
+            ActionKind::DriveWorkflowRun,
+            ActionParams::WorkflowRun(WorkflowRunParams {
+                id: DriveObjectId("".to_owned()),
+                args: vec![],
+            }),
+        )
+        .expect("drive.workflow.run params serialize"),
+    )
+    .expect_err("drive.workflow.run requires non-empty id");
+    assert_eq!(err.code, ErrorCode::InvalidParams);
+}
+
+#[test]
+fn drive_workflow_run_rejects_excluded_submission_arguments() {
+    for name in ["accepted_command", "accepted-command", "agent_prompt", "agent-prompt"] {
+        let err = validate_action_params(
+            &Action::with_params(
+                ActionKind::DriveWorkflowRun,
+                ActionParams::WorkflowRun(WorkflowRunParams {
+                    id: DriveObjectId("workflow_123".to_owned()),
+                    args: vec![WorkflowArgument {
+                        name: name.to_owned(),
+                        value: "payload".to_owned(),
+                    }],
+                }),
+            )
+            .expect("drive.workflow.run params serialize"),
+        )
+        .expect_err("excluded submissions are rejected");
+        assert_eq!(err.code, ErrorCode::UnsupportedAction);
+    }
+}
+
+#[test]
+fn execution_attempts_fail_closed_without_approval_policy_and_include_audit() {
+    let request = RequestEnvelope::new(
+        Action::with_params(
+            ActionKind::InputRun,
+            ActionParams::Text {
+                text: "cargo check".to_owned(),
+            },
+        )
+        .expect("input.run params serialize"),
+    );
+    let err = execution::run_input(&request, "user_123")
+        .expect_err("input.run fails closed without policy");
+    assert_eq!(err.code, ErrorCode::ExecutionContextNotAllowed);
+    let details = err.details.expect("audit details are attached");
+    let audit: ::local_control::LocalControlAuditRecord =
+        serde_json::from_str(&details).expect("audit decodes");
+    assert_eq!(audit.action, "input.run");
+    assert_eq!(
+        audit.permission_category,
+        PermissionCategory::MutateUnderlyingData
+    );
+    assert_eq!(audit.authenticated_user_subject, "user_123");
 }
 
 #[test]

--- a/app/src/local_control/permissions.rs
+++ b/app/src/local_control/permissions.rs
@@ -1,4 +1,5 @@
 //! Permission checks that map protocol action metadata onto local settings.
+use crate::auth::AuthStateProvider;
 use crate::features::FeatureFlag;
 use crate::settings::{LocalControlPermissionCategory, LocalControlSettings};
 use ::local_control::{ActionKind, ControlError, ErrorCode, InvocationContext, PermissionCategory};
@@ -75,6 +76,9 @@ pub(crate) fn ensure_settings_allow_action(
     action: ActionKind,
 ) -> Result<(), ControlError> {
     if context == InvocationContext::InsideWarp {
+        if action.metadata().requires_authenticated_user && action.is_implemented() {
+            return Ok(());
+        }
         return Err(ControlError::new(
             ErrorCode::ExecutionContextNotAllowed,
             "inside-Warp local-control grants are not implemented",
@@ -97,4 +101,23 @@ pub(crate) fn ensure_settings_allow_action(
         ));
     }
     Ok(())
+}
+
+pub(super) fn authenticated_user_subject_for_action(
+    action: ActionKind,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<Option<String>, ControlError> {
+    if !action.metadata().requires_authenticated_user {
+        return Ok(None);
+    }
+    AuthStateProvider::as_ref(ctx)
+        .get()
+        .user_id()
+        .map(|uid| Some(uid.as_string()))
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::AuthenticatedUserUnavailable,
+                format!("{} requires a logged-in Warp user", action.as_str()),
+            )
+        })
 }

--- a/app/src/local_control/resolver.rs
+++ b/app/src/local_control/resolver.rs
@@ -1,5 +1,5 @@
 //! Target and parameter validation for the first local-control action slice.
-use ::local_control::protocol::{PaneTarget, TabTarget, TargetSelector, WindowTarget};
+use ::local_control::protocol::{ActionParams, PaneTarget, TabTarget, TargetSelector, WindowTarget};
 use ::local_control::{ActionKind, ControlError, ErrorCode};
 use warpui::ModelContext;
 
@@ -51,9 +51,51 @@ pub(crate) fn validate_tab_create_target(target: &TargetSelector) -> Result<(), 
 /// bottom branch of the stack: later branches add their own params and expand
 /// this validation alongside the corresponding action handlers.
 pub(crate) fn validate_action_params(action: &::local_control::Action) -> Result<(), ControlError> {
-    if action.kind != ActionKind::TabCreate {
-        return Ok(());
+    match action.kind {
+        ActionKind::TabCreate => validate_empty_action_params(action),
+        ActionKind::InputRun => {
+            let ActionParams::Text { text } = action.params_as::<ActionParams>()? else {
+                return Err(ControlError::new(
+                    ErrorCode::InvalidParams,
+                    "input.run requires text parameters",
+                ));
+            };
+            if text.trim().is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::InvalidParams,
+                    "input.run requires non-empty text",
+                ));
+            }
+            Ok(())
+        }
+        ActionKind::DriveWorkflowRun => {
+            let ActionParams::WorkflowRun(params) = action.params_as::<ActionParams>()? else {
+                return Err(ControlError::new(
+                    ErrorCode::InvalidParams,
+                    "drive.workflow.run requires workflow run parameters",
+                ));
+            };
+            if params.id.0.trim().is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::InvalidParams,
+                    "drive.workflow.run requires a non-empty workflow id",
+                ));
+            }
+            for arg in &params.args {
+                if excluded_submission_argument_name(&arg.name) {
+                    return Err(ControlError::new(
+                        ErrorCode::UnsupportedAction,
+                        "drive.workflow.run does not accept accepted-command or agent-prompt submissions",
+                    ));
+                }
+            }
+            Ok(())
+        }
+        _ => Ok(()),
     }
+}
+
+fn validate_empty_action_params(action: &::local_control::Action) -> Result<(), ControlError> {
     if action
         .params
         .as_object()
@@ -63,8 +105,20 @@ pub(crate) fn validate_action_params(action: &::local_control::Action) -> Result
     }
     Err(ControlError::new(
         ErrorCode::InvalidParams,
-        "tab.create does not accept parameters in the first implementation slice",
+        format!("{} does not accept parameters", action.kind.as_str()),
     ))
+}
+
+fn excluded_submission_argument_name(name: &str) -> bool {
+    matches!(
+        name,
+        "accepted_command"
+            | "accepted-command"
+            | "agent_prompt"
+            | "agent-prompt"
+            | "internal_dispatch"
+            | "internal-dispatch"
+    )
 }
 
 pub(super) fn target_window_id(

--- a/crates/local_control/src/auth.rs
+++ b/crates/local_control/src/auth.rs
@@ -175,6 +175,11 @@ impl CredentialGrant {
         }
     }
 
+    pub fn with_authenticated_user_subject(mut self, subject: impl Into<String>) -> Self {
+        self.authenticated_user.subject = Some(subject.into());
+        self
+    }
+
     pub fn verify_for_action(&self, action: ActionKind) -> Result<(), ControlError> {
         if Utc::now() >= self.expires_at {
             return Err(ControlError::new(

--- a/crates/local_control/src/auth_tests.rs
+++ b/crates/local_control/src/auth_tests.rs
@@ -101,6 +101,35 @@ fn credential_request_rejects_unverified_inside_warp_context() {
 }
 
 #[test]
+fn execution_grant_requires_authenticated_user_subject() {
+    let grant = CredentialGrant::new(
+        InstanceId("inst_test".to_owned()),
+        ActionKind::InputRun,
+        InvocationContext::InsideWarp,
+        Duration::minutes(5),
+    );
+    let err = grant
+        .verify_for_action(ActionKind::InputRun)
+        .expect_err("input.run requires an authenticated user subject");
+    assert_eq!(err.code, ErrorCode::AuthenticatedUserRequired);
+}
+
+#[test]
+fn execution_grant_rejects_outside_warp_context_even_with_subject() {
+    let grant = CredentialGrant::new(
+        InstanceId("inst_test".to_owned()),
+        ActionKind::DriveWorkflowRun,
+        InvocationContext::OutsideWarp,
+        Duration::minutes(5),
+    )
+    .with_authenticated_user_subject("user_123");
+    let err = grant
+        .verify_for_action(ActionKind::DriveWorkflowRun)
+        .expect_err("drive.workflow.run cannot run outside Warp");
+    assert_eq!(err.code, ErrorCode::ExecutionContextNotAllowed);
+}
+
+#[test]
 fn credential_request_rejects_placeholder_inside_warp_terminal_proof() {
     let mut request = CredentialRequest::new(ActionKind::TabCreate, InvocationContext::InsideWarp);
     request.execution_context_proof = Some(ExecutionContextProof::VerifiedWarpTerminal {

--- a/crates/local_control/src/catalog.rs
+++ b/crates/local_control/src/catalog.rs
@@ -18,6 +18,13 @@ pub const EXCLUDED_STANDALONE_SECRET_AUTH_ACTION_NAMES: &[&str] = &[
     "auth.api_key.status",
     "auth.api_key.revoke",
 ];
+pub const EXCLUDED_EXECUTION_SUBMISSION_ACTION_NAMES: &[&str] = &[
+    "accepted_command.submit",
+    "accepted-command.submit",
+    "agent_prompt.submit",
+    "agent-prompt.submit",
+    "internal.dispatch",
+];
 
 /// Runtime context from which a control request was initiated.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -541,9 +548,12 @@ impl ActionKind {
 
     fn implementation_status(self) -> ActionImplementationStatus {
         match self {
-            Self::InstanceList | Self::AppPing | Self::AppVersion | Self::TabCreate => {
-                ActionImplementationStatus::Implemented
-            }
+            Self::InstanceList
+            | Self::AppPing
+            | Self::AppVersion
+            | Self::TabCreate
+            | Self::InputRun
+            | Self::DriveWorkflowRun => ActionImplementationStatus::Implemented,
             Self::InstanceInspect
             | Self::AppActive
             | Self::AppFocus
@@ -590,7 +600,6 @@ impl ActionKind {
             | Self::InputReplace
             | Self::InputClear
             | Self::InputModeSet
-            | Self::InputRun
             | Self::HistoryList
             | Self::ThemeList
             | Self::ThemeGet
@@ -640,7 +649,7 @@ impl ActionKind {
             | Self::DriveObjectDelete
             | Self::DriveObjectInsert
             | Self::DriveObjectShareToTeam
-            | Self::DriveWorkflowRun => ActionImplementationStatus::Stub,
+            => ActionImplementationStatus::Stub,
         }
     }
 

--- a/crates/local_control/src/lib.rs
+++ b/crates/local_control/src/lib.rs
@@ -24,6 +24,6 @@ pub use discovery::{
 };
 pub use protocol::{
     Action, ControlError, ControlResponse, ErrorCode, ErrorResponseEnvelope, ExecutionContextProof,
-    PROTOCOL_VERSION, RequestEnvelope, ResponseEnvelope,
+    LocalControlAuditRecord, PROTOCOL_VERSION, RequestEnvelope, ResponseEnvelope,
 };
 pub use selectors::{PaneSelector, TabSelector, TargetSelector, WindowSelector};

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -1,12 +1,14 @@
 //! Wire protocol envelopes and error types for Warp local control.
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 pub use crate::catalog::{
     ActionImplementationStatus, ActionKind, ActionMetadata, ActionParameterSpec, ActionResultSpec,
-    AuthenticatedUserRequirement, EXCLUDED_LOCAL_FILE_MUTATION_ACTION_NAMES,
-    EXCLUDED_STANDALONE_SECRET_AUTH_ACTION_NAMES, ExecutionContextProof, InvocationContext,
-    PROTOCOL_VERSION, PermissionCategory, RiskTier, StateDataCategory, TargetScope,
+    AuthenticatedUserRequirement, EXCLUDED_EXECUTION_SUBMISSION_ACTION_NAMES,
+    EXCLUDED_LOCAL_FILE_MUTATION_ACTION_NAMES, EXCLUDED_STANDALONE_SECRET_AUTH_ACTION_NAMES,
+    ExecutionContextProof, InvocationContext, PROTOCOL_VERSION, PermissionCategory, RiskTier,
+    StateDataCategory, TargetScope,
 };
 pub use crate::selectors::{
     PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector, WindowTarget,
@@ -242,6 +244,14 @@ pub enum ControlResult {
     Metadata { data: serde_json::Value },
     Content { data: serde_json::Value },
 }
+/// Structured audit payload for local-control execution attempts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalControlAuditRecord {
+    pub action: String,
+    pub target_scope: TargetScope,
+    pub permission_category: PermissionCategory,
+    pub authenticated_user_subject: String,
+}
 
 /// Top-level request sent by a local-control client to a Warp instance.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -278,6 +288,30 @@ impl Action {
             kind,
             params: serde_json::Value::Object(Default::default()),
         }
+    }
+
+    pub fn with_params<T: Serialize>(
+        kind: ActionKind,
+        params: T,
+    ) -> Result<Self, ControlError> {
+        let params = serde_json::to_value(params).map_err(|err| {
+            ControlError::with_details(
+                ErrorCode::InvalidParams,
+                format!("failed to encode {} parameters", kind.as_str()),
+                err.to_string(),
+            )
+        })?;
+        Ok(Self { kind, params })
+    }
+
+    pub fn params_as<T: DeserializeOwned>(&self) -> Result<T, ControlError> {
+        serde_json::from_value(self.params.clone()).map_err(|err| {
+            ControlError::with_details(
+                ErrorCode::InvalidParams,
+                format!("invalid {} parameters", self.kind.as_str()),
+                err.to_string(),
+            )
+        })
     }
 }
 

--- a/crates/local_control/src/protocol_tests.rs
+++ b/crates/local_control/src/protocol_tests.rs
@@ -36,15 +36,76 @@ fn malformed_action_name_is_not_deserialized() {
 
 #[test]
 fn excluded_action_names_are_not_deserialized() {
-    for action in [
-        "file.write",
-        "file.delete",
-        "auth.api_key.set",
-        "auth.api_key.status",
-        "auth.api_key.revoke",
-    ] {
-        assert!(serde_json::from_value::<ActionKind>(serde_json::json!(action)).is_err());
+    for action in EXCLUDED_LOCAL_FILE_MUTATION_ACTION_NAMES
+        .iter()
+        .chain(EXCLUDED_STANDALONE_SECRET_AUTH_ACTION_NAMES)
+        .chain(EXCLUDED_EXECUTION_SUBMISSION_ACTION_NAMES)
+    {
+        assert!(serde_json::from_value::<ActionKind>(serde_json::json!(*action)).is_err());
     }
+}
+
+#[test]
+fn execution_actions_are_implemented_underlying_data_mutations() {
+    for action in [ActionKind::InputRun, ActionKind::DriveWorkflowRun] {
+        let metadata = action.metadata();
+        assert_eq!(
+            metadata.implementation_status,
+            ActionImplementationStatus::Implemented
+        );
+        assert_eq!(
+            metadata.risk_tier,
+            RiskTier::MutatingDestructiveOrExecution
+        );
+        assert_eq!(
+            metadata.state_data_category,
+            StateDataCategory::UnderlyingDataMutation
+        );
+        assert_eq!(
+            metadata.permission_category,
+            PermissionCategory::MutateUnderlyingData
+        );
+        assert!(metadata.authenticated_user.required);
+        assert_eq!(
+            metadata.allowed_invocation_contexts,
+            vec![InvocationContext::InsideWarp]
+        );
+    }
+}
+
+#[test]
+fn execution_action_params_roundtrip() {
+    let action = Action::with_params(
+        ActionKind::InputRun,
+        ActionParams::Text {
+            text: "cargo check".to_owned(),
+        },
+    )
+    .expect("input.run params serialize");
+    let ActionParams::Text { text } = action.params_as::<ActionParams>().expect("params decode")
+    else {
+        panic!("expected text params");
+    };
+    assert_eq!(text, "cargo check");
+
+    let workflow = Action::with_params(
+        ActionKind::DriveWorkflowRun,
+        ActionParams::WorkflowRun(WorkflowRunParams {
+            id: DriveObjectId("workflow_123".to_owned()),
+            args: vec![WorkflowArgument {
+                name: "name".to_owned(),
+                value: "value".to_owned(),
+            }],
+        }),
+    )
+    .expect("drive.workflow.run params serialize");
+    let ActionParams::WorkflowRun(params) =
+        workflow.params_as::<ActionParams>().expect("params decode")
+    else {
+        panic!("expected workflow run params");
+    };
+    assert_eq!(params.id.0, "workflow_123");
+    assert_eq!(params.args[0].name, "name");
 }
 
 #[test]

--- a/crates/warp_cli/src/local_control/commands.rs
+++ b/crates/warp_cli/src/local_control/commands.rs
@@ -1,6 +1,7 @@
 //! Implementations for user-facing `warpctrl` command groups.
 use local_control::protocol::{
-    Action, ActionKind, ActionMetadata, ControlError, ErrorCode, RequestEnvelope,
+    Action, ActionKind, ActionMetadata, ActionParams, ControlError, DriveObjectId, ErrorCode,
+    RequestEnvelope, WorkflowRunParams,
 };
 use local_control::selection::select_instance;
 use serde::Serialize;
@@ -9,7 +10,10 @@ use serde_json::json;
 use crate::agent::OutputFormat;
 use crate::local_control::output::{write_json, write_json_line};
 use crate::local_control::selectors::instance_selector;
-use crate::local_control::{AppCommand, InstanceCommand, TabCommand, TargetArgs};
+use crate::local_control::{
+    AppCommand, DriveCommand, DriveWorkflowCommand, InputCommand, InstanceCommand, TabCommand,
+    TargetArgs,
+};
 
 /// Display-oriented projection of a discoverable Warp instance.
 #[derive(Serialize)]
@@ -98,6 +102,49 @@ pub(super) fn run_tab_command(
             run_action(args, ActionKind::TabCreate, json!({}), output_format)
         }
     }
+}
+
+pub(super) fn run_input_command(
+    command: InputCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        InputCommand::Run(args) => run_action(
+            args.target,
+            ActionKind::InputRun,
+            action_params(ActionParams::Text { text: args.text })?,
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_drive_command(
+    command: DriveCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        DriveCommand::Workflow(command) => match command {
+            DriveWorkflowCommand::Run(args) => run_action(
+                args.target,
+                ActionKind::DriveWorkflowRun,
+                action_params(ActionParams::WorkflowRun(WorkflowRunParams {
+                    id: DriveObjectId(args.id),
+                    args: args.args,
+                }))?,
+                output_format,
+            ),
+        },
+    }
+}
+
+fn action_params(params: ActionParams) -> Result<serde_json::Value, ControlError> {
+    serde_json::to_value(params).map_err(|err| {
+        ControlError::with_details(
+            ErrorCode::InvalidParams,
+            "failed to encode local-control action parameters",
+            err.to_string(),
+        )
+    })
 }
 
 fn run_action(

--- a/crates/warp_cli/src/local_control/mod.rs
+++ b/crates/warp_cli/src/local_control/mod.rs
@@ -10,7 +10,9 @@ use crate::agent::OutputFormat;
 use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::aot::Shell;
 
-use commands::{run_app_command, run_instance_command, run_tab_command};
+use commands::{
+    run_app_command, run_drive_command, run_input_command, run_instance_command, run_tab_command,
+};
 use completions::generate_completions_to_stdout;
 use output::write_control_error;
 
@@ -75,6 +77,14 @@ pub enum ControlCommand {
     #[command(subcommand)]
     Tab(TabCommand),
 
+    /// Execute terminal input actions.
+    #[command(subcommand)]
+    Input(InputCommand),
+
+    /// Run approved Warp Drive actions.
+    #[command(subcommand)]
+    Drive(DriveCommand),
+
     /// Generate shell completions for your shell to stdout.
     ///
     /// For bash, add the following to ~/.bashrc:
@@ -122,6 +132,52 @@ pub enum TabCommand {
     Create(TargetArgs),
 }
 
+/// Commands that operate on terminal input.
+#[derive(Debug, Clone, Subcommand)]
+pub enum InputCommand {
+    /// Run text in the targeted terminal session.
+    Run(InputRunArgs),
+}
+
+/// Commands that operate on Warp Drive.
+#[derive(Debug, Clone, Subcommand)]
+pub enum DriveCommand {
+    /// Operate on Warp Drive workflows.
+    #[command(subcommand)]
+    Workflow(DriveWorkflowCommand),
+}
+
+/// Commands that operate on Warp Drive workflows.
+#[derive(Debug, Clone, Subcommand)]
+pub enum DriveWorkflowCommand {
+    /// Run a Warp Drive workflow by ID.
+    Run(DriveWorkflowRunArgs),
+}
+
+/// Arguments for `input run`.
+#[derive(Debug, Clone, Args)]
+pub struct InputRunArgs {
+    /// Text to run in the target terminal.
+    pub text: String,
+
+    #[command(flatten)]
+    pub target: TargetArgs,
+}
+
+/// Arguments for `drive workflow run`.
+#[derive(Debug, Clone, Args)]
+pub struct DriveWorkflowRunArgs {
+    /// Workflow object ID to run.
+    pub id: String,
+
+    /// Name=value workflow argument. Repeat for multiple arguments.
+    #[arg(long = "arg", value_parser = parse_workflow_argument)]
+    pub args: Vec<local_control::protocol::WorkflowArgument>,
+
+    #[command(flatten)]
+    pub target: TargetArgs,
+}
+
 /// Common flags for selecting which running Warp instance receives a command.
 #[derive(Debug, Clone, Args, Default)]
 pub struct TargetArgs {
@@ -156,8 +212,25 @@ fn run_inner(args: ControlArgs) -> Result<(), local_control::protocol::ControlEr
         ControlCommand::Instance(command) => run_instance_command(command, output_format),
         ControlCommand::App(command) => run_app_command(command, output_format),
         ControlCommand::Tab(command) => run_tab_command(command, output_format),
+        ControlCommand::Input(command) => run_input_command(command, output_format),
+        ControlCommand::Drive(command) => run_drive_command(command, output_format),
         ControlCommand::Completions { shell } => generate_completions_to_stdout(shell),
     }
+}
+
+fn parse_workflow_argument(
+    value: &str,
+) -> Result<local_control::protocol::WorkflowArgument, String> {
+    let Some((name, argument_value)) = value.split_once('=') else {
+        return Err("workflow arguments must be formatted as name=value".to_owned());
+    };
+    if name.trim().is_empty() {
+        return Err("workflow argument names must be non-empty".to_owned());
+    }
+    Ok(local_control::protocol::WorkflowArgument {
+        name: name.to_owned(),
+        value: argument_value.to_owned(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/warp_cli/src/local_control_tests.rs
+++ b/crates/warp_cli/src/local_control_tests.rs
@@ -49,6 +49,43 @@ fn parses_first_slice_app_smoke_metadata_commands() {
 }
 
 #[test]
+fn parses_execution_underlying_commands() {
+    let args = ControlArgs::try_parse_from([
+        "warpctrl",
+        "input",
+        "run",
+        "cargo check",
+        "--instance",
+        "inst_123",
+    ])
+    .expect("input run parses");
+    let ControlCommand::Input(InputCommand::Run(input_args)) = args.command else {
+        panic!("expected input run command");
+    };
+    assert_eq!(input_args.text, "cargo check");
+    assert_eq!(input_args.target.instance.as_deref(), Some("inst_123"));
+
+    let args = ControlArgs::try_parse_from([
+        "warpctrl",
+        "drive",
+        "workflow",
+        "run",
+        "workflow_123",
+        "--arg",
+        "name=value",
+    ])
+    .expect("drive workflow run parses");
+    let ControlCommand::Drive(DriveCommand::Workflow(DriveWorkflowCommand::Run(workflow_args))) =
+        args.command
+    else {
+        panic!("expected drive workflow run command");
+    };
+    assert_eq!(workflow_args.id, "workflow_123");
+    assert_eq!(workflow_args.args[0].name, "name");
+    assert_eq!(workflow_args.args[0].value, "value");
+}
+
+#[test]
 fn parses_completion_generation_command() {
     let args = ControlArgs::try_parse_from(["warpctrl", "completions", "bash"])
         .expect("completions parses");
@@ -73,6 +110,8 @@ fn generated_bash_completions_include_first_slice_commands() {
         generate_completion_string(Shell::Bash).expect("bash completions render to UTF-8");
     assert!(completions.contains("instance"));
     assert!(completions.contains("tab"));
+    assert!(completions.contains("input"));
+    assert!(completions.contains("drive"));
     assert!(completions.contains("completions"));
 }
 


### PR DESCRIPTION
## Summary
- Implements canonical `input.run` and `drive.workflow.run` as implemented warpctrl actions.
- Adds fail-closed execution handlers with structured audit payloads; no command/workflow execution occurs until an explicit execution approval policy is added.
- Adds CLI parsing/routing and tests for permission classification, excluded submission names, malformed params, and fail-closed behavior.

## Validation
- `git diff --cached --check` passed before commit.
- Static excluded action implementation grep passed.
- Rust validation skipped: `rustc`, `cargo`, and `rustfmt` are not installed in this cloud image.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/85d2b223-1307-47de-a597-6d0cb30685b5_
_Run: https://oz.staging.warp.dev/runs/019e6259-399f-7d33-922d-e3caf6335c36_
_This PR was generated with [Oz](https://warp.dev/oz)._
