### PR TITLE
Implement warpctrl readonly capability targets

### DIFF
--- a/app/src/local_control/bridge.rs
+++ b/app/src/local_control/bridge.rs
@@ -9,7 +9,9 @@ use ::local_control::{
 };
 use warpui::{Entity, ModelContext, SingletonEntity};
 
-use crate::local_control::handlers::{layout, metadata};
+use crate::local_control::handlers::{
+    data, drive, layout, metadata, product_metadata, settings_surfaces,
+};
 use crate::local_control::permissions::{ensure_action_allowed, ensure_feature_enabled};
 use crate::local_control::resolver::validate_action_params;
 
@@ -94,6 +96,261 @@ impl LocalControlBridge {
                 }
                 ResponseEnvelope::ok(request.request_id, metadata::version(&self.instance_id))
             }
+            ActionKind::AppActive => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, metadata::active(&self.instance_id, ctx))
+            }
+            ActionKind::InstanceInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(
+                    request.request_id,
+                    metadata::inspect(&self.instance_id, ctx),
+                )
+            }
+            ActionKind::CapabilityList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, metadata::capability_list())
+            }
+            ActionKind::CapabilityInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::capability_inspect(&request.action) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::ActionList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                ResponseEnvelope::ok(request.request_id, metadata::action_list())
+            }
+            ActionKind::ActionInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::action_inspect(&request.action) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::WindowList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::window_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::TabList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::tab_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::TabInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::tab_inspect(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::PaneList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::pane_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::PaneInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::pane_inspect(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::SessionList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::session_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::SessionInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::session_inspect(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::WindowInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match metadata::window_inspect(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::ThemeList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match settings_surfaces::theme_list(ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::ThemeGet => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match settings_surfaces::theme_get(ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::AppearanceGet => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match settings_surfaces::appearance_get(ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::SettingList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match settings_surfaces::setting_list(ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::SettingGet => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match settings_surfaces::setting_get(&request.action, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::KeybindingList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match settings_surfaces::keybinding_list(ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::KeybindingGet => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match settings_surfaces::keybinding_get(&request.action, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::FileList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match product_metadata::file_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::ProjectActive => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match product_metadata::project_active(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::ProjectList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match product_metadata::project_list(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
             ActionKind::TabCreate => {
                 if let Err(error) =
                     ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
@@ -101,6 +358,99 @@ impl LocalControlBridge {
                     return ResponseEnvelope::error(request.request_id, error);
                 }
                 match layout::create_terminal_tab(&self.instance_id, &request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::BlockList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match request
+                    .action
+                    .params_as()
+                    .and_then(|params| data::list_blocks(&request.target, params, ctx))
+                {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::BlockInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match request
+                    .action
+                    .params_as()
+                    .and_then(|params| data::get_block(&request.target, params, ctx))
+                {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::BlockOutput => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match request
+                    .action
+                    .params_as()
+                    .and_then(|params| data::get_block(&request.target, params, ctx))
+                {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::InputGet => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match data::get_input_state(&request.target, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::HistoryList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match request
+                    .action
+                    .params_as()
+                    .and_then(|params| data::list_history(&request.target, params, ctx))
+                {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::DriveList => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match drive::drive_list(&request.target, &request.action, ctx) {
+                    Ok(data) => ResponseEnvelope::ok(request.request_id, data),
+                    Err(error) => ResponseEnvelope::error(request.request_id, error),
+                }
+            }
+            ActionKind::DriveInspect => {
+                if let Err(error) =
+                    ensure_action_allowed(grant.invocation_context, request.action.kind, ctx)
+                {
+                    return ResponseEnvelope::error(request.request_id, error);
+                }
+                match drive::drive_inspect(&request.target, &request.action, ctx) {
                     Ok(data) => ResponseEnvelope::ok(request.request_id, data),
                     Err(error) => ResponseEnvelope::error(request.request_id, error),
                 }

--- a/app/src/local_control/handlers.rs
+++ b/app/src/local_control/handlers.rs
@@ -1,3 +1,7 @@
 //! App-side action handlers invoked by the local-control bridge.
+pub(super) mod data;
+pub(super) mod drive;
 pub(super) mod layout;
 pub(super) mod metadata;
+pub(super) mod product_metadata;
+pub(super) mod settings_surfaces;

--- a/app/src/local_control/handlers/data.rs
+++ b/app/src/local_control/handlers/data.rs
@@ -1,0 +1,410 @@
+use ::local_control::protocol::{
+    BlockIdParams, BlockInspectResult, BlockListParams, BlockListResult, BlockSummary,
+    HistoryEntrySummary, HistoryListParams, HistoryListResult, InputStateResult, PaneTarget,
+    SessionTarget, TabTarget, TargetSelector, WindowTarget,
+};
+use ::local_control::{ActionKind, ControlError, ErrorCode};
+use warpui::{ModelContext, SingletonEntity, ViewHandle};
+
+use crate::local_control::resolver::require_active_window_id_for_action;
+use crate::local_control::LocalControlBridge;
+use crate::pane_group::{PaneGroup, PaneId};
+use crate::terminal::model::session::SessionId;
+use crate::terminal::model::TerminalModel;
+use crate::terminal::view::TerminalView;
+use crate::terminal::History;
+use crate::workspace::Workspace;
+
+struct ResolvedTerminalTarget {
+    terminal_view: ViewHandle<TerminalView>,
+}
+
+pub(crate) fn get_input_state(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let resolved = resolve_terminal_read_target(ActionKind::InputGet, target, ctx)?;
+    let session_id = resolved
+        .terminal_view
+        .read(ctx, |terminal, _| terminal.active_block_session_id())
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                "input.get requires a target terminal session",
+            )
+        })?;
+    let input = resolved
+        .terminal_view
+        .read(ctx, |terminal, _| terminal.input().clone());
+    let (text, cursor_offset) = input.read(ctx, |input, ctx| {
+        let cursor_offset = input
+            .editor()
+            .as_ref(ctx)
+            .start_byte_index_of_first_selection(ctx)
+            .as_usize();
+        (input.buffer_text(ctx), cursor_offset)
+    });
+    let cursor_offset = u32::try_from(cursor_offset).map_err(|err| {
+        ControlError::with_details(
+            ErrorCode::Internal,
+            "input cursor offset is too large to encode",
+            err.to_string(),
+        )
+    })?;
+    to_control_data(InputStateResult {
+        session_id: session_id.as_u64().to_string(),
+        text,
+        cursor_offset,
+    })
+}
+
+pub(crate) fn list_history(
+    target: &TargetSelector,
+    params: HistoryListParams,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let resolved = resolve_terminal_read_target(ActionKind::HistoryList, target, ctx)?;
+    let session_id = resolved
+        .terminal_view
+        .read(ctx, |terminal, _| terminal.active_block_session_id())
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                "history.list requires a target terminal session",
+            )
+        })?;
+    let commands = History::as_ref(ctx)
+        .is_queryable(&session_id)
+        .then(|| {
+            History::as_ref(ctx)
+                .commands_shared(session_id)
+                .unwrap_or_default()
+        })
+        .unwrap_or_default();
+    let start_index = params
+        .limit
+        .and_then(|limit| usize::try_from(limit).ok())
+        .map(|limit| commands.len().saturating_sub(limit))
+        .unwrap_or_default();
+    let entries = commands
+        .iter()
+        .enumerate()
+        .skip(start_index)
+        .map(|(index, entry)| HistoryEntrySummary {
+            entry_id: format!("history:{}:{index}", session_id.as_u64()),
+            command: entry.command.clone(),
+            cwd: entry.pwd.clone(),
+        })
+        .collect();
+    to_control_data(HistoryListResult { entries })
+}
+
+pub(crate) fn list_blocks(
+    target: &TargetSelector,
+    params: BlockListParams,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    validate_block_list_target(target)?;
+    let terminal = target_terminal_view(ctx)?;
+    let result = terminal.read(ctx, |view, _| {
+        let session_id = resolve_session_selector(
+            target.session.as_ref(),
+            view.active_block_session_id(),
+            ActionKind::BlockList,
+        )?;
+        let model = view.model.lock();
+        block_list_result_from_model(&model, session_id, target.session.is_some(), params)
+    })?;
+    to_control_data(result)
+}
+
+pub(crate) fn get_block(
+    target: &TargetSelector,
+    params: BlockIdParams,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    validate_block_get_target(target)?;
+    let terminal = target_terminal_view(ctx)?;
+    let result = terminal.read(ctx, |view, _| {
+        let session_id = resolve_session_selector(
+            target.session.as_ref(),
+            view.active_block_session_id(),
+            ActionKind::BlockInspect,
+        )?;
+        let model = view.model.lock();
+        block_get_result_from_model(&model, session_id, &params.block_id)
+    })?;
+    to_control_data(result)
+}
+
+pub(crate) fn validate_terminal_read_target(
+    action: ActionKind,
+    target: &TargetSelector,
+) -> Result<(), ControlError> {
+    validate_active_terminal_target(action, target)?;
+    if matches!(target.session.as_ref(), Some(SessionTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            format!(
+                "{} cannot resolve the requested session id",
+                action.as_str()
+            ),
+        ));
+    }
+    if !matches!(target.session.as_ref(), None | Some(SessionTarget::Active)) {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!(
+                "{} only supports the active session selector",
+                action.as_str()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_block_list_target(target: &TargetSelector) -> Result<(), ControlError> {
+    validate_active_terminal_target(ActionKind::BlockList, target)
+}
+
+pub(crate) fn validate_block_get_target(target: &TargetSelector) -> Result<(), ControlError> {
+    validate_active_terminal_target(ActionKind::BlockInspect, target)
+}
+
+fn validate_active_terminal_target(
+    action: ActionKind,
+    target: &TargetSelector,
+) -> Result<(), ControlError> {
+    let action_name = action.as_str();
+    if matches!(target.window.as_ref(), Some(WindowTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            format!("{action_name} cannot resolve the requested window id"),
+        ));
+    }
+    if !matches!(target.window.as_ref(), None | Some(WindowTarget::Active)) {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!("{action_name} only supports the active window selector"),
+        ));
+    }
+    if matches!(target.tab.as_ref(), Some(TabTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            format!("{action_name} cannot resolve the requested tab id"),
+        ));
+    }
+    if !matches!(target.tab.as_ref(), None | Some(TabTarget::Active)) {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!("{action_name} only supports the active tab selector"),
+        ));
+    }
+    if matches!(target.pane.as_ref(), Some(PaneTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            format!("{action_name} cannot resolve the requested pane id"),
+        ));
+    }
+    if !matches!(target.pane.as_ref(), None | Some(PaneTarget::Active)) {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!("{action_name} only supports the active pane selector"),
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_terminal_read_target(
+    action: ActionKind,
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<ResolvedTerminalTarget, ControlError> {
+    validate_terminal_read_target(action, target)?;
+    let window_id = require_active_window_id_for_action(ctx.windows().active_window(), action)?;
+    if let Some(workspace) = ctx
+        .views_of_type::<Workspace>(window_id)
+        .and_then(|workspaces| workspaces.into_iter().next())
+    {
+        let pane_group = workspace.read(ctx, |workspace, _| {
+            workspace.active_tab_pane_group().clone()
+        });
+        return resolve_terminal_in_pane_group(action, target, pane_group, ctx);
+    }
+    let terminal_view = ctx
+        .views_of_type::<TerminalView>(window_id)
+        .and_then(|terminals| terminals.into_iter().next())
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                format!("{} requires a target terminal session", action.as_str()),
+            )
+        })?;
+    Ok(ResolvedTerminalTarget { terminal_view })
+}
+
+fn resolve_terminal_in_pane_group(
+    action: ActionKind,
+    target: &TargetSelector,
+    pane_group: ViewHandle<PaneGroup>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<ResolvedTerminalTarget, ControlError> {
+    let terminal_view = pane_group.read(ctx, |pane_group, ctx| {
+        let pane_id = if matches!(target.pane, Some(PaneTarget::Active)) {
+            pane_group.focused_pane_id(ctx)
+        } else {
+            pane_group
+                .active_session_id(ctx)
+                .map(PaneId::from)
+                .ok_or_else(|| {
+                    ControlError::new(
+                        ErrorCode::MissingTarget,
+                        format!("{} requires an active terminal session", action.as_str()),
+                    )
+                })?
+        };
+        let terminal_view = pane_group
+            .terminal_view_from_pane_id(pane_id, ctx)
+            .ok_or_else(|| {
+                ControlError::new(
+                    ErrorCode::TargetStateConflict,
+                    format!(
+                        "{} target pane does not contain a terminal session",
+                        action.as_str()
+                    ),
+                )
+            })?;
+        Ok::<_, ControlError>(terminal_view)
+    })?;
+    Ok(ResolvedTerminalTarget { terminal_view })
+}
+
+fn target_terminal_view(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<ViewHandle<TerminalView>, ControlError> {
+    let window_id =
+        require_active_window_id_for_action(ctx.windows().active_window(), ActionKind::BlockList)?;
+    let workspace = ctx
+        .views_of_type::<Workspace>(window_id)
+        .and_then(|workspaces| workspaces.into_iter().next())
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                "block read requires a workspace in the target window",
+            )
+        })?;
+    workspace
+        .read(ctx, |workspace, ctx| {
+            workspace
+                .active_tab_pane_group()
+                .read(ctx, |pane_group, ctx| pane_group.active_session_view(ctx))
+        })
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                "block read requires an active terminal session",
+            )
+        })
+}
+
+fn resolve_session_selector(
+    target: Option<&SessionTarget>,
+    active_session_id: Option<SessionId>,
+    action: ActionKind,
+) -> Result<SessionId, ControlError> {
+    match target {
+        None | Some(SessionTarget::Active) => active_session_id.ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                format!("{} requires an active terminal session", action.as_str()),
+            )
+        }),
+        Some(SessionTarget::Id { id }) => id.0.parse::<u64>().map(SessionId::from).map_err(|err| {
+            ControlError::with_details(
+                ErrorCode::InvalidSelector,
+                format!("{} received an invalid session id", action.as_str()),
+                err.to_string(),
+            )
+        }),
+    }
+}
+
+fn block_summary(
+    block: &crate::terminal::model::block::Block,
+    index: usize,
+) -> Option<BlockSummary> {
+    let session_id = block.session_id()?;
+    let command = block.command_to_string();
+    Some(BlockSummary {
+        block_id: block.id().to_string(),
+        session_id: session_id.as_u64().to_string(),
+        index: index as u32,
+        command: (!command.is_empty()).then_some(command),
+    })
+}
+
+fn block_list_result_from_model(
+    model: &TerminalModel,
+    session_id: SessionId,
+    explicit_session: bool,
+    params: BlockListParams,
+) -> Result<BlockListResult, ControlError> {
+    let mut blocks: Vec<BlockSummary> = model
+        .block_list()
+        .blocks()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, block)| {
+            let summary = block_summary(block, index)?;
+            (summary.session_id == session_id.as_u64().to_string()).then_some(summary)
+        })
+        .collect();
+    if explicit_session && blocks.is_empty() {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "block.list cannot resolve the requested session id",
+        ));
+    }
+    if let Some(limit) = params.limit {
+        let start = blocks.len().saturating_sub(limit as usize);
+        blocks = blocks.split_off(start);
+    }
+    Ok(BlockListResult { blocks })
+}
+
+fn block_get_result_from_model(
+    model: &TerminalModel,
+    session_id: SessionId,
+    block_id: &str,
+) -> Result<BlockInspectResult, ControlError> {
+    model
+        .block_list()
+        .blocks()
+        .iter()
+        .enumerate()
+        .find_map(|(index, block)| {
+            if block.id().as_str() != block_id || block.session_id() != Some(session_id) {
+                return None;
+            }
+            block_summary(block, index).map(|summary| BlockInspectResult {
+                block: summary,
+                output: Some(block.output_to_string()),
+            })
+        })
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::StaleTarget,
+                "block.inspect cannot resolve the requested block id",
+            )
+        })
+}
+
+fn to_control_data<T: serde::Serialize>(data: T) -> Result<serde_json::Value, ControlError> {
+    serde_json::to_value(data).map_err(|err| {
+        ControlError::with_details(
+            ErrorCode::Internal,
+            "failed to encode local-control response",
+            err.to_string(),
+        )
+    })
+}

--- a/app/src/local_control/handlers/drive.rs
+++ b/app/src/local_control/handlers/drive.rs
@@ -1,0 +1,210 @@
+use ::local_control::protocol::{
+    DriveInspectParams, DriveInspectResult, DriveListParams, DriveListResult, DriveObjectSummary,
+    DriveObjectType, TargetSelector,
+};
+use ::local_control::{ActionKind, ControlError, ErrorCode};
+use serde_json::json;
+use warpui::{ModelContext, SingletonEntity};
+
+use crate::cloud_object::{
+    model::persistence::CloudModel, CloudObject, GenericStringObjectFormat, JsonObjectType,
+    ObjectType,
+};
+use crate::drive::folders::CloudFolder;
+use crate::env_vars::CloudEnvVarCollection;
+use crate::local_control::LocalControlBridge;
+use crate::notebooks::CloudNotebook;
+use crate::workflows::CloudWorkflow;
+
+pub(crate) fn drive_list(
+    target: &TargetSelector,
+    action: &::local_control::Action,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    validate_drive_target(target, ActionKind::DriveList)?;
+    let params = action.params_as::<DriveListParams>()?;
+    let mut objects = CloudModel::as_ref(ctx)
+        .cloud_objects()
+        .filter_map(|object| drive_object_summary(object.as_ref()))
+        .filter(|summary| {
+            params
+                .object_type
+                .is_none_or(|object_type| summary.object_type == object_type)
+        })
+        .collect::<Vec<_>>();
+    objects.sort_by(|left, right| {
+        drive_object_type_rank(left.object_type)
+            .cmp(&drive_object_type_rank(right.object_type))
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    serde_json::to_value(DriveListResult { objects }).map_err(json_response_error)
+}
+
+pub(crate) fn drive_inspect(
+    target: &TargetSelector,
+    action: &::local_control::Action,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    validate_drive_target(target, ActionKind::DriveInspect)?;
+    let params = action.params_as::<DriveInspectParams>()?;
+    let object = CloudModel::as_ref(ctx)
+        .get_by_uid(&params.id)
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::StaleTarget,
+                "drive.inspect could not resolve the requested Drive object id",
+            )
+        })?;
+    drive_object_get_result(object)
+        .and_then(|result| serde_json::to_value(result).map_err(json_response_error))
+}
+
+pub(crate) fn validate_drive_target(
+    target: &TargetSelector,
+    action: ActionKind,
+) -> Result<(), ControlError> {
+    if target.window.is_some()
+        || target.tab.is_some()
+        || target.pane.is_some()
+        || target.session.is_some()
+    {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!(
+                "{} does not accept window, tab, pane, or session selectors",
+                action.as_str()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn drive_object_summary(object: &dyn CloudObject) -> Option<DriveObjectSummary> {
+    Some(DriveObjectSummary {
+        object_type: control_drive_object_type(object)?,
+        id: object.uid(),
+        name: object.display_name(),
+    })
+}
+
+fn drive_object_get_result(object: &dyn CloudObject) -> Result<DriveInspectResult, ControlError> {
+    let summary = drive_object_summary(object).ok_or_else(|| {
+        ControlError::new(
+            ErrorCode::UnsupportedAction,
+            "drive.inspect does not support this Drive object type",
+        )
+    })?;
+    Ok(DriveInspectResult {
+        object: summary,
+        content: drive_object_content(object)?,
+    })
+}
+
+fn control_drive_object_type(object: &dyn CloudObject) -> Option<DriveObjectType> {
+    match object.object_type() {
+        ObjectType::Workflow => {
+            let workflow = object.as_any().downcast_ref::<CloudWorkflow>()?;
+            if workflow.model().data.is_agent_mode_workflow() {
+                Some(DriveObjectType::Prompt)
+            } else {
+                Some(DriveObjectType::Workflow)
+            }
+        }
+        ObjectType::Notebook => Some(DriveObjectType::Notebook),
+        ObjectType::Folder => Some(DriveObjectType::Folder),
+        ObjectType::GenericStringObject(GenericStringObjectFormat::Json(
+            JsonObjectType::EnvVarCollection,
+        )) => Some(DriveObjectType::EnvVarCollection),
+        ObjectType::GenericStringObject(GenericStringObjectFormat::Json(
+            JsonObjectType::AIFact,
+        )) => Some(DriveObjectType::AiFact),
+        ObjectType::GenericStringObject(GenericStringObjectFormat::Json(
+            JsonObjectType::MCPServer | JsonObjectType::TemplatableMCPServer,
+        )) => Some(DriveObjectType::McpServer),
+        _ => None,
+    }
+}
+
+fn drive_object_content(object: &dyn CloudObject) -> Result<serde_json::Value, ControlError> {
+    match control_drive_object_type(object).ok_or_else(drive_unsupported_type_error)? {
+        DriveObjectType::Workflow | DriveObjectType::Prompt => object
+            .as_any()
+            .downcast_ref::<CloudWorkflow>()
+            .ok_or_else(drive_type_mismatch_error)
+            .and_then(|workflow| {
+                serde_json::to_value(&workflow.model().data).map_err(json_response_error)
+            }),
+        DriveObjectType::Notebook => {
+            let notebook = object
+                .as_any()
+                .downcast_ref::<CloudNotebook>()
+                .ok_or_else(drive_type_mismatch_error)?;
+            Ok(json!({
+                "title": notebook.model().title.clone(),
+                "data": notebook.model().data.clone(),
+                "ai_document_id": notebook.model().ai_document_id.as_ref().map(|id| id.to_string()),
+                "conversation_id": notebook.model().conversation_id.clone(),
+            }))
+        }
+        DriveObjectType::EnvVarCollection => object
+            .as_any()
+            .downcast_ref::<CloudEnvVarCollection>()
+            .ok_or_else(drive_type_mismatch_error)
+            .and_then(|env_var_collection| {
+                serde_json::to_value(&env_var_collection.model().string_model)
+                    .map_err(json_response_error)
+            }),
+        DriveObjectType::Folder => {
+            let folder = object
+                .as_any()
+                .downcast_ref::<CloudFolder>()
+                .ok_or_else(drive_type_mismatch_error)?;
+            Ok(json!({
+                "name": folder.model().name.clone(),
+                "is_open": folder.model().is_open,
+                "is_warp_pack": folder.model().is_warp_pack,
+            }))
+        }
+        DriveObjectType::AiFact
+        | DriveObjectType::McpServer
+        | DriveObjectType::Space
+        | DriveObjectType::Trash => Err(drive_unsupported_type_error()),
+    }
+}
+
+fn drive_object_type_rank(object_type: DriveObjectType) -> u8 {
+    match object_type {
+        DriveObjectType::Workflow => 0,
+        DriveObjectType::Prompt => 1,
+        DriveObjectType::Notebook => 2,
+        DriveObjectType::EnvVarCollection => 3,
+        DriveObjectType::Folder => 4,
+        DriveObjectType::AiFact => 5,
+        DriveObjectType::McpServer => 6,
+        DriveObjectType::Space => 7,
+        DriveObjectType::Trash => 8,
+    }
+}
+
+fn drive_type_mismatch_error() -> ControlError {
+    ControlError::new(
+        ErrorCode::TargetStateConflict,
+        "drive.inspect Drive object type does not match the resolved object",
+    )
+}
+
+fn drive_unsupported_type_error() -> ControlError {
+    ControlError::new(
+        ErrorCode::UnsupportedAction,
+        "drive.inspect content reads are not supported for this Drive object type",
+    )
+}
+
+fn json_response_error(error: serde_json::Error) -> ControlError {
+    ControlError::with_details(
+        ErrorCode::Internal,
+        "failed to encode local-control Drive response",
+        error.to_string(),
+    )
+}

--- a/app/src/local_control/handlers/metadata.rs
+++ b/app/src/local_control/handlers/metadata.rs
@@ -1,7 +1,32 @@
 //! Metadata response builders for local-control introspection actions.
-use ::local_control::{ActionKind, InstanceId, PROTOCOL_VERSION};
-use serde_json::json;
+use ::local_control::protocol::{
+    ActionNameParams, ActiveTargetChain, PaneTarget, SessionTarget, TabTarget, TargetSelector,
+    WindowTarget,
+};
+use ::local_control::{ActionKind, ControlError, ErrorCode, InstanceId, PROTOCOL_VERSION};
+use serde_json::{json, Value};
 use warp_core::channel::ChannelState;
+use warpui::{ModelContext, ViewHandle, WindowId};
+
+use crate::local_control::LocalControlBridge;
+use crate::pane_group::{PaneGroup, PaneId};
+use crate::workspace::Workspace;
+
+#[derive(Clone)]
+struct TabEntry {
+    window_id: WindowId,
+    index: usize,
+    workspace_active_tab_index: usize,
+    pane_group: ViewHandle<PaneGroup>,
+}
+
+#[derive(Clone)]
+struct PaneEntry {
+    tab_id: String,
+    index: usize,
+    pane_group: ViewHandle<PaneGroup>,
+    pane_id: PaneId,
+}
 
 pub(crate) fn instance(instance_id: &Option<InstanceId>) -> serde_json::Value {
     json!({
@@ -33,5 +58,658 @@ pub(crate) fn version(instance_id: &Option<InstanceId>) -> serde_json::Value {
         "channel": ChannelState::channel().to_string(),
         "app_id": ChannelState::app_id().to_string(),
         "app_version": ChannelState::app_version(),
+    })
+}
+
+pub(crate) fn active(
+    instance_id: &Option<InstanceId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> serde_json::Value {
+    json!({
+        "action": ActionKind::AppActive.as_str(),
+        "active": active_chain(instance_id, ctx),
+    })
+}
+
+pub(crate) fn inspect(
+    instance_id: &Option<InstanceId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> serde_json::Value {
+    json!({
+        "action": ActionKind::InstanceInspect.as_str(),
+        "instance_id": instance_id.as_ref().map(|id| id.0.as_str()),
+        "version": {
+            "protocol_version": PROTOCOL_VERSION,
+            "channel": ChannelState::channel().to_string(),
+            "app_id": ChannelState::app_id().to_string(),
+            "app_version": ChannelState::app_version(),
+        },
+        "active": active_chain(instance_id, ctx),
+        "actions": ActionKind::implemented_metadata(),
+    })
+}
+
+pub(crate) fn action_list() -> serde_json::Value {
+    json!({
+        "action": ActionKind::ActionList.as_str(),
+        "actions": ActionKind::implemented_metadata(),
+    })
+}
+
+pub(crate) fn action_inspect(
+    action: &::local_control::Action,
+) -> Result<serde_json::Value, ControlError> {
+    let params = action.params_as::<ActionNameParams>()?;
+    let metadata = action_metadata_for_name(&params.action)?;
+    Ok(json!({
+        "action": ActionKind::ActionInspect.as_str(),
+        "requested_action": params.action,
+        "metadata": metadata,
+    }))
+}
+
+pub(crate) fn window_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let window_ids = select_window_ids(target, false, ActionKind::WindowList, ctx)?;
+    let active_window = ctx.windows().active_window();
+    let windows = window_ids
+        .into_iter()
+        .map(|window_id| {
+            let title = ctx
+                .views_of_type::<Workspace>(window_id)
+                .and_then(|workspaces| workspaces.into_iter().next())
+                .map(|workspace| {
+                    workspace.read(ctx, |workspace, ctx| {
+                        workspace
+                            .active_tab_pane_group()
+                            .as_ref(ctx)
+                            .display_title(ctx)
+                    })
+                });
+            json!({
+                "window_id": window_id.to_string(),
+                "is_active": Some(window_id) == active_window,
+                "title": title,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "action": ActionKind::WindowList.as_str(),
+        "windows": windows,
+    }))
+}
+
+pub(crate) fn tab_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    reject_target_families(
+        ActionKind::TabList,
+        target.pane.is_some() || target.session.is_some(),
+        "pane or session selectors",
+    )?;
+    let tabs = select_tab_entries(target, ActionKind::TabList, ctx)?
+        .into_iter()
+        .map(|entry| {
+            let title = entry
+                .pane_group
+                .read(ctx, |pane_group, ctx| pane_group.display_title(ctx));
+            json!({
+                "tab_id": entry.pane_group.id().to_string(),
+                "window_id": entry.window_id.to_string(),
+                "index": entry.index as u32,
+                "is_active": entry.index == entry.workspace_active_tab_index,
+                "title": title,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "action": ActionKind::TabList.as_str(),
+        "tabs": tabs,
+    }))
+}
+
+pub(crate) fn pane_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    reject_target_families(
+        ActionKind::PaneList,
+        target.session.is_some(),
+        "session selectors",
+    )?;
+    let panes = select_pane_entries(target, ActionKind::PaneList, ctx)?
+        .into_iter()
+        .map(|entry| {
+            let (is_active, has_terminal_session) =
+                entry.pane_group.read(ctx, |pane_group, ctx| {
+                    (
+                        pane_group.focused_pane_id(ctx) == entry.pane_id,
+                        pane_group
+                            .terminal_view_from_pane_id(entry.pane_id, ctx)
+                            .is_some(),
+                    )
+                });
+            json!({
+                "pane_id": entry.pane_id.to_string(),
+                "tab_id": entry.tab_id,
+                "index": entry.index as u32,
+                "is_active": is_active,
+                "has_terminal_session": has_terminal_session,
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "action": ActionKind::PaneList.as_str(),
+        "panes": panes,
+    }))
+}
+
+pub(crate) fn session_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let session_target = target.session.as_ref();
+    let session_id_filter = matches!(session_target, Some(SessionTarget::Id { .. }));
+    let sessions = select_pane_entries(target, ActionKind::SessionList, ctx)?
+        .into_iter()
+        .filter_map(|entry| {
+            let (is_active, has_terminal_session) =
+                entry.pane_group.read(ctx, |pane_group, ctx| {
+                    (
+                        pane_group.active_session_id(ctx).map(PaneId::from) == Some(entry.pane_id),
+                        pane_group
+                            .terminal_view_from_pane_id(entry.pane_id, ctx)
+                            .is_some(),
+                    )
+                });
+            if !has_terminal_session {
+                return None;
+            }
+            let session_id = entry.pane_id.to_string();
+            let matches_session = match session_target {
+                None => true,
+                Some(SessionTarget::Active) => is_active,
+                Some(SessionTarget::Id { id }) => id.0 == session_id,
+            };
+            matches_session.then(|| {
+                json!({
+                    "session_id": session_id,
+                    "pane_id": entry.pane_id.to_string(),
+                    "is_active": is_active,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    if session_id_filter && sessions.is_empty() {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "session.list cannot resolve the requested session id",
+        ));
+    }
+    Ok(json!({
+        "action": ActionKind::SessionList.as_str(),
+        "sessions": sessions,
+    }))
+}
+
+
+pub(crate) fn capability_list() -> serde_json::Value {
+    json!({
+        "action": ActionKind::CapabilityList.as_str(),
+        "capabilities": ActionKind::implemented_metadata(),
+    })
+}
+
+pub(crate) fn capability_inspect(
+    action: &::local_control::Action,
+) -> Result<serde_json::Value, ControlError> {
+    let params = action.params_as::<ActionNameParams>()?;
+    let metadata = action_metadata_for_name(&params.action)?;
+    Ok(json!({
+        "action": ActionKind::CapabilityInspect.as_str(),
+        "requested_action": params.action,
+        "capability": metadata,
+    }))
+}
+
+pub(crate) fn window_inspect(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let target = TargetSelector {
+        window: target.window.clone().or(Some(WindowTarget::Active)),
+        tab: None,
+        pane: None,
+        session: None,
+    };
+    let data = window_list(&target, ctx)?;
+    let window = single_entry(data.get("windows"), ActionKind::WindowInspect)?;
+    Ok(json!({
+        "action": ActionKind::WindowInspect.as_str(),
+        "window": window,
+    }))
+}
+
+pub(crate) fn tab_inspect(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let target = TargetSelector {
+        window: target.window.clone(),
+        tab: target.tab.clone().or(Some(TabTarget::Active)),
+        pane: None,
+        session: None,
+    };
+    let data = tab_list(&target, ctx)?;
+    let tab = single_entry(data.get("tabs"), ActionKind::TabInspect)?;
+    Ok(json!({
+        "action": ActionKind::TabInspect.as_str(),
+        "tab": tab,
+    }))
+}
+
+pub(crate) fn pane_inspect(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let target = TargetSelector {
+        window: target.window.clone(),
+        tab: target.tab.clone(),
+        pane: target.pane.clone().or(Some(PaneTarget::Active)),
+        session: None,
+    };
+    let data = pane_list(&target, ctx)?;
+    let pane = single_entry(data.get("panes"), ActionKind::PaneInspect)?;
+    Ok(json!({
+        "action": ActionKind::PaneInspect.as_str(),
+        "pane": pane,
+    }))
+}
+
+pub(crate) fn session_inspect(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let target = TargetSelector {
+        window: target.window.clone(),
+        tab: target.tab.clone(),
+        pane: target.pane.clone(),
+        session: target.session.clone().or(Some(SessionTarget::Active)),
+    };
+    let data = session_list(&target, ctx)?;
+    let session = single_entry(data.get("sessions"), ActionKind::SessionInspect)?;
+    Ok(json!({
+        "action": ActionKind::SessionInspect.as_str(),
+        "session": session,
+    }))
+}
+
+fn single_entry(value: Option<&Value>, action: ActionKind) -> Result<Value, ControlError> {
+    let Some(items) = value.and_then(Value::as_array) else {
+        return Err(ControlError::new(
+            ErrorCode::Internal,
+            format!("{} handler returned malformed metadata", action.as_str()),
+        ));
+    };
+    if items.len() == 1 {
+        return Ok(items[0].clone());
+    }
+    if items.is_empty() {
+        return Err(ControlError::new(
+            ErrorCode::MissingTarget,
+            format!("{} could not resolve a target", action.as_str()),
+        ));
+    }
+    Err(ControlError::new(
+        ErrorCode::AmbiguousTarget,
+        format!("{} resolved multiple targets", action.as_str()),
+    ))
+}
+
+pub(crate) fn action_metadata_for_name(
+    action_name: &str,
+) -> Result<::local_control::ActionMetadata, ControlError> {
+    ActionKind::ALL
+        .iter()
+        .copied()
+        .find(|kind| kind.as_str() == action_name)
+        .map(ActionKind::metadata)
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::NotAllowlisted,
+                format!("{action_name} is not an allowlisted local-control action"),
+            )
+        })
+}
+
+fn active_chain(
+    instance_id: &Option<InstanceId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> ActiveTargetChain {
+    let instance_id = instance_id.as_ref().map(|id| id.0.clone());
+    let active_window = ctx.windows().active_window();
+    let Some(window_id) = active_window else {
+        return ActiveTargetChain {
+            instance_id,
+            window_id: None,
+            tab_id: None,
+            pane_id: None,
+            session_id: None,
+        };
+    };
+    let window_id_string = window_id.to_string();
+    let workspace = ctx
+        .views_of_type::<Workspace>(window_id)
+        .and_then(|workspaces| workspaces.into_iter().next());
+    let Some(workspace) = workspace else {
+        return ActiveTargetChain {
+            instance_id,
+            window_id: Some(window_id_string),
+            tab_id: None,
+            pane_id: None,
+            session_id: None,
+        };
+    };
+    let (tab_id, pane_id, session_id) = workspace.read(ctx, |workspace, ctx| {
+        let pane_group = workspace.active_tab_pane_group();
+        let pane_group_ref = pane_group.as_ref(ctx);
+        let pane_id = pane_group_ref.focused_pane_id(ctx);
+        let session_id = pane_group_ref
+            .active_session_id(ctx)
+            .map(|session_id| PaneId::from(session_id).to_string());
+        (
+            Some(pane_group.id().to_string()),
+            Some(pane_id.to_string()),
+            session_id,
+        )
+    });
+    ActiveTargetChain {
+        instance_id,
+        window_id: Some(window_id_string),
+        tab_id,
+        pane_id,
+        session_id,
+    }
+}
+
+fn reject_target_families(
+    action: ActionKind,
+    rejected: bool,
+    families: &str,
+) -> Result<(), ControlError> {
+    if rejected {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!("{} does not accept {families}", action.as_str()),
+        ));
+    }
+    Ok(())
+}
+
+fn select_window_ids(
+    target: &TargetSelector,
+    force_active_default: bool,
+    action: ActionKind,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<Vec<WindowId>, ControlError> {
+    if action == ActionKind::WindowList {
+        reject_target_families(
+            action,
+            target.tab.is_some() || target.pane.is_some() || target.session.is_some(),
+            "tab, pane, or session selectors",
+        )?;
+    }
+    match target.window.as_ref() {
+        None if force_active_default => {
+            let window_id =
+                require_active_window_id_for_action(ctx.windows().active_window(), action)?;
+            Ok(vec![window_id])
+        }
+        None => Ok(ctx.window_ids().collect()),
+        Some(WindowTarget::Active) => {
+            let window_id =
+                require_active_window_id_for_action(ctx.windows().active_window(), action)?;
+            Ok(vec![window_id])
+        }
+        Some(WindowTarget::Id { id }) => ctx
+            .window_ids()
+            .find(|window_id| window_id.to_string() == id.0)
+            .map(|window_id| vec![window_id])
+            .ok_or_else(|| {
+                ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested window id", action.as_str()),
+                )
+            }),
+        Some(WindowTarget::Index { .. } | WindowTarget::Title { .. }) => Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!(
+                "{} only supports active and opaque window id selectors",
+                action.as_str()
+            ),
+        )),
+    }
+}
+
+fn select_tab_entries(
+    target: &TargetSelector,
+    action: ActionKind,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<Vec<TabEntry>, ControlError> {
+    let force_active_window = matches!(
+        target.tab,
+        Some(TabTarget::Active | TabTarget::Index { .. })
+    ) || matches!(
+        target.pane,
+        Some(PaneTarget::Active | PaneTarget::Index { .. })
+    ) || matches!(target.session, Some(SessionTarget::Active));
+    let window_ids = select_window_ids(target, force_active_window, action, ctx)?;
+    let all_entries = tab_entries_for_windows(window_ids, ctx);
+    let requires_active_tab_default = matches!(
+        target.pane,
+        Some(PaneTarget::Active | PaneTarget::Index { .. })
+    ) || matches!(target.session, Some(SessionTarget::Active));
+    match target.tab.as_ref() {
+        None if requires_active_tab_default => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index == entry.workspace_active_tab_index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active tab", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        None => Ok(all_entries),
+        Some(TabTarget::Active) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index == entry.workspace_active_tab_index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active tab", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(TabTarget::Id { id }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.pane_group.id().to_string() == id.0)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested tab id", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(TabTarget::Index { index }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index as u32 == *index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested tab index", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(TabTarget::Title { .. }) => Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!(
+                "{} only supports active, opaque tab id, and tab index selectors",
+                action.as_str()
+            ),
+        )),
+    }
+}
+
+fn tab_entries_for_windows(
+    window_ids: Vec<WindowId>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Vec<TabEntry> {
+    window_ids
+        .into_iter()
+        .filter_map(|window_id| {
+            let workspace = ctx
+                .views_of_type::<Workspace>(window_id)
+                .and_then(|workspaces| workspaces.into_iter().next())?;
+            Some(workspace.read(ctx, |workspace, _| {
+                workspace
+                    .tab_views()
+                    .enumerate()
+                    .map(|(index, pane_group)| TabEntry {
+                        window_id,
+                        index,
+                        workspace_active_tab_index: workspace.active_tab_index(),
+                        pane_group: pane_group.clone(),
+                    })
+                    .collect::<Vec<_>>()
+            }))
+        })
+        .flatten()
+        .collect()
+}
+
+fn select_pane_entries(
+    target: &TargetSelector,
+    action: ActionKind,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<Vec<PaneEntry>, ControlError> {
+    let tab_entries = select_tab_entries(target, action, ctx)?;
+    let all_entries = pane_entries_for_tabs(tab_entries, ctx);
+    match target.pane.as_ref() {
+        None if matches!(target.session, Some(SessionTarget::Active)) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| {
+                    entry.pane_group.read(ctx, |pane_group, ctx| {
+                        pane_group.active_session_id(ctx).map(PaneId::from) == Some(entry.pane_id)
+                    })
+                })
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active terminal session", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        None => Ok(all_entries),
+        Some(PaneTarget::Active) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| {
+                    entry.pane_group.read(ctx, |pane_group, ctx| {
+                        pane_group.focused_pane_id(ctx) == entry.pane_id
+                    })
+                })
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::MissingTarget,
+                    format!("{} requires an active pane", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(PaneTarget::Id { id }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.pane_id.to_string() == id.0)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!("{} cannot resolve the requested pane id", action.as_str()),
+                ));
+            }
+            Ok(entries)
+        }
+        Some(PaneTarget::Index { index }) => {
+            let entries = all_entries
+                .into_iter()
+                .filter(|entry| entry.index as u32 == *index)
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::StaleTarget,
+                    format!(
+                        "{} cannot resolve the requested pane index",
+                        action.as_str()
+                    ),
+                ));
+            }
+            Ok(entries)
+        }
+    }
+}
+
+fn pane_entries_for_tabs(
+    tab_entries: Vec<TabEntry>,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Vec<PaneEntry> {
+    tab_entries
+        .into_iter()
+        .flat_map(|entry| {
+            let tab_id = entry.pane_group.id().to_string();
+            let pane_group = entry.pane_group.clone();
+            entry
+                .pane_group
+                .read(ctx, |pane_group, _| pane_group.visible_pane_ids())
+                .into_iter()
+                .enumerate()
+                .map(move |(index, pane_id)| PaneEntry {
+                    tab_id: tab_id.clone(),
+                    index,
+                    pane_group: pane_group.clone(),
+                    pane_id,
+                })
+        })
+        .collect()
+}
+
+pub(crate) fn require_active_window_id_for_action(
+    active_window: Option<WindowId>,
+    action: ActionKind,
+) -> Result<WindowId, ControlError> {
+    active_window.ok_or_else(|| {
+        ControlError::new(
+            ErrorCode::MissingTarget,
+            format!("{} requires an active Warp window", action.as_str()),
+        )
     })
 }

--- a/app/src/local_control/handlers/product_metadata.rs
+++ b/app/src/local_control/handlers/product_metadata.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeMap;
+
+use ::local_control::protocol::{
+    FileListResult, FileSummary, ProjectActiveResult, ProjectListResult, ProjectSummary,
+    TargetSelector,
+};
+use ::local_control::{ActionKind, ControlError, ErrorCode};
+use serde::Serialize;
+use warpui::{ModelContext, SingletonEntity};
+
+use crate::code::view::CodeView;
+use crate::local_control::LocalControlBridge;
+use crate::projects::ProjectManagementModel;
+use crate::terminal::view::TerminalView;
+use crate::workspace::ActiveSession;
+
+pub(crate) fn file_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    validate_instance_metadata_read_target(ActionKind::FileList, target)?;
+    to_control_data(FileListResult {
+        files: open_file_summaries(ctx),
+    })
+}
+
+pub(crate) fn project_active(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    validate_instance_metadata_read_target(ActionKind::ProjectActive, target)?;
+    to_control_data(ProjectActiveResult {
+        project: active_project_summary(ctx),
+    })
+}
+
+pub(crate) fn project_list(
+    target: &TargetSelector,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    validate_instance_metadata_read_target(ActionKind::ProjectList, target)?;
+    to_control_data(ProjectListResult {
+        projects: project_summaries(ctx),
+    })
+}
+
+pub(crate) fn validate_instance_metadata_read_target(
+    action: ActionKind,
+    target: &TargetSelector,
+) -> Result<(), ControlError> {
+    if target.window.is_some()
+        || target.tab.is_some()
+        || target.pane.is_some()
+        || target.session.is_some()
+    {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            format!(
+                "{} does not accept target selectors; it reads app-state metadata already represented in Warp",
+                action.as_str()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn open_file_summaries(ctx: &mut ModelContext<LocalControlBridge>) -> Vec<FileSummary> {
+    let window_ids: Vec<_> = ctx.window_ids().collect();
+    let mut files = Vec::new();
+    for window_id in window_ids {
+        let Some(code_views) = ctx.views_of_type::<CodeView>(window_id) else {
+            continue;
+        };
+        for code_view in code_views {
+            code_view.read(ctx, |code_view, _ctx| {
+                for index in 0..code_view.tab_count() {
+                    if let Some(location) = code_view.tab_at(index).and_then(|tab| tab.location()) {
+                        files.push(FileSummary {
+                            path: location.display_path(),
+                            tab_id: None,
+                        });
+                    }
+                }
+            });
+        }
+    }
+    files.sort_by(|left, right| left.path.cmp(&right.path));
+    files.dedup_by(|left, right| left.path == right.path && left.tab_id == right.tab_id);
+    files
+}
+
+fn active_project_path(ctx: &mut ModelContext<LocalControlBridge>) -> Option<String> {
+    let window_id = ctx.windows().active_window()?;
+    let repo_path = ActiveSession::as_ref(ctx)
+        .terminal_view_id(window_id)
+        .and_then(|terminal_view_id| ctx.view_with_id::<TerminalView>(window_id, terminal_view_id))
+        .and_then(|terminal| {
+            terminal
+                .as_ref(ctx)
+                .current_repo_path()
+                .map(|path| path.display_path())
+        });
+    repo_path.or_else(|| {
+        ActiveSession::as_ref(ctx)
+            .working_directory(window_id)
+            .map(|path| path.display_path())
+    })
+}
+
+fn active_project_summary(ctx: &mut ModelContext<LocalControlBridge>) -> Option<ProjectSummary> {
+    active_project_path(ctx).map(|path| ProjectSummary {
+        path,
+        is_active: true,
+        last_opened_at: None,
+    })
+}
+
+fn project_summaries(ctx: &mut ModelContext<LocalControlBridge>) -> Vec<ProjectSummary> {
+    let active_path = active_project_path(ctx);
+    let mut projects = BTreeMap::new();
+    ProjectManagementModel::handle(ctx).read(ctx, |model, _ctx| {
+        for project in model.all_projects() {
+            projects.insert(
+                project.path.clone(),
+                ProjectSummary {
+                    path: project.path.clone(),
+                    is_active: active_path.as_ref() == Some(&project.path),
+                    last_opened_at: project
+                        .last_opened_ts
+                        .map(|timestamp| timestamp.to_string()),
+                },
+            );
+        }
+    });
+    if let Some(path) = active_path {
+        projects.entry(path.clone()).or_insert(ProjectSummary {
+            path,
+            is_active: true,
+            last_opened_at: None,
+        });
+    }
+    projects.into_values().collect()
+}
+
+fn to_control_data<T: Serialize>(value: T) -> Result<serde_json::Value, ControlError> {
+    serde_json::to_value(value).map_err(|err| {
+        ControlError::with_details(
+            ErrorCode::Internal,
+            "failed to serialize local-control response",
+            err.to_string(),
+        )
+    })
+}

--- a/app/src/local_control/handlers/settings_surfaces.rs
+++ b/app/src/local_control/handlers/settings_surfaces.rs
@@ -1,0 +1,329 @@
+use ::local_control::protocol::{
+    AppearanceStateResult, BindingNameParams, KeybindingGetResult, KeybindingListResult,
+    KeybindingSummary, SettingGetParams, SettingGetResult, SettingListResult, SettingSummary,
+    ThemeListResult, ThemeStateResult, ThemeSummary,
+};
+use ::local_control::{ControlError, ErrorCode};
+use serde::Serialize;
+use serde_json::{json, Value};
+use settings::Setting as _;
+use warpui::keymap::DescriptionContext;
+use warpui::{ModelContext, SingletonEntity};
+
+use crate::local_control::LocalControlBridge;
+use crate::settings::{
+    derived_theme_kind, AccessibilitySettings, FontSettings, InputSettings, ThemeSettings,
+};
+use crate::themes::theme::ThemeKind;
+use crate::user_config::WarpConfig;
+use crate::util::bindings::trigger_to_keystroke;
+use crate::WindowSettings;
+
+const ALLOWLISTED_SETTING_KEYS: &[&str] = &[
+    "accessibility.accessibility_verbosity",
+    "appearance.text.font_name",
+    "appearance.text.font_size",
+    "appearance.themes.dark_theme",
+    "appearance.themes.light_theme",
+    "appearance.themes.system_theme",
+    "appearance.themes.theme",
+    "appearance.window.zoom_level",
+    "terminal.input.error_underlining_enabled",
+    "terminal.input.syntax_highlighting",
+];
+
+const PRIVATE_OR_SENSITIVE_SETTING_KEYS: &[&str] = &[
+    "local_control.allow_inside_warp_control",
+    "local_control.allow_inside_warp_metadata_reads",
+    "local_control.allow_inside_warp_underlying_data_reads",
+    "local_control.allow_inside_warp_app_state_mutations",
+    "local_control.allow_inside_warp_metadata_configuration_mutations",
+    "local_control.allow_inside_warp_underlying_data_mutations",
+    "local_control.allow_outside_warp_control",
+    "local_control.allow_outside_warp_metadata_reads",
+    "local_control.allow_outside_warp_underlying_data_reads",
+    "local_control.allow_outside_warp_app_state_mutations",
+    "local_control.allow_outside_warp_metadata_configuration_mutations",
+    "local_control.allow_outside_warp_underlying_data_mutations",
+    "terminal.input.autosuggestion_accepted_count",
+    "terminal.input.completions_menu_height",
+    "terminal.input.completions_menu_width",
+    "terminal.input.inline_menu_custom_content_heights",
+    "terminal.input.workflows_box_expanded",
+];
+
+pub(crate) fn theme_list(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    to_control_data(theme_list_result(ctx)?)
+}
+
+
+pub(crate) fn theme_get(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    to_control_data(theme_state_result(ctx)?)
+}
+
+pub(crate) fn appearance_get(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    to_control_data(appearance_state_result(ctx)?)
+}
+
+pub(crate) fn setting_list(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    to_control_data(setting_list_result(ctx)?)
+}
+
+pub(crate) fn setting_get(
+    action: &::local_control::Action,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let params = action.params_as::<SettingGetParams>()?;
+    to_control_data(setting_get_result(&params.key, ctx)?)
+}
+
+pub(crate) fn keybinding_list(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    to_control_data(KeybindingListResult {
+        keybindings: keybinding_summaries(ctx),
+    })
+}
+
+pub(crate) fn keybinding_get(
+    action: &::local_control::Action,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<serde_json::Value, ControlError> {
+    let params = action.params_as::<BindingNameParams>()?;
+    let keybinding = keybinding_summaries(ctx)
+        .into_iter()
+        .find(|summary| summary.name == params.binding_name)
+        .ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                format!("keybinding.get could not find {}", params.binding_name),
+            )
+        })?;
+    to_control_data(KeybindingGetResult { keybinding })
+}
+
+pub(crate) fn theme_list_result(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<ThemeListResult, ControlError> {
+    let current_theme = active_theme_kind(ThemeSettings::as_ref(ctx), ctx);
+    let mut themes = WarpConfig::as_ref(ctx)
+        .theme_config()
+        .theme_items()
+        .map(|(kind, _)| ThemeSummary {
+            name: public_theme_name(kind),
+            is_current: *kind == current_theme,
+        })
+        .collect::<Vec<_>>();
+    themes.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(ThemeListResult { themes })
+}
+
+
+pub(crate) fn theme_state_result(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<ThemeStateResult, ControlError> {
+    let theme_settings = ThemeSettings::as_ref(ctx);
+    let system_themes = theme_settings.selected_system_themes.value();
+    Ok(ThemeStateResult {
+        name: public_theme_name(theme_settings.theme_kind.value()),
+        follow_system_theme: *theme_settings.use_system_theme.value(),
+        light_theme: Some(public_theme_name(&system_themes.light)),
+        dark_theme: Some(public_theme_name(&system_themes.dark)),
+    })
+}
+
+pub(crate) fn appearance_state_result(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<AppearanceStateResult, ControlError> {
+    let theme_settings = ThemeSettings::as_ref(ctx);
+    let font_settings = FontSettings::as_ref(ctx);
+    let window_settings = WindowSettings::as_ref(ctx);
+    let system_themes = theme_settings.selected_system_themes.value();
+    Ok(AppearanceStateResult {
+        theme: Some(public_theme_name(theme_settings.theme_kind.value())),
+        follow_system_theme: *theme_settings.use_system_theme.value(),
+        light_theme: Some(public_theme_name(&system_themes.light)),
+        dark_theme: Some(public_theme_name(&system_themes.dark)),
+        font_size: rounded_u32(*font_settings.monospace_font_size.value()),
+        ui_zoom_percent: Some(u32::from(*window_settings.zoom_level.value())),
+    })
+}
+
+pub(crate) fn setting_list_result(
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<SettingListResult, ControlError> {
+    let settings = ALLOWLISTED_SETTING_KEYS
+        .iter()
+        .map(|key| setting_summary_for_key(key, ctx))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(SettingListResult { settings })
+}
+
+pub(crate) fn setting_get_result(
+    key: &str,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<SettingGetResult, ControlError> {
+    Ok(SettingGetResult {
+        setting: setting_summary_for_key(key, ctx)?,
+    })
+}
+
+pub(crate) fn rejected_setting_key(key: &str) -> ControlError {
+    if PRIVATE_OR_SENSITIVE_SETTING_KEYS.contains(&key) {
+        return ControlError::new(
+            ErrorCode::NotAllowlisted,
+            format!("{key} is private or sensitive and is not available through local control"),
+        );
+    }
+    ControlError::new(
+        ErrorCode::NotAllowlisted,
+        format!("{key} is not an allowlisted local-control setting"),
+    )
+}
+
+fn setting_summary_for_key(
+    key: &str,
+    ctx: &mut ModelContext<LocalControlBridge>,
+) -> Result<SettingSummary, ControlError> {
+    let theme_settings = ThemeSettings::as_ref(ctx);
+    let font_settings = FontSettings::as_ref(ctx);
+    let input_settings = InputSettings::as_ref(ctx);
+    let accessibility_settings = AccessibilitySettings::as_ref(ctx);
+    let window_settings = WindowSettings::as_ref(ctx);
+    match key {
+        "appearance.themes.theme" => Ok(setting_summary(
+            key,
+            json!(public_theme_name(theme_settings.theme_kind.value())),
+            "string",
+        )),
+        "appearance.themes.system_theme" => Ok(setting_summary(
+            key,
+            json!(*theme_settings.use_system_theme.value()),
+            "bool",
+        )),
+        "appearance.themes.light_theme" => Ok(setting_summary(
+            key,
+            json!(public_theme_name(
+                &theme_settings.selected_system_themes.value().light
+            )),
+            "string",
+        )),
+        "appearance.themes.dark_theme" => Ok(setting_summary(
+            key,
+            json!(public_theme_name(
+                &theme_settings.selected_system_themes.value().dark
+            )),
+            "string",
+        )),
+        "appearance.text.font_name" => Ok(setting_summary(
+            key,
+            json!(font_settings.monospace_font_name.value()),
+            "string",
+        )),
+        "appearance.text.font_size" => Ok(setting_summary(
+            key,
+            json!(*font_settings.monospace_font_size.value()),
+            "number",
+        )),
+        "appearance.window.zoom_level" => Ok(setting_summary(
+            key,
+            json!(*window_settings.zoom_level.value()),
+            "number",
+        )),
+        "terminal.input.syntax_highlighting" => Ok(setting_summary(
+            key,
+            json!(*input_settings.syntax_highlighting.value()),
+            "bool",
+        )),
+        "terminal.input.error_underlining_enabled" => Ok(setting_summary(
+            key,
+            json!(*input_settings.error_underlining.value()),
+            "bool",
+        )),
+        "accessibility.accessibility_verbosity" => Ok(setting_summary(
+            key,
+            json!(format!(
+                "{:?}",
+                accessibility_settings.a11y_verbosity.value()
+            )),
+            "string",
+        )),
+        _ => Err(rejected_setting_key(key)),
+    }
+}
+
+fn setting_summary(key: &str, value: Value, value_type: &str) -> SettingSummary {
+    SettingSummary {
+        key: key.to_owned(),
+        value,
+        value_type: value_type.to_owned(),
+    }
+}
+
+fn public_theme_name(theme: &ThemeKind) -> String {
+    match theme {
+        ThemeKind::Custom(custom) | ThemeKind::CustomBase16(custom) => custom.name(),
+        ThemeKind::InMemory(_) => "In-memory theme".to_owned(),
+        _ => theme.to_string(),
+    }
+}
+
+fn active_theme_kind(
+    theme_settings: &ThemeSettings,
+    ctx: &ModelContext<LocalControlBridge>,
+) -> ThemeKind {
+    derived_theme_kind(theme_settings, ctx.system_theme())
+}
+
+fn rounded_u32(value: f32) -> Option<u32> {
+    if value.is_finite() && value >= 0.0 && value <= u32::MAX as f32 {
+        return Some(value.round() as u32);
+    }
+    None
+}
+
+fn keybinding_summaries(ctx: &mut ModelContext<LocalControlBridge>) -> Vec<KeybindingSummary> {
+    let mut keybindings = ctx
+        .editable_bindings()
+        .map(|binding| {
+            let keystroke = trigger_to_keystroke(binding.trigger);
+            KeybindingSummary {
+                name: binding.name.to_owned(),
+                description: binding
+                    .description
+                    .materialized(ctx)
+                    .in_context(DescriptionContext::Default)
+                    .to_owned(),
+                group: binding.group.map(str::to_owned),
+                keystroke: keystroke.as_ref().map(|keystroke| keystroke.displayed()),
+                normalized_keystroke: keystroke.map(|keystroke| keystroke.normalized()),
+            }
+        })
+        .collect::<Vec<_>>();
+    keybindings.sort_by(|left, right| {
+        left.description
+            .cmp(&right.description)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    keybindings
+        .dedup_by(|left, right| left.name == right.name && left.description == right.description);
+    keybindings
+}
+
+fn to_control_data<T: Serialize>(value: T) -> Result<serde_json::Value, ControlError> {
+    serde_json::to_value(value).map_err(|err| {
+        ControlError::with_details(
+            ErrorCode::Internal,
+            "failed to serialize local-control response",
+            err.to_string(),
+        )
+    })
+}

--- a/app/src/local_control/mod_tests.rs
+++ b/app/src/local_control/mod_tests.rs
@@ -58,6 +58,7 @@ fn tab_create_accepts_default_and_active_targets() {
         window: Some(WindowTarget::Active),
         tab: Some(TabTarget::Active),
         pane: Some(PaneTarget::Active),
+        session: None,
     })
     .expect("active target is accepted");
 }
@@ -70,6 +71,7 @@ fn tab_create_rejects_concrete_targets() {
         }),
         tab: None,
         pane: None,
+        session: None,
     })
     .expect_err("concrete window target is rejected");
     assert_eq!(err.code, ErrorCode::StaleTarget);
@@ -80,6 +82,7 @@ fn tab_create_rejects_concrete_targets() {
             id: TabSelector("tab".to_owned()),
         }),
         pane: None,
+        session: None,
     })
     .expect_err("concrete tab target is rejected");
     assert_eq!(err.code, ErrorCode::StaleTarget);
@@ -90,6 +93,7 @@ fn tab_create_rejects_concrete_targets() {
         pane: Some(PaneTarget::Id {
             id: PaneSelector("pane".to_owned()),
         }),
+        session: None,
     })
     .expect_err("concrete pane target is rejected");
     assert_eq!(err.code, ErrorCode::StaleTarget);
@@ -101,6 +105,7 @@ fn tab_create_rejects_unsupported_selector_forms() {
         window: Some(WindowTarget::Index { index: 0 }),
         tab: None,
         pane: None,
+        session: None,
     })
     .expect_err("indexed window target is rejected");
     assert_eq!(err.code, ErrorCode::InvalidSelector);
@@ -109,22 +114,49 @@ fn tab_create_rejects_unsupported_selector_forms() {
         window: None,
         tab: Some(TabTarget::Index { index: 0 }),
         pane: None,
+        session: None,
     })
     .expect_err("indexed tab target is rejected");
     assert_eq!(err.code, ErrorCode::InvalidSelector);
 }
 
 #[test]
-fn capabilities_advertises_only_first_slice_core_actions() {
-    assert_eq!(
-        capabilities(),
-        vec![
-            ActionKind::InstanceList,
-            ActionKind::AppPing,
-            ActionKind::AppVersion,
-            ActionKind::TabCreate,
-        ]
-    );
+fn capabilities_advertises_readonly_capability_targets() {
+    let capabilities = capabilities();
+
+    for action in [
+        ActionKind::InstanceInspect,
+        ActionKind::CapabilityList,
+        ActionKind::CapabilityInspect,
+        ActionKind::ActionList,
+        ActionKind::ActionInspect,
+        ActionKind::WindowList,
+        ActionKind::WindowInspect,
+        ActionKind::TabList,
+        ActionKind::TabInspect,
+        ActionKind::PaneList,
+        ActionKind::PaneInspect,
+        ActionKind::SessionList,
+        ActionKind::SessionInspect,
+        ActionKind::BlockList,
+        ActionKind::BlockInspect,
+        ActionKind::BlockOutput,
+        ActionKind::InputGet,
+        ActionKind::HistoryList,
+        ActionKind::ThemeGet,
+        ActionKind::KeybindingList,
+        ActionKind::KeybindingGet,
+        ActionKind::FileList,
+        ActionKind::ProjectActive,
+        ActionKind::ProjectList,
+        ActionKind::DriveList,
+        ActionKind::DriveInspect,
+    ] {
+        assert!(capabilities.contains(&action), "missing {}", action.as_str());
+    }
+
+    assert!(!capabilities.contains(&ActionKind::InputRun));
+    assert!(!capabilities.contains(&ActionKind::DriveObjectCreate));
 }
 
 #[test]
@@ -198,6 +230,33 @@ fn disabled_granular_permission_denies_with_insufficient_permissions() {
         ActionKind::TabCreate,
     )
     .expect_err("read-write permission is disabled");
+    assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+}
+
+
+#[test]
+fn disabled_metadata_read_permission_denies_readonly_metadata_actions() {
+    let settings = settings_with_values(true, false, true);
+
+    let err = ensure_settings_allow_action(
+        &settings,
+        InvocationContext::OutsideWarp,
+        ActionKind::WindowList,
+    )
+    .expect_err("metadata read permission is disabled");
+    assert_eq!(err.code, ErrorCode::InsufficientPermissions);
+}
+
+#[test]
+fn disabled_underlying_data_read_permission_denies_content_reads() {
+    let settings = settings_with_values(true, true, true);
+
+    let err = ensure_settings_allow_action(
+        &settings,
+        InvocationContext::OutsideWarp,
+        ActionKind::BlockOutput,
+    )
+    .expect_err("underlying data read permission is disabled");
     assert_eq!(err.code, ErrorCode::InsufficientPermissions);
 }
 

--- a/app/src/local_control/resolver.rs
+++ b/app/src/local_control/resolver.rs
@@ -1,5 +1,10 @@
 //! Target and parameter validation for the first local-control action slice.
-use ::local_control::protocol::{PaneTarget, TabTarget, TargetSelector, WindowTarget};
+use crate::local_control::handlers::metadata::action_metadata_for_name;
+use ::local_control::protocol::{
+    ActionNameParams, BlockIdParams, BlockListParams, DriveInspectParams, DriveListParams,
+    HistoryListParams, BindingNameParams, PaneTarget, SessionTarget, SettingGetParams, TabTarget,
+    TargetSelector, WindowTarget,
+};
 use ::local_control::{ActionKind, ControlError, ErrorCode};
 use warpui::ModelContext;
 
@@ -42,6 +47,18 @@ pub(crate) fn validate_tab_create_target(target: &TargetSelector) -> Result<(), 
             "tab.create does not accept a concrete pane selector",
         ));
     }
+    if matches!(target.session.as_ref(), Some(SessionTarget::Id { .. })) {
+        return Err(ControlError::new(
+            ErrorCode::StaleTarget,
+            "tab.create cannot resolve the requested session id",
+        ));
+    }
+    if !matches!(target.session.as_ref(), None | Some(SessionTarget::Active)) {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            "tab.create does not accept a concrete session selector",
+        ));
+    }
     Ok(())
 }
 
@@ -51,9 +68,74 @@ pub(crate) fn validate_tab_create_target(target: &TargetSelector) -> Result<(), 
 /// bottom branch of the stack: later branches add their own params and expand
 /// this validation alongside the corresponding action handlers.
 pub(crate) fn validate_action_params(action: &::local_control::Action) -> Result<(), ControlError> {
-    if action.kind != ActionKind::TabCreate {
-        return Ok(());
+    match action.kind {
+        ActionKind::ActionInspect | ActionKind::CapabilityInspect => {
+            let params = action.params_as::<ActionNameParams>()?;
+            action_metadata_for_name(&params.action)?;
+            Ok(())
+        }
+        ActionKind::SettingGet => action.params_as::<SettingGetParams>().map(|_| ()),
+        ActionKind::KeybindingGet => action
+            .params_as::<BindingNameParams>()
+            .and_then(|params| {
+                if params.binding_name.is_empty() {
+                    return Err(ControlError::new(
+                        ErrorCode::InvalidParams,
+                        "keybinding.get requires a non-empty name",
+                    ));
+                }
+                Ok(())
+            }),
+        ActionKind::AppPing
+        | ActionKind::InstanceInspect
+        | ActionKind::AppVersion
+        | ActionKind::AppActive
+        | ActionKind::CapabilityList
+        | ActionKind::ActionList
+        | ActionKind::WindowList
+        | ActionKind::WindowInspect
+        | ActionKind::TabList
+        | ActionKind::TabInspect
+        | ActionKind::TabCreate
+        | ActionKind::PaneList
+        | ActionKind::PaneInspect
+        | ActionKind::SessionList
+        | ActionKind::SessionInspect
+        | ActionKind::InputGet
+        | ActionKind::ThemeList
+        | ActionKind::ThemeGet
+        | ActionKind::AppearanceGet
+        | ActionKind::SettingList
+        | ActionKind::KeybindingList
+        | ActionKind::FileList
+        | ActionKind::ProjectActive
+        | ActionKind::ProjectList => validate_empty_action_params(action),
+        ActionKind::BlockList => action.params_as::<BlockListParams>().map(|_| ()),
+        ActionKind::BlockInspect | ActionKind::BlockOutput => action.params_as::<BlockIdParams>().and_then(|params| {
+            if params.block_id.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::InvalidParams,
+                    "block.inspect requires a non-empty block id",
+                ));
+            }
+            Ok(())
+        }),
+        ActionKind::HistoryList => action.params_as::<HistoryListParams>().map(|_| ()),
+        ActionKind::DriveList => action.params_as::<DriveListParams>().map(|_| ()),
+        ActionKind::DriveInspect => action.params_as::<DriveInspectParams>().and_then(|params| {
+            if params.id.is_empty() {
+                return Err(ControlError::new(
+                    ErrorCode::InvalidParams,
+                    "drive.inspect requires a non-empty Drive object id",
+                ));
+            }
+            Ok(())
+        }),
+        _ => Ok(()),
     }
+}
+
+fn validate_empty_action_params(action: &::local_control::Action) -> Result<(), ControlError> {
     if action
         .params
         .as_object()
@@ -63,7 +145,7 @@ pub(crate) fn validate_action_params(action: &::local_control::Action) -> Result
     }
     Err(ControlError::new(
         ErrorCode::InvalidParams,
-        "tab.create does not accept parameters in the first implementation slice",
+        format!("{} does not accept parameters", action.kind.as_str()),
     ))
 }
 
@@ -76,10 +158,17 @@ pub(super) fn target_window_id(
 pub(crate) fn require_active_window_id(
     active_window: Option<warpui::WindowId>,
 ) -> Result<warpui::WindowId, ControlError> {
+    require_active_window_id_for_action(active_window, ActionKind::TabCreate)
+}
+
+pub(crate) fn require_active_window_id_for_action(
+    active_window: Option<warpui::WindowId>,
+    action: ActionKind,
+) -> Result<warpui::WindowId, ControlError> {
     active_window.ok_or_else(|| {
         ControlError::new(
             ErrorCode::MissingTarget,
-            "tab.create requires an active Warp window",
+            format!("{} requires an active Warp window", action.as_str()),
         )
     })
 }

--- a/crates/local_control/src/catalog.rs
+++ b/crates/local_control/src/catalog.rs
@@ -115,6 +115,7 @@ pub enum ActionImplementationStatus {
 pub enum ActionParameterSpec {
     None,
     ActionName,
+    BlockId,
     BindingName,
     BooleanValue,
     ColorValue,
@@ -541,23 +542,47 @@ impl ActionKind {
 
     fn implementation_status(self) -> ActionImplementationStatus {
         match self {
-            Self::InstanceList | Self::AppPing | Self::AppVersion | Self::TabCreate => {
-                ActionImplementationStatus::Implemented
-            }
-            Self::InstanceInspect
+            Self::InstanceList
+            | Self::InstanceInspect
+            | Self::AppPing
+            | Self::AppVersion
             | Self::AppActive
-            | Self::AppFocus
-            | Self::AuthStatus
-            | Self::AuthLogin
             | Self::CapabilityList
             | Self::CapabilityInspect
             | Self::WindowList
             | Self::WindowInspect
+            | Self::TabList
+            | Self::TabInspect
+            | Self::TabCreate
+            | Self::PaneList
+            | Self::PaneInspect
+            | Self::SessionList
+            | Self::SessionInspect
+            | Self::BlockList
+            | Self::BlockInspect
+            | Self::BlockOutput
+            | Self::InputGet
+            | Self::HistoryList
+            | Self::ThemeList
+            | Self::ThemeGet
+            | Self::AppearanceGet
+            | Self::SettingList
+            | Self::SettingGet
+            | Self::KeybindingList
+            | Self::KeybindingGet
+            | Self::ActionList
+            | Self::ActionInspect
+            | Self::FileList
+            | Self::ProjectActive
+            | Self::ProjectList
+            | Self::DriveList
+            | Self::DriveInspect => ActionImplementationStatus::Implemented,
+            Self::AppFocus
+            | Self::AuthStatus
+            | Self::AuthLogin
             | Self::WindowCreate
             | Self::WindowFocus
             | Self::WindowClose
-            | Self::TabList
-            | Self::TabInspect
             | Self::TabActivate
             | Self::TabMove
             | Self::TabClose
@@ -565,8 +590,6 @@ impl ActionKind {
             | Self::TabResetName
             | Self::TabColorSet
             | Self::TabColorClear
-            | Self::PaneList
-            | Self::PaneInspect
             | Self::PaneSplit
             | Self::PaneFocus
             | Self::PaneNavigate
@@ -576,43 +599,27 @@ impl ActionKind {
             | Self::PaneClose
             | Self::PaneRename
             | Self::PaneResetName
-            | Self::SessionList
-            | Self::SessionInspect
             | Self::SessionActivate
             | Self::SessionPrevious
             | Self::SessionNext
             | Self::SessionReopenClosed
-            | Self::BlockList
-            | Self::BlockInspect
-            | Self::BlockOutput
-            | Self::InputGet
             | Self::InputInsert
             | Self::InputReplace
             | Self::InputClear
             | Self::InputModeSet
             | Self::InputRun
-            | Self::HistoryList
-            | Self::ThemeList
-            | Self::ThemeGet
             | Self::ThemeSet
             | Self::ThemeSystemSet
             | Self::ThemeLightSet
             | Self::ThemeDarkSet
-            | Self::AppearanceGet
             | Self::AppearanceFontSizeIncrease
             | Self::AppearanceFontSizeDecrease
             | Self::AppearanceFontSizeReset
             | Self::AppearanceZoomIncrease
             | Self::AppearanceZoomDecrease
             | Self::AppearanceZoomReset
-            | Self::SettingList
-            | Self::SettingGet
             | Self::SettingSet
             | Self::SettingToggle
-            | Self::KeybindingList
-            | Self::KeybindingGet
-            | Self::ActionList
-            | Self::ActionInspect
             | Self::SurfaceSettingsOpen
             | Self::SurfaceCommandPaletteOpen
             | Self::SurfaceCommandSearchOpen
@@ -624,13 +631,8 @@ impl ActionKind {
             | Self::SurfaceLeftPanelToggle
             | Self::SurfaceRightPanelToggle
             | Self::SurfaceVerticalTabsToggle
-            | Self::FileList
             | Self::FileOpen
-            | Self::ProjectActive
-            | Self::ProjectList
             | Self::ProjectOpen
-            | Self::DriveList
-            | Self::DriveInspect
             | Self::DriveOpen
             | Self::DriveNotebookOpen
             | Self::DriveEnvVarCollectionOpen
@@ -729,15 +731,12 @@ impl ActionKind {
             | Self::ThemeSystemSet
             | Self::ThemeLightSet
             | Self::ThemeDarkSet
-            | Self::AppearanceGet
             | Self::AppearanceFontSizeIncrease
             | Self::AppearanceFontSizeDecrease
             | Self::AppearanceFontSizeReset
             | Self::AppearanceZoomIncrease
             | Self::AppearanceZoomDecrease
             | Self::AppearanceZoomReset
-            | Self::SettingList
-            | Self::SettingGet
             | Self::SettingSet
             | Self::SettingToggle
             | Self::KeybindingList
@@ -947,7 +946,6 @@ impl ActionKind {
             | Self::ThemeSystemSet
             | Self::ThemeLightSet
             | Self::ThemeDarkSet
-            | Self::AppearanceGet
             | Self::AppearanceFontSizeIncrease
             | Self::AppearanceFontSizeDecrease
             | Self::AppearanceFontSizeReset
@@ -1036,7 +1034,7 @@ impl ActionKind {
                 ActionParameterSpec::None
             }
             Self::BlockList | Self::HistoryList => ActionParameterSpec::Limit,
-            Self::BlockInspect | Self::BlockOutput => ActionParameterSpec::None,
+            Self::BlockInspect | Self::BlockOutput => ActionParameterSpec::BlockId,
             Self::InputGet => ActionParameterSpec::None,
             Self::InputInsert | Self::InputReplace | Self::InputRun => ActionParameterSpec::Text,
             Self::InputClear => ActionParameterSpec::None,
@@ -1051,7 +1049,7 @@ impl ActionKind {
             | Self::AppearanceZoomIncrease
             | Self::AppearanceZoomDecrease
             | Self::AppearanceZoomReset => ActionParameterSpec::None,
-            Self::SettingList => ActionParameterSpec::Namespace,
+            Self::SettingList => ActionParameterSpec::None,
             Self::SettingGet => ActionParameterSpec::Key,
             Self::SettingSet => ActionParameterSpec::KeyValue,
             Self::SettingToggle => ActionParameterSpec::Key,

--- a/crates/local_control/src/lib.rs
+++ b/crates/local_control/src/lib.rs
@@ -23,7 +23,12 @@ pub use discovery::{
     discovery_dir,
 };
 pub use protocol::{
-    Action, ControlError, ControlResponse, ErrorCode, ErrorResponseEnvelope, ExecutionContextProof,
-    PROTOCOL_VERSION, RequestEnvelope, ResponseEnvelope,
+    Action, ActionNameParams, BindingNameParams, BlockIdParams, BlockInspectResult, BlockListParams,
+    BlockListResult, BlockSummary, ControlError, ControlResponse, DriveInspectParams,
+    DriveInspectResult, DriveObjectListParams, DriveObjectSummary, DriveObjectType, EmptyParams,
+    ErrorCode, ErrorResponseEnvelope, ExecutionContextProof, HistoryListParams, HistoryListResult, InputStateResult,
+    KeybindingGetParams, LimitParams, PROTOCOL_VERSION, RequestEnvelope, ResponseEnvelope, SettingGetParams, ThemeStateResult,
 };
-pub use selectors::{PaneSelector, TabSelector, TargetSelector, WindowSelector};
+pub use selectors::{
+    PaneSelector, SessionSelector, TabSelector, TargetSelector, WindowSelector,
+};

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -1,4 +1,5 @@
 //! Wire protocol envelopes and error types for Warp local control.
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -9,7 +10,8 @@ pub use crate::catalog::{
     PROTOCOL_VERSION, PermissionCategory, RiskTier, StateDataCategory, TargetScope,
 };
 pub use crate::selectors::{
-    PaneSelector, PaneTarget, TabSelector, TabTarget, TargetSelector, WindowSelector, WindowTarget,
+    PaneSelector, PaneTarget, SessionSelector, SessionTarget, TabSelector, TabTarget,
+    TargetSelector, WindowSelector, WindowTarget,
 };
 
 /// Opaque Drive object identifier supplied by Warp metadata.
@@ -78,6 +80,9 @@ pub enum ActionParams {
     None,
     ActionName {
         action: String,
+    },
+    BlockId {
+        block_id: String,
     },
     BindingName {
         binding_name: String,
@@ -272,12 +277,300 @@ pub struct Action {
     pub params: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmptyParams {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionNameParams {
+    pub action: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LimitParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockIdParams {
+    pub block_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindingNameParams {
+    pub binding_name: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DriveObjectListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_type: Option<DriveObjectType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DriveInspectParams {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppActiveParams {}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstanceInspectParams {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettingGetParams {
+    pub key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeybindingGetParams {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DriveListParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_type: Option<DriveObjectType>,
+}
+
+pub type SettingListParams = EmptyParams;
+pub type KeybindingListParams = EmptyParams;
+pub type FileListParams = EmptyParams;
+pub type ProjectActiveParams = EmptyParams;
+pub type ProjectListParams = EmptyParams;
+pub type InputGetParams = EmptyParams;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionListResult {
+    pub actions: Vec<ActionMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionInspectResult {
+    pub action: ActionMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActiveTargetChain {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pane_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockSummary {
+    pub block_id: String,
+    pub session_id: String,
+    pub index: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockListResult {
+    pub blocks: Vec<BlockSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockInspectResult {
+    pub block: BlockSummary,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputStateResult {
+    pub session_id: String,
+    pub text: String,
+    pub cursor_offset: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryEntrySummary {
+    pub entry_id: String,
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryListResult {
+    pub entries: Vec<HistoryEntrySummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThemeSummary {
+    pub name: String,
+    pub is_current: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThemeListResult {
+    pub themes: Vec<ThemeSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThemeStateResult {
+    pub name: String,
+    pub follow_system_theme: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub light_theme: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dark_theme: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppearanceStateResult {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
+    pub follow_system_theme: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub light_theme: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dark_theme: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_size: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ui_zoom_percent: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SettingSummary {
+    pub key: String,
+    pub value: serde_json::Value,
+    pub value_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SettingListResult {
+    pub settings: Vec<SettingSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SettingGetResult {
+    pub setting: SettingSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeybindingSummary {
+    pub name: String,
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keystroke: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub normalized_keystroke: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeybindingListResult {
+    pub keybindings: Vec<KeybindingSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeybindingGetResult {
+    pub keybinding: KeybindingSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileSummary {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileListResult {
+    pub files: Vec<FileSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectSummary {
+    pub path: String,
+    pub is_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_opened_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectActiveResult {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<ProjectSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectListResult {
+    pub projects: Vec<ProjectSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DriveObjectSummary {
+    pub object_type: DriveObjectType,
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DriveListResult {
+    pub objects: Vec<DriveObjectSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DriveInspectResult {
+    pub object: DriveObjectSummary,
+    pub content: serde_json::Value,
+}
+
 impl Action {
     pub fn new(kind: ActionKind) -> Self {
         Self {
             kind,
             params: serde_json::Value::Object(Default::default()),
         }
+    }
+
+    pub fn with_params<T: Serialize>(kind: ActionKind, params: T) -> Result<Self, ControlError> {
+        Ok(Self {
+            kind,
+            params: serde_json::to_value(params).map_err(|err| {
+                ControlError::with_details(
+                    ErrorCode::InvalidParams,
+                    format!("failed to serialize {} parameters", kind.as_str()),
+                    err.to_string(),
+                )
+            })?,
+        })
+    }
+
+    pub fn params_as<T: DeserializeOwned>(&self) -> Result<T, ControlError> {
+        serde_json::from_value(self.params.clone()).map_err(|err| {
+            ControlError::with_details(
+                ErrorCode::InvalidParams,
+                format!("failed to decode {} parameters", self.kind.as_str()),
+                err.to_string(),
+            )
+        })
     }
 }
 

--- a/crates/local_control/src/protocol_tests.rs
+++ b/crates/local_control/src/protocol_tests.rs
@@ -142,6 +142,74 @@ fn logged_out_safe_stub_actions_can_advertise_external_context() {
         .contains(&InvocationContext::OutsideWarp));
 }
 
+
+#[test]
+fn readonly_capability_targets_are_implemented_with_expected_categories() {
+    for action in [
+        ActionKind::InstanceInspect,
+        ActionKind::CapabilityList,
+        ActionKind::CapabilityInspect,
+        ActionKind::ActionList,
+        ActionKind::ActionInspect,
+        ActionKind::WindowList,
+        ActionKind::WindowInspect,
+        ActionKind::TabList,
+        ActionKind::TabInspect,
+        ActionKind::PaneList,
+        ActionKind::PaneInspect,
+        ActionKind::SessionList,
+        ActionKind::SessionInspect,
+        ActionKind::ThemeGet,
+        ActionKind::KeybindingList,
+        ActionKind::KeybindingGet,
+        ActionKind::FileList,
+        ActionKind::ProjectActive,
+        ActionKind::ProjectList,
+    ] {
+        let metadata = action.metadata();
+        assert_eq!(
+            metadata.implementation_status,
+            ActionImplementationStatus::Implemented
+        );
+        assert_eq!(metadata.permission_category, PermissionCategory::ReadMetadata);
+        assert!(!metadata.authenticated_user.required);
+    }
+
+    for action in [
+        ActionKind::BlockInspect,
+        ActionKind::BlockOutput,
+        ActionKind::InputGet,
+        ActionKind::HistoryList,
+    ] {
+        let metadata = action.metadata();
+        assert_eq!(
+            metadata.implementation_status,
+            ActionImplementationStatus::Implemented
+        );
+        assert_eq!(
+            metadata.permission_category,
+            PermissionCategory::ReadUnderlyingData
+        );
+        assert!(!metadata.authenticated_user.required);
+    }
+}
+
+#[test]
+fn block_output_uses_block_id_params() {
+    assert_eq!(
+        ActionKind::BlockOutput.metadata().parameter_spec,
+        ActionParameterSpec::BlockId
+    );
+    let action = Action::with_params(
+        ActionKind::BlockOutput,
+        BlockIdParams {
+            block_id: "block_1".to_owned(),
+        },
+    )
+    .expect("params serialize");
+    assert_eq!(action.params["block_id"], "block_1");
+}
+
 #[test]
 fn authenticated_actions_are_warp_terminal_only_in_the_contract() {
     for action in [

--- a/crates/local_control/src/selectors.rs
+++ b/crates/local_control/src/selectors.rs
@@ -16,6 +16,11 @@ pub struct TabSelector(pub String);
 #[serde(transparent)]
 pub struct PaneSelector(pub String);
 
+/// Opaque session identifier supplied by Warp metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SessionSelector(pub String);
+
 /// Hierarchical target for actions that operate on a specific Warp surface.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -26,6 +31,8 @@ pub struct TargetSelector {
     pub tab: Option<TabTarget>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pane: Option<PaneTarget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<SessionTarget>,
 }
 
 /// Window-level target selector.
@@ -55,4 +62,13 @@ pub enum PaneTarget {
     Active,
     Id { id: PaneSelector },
     Index { index: u32 },
+}
+
+
+/// Session-level target selector.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionTarget {
+    Active,
+    Id { id: SessionSelector },
 }

--- a/crates/warp_cli/src/local_control/commands.rs
+++ b/crates/warp_cli/src/local_control/commands.rs
@@ -1,6 +1,7 @@
 //! Implementations for user-facing `warpctrl` command groups.
 use local_control::protocol::{
-    Action, ActionKind, ActionMetadata, ControlError, ErrorCode, RequestEnvelope,
+    Action, ActionNameParams, ActionKind, ActionMetadata, ControlError, EmptyParams, ErrorCode,
+    RequestEnvelope,
 };
 use local_control::selection::select_instance;
 use serde::Serialize;
@@ -8,8 +9,12 @@ use serde_json::json;
 
 use crate::agent::OutputFormat;
 use crate::local_control::output::{write_json, write_json_line};
-use crate::local_control::selectors::instance_selector;
-use crate::local_control::{AppCommand, InstanceCommand, TabCommand, TargetArgs};
+use crate::local_control::selectors::{instance_selector, target_selector};
+use crate::local_control::{
+    ActionCommand, AppCommand, AppearanceCommand, BlockCommand, CapabilityCommand, DriveCommand, FileCommand,
+    HistoryCommand, InputCommand, InstanceCommand, KeybindingCommand, PaneCommand, ProjectCommand,
+    SessionCommand, SettingCommand, TabCommand, TargetArgs, ThemeCommand, WindowCommand,
+};
 
 /// Display-oriented projection of a discoverable Warp instance.
 #[derive(Serialize)]
@@ -75,6 +80,12 @@ pub(super) fn run_instance_command(
                 }
             }
         }
+        InstanceCommand::Inspect(args) => run_action_with_params(
+            args,
+            ActionKind::InstanceInspect,
+            local_control::EmptyParams {},
+            output_format,
+        ),
     }
 }
 
@@ -87,6 +98,71 @@ pub(super) fn run_app_command(
         AppCommand::Version(args) => {
             run_action(args, ActionKind::AppVersion, json!({}), output_format)
         }
+        AppCommand::Active(args) => run_action_with_params(
+            args,
+            ActionKind::AppActive,
+            local_control::EmptyParams {},
+            output_format,
+        ),
+    }
+}
+
+
+pub(super) fn run_capability_command(
+    command: CapabilityCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        CapabilityCommand::List(args) => run_action_with_params(
+            args,
+            ActionKind::CapabilityList,
+            EmptyParams {},
+            output_format,
+        ),
+        CapabilityCommand::Inspect(args) => run_action_with_params(
+            args.target,
+            ActionKind::CapabilityInspect,
+            ActionNameParams {
+                action: args.action,
+            },
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_action_command(
+    command: ActionCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        ActionCommand::List(args) => run_action_with_params(
+            args,
+            ActionKind::ActionList,
+            EmptyParams {},
+            output_format,
+        ),
+        ActionCommand::Inspect(args) => run_action_with_params(
+            args.target,
+            ActionKind::ActionInspect,
+            ActionNameParams {
+                action: args.action,
+            },
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_window_command(
+    command: WindowCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        WindowCommand::List(args) => {
+            run_action_with_params(args, ActionKind::WindowList, EmptyParams {}, output_format)
+        }
+        WindowCommand::Inspect(args) => {
+            run_action_with_params(args, ActionKind::WindowInspect, EmptyParams {}, output_format)
+        }
     }
 }
 pub(super) fn run_tab_command(
@@ -94,9 +170,224 @@ pub(super) fn run_tab_command(
     output_format: OutputFormat,
 ) -> Result<(), ControlError> {
     match command {
+        TabCommand::List(args) => {
+            run_action_with_params(args, ActionKind::TabList, EmptyParams {}, output_format)
+        }
+        TabCommand::Inspect(args) => {
+            run_action_with_params(args, ActionKind::TabInspect, EmptyParams {}, output_format)
+        }
         TabCommand::Create(args) => {
             run_action(args, ActionKind::TabCreate, json!({}), output_format)
         }
+    }
+}
+
+pub(super) fn run_pane_command(
+    command: PaneCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        PaneCommand::List(args) => {
+            run_action_with_params(args, ActionKind::PaneList, EmptyParams {}, output_format)
+        }
+        PaneCommand::Inspect(args) => {
+            run_action_with_params(args, ActionKind::PaneInspect, EmptyParams {}, output_format)
+        }
+    }
+}
+
+pub(super) fn run_session_command(
+    command: SessionCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        SessionCommand::List(args) => {
+            run_action_with_params(args, ActionKind::SessionList, EmptyParams {}, output_format)
+        }
+        SessionCommand::Inspect(args) => {
+            run_action_with_params(args, ActionKind::SessionInspect, EmptyParams {}, output_format)
+        }
+    }
+}
+
+pub(super) fn run_block_command(
+    command: BlockCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        BlockCommand::List(args) => run_action_with_params(
+            args.target,
+            ActionKind::BlockList,
+            local_control::BlockListParams { limit: args.limit },
+            output_format,
+        ),
+        BlockCommand::Inspect(args) => run_action_with_params(
+            args.target,
+            ActionKind::BlockInspect,
+            local_control::BlockIdParams {
+                block_id: args.block_id,
+            },
+            output_format,
+        ),
+        BlockCommand::Output(args) => run_action_with_params(
+            args.target,
+            ActionKind::BlockOutput,
+            local_control::BlockIdParams {
+                block_id: args.block_id,
+            },
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_input_command(
+    command: InputCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        InputCommand::Get(args) => run_action_with_params(
+            args,
+            ActionKind::InputGet,
+            local_control::EmptyParams {},
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_theme_command(
+    command: ThemeCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        ThemeCommand::List(args) => {
+            run_action_with_params(args, ActionKind::ThemeList, EmptyParams {}, output_format)
+        }
+        ThemeCommand::Get(args) => {
+            run_action_with_params(args, ActionKind::ThemeGet, EmptyParams {}, output_format)
+        }
+    }
+}
+
+pub(super) fn run_appearance_command(
+    command: AppearanceCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        AppearanceCommand::Get(args) => run_action_with_params(
+            args,
+            ActionKind::AppearanceGet,
+            EmptyParams {},
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_history_command(
+    command: HistoryCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        HistoryCommand::List(args) => run_action_with_params(
+            args.target,
+            ActionKind::HistoryList,
+            local_control::HistoryListParams { limit: args.limit },
+            output_format,
+        ),
+    }
+}
+pub(super) fn run_setting_command(
+    command: SettingCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        SettingCommand::List(args) => run_action_with_params(
+            args,
+            ActionKind::SettingList,
+            local_control::EmptyParams {},
+            output_format,
+        ),
+        SettingCommand::Get(args) => run_action_with_params(
+            args.target,
+            ActionKind::SettingGet,
+            local_control::SettingGetParams { key: args.key },
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_keybinding_command(
+    command: KeybindingCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        KeybindingCommand::List(args) => run_action_with_params(
+            args,
+            ActionKind::KeybindingList,
+            local_control::EmptyParams {},
+            output_format,
+        ),
+        KeybindingCommand::Get(args) => run_action_with_params(
+            args.target,
+            ActionKind::KeybindingGet,
+            local_control::BindingNameParams { binding_name: args.name },
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_file_command(
+    command: FileCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        FileCommand::List(args) => run_action_with_params(
+            args,
+            ActionKind::FileList,
+            local_control::EmptyParams {},
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_project_command(
+    command: ProjectCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        ProjectCommand::Active(args) => run_action_with_params(
+            args,
+            ActionKind::ProjectActive,
+            local_control::EmptyParams {},
+            output_format,
+        ),
+        ProjectCommand::List(args) => run_action_with_params(
+            args,
+            ActionKind::ProjectList,
+            local_control::EmptyParams {},
+            output_format,
+        ),
+    }
+}
+
+pub(super) fn run_drive_command(
+    command: DriveCommand,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    match command {
+        DriveCommand::List(args) => run_action_with_params(
+            args.target,
+            ActionKind::DriveList,
+            local_control::DriveObjectListParams {
+                object_type: args.object_type.map(Into::into),
+            },
+            output_format,
+        ),
+        DriveCommand::Inspect(args) => run_action_with_params(
+            args.target,
+            ActionKind::DriveInspect,
+            local_control::DriveInspectParams { id: args.id },
+            output_format,
+        ),
     }
 }
 
@@ -107,12 +398,40 @@ fn run_action(
     output_format: OutputFormat,
 ) -> Result<(), ControlError> {
     let records = local_control::discovery::list_instances();
-    let selector = instance_selector(args);
+    let selector = instance_selector(&args);
+    let target = target_selector(&args)?;
     let instance = select_instance(&records, &selector)?;
-    let request = RequestEnvelope::new(Action {
+    let mut request = RequestEnvelope::new(Action {
         kind: action,
         params,
     });
+    request.target = target;
+    let response = local_control::client::send_request(&instance, &request)?;
+    let local_control::protocol::ControlResponse::Ok { data } = response.response else {
+        return Err(ControlError::new(
+            ErrorCode::Internal,
+            "local-control request failed without an error payload",
+        ));
+    };
+    match output_format {
+        OutputFormat::Json => write_json(&data),
+        OutputFormat::Ndjson => write_json_line(&data),
+        OutputFormat::Pretty | OutputFormat::Text => write_json(&data),
+    }
+}
+
+fn run_action_with_params<T: Serialize>(
+    args: TargetArgs,
+    action: ActionKind,
+    params: T,
+    output_format: OutputFormat,
+) -> Result<(), ControlError> {
+    let records = local_control::discovery::list_instances();
+    let selector = instance_selector(&args);
+    let target = target_selector(&args)?;
+    let instance = select_instance(&records, &selector)?;
+    let mut request = RequestEnvelope::new(Action::with_params(action, params)?);
+    request.target = target;
     let response = local_control::client::send_request(&instance, &request)?;
     let local_control::protocol::ControlResponse::Ok { data } = response.response else {
         return Err(ControlError::new(

--- a/crates/warp_cli/src/local_control/mod.rs
+++ b/crates/warp_cli/src/local_control/mod.rs
@@ -7,10 +7,17 @@ mod selectors;
 use std::process::ExitCode;
 
 use crate::agent::OutputFormat;
-use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
+use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use clap_complete::aot::Shell;
 
-use commands::{run_app_command, run_instance_command, run_tab_command};
+use commands::{
+    run_action_command, run_app_command, run_appearance_command, run_block_command,
+    run_capability_command,
+    run_drive_command, run_file_command, run_history_command, run_input_command,
+    run_instance_command, run_keybinding_command, run_pane_command, run_project_command,
+    run_session_command, run_setting_command, run_tab_command, run_theme_command,
+    run_window_command,
+};
 use completions::generate_completions_to_stdout;
 use output::write_control_error;
 
@@ -70,10 +77,66 @@ pub enum ControlCommand {
     /// Inspect a selected local Warp app.
     #[command(subcommand)]
     App(AppCommand),
+    /// Inspect local-control capabilities.
+    #[command(subcommand)]
+    Capability(CapabilityCommand),
+    /// Inspect the local-control action catalog.
+    #[command(subcommand)]
+    Action(ActionCommand),
+
+    /// Inspect local Warp windows.
+    #[command(subcommand)]
+    Window(WindowCommand),
 
     /// Control local Warp tabs.
     #[command(subcommand)]
     Tab(TabCommand),
+    /// Inspect local Warp panes.
+    #[command(subcommand)]
+    Pane(PaneCommand),
+
+    /// Inspect local Warp sessions.
+    #[command(subcommand)]
+    Session(SessionCommand),
+
+    /// Inspect terminal blocks.
+    #[command(subcommand)]
+    Block(BlockCommand),
+
+    /// Inspect terminal input state.
+    #[command(subcommand)]
+    Input(InputCommand),
+
+    /// Inspect terminal command history.
+    #[command(subcommand)]
+    History(HistoryCommand),
+    /// Inspect Warp themes.
+    #[command(subcommand)]
+    Theme(ThemeCommand),
+
+    /// Inspect appearance state.
+    #[command(subcommand)]
+    Appearance(AppearanceCommand),
+
+    /// Inspect allowlisted settings.
+    #[command(subcommand)]
+    Setting(SettingCommand),
+
+    /// Inspect keybinding metadata.
+    #[command(subcommand)]
+    Keybinding(KeybindingCommand),
+
+    /// Inspect open file app-state metadata.
+    #[command(subcommand)]
+    File(FileCommand),
+
+    /// Inspect project app-state metadata.
+    #[command(subcommand)]
+    Project(ProjectCommand),
+
+    /// Inspect authenticated Warp Drive objects.
+    #[command(subcommand)]
+    Drive(DriveCommand),
 
     /// Generate shell completions for your shell to stdout.
     ///
@@ -103,6 +166,9 @@ pub enum ControlCommand {
 pub enum InstanceCommand {
     /// List locally discoverable Warp instances.
     List,
+
+    /// Print app, protocol, active target, and action metadata for the selected instance.
+    Inspect(TargetArgs),
 }
 
 /// Commands that inspect the selected Warp app instance.
@@ -113,13 +179,157 @@ pub enum AppCommand {
 
     /// Print protocol and app version metadata for the selected local Warp app.
     Version(TargetArgs),
+
+    /// Print the active window/tab/pane/session chain.
+    Active(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum CapabilityCommand {
+    /// List implemented local-control capabilities.
+    List(TargetArgs),
+
+    /// Inspect one local-control capability.
+    #[command(alias = "get")]
+    Inspect(ActionInspectArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ActionCommand {
+    /// List allowlisted local-control actions.
+    List(TargetArgs),
+
+    /// Inspect one allowlisted local-control action.
+    #[command(alias = "get")]
+    Inspect(ActionInspectArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum WindowCommand {
+    /// List windows in the selected local Warp app.
+    List(TargetArgs),
+
+    /// Inspect one window in the selected local Warp app.
+    Inspect(TargetArgs),
 }
 
 /// Commands that control tabs in the selected Warp app instance.
 #[derive(Debug, Clone, Subcommand)]
 pub enum TabCommand {
+    /// List tabs in the selected local Warp app.
+    List(TargetArgs),
+
+    /// Inspect one tab in the selected local Warp app.
+    Inspect(TargetArgs),
+
     /// Create a new terminal tab in the active window.
     Create(TargetArgs),
+}
+
+/// Commands that inspect local Warp panes.
+#[derive(Debug, Clone, Subcommand)]
+pub enum PaneCommand {
+    /// List panes in the selected local Warp app.
+    List(TargetArgs),
+
+    /// Inspect one pane in the selected local Warp app.
+    Inspect(TargetArgs),
+}
+/// Commands that inspect local Warp sessions.
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SessionCommand {
+    /// List sessions in the selected local Warp app.
+    List(TargetArgs),
+
+    /// Inspect one session in the selected local Warp app.
+    Inspect(TargetArgs),
+}
+/// Commands that inspect terminal blocks.
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum BlockCommand {
+    /// List terminal blocks.
+    List(LimitTargetArgs),
+
+    /// Inspect one terminal block.
+    #[command(alias = "get")]
+    Inspect(BlockInspectArgs),
+
+    /// Read one terminal block's output.
+    Output(BlockInspectArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum InputCommand {
+    /// Read the current input buffer.
+    Get(TargetArgs),
+}
+
+/// Commands that inspect Warp themes.
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ThemeCommand {
+    /// List available themes.
+    List(TargetArgs),
+
+    /// Read current theme state.
+    Get(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AppearanceCommand {
+    /// Read appearance state.
+    Get(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum HistoryCommand {
+    /// List command history entries.
+    List(LimitTargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SettingCommand {
+    /// List allowlisted settings.
+    List(TargetArgs),
+
+    /// Read one allowlisted setting.
+    Get(SettingGetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum KeybindingCommand {
+    /// List keybindings.
+    List(TargetArgs),
+
+    /// Read one keybinding by name.
+    Get(KeybindingGetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum FileCommand {
+    /// List files currently open in Warp editor state.
+    List(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum ProjectCommand {
+    /// Read the active project.
+    Active(TargetArgs),
+
+    /// List known projects.
+    List(TargetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum DriveCommand {
+    /// List authenticated Warp Drive objects.
+    List(DriveListArgs),
+
+    /// Read one authenticated Warp Drive object by id.
+    #[command(alias = "get")]
+    Inspect(DriveInspectArgs),
 }
 
 /// Common flags for selecting which running Warp instance receives a command.
@@ -132,6 +342,136 @@ pub struct TargetArgs {
     /// Target a specific local Warp process id.
     #[arg(long = "pid", conflicts_with = "instance")]
     pub pid: Option<u32>,
+
+    /// Target the active window or an opaque window id.
+    #[arg(long = "window", conflicts_with_all = ["window_index", "window_title"])]
+    pub window: Option<String>,
+
+    /// Target a window by scoped index when the handler supports it.
+    #[arg(long = "window-index", conflicts_with_all = ["window", "window_title"])]
+    pub window_index: Option<u32>,
+
+    /// Target a window by exact title when the handler supports it.
+    #[arg(long = "window-title", conflicts_with_all = ["window", "window_index"])]
+    pub window_title: Option<String>,
+
+    /// Target the active tab or an opaque tab id.
+    #[arg(long = "tab", conflicts_with_all = ["tab_index", "tab_title"])]
+    pub tab: Option<String>,
+
+    /// Target a tab by scoped index when the handler supports it.
+    #[arg(long = "tab-index", conflicts_with_all = ["tab", "tab_title"])]
+    pub tab_index: Option<u32>,
+
+    /// Target a tab by exact title when the handler supports it.
+    #[arg(long = "tab-title", conflicts_with_all = ["tab", "tab_index"])]
+    pub tab_title: Option<String>,
+
+    /// Target the active pane or an opaque pane id.
+    #[arg(long = "pane", conflicts_with = "pane_index")]
+    pub pane: Option<String>,
+
+    /// Target a pane by scoped index when the handler supports it.
+    #[arg(long = "pane-index", conflicts_with = "pane")]
+    pub pane_index: Option<u32>,
+
+    /// Target the active session or an opaque session id.
+    #[arg(long = "session")]
+    pub session: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ActionInspectArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Action name, such as tab.create or window.list.
+    pub action: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct LimitTargetArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Maximum number of items to return.
+    #[arg(long = "limit")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct BlockInspectArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Opaque block id returned by block list.
+    pub block_id: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct SettingGetArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Allowlisted setting key.
+    pub key: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KeybindingGetArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Keybinding action name.
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct DriveListArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Filter by Drive object type.
+    #[arg(long = "type", value_enum)]
+    pub object_type: Option<CliDriveObjectType>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct DriveInspectArgs {
+    #[command(flatten)]
+    pub target: TargetArgs,
+
+    /// Opaque Drive object id returned by drive list.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CliDriveObjectType {
+    Workflow,
+    Notebook,
+    EnvVarCollection,
+    Prompt,
+    Folder,
+    AiFact,
+    McpServer,
+    Space,
+    Trash,
+}
+
+impl From<CliDriveObjectType> for local_control::DriveObjectType {
+    fn from(value: CliDriveObjectType) -> Self {
+        match value {
+            CliDriveObjectType::Workflow => Self::Workflow,
+            CliDriveObjectType::Notebook => Self::Notebook,
+            CliDriveObjectType::EnvVarCollection => Self::EnvVarCollection,
+            CliDriveObjectType::Prompt => Self::Prompt,
+            CliDriveObjectType::Folder => Self::Folder,
+            CliDriveObjectType::AiFact => Self::AiFact,
+            CliDriveObjectType::McpServer => Self::McpServer,
+            CliDriveObjectType::Space => Self::Space,
+            CliDriveObjectType::Trash => Self::Trash,
+        }
+    }
 }
 
 pub fn run(args: ControlArgs) -> ExitCode {
@@ -155,7 +495,22 @@ fn run_inner(args: ControlArgs) -> Result<(), local_control::protocol::ControlEr
     match args.command {
         ControlCommand::Instance(command) => run_instance_command(command, output_format),
         ControlCommand::App(command) => run_app_command(command, output_format),
+        ControlCommand::Capability(command) => run_capability_command(command, output_format),
+        ControlCommand::Action(command) => run_action_command(command, output_format),
+        ControlCommand::Window(command) => run_window_command(command, output_format),
         ControlCommand::Tab(command) => run_tab_command(command, output_format),
+        ControlCommand::Pane(command) => run_pane_command(command, output_format),
+        ControlCommand::Session(command) => run_session_command(command, output_format),
+        ControlCommand::Block(command) => run_block_command(command, output_format),
+        ControlCommand::Input(command) => run_input_command(command, output_format),
+        ControlCommand::History(command) => run_history_command(command, output_format),
+        ControlCommand::Theme(command) => run_theme_command(command, output_format),
+        ControlCommand::Appearance(command) => run_appearance_command(command, output_format),
+        ControlCommand::Setting(command) => run_setting_command(command, output_format),
+        ControlCommand::Keybinding(command) => run_keybinding_command(command, output_format),
+        ControlCommand::File(command) => run_file_command(command, output_format),
+        ControlCommand::Project(command) => run_project_command(command, output_format),
+        ControlCommand::Drive(command) => run_drive_command(command, output_format),
         ControlCommand::Completions { shell } => generate_completions_to_stdout(shell),
     }
 }

--- a/crates/warp_cli/src/local_control/selectors.rs
+++ b/crates/warp_cli/src/local_control/selectors.rs
@@ -1,14 +1,100 @@
 //! CLI argument conversion into shared local-control selectors.
+use local_control::protocol::{
+    ControlError, ErrorCode, PaneSelector, PaneTarget, SessionSelector, SessionTarget,
+    TabSelector, TabTarget, TargetSelector, WindowSelector, WindowTarget,
+};
 use local_control::selection::InstanceSelector;
 
 use crate::local_control::TargetArgs;
 
-pub(super) fn instance_selector(args: TargetArgs) -> InstanceSelector {
-    if let Some(instance_id) = args.instance {
-        return InstanceSelector::Id(local_control::discovery::InstanceId(instance_id));
+pub(super) fn instance_selector(args: &TargetArgs) -> InstanceSelector {
+    if let Some(instance_id) = &args.instance {
+        return InstanceSelector::Id(local_control::discovery::InstanceId(instance_id.clone()));
     }
     if let Some(pid) = args.pid {
         return InstanceSelector::Pid(pid);
     }
     InstanceSelector::Active
+}
+
+pub(super) fn target_selector(args: &TargetArgs) -> Result<TargetSelector, ControlError> {
+    Ok(TargetSelector {
+        window: window_target(args)?,
+        tab: tab_target(args)?,
+        pane: pane_target(args)?,
+        session: session_target(args)?,
+    })
+}
+
+fn window_target(args: &TargetArgs) -> Result<Option<WindowTarget>, ControlError> {
+    if let Some(window) = &args.window {
+        if window == "active" {
+            return Ok(Some(WindowTarget::Active));
+        }
+        return Ok(Some(WindowTarget::Id {
+            id: WindowSelector(window.clone()),
+        }));
+    }
+    if let Some(index) = args.window_index {
+        return Ok(Some(WindowTarget::Index { index }));
+    }
+    if let Some(title) = &args.window_title {
+        return Ok(Some(WindowTarget::Title {
+            title: title.clone(),
+        }));
+    }
+    Ok(None)
+}
+
+fn tab_target(args: &TargetArgs) -> Result<Option<TabTarget>, ControlError> {
+    if let Some(tab) = &args.tab {
+        if tab == "active" {
+            return Ok(Some(TabTarget::Active));
+        }
+        return Ok(Some(TabTarget::Id {
+            id: TabSelector(tab.clone()),
+        }));
+    }
+    if let Some(index) = args.tab_index {
+        return Ok(Some(TabTarget::Index { index }));
+    }
+    if let Some(title) = &args.tab_title {
+        return Ok(Some(TabTarget::Title {
+            title: title.clone(),
+        }));
+    }
+    Ok(None)
+}
+
+fn pane_target(args: &TargetArgs) -> Result<Option<PaneTarget>, ControlError> {
+    if let Some(pane) = &args.pane {
+        if pane == "active" {
+            return Ok(Some(PaneTarget::Active));
+        }
+        return Ok(Some(PaneTarget::Id {
+            id: PaneSelector(pane.clone()),
+        }));
+    }
+    if let Some(index) = args.pane_index {
+        return Ok(Some(PaneTarget::Index { index }));
+    }
+    Ok(None)
+}
+
+fn session_target(args: &TargetArgs) -> Result<Option<SessionTarget>, ControlError> {
+    if let Some(session) = &args.session {
+        if session == "active" {
+            return Ok(Some(SessionTarget::Active));
+        }
+        if session.is_empty() {
+            return Err(ControlError::new(
+                ErrorCode::InvalidSelector,
+                "session selector cannot be empty",
+            ));
+        }
+        return Ok(Some(SessionTarget::Id {
+            id: SessionSelector(session.clone()),
+        }));
+    }
+    Ok(None)
 }

--- a/crates/warp_cli/src/local_control_tests.rs
+++ b/crates/warp_cli/src/local_control_tests.rs
@@ -61,18 +61,35 @@ fn parses_completion_generation_command() {
 }
 
 #[test]
-fn rejects_future_catalog_commands_not_in_first_slice() {
-    assert!(ControlArgs::try_parse_from(["warpctrl", "window", "list"]).is_err());
-    assert!(ControlArgs::try_parse_from(["warpctrl", "tab", "list"]).is_err());
-    assert!(ControlArgs::try_parse_from(["warpctrl", "setting", "list"]).is_err());
+fn parses_readonly_capability_and_target_commands() {
+    assert!(ControlArgs::try_parse_from(["warpctrl", "instance", "inspect"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "capability", "list"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "capability", "inspect", "tab.create"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "action", "inspect", "drive.inspect"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "window", "list"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "window", "inspect", "--window", "active"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "tab", "inspect", "--tab-index", "0"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "pane", "inspect", "--pane", "active"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "session", "inspect", "--session", "active"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "block", "output", "block_1"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "input", "get"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "history", "list", "--limit", "5"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "theme", "get"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "keybinding", "get", "copy"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "file", "list"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "project", "active"]).is_ok());
+    assert!(ControlArgs::try_parse_from(["warpctrl", "drive", "inspect", "drive_1"]).is_ok());
 }
 
 #[test]
-fn generated_bash_completions_include_first_slice_commands() {
+fn generated_bash_completions_include_readonly_commands() {
     let completions =
         generate_completion_string(Shell::Bash).expect("bash completions render to UTF-8");
     assert!(completions.contains("instance"));
-    assert!(completions.contains("tab"));
+    assert!(completions.contains("capability"));
+    assert!(completions.contains("window"));
+    assert!(completions.contains("block"));
+    assert!(completions.contains("drive"));
     assert!(completions.contains("completions"));
 }
 


### PR DESCRIPTION
## Summary
- Implements canonical `warpctrl` read-only capability/target/data handlers for instance, capability, action, window/tab/pane/session, block/input/history, theme/settings/keybinding, file/project, and Drive reads.
- Adds session selectors, block id params, typed read result payloads, and CLI target selector flags for active/id/index/title forms where represented by the protocol.
- Adds read metadata vs underlying-data permission coverage and CLI/parser/protocol tests for the expanded read-only surface.

## Validation
- `git diff --check` passed.
- Static catalog/handler coverage check passed: no missing `ActionKind` refs, duplicate implementation-status patterns, or implemented/bridge drift.
- Static stale-name grep passed for old `app.inspect`, `action.get`, `block.get`, and `drive.get` names in edited local-control crates.
- Rust toolchain validation skipped: `cargo` is not installed in this cloud image.

_Conversation: https://staging.warp.dev/conversation/b4756638-6413-4c98-a0c0-5b47f4796ce1_
_Run: https://oz.staging.warp.dev/runs/019e6259-39c4-7d0d-8f19-12ca2c78f6dc_
_This PR was generated with [Oz](https://warp.dev/oz)._
