### PR TITLE
Hide new model choices popup banner on wasm mobile (APP-4607 / #11684)

### DIFF
--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -2319,9 +2319,7 @@ impl View for ProfileModelSelector {
         let is_udi_enabled =
             crate::settings::InputSettings::as_ref(app).is_universal_developer_input_enabled(app);
 
-        // The popup overflows the viewport on wasm mobile and can't be dismissed by touch,
-        // so suppress it entirely on mobile web. `is_mobile_device` returns false on native
-        // builds, so this is effectively a wasm-mobile-only gate.
+        // The popup overflows the viewport on wasm mobile.
         let is_wasm_mobile = warpui::platform::is_mobile_device();
 
         if !is_wasm_mobile

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -2319,12 +2319,20 @@ impl View for ProfileModelSelector {
         let is_udi_enabled =
             crate::settings::InputSettings::as_ref(app).is_universal_developer_input_enabled(app);
 
-        if is_udi_enabled
-            || self
-                .input_model
-                .as_ref(app)
-                .last_ai_autodetection_ts()
-                .is_none_or(|ts| Instant::now().duration_since(ts) > NEW_MODEL_CHOICES_POPUP_DELAY)
+        // The popup overflows the viewport on wasm mobile and can't be dismissed by touch,
+        // so suppress it entirely on mobile web. `is_mobile_device` returns false on native
+        // builds, so this is effectively a wasm-mobile-only gate.
+        let is_wasm_mobile = warpui::platform::is_mobile_device();
+
+        if !is_wasm_mobile
+            && (is_udi_enabled
+                || self
+                    .input_model
+                    .as_ref(app)
+                    .last_ai_autodetection_ts()
+                    .is_none_or(|ts| {
+                        Instant::now().duration_since(ts) > NEW_MODEL_CHOICES_POPUP_DELAY
+                    }))
         {
             let llm_preferences = LLMPreferences::as_ref(app);
             match (


### PR DESCRIPTION
## Description
The new model popup banner overflows on mobile (it's too wide for thin devices and the dismiss button disappears off screen). The easy fix is to just hide it on mobile.

Addresses:
- APP-4607
- https://github.com/warpdotdev/warp/issues/11684

## Linked Issue
- https://github.com/warpdotdev/warp/issues/11684

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/97a01569-489c-420e-896f-18867a93d138_
_Run: https://oz.staging.warp.dev/runs/019e64c3-8591-751d-8db8-c67466d00126_

_This PR was generated with [Oz](https://warp.dev/oz)._
