### PR TITLE
Disable GHA Oz follow-up input

### DIFF
--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -449,6 +449,12 @@ impl AmbientAgentTask {
         self.is_terminal_run_state() && !self.has_active_execution()
     }
 
+    /// GitHub Actions Oz runs are unmanaged by Warp after the workflow-owned
+    /// process exits, so the Warp client should not offer cloud follow-ups.
+    pub fn supports_warp_cloud_followups(&self) -> bool {
+        !matches!(self.source, Some(AgentSource::GitHubAction))
+    }
+
     /// Total credits used (inference + compute + platform).
     pub fn credits_used(&self) -> Option<f32> {
         self.active_run_execution().request_usage.map(|u| {

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -13,6 +13,7 @@ use super::AmbientAgentProgressUIState;
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::extract_user_query_mode;
+use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::github_auth_notifier::{GitHubAuthEvent, GitHubAuthNotifier};
 use crate::ai::ambient_agents::spawn::{spawn_task, submit_run_followup, AmbientAgentEvent};
 use crate::ai::ambient_agents::task::{HarnessAuthSecretsConfig, HarnessConfig};
@@ -249,6 +250,8 @@ pub struct AmbientAgentViewModel {
 
     /// Prompt text for a follow-up that has been submitted but not yet attached to a new session.
     pending_followup_prompt: Option<String>,
+    /// Whether the current task source supports Warp-initiated cloud follow-ups.
+    cloud_followups_enabled: bool,
 
     /// See [`PendingHandoff`].
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -315,6 +318,7 @@ impl AmbientAgentViewModel {
             active_execution_session_id: None,
             last_ended_execution_session_id: None,
             pending_followup_prompt: None,
+            cloud_followups_enabled: true,
             #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
             pending_handoff: None,
         }
@@ -804,7 +808,8 @@ impl AmbientAgentViewModel {
     /// the status stays `AgentRunning` while the active session is cleared, which is the editable
     /// post-run state where follow-ups are allowed.
     pub fn is_ready_for_cloud_followup_prompt(&self) -> bool {
-        self.task_id.is_some()
+        self.cloud_followups_enabled
+            && self.task_id.is_some()
             && self.active_execution_session_id.is_none()
             && self.pending_followup_prompt.is_none()
             && matches!(self.status, Status::AgentRunning)
@@ -870,6 +875,10 @@ impl AmbientAgentViewModel {
 
         // Store the task ID for later use
         self.task_id = Some(task_id);
+        self.cloud_followups_enabled = true;
+        if let Some(task) = AgentConversationsModel::as_ref(ctx).get_task_data(&task_id) {
+            self.cloud_followups_enabled = task.supports_warp_cloud_followups();
+        }
 
         self.status = Status::AgentRunning;
         ctx.emit(AmbientAgentViewModelEvent::RunLifecycleChanged);
@@ -881,6 +890,7 @@ impl AmbientAgentViewModel {
             async move { ai_client.get_ambient_agent_task(&task_id).await },
             |me, result, ctx| match result {
                 Ok(task) => {
+                    me.cloud_followups_enabled = task.supports_warp_cloud_followups();
                     me.apply_viewed_task_config_snapshot(task.agent_config_snapshot.as_ref(), ctx);
                     ctx.emit(AmbientAgentViewModelEvent::ViewerHarnessResolved);
                 }
@@ -977,6 +987,11 @@ impl AmbientAgentViewModel {
             return;
         }
 
+        if !self.cloud_followups_enabled {
+            log::warn!("Attempted to submit cloud follow-up for a task source that does not support Warp follow-ups");
+            return;
+        }
+
         let Some(task_id) = self.task_id else {
             log::warn!("Attempted to submit cloud follow-up without an ambient task ID");
             return;
@@ -1041,6 +1056,7 @@ impl AmbientAgentViewModel {
         self.active_execution_session_id = None;
         self.last_ended_execution_session_id = None;
         self.pending_followup_prompt = None;
+        self.cloud_followups_enabled = true;
         self.request = None;
         self.setup_commands_state = Default::default();
         self.stop_progress_timer();

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -253,6 +253,28 @@ fn followup_github_auth_does_not_reuse_stored_initial_request() {
 }
 
 #[test]
+fn disabled_cloud_followups_do_not_show_or_submit_prompt() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+        let task_id: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-000000000001".parse().unwrap();
+
+        model.update(&mut app, |model, ctx| {
+            model.status = Status::AgentRunning;
+            model.task_id = Some(task_id);
+            model.cloud_followups_enabled = false;
+
+            assert!(!model.is_ready_for_cloud_followup_prompt());
+            model.submit_cloud_followup("follow up".to_string(), ctx);
+            assert!(model.pending_followup_prompt().is_none());
+            assert!(matches!(model.status(), Status::AgentRunning));
+        });
+    });
+}
+
+#[test]
 fn queue_handoff_auto_submit_enters_waiting_state_without_consuming_launch() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -62,6 +62,9 @@ pub(in crate::terminal::view) fn resolve_cloud_conversation_continuation_ui_stat
     if task.has_active_execution() {
         return Err(CloudConversationContinuationError::ActiveTaskExecution);
     }
+    if !task.supports_warp_cloud_followups() {
+        return Ok(CloudConversationContinuationUiState::Tombstone { cta: None });
+    }
     let is_environment_setup_failure = task.state.is_failure_like()
         && task
             .status_message

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -11,7 +11,8 @@ use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIAgentHarness, ServerAIConversationMetadata};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::task::{
-    AgentConfigSnapshot, HarnessConfig, TaskPrincipalInfo, TaskStatusErrorCode, TaskStatusMessage,
+    AgentConfigSnapshot, AgentSource, HarnessConfig, TaskPrincipalInfo, TaskStatusErrorCode,
+    TaskStatusMessage,
 };
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
@@ -205,6 +206,7 @@ fn active_ambient_agent_task(task_id: AmbientAgentTaskId) -> AmbientAgentTask {
 trait AmbientAgentTaskTestExt {
     fn with_creator(self, creator_uid: &str) -> Self;
     fn with_harness(self, harness: Harness) -> Self;
+    fn with_source(self, source: AgentSource) -> Self;
 }
 
 impl AmbientAgentTaskTestExt for AmbientAgentTask {
@@ -226,6 +228,11 @@ impl AmbientAgentTaskTestExt for AmbientAgentTask {
             }),
             ..Default::default()
         });
+        self
+    }
+
+    fn with_source(mut self, source: AgentSource) -> Self {
+        self.source = Some(source);
         self
     }
 }
@@ -366,6 +373,40 @@ fn oz_conversation_with_edit_access_shows_inline_followup_input() {
             assert_eq!(
                 state,
                 Ok(CloudConversationContinuationUiState::FollowupInput)
+            );
+        });
+    });
+}
+
+#[test]
+fn github_action_oz_conversation_with_edit_access_shows_tombstone_without_cta() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_app(
+            &mut app,
+            AuthFixture::LoggedIn,
+            AIAgentHarness::Oz,
+            ConversationPermissionFixture::CurrentUserOwner,
+        );
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(
+                ambient_agent_task(
+                    task_id,
+                    CONVERSATION_TOKEN,
+                    AmbientAgentTaskState::Succeeded,
+                )
+                .with_source(AgentSource::GitHubAction),
+            );
+        });
+
+        app.update(|ctx| {
+            let state =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx);
+            assert_eq!(
+                state,
+                Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
             );
         });
     });


### PR DESCRIPTION
## Summary
- Treat GitHub Actions-created Oz runs as unsupported for Warp-initiated cloud follow-ups.
- Show the non-interactive tombstone state instead of enabling the follow-up prompt.
- Gate ambient follow-up readiness/submission so stale editable input cannot submit for those runs.

## Tests
- `cargo test -p warp github_action_oz_conversation_with_edit_access_shows_tombstone_without_cta`
- `cargo test -p warp disabled_cloud_followups_do_not_show_or_submit_prompt`

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._