### PR TITLE
Fix team owner pill contrast

### DIFF
--- a/app/src/settings_view/teams_page.rs
+++ b/app/src/settings_view/teams_page.rs
@@ -105,6 +105,7 @@ const TEXT_FIELD_TOP_PADDING: f32 = 12.;
 const HORIZONTAL_BAR_TO_SUB_HEADER_PADDING: f32 = 9.;
 const SUBSECTION_HEADER_FONT_SIZE: f32 = 18.;
 const SUBSUBSECTION_HEADER_FONT_SIZE: f32 = 14.;
+const OWNER_STATE_CHIP_ACCENT_OPACITY: u8 = 30;
 
 const INVITE_LINK_PREFIX: &str = "/team/";
 const INVALID_DOMAINS_INSTRUCTIONS: &str =
@@ -130,6 +131,13 @@ lazy_static! {
     static ref PAST_DUE_BADGE_COLOR: ColorU = ColorU::new(254, 253, 194, 255);
     static ref UNPAID_BADGE_COLOR: ColorU = ColorU::new(255, 130, 114, 255);
     static ref DELINQUENCY_BADGE_TEXT_COLOR: ColorU = ColorU::new(0, 0, 0, 190);
+}
+
+fn owner_state_chip_text_color(theme: &themes::theme::WarpTheme) -> ColorU {
+    let chip_background = theme
+        .background()
+        .blend(&theme.accent().with_opacity(OWNER_STATE_CHIP_ACCENT_OPACITY));
+    theme.main_text_color(chip_background).into_solid()
 }
 
 #[derive(Debug, Clone)]
@@ -3502,14 +3510,20 @@ impl TeamsWidget {
                         );
                     }
                     ItemState::Owner => {
-                        pending_and_close_row.add_child(self.render_state_chip(
-                            appearance,
-                            "OWNER".into(),
-                            appearance.theme().accent().into(),
-                            appearance.theme().accent().with_opacity(30).into(),
-                            appearance.ui_font_size() - 1.,
-                            Weight::Normal,
-                        ));
+                        pending_and_close_row.add_child(
+                            self.render_state_chip(
+                                appearance,
+                                "OWNER".into(),
+                                owner_state_chip_text_color(appearance.theme()),
+                                appearance
+                                    .theme()
+                                    .accent()
+                                    .with_opacity(OWNER_STATE_CHIP_ACCENT_OPACITY)
+                                    .into(),
+                                appearance.ui_font_size() - 1.,
+                                Weight::Normal,
+                            ),
+                        );
                     }
                     ItemState::Admin => {
                         pending_and_close_row.add_child(
@@ -4423,4 +4437,31 @@ pub fn test_valid_domains() {
     assert!(TeamsPageView::is_valid_domain("warp0.dev0"));
     assert!(TeamsPageView::is_valid_domain("warp.dev"));
     assert!(TeamsPageView::is_valid_domain("miniclip.com"));
+}
+
+#[cfg(test)]
+#[test]
+pub fn test_owner_state_chip_text_contrasts_with_accent_overlay() {
+    let theme_config = themes::theme::WarpThemeConfig::new();
+
+    for theme_kind in [
+        themes::theme::ThemeKind::CyberWave,
+        themes::theme::ThemeKind::WillowDream,
+        themes::theme::ThemeKind::SolarFlare,
+    ] {
+        let theme = theme_config.theme(&theme_kind);
+        let chip_background = theme
+            .background()
+            .blend(&theme.accent().with_opacity(OWNER_STATE_CHIP_ACCENT_OPACITY));
+        let text_color = owner_state_chip_text_color(&theme);
+
+        assert!(
+            crate::util::color::high_enough_contrast(
+                text_color,
+                chip_background.into_solid(),
+                crate::util::color::MinimumAllowedContrast::Text,
+            ),
+            "{theme_kind} owner chip text should contrast with its accent overlay"
+        );
+    }
 }


### PR DESCRIPTION
## Testing

see before [here](https://warpdev.slack.com/archives/C097ZGA1AMB/p1779809144889669?thread_ts=1779733378.222149&cid=C097ZGA1AMB)

and after:

### Cyber wave:
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/abf10bd1-ff02-49fe-9920-be28a6f4b37c" />

### Willow dream

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/0d776adf-71d4-4041-8b91-6fc6279b1616" />

###

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/d997c0e7-d63b-4b63-8b87-67e98029c59c" />


## Description
Fixes the team settings owner pill contrast for themes where the accent color/gradient is too close to the accent-tinted chip background, including Cyber Wave, Willow Dream, and Solar Flare.

The owner chip previously used `theme.accent()` for the foreground and `theme.accent().with_opacity(30)` for the background. This differed from other theme-safe UI patterns that choose text color using theme contrast helpers against the actual visible background. The fix keeps the accent-tinted chip background and derives the text color with `theme.main_text_color(...)` against the chip background composited over the theme background.

## Linked Issue
Slack report in `#feedback-revenue`.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all -- --check`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp test_owner_state_chip_text_contrasts_with_accent_overlay --lib`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml --workspace --all-targets --all-features --tests -- -D warnings` (fails on pre-existing `warpui_core` clippy diagnostics in `crates/warpui_core/src/elements/{event_handler,hoverable,resizable,text}.rs`, unrelated to this change)
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --lib --tests -- -D warnings` (same pre-existing `warpui_core` diagnostics)

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; this change is covered by a targeted contrast regression test for Cyber Wave, Willow Dream, and Solar Flare.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the team settings owner badge being unreadable on some themes.

_Conversation: https://staging.warp.dev/conversation/052a8328-c4eb-480b-a98e-c16fe73498f1_
_Run: https://oz.staging.warp.dev/runs/019e64e4-5de3-798c-b8ad-cff12af7d02f_
_This PR was generated with [Oz](https://warp.dev/oz)._
