### PR TITLE
fix: suppress input for github action session shares

### DIFF
--- a/app/src/ai/ambient_agents/task.rs
+++ b/app/src/ai/ambient_agents/task.rs
@@ -225,6 +225,21 @@ impl AgentSource {
         }
     }
 
+    /// Returns true when tasks from this source must not accept user-triggered cloud follow-ups.
+    pub fn blocks_cloud_followups(&self) -> bool {
+        match self {
+            AgentSource::GitHubAction => true,
+            AgentSource::Linear
+            | AgentSource::AgentWebhook
+            | AgentSource::Slack
+            | AgentSource::Cli
+            | AgentSource::ScheduledAgent
+            | AgentSource::Interactive
+            | AgentSource::WebApp
+            | AgentSource::CloudMode => false,
+        }
+    }
+
     /// Returns true if this source represents a user-initiated conversation
     /// (as opposed to automated/programmatic sources like CLI or scheduled runs).
     pub fn is_user_initiated(&self) -> bool {
@@ -392,6 +407,13 @@ impl AmbientAgentTask {
 
     pub fn conversation_id(&self) -> Option<&str> {
         self.conversation_id.as_deref()
+    }
+
+    /// Returns true when this task's source must not accept user-triggered cloud follow-ups.
+    pub fn blocks_cloud_followups(&self) -> bool {
+        self.source
+            .as_ref()
+            .is_some_and(AgentSource::blocks_cloud_followups)
     }
 
     pub fn active_run_execution(&self) -> RunExecution<'_> {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7431,6 +7431,9 @@ impl TerminalView {
         if self.conversation_ended_tombstone_view_id.is_some() {
             return false;
         }
+        if self.is_github_action_ambient_agent_session_from_model(model, app) {
+            return false;
+        }
         if self.has_active_cli_agent_input_session(app) {
             return true;
         }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7431,7 +7431,7 @@ impl TerminalView {
         if self.conversation_ended_tombstone_view_id.is_some() {
             return false;
         }
-        if self.is_github_action_ambient_agent_session_from_model(model, app) {
+        if self.blocks_cloud_followups_for_ambient_agent_session_from_model(model, app) {
             return false;
         }
         if self.has_active_cli_agent_input_session(app) {
@@ -20460,6 +20460,14 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) -> bool {
         if !FeatureFlag::HandoffCloudCloud.is_enabled() {
+            return false;
+        }
+        let blocks_cloud_followups = {
+            let model = self.model.lock();
+            self.blocks_cloud_followups_for_ambient_agent_session_from_model(&model, ctx)
+        };
+        if blocks_cloud_followups {
+            self.pending_cloud_followup_task_id = None;
             return false;
         }
         let Some(task_id) = self

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -18,7 +18,7 @@ use crate::ai::ambient_agents::spawn::{spawn_task, submit_run_followup, AmbientA
 use crate::ai::ambient_agents::task::{HarnessAuthSecretsConfig, HarnessConfig};
 use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
 use crate::ai::ambient_agents::{
-    github_auth_url, AmbientAgentTaskId, OUT_OF_CREDITS_TASK_FAILURE_MESSAGE,
+    github_auth_url, AgentSource, AmbientAgentTaskId, OUT_OF_CREDITS_TASK_FAILURE_MESSAGE,
     SERVER_OVERLOADED_TASK_FAILURE_MESSAGE,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -217,6 +217,9 @@ pub struct AmbientAgentViewModel {
     /// The task ID for the current cloud agent task, if one has been spawned.
     task_id: Option<AmbientAgentTaskId>,
 
+    /// Source of the current cloud agent task, once known.
+    source: Option<AgentSource>,
+
     /// The local conversation associated with this cloud agent run, if any.
     /// Set for remote child agents spawned via `start_agent` so the `run_id`
     /// from the server response can be wired back to the conversation.
@@ -305,6 +308,7 @@ impl AmbientAgentViewModel {
             ui_state,
             setup_commands_state: Default::default(),
             task_id: None,
+            source: None,
             conversation_id: None,
             harness,
             worker_host: None,
@@ -762,6 +766,10 @@ impl AmbientAgentViewModel {
         self.task_id
     }
 
+    pub(in crate::terminal::view) fn is_github_action_source(&self) -> bool {
+        self.source == Some(AgentSource::GitHubAction)
+    }
+
     /// Whether or not this terminal session is in the setup state (first-time environment creation).
     pub fn is_in_setup(&self) -> bool {
         matches!(self.status, Status::Setup)
@@ -870,6 +878,7 @@ impl AmbientAgentViewModel {
 
         // Store the task ID for later use
         self.task_id = Some(task_id);
+        self.source = None;
 
         self.status = Status::AgentRunning;
         ctx.emit(AmbientAgentViewModelEvent::RunLifecycleChanged);
@@ -881,6 +890,7 @@ impl AmbientAgentViewModel {
             async move { ai_client.get_ambient_agent_task(&task_id).await },
             |me, result, ctx| match result {
                 Ok(task) => {
+                    me.source = task.source.clone();
                     me.apply_viewed_task_config_snapshot(task.agent_config_snapshot.as_ref(), ctx);
                     ctx.emit(AmbientAgentViewModelEvent::ViewerHarnessResolved);
                 }
@@ -1034,6 +1044,7 @@ impl AmbientAgentViewModel {
         self.environment_id = None;
         self.environment_id_from_viewed_task = false;
         self.task_id = None;
+        self.source = None;
         self.conversation_id = None;
         self.harness_model_id = None;
         self.harness_reasoning_level = None;
@@ -1177,6 +1188,7 @@ impl AmbientAgentViewModel {
         request.interactive = Some(true);
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         self.request = Some(request.clone());
+        self.source = None;
         let stream = spawn_task(request, ai_client, None);
 
         ctx.spawn_stream_local(

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -766,8 +766,10 @@ impl AmbientAgentViewModel {
         self.task_id
     }
 
-    pub(in crate::terminal::view) fn is_github_action_source(&self) -> bool {
-        self.source == Some(AgentSource::GitHubAction)
+    pub(in crate::terminal::view) fn blocks_cloud_followups(&self) -> bool {
+        self.source
+            .as_ref()
+            .is_some_and(AgentSource::blocks_cloud_followups)
     }
 
     /// Whether or not this terminal session is in the setup state (first-time environment creation).

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -34,17 +34,13 @@ pub(in crate::terminal::view) enum CloudConversationContinuationError {
     ActiveTaskExecution,
     MissingConversationToken,
     MissingServerConversationMetadata,
-    SourceDoesNotSupportContinuation,
     UnknownHarness,
     UnknownConversationAccess,
 }
 
 impl CloudConversationContinuationError {
     pub(in crate::terminal::view) fn should_fallback_to_tombstone(self) -> bool {
-        !matches!(
-            self,
-            Self::ActiveTaskExecution | Self::SourceDoesNotSupportContinuation
-        )
+        !matches!(self, Self::ActiveTaskExecution)
     }
 }
 
@@ -64,7 +60,7 @@ pub(in crate::terminal::view) fn resolve_cloud_conversation_continuation_ui_stat
         return Err(CloudConversationContinuationError::MissingTask);
     };
     if task.source == Some(AgentSource::GitHubAction) {
-        return Err(CloudConversationContinuationError::SourceDoesNotSupportContinuation);
+        return Ok(CloudConversationContinuationUiState::Tombstone { cta: None });
     }
     if task.has_active_execution() {
         return Err(CloudConversationContinuationError::ActiveTaskExecution);

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -7,8 +7,8 @@ use crate::ai::agent::conversation::{
 };
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::{
-    conversation_output_status_from_conversation, AmbientAgentTask, AmbientAgentTaskId,
-    AmbientConversationStatus,
+    conversation_output_status_from_conversation, AgentSource, AmbientAgentTask,
+    AmbientAgentTaskId, AmbientConversationStatus,
 };
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::auth::AuthStateProvider;
@@ -34,13 +34,17 @@ pub(in crate::terminal::view) enum CloudConversationContinuationError {
     ActiveTaskExecution,
     MissingConversationToken,
     MissingServerConversationMetadata,
+    SourceDoesNotSupportContinuation,
     UnknownHarness,
     UnknownConversationAccess,
 }
 
 impl CloudConversationContinuationError {
     pub(in crate::terminal::view) fn should_fallback_to_tombstone(self) -> bool {
-        !matches!(self, Self::ActiveTaskExecution)
+        !matches!(
+            self,
+            Self::ActiveTaskExecution | Self::SourceDoesNotSupportContinuation
+        )
     }
 }
 
@@ -59,6 +63,9 @@ pub(in crate::terminal::view) fn resolve_cloud_conversation_continuation_ui_stat
     let Some(task) = AgentConversationsModel::as_ref(app).get_task_data(&task_id) else {
         return Err(CloudConversationContinuationError::MissingTask);
     };
+    if task.source == Some(AgentSource::GitHubAction) {
+        return Err(CloudConversationContinuationError::SourceDoesNotSupportContinuation);
+    }
     if task.has_active_execution() {
         return Err(CloudConversationContinuationError::ActiveTaskExecution);
     }

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -7,8 +7,8 @@ use crate::ai::agent::conversation::{
 };
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::{
-    conversation_output_status_from_conversation, AgentSource, AmbientAgentTask,
-    AmbientAgentTaskId, AmbientConversationStatus,
+    conversation_output_status_from_conversation, AmbientAgentTask, AmbientAgentTaskId,
+    AmbientConversationStatus,
 };
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::auth::AuthStateProvider;
@@ -59,7 +59,7 @@ pub(in crate::terminal::view) fn resolve_cloud_conversation_continuation_ui_stat
     let Some(task) = AgentConversationsModel::as_ref(app).get_task_data(&task_id) else {
         return Err(CloudConversationContinuationError::MissingTask);
     };
-    if task.source == Some(AgentSource::GitHubAction) {
+    if task.blocks_cloud_followups() {
         return Ok(CloudConversationContinuationUiState::Tombstone { cta: None });
     }
     if task.has_active_execution() {

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -350,7 +350,7 @@ fn missing_task_returns_error() {
 }
 
 #[test]
-fn github_action_source_returns_error_without_tombstone_fallback() {
+fn github_action_source_shows_tombstone_without_cta() {
     App::test((), |mut app| async move {
         let TestHandles {
             terminal_view_id,
@@ -368,15 +368,10 @@ fn github_action_source_returns_error_without_tombstone_fallback() {
         });
 
         app.update(|ctx| {
-            let error =
-                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx)
-                    .unwrap_err();
-
             assert_eq!(
-                error,
-                CloudConversationContinuationError::SourceDoesNotSupportContinuation
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx),
+                Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
             );
-            assert!(!error.should_fallback_to_tombstone());
         });
     });
 }

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -13,7 +13,9 @@ use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::task::{
     AgentConfigSnapshot, HarnessConfig, TaskPrincipalInfo, TaskStatusErrorCode, TaskStatusMessage,
 };
-use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState};
+use crate::ai::ambient_agents::{
+    AgentSource, AmbientAgentTask, AmbientAgentTaskId, AmbientAgentTaskState,
+};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 use crate::auth::user::TEST_USER_UID;
 use crate::auth::{AuthStateProvider, UserUid};
@@ -343,6 +345,38 @@ fn missing_task_returns_error() {
                 ctx,
             );
             assert_eq!(state, Err(CloudConversationContinuationError::MissingTask));
+        });
+    });
+}
+
+#[test]
+fn github_action_source_returns_error_without_tombstone_fallback() {
+    App::test((), |mut app| async move {
+        let TestHandles {
+            terminal_view_id,
+            task_id,
+        } = setup_owned_task_without_server_metadata(&mut app);
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            let mut task = ambient_agent_task(
+                task_id,
+                CONVERSATION_TOKEN,
+                AmbientAgentTaskState::Succeeded,
+            )
+            .with_creator(TEST_USER_UID);
+            task.source = Some(AgentSource::GitHubAction);
+            model.insert_task_for_test(task);
+        });
+
+        app.update(|ctx| {
+            let error =
+                resolve_cloud_conversation_continuation_ui_state(terminal_view_id, task_id, ctx)
+                    .unwrap_err();
+
+            assert_eq!(
+                error,
+                CloudConversationContinuationError::SourceDoesNotSupportContinuation
+            );
+            assert!(!error.should_fallback_to_tombstone());
         });
     });
 }

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -908,15 +908,6 @@ impl TerminalView {
             self.insert_conversation_ended_tombstone_with_cta(None, ctx);
             return;
         }
-        {
-            let model = self.model.lock();
-            if self.is_github_action_ambient_agent_session_from_model(&model, ctx) {
-                drop(model);
-                self.remove_conversation_ended_tombstone(ctx);
-                self.pending_cloud_followup_task_id = None;
-                return;
-            }
-        }
         let Some(state) = self.cloud_conversation_continuation_ui_state(ctx) else {
             return;
         };
@@ -1803,15 +1794,6 @@ impl TerminalView {
         &mut self,
         ctx: &mut ViewContext<Self>,
     ) {
-        {
-            let model = self.model.lock();
-            if self.is_github_action_ambient_agent_session_from_model(&model, ctx) {
-                drop(model);
-                self.remove_conversation_ended_tombstone(ctx);
-                self.pending_cloud_followup_task_id = None;
-                return;
-            }
-        }
         if !FeatureFlag::HandoffCloudCloud.is_enabled() {
             self.insert_conversation_ended_tombstone_with_cta(None, ctx);
             return;

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -31,7 +31,7 @@ use super::sharer::Sharer;
 use super::viewer::Viewer;
 use super::{ConversationEndedTombstoneEvent, ConversationEndedTombstoneView};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
-use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::ambient_agents::{AgentSource, AmbientAgentTaskId};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::auth::UserUid;
 use crate::context_chips::ContextChipKind;
@@ -143,6 +143,29 @@ impl TerminalView {
                 .should_fallback_to_tombstone()
                 .then_some(CloudConversationContinuationUiState::Tombstone { cta: None }),
         }
+    }
+
+    pub(in crate::terminal::view) fn is_github_action_ambient_agent_session_from_model(
+        &self,
+        model: &TerminalModel,
+        ctx: &AppContext,
+    ) -> bool {
+        if self
+            .ambient_agent_view_model
+            .as_ref()
+            .is_some_and(|model| model.as_ref(ctx).is_github_action_source())
+        {
+            return true;
+        }
+
+        let Some(task_id) = self.ambient_agent_task_id_for_details_panel_from_model(model, ctx)
+        else {
+            return false;
+        };
+
+        AgentConversationsModel::as_ref(ctx)
+            .get_task_data(&task_id)
+            .is_some_and(|task| task.source == Some(AgentSource::GitHubAction))
     }
 
     pub(crate) fn owned_ambient_agent_task_id(
@@ -884,6 +907,15 @@ impl TerminalView {
         if !FeatureFlag::HandoffCloudCloud.is_enabled() {
             self.insert_conversation_ended_tombstone_with_cta(None, ctx);
             return;
+        }
+        {
+            let model = self.model.lock();
+            if self.is_github_action_ambient_agent_session_from_model(&model, ctx) {
+                drop(model);
+                self.remove_conversation_ended_tombstone(ctx);
+                self.pending_cloud_followup_task_id = None;
+                return;
+            }
         }
         let Some(state) = self.cloud_conversation_continuation_ui_state(ctx) else {
             return;
@@ -1771,6 +1803,15 @@ impl TerminalView {
         &mut self,
         ctx: &mut ViewContext<Self>,
     ) {
+        {
+            let model = self.model.lock();
+            if self.is_github_action_ambient_agent_session_from_model(&model, ctx) {
+                drop(model);
+                self.remove_conversation_ended_tombstone(ctx);
+                self.pending_cloud_followup_task_id = None;
+                return;
+            }
+        }
         if !FeatureFlag::HandoffCloudCloud.is_enabled() {
             self.insert_conversation_ended_tombstone_with_cta(None, ctx);
             return;

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -31,7 +31,7 @@ use super::sharer::Sharer;
 use super::viewer::Viewer;
 use super::{ConversationEndedTombstoneEvent, ConversationEndedTombstoneView};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
-use crate::ai::ambient_agents::{AgentSource, AmbientAgentTaskId};
+use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::auth::UserUid;
 use crate::context_chips::ContextChipKind;
@@ -145,7 +145,7 @@ impl TerminalView {
         }
     }
 
-    pub(in crate::terminal::view) fn is_github_action_ambient_agent_session_from_model(
+    pub(in crate::terminal::view) fn blocks_cloud_followups_for_ambient_agent_session_from_model(
         &self,
         model: &TerminalModel,
         ctx: &AppContext,
@@ -153,7 +153,7 @@ impl TerminalView {
         if self
             .ambient_agent_view_model
             .as_ref()
-            .is_some_and(|model| model.as_ref(ctx).is_github_action_source())
+            .is_some_and(|model| model.as_ref(ctx).blocks_cloud_followups())
         {
             return true;
         }
@@ -165,7 +165,7 @@ impl TerminalView {
 
         AgentConversationsModel::as_ref(ctx)
             .get_task_data(&task_id)
-            .is_some_and(|task| task.source == Some(AgentSource::GitHubAction))
+            .is_some_and(|task| task.blocks_cloud_followups())
     }
 
     pub(crate) fn owned_ambient_agent_task_id(

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -118,7 +118,7 @@ fn test_on_ambient_agent_execution_ended_enables_followup_input_for_editable_non
             let model = view.model.lock();
             assert_eq!(
                 model.block_list().block_heights().items().len(),
-                initial_block_height_items
+                initial_block_height_items + 1
             );
             assert!(matches!(
                 model.shared_session_status(),
@@ -1113,7 +1113,7 @@ fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owne
 }
 
 #[test]
-fn test_on_session_share_ended_suppresses_input_for_github_action_ambient_session() {
+fn test_on_session_share_ended_shows_tombstone_for_github_action_ambient_session() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
@@ -1147,9 +1147,9 @@ fn test_on_session_share_ended_suppresses_input_for_github_action_ambient_sessio
             let model = view.model.lock();
             assert_eq!(
                 model.block_list().block_heights().items().len(),
-                initial_block_height_items + 1
+                initial_block_height_items + 2
             );
-            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert!(view.conversation_ended_tombstone_view_id.is_some());
             assert_eq!(view.pending_cloud_followup_task_id, None);
             assert!(!view.is_input_box_visible(&model, ctx));
             assert_eq!(
@@ -1426,7 +1426,7 @@ fn test_on_ambient_agent_execution_ended_enables_followup_for_owned_task_without
 }
 
 #[test]
-fn test_on_ambient_agent_execution_ended_suppresses_input_for_github_action_ambient_session() {
+fn test_on_ambient_agent_execution_ended_shows_tombstone_for_github_action_ambient_session() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
 
@@ -1462,9 +1462,9 @@ fn test_on_ambient_agent_execution_ended_suppresses_input_for_github_action_ambi
             let model = view.model.lock();
             assert_eq!(
                 model.block_list().block_heights().items().len(),
-                initial_block_height_items
+                initial_block_height_items + 1
             );
-            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert!(view.conversation_ended_tombstone_view_id.is_some());
             assert_eq!(view.pending_cloud_followup_task_id, None);
             assert!(!view.is_input_box_visible(&model, ctx));
             assert_eq!(

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -1113,6 +1113,58 @@ fn test_on_session_share_ended_enables_followup_input_without_tombstone_for_owne
 }
 
 #[test]
+fn test_on_session_share_ended_suppresses_input_for_github_action_ambient_session() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = terminal_view_for_viewer(&mut app);
+        let mut task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        task.source = Some(AgentSource::GitHubAction);
+        let task_id = task.task_id;
+
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
+        let initial_block_height_items = terminal.read(&app, |view, _| {
+            view.model.lock().block_list().block_heights().items().len()
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.model
+                .lock()
+                .set_shared_session_source(SharedSessionSource::ambient_agent(Some(
+                    task_id.to_string(),
+                )));
+            view.on_session_share_ended(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            assert_eq!(
+                model.block_list().block_heights().items().len(),
+                initial_block_height_items + 1
+            );
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, None);
+            assert!(!view.is_input_box_visible(&model, ctx));
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Selectable
+            );
+        });
+    });
+}
+
+#[test]
 fn test_on_session_share_ended_hides_input_for_no_cta_tombstone() {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
     let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
@@ -1368,6 +1420,60 @@ fn test_on_ambient_agent_execution_ended_enables_followup_for_owned_task_without
                     .as_ref(ctx)
                     .interaction_state(ctx),
                 InteractionState::Editable
+            );
+        });
+    });
+}
+
+#[test]
+fn test_on_ambient_agent_execution_ended_suppresses_input_for_github_action_ambient_session() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = terminal_view_for_viewer(&mut app);
+        let mut task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        task.source = Some(AgentSource::GitHubAction);
+        let task_id = task.task_id;
+
+        insert_cloud_mode_task_with_server_metadata(
+            &mut app,
+            terminal.id(),
+            task,
+            AIAgentHarness::Oz,
+            current_user_owner_permissions(),
+        );
+        let initial_block_height_items = terminal.read(&app, |view, _| {
+            view.model.lock().block_list().block_heights().items().len()
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let mut model = view.model.lock();
+            model.set_shared_session_source(SharedSessionSource::ambient_agent(Some(
+                task_id.to_string(),
+            )));
+            model.set_shared_session_status(SharedSessionStatus::NotShared);
+            drop(model);
+
+            view.on_ambient_agent_execution_ended(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            assert_eq!(
+                model.block_list().block_heights().items().len(),
+                initial_block_height_items
+            );
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, None);
+            assert!(!view.is_input_box_visible(&model, ctx));
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Selectable
             );
         });
     });

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -1749,6 +1749,49 @@ fn test_try_submit_pending_cloud_followup_allows_repeat_submission_for_owned_tas
         });
     });
 }
+
+#[test]
+fn test_try_submit_pending_cloud_followup_rejects_task_source_that_blocks_followups() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        let terminal = cloud_mode_terminal_for_test(&mut app);
+        let mut task = create_cloud_mode_task_for_user(TEST_USER_UID);
+        task.source = Some(AgentSource::GitHubAction);
+        let task_id = task.task_id;
+
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.model
+                .lock()
+                .set_shared_session_source(SharedSessionSource::ambient_agent(Some(
+                    task_id.to_string(),
+                )));
+
+            let ambient_agent_view_model = view
+                .ambient_agent_view_model()
+                .expect("cloud mode terminal should have ambient model")
+                .clone();
+            ambient_agent_view_model.update(ctx, |model, ctx| {
+                model.enter_viewing_existing_session(task_id, ctx);
+            });
+
+            view.enable_cloud_followup_input(task_id, ctx);
+            assert!(!view.try_submit_pending_cloud_followup("follow up".to_string(), ctx));
+            assert_eq!(view.pending_cloud_followup_task_id, None);
+            assert_eq!(
+                ambient_agent_view_model
+                    .as_ref(ctx)
+                    .pending_followup_prompt(),
+                None
+            );
+        });
+    });
+}
 #[test]
 fn test_shared_followup_on_existing_conversation_converts_user_query_input() {
     App::test((), |mut app| async move {

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -118,7 +118,7 @@ fn test_on_ambient_agent_execution_ended_enables_followup_input_for_editable_non
             let model = view.model.lock();
             assert_eq!(
                 model.block_list().block_heights().items().len(),
-                initial_block_height_items + 1
+                initial_block_height_items
             );
             assert!(matches!(
                 model.shared_session_status(),


### PR DESCRIPTION
## Description
Suppresses the universal input and cloud continuation UI for ambient session shares whose task source is `AgentSource::GitHubAction`.

Changes include:
- Tracking ambient task source on the ambient agent view model when viewing existing sessions.
- Treating GitHub Action-sourced tasks as unsupported for cloud continuation/follow-up UI.
- Hiding the terminal input box for GitHub Action ambient sessions.
- Clearing stale tombstone/follow-up state if a session resolves as GitHub Action-sourced.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Slack request: universal input should not show on GitHub Action-sourced session shares, and hand-off follow-ups should not trigger.

## Testing
- [x] `cargo +1.92.0 fmt --manifest-path /workspace/warp/Cargo.toml -p warp`
- [x] `cargo +1.92.0 test --manifest-path /workspace/warp/Cargo.toml -p warp github_action -- --nocapture`
- [x] `cargo +1.92.0 test --manifest-path /workspace/warp/Cargo.toml -p warp on_session_share_ended -- --nocapture`
- [x] `cargo +1.92.0 test --manifest-path /workspace/warp/Cargo.toml -p warp on_ambient_agent_execution_ended -- --nocapture`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
- Loom: https://www.loom.com/share/beeaa40e63724b4a89bdacbf57f8dd2a

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/46c8366c-c57e-4f9b-9f48-d3679ad3801d_
_Run: https://oz.staging.warp.dev/runs/019e64f7-3b06-78ce-b9b2-2dd0d8471602_
_This PR was generated with [Oz](https://warp.dev/oz)._
