### PR TITLE
Hide add-on credits panel for free solo users

### DIFF
--- a/app/src/settings_view/billing_and_usage_page_v2.rs
+++ b/app/src/settings_view/billing_and_usage_page_v2.rs
@@ -1681,10 +1681,14 @@ impl BillingAndUsagePageV2View {
             UserWorkspaces::as_ref(app).current_team(),
         ) {
             let workspace_bonus_credits = ai_model.total_workspace_bonus_credits_remaining(ws.uid);
+            let is_free_solo_user = ws.billing_metadata.customer_type == CustomerType::Free
+                && team.billing_metadata.customer_type == CustomerType::Free
+                && ws.members.len() <= 1
+                && team.members.len() <= 1;
             let is_payg_zero = ws.billing_metadata.is_enterprise_pay_as_you_go_enabled()
                 && workspace_bonus_credits == 0;
 
-            if !is_payg_zero {
+            if !is_free_solo_user && !is_payg_zero {
                 let current_user_is_admin = {
                     let email = AuthStateProvider::as_ref(app)
                         .get()


### PR DESCRIPTION
## Description
Fixes the Billing & Usage v2 overview showing the add-on credits panel for free solo users who are not meaningfully on a team.

This now keeps the visibility logic inline with the existing Enterprise PAYG zero-credit guard:
- hides the panel for free solo users
- preserves the existing Enterprise PAYG zero-credit hide behavior

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; this is a small visibility condition change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the add-on credits panel showing for free solo users on the Billing & Usage page.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/637f3648-8420-483a-b50f-b36aa8d173cf_
_Run: https://oz.staging.warp.dev/runs/019e6558-5763-746d-a8a7-3b92775b1dde_
_This PR was generated with [Oz](https://warp.dev/oz)._
