### PR TITLE
Improve cloud prompt history discoverability

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -64,6 +64,7 @@ pub struct AgentMessageBarMouseStates {
     pub fork_from_last_known_good_state: MouseStateHandle,
     pub toggle_shortcuts: MouseStateHandle,
     pub toggle_slash_commands: MouseStateHandle,
+    pub open_prompt_history: MouseStateHandle,
     pub toggle_plan: MouseStateHandle,
     pub toggle_conversation_menu: MouseStateHandle,
     pub toggle_code_review: MouseStateHandle,
@@ -579,6 +580,32 @@ impl MessageProvider<AgentMessageArgs<'_>> for ZeroStateMessageProducer {
         let is_cloud_agent =
             is_in_cloud_context(agent_view_controller.agent_view_state(), terminal_model);
         let ai_settings = AISettings::as_ref(app);
+
+        if is_cloud_agent {
+            items.push(
+                MessageItem::clickable(
+                    vec![
+                        MessageItem::Keystroke {
+                            keystroke: Keystroke {
+                                key: "up".to_owned(),
+                                ..Default::default()
+                            },
+                            color: color_override_for_shortcuts_and_commands,
+                            background_color: bg_color_override_for_shortcuts_and_commands,
+                        },
+                        MessageItem::Text {
+                            content: "for prompt history".into(),
+                            color: color_override_for_shortcuts_and_commands,
+                        },
+                    ],
+                    |ctx| {
+                        ctx.dispatch_typed_action(InputAction::OpenInlineHistoryMenu);
+                    },
+                    mouse_states.open_prompt_history.clone(),
+                )
+                .with_is_disabled(!is_buffer_empty),
+            );
+        }
 
         // Handoff to cloud only available for local agents.
         if !is_cloud_agent

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -501,6 +501,15 @@ pub const CONVERSATIONS: StaticCommand = StaticCommand {
     argument: None,
 };
 
+pub const HISTORY: StaticCommand = StaticCommand {
+    name: "/history",
+    description: "Open prompt history",
+    icon_path: "bundled/svg/conversation.svg",
+    availability: Availability::AI_ENABLED,
+    auto_enter_ai_mode: false,
+    argument: None,
+};
+
 pub static PROMPTS: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     name: "/prompts",
     description: "Search saved prompts",
@@ -631,6 +640,7 @@ fn all_commands() -> Vec<StaticCommand> {
         SET_TAB_COLOR.clone(),
         USAGE,
         CONVERSATIONS,
+        HISTORY,
         EXPORT_TO_CLIPBOARD,
         MODEL.clone(),
     ];
@@ -768,6 +778,20 @@ mod tests {
         assert!(!argument.is_optional);
         assert!(!argument.should_execute_on_selection);
         assert_eq!(argument.hint_text, Some("<tab name>"));
+    }
+
+    #[test]
+    fn history_command_alias_is_registered() {
+        let command = COMMAND_REGISTRY
+            .get_command_with_name(HISTORY.name)
+            .expect("expected /history to be registered");
+
+        assert_eq!(command.name, "/history");
+        assert_eq!(command.description, "Open prompt history");
+        assert_eq!(command.icon_path, CONVERSATIONS.icon_path);
+        assert_eq!(command.availability, Availability::AI_ENABLED);
+        assert!(!command.auto_enter_ai_mode);
+        assert!(command.argument.is_none());
     }
 
     #[cfg(not(target_family = "wasm"))]

--- a/app/src/terminal/input/slash_commands/data_source/zero_state.rs
+++ b/app/src/terminal/input/slash_commands/data_source/zero_state.rs
@@ -58,6 +58,7 @@ impl SyncDataSource for ZeroStateDataSource {
             &*commands::CREATE_ENVIRONMENT,
             &*commands::EDIT,
             &commands::CONVERSATIONS,
+            &commands::HISTORY,
             &commands::PROMPTS,
             &*commands::PLAN,
             &commands::AGENT,

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -469,7 +469,9 @@ impl Input {
             create_docker_sandbox if command.name == commands::CREATE_DOCKER_SANDBOX.name => {
                 ctx.emit(Event::CreateDockerSandbox);
             }
-            conversations if command.name == commands::CONVERSATIONS.name => {
+            _ if command.name == commands::CONVERSATIONS.name
+                || command.name == commands::HISTORY.name =>
+            {
                 if self.is_cloud_mode_input_v2_composing(ctx) {
                     self.suggestions_mode_model.update(ctx, |model, ctx| {
                         model.set_mode(InputSuggestionsMode::Closed, ctx);


### PR DESCRIPTION
## Summary
- Add `/history` as a slash-command alias for opening prompt/conversation history
- Show an up-arrow prompt-history hint in the cloud agent message bar zero state
- Keep `/history` prioritized in slash-command zero-state results

## Tests
- `cargo test -p warp search::slash_command_menu::static_commands::commands::tests::history_command_alias_is_registered --lib`
- `cargo check -p warp --lib`

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._