### PR TITLE
[APP-4612] Stop agent event SSE retry loops

### DIFF
--- a/app/src/ai/agent_events/driver.rs
+++ b/app/src/ai/agent_events/driver.rs
@@ -17,6 +17,7 @@ pub(crate) const DEFAULT_AGENT_EVENT_RECONNECT_BACKOFF_STEPS: &[u64] = &[1, 2, 5
 pub(crate) const DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS: &[u64] = &[30];
 pub(crate) const DEFAULT_AGENT_EVENT_PROACTIVE_RECONNECT: Duration = Duration::from_secs(14 * 60);
 pub(crate) const DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG: usize = 5;
+pub(crate) const DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES: usize = 5;
 
 /// Configuration for the shared agent-event stream driver.
 #[derive(Clone, Debug)]
@@ -40,6 +41,11 @@ pub(crate) struct AgentEventDriverConfig {
     /// Failure count at which reconnect logging is escalated from debug to warn.
     /// This only affects log severity; retry behavior stays the same.
     pub failures_before_error_log: usize,
+    /// Maximum number of consecutive HTTP-status stream failures before the
+    /// driver gives up. Network errors without an HTTP status still retry
+    /// forever, but repeated backend/rate-limit responses should not keep a
+    /// long-lived Agent Mode session alive indefinitely.
+    pub max_consecutive_http_failures: Option<usize>,
 }
 
 impl AgentEventDriverConfig {
@@ -53,8 +59,22 @@ impl AgentEventDriverConfig {
             permanent_error_backoff_steps: DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
             proactive_reconnect_after: Some(DEFAULT_AGENT_EVENT_PROACTIVE_RECONNECT),
             failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+            max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
         }
     }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("agent event stream stopped after HTTP status {status} ({consecutive_failures} consecutive failure(s)): {message}")]
+pub(crate) struct AgentEventStreamTerminalError {
+    pub status: u16,
+    pub consecutive_failures: usize,
+    message: String,
+}
+
+pub(crate) fn is_terminal_agent_event_stream_error(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<AgentEventStreamTerminalError>()
+        .is_some()
 }
 
 /// Tells the shared driver whether to continue or stop after a handled event.
@@ -227,6 +247,7 @@ where
 {
     let mut since_sequence = config.since_sequence;
     let mut failures = 0usize;
+    let mut consecutive_http_failures = 0usize;
     let mut has_connected_once = false;
 
     loop {
@@ -239,6 +260,15 @@ where
             Ok(stream) => stream,
             Err(err) => {
                 failures += 1;
+                let http_failures =
+                    increment_http_failure_count(&err, &mut consecutive_http_failures);
+                if let Some(terminal_error) =
+                    terminal_http_stream_error(&err, http_failures, &config)
+                {
+                    log_terminal_stream_failure(&config.run_ids, &terminal_error);
+                    return Err(terminal_error.into());
+                }
+
                 let backoff_steps = if is_transient_http_error(&err) {
                     config.reconnect_backoff_steps
                 } else {
@@ -302,6 +332,7 @@ where
                 }
                 NextDriverItem::StreamItem(Some(Ok(AgentEventSourceItem::Event(event)))) => {
                     failures = 0;
+                    consecutive_http_failures = 0;
                     if event.sequence <= since_sequence {
                         continue;
                     }
@@ -322,6 +353,15 @@ where
                 }
                 NextDriverItem::StreamItem(Some(Err(err))) => {
                     failures += 1;
+                    let http_failures =
+                        increment_http_failure_count(&err, &mut consecutive_http_failures);
+                    if let Some(terminal_error) =
+                        terminal_http_stream_error(&err, http_failures, &config)
+                    {
+                        log_terminal_stream_failure(&config.run_ids, &terminal_error);
+                        return Err(terminal_error.into());
+                    }
+
                     let backoff_steps = if is_transient_http_error(&err) {
                         config.reconnect_backoff_steps
                     } else {
@@ -406,6 +446,56 @@ fn log_stream_failure(
             run_ids
         );
     }
+}
+
+fn increment_http_failure_count(err: &anyhow::Error, failures: &mut usize) -> usize {
+    if http_status_from_error(err).is_some() {
+        *failures += 1;
+        *failures
+    } else {
+        0
+    }
+}
+
+fn terminal_http_stream_error(
+    err: &anyhow::Error,
+    http_failures: usize,
+    config: &AgentEventDriverConfig,
+) -> Option<AgentEventStreamTerminalError> {
+    let status = http_status_from_error(err)?;
+    let is_transient = is_transient_http_error(err);
+    let reached_http_failure_limit = config
+        .max_consecutive_http_failures
+        .is_some_and(|max_failures| http_failures >= max_failures);
+
+    if is_transient && !reached_http_failure_limit {
+        return None;
+    }
+
+    Some(AgentEventStreamTerminalError {
+        status,
+        consecutive_failures: http_failures,
+        message: format!("{err:#}"),
+    })
+}
+
+fn http_status_from_error(err: &anyhow::Error) -> Option<u16> {
+    for cause in err.chain() {
+        if let Some(http_err) = cause.downcast_ref::<HttpStatusError>() {
+            return Some(http_err.status);
+        }
+    }
+    None
+}
+
+fn log_terminal_stream_failure(run_ids: &[String], err: &AgentEventStreamTerminalError) {
+    log::error!(
+        "Agent event stream stopped for {:?} after HTTP status {} ({} consecutive failure(s)): {}",
+        run_ids,
+        err.status,
+        err.consecutive_failures,
+        err.message
+    );
 }
 
 pub(crate) fn agent_event_backoff(failures: usize, backoff_steps: &[u64]) -> Duration {

--- a/app/src/ai/agent_events/driver_tests.rs
+++ b/app/src/ai/agent_events/driver_tests.rs
@@ -142,6 +142,7 @@ async fn driver_skips_duplicate_sequences_and_persists_new_cursor() {
         permanent_error_backoff_steps: DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
     };
 
     run_agent_event_driver(source, config, &mut consumer)
@@ -188,6 +189,7 @@ async fn driver_resets_failures_after_successful_event_delivery() {
         permanent_error_backoff_steps: DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
     };
 
     run_agent_event_driver(source, config, &mut consumer)
@@ -233,6 +235,7 @@ async fn driver_ignores_persist_cursor_errors() {
         permanent_error_backoff_steps: DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
     };
 
     run_agent_event_driver(source, config, &mut consumer)
@@ -267,6 +270,7 @@ async fn driver_ignores_driver_state_errors() {
         permanent_error_backoff_steps: DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
     };
 
     run_agent_event_driver(source, config, &mut consumer)
@@ -303,6 +307,7 @@ async fn driver_retries_initial_connection_until_stream_opens() {
         permanent_error_backoff_steps: DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
     };
 
     run_agent_event_driver(source, config, &mut consumer)
@@ -366,56 +371,36 @@ fn make_http_status_error(status: u16) -> anyhow::Error {
 }
 
 #[tokio::test]
-async fn driver_uses_slow_backoff_on_permanent_http_error() {
-    let source = FakeAgentEventSource::new(vec![
-        // First attempt: stream opens then returns a 404-enriched error.
-        ok_stream(vec![
-            Ok(AgentEventSourceItem::Open),
-            Err(make_http_status_error(404)),
-        ]),
-        // Second attempt: succeeds with a stoppable event.
-        ok_stream(vec![
-            Ok(AgentEventSourceItem::Open),
-            Ok(AgentEventSourceItem::Event(make_run_event(
-                1,
-                "new_message",
-                "child-run",
-                Some("msg-1"),
-            ))),
-        ]),
-    ]);
+async fn driver_stops_on_permanent_http_error() {
+    let source = FakeAgentEventSource::new(vec![ok_stream(vec![
+        Ok(AgentEventSourceItem::Open),
+        Err(make_http_status_error(403)),
+    ])]);
     let mut consumer = RecordingConsumer {
         stop_after: 1,
         ..Default::default()
     };
 
-    // Use asymmetric values: transient=9999s (would block if chosen),
-    // permanent=0s (instant). Proving backoff is 0s confirms the
-    // permanent schedule was selected.
     let config = AgentEventDriverConfig {
         run_ids: vec!["child-run".to_string()],
         since_sequence: 0,
-        reconnect_backoff_steps: &[9999],
+        reconnect_backoff_steps: ZERO_BACKOFF_STEPS,
         permanent_error_backoff_steps: ZERO_BACKOFF_STEPS,
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
     };
 
-    run_agent_event_driver(source, config, &mut consumer)
+    let err = run_agent_event_driver(source, config, &mut consumer)
         .await
-        .unwrap();
+        .expect_err("403 should stop the stream");
 
-    assert_eq!(consumer.handled_sequences, vec![1]);
-    // The backoff must be from the permanent schedule (0s), not transient (9999s).
-    let retry_backoff = consumer
+    assert!(is_terminal_agent_event_stream_error(&err));
+    assert_eq!(consumer.handled_sequences, Vec::<i64>::new());
+    assert!(!consumer
         .driver_states
         .iter()
-        .find_map(|s| match s {
-            AgentEventDriverState::RetryScheduled { backoff, .. } => Some(*backoff),
-            _ => None,
-        })
-        .unwrap();
-    assert_eq!(retry_backoff, Duration::from_secs(0));
+        .any(|state| matches!(state, AgentEventDriverState::RetryScheduled { .. })));
 }
 
 #[tokio::test]
@@ -450,6 +435,7 @@ async fn driver_uses_fast_backoff_on_transient_http_error() {
         permanent_error_backoff_steps: &[9999],
         proactive_reconnect_after: None,
         failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES),
     };
 
     run_agent_event_driver(source, config, &mut consumer)
@@ -468,4 +454,50 @@ async fn driver_uses_fast_backoff_on_transient_http_error() {
         })
         .unwrap();
     assert_eq!(retry_backoff, Duration::from_secs(0));
+}
+
+#[tokio::test]
+async fn driver_stops_after_repeated_transient_http_errors() {
+    let source = FakeAgentEventSource::new(vec![
+        ok_stream(vec![
+            Ok(AgentEventSourceItem::Open),
+            Err(make_http_status_error(429)),
+        ]),
+        ok_stream(vec![
+            Ok(AgentEventSourceItem::Open),
+            Err(make_http_status_error(429)),
+        ]),
+    ]);
+    let mut consumer = RecordingConsumer {
+        stop_after: 1,
+        ..Default::default()
+    };
+
+    let config = AgentEventDriverConfig {
+        run_ids: vec!["child-run".to_string()],
+        since_sequence: 0,
+        reconnect_backoff_steps: ZERO_BACKOFF_STEPS,
+        permanent_error_backoff_steps: ZERO_BACKOFF_STEPS,
+        proactive_reconnect_after: None,
+        failures_before_error_log: DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
+        max_consecutive_http_failures: Some(2),
+    };
+
+    let err = run_agent_event_driver(source, config, &mut consumer)
+        .await
+        .expect_err("repeated 429s should stop the stream");
+
+    assert!(is_terminal_agent_event_stream_error(&err));
+    let retry_failures = consumer
+        .driver_states
+        .iter()
+        .filter_map(|state| match state {
+            AgentEventDriverState::RetryScheduled {
+                consecutive_failures,
+                ..
+            } => Some(*consecutive_failures),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(retry_failures, vec![1]);
 }

--- a/app/src/ai/agent_events/mod.rs
+++ b/app/src/ai/agent_events/mod.rs
@@ -8,11 +8,13 @@ mod message_hydrator;
 pub(crate) use driver::{
     agent_event_backoff, agent_event_failures_exceeded_threshold, AgentEventDriverState,
     AgentEventSource, AgentEventSourceItem, DEFAULT_AGENT_EVENT_FAILURES_BEFORE_ERROR_LOG,
-    DEFAULT_AGENT_EVENT_RECONNECT_BACKOFF_STEPS, DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
+    DEFAULT_AGENT_EVENT_MAX_CONSECUTIVE_HTTP_FAILURES, DEFAULT_AGENT_EVENT_RECONNECT_BACKOFF_STEPS,
+    DEFAULT_PERMANENT_ERROR_BACKOFF_STEPS,
 };
 pub(crate) use driver::{
-    run_agent_event_driver, AgentEventConsumer, AgentEventConsumerControlFlow,
-    AgentEventDriverConfig, AgentMessageEventMetadata, ServerApiAgentEventSource,
+    is_terminal_agent_event_stream_error, run_agent_event_driver, AgentEventConsumer,
+    AgentEventConsumerControlFlow, AgentEventDriverConfig, AgentMessageEventMetadata,
+    ServerApiAgentEventSource,
 };
 pub(crate) use message_hydrator::MessageHydrator;
 

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -22,8 +22,9 @@ use super::orchestration_events::{
 use crate::ai::agent::conversation::{AIAgentHarness, AIConversationId, ConversationStatus};
 use crate::ai::agent::{AIAgentExchangeId, AIAgentOutputMessageType, ReceivedMessageInput};
 use crate::ai::agent_events::{
-    run_agent_event_driver, AgentEventConsumer, AgentEventConsumerControlFlow,
-    AgentEventDriverConfig, AgentMessageEventMetadata, MessageHydrator, ServerApiAgentEventSource,
+    is_terminal_agent_event_stream_error, run_agent_event_driver, AgentEventConsumer,
+    AgentEventConsumerControlFlow, AgentEventDriverConfig, AgentMessageEventMetadata,
+    MessageHydrator, ServerApiAgentEventSource,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::server::retry_strategies::is_transient_http_error;
@@ -1250,6 +1251,10 @@ impl OrchestrationEventStreamer {
                     log::warn!(
                         "SSE driver exited for {conversation_id:?} (gen={generation}): {err:#}"
                     );
+                    if is_terminal_agent_event_stream_error(&err) {
+                        me.teardown_sse(conversation_id, ctx);
+                        return;
+                    }
                     me.reconnect_sse(conversation_id, ctx);
                 }
             },


### PR DESCRIPTION
## Summary
- stop the shared Agent Mode event SSE driver immediately on permanent HTTP status failures such as 403
- bound repeated transient HTTP status failures such as 429/5xx so status loops cannot reconnect forever
- prevent the orchestration streamer from reopening SSE after a terminal stream error

## Tests
- cargo fmt --check
- cargo test -p warp ai::agent_events::driver_tests --lib

_This PR was created by [Oz](https://warp.dev/oz) (running Codex)._
