### PR TITLE
Update file invalidation error logs

### DIFF
--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -248,16 +248,12 @@ impl LocalDiffStateModel {
                         ctx.emit(DiffStateModelEvent::SingleFileUpdated { path, diff });
                     }
                     Err(err) => {
-                        let safe_error = err.safe_message();
-                        warp_core::safe_error!(
-                            safe: ("File invalidation error: {safe_error}"),
-                            full: ("File invalidation error: {err}")
-                        );
+                        warp_core::report_error!(err.as_ref());
                         send_telemetry_from_ctx!(
                             CodeReviewTelemetryEvent::LoadDiffFailed {
                                 is_local: Some(true),
                                 mode: me.mode.clone(),
-                                error: safe_error.to_string(),
+                                error: err.kind.to_string(),
                                 // Per-file invalidation errors are not tied to a full
                                 // tracked load, so `load_duration` is intentionally `None`.
                                 load_duration: None,

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -248,12 +248,16 @@ impl LocalDiffStateModel {
                         ctx.emit(DiffStateModelEvent::SingleFileUpdated { path, diff });
                     }
                     Err(err) => {
-                        log::error!("File invalidation error: {err}");
+                        let safe_error = err.safe_message();
+                        warp_core::safe_error!(
+                            safe: ("File invalidation error: {safe_error}"),
+                            full: ("File invalidation error: {err}")
+                        );
                         send_telemetry_from_ctx!(
                             CodeReviewTelemetryEvent::LoadDiffFailed {
                                 is_local: Some(true),
                                 mode: me.mode.clone(),
-                                error: err.to_string(),
+                                error: safe_error.to_string(),
                                 // Per-file invalidation errors are not tied to a full
                                 // tracked load, so `load_duration` is intentionally `None`.
                                 load_duration: None,

--- a/app/src/code_review/file_invalidation_queue.rs
+++ b/app/src/code_review/file_invalidation_queue.rs
@@ -2,56 +2,123 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
+use warp_core::errors::{AnyhowErrorExt as _, ErrorExt};
 
 use warp_core::sync_queue::{IsTransientError, SyncQueueTaskTrait};
 
 use super::diff_state::{DiffMode, FileDiffAndContent, LocalDiffStateModel};
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+pub(crate) enum FileInvalidationErrorKind {
+    #[error("git rejected repository ownership")]
+    GitRejectedRepositoryOwnership,
+    #[error("git is unavailable")]
+    GitUnavailable,
+    #[error("git lfs is unavailable")]
+    GitLfsUnavailable,
+    #[error("xcode license is not accepted")]
+    XcodeLicenseNotAccepted,
+    #[error("invalid empty pathspec")]
+    InvalidEmptyPathspec,
+    #[error("path is outside repository")]
+    PathOutsideRepository,
+    #[error("path is not a git repository")]
+    NotGitRepository,
+    #[error("repository is not a work tree")]
+    NotWorkTree,
+    #[error("repository path is not accessible")]
+    RepositoryPathNotAccessible,
+    #[error("path is not valid UTF-8")]
+    NonUtf8Path,
+    #[error("git revision is unavailable")]
+    GitRevisionUnavailable,
+    #[error("git head tree is invalid")]
+    GitHeadTreeInvalid,
+    #[error("git status output is invalid")]
+    InvalidGitStatusOutput,
+    #[error("repository path is invalid")]
+    RepositoryPathInvalid,
+    #[error("unknown file invalidation error")]
+    Unknown,
+}
 
-#[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub struct FileInvalidationError(#[from] anyhow::Error);
-impl FileInvalidationError {
-    pub(crate) fn safe_message(&self) -> &'static str {
-        let message = format!("{self:#}");
-
+impl FileInvalidationErrorKind {
+    fn from_message(message: &str) -> Self {
         if message.contains("detected dubious ownership in repository") {
-            "git rejected repository ownership"
+            Self::GitRejectedRepositoryOwnership
         } else if message.contains("No such file or directory")
             || message.contains("program not found")
             || message.contains("No developer tools were found")
         {
-            "git is unavailable"
+            Self::GitUnavailable
         } else if message.contains("git-lfs: command not found") {
-            "git lfs is unavailable"
+            Self::GitLfsUnavailable
         } else if message.contains("Xcode license agreements") {
-            "xcode license is not accepted"
+            Self::XcodeLicenseNotAccepted
         } else if message.contains("empty string is not a valid pathspec") {
-            "invalid empty pathspec"
+            Self::InvalidEmptyPathspec
         } else if message.contains("outside repository") {
-            "path is outside repository"
+            Self::PathOutsideRepository
         } else if message.contains("not a git repository") {
-            "path is not a git repository"
+            Self::NotGitRepository
         } else if message.contains("this operation must be run in a work tree") {
-            "repository is not a work tree"
+            Self::NotWorkTree
         } else if message.contains("Operation not permitted")
             || message.contains("Permission denied")
         {
-            "repository path is not accessible"
+            Self::RepositoryPathNotAccessible
         } else if message.contains("non-UTF-8 path") {
-            "path is not valid UTF-8"
+            Self::NonUtf8Path
         } else if message.contains("bad revision") || message.contains("unknown revision") {
-            "git revision is unavailable"
+            Self::GitRevisionUnavailable
         } else if message.contains("bad tree object HEAD") {
-            "git head tree is invalid"
+            Self::GitHeadTreeInvalid
         } else if message.contains("Invalid status code") {
-            "git status output is invalid"
+            Self::InvalidGitStatusOutput
         } else if message.contains("os error 267") {
-            "repository path is invalid"
+            Self::RepositoryPathInvalid
         } else {
-            "unknown file invalidation error"
+            Self::Unknown
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("{kind}")]
+pub struct FileInvalidationError {
+    pub(crate) kind: FileInvalidationErrorKind,
+    error: anyhow::Error,
+}
+
+impl From<anyhow::Error> for FileInvalidationError {
+    fn from(error: anyhow::Error) -> Self {
+        let message = format!("{error:#}");
+        let kind = FileInvalidationErrorKind::from_message(&message);
+        Self { kind, error }
+    }
+}
+
+impl ErrorExt for FileInvalidationError {
+    fn is_actionable(&self) -> bool {
+        match self.kind {
+            FileInvalidationErrorKind::InvalidEmptyPathspec
+            | FileInvalidationErrorKind::InvalidGitStatusOutput => true,
+            FileInvalidationErrorKind::Unknown => self.error.is_actionable(),
+            FileInvalidationErrorKind::GitRejectedRepositoryOwnership
+            | FileInvalidationErrorKind::GitUnavailable
+            | FileInvalidationErrorKind::GitLfsUnavailable
+            | FileInvalidationErrorKind::XcodeLicenseNotAccepted
+            | FileInvalidationErrorKind::PathOutsideRepository
+            | FileInvalidationErrorKind::NotGitRepository
+            | FileInvalidationErrorKind::NotWorkTree
+            | FileInvalidationErrorKind::RepositoryPathNotAccessible
+            | FileInvalidationErrorKind::NonUtf8Path
+            | FileInvalidationErrorKind::GitRevisionUnavailable
+            | FileInvalidationErrorKind::GitHeadTreeInvalid
+            | FileInvalidationErrorKind::RepositoryPathInvalid => false,
+        }
+    }
+}
+warp_core::errors::register_error!(FileInvalidationError);
 
 impl IsTransientError for FileInvalidationError {
     fn is_transient(&self) -> bool {

--- a/app/src/code_review/file_invalidation_queue.rs
+++ b/app/src/code_review/file_invalidation_queue.rs
@@ -10,6 +10,48 @@ use super::diff_state::{DiffMode, FileDiffAndContent, LocalDiffStateModel};
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct FileInvalidationError(#[from] anyhow::Error);
+impl FileInvalidationError {
+    pub(crate) fn safe_message(&self) -> &'static str {
+        let message = format!("{self:#}");
+
+        if message.contains("detected dubious ownership in repository") {
+            "git rejected repository ownership"
+        } else if message.contains("No such file or directory")
+            || message.contains("program not found")
+            || message.contains("No developer tools were found")
+        {
+            "git is unavailable"
+        } else if message.contains("git-lfs: command not found") {
+            "git lfs is unavailable"
+        } else if message.contains("Xcode license agreements") {
+            "xcode license is not accepted"
+        } else if message.contains("empty string is not a valid pathspec") {
+            "invalid empty pathspec"
+        } else if message.contains("outside repository") {
+            "path is outside repository"
+        } else if message.contains("not a git repository") {
+            "path is not a git repository"
+        } else if message.contains("this operation must be run in a work tree") {
+            "repository is not a work tree"
+        } else if message.contains("Operation not permitted")
+            || message.contains("Permission denied")
+        {
+            "repository path is not accessible"
+        } else if message.contains("non-UTF-8 path") {
+            "path is not valid UTF-8"
+        } else if message.contains("bad revision") || message.contains("unknown revision") {
+            "git revision is unavailable"
+        } else if message.contains("bad tree object HEAD") {
+            "git head tree is invalid"
+        } else if message.contains("Invalid status code") {
+            "git status output is invalid"
+        } else if message.contains("os error 267") {
+            "repository path is invalid"
+        } else {
+            "unknown file invalidation error"
+        }
+    }
+}
 
 impl IsTransientError for FileInvalidationError {
     fn is_transient(&self) -> bool {


### PR DESCRIPTION
## Description
* Context: https://warpdev.slack.com/archives/C0AMRA82ZKL/p1779812891587159 
* We're getting a lot of sentry errors for the following "File invalidation error: Git command failed: fatal: detected dubious ownership in repository at `/path`" 
* This PR helps sanitize the logs such that each the sentry errors aren't reporting specific repo paths
  * We add a `safe_message` implementation of `FileInvalidationError` to handle various cases that may report the path 
  * We also use `safe_error!` when sending the logs 

## Testing
Verified the proper errors are sent 

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

