### PR TITLE
Fix CreateProcessW failure caused by REG_MULTI_SZ environment variables

### DIFF
--- a/app/src/terminal/local_tty/windows/environment.rs
+++ b/app/src/terminal/local_tty/windows/environment.rs
@@ -338,7 +338,13 @@ fn reg_value_to_string(value: &RegValue, key: &str) -> anyhow::Result<OsString> 
     };
 
     // These are null-terminated, but we don't want the terminator here. We add it back later.
-    os_str.map(|v| v.to_string_lossy().trim_end_matches('\0').into())
+    os_str.map(|v| {
+        let s = v.to_string_lossy();
+        match s.find('\0') {
+            Some(pos) => s[..pos].into(),
+            None => v,
+        }
+    })
 }
 
 /// Best-effort lowercase transformation of an OsString.

--- a/app/src/terminal/local_tty/windows/environment.rs
+++ b/app/src/terminal/local_tty/windows/environment.rs
@@ -297,6 +297,15 @@ fn add_user_env(env: &mut BTreeMap<OsString, EnvEntry>) {
 }
 
 fn reg_value_to_string(value: &RegValue, key: &str) -> anyhow::Result<OsString> {
+    // Only REG_SZ and REG_EXPAND_SZ are valid for environment variables.
+    // https://github.com/microsoft/terminal/blob/1ba28b298f677d838c3a2e457a8a1f569bff6299/src/inc/til/env.h#L247-L259
+    if value.vtype != RegType::REG_SZ && value.vtype != RegType::REG_EXPAND_SZ {
+        anyhow::bail!(
+            "Unsupported registry type {:?} for env var {key:?}",
+            value.vtype
+        );
+    }
+
     let key_lower = key.to_ascii_lowercase();
     // RegType::REG_EXPAND_SZ requires expansion of nested env vars, e.g. %USERPROFILE%\AppData to
     // C:\Users\andy\AppData


### PR DESCRIPTION
## Description
Skip registry environment variables that are not `REG_SZ` or `REG_EXPAND_SZ` when building the environment block for `CreateProcessW`.

`REG_MULTI_SZ` values contain embedded null bytes which corrupt the environment block — each null is treated as an entry separator, producing malformed entries without `=` that cause `CreateProcessW` to fail with error `0x80070057` ("The parameter is incorrect").

This was observed in a user's log where a third-party driver had stored a `REG_MULTI_SZ` value (`DriverYz2`) in the registry environment, which prevented Warp from spawning any shell process.

This matches how [Windows Terminal](https://github.com/microsoft/terminal/blob/1ba28b298f677d838c3a2e457a8a1f569bff6299/src/inc/til/env.h#L247-L259) handles registry environment variables — it only processes `REG_SZ` and `REG_EXPAND_SZ` types.

## Linked Issue

Closes #8524

## Testing

TODO: Send the user a build.


<!--
CHANGELOG-BUG-FIX: Fixed shell failing to launch on Windows when a registry environment variable uses an unsupported type like REG_MULTI_SZ.
-->

