### PR TITLE
update FilterableDropdown to use trait for SelectActionAndClose instead of generic on entire DropdownAction

### DIFF
--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -30,7 +30,7 @@ use warpui::scene::DropShadow;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{UiComponent, UiComponentStyles};
 use warpui::{
-    Action, AppContext, Entity, FocusContext, ModelHandle, SingletonEntity, TypedActionView, View,
+    AppContext, Entity, FocusContext, ModelHandle, SingletonEntity, TypedActionView, View,
     ViewContext, ViewHandle, WeakViewHandle,
 };
 
@@ -81,7 +81,9 @@ use crate::view_components::action_button::{
 use crate::view_components::compactible_action_button::{
     CompactibleActionButton, MEDIUM_SIZE_SWITCH_THRESHOLD,
 };
-use crate::view_components::dropdown::{Dropdown, DropdownAction, DropdownStyle};
+use crate::view_components::dropdown::{
+    Dropdown, DropdownAction, DropdownItemAction, DropdownStyle,
+};
 use crate::view_components::{DismissibleToast, FilterableDropdown};
 use crate::workflows::WorkflowType;
 use crate::workspace::{
@@ -491,7 +493,7 @@ impl AgentManagementView {
         let make_status_option =
             |label: &str, action: AgentManagementViewAction, icon_data: Option<(Icon, Fill)>| {
                 let mut fields = MenuItemFields::new(label)
-                    .with_on_select_action(DropdownAction::SelectActionAndClose(action));
+                    .with_on_select_action(DropdownAction::select_action_and_close(action));
                 if let Some((icon, color)) = icon_data {
                     fields = fields.with_icon(icon).with_override_icon_color(color);
                 }
@@ -541,7 +543,7 @@ impl AgentManagementView {
     }
 
     /// Build the list of source filter items.
-    fn build_source_dropdown_items() -> Vec<MenuItem<DropdownAction<AgentManagementViewAction>>> {
+    fn build_source_dropdown_items() -> Vec<MenuItem<DropdownAction>> {
         // Build up the sources list
         let mut sources = vec![
             AgentSource::WebApp,
@@ -559,14 +561,16 @@ impl AgentManagementView {
         }
 
         let mut items = vec![MenuItem::Item(
-            MenuItemFields::new("All").with_on_select_action(DropdownAction::SelectActionAndClose(
-                AgentManagementViewAction::SetSourceFilter(SourceFilter::All),
-            )),
+            MenuItemFields::new("All").with_on_select_action(
+                DropdownAction::select_action_and_close(
+                    AgentManagementViewAction::SetSourceFilter(SourceFilter::All),
+                ),
+            ),
         )];
         for source in sources {
             items.push(MenuItem::Item(
                 MenuItemFields::new(source.display_name()).with_on_select_action(
-                    DropdownAction::SelectActionAndClose(
+                    DropdownAction::select_action_and_close(
                         AgentManagementViewAction::SetSourceFilter(SourceFilter::Specific(source)),
                     ),
                 ),
@@ -596,22 +600,22 @@ impl AgentManagementView {
 
         let items = vec![
             MenuItem::Item(MenuItemFields::new("All").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
+                DropdownAction::select_action_and_close(
                     AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::All),
                 ),
             )),
             MenuItem::Item(MenuItemFields::new("Last 24 hours").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
+                DropdownAction::select_action_and_close(
                     AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::Last24Hours),
                 ),
             )),
             MenuItem::Item(MenuItemFields::new("Past 3 days").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
+                DropdownAction::select_action_and_close(
                     AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::Past3Days),
                 ),
             )),
             MenuItem::Item(MenuItemFields::new("Last week").with_on_select_action(
-                DropdownAction::SelectActionAndClose(
+                DropdownAction::select_action_and_close(
                     AgentManagementViewAction::SetCreatedOnFilter(CreatedOnFilter::LastWeek),
                 ),
             )),
@@ -630,29 +634,29 @@ impl AgentManagementView {
 
         let items = vec![
             MenuItem::Item(MenuItemFields::new("All").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::All,
-                )),
+                DropdownAction::select_action_and_close(
+                    AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::All),
+                ),
             )),
             MenuItem::Item(MenuItemFields::new("Pull Request").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::PullRequest,
-                )),
+                DropdownAction::select_action_and_close(
+                    AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::PullRequest),
+                ),
             )),
             MenuItem::Item(MenuItemFields::new("Plan").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::Plan,
-                )),
+                DropdownAction::select_action_and_close(
+                    AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::Plan),
+                ),
             )),
             MenuItem::Item(MenuItemFields::new("Screenshot").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::Screenshot,
-                )),
+                DropdownAction::select_action_and_close(
+                    AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::Screenshot),
+                ),
             )),
             MenuItem::Item(MenuItemFields::new("File").with_on_select_action(
-                DropdownAction::SelectActionAndClose(AgentManagementViewAction::SetArtifactFilter(
-                    ArtifactFilter::File,
-                )),
+                DropdownAction::select_action_and_close(
+                    AgentManagementViewAction::SetArtifactFilter(ArtifactFilter::File),
+                ),
             )),
         ];
 
@@ -673,13 +677,13 @@ impl AgentManagementView {
         dropdown
     }
 
-    fn build_harness_dropdown_items(
-        app: &AppContext,
-    ) -> Vec<MenuItem<DropdownAction<AgentManagementViewAction>>> {
+    fn build_harness_dropdown_items(app: &AppContext) -> Vec<MenuItem<DropdownAction>> {
         let mut items = vec![MenuItem::Item(
-            MenuItemFields::new("All").with_on_select_action(DropdownAction::SelectActionAndClose(
-                AgentManagementViewAction::SetHarnessFilter(HarnessFilter::All),
-            )),
+            MenuItemFields::new("All").with_on_select_action(
+                DropdownAction::select_action_and_close(
+                    AgentManagementViewAction::SetHarnessFilter(HarnessFilter::All),
+                ),
+            ),
         )];
 
         let availability = HarnessAvailabilityModel::as_ref(app);
@@ -687,7 +691,7 @@ impl AgentManagementView {
             let harness = entry.harness;
             let mut fields = MenuItemFields::new(entry.display_name.clone())
                 .with_icon(harness_display::icon_for(harness))
-                .with_on_select_action(DropdownAction::SelectActionAndClose(
+                .with_on_select_action(DropdownAction::select_action_and_close(
                     AgentManagementViewAction::SetHarnessFilter(HarnessFilter::Specific(harness)),
                 ));
             if let Some(color) = harness_display::brand_color(harness) {
@@ -735,7 +739,7 @@ impl AgentManagementView {
     }
 
     // Initialize the dropdown menu for the filter dropdowns (status, source)
-    fn setup_filter_menu<A: Action + Clone>(
+    fn setup_filter_menu<A: DropdownItemAction>(
         dropdown: &mut Dropdown<A>,
         label_prefix: &'static str,
         ctx: &mut ViewContext<Dropdown<A>>,
@@ -747,7 +751,7 @@ impl AgentManagementView {
     }
 
     // Initialize the dropdown menu for the searchable filter dropdowns (creator)
-    fn setup_searchable_filter_menu<A: Action + Clone>(
+    fn setup_searchable_filter_menu<A: DropdownItemAction>(
         dropdown: &mut FilterableDropdown<A>,
         label_prefix: &'static str,
         ctx: &mut ViewContext<FilterableDropdown<A>>,
@@ -781,7 +785,7 @@ impl AgentManagementView {
         self.environment_dropdown.update(ctx, |dropdown, ctx| {
             let mut items = vec![MenuItem::Item(
                 MenuItemFields::new("All").with_on_select_action(
-                    DropdownAction::SelectActionAndClose(
+                    DropdownAction::select_action_and_close(
                         AgentManagementViewAction::SetEnvironmentFilter(EnvironmentFilter::All),
                     ),
                 ),
@@ -789,7 +793,7 @@ impl AgentManagementView {
 
             items.push(MenuItem::Item(
                 MenuItemFields::new("None").with_on_select_action(
-                    DropdownAction::SelectActionAndClose(
+                    DropdownAction::select_action_and_close(
                         AgentManagementViewAction::SetEnvironmentFilter(
                             EnvironmentFilter::NoEnvironment,
                         ),
@@ -803,7 +807,7 @@ impl AgentManagementView {
             for (environment_id, environment_name) in sorted_envs {
                 items.push(MenuItem::Item(
                     MenuItemFields::new(environment_name).with_on_select_action(
-                        DropdownAction::SelectActionAndClose(
+                        DropdownAction::select_action_and_close(
                             AgentManagementViewAction::SetEnvironmentFilter(
                                 EnvironmentFilter::Specific(environment_id),
                             ),
@@ -828,7 +832,7 @@ impl AgentManagementView {
         self.creator_dropdown.update(ctx, |dropdown, ctx| {
             let mut items = vec![MenuItem::Item(
                 MenuItemFields::new("All").with_on_select_action(
-                    DropdownAction::SelectActionAndClose(
+                    DropdownAction::select_action_and_close(
                         AgentManagementViewAction::SetCreatorFilter(CreatorFilter::All),
                     ),
                 ),
@@ -836,7 +840,7 @@ impl AgentManagementView {
             for (name, uid) in creators {
                 items.push(MenuItem::Item(
                     MenuItemFields::new(&name).with_on_select_action(
-                        DropdownAction::SelectActionAndClose(
+                        DropdownAction::select_action_and_close(
                             AgentManagementViewAction::SetCreatorFilter(CreatorFilter::Specific {
                                 name,
                                 uid,

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -85,6 +85,7 @@ use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::util::link_detection::DetectedLinkType;
 use crate::util::truncation::truncate_from_end;
+use crate::view_components::dropdown::DropdownItemAction;
 use crate::workspace::WorkspaceAction;
 
 /// Helper function to create gray strikethrough highlight for secrets
@@ -730,7 +731,7 @@ pub fn render_autonomy_dropdown_setting_speedbump_footer<A>(
     app: &AppContext,
 ) -> Box<dyn Element>
 where
-    A: warpui::Action + Clone,
+    A: DropdownItemAction,
 {
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -145,7 +145,7 @@ pub fn init(app: &mut AppContext) {
 }
 
 /// View-level interactions for the ask-user-question UI (buttons, keyboard, and text input).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AskUserQuestionViewAction {
     OptionToggled { option_index: usize },
     SelectionConfirmed,

--- a/app/src/ai/blocklist/inline_action/host_picker.rs
+++ b/app/src/ai/blocklist/inline_action/host_picker.rs
@@ -422,8 +422,8 @@ pub(crate) fn build_menu_items(
     default_host: Option<&str>,
     recent_host: Option<&str>,
     connected_hosts: &[String],
-) -> Vec<MenuItem<DropdownAction<InternalAction>>> {
-    let mut items: Vec<MenuItem<DropdownAction<InternalAction>>> = Vec::new();
+) -> Vec<MenuItem<DropdownAction>> {
+    let mut items: Vec<MenuItem<DropdownAction>> = Vec::new();
     let mut known_slugs: Vec<String> = Vec::new();
 
     if let Some(slug) = default_host {
@@ -472,7 +472,7 @@ pub(crate) fn build_menu_items(
     }
     items.push(MenuItem::Item(
         MenuItemFields::new(CUSTOM_HOST_LABEL).with_on_select_action(
-            DropdownAction::SelectActionAndClose(InternalAction::EnterCustomMode),
+            DropdownAction::select_action_and_close(InternalAction::EnterCustomMode),
         ),
     ));
 
@@ -500,10 +500,10 @@ fn menu_item_for_known(
     slug: &str,
     badge: Option<&str>,
     action: InternalAction,
-) -> MenuItem<DropdownAction<InternalAction>> {
+) -> MenuItem<DropdownAction> {
     MenuItem::Item(
         MenuItemFields::new(format_known_label(slug, badge))
-            .with_on_select_action(DropdownAction::SelectActionAndClose(action)),
+            .with_on_select_action(DropdownAction::select_action_and_close(action)),
     )
 }
 

--- a/app/src/ai/blocklist/inline_action/host_picker_tests.rs
+++ b/app/src/ai/blocklist/inline_action/host_picker_tests.rs
@@ -10,7 +10,7 @@ use super::{
 /// Extracts the visible label text out of a `MenuItem::Item`, panicking
 /// on the unreachable `Header` / `Separator` cases that our builder
 /// doesn't emit.
-fn item_label(item: &MenuItem<DropdownAction<InternalAction>>) -> &str {
+fn item_label(item: &MenuItem<DropdownAction>) -> &str {
     match item {
         MenuItem::Item(fields) => fields.label(),
         other => panic!("expected MenuItem::Item, got {other:?}"),
@@ -18,7 +18,7 @@ fn item_label(item: &MenuItem<DropdownAction<InternalAction>>) -> &str {
 }
 
 /// Extracts the on-select action from a `MenuItem::Item`.
-fn item_action(item: &MenuItem<DropdownAction<InternalAction>>) -> &DropdownAction<InternalAction> {
+fn item_action(item: &MenuItem<DropdownAction>) -> &DropdownAction {
     match item {
         MenuItem::Item(fields) => fields
             .on_select_action()
@@ -91,8 +91,17 @@ fn build_menu_items_adds_connected_hosts_before_recent_and_dedups_known_hosts() 
 fn build_menu_items_warp_entry_dispatches_select_known_warp() {
     let items = build_menu_items(None, None, &[]);
     match item_action(&items[0]) {
-        DropdownAction::SelectActionAndClose(InternalAction::SelectKnown(slug)) => {
-            assert_eq!(slug, ORCHESTRATION_WARP_WORKER_HOST);
+        DropdownAction::SelectActionAndClose(action) => {
+            let action = action
+                .as_any()
+                .downcast_ref::<InternalAction>()
+                .expect("expected InternalAction");
+            match action {
+                InternalAction::SelectKnown(slug) => {
+                    assert_eq!(slug, ORCHESTRATION_WARP_WORKER_HOST);
+                }
+                other => panic!("expected SelectKnown, got {other:?}"),
+            }
         }
         other => panic!("expected SelectActionAndClose(SelectKnown), got {other:?}"),
     }
@@ -103,7 +112,12 @@ fn build_menu_items_custom_entry_dispatches_enter_custom_mode() {
     let items = build_menu_items(None, None, &[]);
     let custom = items.last().expect("custom entry is always last");
     match item_action(custom) {
-        DropdownAction::SelectActionAndClose(InternalAction::EnterCustomMode) => {}
+        DropdownAction::SelectActionAndClose(action) => {
+            assert_eq!(
+                action.as_any().downcast_ref::<InternalAction>(),
+                Some(&InternalAction::EnterCustomMode)
+            );
+        }
         other => panic!("expected EnterCustomMode, got {other:?}"),
     }
 }

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -7,7 +7,6 @@
 //! from field-change events to their own action enum.
 
 use std::collections::HashMap;
-use std::fmt::Debug;
 
 use ai::agent::action::RunAgentsExecutionMode;
 use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutionMode};
@@ -48,7 +47,9 @@ use crate::cloud_object::CloudObjectLookup as _;
 use crate::menu::{MenuItem, MenuItemFields};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
-use crate::view_components::dropdown::{Dropdown, DropdownAction, DropdownStyle};
+use crate::view_components::dropdown::{
+    Dropdown, DropdownAction, DropdownItemAction, DropdownStyle,
+};
 use crate::view_components::FilterableDropdown;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::{report_if_error, LLMPreferences};
@@ -82,7 +83,7 @@ const AUTH_SECRET_CREATE_NEW_LABEL: &str = "New API key…";
 /// Trait that both `RunAgentsCardViewAction` and
 /// `OrchestrationConfigBlockAction` implement so the shared picker
 /// creation and render helpers can produce the correct action variant.
-pub trait OrchestrationControlAction: Clone + Debug + Send + Sync + 'static {
+pub trait OrchestrationControlAction: DropdownItemAction + Clone {
     fn execution_mode_toggled(is_remote: bool) -> Self;
     fn model_changed(model_id: String) -> Self;
     fn harness_changed(harness_type: String) -> Self;
@@ -491,7 +492,9 @@ pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>
                 let items = available_model_menu_items(
                     ordered_choices,
                     move |llm| {
-                        DropdownAction::SelectActionAndClose(A::model_changed(llm.id.to_string()))
+                        DropdownAction::select_action_and_close(A::model_changed(
+                            llm.id.to_string(),
+                        ))
                     },
                     None,
                     None,
@@ -513,14 +516,13 @@ pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>
             Some(harness) => {
                 // Non-Oz harness: "Default model" at top, then server-provided
                 // harness models.
-                let mut items: Vec<MenuItem<DropdownAction<A>>> =
-                    vec![default_model_menu_item::<A>()];
+                let mut items: Vec<MenuItem<DropdownAction>> = vec![default_model_menu_item::<A>()];
                 let availability = HarnessAvailabilityModel::as_ref(ctx_dropdown);
                 if let Some(models) = availability.models_for(harness) {
                     for model in models {
                         let model_id = model.id.clone();
                         let fields = MenuItemFields::new(&model.display_name)
-                            .with_on_select_action(DropdownAction::SelectActionAndClose(
+                            .with_on_select_action(DropdownAction::select_action_and_close(
                                 A::model_changed(model_id),
                             ));
                         items.push(MenuItem::Item(fields));
@@ -550,10 +552,10 @@ pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>
 }
 
 /// Creates a "Default model" menu item that emits an empty model_id.
-fn default_model_menu_item<A: OrchestrationControlAction>() -> MenuItem<DropdownAction<A>> {
+fn default_model_menu_item<A: OrchestrationControlAction>() -> MenuItem<DropdownAction> {
     MenuItem::Item(
         MenuItemFields::new(DEFAULT_MODEL_LABEL).with_on_select_action(
-            DropdownAction::SelectActionAndClose(A::model_changed(String::new())),
+            DropdownAction::select_action_and_close(A::model_changed(String::new())),
         ),
     )
 }
@@ -657,7 +659,7 @@ pub fn populate_harness_picker<A: OrchestrationControlAction, V: View>(
         // cached entry.harness deserialized as Unknown.
         let target_harness = Harness::parse_orchestration_harness(&initial_harness);
 
-        let mut items: Vec<MenuItem<DropdownAction<A>>> = Vec::new();
+        let mut items: Vec<MenuItem<DropdownAction>> = Vec::new();
         let mut selected_name: Option<String> = None;
         let target_display = target_harness.map(|harness| availability.display_name_for(harness));
 
@@ -673,7 +675,7 @@ pub fn populate_harness_picker<A: OrchestrationControlAction, V: View>(
             }
             let harness_str = harness.to_string();
             if entry.enabled {
-                fields = fields.with_on_select_action(DropdownAction::SelectActionAndClose(
+                fields = fields.with_on_select_action(DropdownAction::select_action_and_close(
                     A::harness_changed(harness_str.clone()),
                 ));
             } else {
@@ -733,11 +735,11 @@ pub fn create_environment_picker<A: OrchestrationControlAction, V: View>(
             .collect();
         sorted_envs.sort_by(|a, b| a.1.cmp(&b.1));
 
-        let mut items: Vec<MenuItem<DropdownAction<A>>> = Vec::new();
+        let mut items: Vec<MenuItem<DropdownAction>> = Vec::new();
         let mut selected_name: Option<String> = None;
         items.push(MenuItem::Item(
             MenuItemFields::new(ORCHESTRATION_ENV_NONE_LABEL).with_on_select_action(
-                DropdownAction::SelectActionAndClose(A::environment_changed(String::new())),
+                DropdownAction::select_action_and_close(A::environment_changed(String::new())),
             ),
         ));
         if initial_env.is_empty() {
@@ -750,7 +752,9 @@ pub fn create_environment_picker<A: OrchestrationControlAction, V: View>(
             let env_id_for_item = env_id.clone();
             items.push(MenuItem::Item(
                 MenuItemFields::new(env_name).with_on_select_action(
-                    DropdownAction::SelectActionAndClose(A::environment_changed(env_id_for_item)),
+                    DropdownAction::select_action_and_close(A::environment_changed(
+                        env_id_for_item,
+                    )),
                 ),
             ));
         }
@@ -776,11 +780,11 @@ pub fn populate_environment_picker<A: OrchestrationControlAction, V: View>(
             .collect();
         sorted_envs.sort_by(|a, b| a.1.cmp(&b.1));
 
-        let mut items: Vec<MenuItem<DropdownAction<A>>> = Vec::new();
+        let mut items: Vec<MenuItem<DropdownAction>> = Vec::new();
         let mut selected_name: Option<String> = None;
         items.push(MenuItem::Item(
             MenuItemFields::new(ORCHESTRATION_ENV_NONE_LABEL).with_on_select_action(
-                DropdownAction::SelectActionAndClose(A::environment_changed(String::new())),
+                DropdownAction::select_action_and_close(A::environment_changed(String::new())),
             ),
         ));
         if initial_env.is_empty() {
@@ -793,7 +797,9 @@ pub fn populate_environment_picker<A: OrchestrationControlAction, V: View>(
             let env_id_for_item = env_id.clone();
             items.push(MenuItem::Item(
                 MenuItemFields::new(env_name).with_on_select_action(
-                    DropdownAction::SelectActionAndClose(A::environment_changed(env_id_for_item)),
+                    DropdownAction::select_action_and_close(A::environment_changed(
+                        env_id_for_item,
+                    )),
                 ),
             ));
         }
@@ -1136,11 +1142,11 @@ pub fn populate_auth_secret_picker_for_harness<A: OrchestrationControlAction, V:
     let selection = selection.clone();
     dropdown.update(ctx, |dropdown, ctx_dropdown| {
         let availability = HarnessAvailabilityModel::as_ref(ctx_dropdown);
-        let mut items: Vec<MenuItem<DropdownAction<A>>> = Vec::new();
+        let mut items: Vec<MenuItem<DropdownAction>> = Vec::new();
 
         items.push(MenuItem::Item(
             MenuItemFields::new(AUTH_SECRET_INHERIT_LABEL).with_on_select_action(
-                DropdownAction::SelectActionAndClose(A::auth_secret_changed(None)),
+                DropdownAction::select_action_and_close(A::auth_secret_changed(None)),
             ),
         ));
 
@@ -1154,7 +1160,7 @@ pub fn populate_auth_secret_picker_for_harness<A: OrchestrationControlAction, V:
                     }
                     items.push(MenuItem::Item(
                         MenuItemFields::new(&name).with_on_select_action(
-                            DropdownAction::SelectActionAndClose(A::auth_secret_changed(Some(
+                            DropdownAction::select_action_and_close(A::auth_secret_changed(Some(
                                 name.clone(),
                             ))),
                         ),
@@ -1177,7 +1183,7 @@ pub fn populate_auth_secret_picker_for_harness<A: OrchestrationControlAction, V:
             items.push(MenuItem::Separator);
             items.push(MenuItem::Item(
                 MenuItemFields::new(AUTH_SECRET_CREATE_NEW_LABEL).with_on_select_action(
-                    DropdownAction::SelectActionAndClose(A::create_new_auth_secret_requested()),
+                    DropdownAction::select_action_and_close(A::create_new_auth_secret_requested()),
                 ),
             ));
         }

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -180,7 +180,7 @@ struct RunAgentsCardHandles {
     pickers: OrchestrationPickerHandles<RunAgentsCardViewAction>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RunAgentsCardViewAction {
     Accept,
     AcceptWithoutOrchestration,

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -112,7 +112,7 @@ const BASE_MODEL_HELPER: &str = "The primary model all agents will use.";
 
 // ── Action type ─────────────────────────────────────────────────────
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OrchestrationConfigBlockAction {
     ToggleApproval,
     ToggleDetails,

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -40,6 +40,7 @@ use crate::pane_group::{BackingView, PaneConfiguration, PaneEvent};
 use crate::settings::{AISettings, AISettingsChangedEvent, AgentModeCommandExecutionPredicate};
 use crate::ui_components::icons::Icon;
 use crate::view_components::action_button::{ActionButton, DangerSecondaryTheme};
+use crate::view_components::dropdown::DropdownAction;
 use crate::view_components::{
     Dropdown, DropdownItem, FilterableDropdown, SubmittableTextInput, SubmittableTextInputEvent,
 };
@@ -1185,7 +1186,7 @@ impl ExecutionProfileEditorView {
 
             let items = available_model_menu_items(
                 choices,
-                |llm| create_action(llm.id.clone()).into(),
+                |llm| DropdownAction::select_action_and_close(create_action(llm.id.clone())),
                 None,
                 None,
                 false,
@@ -1234,7 +1235,9 @@ impl ExecutionProfileEditorView {
             let items = available_model_menu_items(
                 choices,
                 |llm| {
-                    ExecutionProfileEditorViewAction::SetCodingModel { id: llm.id.clone() }.into()
+                    DropdownAction::select_action_and_close(
+                        ExecutionProfileEditorViewAction::SetCodingModel { id: llm.id.clone() },
+                    )
                 },
                 None,
                 None,

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -16,7 +16,9 @@ use crate::ai::execution_profiles::{AIExecutionProfile, ActionPermission};
 use crate::editor::EditorView;
 use crate::settings::AISettings;
 use crate::ui_components::icons::Icon;
-use crate::view_components::{Dropdown, FilterableDropdown, SubmittableTextInput};
+use crate::view_components::{
+    Dropdown, DropdownItemAction, FilterableDropdown, SubmittableTextInput,
+};
 use crate::{Appearance, TemplatableMCPServerManager};
 
 const CONTEXT_WINDOW_SLIDER_WIDTH: f32 = 220.;
@@ -124,7 +126,7 @@ pub fn render_section_label(label: &str, appearance: &Appearance) -> Box<dyn Ele
     .finish()
 }
 
-fn render_filterable_dropdown_row<T: Clone + 'static + std::fmt::Debug + Send + Sync>(
+fn render_filterable_dropdown_row<T: DropdownItemAction>(
     appearance: &Appearance,
     label: &str,
     desc: &str,
@@ -196,7 +198,7 @@ fn render_info_section(
     Container::new(description).with_margin_bottom(12.).finish()
 }
 
-fn render_permission_row<T: Clone + 'static + std::fmt::Debug + Send + Sync>(
+fn render_permission_row<T: DropdownItemAction>(
     appearance: &Appearance,
     icon: Icon,
     label: &str,

--- a/app/src/chip_configurator/mod.rs
+++ b/app/src/chip_configurator/mod.rs
@@ -327,7 +327,7 @@ pub struct CurrentDraggingState {
     pub current_location: ChipLocation,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ChipConfiguratorAction {
     StartDraggingChip { location: ChipLocation },
     DragChip { current_position: RectF },

--- a/app/src/drive/index.rs
+++ b/app/src/drive/index.rs
@@ -232,7 +232,7 @@ pub enum DriveIndexSection {
     JoinTeam,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DriveIndexAction {
     OpenObject(CloudObjectTypeAndId),
     OpenWorkflowInPane {

--- a/app/src/drive/mod.rs
+++ b/app/src/drive/mod.rs
@@ -46,7 +46,7 @@ pub struct OpenWarpDriveObjectArgs {
     pub settings: OpenWarpDriveObjectSettings,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DriveObjectType {
     Workflow,
     AgentModeWorkflow,

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1570,6 +1570,7 @@ pub(crate) fn initialize_app(
     editor::init(ctx);
     onboarding::init(ctx);
     menu::init(ctx);
+    view_components::init(ctx);
     tips::tip_view::init(ctx);
     launch_configs::init(ctx);
     workflows::init(ctx);

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1570,7 +1570,6 @@ pub(crate) fn initialize_app(
     editor::init(ctx);
     onboarding::init(ctx);
     menu::init(ctx);
-    view_components::init(ctx);
     tips::tip_view::init(ctx);
     launch_configs::init(ctx);
     workflows::init(ctx);

--- a/app/src/notebooks/editor/notebook_command.rs
+++ b/app/src/notebooks/editor/notebook_command.rs
@@ -195,7 +195,7 @@ impl NotebookCommand {
             dropdown.set_rich_items(
                 CodeBlockType::all().map(|code_block_type| {
                     let mut item = MenuItemFields::new(code_block_type.to_string())
-                        .with_on_select_action(DropdownAction::SelectActionAndClose(
+                        .with_on_select_action(DropdownAction::select_action_and_close(
                             EditorViewAction::CodeBlockTypeSelectedAtOffset {
                                 code_block_type: code_block_type.clone(),
                                 start_anchor: start.clone(),

--- a/app/src/notebooks/editor/omnibar.rs
+++ b/app/src/notebooks/editor/omnibar.rs
@@ -372,7 +372,7 @@ impl View for Omnibar {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum OmnibarAction {
     /// Toggle bold styling on the selected text.
     BoldSelection,

--- a/app/src/prompt/editor_modal.rs
+++ b/app/src/prompt/editor_modal.rs
@@ -147,7 +147,7 @@ impl PromptType {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EditorModalAction {
     Cancel,
     Save,

--- a/app/src/settings/mod.rs
+++ b/app/src/settings/mod.rs
@@ -258,7 +258,7 @@ pub struct Settings;
 /// later allow users to have both quake mode and activation mode enabled simultaneously. If/when
 /// that happens we'll remove this enum. These options are not modeled as a ternary option in the
 /// serialized user-defaults, but as independent options.
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GlobalHotkeyMode {
     #[default]
     Disabled,

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -2134,7 +2134,11 @@ impl AISettingsPageView {
 
             let items = available_model_menu_items(
                 choices,
-                |llm| AISettingsPageAction::SetBaseModel(llm.id.clone()).into(),
+                |llm| {
+                    DropdownAction::select_action_and_close(AISettingsPageAction::SetBaseModel(
+                        llm.id.clone(),
+                    ))
+                },
                 None,
                 None,
                 false,
@@ -2169,7 +2173,11 @@ impl AISettingsPageView {
 
             let items = available_model_menu_items(
                 choices,
-                |llm| AISettingsPageAction::SetCodingModel(llm.id.clone()).into(),
+                |llm| {
+                    DropdownAction::select_action_and_close(AISettingsPageAction::SetCodingModel(
+                        llm.id.clone(),
+                    ))
+                },
                 None,
                 None,
                 false,
@@ -2516,7 +2524,7 @@ impl AISettingsPageView {
                     dropdown.set_menu_width(180., ctx);
                     dropdown.set_main_axis_size(MainAxisSize::Min, ctx);
 
-                    let mut items: Vec<MenuItem<DropdownAction<AISettingsPageAction>>> = Vec::new();
+                    let mut items: Vec<MenuItem<DropdownAction>> = Vec::new();
 
                     for agent in all::<CLIAgent>() {
                         if matches!(agent, CLIAgent::Unknown) {
@@ -2524,7 +2532,7 @@ impl AISettingsPageView {
                         }
                         let icon = agent.icon();
                         let mut fields = MenuItemFields::new(agent.display_name())
-                            .with_on_select_action(DropdownAction::SelectActionAndClose(
+                            .with_on_select_action(DropdownAction::select_action_and_close(
                                 AISettingsPageAction::SetCLIAgentForCommand {
                                     pattern: pattern_clone.clone(),
                                     agent: Some(agent),
@@ -2538,7 +2546,7 @@ impl AISettingsPageView {
 
                     items.push(
                         MenuItemFields::new("Other")
-                            .with_on_select_action(DropdownAction::SelectActionAndClose(
+                            .with_on_select_action(DropdownAction::select_action_and_close(
                                 AISettingsPageAction::SetCLIAgentForCommand {
                                     pattern: pattern_clone.clone(),
                                     agent: None,
@@ -7102,10 +7110,7 @@ impl ApiKeysWidget {
             FormattedTextFragment::plain_text(
                 "Use your own API keys from model providers for Warp Agent. You can also add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored locally and are never synced to the cloud. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
             ),
-            FormattedTextFragment::hyperlink(
-                "Learn more",
-                CUSTOM_INFERENCE_LEARN_MORE_URL,
-            ),
+            FormattedTextFragment::hyperlink("Learn more", CUSTOM_INFERENCE_LEARN_MORE_URL),
         ];
         let description = FormattedTextElement::new(
             FormattedText::new([FormattedTextLine::Line(text_fragments)]),
@@ -7143,10 +7148,7 @@ impl ApiKeysWidget {
             FormattedTextFragment::plain_text(
                 "By using BYOK or custom endpoints, you agree to use them only as permitted by ",
             ),
-            FormattedTextFragment::hyperlink(
-                "Warp's Terms of Service",
-                CUSTOM_INFERENCE_TERMS_URL,
-            ),
+            FormattedTextFragment::hyperlink("Warp's Terms of Service", CUSTOM_INFERENCE_TERMS_URL),
             FormattedTextFragment::plain_text(
                 ". BYOK and custom endpoints are intended for individual use and small teams. Companies or organizations with more than 10 employees should use Warp Business or Enterprise.",
             ),

--- a/app/src/settings_view/features/external_editor.rs
+++ b/app/src/settings_view/features/external_editor.rs
@@ -24,7 +24,7 @@ use crate::{report_if_error, send_telemetry_from_ctx};
 const TABBED_FILE_VIEWER_TOGGLE_HEADER: &str = "Group files into single editor pane";
 const TABBED_FILE_VIEWER_TOGGLE_DESCRIPTION: &str = "When this setting is on, any files opened in the same tab will be automatically grouped into a single editor pane.";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ExternalEditorAction {
     SetEditor(EditorChoice),
     SetCodePanelsEditor(EditorChoice),

--- a/app/src/settings_view/features/startup_shell.rs
+++ b/app/src/settings_view/features/startup_shell.rs
@@ -30,7 +30,7 @@ pub struct StartupShellView {
     is_custom_path_valid: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum NewSessionShellAction {
     /// Changes the user's startup shell to the given option. This also hides
     /// the custom shell path editor if a non-custom shell was chosen.

--- a/app/src/settings_view/features/working_directory.rs
+++ b/app/src/settings_view/features/working_directory.rs
@@ -13,7 +13,7 @@ use crate::view_components::dropdown::TOP_MENU_BAR_HEIGHT;
 use crate::view_components::{Dropdown, DropdownItem};
 use crate::{report_if_error, send_telemetry_from_ctx};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::enum_variant_names)]
 pub enum WorkingDirectoryAction {
     /// Sets the mode that should be used for all new sessions, independent of

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -556,7 +556,7 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum FeaturesPageAction {
     ToggleCopyOnSelect,
     ToggleNotifications,

--- a/app/src/settings_view/settings_page.rs
+++ b/app/src/settings_view/settings_page.rs
@@ -48,7 +48,7 @@ use crate::settings::CloudPreferencesSettings;
 use crate::themes::theme::Fill;
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
-use crate::view_components::{Dropdown, SubmittableTextInput};
+use crate::view_components::{Dropdown, DropdownItemAction, SubmittableTextInput};
 
 pub const TOGGLE_BUTTON_RIGHT_PADDING: f32 = 5.;
 pub const HEADER_PADDING: f32 = 15.;
@@ -914,7 +914,7 @@ pub fn render_dropdown_item_label(
     }
 }
 
-pub(crate) fn render_dropdown_item<T: Clone + Action>(
+pub(crate) fn render_dropdown_item<T: DropdownItemAction>(
     appearance: &Appearance,
     label: &str,
     secondary_text: Option<&str>,

--- a/app/src/terminal/buy_credits_banner.rs
+++ b/app/src/terminal/buy_credits_banner.rs
@@ -32,7 +32,7 @@ use crate::send_telemetry_from_ctx;
 use crate::server::ids::ServerId;
 use crate::server::telemetry::{OutOfCreditsBannerAction, TelemetryEvent};
 use crate::settings_view::create_discount_badge;
-use crate::view_components::Dropdown;
+use crate::view_components::{Dropdown, DropdownAction};
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 
 #[derive(Default)]
@@ -368,11 +368,15 @@ impl BuyCreditsBanner {
                         })),
                         Some(primary_text)
                     )
-                    .with_on_select_action(Action::SelectDenomination(index).into())
+                    .with_on_select_action(DropdownAction::select_action_and_close(
+                        Action::SelectDenomination(index),
+                    ))
                     .into_item()
                 } else {
                     MenuItemFields::new(primary_text.clone())
-                        .with_on_select_action(Action::SelectDenomination(index).into())
+                        .with_on_select_action(DropdownAction::select_action_and_close(
+                            Action::SelectDenomination(index),
+                        ))
                         .into_item()
                 }
             })
@@ -839,7 +843,7 @@ impl View for BuyCreditsBanner {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Action {
     SelectDenomination(usize),
     Close,

--- a/app/src/terminal/enable_auto_reload_modal.rs
+++ b/app/src/terminal/enable_auto_reload_modal.rs
@@ -22,7 +22,7 @@ use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::{AutoReloadModalAction, TelemetryEvent};
 use crate::settings_view::create_discount_badge;
 use crate::ui_components::blended_colors;
-use crate::view_components::{Dropdown, ToastFlavor};
+use crate::view_components::{Dropdown, DropdownAction, ToastFlavor};
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 
 const DENOMINATION_DROPDOWN_WIDTH: f32 = MODAL_WIDTH - 2. * MODAL_PADDING;
@@ -194,11 +194,15 @@ impl EnableAutoReloadModalBody {
                         })),
                         Some(primary_text),
                     )
-                    .with_on_select_action(Action::SelectDenomination(index).into())
+                    .with_on_select_action(DropdownAction::select_action_and_close(
+                        Action::SelectDenomination(index),
+                    ))
                     .into_item()
                 } else {
                     MenuItemFields::new(primary_text.clone())
-                        .with_on_select_action(Action::SelectDenomination(index).into())
+                        .with_on_select_action(DropdownAction::select_action_and_close(
+                            Action::SelectDenomination(index),
+                        ))
                         .into_item()
                 }
             })
@@ -363,7 +367,7 @@ impl View for EnableAutoReloadModalBody {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Action {
     SelectDenomination(usize),
     Cancel,

--- a/app/src/terminal/session_settings/working_directory_config.rs
+++ b/app/src/terminal/session_settings/working_directory_config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use settings::Setting;
 
 /// The source for a newly-created session.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NewSessionSource {
     /// The user split a pane to create a new session.
     SplitPane,

--- a/app/src/view_components/compact_dropdown.rs
+++ b/app/src/view_components/compact_dropdown.rs
@@ -1,4 +1,5 @@
 use pathfinder_geometry::vector::vec2f;
+use std::marker::PhantomData;
 use warpui::elements::{
     Border, ChildAnchor, ConstrainedBox, CornerRadius, CrossAxisAlignment, Flex,
     Icon as WarpUiIcon, MainAxisAlignment, MouseStateHandle, OffsetPositioning, ParentElement,
@@ -8,11 +9,11 @@ use warpui::presenter::ChildView;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
-    Action, AppContext, BlurContext, Element, Entity, SingletonEntity, TypedActionView, View,
-    ViewContext, ViewHandle,
+    AppContext, BlurContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
 };
 
-use super::dropdown::DropdownAction;
+use super::dropdown::{DropdownAction, DropdownItemAction};
 use crate::appearance::Appearance;
 use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuVariant};
 use crate::themes::theme::Fill;
@@ -27,18 +28,19 @@ mod tests;
 ///
 /// This is useful instead of [`crate::dropdown::Dropdown`] when showing a
 /// dropdown alongside other controls, such as in a formatting UI.
-pub struct CompactDropdown<A: Action + Clone> {
+pub struct CompactDropdown<A: DropdownItemAction = ()> {
     /// Whether the dropdown is open.
     is_expanded: bool,
     /// Mouse state for the dropdown button.
     top_bar_mouse_state: MouseStateHandle,
     /// Dropdown menu.
-    dropdown: ViewHandle<Menu<DropdownAction<A>>>,
+    dropdown: ViewHandle<Menu<DropdownAction>>,
     /// The size that icons are scaled to. Defaults to the UI font size if not set.
     icon_size: Option<f32>,
+    _action_type: PhantomData<A>,
 }
 
-pub struct CompactDropdownItem<A: Action + Clone> {
+pub struct CompactDropdownItem<A: DropdownItemAction = ()> {
     /// Icon identifier for this item.
     icon: Icon,
     /// Optional override color for the icon.
@@ -49,7 +51,7 @@ pub struct CompactDropdownItem<A: Action + Clone> {
     action: A,
 }
 
-impl<A: Action + Clone> CompactDropdown<A> {
+impl<A: DropdownItemAction> CompactDropdown<A> {
     /// Create a new, empty compact dropdown. The [`MenuVariant`] determines whether or not the
     /// dropdown is scrollable when expanded.
     pub fn new(menu_variant: MenuVariant, ctx: &mut ViewContext<Self>) -> Self {
@@ -70,6 +72,7 @@ impl<A: Action + Clone> CompactDropdown<A> {
             dropdown,
             top_bar_mouse_state: Default::default(),
             icon_size: None,
+            _action_type: PhantomData,
         }
     }
 
@@ -159,7 +162,7 @@ impl<A: Action + Clone> CompactDropdown<A> {
         // if the dropdown is not expanded.
         if !self.is_expanded {
             top_bar = top_bar.on_click(|ctx, _, _| {
-                ctx.dispatch_typed_action(DropdownAction::<A>::ToggleExpanded);
+                ctx.dispatch_typed_action(DropdownAction::ToggleExpanded);
             });
         }
 
@@ -200,7 +203,11 @@ impl<A: Action + Clone> CompactDropdown<A> {
     /// Adapter between [`MenuItem`] click callbacks and the parent action type.
     /// When a dropdown menu item is selected, we dispatch its action and close
     /// the dropdown.
-    fn select_action_and_close(&mut self, action: &A, ctx: &mut ViewContext<Self>) {
+    fn select_action_and_close(
+        &mut self,
+        action: &dyn DropdownItemAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
         ctx.dispatch_typed_action(action);
         self.close(ctx);
     }
@@ -213,11 +220,11 @@ impl<A: Action + Clone> CompactDropdown<A> {
     }
 }
 
-impl<A: Action + Clone> Entity for CompactDropdown<A> {
+impl<A: DropdownItemAction> Entity for CompactDropdown<A> {
     type Event = CompactDropdownEvent;
 }
 
-impl<A: Action + Clone> View for CompactDropdown<A> {
+impl<A: DropdownItemAction> View for CompactDropdown<A> {
     fn ui_name() -> &'static str {
         "CompactDropdown"
     }
@@ -248,22 +255,22 @@ impl<A: Action + Clone> View for CompactDropdown<A> {
     }
 }
 
-impl<A: Action + Clone> TypedActionView for CompactDropdown<A> {
-    type Action = DropdownAction<A>;
+impl<A: DropdownItemAction> TypedActionView for CompactDropdown<A> {
+    type Action = DropdownAction;
 
-    fn handle_action(&mut self, action: &DropdownAction<A>, ctx: &mut ViewContext<Self>) {
+    fn handle_action(&mut self, action: &DropdownAction, ctx: &mut ViewContext<Self>) {
         match action {
             DropdownAction::Focus(_) => self.focus(ctx),
             DropdownAction::Close => self.close(ctx),
             DropdownAction::SelectActionAndClose(action) => {
-                self.select_action_and_close(action, ctx)
+                self.select_action_and_close(action.as_ref(), ctx)
             }
             DropdownAction::ToggleExpanded => self.toggle_expanded(ctx),
         }
     }
 }
 
-impl<A: Action + Clone> CompactDropdownItem<A> {
+impl<A: DropdownItemAction> CompactDropdownItem<A> {
     pub fn new(icon: Icon, display_text: impl Into<String>, action: A) -> Self {
         Self {
             display_text: display_text.into(),
@@ -280,10 +287,10 @@ impl<A: Action + Clone> CompactDropdownItem<A> {
         self
     }
 
-    fn menu_item(self) -> MenuItem<DropdownAction<A>> {
+    fn menu_item(self) -> MenuItem<DropdownAction> {
         let mut item = MenuItemFields::new(self.display_text)
             .with_icon(self.icon)
-            .with_on_select_action(DropdownAction::SelectActionAndClose(self.action));
+            .with_on_select_action(DropdownAction::SelectActionAndClose(Box::new(self.action)));
         if let Some(color) = self.icon_color {
             item = item.with_override_icon_color(color);
         }

--- a/app/src/view_components/compact_dropdown_tests.rs
+++ b/app/src/view_components/compact_dropdown_tests.rs
@@ -6,7 +6,7 @@ use super::{CompactDropdown, CompactDropdownItem};
 use crate::menu::MenuVariant;
 use crate::ui_components::icons::Icon;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct TestAction;
 
 /// Baseline test that the view can render.

--- a/app/src/view_components/dropdown.rs
+++ b/app/src/view_components/dropdown.rs
@@ -94,9 +94,10 @@ impl DropdownStyle {
 /// A dropdown menu view. The view renders each DropdownItem. When a menu item is clicked,
 /// on_click_action_name is dispatched, with the value of the corresponding menu item.
 ///
-/// The default item action type is `()`, so callers that only need a static dropdown shell can
-/// name `Dropdown` without specifying an action type. Callers that dispatch item selections should
-/// use a concrete action type.
+/// The item action type powers typed item helpers like `set_items` and
+/// `set_selected_by_action`. Callers that populate the menu with already-erased rich
+/// [`MenuItem<DropdownAction>`] values through `set_rich_items` do not need to name a concrete
+/// item action type.
 pub struct Dropdown<A: DropdownItemAction = ()> {
     is_expanded: bool,
     disabled: bool,
@@ -443,8 +444,9 @@ where
 
     /// Set items from rich menu items.
     ///
-    /// Rich menu items carry erased [`DropdownAction`]s, so callers are responsible for ensuring
-    /// each item dispatches an action handled by the parent view.
+    /// Rich menu items already carry erased [`DropdownAction`]s. The dropdown dispatches selected
+    /// item actions through normal action propagation, so callers should ensure each action is
+    /// handled by an appropriate view in the containing view hierarchy.
     pub fn set_rich_items(
         &mut self,
         items: impl IntoIterator<Item = MenuItem<DropdownAction>>,

--- a/app/src/view_components/dropdown.rs
+++ b/app/src/view_components/dropdown.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use pathfinder_color::ColorU;
 use warpui::elements::{
@@ -25,6 +26,38 @@ pub const TOP_MENU_BAR_MAX_WIDTH: f32 = 190.;
 pub const DROPDOWN_PADDING: f32 = 6.;
 
 pub type MenuHeaderTextFormatter = Box<dyn Fn(&str) -> String>;
+pub trait DropdownItemAction: Action {
+    fn clone_box(&self) -> Box<dyn DropdownItemAction>;
+    fn eq_action(&self, other: &dyn DropdownItemAction) -> bool;
+}
+
+impl<T> DropdownItemAction for T
+where
+    T: Action + Clone + PartialEq + 'static,
+{
+    fn clone_box(&self) -> Box<dyn DropdownItemAction> {
+        Box::new(self.clone())
+    }
+
+    fn eq_action(&self, other: &dyn DropdownItemAction) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<T>()
+            .is_some_and(|other| self == other)
+    }
+}
+
+impl Clone for Box<dyn DropdownItemAction> {
+    fn clone(&self) -> Self {
+        self.as_ref().clone_box()
+    }
+}
+
+impl PartialEq for Box<dyn DropdownItemAction> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq_action(other.as_ref())
+    }
+}
 
 #[derive(Clone, Default)]
 pub enum DropdownStyle {
@@ -60,7 +93,11 @@ impl DropdownStyle {
 
 /// A dropdown menu view. The view renders each DropdownItem. When a menu item is clicked,
 /// on_click_action_name is dispatched, with the value of the corresponding menu item.
-pub struct Dropdown<A: Action + Clone> {
+///
+/// The default item action type is `()`, so callers that only need a static dropdown shell can
+/// name `Dropdown` without specifying an action type. Callers that dispatch item selections should
+/// use a concrete action type.
+pub struct Dropdown<A: DropdownItemAction = ()> {
     is_expanded: bool,
     disabled: bool,
     top_bar_mouse_state: MouseStateHandle,
@@ -69,8 +106,8 @@ pub struct Dropdown<A: Action + Clone> {
     child_anchor: ChildAnchor,
     main_axis_size: MainAxisSize,
 
-    dropdown: ViewHandle<Menu<DropdownAction<A>>>,
-    selected_item: Option<MenuItem<DropdownAction<A>>>,
+    dropdown: ViewHandle<Menu<DropdownAction>>,
+    selected_item: Option<MenuItem<DropdownAction>>,
     // Function for overriding the default closed-state text (the selected item)
     menu_header_text_override: Option<MenuHeaderTextFormatter>,
     self_handle: WeakViewHandle<Self>,
@@ -110,10 +147,13 @@ pub struct Dropdown<A: Action + Clone> {
     /// confirmation card pickers.
     use_overlay_layer: bool,
     match_menu_width_to_top_bar: bool,
+    // The menu stores erased `DropdownAction`s internally, but the public API remains generic over
+    // the caller's concrete item action type (`set_items`, `set_selected_by_action`, etc.).
+    _item_action_type: PhantomData<A>,
 }
 
 #[derive(Clone)]
-pub struct DropdownItem<A: Action + Clone> {
+pub struct DropdownItem<A: DropdownItemAction = ()> {
     /// Text to display for the item
     pub display_text: String,
     /// Constructor for the typed action object
@@ -129,7 +169,7 @@ pub struct DropdownItem<A: Action + Clone> {
 
 impl<A> DropdownItem<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
     pub fn new<S>(display_text: S, action: A) -> Self
     where
@@ -167,14 +207,14 @@ where
     }
 }
 
-impl<A> From<&DropdownItem<A>> for MenuItem<DropdownAction<A>>
+impl<A> From<&DropdownItem<A>> for MenuItem<DropdownAction>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
-    fn from(dropdown_item: &DropdownItem<A>) -> MenuItem<DropdownAction<A>> {
+    fn from(dropdown_item: &DropdownItem<A>) -> MenuItem<DropdownAction> {
         let mut menu_item = MenuItemFields::new(dropdown_item.display_text.clone())
             .with_on_select_action(DropdownAction::SelectActionAndClose(
-                dropdown_item.action.clone(),
+                dropdown_item.action.clone_box(),
             ));
         if let Some(tooltip) = &dropdown_item.tooltip {
             menu_item = menu_item.with_tooltip(tooltip.clone());
@@ -190,21 +230,27 @@ where
     }
 }
 
-impl<A> From<A> for DropdownAction<A>
-where
-    A: Action + Clone,
-{
-    fn from(action: A) -> DropdownAction<A> {
-        DropdownAction::SelectActionAndClose(action)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
-pub enum DropdownAction<A: Action + Clone> {
+pub enum DropdownAction {
     Focus(usize),
     Close,
-    SelectActionAndClose(A),
+    SelectActionAndClose(Box<dyn DropdownItemAction>),
     ToggleExpanded,
+}
+
+impl DropdownAction {
+    /// Wraps a caller item action so menu selection can close the dropdown before dispatching the
+    /// typed action.
+    ///
+    /// This is an inherent constructor instead of `From<A>` because a blanket
+    /// `impl<A> From<A> for DropdownAction` would overlap with Rust's `impl<T> From<T> for T`
+    /// when `A = DropdownAction`.
+    pub fn select_action_and_close<A>(action: A) -> Self
+    where
+        A: DropdownItemAction,
+    {
+        Self::SelectActionAndClose(Box::new(action))
+    }
 }
 
 pub enum DropdownEvent {
@@ -214,7 +260,7 @@ pub enum DropdownEvent {
 
 impl<A> Dropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
     pub fn new(ctx: &mut ViewContext<Self>) -> Self {
         let dropdown = ctx.add_typed_action_view(|ctx| {
@@ -253,6 +299,7 @@ where
             top_bar_height: TOP_MENU_BAR_HEIGHT,
             use_overlay_layer: true,
             match_menu_width_to_top_bar: false,
+            _item_action_type: PhantomData,
         }
     }
 
@@ -394,11 +441,13 @@ where
         ctx.notify();
     }
 
-    // Most dropdowns don't need to use rich menu features like separators, indents, and submenus.
-    // But some do and, for those, we expose a "rich" item API.
+    /// Set items from rich menu items.
+    ///
+    /// Rich menu items carry erased [`DropdownAction`]s, so callers are responsible for ensuring
+    /// each item dispatches an action handled by the parent view.
     pub fn set_rich_items(
         &mut self,
-        items: impl IntoIterator<Item = MenuItem<DropdownAction<A>>>,
+        items: impl IntoIterator<Item = MenuItem<DropdownAction>>,
         ctx: &mut ViewContext<Self>,
     ) {
         self.dropdown.update(ctx, |dropdown, ctx| {
@@ -445,12 +494,10 @@ where
     /// this clears the selection.
     ///
     /// This is primarily useful when items are dynamically generated and correspond to some backing data that's captured by the action.
-    pub fn set_selected_by_action(&mut self, action: A, ctx: &mut ViewContext<Self>)
-    where
-        A: PartialEq,
-    {
+    pub fn set_selected_by_action(&mut self, action: A, ctx: &mut ViewContext<Self>) {
+        let action = DropdownAction::SelectActionAndClose(Box::new(action));
         self.dropdown.update(ctx, |dropdown, ctx| {
-            dropdown.set_selected_by_action(&DropdownAction::SelectActionAndClose(action), ctx);
+            dropdown.set_selected_by_action(&action, ctx);
             ctx.notify();
         });
         self.selected_item = self.selected_item(ctx);
@@ -480,7 +527,7 @@ where
         })
     }
 
-    fn selected_item(&self, ctx: &mut ViewContext<Self>) -> Option<MenuItem<DropdownAction<A>>> {
+    fn selected_item(&self, ctx: &mut ViewContext<Self>) -> Option<MenuItem<DropdownAction>> {
         self.dropdown
             .read(ctx, |dropdown, _| dropdown.selected_item())
     }
@@ -490,7 +537,11 @@ where
         ctx.notify();
     }
 
-    fn select_action_and_close(&mut self, action: &A, ctx: &mut ViewContext<Self>) {
+    fn select_action_and_close(
+        &mut self,
+        action: &dyn DropdownItemAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
         ctx.dispatch_typed_action(action);
         self.close(ctx);
     }
@@ -581,7 +632,7 @@ where
         }
 
         let top_bar_element = top_bar.build().on_click(|ctx, _, _| {
-            ctx.dispatch_typed_action(DropdownAction::<A>::ToggleExpanded);
+            ctx.dispatch_typed_action(DropdownAction::ToggleExpanded);
         });
 
         SavePosition::new(
@@ -615,23 +666,23 @@ where
 
 impl<A> Entity for Dropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
     type Event = DropdownEvent;
 }
 
 impl<A> TypedActionView for Dropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
-    type Action = DropdownAction<A>;
+    type Action = DropdownAction;
 
-    fn handle_action(&mut self, action: &DropdownAction<A>, ctx: &mut ViewContext<Self>) {
+    fn handle_action(&mut self, action: &DropdownAction, ctx: &mut ViewContext<Self>) {
         match action {
             DropdownAction::Focus(delta) => self.focus(*delta, ctx),
             DropdownAction::Close => self.close(ctx),
             DropdownAction::SelectActionAndClose(action) => {
-                self.select_action_and_close(action, ctx)
+                self.select_action_and_close(action.as_ref(), ctx)
             }
             DropdownAction::ToggleExpanded => self.toggle_expanded(ctx),
         }
@@ -640,7 +691,7 @@ where
 
 impl<A> View for Dropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
     fn ui_name() -> &'static str {
         "Dropdown"

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use warp_editor::editor::NavigationKey;
 use warpui::elements::{
     Align, Border, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container, CornerRadius,
@@ -6,16 +7,17 @@ use warpui::elements::{
     PositionedElementOffsetBounds, Radius, SavePosition, Shrinkable, Stack,
 };
 use warpui::geometry::vector::vec2f;
+use warpui::keymap::{Context, FixedBinding};
 use warpui::ui_components::button::{ButtonVariant, TextAndIcon, TextAndIconAlignment};
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
-    Action, AppContext, BlurContext, Entity, FocusContext, SingletonEntity, TypedActionView, View,
+    AppContext, BlurContext, Entity, FocusContext, SingletonEntity, TypedActionView, View,
     ViewContext, ViewHandle,
 };
 
 use super::dropdown::{
-    DropdownAction, DropdownItem, MenuHeaderTextFormatter, DROPDOWN_PADDING, TOP_MENU_BAR_HEIGHT,
-    TOP_MENU_BAR_MAX_WIDTH,
+    DropdownAction, DropdownItem, DropdownItemAction, MenuHeaderTextFormatter, DROPDOWN_PADDING,
+    TOP_MENU_BAR_HEIGHT, TOP_MENU_BAR_MAX_WIDTH,
 };
 use crate::appearance::Appearance;
 use crate::editor::{
@@ -26,6 +28,17 @@ use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuVariant};
 use crate::ui_components::icons;
 
 const EMPTY_DROPDOWN_HEIGHT: f32 = 50.0;
+const FILTERABLE_DROPDOWN_COLLAPSED: &str = "FilterableDropdownCollapsed";
+
+pub fn init(app: &mut AppContext) {
+    use warpui::keymap::macros::*;
+
+    app.register_fixed_bindings([FixedBinding::new(
+        "space",
+        DropdownAction::ToggleExpanded,
+        id!(FilterableDropdown::<()>::ui_name()) & id!(FILTERABLE_DROPDOWN_COLLAPSED),
+    )]);
+}
 
 pub enum FilterableDropdownEvent {
     ToggleExpanded,
@@ -39,16 +52,16 @@ pub enum FilterableDropdownOrientation {
     Down,
 }
 
-pub struct FilterableDropdown<A: Action + Clone> {
+pub struct FilterableDropdown<A: DropdownItemAction = ()> {
     is_expanded: bool,
     disabled: bool,
     top_bar_mouse_state: MouseStateHandle,
     top_bar_max_width: f32,
     main_axis_size: MainAxisSize,
-    dropdown: ViewHandle<Menu<DropdownAction<A>>>,
+    dropdown: ViewHandle<Menu<DropdownAction>>,
     filter_editor: ViewHandle<EditorView>,
-    selected_item: Option<MenuItem<DropdownAction<A>>>,
-    items: Vec<DropdownItem<A>>,
+    selected_item: Option<MenuItem<DropdownAction>>,
+    items: Vec<MenuItem<DropdownAction>>,
     orientation: FilterableDropdownOrientation,
     static_menu_header: Option<&'static str>,
     button_variant: ButtonVariant,
@@ -71,11 +84,12 @@ pub struct FilterableDropdown<A: Action + Clone> {
     /// instead of an overlay.
     use_overlay_layer: bool,
     match_menu_width_to_top_bar: bool,
+    _action_type: PhantomData<A>,
 }
 
 impl<A> FilterableDropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
     pub fn new(ctx: &mut ViewContext<Self>) -> Self {
         let theme = Appearance::as_ref(ctx).theme();
@@ -130,6 +144,7 @@ where
             top_bar_height: TOP_MENU_BAR_HEIGHT,
             use_overlay_layer: true,
             match_menu_width_to_top_bar: false,
+            _action_type: PhantomData,
         }
     }
 
@@ -201,12 +216,12 @@ where
     }
 
     pub fn add_items(&mut self, items: Vec<DropdownItem<A>>, ctx: &mut ViewContext<Self>) {
-        self.items.extend(items.iter().cloned());
+        self.items.extend(items.iter().map(|item| item.into()));
         self.set_filtered_items(ctx);
     }
 
     pub fn set_items(&mut self, items: Vec<DropdownItem<A>>, ctx: &mut ViewContext<Self>) {
-        self.items = items;
+        self.items = items.iter().map(|item| item.into()).collect();
         self.set_filtered_items(ctx);
 
         // set_filtered_items intentionally preserves self.selected_item when
@@ -216,43 +231,30 @@ where
         // items is stale and must be cleared — otherwise the top bar shows a
         // ghost label and selected_item_label() returns a value that doesn't
         // correspond to any actual item.
-        let label = self.current_selected_item_label();
-        if !label.is_empty() && !self.items.iter().any(|item| item.display_text == label) {
+        let label = self.current_selected_item_label().to_string();
+        if !label.is_empty()
+            && !self
+                .items
+                .iter()
+                .any(|item| Self::item_label(item) == Some(label.as_str()))
+        {
             self.selected_item = None;
             ctx.notify();
         }
     }
 
-    /// Set items from rich menu items (MenuItem). This passes the rich menu items to the
-    /// internal dropdown but also extracts searchable DropdownItem objects for filtering.
+    /// Set items from rich menu items (MenuItem). This preserves the rich menu items for
+    /// filtering and passes the filtered items to the internal dropdown.
+    ///
+    /// Rich menu items carry erased [`DropdownAction`]s, so callers are responsible for ensuring
+    /// each item dispatches an action handled by the parent view.
     pub fn set_rich_items(
         &mut self,
-        items: Vec<MenuItem<DropdownAction<A>>>,
+        items: Vec<MenuItem<DropdownAction>>,
         ctx: &mut ViewContext<Self>,
     ) {
-        // Extract simple DropdownItem objects from MenuItem for filtering
-        self.items = items
-            .iter()
-            .filter_map(|item| match item {
-                MenuItem::Item(fields) => {
-                    let label = fields.label().to_string();
-                    fields.on_select_action().and_then(|action| {
-                        if let DropdownAction::SelectActionAndClose(a) = action {
-                            Some(DropdownItem::new(label, a.clone()))
-                        } else {
-                            None
-                        }
-                    })
-                }
-                _ => None, // Skip headers and separators
-            })
-            .collect();
-
-        // Set the full rich items on the internal dropdown
-        self.dropdown.update(ctx, |dropdown, ctx| {
-            dropdown.set_items(items, ctx);
-        });
-        ctx.notify();
+        self.items = items;
+        self.set_filtered_items(ctx);
     }
 
     /// The number of items in the dropdown.
@@ -305,12 +307,10 @@ where
     /// this clears the selection.
     ///
     /// This is primarily useful when items are dynamically generated and correspond to some backing data that's captured by the action.
-    pub fn set_selected_by_action(&mut self, action: A, ctx: &mut ViewContext<Self>)
-    where
-        A: PartialEq,
-    {
+    pub fn set_selected_by_action(&mut self, action: A, ctx: &mut ViewContext<Self>) {
+        let action = DropdownAction::SelectActionAndClose(Box::new(action));
         self.dropdown.update(ctx, |dropdown, ctx| {
-            dropdown.set_selected_by_action(&DropdownAction::SelectActionAndClose(action), ctx);
+            dropdown.set_selected_by_action(&action, ctx);
         });
         self.selected_item = self.selected_item_in_dropdown(ctx);
         ctx.notify();
@@ -357,7 +357,7 @@ where
     fn selected_item_in_dropdown(
         &self,
         ctx: &mut ViewContext<Self>,
-    ) -> Option<MenuItem<DropdownAction<A>>> {
+    ) -> Option<MenuItem<DropdownAction>> {
         self.dropdown
             .read(ctx, |dropdown, _| dropdown.selected_item())
     }
@@ -378,8 +378,10 @@ where
     }
 
     fn focus(&mut self, _delta: usize, ctx: &mut ViewContext<Self>) {
-        ctx.focus(&self.filter_editor);
-        ctx.notify();
+        if self.is_expanded {
+            ctx.focus(&self.filter_editor);
+            ctx.notify();
+        }
     }
 
     /// Dispatches the item's action up the responder chain and then closes the
@@ -392,7 +394,11 @@ where
     /// dropdown from their `Select`-equivalent branch, or `update_view` will
     /// panic with "Circular view update". The dropdown is already closed here
     /// after the dispatch returns, so parents don't need to close it themselves.
-    fn select_action_and_close(&mut self, action: &A, ctx: &mut ViewContext<Self>) {
+    fn select_action_and_close(
+        &mut self,
+        action: &dyn DropdownItemAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
         // Check against the length of the dropdown to no-op in the case
         // there aren't any elements being rendered
         if self.dropdown_items_len(ctx) > 0 {
@@ -486,7 +492,7 @@ where
         top_bar
             .build()
             .on_click(|ctx, _, _| {
-                ctx.dispatch_typed_action(DropdownAction::<A>::ToggleExpanded);
+                ctx.dispatch_typed_action(DropdownAction::ToggleExpanded);
             })
             .finish()
     }
@@ -581,7 +587,7 @@ where
         // Wrap with Dismiss to handle clicks outside the empty menu
         Dismiss::new(EventHandler::new(empty_menu).finish())
             .on_dismiss(|ctx, _app| {
-                ctx.dispatch_typed_action(DropdownAction::<A>::Close);
+                ctx.dispatch_typed_action(DropdownAction::Close);
             })
             .prevent_interaction_with_other_elements()
             .finish()
@@ -656,32 +662,46 @@ where
         // it won't be visible in the newly computed list of filtered items.
         // If it isn't, we set the selected element to the first index of
         // the new elements such that there's always a candidate element to select.
-        let current_label = self.current_selected_item_label();
+        let current_label = self.current_selected_item_label().to_string();
         let mut current_label_not_visible = true;
         self.dropdown.update(ctx, |dropdown, ctx| {
             dropdown.set_items(
                 self.items
                     .iter()
                     .filter(|item| {
-                        let item_matches_filter =
-                            item.display_text.to_lowercase().contains(&filter_query);
-                        if item.display_text == current_label && item_matches_filter {
+                        let item_matches_filter = Self::item_matches_filter(item, &filter_query);
+                        if Self::item_label(item) == Some(current_label.as_str())
+                            && item_matches_filter
+                        {
                             current_label_not_visible = false;
                         };
                         item_matches_filter
                     })
-                    .map(|item| item.into()),
+                    .cloned(),
                 ctx,
             );
 
             if current_label_not_visible && !dropdown.is_empty() {
                 dropdown.set_selected_by_index(0, ctx);
             } else {
-                dropdown.set_selected_by_name(current_label, ctx);
+                dropdown.set_selected_by_name(&current_label, ctx);
             }
             ctx.notify();
         });
         ctx.notify();
+    }
+
+    fn item_label(item: &MenuItem<DropdownAction>) -> Option<&str> {
+        match item {
+            MenuItem::Item(fields) => Some(fields.label()),
+            _ => None,
+        }
+    }
+
+    fn item_matches_filter(item: &MenuItem<DropdownAction>, filter_query: &str) -> bool {
+        filter_query.is_empty()
+            || Self::item_label(item)
+                .is_some_and(|label| label.to_lowercase().contains(filter_query))
     }
 
     fn dropdown_items_len(&self, ctx: &AppContext) -> usize {
@@ -702,23 +722,23 @@ where
 
 impl<A> Entity for FilterableDropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
     type Event = FilterableDropdownEvent;
 }
 
 impl<A> TypedActionView for FilterableDropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
-    type Action = DropdownAction<A>;
+    type Action = DropdownAction;
 
-    fn handle_action(&mut self, action: &DropdownAction<A>, ctx: &mut ViewContext<Self>) {
+    fn handle_action(&mut self, action: &DropdownAction, ctx: &mut ViewContext<Self>) {
         match action {
             DropdownAction::Focus(delta) => self.focus(*delta, ctx),
             DropdownAction::Close => self.close(ctx),
             DropdownAction::SelectActionAndClose(action) => {
-                self.select_action_and_close(action, ctx)
+                self.select_action_and_close(action.as_ref(), ctx)
             }
             DropdownAction::ToggleExpanded => self.toggle_expanded(ctx),
         }
@@ -727,16 +747,24 @@ where
 
 impl<A> View for FilterableDropdown<A>
 where
-    A: Action + Clone,
+    A: DropdownItemAction,
 {
     fn ui_name() -> &'static str {
         "FilterableDropdown"
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
-        if focus_ctx.is_self_focused() {
+        if focus_ctx.is_self_focused() && self.is_expanded {
             self.focus(0, ctx)
         }
+    }
+
+    fn keymap_context(&self, _app: &AppContext) -> Context {
+        let mut context = Self::default_keymap_context();
+        if !self.is_expanded && !self.disabled {
+            context.set.insert(FILTERABLE_DROPDOWN_COLLAPSED);
+        }
+        context
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -237,8 +237,9 @@ where
     /// Set items from rich menu items (MenuItem). This preserves the rich menu items for
     /// filtering and passes the filtered items to the internal dropdown.
     ///
-    /// Rich menu items carry erased [`DropdownAction`]s, so callers are responsible for ensuring
-    /// each item dispatches an action handled by the parent view.
+    /// Rich menu items already carry erased [`DropdownAction`]s. The dropdown dispatches selected
+    /// item actions through normal action propagation, so callers should ensure each action is
+    /// handled by an appropriate view in the containing view hierarchy.
     pub fn set_rich_items(
         &mut self,
         items: Vec<MenuItem<DropdownAction>>,

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -2,17 +2,17 @@ use std::marker::PhantomData;
 use warp_editor::editor::NavigationKey;
 use warpui::elements::{
     Align, Border, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container, CornerRadius,
-    CrossAxisAlignment, Dismiss, Element, EventHandler, Flex, MainAxisAlignment, MainAxisSize,
-    MouseStateHandle, OffsetPositioning, ParentElement, PositionedElementAnchor,
-    PositionedElementOffsetBounds, Radius, SavePosition, Shrinkable, Stack,
+    CrossAxisAlignment, Dismiss, DispatchEventResult, Element, EventHandler, Flex,
+    MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning, ParentElement,
+    PositionedElementAnchor, PositionedElementOffsetBounds, Radius, SavePosition, Shrinkable,
+    Stack,
 };
 use warpui::geometry::vector::vec2f;
-use warpui::keymap::{Context, FixedBinding};
 use warpui::ui_components::button::{ButtonVariant, TextAndIcon, TextAndIconAlignment};
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
     AppContext, BlurContext, Entity, FocusContext, SingletonEntity, TypedActionView, View,
-    ViewContext, ViewHandle,
+    ViewContext, ViewHandle, WeakViewHandle,
 };
 
 use super::dropdown::{
@@ -28,17 +28,6 @@ use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuVariant};
 use crate::ui_components::icons;
 
 const EMPTY_DROPDOWN_HEIGHT: f32 = 50.0;
-const FILTERABLE_DROPDOWN_COLLAPSED: &str = "FilterableDropdownCollapsed";
-
-pub fn init(app: &mut AppContext) {
-    use warpui::keymap::macros::*;
-
-    app.register_fixed_bindings([FixedBinding::new(
-        "space",
-        DropdownAction::ToggleExpanded,
-        id!(FilterableDropdown::<()>::ui_name()) & id!(FILTERABLE_DROPDOWN_COLLAPSED),
-    )]);
-}
 
 pub enum FilterableDropdownEvent {
     ToggleExpanded,
@@ -60,6 +49,7 @@ pub struct FilterableDropdown<A: DropdownItemAction = ()> {
     main_axis_size: MainAxisSize,
     dropdown: ViewHandle<Menu<DropdownAction>>,
     filter_editor: ViewHandle<EditorView>,
+    self_handle: WeakViewHandle<Self>,
     selected_item: Option<MenuItem<DropdownAction>>,
     items: Vec<MenuItem<DropdownAction>>,
     orientation: FilterableDropdownOrientation,
@@ -127,6 +117,7 @@ where
             disabled: false,
             dropdown,
             filter_editor,
+            self_handle: ctx.handle(),
             top_bar_mouse_state: Default::default(),
             top_bar_max_width: TOP_MENU_BAR_MAX_WIDTH,
             main_axis_size: MainAxisSize::Max,
@@ -488,11 +479,30 @@ where
             top_bar =
                 top_bar.with_style(UiComponentStyles::default().set_font_family_id(font_family_id))
         }
-
-        top_bar
+        let disabled = self.disabled;
+        let self_handle = self.self_handle.clone();
+        let dropdown = self.dropdown.clone();
+        let filter_editor = self.filter_editor.clone();
+        let top_bar_element = top_bar
             .build()
             .on_click(|ctx, _, _| {
                 ctx.dispatch_typed_action(DropdownAction::ToggleExpanded);
+            })
+            .finish();
+
+        EventHandler::new(top_bar_element)
+            .on_keydown(move |ctx, app, keystroke| {
+                let is_focused = self_handle
+                    .upgrade(app)
+                    .is_some_and(|handle| handle.is_focused(app))
+                    || dropdown.is_focused(app)
+                    || filter_editor.is_focused(app);
+                if !disabled && is_focused && keystroke.is_unmodified_key(" ") {
+                    ctx.dispatch_typed_action(DropdownAction::ToggleExpanded);
+                    DispatchEventResult::StopPropagation
+                } else {
+                    DispatchEventResult::PropagateToParent
+                }
             })
             .finish()
     }
@@ -757,14 +767,6 @@ where
         if focus_ctx.is_self_focused() && self.is_expanded {
             self.focus(0, ctx)
         }
-    }
-
-    fn keymap_context(&self, _app: &AppContext) -> Context {
-        let mut context = Self::default_keymap_context();
-        if !self.is_expanded && !self.disabled {
-            context.set.insert(FILTERABLE_DROPDOWN_COLLAPSED);
-        }
-        context
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {

--- a/app/src/view_components/mod.rs
+++ b/app/src/view_components/mod.rs
@@ -32,7 +32,3 @@ pub use filterable_dropdown::{
 pub use markdown_toggle_view::{MarkdownToggleEvent, MarkdownToggleView};
 pub use submittable_text_input::*;
 pub use warning_box::*;
-
-pub fn init(app: &mut warpui::AppContext) {
-    filterable_dropdown::init(app);
-}

--- a/app/src/view_components/mod.rs
+++ b/app/src/view_components/mod.rs
@@ -24,7 +24,7 @@ pub use clickable_text_input::*;
 pub use compact_dropdown::{CompactDropdown, CompactDropdownEvent, CompactDropdownItem};
 pub use copyable_text_field::*;
 pub use dismissible_toast::*;
-pub use dropdown::{Dropdown, DropdownEvent, DropdownItem};
+pub use dropdown::{Dropdown, DropdownAction, DropdownEvent, DropdownItem, DropdownItemAction};
 pub use feature_popup::*;
 pub use filterable_dropdown::{
     FilterableDropdown, FilterableDropdownEvent, FilterableDropdownOrientation,
@@ -32,3 +32,7 @@ pub use filterable_dropdown::{
 pub use markdown_toggle_view::{MarkdownToggleEvent, MarkdownToggleView};
 pub use submittable_text_input::*;
 pub use warning_box::*;
+
+pub fn init(app: &mut warpui::AppContext) {
+    filterable_dropdown::init(app);
+}

--- a/app/src/workflows/mod.rs
+++ b/app/src/workflows/mod.rs
@@ -81,7 +81,7 @@ pub enum WorkflowSelectionSource {
     Alias,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkflowViewMode {
     View,
     Edit,

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -330,7 +330,7 @@ impl CodeReviewState {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 pub enum RightPanelAction {
     ToggleFileSidebar,


### PR DESCRIPTION
## Description
Out of [this PR](https://github.com/warpdotdev/warp/pull/11412), @vorporeal and I discussed that it would be better to refactor `FilterableDropdown` to not have a generic on `DropdownAction` but to instead use a Box dyn trait on `SelectActionAndClose` so that the other actions don't have to specify the generic.

## Testing
Locally ran and saw no regressions in filterable dropdown behavior + space toggles the dropdown if the dropdown is focused
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
https://github.com/user-attachments/assets/21aefd19-8120-48f4-bbc9-63cb257caee0

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode