### PR TITLE
Size ask-question cards to their content instead of a fixed height

### DIFF
--- a/app/src/ai/blocklist/block/number_shortcut_buttons.rs
+++ b/app/src/ai/blocklist/block/number_shortcut_buttons.rs
@@ -131,6 +131,15 @@ impl NumberShortcutButtonBuilder {
             on_click: Box::new(on_click),
         }
     }
+
+    /// Builds just this option's visual element, with no click or keyboard handling. The
+    /// ask-user-question card uses it to lay out off-screen measurement copies of every option, so
+    /// a multi-question card can size itself to its tallest question. Only the rendered size matters
+    /// there, so the button builder is invoked in its unselected state and the interactive
+    /// `on_click` half is dropped.
+    pub fn build_measurement_element(&self, app: &AppContext) -> Box<dyn Element> {
+        (self.button_builder)(false, app).build().finish()
+    }
 }
 
 pub fn numbered_shortcut_button<A: warpui::Action + Clone + 'static>(

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -63,6 +63,7 @@ const ASK_USER_QUESTION_ACTIVE: &str = "AskUserQuestionActive";
 
 pub(crate) const ASK_USER_QUESTION_AUTO_ADVANCE_DELAY: Duration = Duration::from_millis(300);
 pub(crate) const ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT: f32 = 320.;
+pub(crate) const ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT: f32 = 520.;
 pub(crate) const ASK_USER_QUESTION_OPTION_BUTTON_VERTICAL_SPACING: f32 = 4.;
 pub(crate) const ASK_USER_QUESTION_TEXT_TOP_PADDING: f32 = 16.;
 pub(crate) const ASK_USER_QUESTION_TEXT_BOTTOM_PADDING: f32 = 8.;
@@ -99,16 +100,22 @@ fn ask_user_question_header_height(appearance: &Appearance, app: &AppContext) ->
 fn ask_user_question_container_height(
     max_option_count: usize,
     appearance: &Appearance,
+    is_single_question: bool,
     has_nav_footer: bool,
     app: &AppContext,
 ) -> f32 {
+    let max_height = if is_single_question {
+        ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT
+    } else {
+        ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT
+    };
     let mut natural_height = ask_user_question_header_height(appearance, app)
         + ask_user_question_text_height(appearance, app)
         + estimated_min_height_for_all_options(max_option_count, appearance.monospace_font_size());
     if has_nav_footer {
         natural_height += standard_message_bar_height(app) + 1.;
     }
-    natural_height.min(ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT)
+    natural_height.min(max_height)
 }
 
 fn ask_user_question_auto_advance_enabled(is_multiselect: bool, is_last_question: bool) -> bool {
@@ -1266,10 +1273,12 @@ impl AskUserQuestionView {
         if current.question.is_multiselect() {
             question_text.push_str(" (select all that apply)");
         }
+        let is_single_question = !self.session.has_multiple_questions();
         let has_nav_footer = self.session.has_multiple_questions();
         let container_height = ask_user_question_container_height(
             self.session.max_option_count(),
             appearance,
+            is_single_question,
             has_nav_footer,
             app,
         );

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -65,7 +65,7 @@ use crate::Appearance;
 const ASK_USER_QUESTION_ACTIVE: &str = "AskUserQuestionActive";
 
 pub(crate) const ASK_USER_QUESTION_AUTO_ADVANCE_DELAY: Duration = Duration::from_millis(300);
-pub(crate) const ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT: f32 = 320.;
+pub(crate) const ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT: f32 = 520.;
 pub(crate) const ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT: f32 = 800.;
 // Must match `MARGIN_BETWEEN_BUTTONS` in number_shortcut_buttons.rs so off-screen measurement
 // copies match the interactive option list's height.
@@ -375,6 +375,17 @@ impl AskUserQuestionSession {
             question: self.questions.get(editing.current_question_index())?,
             draft: editing.current_draft(),
         })
+    }
+
+    /// Saved draft for the question at `index` (None when unanswered or not editing). Lets the
+    /// off-screen measurement copies reflect each question's real answer state, so a long saved
+    /// "Other..." answer is accounted for in the reserved height instead of resizing the card when
+    /// the user navigates back to that question.
+    fn draft_for_question(&self, index: usize) -> Option<&QuestionDraft> {
+        let AskUserQuestionState::Editing(editing) = &self.state else {
+            return None;
+        };
+        editing.draft_for_question(index)
     }
 
     fn current_question_index(&self) -> usize {
@@ -1230,7 +1241,7 @@ impl AskUserQuestionView {
         let current = self.session.current()?;
         let question_text = Self::question_display_text(current.question);
         let is_single_question = !self.session.has_multiple_questions();
-        let has_nav_footer = self.session.has_multiple_questions();
+        let has_nav_footer = !is_single_question;
 
         let max_height = if is_single_question {
             ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT
@@ -1271,9 +1282,13 @@ impl AskUserQuestionView {
             visible_body
         } else {
             let mut stack = Stack::new();
-            for question in self.session.questions() {
+            for (index, question) in self.session.questions().iter().enumerate() {
                 stack.add_child(Self::render_measurement_body(
-                    question, appearance, theme, app,
+                    question,
+                    self.session.draft_for_question(index),
+                    appearance,
+                    theme,
+                    app,
                 ));
             }
             stack.add_child(visible_body);
@@ -1498,8 +1513,8 @@ impl AskUserQuestionView {
     }
 
     /// Stacks the question text above its options. Shared by the live body and its measurement
-    /// copies. `MainAxisSize::Min` keeps the column content-sized under a bounded constraint, which
-    /// the measurement copies rely on since they have no scrollable to absorb a fill.
+    /// copies. `MainAxisSize::Min` keeps the column content-sized so the surrounding scrollable
+    /// reports the natural height (clamped to the cap) instead of filling the available space.
     fn body_column(question_text: Box<dyn Element>, options: Box<dyn Element>) -> Box<dyn Element> {
         Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
@@ -1539,22 +1554,25 @@ impl AskUserQuestionView {
     }
 
     /// Builds a non-interactive, non-painted copy of a question's body purely for layout
-    /// measurement. It mirrors the live body's column and insets but omits the scrollable (the copy
-    /// is never scrolled or painted); `MeasureOnly` clamps its height to the available space.
+    /// measurement. It goes through the same `wrap_scrollable_body` wrapper as the live body so the
+    /// two measure identically once a question overflows (the scrollable affects wrapping and
+    /// clamping); `MeasureOnly` keeps it off-screen and inert. The question's saved `draft` is
+    /// passed through so the copy reflects its real answer state (e.g. a long custom "Other..."
+    /// answer) and the card stays a fixed height across navigation.
     fn render_measurement_body(
         question: &AskUserQuestionItem,
+        draft: Option<&QuestionDraft>,
         appearance: &Appearance,
         theme: &WarpTheme,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        let current = AskUserQuestionCurrent {
-            question,
-            draft: None,
-        };
-        let body = Self::with_body_insets(Self::body_column(
+        let current = AskUserQuestionCurrent { question, draft };
+        let body = Self::wrap_scrollable_body(
             Self::render_question_text(&Self::question_display_text(question), appearance, theme),
             Self::render_static_options(current, app),
-        ));
+            ClippedScrollStateHandle::new(),
+            theme,
+        );
         MeasureOnly::new(body).finish()
     }
 

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -10,16 +10,19 @@ use warp_core::ui::theme::WarpTheme;
 use warpui::elements::new_scrollable::SingleAxisConfig;
 use warpui::elements::{
     Border, ChildView, Clipped, ClippedScrollStateHandle, ConstrainedBox, Container, CornerRadius,
-    CrossAxisAlignment, Expanded, Fill, Flex, FormattedTextElement, MainAxisAlignment,
-    MainAxisSize, MouseStateHandle, ParentElement, Radius, Text, DEFAULT_UI_LINE_HEIGHT_RATIO,
+    CrossAxisAlignment, Fill, Flex, FormattedTextElement, MainAxisAlignment, MainAxisSize,
+    MouseStateHandle, ParentElement, Point, Radius, Stack, Text, DEFAULT_UI_LINE_HEIGHT_RATIO,
 };
+use warpui::event::DispatchedEvent;
+use warpui::geometry::vector::Vector2F;
 use warpui::keymap::{FixedBinding, Keystroke};
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::ui_components::components::Coords;
 use warpui::units::Pixels;
 use warpui::{
-    AppContext, Element, Entity, EntityId, FocusContext, ModelHandle, SingletonEntity,
-    TypedActionView, View, ViewContext, ViewHandle,
+    AfterLayoutContext, AppContext, Element, Entity, EntityId, EventContext, FocusContext,
+    LayoutContext, ModelHandle, PaintContext, SingletonEntity, SizeConstraint, TypedActionView,
+    View, ViewContext, ViewHandle,
 };
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -63,28 +66,13 @@ const ASK_USER_QUESTION_ACTIVE: &str = "AskUserQuestionActive";
 
 pub(crate) const ASK_USER_QUESTION_AUTO_ADVANCE_DELAY: Duration = Duration::from_millis(300);
 pub(crate) const ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT: f32 = 320.;
-pub(crate) const ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT: f32 = 520.;
-pub(crate) const ASK_USER_QUESTION_OPTION_BUTTON_VERTICAL_SPACING: f32 = 4.;
+pub(crate) const ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT: f32 = 800.;
+// Must match `MARGIN_BETWEEN_BUTTONS` in number_shortcut_buttons.rs so off-screen measurement
+// copies match the interactive option list's height.
+const ASK_USER_QUESTION_OPTION_BUTTON_VERTICAL_SPACING: f32 = 4.;
 pub(crate) const ASK_USER_QUESTION_TEXT_TOP_PADDING: f32 = 16.;
 pub(crate) const ASK_USER_QUESTION_TEXT_BOTTOM_PADDING: f32 = 8.;
 pub(crate) const ASK_USER_QUESTION_OPTIONS_BOTTOM_PADDING: f32 = 16.;
-
-// Assumes single-line labels; wrapped text will be taller but the container
-// caps at ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT and scrolls on overflow.
-fn estimated_min_height_for_all_options(max_option_count: usize, monospace_font_size: f32) -> f32 {
-    (max_option_count as f32 * (monospace_font_size + 16.))
-        + (max_option_count.saturating_sub(1) as f32
-            * ASK_USER_QUESTION_OPTION_BUTTON_VERTICAL_SPACING)
-        + ASK_USER_QUESTION_OPTIONS_BOTTOM_PADDING
-}
-
-fn ask_user_question_text_height(appearance: &Appearance, app: &AppContext) -> f32 {
-    app.font_cache().line_height(
-        appearance.monospace_font_size(),
-        appearance.line_height_ratio(),
-    ) + ASK_USER_QUESTION_TEXT_TOP_PADDING
-        + ASK_USER_QUESTION_TEXT_BOTTOM_PADDING
-}
 
 fn ask_user_question_header_height(appearance: &Appearance, app: &AppContext) -> f32 {
     let title_line_height = app.font_cache().line_height(
@@ -95,27 +83,6 @@ fn ask_user_question_header_height(appearance: &Appearance, app: &AppContext) ->
         .max(icon_size(app))
         .max(ButtonSize::InlineActionHeader.button_height(appearance, app))
         + (2. * INLINE_ACTION_HEADER_VERTICAL_PADDING)
-}
-
-fn ask_user_question_container_height(
-    max_option_count: usize,
-    appearance: &Appearance,
-    is_single_question: bool,
-    has_nav_footer: bool,
-    app: &AppContext,
-) -> f32 {
-    let max_height = if is_single_question {
-        ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT
-    } else {
-        ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT
-    };
-    let mut natural_height = ask_user_question_header_height(appearance, app)
-        + ask_user_question_text_height(appearance, app)
-        + estimated_min_height_for_all_options(max_option_count, appearance.monospace_font_size());
-    if has_nav_footer {
-        natural_height += standard_message_bar_height(app) + 1.;
-    }
-    natural_height.min(max_height)
 }
 
 fn ask_user_question_auto_advance_enabled(is_multiselect: bool, is_last_question: bool) -> bool {
@@ -424,14 +391,6 @@ impl AskUserQuestionSession {
             }
             AskUserQuestionState::Completed { .. } => false,
         }
-    }
-
-    fn max_option_count(&self) -> usize {
-        self.questions
-            .iter()
-            .map(AskUserQuestionItem::numbered_option_count)
-            .max()
-            .unwrap_or(1)
     }
 
     // Centralize all state transitions so the view layer only maps UI events to actions and then
@@ -1269,22 +1228,23 @@ impl AskUserQuestionView {
     fn render_active(&self, appearance: &Appearance, app: &AppContext) -> Option<Box<dyn Element>> {
         let theme = appearance.theme();
         let current = self.session.current()?;
-        let mut question_text = current.question.question.clone();
-        if current.question.is_multiselect() {
-            question_text.push_str(" (select all that apply)");
-        }
+        let question_text = Self::question_display_text(current.question);
         let is_single_question = !self.session.has_multiple_questions();
         let has_nav_footer = self.session.has_multiple_questions();
-        let container_height = ask_user_question_container_height(
-            self.session.max_option_count(),
-            appearance,
-            is_single_question,
-            has_nav_footer,
-            app,
-        );
+
+        let max_height = if is_single_question {
+            ASK_USER_QUESTION_SINGLE_MAX_CONTAINER_HEIGHT
+        } else {
+            ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT
+        };
+        let mut non_body_height = ask_user_question_header_height(appearance, app);
+        if has_nav_footer {
+            non_body_height += standard_message_bar_height(app) + 1.;
+        }
+        let body_max_height = (max_height - non_body_height).max(0.);
 
         let mut content = Flex::column()
-            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
 
         let mut header_right = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
@@ -1300,12 +1260,29 @@ impl AskUserQuestionView {
                 .with_corner_radius_override(CornerRadius::with_top(Radius::Pixels(8.)))
                 .render_header(app, Some(header_right.finish())),
         );
+
+        // The body sizes to its content, capped at `body_max_height` (scrolling beyond that). For
+        // multi-question cards we stack an off-screen, non-interactive measurement copy of every
+        // question behind the visible one. `Stack` sizes to its tallest child, so the card collapses
+        // to the height of the tallest question and stays fixed as the user navigates, rather than
+        // resizing per question (only the visible question can be measured directly otherwise).
+        let visible_body = self.render_question_body(&question_text, appearance, theme);
+        let body: Box<dyn Element> = if is_single_question {
+            visible_body
+        } else {
+            let mut stack = Stack::new();
+            for question in self.session.questions() {
+                stack.add_child(Self::render_measurement_body(
+                    question, appearance, theme, app,
+                ));
+            }
+            stack.add_child(visible_body);
+            stack.finish()
+        };
         content.add_child(
-            Expanded::new(
-                1.,
-                self.render_question_body(&question_text, appearance, theme),
-            )
-            .finish(),
+            ConstrainedBox::new(body)
+                .with_max_height(body_max_height)
+                .finish(),
         );
 
         if has_nav_footer {
@@ -1316,7 +1293,7 @@ impl AskUserQuestionView {
         Some(
             wrap_with_content_item_spacing(
                 ConstrainedBox::new(content.finish())
-                    .with_height(container_height)
+                    .with_max_height(max_height)
                     .finish(),
             )
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
@@ -1473,6 +1450,16 @@ impl AskUserQuestionView {
         )
     }
 
+    /// The question prompt as shown to the user, with the multiselect hint appended. Shared by the
+    /// live body and its measurement copies so both wrap at the same height.
+    fn question_display_text(question: &AskUserQuestionItem) -> String {
+        let mut text = question.question.clone();
+        if question.is_multiselect() {
+            text.push_str(" (select all that apply)");
+        }
+        text
+    }
+
     fn render_question_text(
         question_text: &str,
         appearance: &Appearance,
@@ -1502,16 +1489,45 @@ impl AskUserQuestionView {
         appearance: &Appearance,
         theme: &WarpTheme,
     ) -> Box<dyn Element> {
-        let body = Flex::column()
-            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_child(Self::render_question_text(question_text, appearance, theme))
-            .with_child(self.render_options_list())
-            .finish();
+        Self::wrap_scrollable_body(
+            Self::render_question_text(question_text, appearance, theme),
+            self.render_options_list(),
+            self.options_scroll_state.clone(),
+            theme,
+        )
+    }
 
+    /// Stacks the question text above its options. Shared by the live body and its measurement
+    /// copies. `MainAxisSize::Min` keeps the column content-sized under a bounded constraint, which
+    /// the measurement copies rely on since they have no scrollable to absorb a fill.
+    fn body_column(question_text: Box<dyn Element>, options: Box<dyn Element>) -> Box<dyn Element> {
+        Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(question_text)
+            .with_child(options)
+            .finish()
+    }
+
+    /// Applies the body's horizontal insets. Shared so the live body and its measurement copies
+    /// wrap text at exactly the same width.
+    fn with_body_insets(content: Box<dyn Element>) -> Box<dyn Element> {
+        Container::new(content)
+            .with_margin_left(INLINE_ACTION_HORIZONTAL_PADDING)
+            .with_margin_right(12.)
+            .finish()
+    }
+
+    fn wrap_scrollable_body(
+        question_text: Box<dyn Element>,
+        options: Box<dyn Element>,
+        scroll_state: ClippedScrollStateHandle,
+        theme: &WarpTheme,
+    ) -> Box<dyn Element> {
         let scrollable = warpui::elements::NewScrollable::vertical(
             SingleAxisConfig::Clipped {
-                handle: self.options_scroll_state.clone(),
-                child: body,
+                handle: scroll_state,
+                child: Self::body_column(question_text, options),
             },
             theme.nonactive_ui_detail().into(),
             theme.active_ui_detail().into(),
@@ -1519,9 +1535,52 @@ impl AskUserQuestionView {
         )
         .finish();
 
-        Container::new(Clipped::new(scrollable).finish())
-            .with_margin_left(INLINE_ACTION_HORIZONTAL_PADDING)
-            .with_margin_right(12.)
+        Self::with_body_insets(Clipped::new(scrollable).finish())
+    }
+
+    /// Builds a non-interactive, non-painted copy of a question's body purely for layout
+    /// measurement. It mirrors the live body's column and insets but omits the scrollable (the copy
+    /// is never scrolled or painted); `MeasureOnly` clamps its height to the available space.
+    fn render_measurement_body(
+        question: &AskUserQuestionItem,
+        appearance: &Appearance,
+        theme: &WarpTheme,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let current = AskUserQuestionCurrent {
+            question,
+            draft: None,
+        };
+        let body = Self::with_body_insets(Self::body_column(
+            Self::render_question_text(&Self::question_display_text(question), appearance, theme),
+            Self::render_static_options(current, app),
+        ));
+        MeasureOnly::new(body).finish()
+    }
+
+    /// Renders a question's option buttons as static, non-interactive elements matching the live
+    /// `NumberShortcutButtons` layout. Used only for measurement copies.
+    fn render_static_options(
+        current: AskUserQuestionCurrent<'_>,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let builders = Self::build_question_buttons(Some(current), None);
+        let button_count = builders.len();
+        let mut options = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        for (index, builder) in builders.iter().enumerate() {
+            let margin_bottom = if index + 1 == button_count {
+                0.
+            } else {
+                ASK_USER_QUESTION_OPTION_BUTTON_VERTICAL_SPACING
+            };
+            options.add_child(
+                Container::new(builder.build_measurement_element(app))
+                    .with_margin_bottom(margin_bottom)
+                    .finish(),
+            );
+        }
+        Container::new(options.finish())
+            .with_padding_bottom(ASK_USER_QUESTION_OPTIONS_BOTTOM_PADDING)
             .finish()
     }
 
@@ -1848,6 +1907,58 @@ pub(crate) fn render_text_with_markdown_support(
             .soft_wrap(true)
             .with_color(text_color)
             .finish()
+    }
+}
+
+/// An element that lays out its child—so the child contributes to sizing—but never paints it or
+/// routes events to it, clamping the reported size to the incoming constraint. Combined with
+/// `Stack`, this lets a multi-question card measure off-screen copies of every question and size to
+/// the tallest one, without showing or interacting with them.
+struct MeasureOnly {
+    child: Box<dyn Element>,
+}
+
+impl MeasureOnly {
+    fn new(child: Box<dyn Element>) -> Self {
+        Self { child }
+    }
+}
+
+impl Element for MeasureOnly {
+    fn layout(
+        &mut self,
+        constraint: SizeConstraint,
+        ctx: &mut LayoutContext,
+        app: &AppContext,
+    ) -> Vector2F {
+        // Clamp to the incoming constraint so an over-tall copy can't push the `Stack` past the
+        // available height (the copy has no scrollable of its own to do this clamping).
+        self.child.layout(constraint, ctx, app).min(constraint.max)
+    }
+
+    fn after_layout(&mut self, _ctx: &mut AfterLayoutContext, _app: &AppContext) {
+        // Measurement-only: the child is never painted, so there is nothing to register here.
+    }
+
+    fn paint(&mut self, _origin: Vector2F, _ctx: &mut PaintContext, _app: &AppContext) {
+        // Intentionally not painted.
+    }
+
+    fn size(&self) -> Option<Vector2F> {
+        self.child.size()
+    }
+
+    fn origin(&self) -> Option<Point> {
+        None
+    }
+
+    fn dispatch_event(
+        &mut self,
+        _event: &DispatchedEvent,
+        _ctx: &mut EventContext,
+        _app: &AppContext,
+    ) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
## Description
Make the ask-user-question card size to its content instead of a fixed-height cap.

- **Single-question cards** grow to fit their content, up to an 800px cap (previously limited to 320px), so long markdown questions/options aren't squeezed into a small, heavily-scrolling panel.

- **Multi-question cards** size to their **tallest** question — up to a 520px cap (raised from 320px) — and hold that height as you navigate between questions, scrolling only when the tallest question itself exceeds the cap. This avoids the extra scrolling the old single-line height estimate caused for wrapped/markdown options, and keeps the card from resizing as you move between questions of different lengths.

Demo Loom: https://www.loom.com/share/c6ba9190113f4b2da79fdc518434a64d

### Why
The original 320px cap forced excessive scrolling for long single questions. Naive content-based sizing isn't enough on its own, because the framework can only measure the *currently visible* question — so a multi-question card would resize every time you navigated to a question of a different length.

### How
- **Single-question:** `MainAxisSize::Min` + `ConstrainedBox::with_max_height`, so the card grows to fit and scrolls past the cap.
- **Multi-question:** lay out an off-screen, non-interactive **measurement copy** of every question inside a `Stack` (which sizes to its tallest child). Only the visible question is painted; the copies just contribute to sizing, so the card collapses to the tallest question and never resizes during navigation.
- Each copy is built from that question's **saved draft** and goes through the **same scrollable wrapper** as the live body, so the reserved height matches the real answer state — including a long saved "Other…" answer — and a question that overflows the cap measures identically (no shift when you open it).
- New `MeasureOnly` element — lays out its child for sizing but never paints it or routes events to it, clamping the reported size to the incoming constraint.
- New `NumberShortcutButtonBuilder::build_measurement_element` — builds an option's visual element without click/keyboard handling, used to build the copies' options.

### Changes
- `app/src/ai/blocklist/inline_action/ask_user_question_view.rs` — sizing logic, `MeasureOnly`, measurement copies, shared `body_column`/`with_body_insets` helpers.
- `app/src/ai/blocklist/block/number_shortcut_buttons.rs` — `build_measurement_element`.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Ran on the `warp` crate (the whole diff lives there; CI runs the full-workspace matrix):
- `./script/format`
- `cargo clippy -p warp --all-targets --tests -- -D warnings` — clean
- `cargo nextest run -p warp ask_user_question` — 29/29 passed

Existing unit tests cover the questionnaire state machine, not layout, so manual verification of the rendering is still needed:

1. Single short question → collapses, no scrollbar.
2. Single long question → grows to ~800px, then scrolls.
3. Multi-question, mixed lengths → sizes to the tallest; ←/→ never changes the card height.
4. Multi-question, tallest exceeds the 520px cap → holds at the cap and scrolls; still stable on navigation.
5. Hidden copies → no ghost text; clicks, number/arrow keys, and text selection affect only the visible question.
6. "Other…" input opens/grows/typeable; multiselect "(select all that apply)" suffix shows; a saved "Other…" answer doesn't resize the card when revisited.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Agent questions now size to their content. A single question can use more vertical room.
-->

_Conversation: https://staging.warp.dev/conversation/ad7b06d9-f299-464c-987f-156a15b14cc9_
_This PR was generated with [Oz](https://warp.dev/oz)._
