### PR TITLE
Fix filtered run RTC refresh

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -50,7 +50,7 @@ use crate::server::ids::{ServerId, SyncId};
 use crate::server::retry_strategies::{
     is_transient_http_error, OUT_OF_BAND_REQUEST_RETRY_STRATEGY, PERIODIC_POLL_RETRY_STRATEGY,
 };
-use crate::server::server_api::ai::TaskListFilter;
+use crate::server::server_api::ai::{ArtifactType as ServerArtifactType, TaskListFilter};
 use crate::server::server_api::ServerApiProvider;
 use crate::settings::AISettings;
 use crate::ui_components::icons::Icon;
@@ -522,6 +522,8 @@ pub struct AgentConversationsModel {
     /// Set of view IDs actively consuming this model's data per window.
     /// When a window has at least one consumer, we poll for new tasks while that window is active.
     active_data_consumers_per_window: HashMap<WindowId, HashSet<EntityId>>,
+    /// Server-side task filters for active data consumers that need filtered RTC refreshes.
+    active_data_consumer_task_filters: HashMap<EntityId, TaskListFilter>,
     /// Whether we have finished the initial task load
     has_finished_initial_load: bool,
     /// Per-task fetch state for `get_or_async_fetch_task_data`. See [`TaskFetchState`] for
@@ -530,7 +532,7 @@ pub struct AgentConversationsModel {
     task_fetch_state: HashMap<AmbientAgentTaskId, TaskFetchState>,
     rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState,
     /// Earliest RTC timestamp received while no list surface was open.
-    /// On next `register_view_open`, triggers a single `fetch_tasks_updated_after`.
+    /// On next `register_view_open`, flushes updated tasks.
     dirty_since: Option<DateTime<Utc>>,
 }
 
@@ -576,6 +578,7 @@ impl AgentConversationsModel {
                 in_flight_poll_abort_handle: None,
                 next_poll_abort_handle: None,
                 active_data_consumers_per_window: HashMap::new(),
+                active_data_consumer_task_filters: HashMap::new(),
                 has_finished_initial_load: true,
                 task_fetch_state: HashMap::new(),
                 rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
@@ -615,6 +618,7 @@ impl AgentConversationsModel {
             in_flight_poll_abort_handle: None,
             next_poll_abort_handle: None,
             active_data_consumers_per_window: HashMap::new(),
+            active_data_consumer_task_filters: HashMap::new(),
             has_finished_initial_load: false,
             task_fetch_state: HashMap::new(),
             rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
@@ -709,6 +713,24 @@ impl AgentConversationsModel {
         }
     }
 
+    fn active_task_list_filters_for_rtc(&self) -> Vec<TaskListFilter> {
+        let has_unfiltered_consumer = self
+            .active_data_consumers_per_window
+            .values()
+            .flat_map(|views| views.iter())
+            .any(|view_id| !self.active_data_consumer_task_filters.contains_key(view_id));
+        let mut task_filters: Vec<_> = self
+            .active_data_consumers_per_window
+            .values()
+            .flat_map(|views| views.iter())
+            .filter_map(|view_id| self.active_data_consumer_task_filters.get(view_id).cloned())
+            .collect();
+        if has_unfiltered_consumer || task_filters.is_empty() {
+            task_filters.push(TaskListFilter::default());
+        }
+        task_filters
+    }
+
     // Handle RTC invalidations for list views, respecting the refresh throttling.
     fn handle_rtc_for_list_views(
         &mut self,
@@ -717,7 +739,7 @@ impl AgentConversationsModel {
     ) {
         match std::mem::take(&mut self.rtc_task_refresh_throttle_state) {
             RtcTaskRefreshThrottleState::Idle => {
-                self.fetch_tasks_updated_after(timestamp, ctx);
+                self.fetch_tasks_updated_after_for_active_filters(timestamp, ctx);
                 self.start_rtc_task_refresh_throttle_timer(ctx);
             }
             RtcTaskRefreshThrottleState::CoolingDown {
@@ -748,7 +770,7 @@ impl AgentConversationsModel {
                     };
 
                 if let Some(timestamp) = pending_timestamp {
-                    model.fetch_tasks_updated_after(timestamp, ctx);
+                    model.fetch_tasks_updated_after_for_active_filters(timestamp, ctx);
                     model.start_rtc_task_refresh_throttle_timer(ctx);
                 }
             },
@@ -768,31 +790,37 @@ impl AgentConversationsModel {
         }
     }
 
-    /// Fetch tasks updated after the given timestamp (minus 1 second buffer since server uses `>` not `>=`).
-    fn fetch_tasks_updated_after(
+    fn fetch_tasks_updated_after_for_active_filters(
         &mut self,
         timestamp: DateTime<Utc>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        for task_filter in self.active_task_list_filters_for_rtc() {
+            self.fetch_tasks_updated_after_with_filter(timestamp, task_filter, ctx);
+        }
+    }
+
+    fn fetch_tasks_updated_after_with_filter(
+        &mut self,
+        timestamp: DateTime<Utc>,
+        mut task_filter: TaskListFilter,
         ctx: &mut ModelContext<Self>,
     ) {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
 
         // Subtract 1 second to give buffer for clock differences with server
         let updated_after = timestamp - chrono::Duration::seconds(1);
+        task_filter.updated_after = Some(updated_after);
         // Reset `dirty_since` now that we are doing a fetch.
         self.dirty_since = None;
 
         ctx.spawn_with_retry_on_error(
             move || {
                 let ai_client = ai_client.clone();
+                let task_filter = task_filter.clone();
                 async move {
                     ai_client
-                        .list_ambient_agent_tasks(
-                            INITIAL_TASK_AMOUNT,
-                            TaskListFilter {
-                                updated_after: Some(updated_after),
-                                ..Default::default()
-                            },
-                        )
+                        .list_ambient_agent_tasks(INITIAL_TASK_AMOUNT, task_filter)
                         .await
                 }
             },
@@ -984,7 +1012,7 @@ impl AgentConversationsModel {
 
         // Flush dirty tasks accumulated while no list surface was open.
         if let Some(dirty_since) = self.dirty_since.take() {
-            self.fetch_tasks_updated_after(dirty_since, ctx);
+            self.fetch_tasks_updated_after_for_active_filters(dirty_since, ctx);
         }
     }
 
@@ -1002,7 +1030,19 @@ impl AgentConversationsModel {
                 self.active_data_consumers_per_window.remove(&window_id);
             }
         }
+        self.active_data_consumer_task_filters.remove(&view_id);
         self.update_polling_state(ctx);
+    }
+
+    pub fn set_data_consumer_filters(
+        &mut self,
+        view_id: EntityId,
+        filters: &AgentManagementFilters,
+        current_user_uid: &str,
+    ) {
+        let task_filter = self.build_task_list_filter(filters, current_user_uid);
+        self.active_data_consumer_task_filters
+            .insert(view_id, task_filter);
     }
 
     /// Updates the polling state based on whether the active window has the view open.
@@ -1772,12 +1812,21 @@ impl AgentConversationsModel {
             EnvironmentFilter::Specific(id) => Some(id.clone()),
         };
 
+        let artifact_type = match filters.artifact {
+            ArtifactFilter::All => None,
+            ArtifactFilter::PullRequest => Some(ServerArtifactType::PullRequest),
+            ArtifactFilter::Plan => Some(ServerArtifactType::Plan),
+            ArtifactFilter::Screenshot => Some(ServerArtifactType::Screenshot),
+            ArtifactFilter::File => Some(ServerArtifactType::File),
+        };
+
         TaskListFilter {
             creator_uid,
             states,
             source,
             created_after,
             environment_id,
+            artifact_type,
             ..TaskListFilter::default()
         }
     }
@@ -1873,6 +1922,7 @@ impl AgentConversationsModel {
         self.abort_existing_poll();
         self.abort_rtc_task_refresh_throttle();
         self.active_data_consumers_per_window.clear();
+        self.active_data_consumer_task_filters.clear();
         self.task_fetch_state.clear();
         self.dirty_since = None;
         // Reset the initial load flag so that we can retry the initial sync with the new logged in user

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -8,7 +8,7 @@ use parking_lot::Mutex;
 use persistence::model::{AgentConversationData, ConversationUsageMetadata};
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
-use warpui::{App, EntityId, ModelHandle, SingletonEntity};
+use warpui::{App, EntityId, ModelHandle, SingletonEntity, WindowId};
 
 use super::entry::{
     AgentConversationEntryId, AgentConversationNavigationSubject, AgentConversationProvenance,
@@ -37,6 +37,7 @@ use crate::ai::conversation_navigation::ConversationNavigationData;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::{Owner, Revision, ServerMetadata, ServerPermissions};
 use crate::server::ids::ServerId;
+use crate::server::server_api::ai::ArtifactType as ServerArtifactType;
 use crate::test_util::ai_agent_tasks::{create_api_task, create_message};
 use crate::workspace::WorkspaceAction;
 
@@ -579,11 +580,71 @@ fn create_test_model() -> AgentConversationsModel {
         in_flight_poll_abort_handle: None,
         next_poll_abort_handle: None,
         active_data_consumers_per_window: HashMap::new(),
+        active_data_consumer_task_filters: HashMap::new(),
         has_finished_initial_load: false,
         task_fetch_state: Default::default(),
         rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
         dirty_since: None,
     }
+}
+
+#[test]
+fn task_list_filter_includes_artifact_type() {
+    let model = create_test_model();
+    let cases = [
+        (ArtifactFilter::PullRequest, ServerArtifactType::PullRequest),
+        (ArtifactFilter::Plan, ServerArtifactType::Plan),
+        (ArtifactFilter::Screenshot, ServerArtifactType::Screenshot),
+        (ArtifactFilter::File, ServerArtifactType::File),
+    ];
+
+    for (artifact, expected) in cases {
+        let filters = AgentManagementFilters {
+            artifact,
+            ..Default::default()
+        };
+        assert_eq!(
+            model
+                .build_task_list_filter(&filters, "user-a")
+                .artifact_type,
+            Some(expected)
+        );
+    }
+}
+
+#[test]
+fn rtc_filters_use_registered_consumer_filters() {
+    let mut model = create_test_model();
+    let view_id = EntityId::new();
+    model
+        .active_data_consumers_per_window
+        .insert(WindowId::new(), HashSet::from([view_id]));
+    let filters = AgentManagementFilters {
+        owners: OwnerFilter::PersonalOnly,
+        artifact: ArtifactFilter::Plan,
+        ..Default::default()
+    };
+
+    model.set_data_consumer_filters(view_id, &filters, "user-a");
+
+    let filters = model.active_task_list_filters_for_rtc();
+    assert_eq!(filters.len(), 1);
+    assert_eq!(filters[0].creator_uid.as_deref(), Some("user-a"));
+    assert_eq!(filters[0].artifact_type, Some(ServerArtifactType::Plan));
+}
+
+#[test]
+fn rtc_filters_include_default_for_unregistered_consumer() {
+    let mut model = create_test_model();
+    let view_id = EntityId::new();
+    model
+        .active_data_consumers_per_window
+        .insert(WindowId::new(), HashSet::from([view_id]));
+
+    let filters = model.active_task_list_filters_for_rtc();
+    assert_eq!(filters.len(), 1);
+    assert_eq!(filters[0].creator_uid, None);
+    assert_eq!(filters[0].artifact_type, None);
 }
 
 #[test]

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -375,6 +375,7 @@ impl AgentManagementView {
         view.sync_with_loaded_filters(ctx);
         view.update_creator_dropdown(ctx);
         view.update_environment_dropdown(ctx);
+        view.update_registered_filters(ctx);
 
         // Trigger server fetch if persisted filters differ from defaults
         // (team tasks are not loaded at startup, so we need to fetch them)
@@ -866,6 +867,20 @@ impl AgentManagementView {
         self.get_tasks_from_model(ctx);
         ctx.dispatch_global_action("workspace:save_app", ());
     }
+    fn update_registered_filters(&self, ctx: &mut ViewContext<Self>) {
+        let current_user_uid = AuthStateProvider::handle(ctx)
+            .as_ref(ctx)
+            .get()
+            .user_id()
+            .map(|uid| uid.as_string());
+        if let Some(uid) = current_user_uid {
+            let view_id = ctx.view_id();
+            let filters = self.filters.clone();
+            AgentConversationsModel::handle(ctx).update(ctx, |model, _| {
+                model.set_data_consumer_filters(view_id, &filters, &uid);
+            });
+        }
+    }
 
     /// Trigger a server fetch for tasks matching current filters.
     fn trigger_filter_fetch(&self, ctx: &mut ViewContext<Self>) {
@@ -875,8 +890,10 @@ impl AgentManagementView {
             .user_id()
             .map(|uid| uid.as_string());
         if let Some(uid) = current_user_uid {
+            let view_id = ctx.view_id();
             let filters = self.filters.clone();
             AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+                model.set_data_consumer_filters(view_id, &filters, &uid);
                 model.fetch_tasks_for_filters(&filters, &uid, ctx);
             });
         }
@@ -2275,8 +2292,7 @@ impl TypedActionView for AgentManagementView {
             }
             AgentManagementViewAction::SetArtifactFilter(filter) => {
                 self.filters.artifact = *filter;
-                self.get_tasks_from_model(ctx);
-                ctx.dispatch_global_action("workspace:save_app", ());
+                self.on_filter_changed(ctx);
             }
             AgentManagementViewAction::SetEnvironmentFilter(filter) => {
                 self.filters.environment = filter.clone();


### PR DESCRIPTION
## Description
Fix AgentManagementView RTC refreshes after filters are applied.

The model now records server-side filters for active data consumers and uses those filters for RTC `updated_after` fetches. Artifact filters now also map to the server task-list filter and trigger a server fetch when changed.

## Linked Issue
Slack: lili-warpy thread 1779839304.000359

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `rustfmt --edition 2021 app/src/ai/agent_conversations_model.rs app/src/ai/agent_conversations_model_tests.rs app/src/ai/agent_management/view.rs`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp rtc_filters --lib`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp task_list_filter_includes_artifact_type --lib`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed AgentManagementView missing new runs after filters are applied.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/ae3e6d73-aa3f-4f65-ad99-52aa159d2511_
_Run: https://oz.staging.warp.dev/runs/019e66b0-86fa-78eb-b153-452426ce201b_
_This PR was generated with [Oz](https://warp.dev/oz)._
