### PR TITLE
feat(rich_input): toggle for Ctrl+Enter as submit

### DIFF
--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -388,6 +388,7 @@ pub fn init(ctx: &mut AppContext) {
             id!("EditorView")
                 & !id!("IMEOpen")
                 & !id!(flags::CTRL_ENTER_ACCEPTS_PROMPT_SUGGESTION)
+                & !id!(flags::CTRL_ENTER_SUBMITS_CLI_AGENT_RICH_INPUT)
                 & !(id!(flags::AGENT_VIEW_ENABLED) & id!(flags::CTRL_ENTER_ENTERS_AGENT_VIEW)),
         ),
         FixedBinding::new(

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1301,6 +1301,18 @@ define_settings_group!(AISettings, settings: [
         description: "Whether CLI agent Rich Input automatically closes after the user submits a prompt.",
     }
 
+    // When enabled, CLI agent Rich Input submits prompts with Ctrl+Enter
+    // and lets Enter insert a newline.
+    submit_on_ctrl_enter: SubmitOnCtrlEnter {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "agents.third_party.submit_on_ctrl_enter",
+        description: "Whether CLI agent Rich Input submits with Ctrl+Enter instead of Enter.",
+    }
+
     // Maps custom toolbar command regex patterns to specific CLI agents.
     // Keys are regex patterns matched against the full command string.
     // Values are serialized CLIAgent names (empty string = any agent).

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -2677,6 +2677,7 @@ pub enum AISettingsPageAction {
     ToggleAutoToggleRichInput,
     ToggleAutoOpenRichInputOnCLIAgentStart,
     ToggleAutoDismissRichInputAfterSubmit,
+    ToggleSubmitOnCtrlEnter,
     SetCLIAgentForCommand {
         pattern: String,
         agent: Option<CLIAgent>,
@@ -2952,6 +2953,12 @@ impl TypedActionView for AISettingsPageView {
                     report_if_error!(settings
                         .auto_dismiss_rich_input_after_submit
                         .toggle_and_save_value(ctx));
+                });
+                ctx.notify();
+            }
+            AISettingsPageAction::ToggleSubmitOnCtrlEnter => {
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings.submit_on_ctrl_enter.toggle_and_save_value(ctx));
                 });
                 ctx.notify();
             }
@@ -6237,13 +6244,14 @@ struct CLIAgentWidget {
     auto_toggle_rich_input_info_tooltip: MouseStateHandle,
     auto_open_rich_input_on_cli_agent_start_toggle: SwitchStateHandle,
     auto_dismiss_rich_input_toggle: SwitchStateHandle,
+    submit_on_ctrl_enter_toggle: SwitchStateHandle,
 }
 
 impl SettingsWidget for CLIAgentWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "third party cli coding agent claude codex gemini toolbar footer layout chip chips rearrange re-arrange bar command regex auto show rich input dismiss"
+        "third party cli coding agent claude codex gemini toolbar footer layout chip chips rearrange re-arrange bar command regex auto show rich input dismiss ctrl enter"
     }
 
     fn render(
@@ -6313,7 +6321,7 @@ impl SettingsWidget for CLIAgentWidget {
             use super::settings_page::AdditionalInfo;
             use crate::settings::{
                 AutoDismissRichInputAfterSubmit, AutoOpenRichInputOnCLIAgentStart,
-                AutoToggleRichInput,
+                AutoToggleRichInput, SubmitOnCtrlEnter,
             };
 
             if FeatureFlag::CLIAgentRichInput.is_enabled() {
@@ -6370,6 +6378,16 @@ impl SettingsWidget for CLIAgentWidget {
                     *ai_settings.auto_dismiss_rich_input_after_submit,
                     true,
                     self.auto_dismiss_rich_input_toggle.clone(),
+                    &view.local_only_icon_tooltip_states,
+                    app,
+                ));
+
+                column.add_child(render_ai_setting_toggle::<SubmitOnCtrlEnter>(
+                    "Submit with Ctrl+Enter (Enter inserts newline)",
+                    AISettingsPageAction::ToggleSubmitOnCtrlEnter,
+                    *ai_settings.submit_on_ctrl_enter,
+                    true,
+                    self.submit_on_ctrl_enter_toggle.clone(),
                     &view.local_only_icon_tooltip_states,
                     app,
                 ));

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -513,6 +513,8 @@ pub mod flags {
     ///
     /// This is true on linux and windows.
     pub const CTRL_ENTER_ENTERS_AGENT_VIEW: &str = "CtrlEnterEntersAgentView";
+    /// When set, ctrl-enter should submit CLI agent rich input instead of inserting a newline.
+    pub const CTRL_ENTER_SUBMITS_CLI_AGENT_RICH_INPUT: &str = "CtrlEnterSubmitsCLIAgentRichInput";
     pub const AGENT_VIEW_ENABLED: &str = "FeatureFlag.AgentView";
     pub const LOCKED_INPUT: &str = "LockedInput";
     pub const OPEN_INLINE_CONVERSATION_MENU: &str = "OpenInlineConversationMenu";

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -1151,6 +1151,9 @@ pub enum InputAction {
 
     /// Activates `&` cloud handoff compose mode from the message bar hint.
     ActivateCloudHandoff,
+
+    /// Submits the CLI agent rich input with the configured modifier keybinding.
+    SubmitCLIAgentRichInput,
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -1768,6 +1771,11 @@ pub fn init(app: &mut AppContext) {
 
     app.register_fixed_bindings(vec![
         FixedBinding::new("ctrl-d", InputAction::CtrlD, id!("Input")),
+        FixedBinding::new(
+            "ctrl-enter",
+            InputAction::SubmitCLIAgentRichInput,
+            id!("Input") & !id!("IMEOpen") & id!(flags::CTRL_ENTER_SUBMITS_CLI_AGENT_RICH_INPUT),
+        ),
         FixedBinding::custom(
             CustomAction::History,
             InputAction::Up,
@@ -2801,6 +2809,11 @@ impl Input {
 
                         if CLIAgentSessionsModel::as_ref(app).is_input_open(terminal_view_id) {
                             context.set.insert(flags::CLI_AGENT_RICH_INPUT_OPEN);
+                            if *AISettings::as_ref(app).submit_on_ctrl_enter {
+                                context
+                                    .set
+                                    .insert(flags::CTRL_ENTER_SUBMITS_CLI_AGENT_RICH_INPUT);
+                            }
                         }
                     })),
                     ..Default::default()
@@ -12502,15 +12515,12 @@ impl Input {
                 return;
             }
 
-            // When the `!` prefix was stripped (shell mode in CLI agent input),
-            // prepend it back so the CLI agent receives the mode-switch prefix,
-            // then exit shell mode so the next prompt starts in AI mode.
-            let mut text = self.editor.as_ref(ctx).buffer_text(ctx);
-            if self.is_locked_in_shell_mode(ctx) {
-                text = format!("{TERMINAL_INPUT_PREFIX}{text}");
-                self.exit_shell_mode_to_ai(ctx);
+            if *AISettings::as_ref(ctx).submit_on_ctrl_enter {
+                self.insert_newline(ctx);
+                return;
             }
-            ctx.emit(Event::SubmitCLIAgentInput { text });
+
+            self.submit_cli_agent_rich_input(ctx);
             return;
         }
         let command = self.editor.as_ref(ctx).buffer_text(ctx);
@@ -12899,6 +12909,24 @@ impl Input {
             ai_settings.mark_quota_banner_as_dismissed(ctx);
             ctx.notify();
         });
+    }
+
+    fn insert_newline(&mut self, ctx: &mut ViewContext<Self>) {
+        self.editor.update(ctx, |editor, ctx| {
+            editor.user_initiated_insert("\n", PlainTextEditorViewAction::NewLine, ctx)
+        });
+    }
+
+    fn submit_cli_agent_rich_input(&mut self, ctx: &mut ViewContext<Self>) {
+        // When the `!` prefix was stripped (shell mode in CLI agent input),
+        // prepend it back so the CLI agent receives the mode-switch prefix,
+        // then exit shell mode so the next prompt starts in AI mode.
+        let mut text = self.editor.as_ref(ctx).buffer_text(ctx);
+        if self.is_locked_in_shell_mode(ctx) {
+            text = format!("{TERMINAL_INPUT_PREFIX}{text}");
+            self.exit_shell_mode_to_ai(ctx);
+        }
+        ctx.emit(Event::SubmitCLIAgentInput { text });
     }
 
     fn input_cmd_enter(&mut self, ctx: &mut ViewContext<Self>) {
@@ -14887,6 +14915,13 @@ impl TypedActionView for Input {
             InputAction::CtrlD => self.ctrl_d(ctx),
             InputAction::CtrlR => self.ctrl_r(ctx),
             InputAction::ClearScreen => self.clear_screen(ctx),
+            InputAction::SubmitCLIAgentRichInput => {
+                if CLIAgentSessionsModel::as_ref(ctx).is_input_open(self.terminal_view_id)
+                    && *AISettings::as_ref(ctx).submit_on_ctrl_enter
+                {
+                    self.submit_cli_agent_rich_input(ctx);
+                }
+            }
             InputAction::SelectAndRefreshVoltron(feature_name) => {
                 self.select_and_refresh_voltron(*feature_name, ctx);
             }
@@ -15163,6 +15198,14 @@ impl View for Input {
 
         if ai_settings.is_ai_autodetection_enabled(app) {
             ctx.set.insert(flags::AI_INPUT_AUTODETECTION_FLAG);
+        }
+
+        if CLIAgentSessionsModel::as_ref(app).is_input_open(self.terminal_view_id) {
+            ctx.set.insert(flags::CLI_AGENT_RICH_INPUT_OPEN);
+            if *ai_settings.submit_on_ctrl_enter {
+                ctx.set
+                    .insert(flags::CTRL_ENTER_SUBMITS_CLI_AGENT_RICH_INPUT);
+            }
         }
 
         if ai_settings.is_code_suggestions_enabled(app) {


### PR DESCRIPTION
## Summary
- Adds `require_modifier_for_rich_input_submit` setting (default `false` to preserve current behavior). When `true`, the rich input only submits on `Ctrl+Enter`; bare `Enter` inserts a newline.
- Implements the design @advait-m and @cbeaulieu-gt settled on in the issue thread: default off, single toggle, no behavior change for existing users.

## Changes
- `app/src/settings/ai.rs`: new field on the rich-input settings struct with default + serde defaulting.
- `app/src/settings_view/ai_page.rs`: toggle row in the AI settings UI.

Closes #11588.

AI was used for assistance.