### PR TITLE
Focus finished cloud session content after details auto-open

### DIFF
--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -1006,6 +1006,11 @@ impl TerminalView {
             ConversationDetailsPanelAutoOpenPolicy::DefaultOpen => {
                 self.is_conversation_details_panel_open = true;
                 self.fetch_and_update_conversation_details_panel(ctx);
+                // Keep the session content as the primary scroll target when a cloud run opens
+                // with the details panel visible. Otherwise the newly-rendered side panel can
+                // retain focus, making finished transcripts feel artificially short because
+                // mouse-wheel input scrolls the details panel instead of the session.
+                self.redetermine_global_focus(ctx);
                 ctx.notify();
             }
             ConversationDetailsPanelAutoOpenPolicy::DefaultClosed => {}

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -668,6 +668,28 @@ fn test_conversation_details_auto_open_policy_defaults_to_open_for_ambient_share
 }
 
 #[test]
+fn test_conversation_details_auto_open_restores_focus_to_session_content() {
+    App::test((), |mut app| async move {
+        let terminal = terminal_view_for_viewer(&mut app);
+        configure_ambient_details_panel_test(
+            &mut app,
+            &terminal,
+            create_cloud_mode_task_for_user(TEST_USER_UID),
+        );
+
+        terminal.update(&mut app, |view, ctx| {
+            view.maybe_auto_open_conversation_details_panel(ctx);
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            assert!(view.is_conversation_details_panel_open);
+            assert!(ctx.is_self_or_child_focused());
+            assert!(!view.conversation_details_panel.is_self_or_child_focused(ctx));
+        });
+    });
+}
+
+#[test]
 fn test_suppressed_conversation_details_auto_open_consumes_initial_open_but_manual_toggle_works() {
     App::test((), |mut app| async move {
         let terminal = terminal_view_for_viewer(&mut app);


### PR DESCRIPTION
## Summary
- Restore terminal/session focus after auto-opening the conversation details panel for cloud sessions.
- Add a regression test covering details auto-open focus returning to session content instead of the side panel.

## Validation
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp test_conversation_details_auto_open_restores_focus_to_session_content`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml` could not run because `rustfmt` is not installed for the active toolchain in this sandbox.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/19b48453-f06d-4e5c-859f-60b090cf1e2e_
_Run: https://oz.staging.warp.dev/runs/019e66f5-c003-7f36-9e23-4f17e3ad121b_

_This PR was generated with [Oz](https://warp.dev/oz)._
