### PR TITLE
Add IAP (Identity-Aware Proxy) support for staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6222,6 +6222,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "warp_core",
  "warpui",
 ]
 

--- a/app/src/bin/integration.rs
+++ b/app/src/bin/integration.rs
@@ -33,6 +33,7 @@ pub fn main() -> Result<()> {
                 server_root_url: "http://192.0.2.0:9".into(),
                 rtc_server_url: "ws://192.0.2.0:9/graphql/v2".into(),
                 session_sharing_server_url: None,
+                iap_config: None,
             },
             oz_config: OzConfig {
                 // Use an IP in the IANA testing range, with the TCP discard port, to

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -277,6 +277,8 @@ use crate::root_view::{
 use crate::server::cloud_objects::listener::Listener;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::experiments::ServerExperiments;
+#[cfg(not(target_family = "wasm"))]
+use crate::server::iap::IapManager;
 use crate::server::sync_queue::{QueueItem, SyncQueue};
 pub use crate::server::telemetry::{
     AgentModeEntrypoint, AgentModeEntrypointSelectionType, TelemetryEvent,
@@ -1124,8 +1126,23 @@ pub(crate) fn initialize_app(
     // captured by the HTTP client hooks.
     ctx.add_singleton_model(|_ctx| NetworkLogModel::default());
 
-    let server_api_provider = ctx
-        .add_singleton_model(|ctx| ServerApiProvider::new(auth_state.clone(), agent_source, ctx));
+    // Create a shared IAP state for staging builds. The same `Arc<IapState>`
+    // is handed to both `ServerApi` (for sync reads on the request path) and
+    // `IapManager` (which owns refresh logic on the main thread).
+    #[cfg(not(target_family = "wasm"))]
+    let iap_state =
+        ChannelState::iap_config().map(|cfg| Arc::new(crate::server::iap::IapState::new(&cfg)));
+    #[cfg(target_family = "wasm")]
+    let iap_state: Option<Arc<crate::server::iap::IapState>> = None;
+
+    let server_api_provider = ctx.add_singleton_model({
+        let auth_state = auth_state.clone();
+        let iap_state = iap_state.clone();
+        move |ctx| ServerApiProvider::new(auth_state, agent_source, iap_state, ctx)
+    });
+
+    #[cfg(not(target_family = "wasm"))]
+    ctx.add_singleton_model(move |ctx| IapManager::new(iap_state, ctx));
     let server_api = server_api_provider.as_ref(ctx).get();
     let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
 

--- a/app/src/server/iap.rs
+++ b/app/src/server/iap.rs
@@ -9,8 +9,10 @@ use warp_core::channel::IapConfig;
 use warpui::r#async::Timer;
 use warpui::{Entity, ModelContext, SingletonEntity};
 
+use crate::view_components::DismissibleToast;
+use crate::workspace::{ToastStack, WorkspaceAction};
+
 const PROACTIVE_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
-const FALLBACK_TOKEN_VALIDITY: Duration = Duration::from_secs(55 * 60);
 const INJECTED_TOKEN_ENV_VAR: &str = "WARP_IAP_TOKEN";
 
 const BASE_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(30);
@@ -22,6 +24,18 @@ const MAX_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
 const MAX_FAILURE_RETRIES: u32 = 5;
 
 #[derive(Debug, Clone)]
+pub struct CachedToken {
+    pub token: String,
+    pub expires_at: Instant,
+}
+
+impl CachedToken {
+    fn valid_token(&self) -> Option<String> {
+        (self.expires_at > Instant::now()).then(|| self.token.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum IapCredentialsState {
     Missing,
     /// A credential fetch is in progress. `previous` carries the last
@@ -29,14 +43,13 @@ pub enum IapCredentialsState {
     /// outbound requests while we're refreshing so that proactive refreshes
     /// (i.e. refresh the token 5min before exp) don't prevent active requests.
     Refreshing {
-        previous: Option<(String, Instant)>,
+        previous: Option<CachedToken>,
     },
-    Loaded {
-        token: String,
-        expires_at: Instant,
-    },
+    Loaded(CachedToken),
     Failed {
         message: String,
+        // in case the last token still works... we can try to use that for a couple more mins
+        previous: Option<CachedToken>,
     },
     /// Represents a terminal state in the iap creds state machine.
     /// The gcloud refresh loop will never run, and an IAP challenge is logged
@@ -47,6 +60,17 @@ pub enum IapCredentialsState {
     EnvInjected {
         token: String,
     },
+}
+
+impl IapCredentialsState {
+    fn previous_token(&self) -> Option<CachedToken> {
+        match self {
+            IapCredentialsState::Loaded(cached) => Some(cached.clone()),
+            IapCredentialsState::Refreshing { previous }
+            | IapCredentialsState::Failed { previous, .. } => previous.clone(),
+            IapCredentialsState::EnvInjected { .. } | IapCredentialsState::Missing => None,
+        }
+    }
 }
 
 pub struct IapState {
@@ -71,13 +95,13 @@ impl IapState {
 
     pub fn get_cached(&self) -> Option<String> {
         match &*self.inner.read().expect("IAP state lock poisoned") {
-            IapCredentialsState::Loaded { token, .. }
-            | IapCredentialsState::EnvInjected { token } => Some(token.clone()),
-            IapCredentialsState::Refreshing { previous } => {
-                let (token, expires_at) = previous.as_ref()?;
-                (*expires_at > Instant::now()).then(|| token.clone())
+            IapCredentialsState::Loaded(cached) => Some(cached.token.clone()),
+            IapCredentialsState::EnvInjected { token } => Some(token.clone()),
+            IapCredentialsState::Refreshing { previous }
+            | IapCredentialsState::Failed { previous, .. } => {
+                previous.as_ref().and_then(CachedToken::valid_token)
             }
-            IapCredentialsState::Missing | IapCredentialsState::Failed { .. } => None,
+            IapCredentialsState::Missing => None,
         }
     }
 
@@ -95,24 +119,21 @@ impl IapState {
 
     fn set_refreshing(&self) {
         let mut state = self.inner.write().expect("IAP state lock poisoned");
-        let previous = match &*state {
-            IapCredentialsState::Loaded { token, expires_at } => Some((token.clone(), *expires_at)),
-            IapCredentialsState::Refreshing { previous } => previous.clone(),
-            IapCredentialsState::EnvInjected { .. }
-            | IapCredentialsState::Missing
-            | IapCredentialsState::Failed { .. } => None,
+        *state = IapCredentialsState::Refreshing {
+            previous: state.previous_token(),
         };
-        *state = IapCredentialsState::Refreshing { previous };
     }
 
-    fn set_loaded(&self, token: String, expires_at: Instant) {
-        *self.inner.write().expect("IAP state lock poisoned") =
-            IapCredentialsState::Loaded { token, expires_at };
+    fn set_loaded(&self, cached: CachedToken) {
+        *self.inner.write().expect("IAP state lock poisoned") = IapCredentialsState::Loaded(cached);
     }
 
     fn set_failed(&self, message: String) {
-        *self.inner.write().expect("IAP state lock poisoned") =
-            IapCredentialsState::Failed { message };
+        let mut state = self.inner.write().expect("IAP state lock poisoned");
+        *state = IapCredentialsState::Failed {
+            message,
+            previous: state.previous_token(),
+        };
     }
 }
 
@@ -197,8 +218,9 @@ impl IapManager {
                     return;
                 };
                 match result {
-                    Ok((token, expires_at)) => {
-                        state.set_loaded(token, expires_at);
+                    Ok(cached) => {
+                        let expires_at = cached.expires_at;
+                        state.set_loaded(cached);
                         manager.consecutive_failures = 0;
                         log::info!("IAP token refreshed");
                         ctx.emit(IapManagerEvent::StateChanged);
@@ -208,7 +230,11 @@ impl IapManager {
                     Err(err) => {
                         let message = format!("{err:#}");
                         log::warn!("IAP token fetch failed: {message}");
-                        state.set_failed(message);
+                        let is_first_failure_of_streak = manager.consecutive_failures == 0;
+                        state.set_failed(message.clone());
+                        if is_first_failure_of_streak {
+                            manager.show_failure_toast(&message, ctx);
+                        }
                         ctx.emit(IapManagerEvent::StateChanged);
                         ctx.notify();
                         manager.schedule_failure_retry(ctx);
@@ -257,6 +283,21 @@ impl IapManager {
             },
         );
     }
+
+    fn show_failure_toast(&self, message: &str, ctx: &mut ModelContext<Self>) {
+        let window_id = ctx
+            .windows()
+            .active_window()
+            .or_else(|| ctx.windows().ordered_window_ids().first().copied());
+        let Some(window_id) = window_id else {
+            return;
+        };
+        let toast: DismissibleToast<WorkspaceAction> =
+            DismissibleToast::error(format!("IAP credential refresh failed: {message}"));
+        ToastStack::handle(ctx).update(ctx, |stack, ctx| {
+            stack.add_ephemeral_toast(toast, window_id, ctx);
+        });
+    }
 }
 
 impl Entity for IapManager {
@@ -268,7 +309,7 @@ impl SingletonEntity for IapManager {}
 /// How long to wait for `auth print-identity-token` command to respond before killing it.
 const GCLOUD_TIMEOUT: Duration = Duration::from_secs(30);
 
-fn fetch_iap_token(audiences: &str, service_account_email: &str) -> Result<(String, Instant)> {
+fn fetch_iap_token(audiences: &str, service_account_email: &str) -> Result<CachedToken> {
     let args = [
         "auth",
         "print-identity-token",
@@ -324,28 +365,25 @@ fn fetch_iap_token(audiences: &str, service_account_email: &str) -> Result<(Stri
 
     anyhow::ensure!(!token.is_empty(), "gcloud returned an empty token");
 
-    let expires_at = get_expires_at(&token);
-    Ok((token, expires_at))
+    let expires_at = get_expires_at(&token)?;
+    Ok(CachedToken { token, expires_at })
 }
 
-/// Returns the [`Instant`] at which the given IAP identity token expires.
-fn get_expires_at(token: &str) -> Instant {
-    parse_exp_from_jwt(token)
-        .and_then(|exp| {
-            // `exp` is Unix wall-clock seconds; `Instant` is monotonic and
-            // has no Unix-time API, so bridge via `SystemTime::now()` to
-            // compute a delta, then add that to `Instant::now()`.
-            let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
-            let secs_remaining = exp.checked_sub(now)?;
-            Some(Instant::now() + Duration::from_secs(secs_remaining))
-        })
-        .unwrap_or_else(|| {
-            log::warn!(
-                "Could not parse `exp` claim from IAP token; falling back to {}s validity",
-                FALLBACK_TOKEN_VALIDITY.as_secs()
-            );
-            Instant::now() + FALLBACK_TOKEN_VALIDITY
-        })
+fn get_expires_at(token: &str) -> Result<Instant> {
+    let exp = parse_exp_from_jwt(token).ok_or_else(|| {
+        anyhow::anyhow!("IAP token missing or unparseable `exp` claim; refusing to cache")
+    })?;
+    // `exp` is Unix wall-clock seconds; `Instant` is monotonic and
+    // has no Unix-time API, so bridge via `SystemTime::now()` to
+    // compute a delta, then add that to `Instant::now()`.
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| anyhow::anyhow!("system clock is before unix epoch: {err}"))?
+        .as_secs();
+    let secs_remaining = exp
+        .checked_sub(now)
+        .ok_or_else(|| anyhow::anyhow!("IAP token is already expired (exp={exp}, now={now})"))?;
+    Ok(Instant::now() + Duration::from_secs(secs_remaining))
 }
 
 fn parse_exp_from_jwt(token: &str) -> Option<u64> {

--- a/app/src/server/iap.rs
+++ b/app/src/server/iap.rs
@@ -1,0 +1,358 @@
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use base64::Engine;
+use blocking::unblock;
+use instant::Instant;
+use warp_core::channel::IapConfig;
+use warpui::r#async::Timer;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+const PROACTIVE_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
+const FALLBACK_TOKEN_VALIDITY: Duration = Duration::from_secs(55 * 60);
+const INJECTED_TOKEN_ENV_VAR: &str = "WARP_IAP_TOKEN";
+
+const BASE_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(30);
+const MAX_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
+/// Maximum number of consecutive failed fetches to automatically retry
+/// before giving up and waiting for a manual Refresh or an inbound
+/// IAP challenge. i.e. so a persistently broken setup (no gcloud,
+/// bad credentials) doesn't loop forever.
+const MAX_FAILURE_RETRIES: u32 = 5;
+
+#[derive(Debug, Clone)]
+pub enum IapCredentialsState {
+    Missing,
+    /// A credential fetch is in progress. `previous` carries the last
+    /// successfully-loaded token (if any). Allows us to attach it to
+    /// outbound requests while we're refreshing so that proactive refreshes
+    /// (i.e. refresh the token 5min before exp) don't prevent active requests.
+    Refreshing {
+        previous: Option<(String, Instant)>,
+    },
+    Loaded {
+        token: String,
+        expires_at: Instant,
+    },
+    Failed {
+        message: String,
+    },
+    /// Represents a terminal state in the iap creds state machine.
+    /// The gcloud refresh loop will never run, and an IAP challenge is logged
+    /// rather than triggering a refresh (we have no way to refresh a new token
+    /// from ambient agent context yet).
+    /// TODO(Isaiah/Jason): implement token refreshing scheme.
+    /// see: https://linear.app/warpdotdev/issue/REMOTE-1370/refresh-github-token
+    EnvInjected {
+        token: String,
+    },
+}
+
+pub struct IapState {
+    audiences: String,
+    service_account_email: String,
+    inner: RwLock<IapCredentialsState>,
+}
+
+impl IapState {
+    pub fn new(config: &IapConfig) -> Self {
+        let initial = std::env::var(INJECTED_TOKEN_ENV_VAR)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|token| IapCredentialsState::EnvInjected { token })
+            .unwrap_or(IapCredentialsState::Missing);
+        Self {
+            audiences: config.audiences.to_string(),
+            service_account_email: config.service_account_email.to_string(),
+            inner: RwLock::new(initial),
+        }
+    }
+
+    pub fn get_cached(&self) -> Option<String> {
+        match &*self.inner.read().expect("IAP state lock poisoned") {
+            IapCredentialsState::Loaded { token, .. }
+            | IapCredentialsState::EnvInjected { token } => Some(token.clone()),
+            IapCredentialsState::Refreshing { previous } => {
+                let (token, expires_at) = previous.as_ref()?;
+                (*expires_at > Instant::now()).then(|| token.clone())
+            }
+            IapCredentialsState::Missing | IapCredentialsState::Failed { .. } => None,
+        }
+    }
+
+    pub fn state(&self) -> IapCredentialsState {
+        self.inner.read().expect("IAP state lock poisoned").clone()
+    }
+
+    pub fn audiences(&self) -> &str {
+        &self.audiences
+    }
+
+    pub fn service_account_email(&self) -> &str {
+        &self.service_account_email
+    }
+
+    fn set_refreshing(&self) {
+        let mut state = self.inner.write().expect("IAP state lock poisoned");
+        let previous = match &*state {
+            IapCredentialsState::Loaded { token, expires_at } => Some((token.clone(), *expires_at)),
+            IapCredentialsState::Refreshing { previous } => previous.clone(),
+            IapCredentialsState::EnvInjected { .. }
+            | IapCredentialsState::Missing
+            | IapCredentialsState::Failed { .. } => None,
+        };
+        *state = IapCredentialsState::Refreshing { previous };
+    }
+
+    fn set_loaded(&self, token: String, expires_at: Instant) {
+        *self.inner.write().expect("IAP state lock poisoned") =
+            IapCredentialsState::Loaded { token, expires_at };
+    }
+
+    fn set_failed(&self, message: String) {
+        *self.inner.write().expect("IAP state lock poisoned") =
+            IapCredentialsState::Failed { message };
+    }
+}
+
+impl http_client::iap::IapTokenProvider for IapState {
+    fn cached_token(&self) -> Option<String> {
+        self.get_cached()
+    }
+}
+
+/// Owns the IAP refresh lifecycle: initial fetch, proactive time-based
+/// refresh, and reactive refresh on challenge events.
+pub struct IapManager {
+    state: Option<Arc<IapState>>,
+    /// Number of consecutive failed fetches since the last success.
+    consecutive_failures: u32,
+}
+
+pub enum IapManagerEvent {
+    StateChanged,
+}
+
+impl IapManager {
+    pub fn new(state: Option<Arc<IapState>>, ctx: &mut ModelContext<Self>) -> Self {
+        let mut manager = Self {
+            state,
+            consecutive_failures: 0,
+        };
+        manager.start_refresh(ctx);
+        manager
+    }
+
+    /// Returns `true` if IAP is active for this build. When `false`, all
+    /// other methods on this type are no-ops.
+    pub fn is_enabled(&self) -> bool {
+        self.state.is_some()
+    }
+
+    pub fn state(&self) -> Option<IapCredentialsState> {
+        self.state.as_ref().map(|s| s.state())
+    }
+
+    pub fn handle_challenge(&mut self, ctx: &mut ModelContext<Self>) {
+        let Some(state) = self.state.as_ref() else {
+            return;
+        };
+        if matches!(state.state(), IapCredentialsState::EnvInjected { .. }) {
+            log::warn!(
+                "Env-injected IAP token ({INJECTED_TOKEN_ENV_VAR}) was rejected by IAP; \
+                 token is likely stale — re-inject to recover"
+            );
+            return;
+        }
+        self.consecutive_failures = 0;
+        self.start_refresh(ctx);
+    }
+
+    pub fn start_refresh(&mut self, ctx: &mut ModelContext<Self>) {
+        let Some(state) = self.state.clone() else {
+            return;
+        };
+        // Don't touch state if a refresh is already running, or if we're
+        // in the terminal env-injected state (no refresh path exists).
+        if matches!(
+            state.state(),
+            IapCredentialsState::Refreshing { .. } | IapCredentialsState::EnvInjected { .. }
+        ) {
+            return;
+        }
+        state.set_refreshing();
+        ctx.emit(IapManagerEvent::StateChanged);
+        ctx.notify();
+
+        let audiences = state.audiences().to_string();
+        let service_account_email = state.service_account_email().to_string();
+
+        ctx.spawn(
+            async move {
+                unblock(move || fetch_iap_token(&audiences, &service_account_email)).await
+            },
+            move |manager, result, ctx| {
+                let Some(state) = manager.state.as_ref() else {
+                    return;
+                };
+                match result {
+                    Ok((token, expires_at)) => {
+                        state.set_loaded(token, expires_at);
+                        manager.consecutive_failures = 0;
+                        log::info!("IAP token refreshed");
+                        ctx.emit(IapManagerEvent::StateChanged);
+                        ctx.notify();
+                        manager.schedule_next_refresh(expires_at, ctx);
+                    }
+                    Err(err) => {
+                        let message = format!("{err:#}");
+                        log::warn!("IAP token fetch failed: {message}");
+                        state.set_failed(message);
+                        ctx.emit(IapManagerEvent::StateChanged);
+                        ctx.notify();
+                        manager.schedule_failure_retry(ctx);
+                    }
+                }
+            },
+        );
+    }
+
+    fn schedule_next_refresh(&mut self, expires_at: Instant, ctx: &mut ModelContext<Self>) {
+        let sleep_duration = expires_at
+            .saturating_duration_since(Instant::now())
+            .saturating_sub(PROACTIVE_REFRESH_BUFFER);
+        self.schedule_retry(sleep_duration, ctx);
+    }
+
+    fn schedule_failure_retry(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.consecutive_failures >= MAX_FAILURE_RETRIES {
+            log::warn!(
+                "IAP token fetch failed {MAX_FAILURE_RETRIES} times in a row; giving up until \
+                 manual refresh or server challenge"
+            );
+            return;
+        }
+        // Delay = BASE * 2^failures, capped at MAX. Using u32 shift is
+        // safe because we cap failures at MAX_FAILURE_RETRIES (< 32).
+        let delay = BASE_FAILURE_RETRY_DELAY
+            .saturating_mul(1u32 << self.consecutive_failures)
+            .min(MAX_FAILURE_RETRY_DELAY);
+        self.consecutive_failures += 1;
+        log::info!(
+            "Scheduling IAP refresh retry #{} in {}s",
+            self.consecutive_failures,
+            delay.as_secs()
+        );
+        self.schedule_retry(delay, ctx);
+    }
+
+    fn schedule_retry(&mut self, delay: Duration, ctx: &mut ModelContext<Self>) {
+        ctx.spawn(
+            async move {
+                Timer::after(delay).await;
+            },
+            |manager, _, ctx| {
+                manager.start_refresh(ctx);
+            },
+        );
+    }
+}
+
+impl Entity for IapManager {
+    type Event = IapManagerEvent;
+}
+
+impl SingletonEntity for IapManager {}
+
+/// How long to wait for `auth print-identity-token` command to respond before killing it.
+const GCLOUD_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn fetch_iap_token(audiences: &str, service_account_email: &str) -> Result<(String, Instant)> {
+    let args = [
+        "auth",
+        "print-identity-token",
+        "--audiences",
+        audiences,
+        "--impersonate-service-account",
+        service_account_email,
+        "--include-email",
+    ];
+    let cmd_display = format!("gcloud {}", args.join(" "));
+
+    let mut child = command::blocking::Command::new("gcloud")
+        // Prevent gcloud from waiting for interactive input (fail fast instead of hanging)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .args(args)
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("Failed to spawn `{cmd_display}`: {err}"))?;
+
+    // Poll for completion, killing the child if it exceeds the timeout.
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if start.elapsed() > GCLOUD_TIMEOUT {
+                    let _ = child.kill();
+                    anyhow::bail!(
+                        "`{cmd_display}` timed out after {}s",
+                        GCLOUD_TIMEOUT.as_secs()
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(err) => anyhow::bail!("Failed to wait for `{cmd_display}`: {err}"),
+        }
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|err| anyhow::anyhow!("Failed to collect output from `{cmd_display}`: {err}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!("`{cmd_display}` failed: {stderr}");
+    }
+
+    let token = String::from_utf8(output.stdout)
+        .map_err(|err| anyhow::anyhow!("gcloud output is not valid UTF-8: {err}"))?
+        .trim()
+        .to_string();
+
+    anyhow::ensure!(!token.is_empty(), "gcloud returned an empty token");
+
+    let expires_at = get_expires_at(&token);
+    Ok((token, expires_at))
+}
+
+/// Returns the [`Instant`] at which the given IAP identity token expires.
+fn get_expires_at(token: &str) -> Instant {
+    parse_exp_from_jwt(token)
+        .and_then(|exp| {
+            // `exp` is Unix wall-clock seconds; `Instant` is monotonic and
+            // has no Unix-time API, so bridge via `SystemTime::now()` to
+            // compute a delta, then add that to `Instant::now()`.
+            let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+            let secs_remaining = exp.checked_sub(now)?;
+            Some(Instant::now() + Duration::from_secs(secs_remaining))
+        })
+        .unwrap_or_else(|| {
+            log::warn!(
+                "Could not parse `exp` claim from IAP token; falling back to {}s validity",
+                FALLBACK_TOKEN_VALIDITY.as_secs()
+            );
+            Instant::now() + FALLBACK_TOKEN_VALIDITY
+        })
+}
+
+fn parse_exp_from_jwt(token: &str) -> Option<u64> {
+    let payload_b64 = token.split('.').nth(1)?;
+    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .ok()?;
+    let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).ok()?;
+    payload.get("exp")?.as_u64()
+}

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -3,6 +3,10 @@ pub mod cloud_objects;
 pub mod datetime_ext;
 pub mod experiments;
 pub mod graphql;
+// IAP items are only referenced from native code paths; on wasm the
+// module compiles but every function is dead code.
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
+pub(crate) mod iap;
 pub mod ids;
 pub mod network_log_pane_manager;
 pub mod network_log_view;

--- a/app/src/server/retry_strategies.rs
+++ b/app/src/server/retry_strategies.rs
@@ -73,7 +73,9 @@ pub(crate) fn is_transient_graphql_or_http_error(e: &anyhow::Error) -> bool {
             return match graphql_err {
                 GraphQLError::RequestError(_) => true,
                 GraphQLError::HttpError { status, .. } => is_transient_status(status.as_u16()),
-                GraphQLError::StagingAccessBlocked | GraphQLError::ResponseError(_) => false,
+                GraphQLError::StagingAccessBlocked
+                | GraphQLError::IapChallengeBlocked
+                | GraphQLError::ResponseError(_) => false,
             };
         }
 

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -56,10 +56,10 @@ use crate::auth::auth_manager::AuthManager;
 use crate::auth::auth_state::AuthState;
 use crate::auth::UserUid;
 use crate::server::graphql::default_request_options;
+use crate::server::iap::{IapManager, IapState};
 use crate::server::server_api::presigned_upload::HttpStatusError;
 use crate::server::telemetry::TelemetryApi;
 use crate::settings::PrivacySettingsSnapshot;
-use crate::server::iap::{IapManager, IapState};
 use crate::{settings_view, ChannelState};
 
 pub const FETCH_CHANNEL_VERSIONS_TIMEOUT: std::time::Duration = Duration::from_secs(60);
@@ -447,8 +447,17 @@ impl ServerApi {
         agent_source: Option<ai::AgentSource>,
         iap_state: Option<Arc<IapState>>,
     ) -> Self {
-        let client = Arc::new(http_client::Client::new());
-        Self::new_with_parts(client, auth_state, event_sender, agent_source)
+        let mut client = http_client::Client::new();
+        if let Some(state) = iap_state.as_ref() {
+            client.set_iap_token_provider(state.clone());
+        }
+        Self::new_with_parts(
+            Arc::new(client),
+            auth_state,
+            event_sender,
+            agent_source,
+            iap_state,
+        )
     }
 
     fn new_with_parts(
@@ -456,6 +465,7 @@ impl ServerApi {
         auth_state: Arc<AuthState>,
         event_sender: async_channel::Sender<ServerApiEvent>,
         agent_source: Option<ai::AgentSource>,
+        iap_state: Option<Arc<IapState>>,
     ) -> Self {
         // We generate a random user ID for evals so we can run evals in parallel.
         #[cfg(feature = "agent_mode_evals")]
@@ -466,13 +476,8 @@ impl ServerApi {
 
         let oauth_client = Self::create_oauth_client();
 
-        let mut client = http_client::Client::new();
-        if let Some(state) = iap_state.as_ref() {
-            client.set_iap_token_provider(state.clone());
-        }
-
         Self {
-            client: Arc::new(client),
+            client,
             auth_state,
             event_sender,
             telemetry_api: TelemetryApi::new(),
@@ -493,7 +498,7 @@ impl ServerApi {
         let auth_state = Arc::new(AuthState::new_for_test());
         let client = Arc::new(http_client::Client::new_for_test());
 
-        Self::new_with_parts(client, auth_state, tx, None)
+        Self::new_with_parts(client, auth_state, tx, None, None)
     }
 
     #[cfg(test)]
@@ -509,6 +514,7 @@ impl ServerApi {
             Arc::new(http_client::Client::new_for_test()),
             auth_state,
             event_sender,
+            None,
             None,
         )
     }
@@ -757,6 +763,7 @@ impl ServerApi {
             }
             GraphQLError::RequestError(_)
             | GraphQLError::StagingAccessBlocked
+            | GraphQLError::IapChallengeBlocked
             | GraphQLError::ResponseError(_) => false,
         }
     }

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -545,6 +545,10 @@ impl ServerApi {
     /// Inspects a response for the IAP challenge header and emits an
     /// `IapChallengeReceived` event if detected. Returns `true` if the
     /// response was an IAP challenge.
+    ///
+    /// TODO(isaiah): implement retries on IAP challenge failures so the
+    /// triggering request transparently succeeds after the refresh
+    /// completes instead of bubbling up a one-off error to the caller.
     fn check_for_iap_challenge(&self, response: &http_client::Response) -> bool {
         if self.iap_state.is_none() {
             return false;
@@ -554,9 +558,12 @@ impl ServerApi {
                 "Received IAP challenge (status {}); notifying IapManager",
                 response.status()
             );
-            let _ = self
+            if let Err(err) = self
                 .event_sender
-                .try_send(ServerApiEvent::IapChallengeReceived);
+                .try_send(ServerApiEvent::IapChallengeReceived)
+            {
+                log::warn!("Failed to enqueue IapChallengeReceived event: {err}");
+            }
             true
         } else {
             false
@@ -565,7 +572,11 @@ impl ServerApi {
 
     /// Wraps an eventsource stream so that any `InvalidStatusCode` error
     /// carrying an IAP challenge header triggers an `IapChallengeReceived`
-    /// event. The original error is passed through unchanged.
+    /// event. The original error is passed through unchanged — the
+    /// stream is not transparently reconnected after the refresh.
+    ///
+    /// TODO(isaiah): implement retries on IAP challenge failures so
+    /// streams transparently reconnect after the refresh completes.
     fn wrap_eventsource_with_iap_detection(
         &self,
         stream: http_client::EventSourceStream,
@@ -581,7 +592,11 @@ impl ServerApi {
                     log::warn!(
                         "Received IAP challenge on eventsource (status {status}); notifying IapManager"
                     );
-                    let _ = event_sender.try_send(ServerApiEvent::IapChallengeReceived);
+                    if let Err(err) = event_sender.try_send(ServerApiEvent::IapChallengeReceived) {
+                        log::warn!(
+                            "Failed to enqueue IapChallengeReceived event from eventsource: {err}"
+                        );
+                    }
                 }
             }
             event

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -59,6 +59,7 @@ use crate::server::graphql::default_request_options;
 use crate::server::server_api::presigned_upload::HttpStatusError;
 use crate::server::telemetry::TelemetryApi;
 use crate::settings::PrivacySettingsSnapshot;
+use crate::server::iap::{IapManager, IapState};
 use crate::{settings_view, ChannelState};
 
 pub const FETCH_CHANNEL_VERSIONS_TIMEOUT: std::time::Duration = Duration::from_secs(60);
@@ -391,6 +392,10 @@ pub enum ServerApiEvent {
         #[cfg_attr(target_family = "wasm", allow(dead_code))]
         token: String,
     },
+    /// An IAP (Identity-Aware Proxy) challenge was received, indicating that
+    /// the cached IAP credentials are stale. The UI thread should trigger a
+    /// refresh via [`super::iap::IapManager::start_refresh`].
+    IapChallengeReceived,
 }
 
 impl fmt::Debug for ServerApiEvent {
@@ -403,6 +408,7 @@ impl fmt::Debug for ServerApiEvent {
                 .debug_struct("AccessTokenRefreshed")
                 .field("token", &"<redacted>")
                 .finish(),
+            Self::IapChallengeReceived => f.write_str("IapChallengeReceived"),
         }
     }
 }
@@ -427,6 +433,8 @@ pub struct ServerApi {
     ambient_agent_task_id: Arc<RwLock<Option<AmbientAgentTaskId>>>,
     /// The source of agent runs (e.g. CLI, GitHub Action). Set once at startup and immutable.
     agent_source: Option<ai::AgentSource>,
+    /// IAP credential cache for staging server access. [`None`] on production builds.
+    iap_state: Option<Arc<super::iap::IapState>>,
 
     #[cfg(feature = "agent_mode_evals")]
     eval_user_id: Option<i32>,
@@ -437,6 +445,7 @@ impl ServerApi {
         auth_state: Arc<AuthState>,
         event_sender: async_channel::Sender<ServerApiEvent>,
         agent_source: Option<ai::AgentSource>,
+        iap_state: Option<Arc<IapState>>,
     ) -> Self {
         let client = Arc::new(http_client::Client::new());
         Self::new_with_parts(client, auth_state, event_sender, agent_source)
@@ -457,8 +466,13 @@ impl ServerApi {
 
         let oauth_client = Self::create_oauth_client();
 
+        let mut client = http_client::Client::new();
+        if let Some(state) = iap_state.as_ref() {
+            client.set_iap_token_provider(state.clone());
+        }
+
         Self {
-            client,
+            client: Arc::new(client),
             auth_state,
             event_sender,
             telemetry_api: TelemetryApi::new(),
@@ -467,6 +481,7 @@ impl ServerApi {
             ambient_workload_token: Arc::new(Mutex::new(None)),
             ambient_agent_task_id: Arc::new(RwLock::new(None)),
             agent_source,
+            iap_state,
             #[cfg(feature = "agent_mode_evals")]
             eval_user_id,
         }
@@ -519,6 +534,59 @@ impl ServerApi {
     /// Sets the ambient agent task ID to be sent with all subsequent requests.
     pub fn set_ambient_agent_task_id(&self, task_id: Option<AmbientAgentTaskId>) {
         *self.ambient_agent_task_id.write() = task_id;
+    }
+
+    /// Inspects a response for the IAP challenge header and emits an
+    /// `IapChallengeReceived` event if detected. Returns `true` if the
+    /// response was an IAP challenge.
+    fn check_for_iap_challenge(&self, response: &http_client::Response) -> bool {
+        if self.iap_state.is_none() {
+            return false;
+        }
+        if http_client::iap::is_iap_challenge(response.status(), response.headers()) {
+            log::warn!(
+                "Received IAP challenge (status {}); notifying IapManager",
+                response.status()
+            );
+            let _ = self
+                .event_sender
+                .try_send(ServerApiEvent::IapChallengeReceived);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Wraps an eventsource stream so that any `InvalidStatusCode` error
+    /// carrying an IAP challenge header triggers an `IapChallengeReceived`
+    /// event. The original error is passed through unchanged.
+    fn wrap_eventsource_with_iap_detection(
+        &self,
+        stream: http_client::EventSourceStream,
+    ) -> http_client::EventSourceStream {
+        if self.iap_state.is_none() {
+            return stream;
+        }
+        let event_sender = self.event_sender.clone();
+        let wrapped = stream.map(move |event| {
+            if let Err(reqwest_eventsource::Error::InvalidStatusCode(status, ref response)) = event
+            {
+                if http_client::iap::is_iap_challenge(status, response.headers()) {
+                    log::warn!(
+                        "Received IAP challenge on eventsource (status {status}); notifying IapManager"
+                    );
+                    let _ = event_sender.try_send(ServerApiEvent::IapChallengeReceived);
+                }
+            }
+            event
+        });
+        cfg_if::cfg_if! {
+            if #[cfg(target_family = "wasm")] {
+                wrapped.boxed_local()
+            } else {
+                wrapped.boxed()
+            }
+        }
     }
 
     /// Returns ambient agent headers to attach to requests.
@@ -617,6 +685,10 @@ impl ServerApi {
                 Err(GraphQLError::StagingAccessBlocked) => {
                     let _ = event_sender.try_send(ServerApiEvent::StagingAccessBlocked);
                     anyhow::bail!(GraphQLError::StagingAccessBlocked)
+                }
+                Err(GraphQLError::IapChallengeBlocked) => {
+                    let _ = event_sender.try_send(ServerApiEvent::IapChallengeReceived);
+                    anyhow::bail!(GraphQLError::IapChallengeBlocked)
                 }
                 Err(err) => {
                     if !self.allowed_to_refresh_token() && Self::is_graphql_auth_rejection(&err) {
@@ -734,6 +806,7 @@ impl ServerApi {
         if response.status().is_success() {
             Ok(response)
         } else {
+            self.check_for_iap_challenge(&response);
             // Put `HttpStatusError` in the error chain so shared retry classifiers
             // (`is_transient_http_error`) can distinguish transient 5xx / 408 / 429
             // from permanent 4xx without string-matching the Display output.
@@ -792,7 +865,7 @@ impl ServerApi {
             request = request.header(name, value);
         }
 
-        Ok(request.eventsource())
+        Ok(self.wrap_eventsource_with_iap_detection(request.eventsource()))
     }
 
     pub async fn stream_agent_events_for_task(
@@ -862,6 +935,7 @@ impl ServerApi {
         if response.status().is_success() {
             Ok(response)
         } else {
+            self.check_for_iap_challenge(&response);
             Err(Self::error_from_response(response).await)
         }
     }
@@ -1361,7 +1435,8 @@ impl ServerApi {
             }
         }
 
-        let output_stream = request.eventsource().filter_map(|event| async {
+        let raw_stream = self.wrap_eventsource_with_iap_detection(request.eventsource());
+        let output_stream = raw_stream.filter_map(|event| async {
             let result = match event {
                 Ok(reqwest_eventsource::Event::Message(message_event)) => {
                     match BASE64_URL_SAFE.decode(message_event.data.trim_matches('"')) {
@@ -1420,6 +1495,10 @@ impl ServerApi {
         let time_endpoint = format!("{}/current_time", ChannelState::server_root_url());
         log::info!("Sending server time request to {}", &time_endpoint);
         let res = self.client.get(&time_endpoint).send().await?;
+
+        if !res.status().is_success() {
+            self.check_for_iap_challenge(&res);
+        }
 
         match res.status() {
             StatusCode::OK => {
@@ -1490,6 +1569,9 @@ impl ServerApi {
         }
 
         let response = request_builder.send().await?;
+        if !response.status().is_success() {
+            self.check_for_iap_challenge(&response);
+        }
         let versions: ChannelVersions = response.json().await?;
         log::info!("Received channel versions from Warp server: {versions}");
         Ok(versions)
@@ -1504,13 +1586,17 @@ pub struct ServerApiProvider {
 
 impl ServerApiProvider {
     /// Constructs a new ServerApiProvider.
+    #[cfg_attr(target_family = "wasm", allow(unused_variables))]
     pub fn new(
         auth_state: Arc<AuthState>,
         agent_source: Option<ai::AgentSource>,
+        iap_state: Option<Arc<super::iap::IapState>>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let (event_sender, event_receiver) = async_channel::bounded(10);
-        let mut server_api = ServerApi::new(auth_state.clone(), event_sender, agent_source);
+
+        let mut server_api =
+            ServerApi::new(auth_state.clone(), event_sender, agent_source, iap_state);
 
         if ContextFlag::NetworkLogConsole.is_enabled() {
             super::network_logging::init(
@@ -1542,6 +1628,10 @@ impl ServerApiProvider {
                         AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
                             auth_manager.set_needs_reauth(true, ctx);
                         });
+                    }
+                    ServerApiEvent::IapChallengeReceived => {
+                        IapManager::handle(ctx)
+                            .update(ctx, |manager, ctx| manager.handle_challenge(ctx));
                     }
                     // Re-emit the event for subscribers.
                     // TODO: we probably want a different type for the event emitted to subscribers

--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -1,8 +1,8 @@
-use std::sync::{Arc, Mutex};
 use ::settings::{Setting, ToggleableSetting};
 use lazy_static::lazy_static;
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
+use std::sync::{Arc, Mutex};
 use warp_core::channel::ChannelState;
 use warp_core::context_flag::ContextFlag;
 use warp_core::features::FeatureFlag;

--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -1,5 +1,4 @@
 use std::sync::{Arc, Mutex};
-
 use ::settings::{Setting, ToggleableSetting};
 use lazy_static::lazy_static;
 use pathfinder_color::ColorU;
@@ -37,6 +36,8 @@ use crate::auth::auth_state::AuthState;
 use crate::auth::auth_view_modal::AuthViewVariant;
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::autoupdate::{self, AutoupdateStage, AutoupdateState};
+#[cfg(not(target_family = "wasm"))]
+use crate::server::iap::{IapCredentialsState, IapManager, IapManagerEvent};
 use crate::server::ids::ServerId;
 use crate::settings::cloud_preferences::CloudPreferencesSettings;
 use crate::workspace::WorkspaceAction;
@@ -122,6 +123,8 @@ pub enum MainPageAction {
     },
     SignupAnonymousUser,
     OpenUrl(String),
+    #[cfg(not(target_family = "wasm"))]
+    RefreshIapCredentials,
 }
 
 impl MainPageAction {
@@ -229,6 +232,11 @@ impl TypedActionView for MainSettingsPageView {
             MainPageAction::OpenUrl(url) => {
                 ctx.open_url(url);
             }
+            #[cfg(not(target_family = "wasm"))]
+            MainPageAction::RefreshIapCredentials => {
+                IapManager::handle(ctx).update(ctx, |manager, ctx| manager.start_refresh(ctx));
+                ctx.notify();
+            }
         }
     }
 }
@@ -270,6 +278,17 @@ impl MainSettingsPageView {
         widgets.push(Box::new(SettingsSyncWidget::default()));
 
         widgets.push(Box::new(EarnRewardsWidget::default()));
+
+        #[cfg(not(target_family = "wasm"))]
+        if IapManager::as_ref(ctx).is_enabled() {
+            widgets.push(Box::new(IapCredentialsWidget::default()));
+            let iap_manager_handle = IapManager::handle(ctx);
+            ctx.subscribe_to_model(&iap_manager_handle, |_, _, e, ctx| {
+                match e {
+                    IapManagerEvent::StateChanged => ctx.notify(),
+                };
+            })
+        }
 
         if ChannelState::app_version().is_some() {
             widgets.push(Box::new(VersionInfoWidget::default()));
@@ -1049,6 +1068,118 @@ impl LogoutWidget {
                 ctx.dispatch_typed_action(WorkspaceAction::LogOut);
             })
             .finish()
+    }
+}
+
+/// Widget displaying IAP credential state and a refresh button. Only
+/// visible on staging channels where IAP is active.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Default)]
+struct IapCredentialsWidget {
+    refresh_button_mouse_state: MouseStateHandle,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl SettingsWidget for IapCredentialsWidget {
+    type View = MainSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "iap staging gcloud proxy credentials"
+    }
+
+    fn render(
+        &self,
+        _view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        // `is_enabled()` gates widget registration in `MainSettingsPageView::new`,
+        // so `state()` should be `Some` here; bail out defensively though.
+        let Some(state) = IapManager::as_ref(app).state() else {
+            return Empty::new().finish();
+        };
+        let ansi_red: ColorU = appearance.theme().terminal_colors().bright.red.into();
+        let disabled: ColorU = appearance.theme().disabled_ui_text_color().into();
+        let active: ColorU = appearance.theme().active_ui_text_color().into();
+        let (status_text, status_color): (String, ColorU) = match &state {
+            IapCredentialsState::Missing => ("Not yet loaded".to_string(), disabled),
+            IapCredentialsState::Refreshing { .. } => ("Refreshing…".to_string(), active),
+            IapCredentialsState::Loaded { expires_at, .. } => {
+                let remaining = expires_at.saturating_duration_since(instant::Instant::now());
+                let mins = remaining.as_secs() / 60;
+                (format!("Loaded (refreshes in ~{mins}m)"), active)
+            }
+            IapCredentialsState::Failed { message } => (format!("Failed: {message}"), ansi_red),
+            IapCredentialsState::EnvInjected { .. } => {
+                ("Using injected token (WARP_IAP_TOKEN)".to_string(), active)
+            }
+        };
+
+        let is_refreshing = matches!(state, IapCredentialsState::Refreshing { .. });
+
+        let label = Align::new(
+            Text::new_inline(
+                "Staging IAP credentials".to_string(),
+                appearance.ui_font_family(),
+                REGULAR_TEXT_FONT_SIZE,
+            )
+            .with_color(appearance.theme().active_ui_text_color().into())
+            .finish(),
+        )
+        .left()
+        .finish();
+
+        let status = Container::new(
+            appearance
+                .ui_builder()
+                .paragraph(status_text)
+                .with_style(UiComponentStyles {
+                    font_color: Some(status_color),
+                    font_size: Some(REGULAR_TEXT_FONT_SIZE),
+                    ..Default::default()
+                })
+                .build()
+                .finish(),
+        )
+        .with_margin_top(4.)
+        .finish();
+
+        let refresh_button = appearance
+            .ui_builder()
+            .button(
+                ButtonVariant::Secondary,
+                self.refresh_button_mouse_state.clone(),
+            )
+            .with_text_label(if is_refreshing {
+                "Refreshing…".into()
+            } else {
+                "Refresh".into()
+            })
+            .with_style(UiComponentStyles {
+                font_size: Some(12.),
+                padding: Some(Coords::uniform(6.).left(16.).right(16.)),
+                ..Default::default()
+            })
+            .build()
+            .on_click(|ctx, _, _| {
+                ctx.dispatch_typed_action(MainPageAction::RefreshIapCredentials);
+            })
+            .finish();
+
+        let button_row = Container::new(Align::new(refresh_button).left().finish())
+            .with_margin_top(8.)
+            .finish();
+
+        Container::new(
+            Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Start)
+                .with_child(label)
+                .with_child(status)
+                .with_child(button_row)
+                .finish(),
+        )
+        .with_margin_top(VERTICAL_MARGIN)
+        .finish()
     }
 }
 

--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -1104,12 +1104,14 @@ impl SettingsWidget for IapCredentialsWidget {
         let (status_text, status_color): (String, ColorU) = match &state {
             IapCredentialsState::Missing => ("Not yet loaded".to_string(), disabled),
             IapCredentialsState::Refreshing { .. } => ("Refreshing…".to_string(), active),
-            IapCredentialsState::Loaded { expires_at, .. } => {
-                let remaining = expires_at.saturating_duration_since(instant::Instant::now());
+            IapCredentialsState::Loaded(cached) => {
+                let remaining = cached
+                    .expires_at
+                    .saturating_duration_since(instant::Instant::now());
                 let mins = remaining.as_secs() / 60;
                 (format!("Loaded (refreshes in ~{mins}m)"), active)
             }
-            IapCredentialsState::Failed { message } => (format!("Failed: {message}"), ansi_red),
+            IapCredentialsState::Failed { message, .. } => (format!("Failed: {message}"), ansi_red),
             IapCredentialsState::EnvInjected { .. } => {
                 ("Using injected token (WARP_IAP_TOKEN)".to_string(), active)
             }

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -37,6 +37,7 @@ use crate::ai::blocklist::{
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
 use crate::persistence::model::AgentConversationData;
+use crate::server::server_api::ServerApiProvider;
 use crate::terminal::find::TerminalFindModel;
 use crate::terminal::input::message_bar::{Message as InputMessage, MessageItem};
 use crate::terminal::model::block::SerializedBlock;
@@ -1120,10 +1121,11 @@ impl TerminalView {
 
         log::info!("Downloading conversation data from: {proto_url}");
 
+        let client = ServerApiProvider::as_ref(ctx).get_http_client();
+
         // Download the protobuf data
         ctx.spawn(
             async move {
-                let client = http_client::Client::new();
                 let response = client
                     .get(&proto_url)
                     .header("Accept", "application/protobuf")

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -167,6 +167,10 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(voice_input::VoiceInput::new);
     app.add_singleton_model(BlocklistAIPermissions::new);
     app.add_singleton_model(|_| GPUState::new());
+    // Register IapManager in a disabled state (no IapState). The settings
+    // page's `IapManager::as_ref(ctx).is_enabled()` check panics if the
+    // singleton isn't registered, even though it's a no-op on production.
+    app.add_singleton_model(|ctx| crate::server::iap::IapManager::new(None, ctx));
     app.add_singleton_model(|_| RestoredAgentConversations::new(vec![]));
     app.add_singleton_model(OneTimeModalModel::new);
     // Register GlobalResourceHandlesProvider before ServerExperiments which depends on it

--- a/crates/graphql/src/client.rs
+++ b/crates/graphql/src/client.rs
@@ -45,6 +45,10 @@ pub enum GraphQLError {
     /// Not authorized to talk to the staging server.
     #[error("not authorized for staging")]
     StagingAccessBlocked,
+    /// The request was blocked by GCP Identity-Aware Proxy, indicating that
+    /// the IAP bearer token is stale or missing.
+    #[error("blocked by IAP challenge")]
+    IapChallengeBlocked,
     #[error("received non-OK response code {status}")]
     HttpError { status: StatusCode, body: String },
     #[error("Failed to deserialize GraphQL response: {0:?}")]
@@ -132,6 +136,11 @@ where
             log::debug!("{operation_name} request to /graphql/v2 succeeded.");
         }
         status_code => {
+            // Check for IAP challenge first — IAP rejects with 302/401/403 and its own
+            // `x-goog-iap-generated-response` header.
+            if http_client::iap::is_iap_challenge(status_code, response.headers()) {
+                return Err(GraphQLError::IapChallengeBlocked);
+            }
             if status_code == StatusCode::FORBIDDEN && ChannelState::uses_staging_server() {
                 // Both our server and Cloud Armor can send back HTTP 403 errors.
                 // Since Cloud Armor sends back an HTML error page, check for that to determine

--- a/crates/http_client/src/iap.rs
+++ b/crates/http_client/src/iap.rs
@@ -1,0 +1,21 @@
+/// The response header set by GCP Identity-Aware Proxy on its generated responses.
+pub const IAP_GENERATED_RESPONSE_HEADER: &str = "x-goog-iap-generated-response";
+
+/// HTTP header used to attach the IAP bearer token to outbound requests.
+pub const IAP_PROXY_AUTH_HEADER: &str = "Proxy-Authorization";
+
+/// Returns `true` if the given status + headers appear to be an IAP-generated
+/// challenge (302, 401, or 403 with the IAP response header present). Useful
+/// for detecting stale credentials and triggering a re-fetch.
+pub fn is_iap_challenge(status: reqwest::StatusCode, headers: &http::HeaderMap) -> bool {
+    let is_challenge_status = status == reqwest::StatusCode::FOUND
+        || status == reqwest::StatusCode::UNAUTHORIZED
+        || status == reqwest::StatusCode::FORBIDDEN;
+
+    is_challenge_status && headers.get(IAP_GENERATED_RESPONSE_HEADER).is_some()
+}
+
+/// Source of the current IAP bearer token.
+pub trait IapTokenProvider: Send + Sync {
+    fn cached_token(&self) -> Option<String>;
+}

--- a/crates/http_client/src/lib.rs
+++ b/crates/http_client/src/lib.rs
@@ -224,10 +224,9 @@ impl Client {
     }
 
     pub fn patch<U: IntoUrl + Clone>(&self, url: U) -> RequestBuilder<'_> {
-        self.builder(
-            self.wrapped.patch(url.clone()),
-            Self::include_warp_http_headers(url),
-        )
+        let include_warp_headers = Self::include_warp_http_headers(url.clone());
+        let iap_token = self.iap_token_for(url.clone());
+        self.builder(self.wrapped.patch(url), include_warp_headers, iap_token)
     }
 
     pub fn delete<U: IntoUrl + Clone>(&self, url: U) -> RequestBuilder<'_> {

--- a/crates/http_client/src/lib.rs
+++ b/crates/http_client/src/lib.rs
@@ -1,5 +1,8 @@
+pub mod iap;
+
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, future};
 
@@ -19,6 +22,8 @@ use serde::de::DeserializeOwned;
 use warp_core::channel::{Channel, ChannelState};
 use warp_core::operating_system_info::OperatingSystemInfo;
 use warp_core::{execution_mode, report_error};
+
+use crate::iap::{IAP_PROXY_AUTH_HEADER, IapTokenProvider};
 
 pub mod headers {
     /// Custom Warp header indicating the version of the Warp app.
@@ -60,6 +65,11 @@ pub struct Client {
 
     /// A callback that is executed on after each response is received.
     after_response_received: Option<ResponseHookFn>,
+
+    /// If set, provides IAP bearer tokens to attach as `Proxy-Authorization`
+    /// headers on outbound requests to the Warp staging server. Wired in by
+    /// the app layer on IAP-enabled builds (staging).
+    iap_token_provider: Option<Arc<dyn IapTokenProvider>>,
 }
 
 /// Type for 'hook' functions to be executed prior to sending a request. A reference to the
@@ -155,6 +165,7 @@ impl Client {
             wrapped: client,
             before_request_sent: None,
             after_response_received: None,
+            iap_token_provider: None,
         })
     }
 
@@ -166,10 +177,15 @@ impl Client {
         self.after_response_received = Some(hook_fn);
     }
 
+    pub fn set_iap_token_provider(&mut self, provider: Arc<dyn IapTokenProvider>) {
+        self.iap_token_provider = Some(provider);
+    }
+
     fn builder(
         &self,
         wrapped: reqwest::RequestBuilder,
         include_warp_headers: bool,
+        iap_token: Option<String>,
     ) -> RequestBuilder<'_> {
         let mut builder = RequestBuilder {
             wrapped,
@@ -182,28 +198,29 @@ impl Client {
             builder = Self::add_warp_http_headers(builder);
         }
 
+        if let Some(token) = iap_token {
+            builder = builder.header(IAP_PROXY_AUTH_HEADER, format!("Bearer {token}"));
+        }
+
         builder
     }
 
     pub fn get<U: IntoUrl + Clone>(&self, url: U) -> RequestBuilder<'_> {
-        self.builder(
-            self.wrapped.get(url.clone()),
-            Self::include_warp_http_headers(url),
-        )
+        let include_warp_headers = Self::include_warp_http_headers(url.clone());
+        let iap_token = self.iap_token_for(url.clone());
+        self.builder(self.wrapped.get(url), include_warp_headers, iap_token)
     }
 
     pub fn post<U: IntoUrl + Clone>(&self, url: U) -> RequestBuilder<'_> {
-        self.builder(
-            self.wrapped.post(url.clone()),
-            Self::include_warp_http_headers(url),
-        )
+        let include_warp_headers = Self::include_warp_http_headers(url.clone());
+        let iap_token = self.iap_token_for(url.clone());
+        self.builder(self.wrapped.post(url), include_warp_headers, iap_token)
     }
 
     pub fn put<U: IntoUrl + Clone>(&self, url: U) -> RequestBuilder<'_> {
-        self.builder(
-            self.wrapped.put(url.clone()),
-            Self::include_warp_http_headers(url),
-        )
+        let include_warp_headers = Self::include_warp_http_headers(url.clone());
+        let iap_token = self.iap_token_for(url.clone());
+        self.builder(self.wrapped.put(url), include_warp_headers, iap_token)
     }
 
     pub fn patch<U: IntoUrl + Clone>(&self, url: U) -> RequestBuilder<'_> {
@@ -214,10 +231,21 @@ impl Client {
     }
 
     pub fn delete<U: IntoUrl + Clone>(&self, url: U) -> RequestBuilder<'_> {
-        self.builder(
-            self.wrapped.delete(url.clone()),
-            Self::include_warp_http_headers(url),
-        )
+        let include_warp_headers = Self::include_warp_http_headers(url.clone());
+        let iap_token = self.iap_token_for(url.clone());
+        self.builder(self.wrapped.delete(url), include_warp_headers, iap_token)
+    }
+
+    /// Returns the IAP bearer token to attach to a request targeting
+    /// `url`, scoped to the Warp server's origin.
+    fn iap_token_for<U: IntoUrl>(&self, url: U) -> Option<String> {
+        let provider = self.iap_token_provider.as_ref()?;
+        let url = url.into_url().ok()?;
+        let server_url = reqwest::Url::parse(ChannelState::server_root_url().as_ref()).ok()?;
+        if url.origin() != server_url.origin() {
+            return None;
+        }
+        provider.cached_token()
     }
 
     /// Helper method to determine if the request should include warp-specific headers. The only case
@@ -322,6 +350,11 @@ impl Client {
     }
 
     pub async fn execute(&self, request: Request) -> reqwest::Result<Response> {
+        self.execute_inner(request).await
+    }
+
+    /// Core request execution logic shared by all platforms.
+    async fn execute_inner(&self, request: Request) -> reqwest::Result<Response> {
         let Request {
             wrapped: request,
             serialized_payload,
@@ -692,18 +725,20 @@ impl<'c> oauth2::AsyncHttpClient<'c> for Client {
     type Future = Pin<Box<dyn Future<Output = Result<oauth2::HttpResponse, Self::Error>> + 'c>>;
     #[cfg(not(target_arch = "wasm32"))]
     type Future =
-        Pin<Box<dyn Future<Output = Result<oauth2::HttpResponse, Self::Error>> + Send + Sync + 'c>>;
+        Pin<Box<dyn Future<Output = Result<oauth2::HttpResponse, Self::Error>> + Send + 'c>>;
 
     fn call(&'c self, request: oauth2::HttpRequest) -> Self::Future {
         Box::pin(async move {
-            let include_warp_headers = Self::include_warp_http_headers(request.uri().to_string());
+            let uri = request.uri().to_string();
+            let include_warp_headers = Self::include_warp_http_headers(uri.clone());
+            let iap_token = self.iap_token_for(uri);
             let builder = reqwest::RequestBuilder::from_parts(
                 self.wrapped.clone(),
                 request.try_into().map_err(Box::new)?,
             );
 
             let response = self
-                .builder(builder, include_warp_headers)
+                .builder(builder, include_warp_headers, iap_token)
                 .send()
                 .await
                 .map_err(Box::new)?;

--- a/crates/http_server/Cargo.toml
+++ b/crates/http_server/Cargo.toml
@@ -12,3 +12,4 @@ tokio.workspace = true
 tower.workspace = true
 tower-http = { workspace = true, features = ["trace", "cors"] } 
 warpui.workspace = true
+warp_core.workspace = true

--- a/crates/http_server/src/lib.rs
+++ b/crates/http_server/src/lib.rs
@@ -71,7 +71,7 @@ impl HttpServer {
             Channel::Dev => PORT_BASE + 2,
             Channel::Local => PORT_BASE + 3,
             Channel::Integration => PORT_BASE + 4,
-            Channel::OpenWarp => PORT_BASE + 5,
+            Channel::Oss => PORT_BASE + 5,
         }
     }
 }

--- a/crates/http_server/src/lib.rs
+++ b/crates/http_server/src/lib.rs
@@ -1,11 +1,12 @@
 use std::net::SocketAddr;
 
 use tower_http::trace::TraceLayer;
+use warp_core::channel::{Channel, ChannelState};
 use warpui::{Entity, ModelContext, SingletonEntity};
 
 // Spells "Warp" - should hopefully not conflict with other ports.
 // Does not conflict with known ports on https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
-const PORT: u16 = 9277;
+const PORT_BASE: u16 = 9277;
 
 /// A singleton model for the small HTTP server that is run by the Warp client.
 pub struct HttpServer {
@@ -46,13 +47,32 @@ impl HttpServer {
         }
 
         runtime.spawn(async move {
-            let addr = SocketAddr::from(([127, 0, 0, 1], PORT));
-            let listener = tokio::net::TcpListener::bind(addr).await?;
+            let addr = SocketAddr::from(([127, 0, 0, 1], Self::port()));
+            let listener = match tokio::net::TcpListener::bind(addr).await {
+                Ok(listener) => listener,
+                Err(err) => {
+                    log::error!("Failed to bind local HTTP server to {addr}: {err}");
+                    return;
+                }
+            };
 
-            axum::serve(listener, root.layer(TraceLayer::new_for_http())).await
+            if let Err(err) = axum::serve(listener, root.layer(TraceLayer::new_for_http())).await {
+                log::error!("Local HTTP server exited with error: {err}");
+            }
         });
 
         Ok(runtime)
+    }
+
+    pub fn port() -> u16 {
+        match ChannelState::channel() {
+            Channel::Stable => PORT_BASE,
+            Channel::Preview => PORT_BASE + 1,
+            Channel::Dev => PORT_BASE + 2,
+            Channel::Local => PORT_BASE + 3,
+            Channel::Integration => PORT_BASE + 4,
+            Channel::OpenWarp => PORT_BASE + 5,
+        }
     }
 }
 

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -39,6 +39,7 @@ pub fn main() -> Result<()> {
             logfile_name: "warp_integration.log".into(),
             server_config: WarpServerConfig {
                 firebase_auth_api_key: "".into(),
+                iap_config: None,
                 // Use an IP in the IANA testing range, with the TCP discard port, to
                 // black-hole server traffic.
                 server_root_url: "http://192.0.2.0:9".into(),

--- a/crates/warp_core/src/channel/config.rs
+++ b/crates/warp_core/src/channel/config.rs
@@ -49,6 +49,7 @@ pub struct WarpServerConfig {
     pub firebase_auth_api_key: Cow<'static, str>,
     /// Configuration for GCP Identity-Aware Proxy authentication, present only on
     /// staging builds. [`None`] on production builds.
+    #[serde(default)]
     pub iap_config: Option<IapConfig>,
 }
 

--- a/crates/warp_core/src/channel/config.rs
+++ b/crates/warp_core/src/channel/config.rs
@@ -27,6 +27,15 @@ pub struct ChannelConfig {
     pub mcp_static_config: Option<McpStaticConfig>,
 }
 
+/// Configuration for GCP Identity-Aware Proxy authentication, present only on staging builds.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IapConfig {
+    /// The IAP OAuth2 client ID used as the audience for identity tokens.
+    pub audiences: Cow<'static, str>,
+    /// The service account email to impersonate when acquiring IAP credentials.
+    pub service_account_email: Cow<'static, str>,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct WarpServerConfig {
     /// The root URL for the standard server pool.
@@ -38,6 +47,9 @@ pub struct WarpServerConfig {
     pub session_sharing_server_url: Option<Cow<'static, str>>,
     /// The API key to use when making requests to Firebase Authentication endpoints.
     pub firebase_auth_api_key: Cow<'static, str>,
+    /// Configuration for GCP Identity-Aware Proxy authentication, present only on
+    /// staging builds. [`None`] on production builds.
+    pub iap_config: Option<IapConfig>,
 }
 
 impl WarpServerConfig {
@@ -47,6 +59,7 @@ impl WarpServerConfig {
             rtc_server_url: "wss://rtc.app.warp.dev/graphql/v2".into(),
             session_sharing_server_url: Some("wss://sessions.app.warp.dev".into()),
             firebase_auth_api_key: "AIzaSyBdy3O3S9hrdayLJxJ7mriBR4qgUaUygAs".into(),
+            iap_config: None,
         }
     }
 }

--- a/crates/warp_core/src/channel/state.rs
+++ b/crates/warp_core/src/channel/state.rs
@@ -7,7 +7,8 @@ use url::{Origin, ParseError, Url};
 
 use super::Channel;
 use crate::channel::config::{
-    ChannelConfig, McpOAuthProviderConfig, OzConfig, RudderStackDestination, WarpServerConfig,
+    ChannelConfig, IapConfig, McpOAuthProviderConfig, OzConfig, RudderStackDestination,
+    WarpServerConfig,
 };
 use crate::features::FeatureFlag;
 use crate::AppId;
@@ -213,6 +214,10 @@ impl ChannelState {
             .server_config
             .firebase_auth_api_key
             .clone()
+    }
+
+    pub fn iap_config() -> Option<IapConfig> {
+        CHANNEL_STATE.lock().config.server_config.iap_config.clone()
     }
 
     pub fn ws_server_url() -> Cow<'static, str> {


### PR DESCRIPTION
on staging builds, the new iap manager will inject Proxy-Auth headers in the http client headers.

A similar thing is done with the `AuthState` / `AuthManager`...

#### Also includes a staging-only view of iap credentials:

<img width="1464" height="809" alt="image" src="https://github.com/user-attachments/assets/93911ead-231f-45f6-ba1c-1485f0f30646" />


## Audit logging

we dont get to see WHO is making the requests (we need to generate an iap token via service account impersonation because of _reasons_) so it looks like all requests are coming in from the same IAP user (although... you'll still need to be logged in normally with an Auth Bearer token as yourself like normal (except for non-auth'd endpoints))

but we can see who & when this SA got impersonated with [these audit logs](https://console.cloud.google.com/logs/query;query=protoPayload.serviceName%3D%22iamcredentials.googleapis.com%22%0AprotoPayload.methodName%3D%22GenerateAccessToken%22%0AprotoPayload.request.name%3D%22projects%2F-%2FserviceAccounts%2Fiap-access@warp-server-staging.iam.gserviceaccount.com%22;cursorTimestamp=2026-04-24T18:09:41.026309487Z?project=warp-server-staging)
