### PR TITLE
feat(ai): auto-discover models from /v1/models for custom inference endpoints

### DIFF
--- a/app/src/ai/discover_models.rs
+++ b/app/src/ai/discover_models.rs
@@ -1,0 +1,118 @@
+//! Discover models available from an OpenAI-compatible custom inference
+//! endpoint by calling its `/models` endpoint and parsing the response.
+//!
+//! Wired into the "Fetch from endpoint" button in
+//! [`crate::settings_view::custom_inference_modal`] so a user does not have
+//! to type out every model name when configuring a [`CustomEndpoint`].
+
+use anyhow::{anyhow, Context};
+use serde::Deserialize;
+
+/// Maximum response body size we'll try to parse from `/models`. Reqwest has
+/// already buffered the body by the time we check, so this only caps the work
+/// the JSON parser does — not the memory the HTTP client allocates.
+const MAX_RESPONSE_BYTES: usize = 1024 * 1024; // 1 MiB
+
+#[derive(Debug, Deserialize)]
+struct ModelsResponse {
+    data: Vec<ModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelEntry {
+    id: String,
+}
+
+/// Hit `<base_url>/models` with bearer auth and return the list of model IDs.
+///
+/// `base_url` is the user-provided endpoint root (e.g. `https://openrouter.ai/api/v1`).
+/// A trailing slash is tolerated. Empty model IDs are filtered out.
+pub async fn discover_models(
+    client: &http_client::Client,
+    base_url: &str,
+    api_key: &str,
+) -> anyhow::Result<Vec<String>> {
+    let base_trimmed = base_url.trim().trim_end_matches('/');
+    if base_trimmed.is_empty() {
+        return Err(anyhow!("Endpoint URL is empty"));
+    }
+    if api_key.trim().is_empty() {
+        return Err(anyhow!("API key is empty"));
+    }
+    let url = format!("{base_trimmed}/models");
+
+    let response = client
+        .get(&url)
+        .bearer_auth(api_key)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .with_context(|| format!("network error fetching {url}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let snippet: String = body.chars().take(200).collect();
+        return Err(anyhow!(
+            "endpoint returned HTTP {status}: {snippet}",
+            status = status,
+            snippet = snippet
+        ));
+    }
+
+    let bytes = response.bytes().await.context("reading response body")?;
+    if bytes.len() > MAX_RESPONSE_BYTES {
+        return Err(anyhow!(
+            "response body too large: {} bytes (max {})",
+            bytes.len(),
+            MAX_RESPONSE_BYTES
+        ));
+    }
+
+    let parsed: ModelsResponse =
+        serde_json::from_slice(&bytes).context("response was not OpenAI-compatible JSON")?;
+
+    let ids: Vec<String> = parsed
+        .data
+        .into_iter()
+        .map(|entry| entry.id)
+        .filter(|id| !id.trim().is_empty())
+        .collect();
+
+    if ids.is_empty() {
+        return Err(anyhow!("endpoint returned no models"));
+    }
+
+    Ok(ids)
+}
+
+/// Merge `discovered` model IDs into `existing` rows. Returns the IDs that
+/// were not already present (in the order they appeared in `discovered`).
+///
+/// "Already present" matches case-insensitively on the row name and skips
+/// rows whose name field is blank, so a freshly-opened modal with one empty
+/// row is treated as "no existing models" rather than blocking the merge.
+pub fn new_model_ids<'a>(discovered: &'a [String], existing: &[String]) -> Vec<&'a str> {
+    let existing_lower: std::collections::HashSet<String> = existing
+        .iter()
+        .map(|name| name.trim().to_lowercase())
+        .filter(|name| !name.is_empty())
+        .collect();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for id in discovered {
+        let key = id.trim().to_lowercase();
+        if key.is_empty() {
+            continue;
+        }
+        if existing_lower.contains(&key) || !seen.insert(key) {
+            continue;
+        }
+        out.push(id.as_str());
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "discover_models_tests.rs"]
+mod tests;

--- a/app/src/ai/discover_models_tests.rs
+++ b/app/src/ai/discover_models_tests.rs
@@ -1,0 +1,193 @@
+//! Tests for [`super::discover_models`] and [`super::new_model_ids`].
+//!
+//! Network paths use `mockito::Server` against `http_client::Client::new_for_test()`.
+
+use futures::executor::block_on;
+use mockito::Server;
+
+use super::{discover_models, new_model_ids};
+
+fn test_client() -> http_client::Client {
+    http_client::Client::new_for_test()
+}
+
+#[test]
+fn returns_model_ids_on_happy_path() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/models")
+        .match_header("authorization", "Bearer sk-test")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+                "object": "list",
+                "data": [
+                    {"id": "gpt-4o", "object": "model"},
+                    {"id": "gpt-4o-mini", "object": "model"},
+                    {"id": "o1-preview", "object": "model"}
+                ]
+            }"#,
+        )
+        .create();
+
+    let result = block_on(discover_models(&test_client(), &server.url(), "sk-test")).unwrap();
+
+    mock.assert();
+    assert_eq!(result, vec!["gpt-4o", "gpt-4o-mini", "o1-preview"]);
+}
+
+#[test]
+fn tolerates_trailing_slash_on_base_url() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/models")
+        .with_status(200)
+        .with_body(r#"{"data":[{"id":"only-one"}]}"#)
+        .create();
+
+    let url_with_slash = format!("{}/", server.url());
+    let result = block_on(discover_models(&test_client(), &url_with_slash, "k")).unwrap();
+
+    mock.assert();
+    assert_eq!(result, vec!["only-one"]);
+}
+
+#[test]
+fn rejects_empty_url() {
+    let err = block_on(discover_models(&test_client(), "  ", "k")).unwrap_err();
+    assert!(err.to_string().contains("URL is empty"));
+}
+
+#[test]
+fn rejects_empty_api_key() {
+    let err = block_on(discover_models(
+        &test_client(),
+        "https://example.com/v1",
+        "  ",
+    ))
+    .unwrap_err();
+    assert!(err.to_string().contains("API key is empty"));
+}
+
+#[test]
+fn surfaces_401_unauthorized() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/models")
+        .with_status(401)
+        .with_body("Invalid API key")
+        .create();
+
+    let err = block_on(discover_models(&test_client(), &server.url(), "bad-key")).unwrap_err();
+    mock.assert();
+    let msg = err.to_string();
+    assert!(msg.contains("401"), "unexpected error: {msg}");
+    assert!(msg.contains("Invalid API key"), "unexpected error: {msg}");
+}
+
+#[test]
+fn surfaces_404_not_found() {
+    let mut server = Server::new();
+    let mock = server.mock("GET", "/models").with_status(404).create();
+
+    let err = block_on(discover_models(&test_client(), &server.url(), "k")).unwrap_err();
+    mock.assert();
+    assert!(err.to_string().contains("404"));
+}
+
+#[test]
+fn fails_on_non_json_response() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/models")
+        .with_status(200)
+        .with_body("<html>oops, you hit a captive portal</html>")
+        .create();
+
+    let err = block_on(discover_models(&test_client(), &server.url(), "k")).unwrap_err();
+    mock.assert();
+    assert!(err.to_string().contains("OpenAI-compatible JSON"));
+}
+
+#[test]
+fn fails_on_missing_data_field() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/models")
+        .with_status(200)
+        .with_body(r#"{"models":[{"id":"x"}]}"#)
+        .create();
+
+    let err = block_on(discover_models(&test_client(), &server.url(), "k")).unwrap_err();
+    mock.assert();
+    assert!(err.to_string().contains("OpenAI-compatible JSON"));
+}
+
+#[test]
+fn fails_on_empty_model_list() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/models")
+        .with_status(200)
+        .with_body(r#"{"data":[]}"#)
+        .create();
+
+    let err = block_on(discover_models(&test_client(), &server.url(), "k")).unwrap_err();
+    mock.assert();
+    assert!(err.to_string().contains("no models"));
+}
+
+#[test]
+fn filters_empty_ids_but_keeps_nonempty() {
+    let mut server = Server::new();
+    let mock = server
+        .mock("GET", "/models")
+        .with_status(200)
+        .with_body(r#"{"data":[{"id":""},{"id":"keep-me"},{"id":"   "}]}"#)
+        .create();
+
+    let result = block_on(discover_models(&test_client(), &server.url(), "k")).unwrap();
+    mock.assert();
+    assert_eq!(result, vec!["keep-me"]);
+}
+
+#[test]
+fn surfaces_network_error_for_unreachable_endpoint() {
+    let err = block_on(discover_models(
+        &test_client(),
+        "http://127.0.0.1:1/v1",
+        "k",
+    ))
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("network error"), "unexpected error: {msg}");
+}
+
+#[test]
+fn new_model_ids_excludes_existing_case_insensitive() {
+    let discovered = vec![
+        "GPT-4o".to_string(),
+        "gpt-4o-mini".to_string(),
+        "o1-preview".to_string(),
+    ];
+    let existing = vec!["gpt-4o".to_string(), "o1-preview".to_string()];
+    let new_ids = new_model_ids(&discovered, &existing);
+    assert_eq!(new_ids, vec!["gpt-4o-mini"]);
+}
+
+#[test]
+fn new_model_ids_dedups_within_discovery() {
+    let discovered = vec!["a".to_string(), "A".to_string(), "b".to_string()];
+    let existing: Vec<String> = Vec::new();
+    let new_ids = new_model_ids(&discovered, &existing);
+    assert_eq!(new_ids, vec!["a", "b"]);
+}
+
+#[test]
+fn new_model_ids_ignores_blank_existing_rows() {
+    let discovered = vec!["new-model".to_string()];
+    let existing = vec!["".to_string(), "   ".to_string()];
+    let new_ids = new_model_ids(&discovered, &existing);
+    assert_eq!(new_ids, vec!["new-model"]);
+}

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod conversation_details_panel;
 pub(crate) mod conversation_navigation;
 pub(crate) mod conversation_status_ui;
 pub(crate) mod conversation_utils;
+pub(crate) mod discover_models;
 pub(crate) mod document;
 pub(crate) mod get_relevant_files;
 pub mod harness_availability;

--- a/app/src/settings_view/custom_inference_modal.rs
+++ b/app/src/settings_view/custom_inference_modal.rs
@@ -8,12 +8,14 @@ use warpui::elements::{
     Expanded, Flex, MainAxisSize, MouseStateHandle, ParentElement, Radius, Text,
 };
 use warpui::fonts::FamilyId;
+use warpui::r#async::SpawnedFutureHandle;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
+use crate::ai::discover_models::{discover_models, new_model_ids};
 use crate::appearance::Appearance;
 use crate::editor::{
     EditorView, Event as EditorEvent, PropagateAndNoOpNavigationKeys, SingleLineEditorOptions,
@@ -58,6 +60,16 @@ pub enum CustomEndpointModalAction {
     AddModel,
     RemoveModel(usize),
     RemoveEndpoint,
+    FetchModels,
+}
+
+/// Status displayed under the model rows after a "Fetch from endpoint" click.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FetchStatus {
+    Idle,
+    InProgress,
+    Success { added: usize, skipped: usize },
+    Error(String),
 }
 
 struct ModelRow {
@@ -75,9 +87,12 @@ pub struct CustomEndpointModal {
     cancel_button_mouse_state: MouseStateHandle,
     save_button_mouse_state: MouseStateHandle,
     add_model_button_mouse_state: MouseStateHandle,
+    fetch_models_button_mouse_state: MouseStateHandle,
     remove_endpoint_button: ViewHandle<ActionButton>,
     editing_index: Option<usize>,
     url_has_error: bool,
+    fetch_status: FetchStatus,
+    fetch_handle: Option<SpawnedFutureHandle>,
 }
 
 impl CustomEndpointModal {
@@ -212,9 +227,12 @@ impl CustomEndpointModal {
             cancel_button_mouse_state: Default::default(),
             save_button_mouse_state: Default::default(),
             add_model_button_mouse_state: Default::default(),
+            fetch_models_button_mouse_state: Default::default(),
             remove_endpoint_button,
             editing_index,
             url_has_error,
+            fetch_status: FetchStatus::Idle,
+            fetch_handle: None,
         }
     }
 
@@ -280,6 +298,10 @@ impl CustomEndpointModal {
         editing_index: Option<usize>,
         ctx: &mut ViewContext<Self>,
     ) {
+        if let Some(handle) = self.fetch_handle.take() {
+            handle.abort();
+        }
+        self.fetch_status = FetchStatus::Idle;
         self.editing_index = editing_index;
         self.endpoint_name_editor.update(ctx, |editor, ctx| {
             editor.set_buffer_text(endpoint.map(|e| e.name.as_str()).unwrap_or(""), ctx);
@@ -337,6 +359,10 @@ impl CustomEndpointModal {
     }
 
     pub fn on_close(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(handle) = self.fetch_handle.take() {
+            handle.abort();
+        }
+        self.fetch_status = FetchStatus::Idle;
         self.endpoint_name_editor.update(ctx, |editor, ctx| {
             editor.clear_buffer_and_reset_undo_stack(ctx);
         });
@@ -423,6 +449,117 @@ impl CustomEndpointModal {
             let _row = self.model_rows.remove(index);
             ctx.notify();
         }
+    }
+
+    /// Kick off a `/models` fetch against the URL + API key currently in the
+    /// form. If a previous fetch is still in flight, abort it first so the UI
+    /// only ever shows the result of the most-recent click.
+    fn fetch_models(&mut self, ctx: &mut ViewContext<Self>) {
+        let url = self.endpoint_url_editor.as_ref(ctx).buffer_text(ctx);
+        let api_key = self.api_key_editor.as_ref(ctx).buffer_text(ctx);
+        if url.trim().is_empty() || api_key.trim().is_empty() {
+            self.fetch_status =
+                FetchStatus::Error("Endpoint URL and API key are required.".to_string());
+            ctx.notify();
+            return;
+        }
+        if validate_url(&url).is_err() {
+            self.url_has_error = true;
+            self.fetch_status = FetchStatus::Error("Invalid endpoint URL.".to_string());
+            ctx.notify();
+            return;
+        }
+
+        if let Some(handle) = self.fetch_handle.take() {
+            handle.abort();
+        }
+        self.fetch_status = FetchStatus::InProgress;
+        ctx.notify();
+
+        let handle = ctx.spawn(
+            async move {
+                let client = http_client::Client::new();
+                discover_models(&client, &url, &api_key).await
+            },
+            |me, result, ctx| {
+                me.apply_fetch_result(result, ctx);
+            },
+        );
+        self.fetch_handle = Some(handle);
+    }
+
+    fn apply_fetch_result(
+        &mut self,
+        result: anyhow::Result<Vec<String>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.fetch_handle = None;
+        match result {
+            Ok(discovered) => {
+                let existing: Vec<String> = self
+                    .model_rows
+                    .iter()
+                    .map(|row| row.name_editor.as_ref(ctx).buffer_text(ctx))
+                    .collect();
+                let to_add: Vec<String> = new_model_ids(&discovered, &existing)
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect();
+                let added = to_add.len();
+                let skipped = discovered.len().saturating_sub(added);
+
+                if added > 0 {
+                    // Drop the trailing blank row if the user hasn't typed
+                    // anything yet, so we don't leave a stray empty input
+                    // after merging discovered models.
+                    if let Some(last) = self.model_rows.last() {
+                        let name_blank = last
+                            .name_editor
+                            .as_ref(ctx)
+                            .buffer_text(ctx)
+                            .trim()
+                            .is_empty();
+                        let alias_blank = last
+                            .alias_editor
+                            .as_ref(ctx)
+                            .buffer_text(ctx)
+                            .trim()
+                            .is_empty();
+                        if name_blank && alias_blank && self.model_rows.len() == 1 {
+                            self.model_rows.clear();
+                        }
+                    }
+
+                    let font_family = Appearance::as_ref(ctx).ui_font_family();
+                    let text_colors =
+                        crate::settings_view::editor_text_colors(Appearance::as_ref(ctx));
+                    for name in &to_add {
+                        let row = Self::create_model_row(
+                            Some(name),
+                            None,
+                            None,
+                            font_family,
+                            &text_colors,
+                            ctx,
+                        );
+                        let name_editor = row.name_editor.clone();
+                        ctx.subscribe_to_view(&name_editor, |me, editor, event, ctx| {
+                            me.handle_model_editor_event(&editor, event, ctx);
+                        });
+                        let alias_editor = row.alias_editor.clone();
+                        ctx.subscribe_to_view(&alias_editor, |me, editor, event, ctx| {
+                            me.handle_model_editor_event(&editor, event, ctx);
+                        });
+                        self.model_rows.push(row);
+                    }
+                }
+                self.fetch_status = FetchStatus::Success { added, skipped };
+            }
+            Err(err) => {
+                self.fetch_status = FetchStatus::Error(format!("{err:#}"));
+            }
+        }
+        ctx.notify();
     }
 
     fn is_valid(&self, app: &AppContext) -> bool {
@@ -776,30 +913,129 @@ impl View for CustomEndpointModal {
             column.add_child(Container::new(row).with_margin_bottom(12.).finish());
         }
 
-        // + Add model button
-        column.add_child(
-            Container::new(
-                appearance
-                    .ui_builder()
-                    .button(
-                        ButtonVariant::Secondary,
-                        self.add_model_button_mouse_state.clone(),
-                    )
-                    .with_text_label("+ Add model".to_string())
-                    .with_style(UiComponentStyles {
-                        font_size: Some(14.),
-                        padding: Some(Coords::uniform(6.).left(8.).right(8.)),
-                        ..Default::default()
-                    })
-                    .build()
-                    .on_click(move |ctx, _, _| {
-                        ctx.dispatch_typed_action(CustomEndpointModalAction::AddModel);
-                    })
-                    .finish(),
+        // + Add model and Fetch from endpoint buttons
+        let small_button_style = UiComponentStyles {
+            font_size: Some(14.),
+            padding: Some(Coords::uniform(6.).left(8.).right(8.)),
+            ..Default::default()
+        };
+
+        let url_present = !self
+            .endpoint_url_editor
+            .as_ref(app)
+            .buffer_text(app)
+            .trim()
+            .is_empty();
+        let api_key_present = !self
+            .api_key_editor
+            .as_ref(app)
+            .buffer_text(app)
+            .trim()
+            .is_empty();
+        let fetch_enabled = url_present
+            && api_key_present
+            && !self.url_has_error
+            && !matches!(self.fetch_status, FetchStatus::InProgress);
+        let fetch_label = if matches!(self.fetch_status, FetchStatus::InProgress) {
+            "Fetching…".to_string()
+        } else {
+            "Fetch from endpoint".to_string()
+        };
+
+        let add_model_button = appearance
+            .ui_builder()
+            .button(
+                ButtonVariant::Secondary,
+                self.add_model_button_mouse_state.clone(),
             )
-            .with_margin_bottom(24.)
-            .finish(),
+            .with_text_label("+ Add model".to_string())
+            .with_style(small_button_style);
+        let mut fetch_button = appearance
+            .ui_builder()
+            .button(
+                ButtonVariant::Secondary,
+                self.fetch_models_button_mouse_state.clone(),
+            )
+            .with_text_label(fetch_label)
+            .with_style(small_button_style);
+        if !fetch_enabled {
+            fetch_button = fetch_button.disabled();
+        }
+
+        let mut model_buttons_row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(8.);
+        model_buttons_row.add_child(
+            add_model_button
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(CustomEndpointModalAction::AddModel);
+                })
+                .finish(),
         );
+        model_buttons_row.add_child(
+            fetch_button
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(CustomEndpointModalAction::FetchModels);
+                })
+                .finish(),
+        );
+
+        column.add_child(
+            Container::new(model_buttons_row.finish())
+                .with_margin_bottom(8.)
+                .finish(),
+        );
+
+        if let Some((status_text, status_color)) = match &self.fetch_status {
+            FetchStatus::Idle => None,
+            FetchStatus::InProgress => Some((
+                "Fetching models from endpoint…".to_string(),
+                theme.nonactive_ui_text_color().into(),
+            )),
+            FetchStatus::Success { added: 0, skipped } => Some((
+                format!(
+                    "No new models found ({skipped} already configured).",
+                    skipped = skipped
+                ),
+                theme.nonactive_ui_text_color().into(),
+            )),
+            FetchStatus::Success { added, skipped } => Some((
+                if *skipped == 0 {
+                    format!(
+                        "Added {added} model{s} from endpoint.",
+                        s = if *added == 1 { "" } else { "s" }
+                    )
+                } else {
+                    format!(
+                        "Added {added} model{s} ({skipped} already configured).",
+                        s = if *added == 1 { "" } else { "s" }
+                    )
+                },
+                theme.nonactive_ui_text_color().into(),
+            )),
+            FetchStatus::Error(msg) => {
+                Some((format!("Fetch failed: {msg}"), theme.ui_error_color()))
+            }
+        } {
+            column.add_child(
+                Container::new(
+                    Text::new(status_text, appearance.ui_font_family(), LABEL_FONT_SIZE)
+                        .with_color(status_color)
+                        .soft_wrap(true)
+                        .finish(),
+                )
+                .with_margin_bottom(24.)
+                .finish(),
+            );
+        } else {
+            column.add_child(
+                Container::new(Empty::new().finish())
+                    .with_margin_bottom(16.)
+                    .finish(),
+            );
+        }
 
         // Bottom buttons row
         let mut buttons_row = Flex::row()
@@ -935,6 +1171,7 @@ impl TypedActionView for CustomEndpointModal {
             CustomEndpointModalAction::Save => self.save(ctx),
             CustomEndpointModalAction::AddModel => self.add_model(ctx),
             CustomEndpointModalAction::RemoveModel(index) => self.remove_model(*index, ctx),
+            CustomEndpointModalAction::FetchModels => self.fetch_models(ctx),
             CustomEndpointModalAction::RemoveEndpoint => {
                 if let Some(index) = self.editing_index {
                     ctx.emit(CustomEndpointModalEvent::RemoveEndpoint { index });

--- a/specs/gh-11514/PRODUCT.md
+++ b/specs/gh-11514/PRODUCT.md
@@ -1,0 +1,121 @@
+# gh-11514: Auto-discover models from `/v1/models` for custom inference endpoints
+
+## Overview
+
+When a user configures a custom inference endpoint (Settings → AI → Custom
+inference), they currently have to type every model name by hand. Most
+OpenAI-compatible providers expose a `GET /models` catalog, so Warp can fetch
+that list and populate the model rows for the user.
+
+This adds a **"Fetch from endpoint"** button to the custom endpoint modal that
+calls the endpoint's `/models` route with the entered credentials, parses the
+OpenAI-compatible response, and merges the returned model IDs into the modal's
+model rows.
+
+- Issue: [#11514](https://github.com/warpdotdev/warp/issues/11514)
+- Related / duplicate request: [#11586](https://github.com/warpdotdev/warp/issues/11586)
+- Builds on: [#10781](https://github.com/warpdotdev/warp/pull/10781) (custom inference endpoints / BYOK)
+
+This is a user-triggered, additive convenience. It changes nothing about how
+endpoints are persisted or sent on the wire — it only fills in the same model
+rows the user would otherwise type.
+
+## Problem
+
+Manual entry is slow and error-prone, especially for providers that expose
+many model IDs (OpenRouter) or rotate them often. A mistyped model name fails
+silently at request time rather than at configuration time.
+
+## Desired behavior
+
+### The button
+- A **"Fetch from endpoint"** button sits next to **"+ Add model"** in the
+  custom endpoint modal.
+- It is **disabled** unless all of the following hold:
+  - the Endpoint URL field is non-empty,
+  - the API key field is non-empty,
+  - the URL passes the modal's existing validation (HTTPS, has host, not a
+    local/private host — the same rules that gate the Save button).
+- While a fetch is in flight the button shows **"Fetching…"** and is disabled
+  so a second fetch can't be launched on top of the first.
+
+### On click
+1. Warp issues `GET <endpoint-url>/models` with `Authorization: Bearer <api key>`
+   and `Accept: application/json`.
+2. On success, the returned model IDs are merged into the model rows:
+   - IDs not already present (case-insensitive match against existing row
+     names) are appended as new rows.
+   - If the modal currently has a single blank row (the default on open), it is
+     replaced rather than left dangling above the fetched rows.
+   - Aliases the user already typed on existing rows are preserved.
+3. An inline status line below the buttons reports the outcome:
+   - `Added N models from endpoint.`
+   - `Added N models (M already configured).`
+   - `No new models found (M already configured).`
+   - `Fetch failed: <reason>` (rendered in the theme's error color).
+
+### Result states the user can see
+| Situation | Status line |
+|---|---|
+| Fetch returned new IDs | "Added N models from endpoint." |
+| Some new, some already present | "Added N models (M already configured)." |
+| All returned IDs already present | "No new models found (M already configured)." |
+| Network error / unreachable | "Fetch failed: network error fetching …" |
+| 401 / 403 (bad key) | "Fetch failed: endpoint returned HTTP 401 …" |
+| 404 (no `/models` route) | "Fetch failed: endpoint returned HTTP 404 …" |
+| Non-JSON / HTML body | "Fetch failed: response was not OpenAI-compatible JSON" |
+| Valid JSON, empty `data` | "Fetch failed: endpoint returned no models" |
+
+## Invariants and edge cases
+
+- **Discovery never overwrites user input.** It only appends model rows that
+  aren't already present and never edits or removes existing rows or aliases.
+- **Trailing slash tolerance.** `https://host/v1` and `https://host/v1/` both
+  resolve to `https://host/v1/models`.
+- **Empty model IDs are dropped.** Entries in `data[]` with a blank `id` are
+  ignored; if that leaves nothing, the fetch reports "no models" rather than
+  adding blank rows.
+- **In-flight fetch is cancellable.** Closing the modal, or re-prefilling it
+  for a different endpoint, aborts any pending fetch and clears the status.
+- **Same security envelope as Save.** Discovery reuses the modal's URL
+  validation, so it can't be pointed at `http://`, `localhost`, or
+  private/loopback IPs even though Save would reject those too. (This means
+  local providers like Ollama on `http://localhost:11434/v1` are not reachable
+  via this button — that's an intentional consequence of the existing endpoint
+  validation, not a discovery-specific rule, and is called out as a known
+  limitation below.)
+- **Response size is bounded.** Bodies larger than 1 MiB are rejected before
+  JSON parsing.
+
+## Out of scope
+
+- Capability introspection (context window, vision/tool-call support). The
+  `/models` response shape for these fields is non-standard across providers;
+  deferred until there's enough demand.
+- Headless / `oz-cli` configuration of endpoints
+  ([#8937](https://github.com/warpdotdev/warp/issues/8937)).
+- Reaching local (`http://localhost`) providers — blocked by the existing
+  custom-endpoint URL validation, not by this feature. Relaxing that is a
+  separate decision.
+- Team-level sharing of endpoints/aliases
+  ([#11726](https://github.com/warpdotdev/warp/issues/11726)).
+
+## Success criteria
+
+- A user can configure an OpenRouter (or other OpenAI-compatible) endpoint by
+  entering URL + key and clicking "Fetch from endpoint" instead of typing
+  model names.
+- Every failure mode above produces a clear inline message and never a crash,
+  hang, or partially-populated/blank row.
+- Discovery is purely additive: existing rows and aliases are untouched.
+
+## Validation
+
+- Unit tests for `discover_models` cover the happy path plus every failure mode
+  (empty URL, empty key, 401, 404, network error, non-JSON, missing `data`,
+  empty model list, blank-ID filtering, trailing-slash) against a mock HTTP
+  server.
+- Unit tests for the merge helper cover case-insensitive dedup, dedup within a
+  single response, and ignoring blank existing rows.
+- Manual: configure a real OpenRouter endpoint, click Fetch, confirm rows
+  populate; repeat to confirm idempotence ("No new models found").

--- a/specs/gh-11514/TECH.md
+++ b/specs/gh-11514/TECH.md
@@ -1,0 +1,139 @@
+# gh-11514 — `/v1/models` auto-discovery for custom inference endpoints
+
+## Context
+
+[Issue #11514](https://github.com/warpdotdev/warp/issues/11514) asks for a way
+to populate a custom inference endpoint's model list from the provider's
+OpenAI-compatible `GET /models` catalog instead of typing each model ID by
+hand. [#11586](https://github.com/warpdotdev/warp/issues/11586) is an
+independently-filed request for the same feature.
+
+This builds directly on [#10781](https://github.com/warpdotdev/warp/pull/10781),
+which shipped custom inference endpoints (BYOK + arbitrary OpenAI-compatible
+URLs) behind the `CustomInferenceEndpoints` feature flag. That PR established
+the data model and the configuration modal this feature extends:
+
+- `crates/ai/src/api_keys.rs` — `CustomEndpoint { name, url, api_key, models }`
+  and `CustomEndpointModel { name, alias, config_key }`. **Unchanged** by this
+  work; discovery only fills in the same `models` rows the user would type.
+- `app/src/settings_view/custom_inference_modal.rs` — the
+  `CustomEndpointModal` view, its `ModelRow`s, `AddModel`/`RemoveModel`
+  actions, URL validation, and `Save`.
+
+The persisted shape and the request wire format are untouched. This is a
+client-only, additive convenience layer over the existing modal.
+
+## Design
+
+Two pieces:
+
+1. A small, self-contained network/parse helper (`discover_models`) plus a pure
+   merge helper (`new_model_ids`), both unit-testable without UI.
+2. Modal wiring: a "Fetch from endpoint" button that runs the helper as a
+   background task and merges the result into the existing model rows.
+
+### `app/src/ai/discover_models.rs` (new)
+
+```rust
+pub async fn discover_models(
+    client: &http_client::Client,
+    base_url: &str,
+    api_key: &str,
+) -> anyhow::Result<Vec<String>>
+```
+
+- Trims `base_url`, strips a trailing `/`, and requests `<base>/models`.
+- Rejects empty URL / empty key up front with a clear error.
+- `GET` with `bearer_auth(api_key)` + `Accept: application/json` via the
+  existing `http_client::Client` wrapper (same client used elsewhere in the
+  app, e.g. `load_ai_conversation.rs`).
+- Non-2xx → error carrying the status and a 200-char body snippet.
+- Caps the buffered body at `MAX_RESPONSE_BYTES` (1 MiB) before parsing.
+- Parses the OpenAI-compatible shape with serde:
+  ```rust
+  struct ModelsResponse { data: Vec<ModelEntry> }
+  struct ModelEntry { id: String }
+  ```
+  Unknown fields are ignored, so provider-specific extras don't break parsing.
+- Filters blank IDs; empty result → error ("endpoint returned no models").
+
+```rust
+pub fn new_model_ids<'a>(discovered: &'a [String], existing: &[String]) -> Vec<&'a str>
+```
+
+- Returns discovered IDs not already present, preserving discovery order.
+- Case-insensitive match against existing row names; dedups within the
+  discovered list; ignores blank existing rows (so a fresh modal with one empty
+  row counts as "no existing models").
+
+### Modal wiring — `custom_inference_modal.rs`
+
+- New `CustomEndpointModalAction::FetchModels`.
+- New private `FetchStatus` enum: `Idle | InProgress | Success { added, skipped } | Error(String)`.
+- New fields on `CustomEndpointModal`: `fetch_models_button_mouse_state`,
+  `fetch_status: FetchStatus`, `fetch_handle: Option<SpawnedFutureHandle>`.
+- `fetch_models(&mut self, ctx)`:
+  - Reads URL + key from the editors; guards on empty and on `validate_url`
+    (the modal's existing HTTPS/host/non-private check), surfacing an inline
+    error instead of firing a request.
+  - Aborts any prior in-flight `fetch_handle`, sets `InProgress`, and spawns the
+    request via `ctx.spawn(async { discover_models(&Client::new(), &url, &key).await }, on_done)`.
+- `apply_fetch_result(result, ctx)` (the spawn continuation):
+  - On `Ok`, collects existing row names, computes `new_model_ids`, and appends
+    a `ModelRow` per new ID (subscribing each new editor to the existing model
+    editor event handler). If the only row was the default blank row, it's
+    cleared first so no stray empty input remains. Sets
+    `Success { added, skipped }`.
+  - On `Err`, sets `Error(format!("{err:#}"))` (anyhow chain).
+- Render: "Fetch from endpoint" button beside "+ Add model", disabled unless URL
+  + key are present, the URL is valid, and no fetch is in flight; label flips to
+  "Fetching…" during the request. A status line renders below, in the error
+  color for `Error`.
+- Lifecycle: `prefill` and `on_close` abort any in-flight handle and reset
+  `fetch_status` to `Idle`, so a stale fetch can't land on a different endpoint
+  or a closed modal.
+
+## Cancellation & threading
+
+`ctx.spawn` runs the future on a background executor and invokes the
+continuation back on the UI thread, where it mutates `model_rows` and calls
+`ctx.notify()`. The returned `SpawnedFutureHandle` is stored so the modal can
+`abort()` it on close / re-prefill / a superseding fetch. Dropping/aborting is
+safe: the continuation simply never runs.
+
+## Security / resource considerations
+
+- **No new reachable surface.** Discovery reuses `validate_url`, so it inherits
+  the endpoint allow-list (HTTPS only, must have a host, no localhost / private
+  / loopback). It can't be pointed anywhere `Save` couldn't already point.
+- **Bounded body.** 1 MiB cap before JSON parsing guards against a hostile or
+  misconfigured endpoint streaming an oversized response.
+- **Bearer key handling.** The key is read from the existing password editor and
+  sent only to the user-entered endpoint over the bearer header; it is not
+  logged. Error snippets are capped at 200 chars and come from the response
+  body, not the request.
+
+## Testing
+
+- `app/src/ai/discover_models_tests.rs` (14 tests) using `mockito::Server`
+  against `http_client::Client::new_for_test()`:
+  happy path (asserts the `Authorization: Bearer` header), trailing-slash,
+  empty-URL, empty-key, 401, 404, non-JSON, missing `data`, empty `data`,
+  blank-ID filtering, network-unreachable; plus three `new_model_ids` cases
+  (case-insensitive exclude, intra-response dedup, blank-existing-row).
+- These cover every branch in the helper without standing up the UI. The modal
+  wiring is thin glue over the tested helper; behavior there is validated
+  manually (configure a real OpenRouter endpoint, Fetch, confirm rows populate
+  and re-fetch is idempotent).
+
+## Rollout
+
+Lives behind the same `CustomInferenceEndpoints` feature flag as the modal it
+extends — no separate flag. No migration: persisted `CustomEndpoint` data and
+the request wire format are unchanged.
+
+## Out of scope (see PRODUCT.md)
+
+Capability introspection (context window / vision), headless config (#8937),
+reaching `http://localhost` providers (blocked by endpoint validation), and
+team-level endpoint sharing (#11726).


### PR DESCRIPTION
## Status: DRAFT — spec-first, awaiting `ready-to-implement` on #11514

Opening as a **draft** deliberately so it doesn't kick off review before the
linked issue is promoted. [#11514](https://github.com/warpdotdev/warp/issues/11514)
is currently `ready-to-spec`; this PR supplies that spec (and the
implementation it describes) for review. Please **don't** treat it as
ready-to-review until #11514 carries `ready-to-implement`.

## What this adds

A **"Fetch from endpoint"** button in the custom inference endpoint modal that
calls the provider's OpenAI-compatible `GET /models` catalog and populates the
model rows, so users don't type every model ID by hand. Builds on #10781
(custom inference endpoints / BYOK).

This also covers the independently-filed [#11586](https://github.com/warpdotdev/warp/issues/11586),
which requests the same feature.

## Specs

- [`specs/gh-11514/PRODUCT.md`](specs/gh-11514/PRODUCT.md) — user-facing behavior, status states, invariants, out-of-scope.
- [`specs/gh-11514/TECH.md`](specs/gh-11514/TECH.md) — `discover_models` helper, merge logic, modal wiring, cancellation, security envelope.

## Implementation summary

- `app/src/ai/discover_models.rs` — `discover_models(client, base_url, api_key)`
  hits `<base>/models` with bearer auth, parses the OpenAI-compatible
  `{ "data": [{ "id": … }] }` shape, bounds the body at 1 MiB, and filters
  blank IDs. `new_model_ids` merges results case-insensitively without touching
  existing rows or aliases.
- `app/src/settings_view/custom_inference_modal.rs` — the button + inline
  status (`Fetching…` / `Added N models` / `No new models` / `Fetch failed: …`),
  run as a cancellable background task. Reuses the modal's existing URL
  validation, so discovery inherits the same HTTPS/non-private allow-list as
  Save.

No change to persisted `CustomEndpoint` data or the request wire format. Gated
by the existing `CustomInferenceEndpoints` feature flag.

## Tests

14 unit tests for `discover_models` (happy path + 401/404/network/non-JSON/
missing-`data`/empty/blank-ID/trailing-slash, plus the three merge cases)
against a `mockito` server. `cargo test -p warp --lib ai::discover_models`
passes; clippy + fmt clean.

Refs #11514. Refs #11586.