### PR TITLE
fix: persist custom/BYOK model selection across profile reconciliation (#11564)

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -1178,6 +1178,16 @@ impl LLMPreferences {
     ///
     /// Called both when the model list is refreshed from the server and when
     /// BYOK API keys change (since `RequiresUpgrade` usability is BYOK-aware).
+    ///
+    /// A saved selection is considered usable if it resolves to a usable
+    /// server model *or* an enabled custom/BYOK model (`custom_llms`). This
+    /// must stay symmetric with the model getters (e.g. `get_preferred_base_model`),
+    /// which resolve against both collections — otherwise a custom model id
+    /// (a `config_key` UUID absent from the server `choices`) is treated as
+    /// unusable here and the profile is silently reset to the default `auto`
+    /// model on restart. Custom-model clearing when custom inference is
+    /// *disabled* is handled separately by
+    /// `sanitize_disabled_custom_model_preferences`.
     fn reconcile_disabled_model_preferences(&self, ctx: &mut ModelContext<Self>) {
         let profiles_model = AIExecutionProfilesModel::handle(ctx);
         profiles_model.update(ctx, |profiles, ctx| {
@@ -1191,7 +1201,10 @@ impl LLMPreferences {
                     let effective_base_model_usable = self
                         .models_by_feature
                         .agent_mode
-                        .usable_info_for_id(effective_base_model_id, ctx);
+                        .usable_info_for_id(effective_base_model_id, ctx)
+                        .or_else(|| {
+                            self.custom_llm_info_for_id_if_enabled(effective_base_model_id, ctx)
+                        });
                     let effective_base_model_unusable = effective_base_model_usable.is_none();
                     let effective_base_model_is_configurable = effective_base_model_usable
                         .is_some_and(|info| info.context_window.is_configurable);
@@ -1210,6 +1223,7 @@ impl LLMPreferences {
                             .models_by_feature
                             .coding
                             .usable_info_for_id(preferred_llm_id, ctx)
+                            .or_else(|| self.custom_llm_info_for_id_if_enabled(preferred_llm_id, ctx))
                             .is_none()
                         {
                             profiles.set_coding_model(profile_id, None, ctx);
@@ -1219,6 +1233,7 @@ impl LLMPreferences {
                         if self
                             .get_cli_agent_available()
                             .usable_info_for_id(preferred_llm_id, ctx)
+                            .or_else(|| self.custom_llm_info_for_id_if_enabled(preferred_llm_id, ctx))
                             .is_none()
                         {
                             profiles.set_cli_agent_model(profile_id, None, ctx);

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -343,3 +343,138 @@ fn removing_endpoint_purges_all_its_models_from_custom_llms() {
     assert_eq!(infos.len(), 1);
     assert_eq!(infos[0].id.as_str(), "uuid-k1");
 }
+
+// -- reconcile_disabled_model_preferences: custom/BYOK persistence --
+
+use warpui::App;
+
+use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::mcp::TemplatableMCPServerManager;
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::sync_queue::SyncQueue;
+use crate::settings::PrivacySettings;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::workspaces::team_tester::TeamTesterStatus;
+use crate::LaunchMode;
+
+/// Installs the minimal singleton graph needed to construct an
+/// `AIExecutionProfilesModel` and run `reconcile_disabled_model_preferences`.
+///
+/// Uses a logged-in auth state because `is_custom_inference_enabled` (and thus
+/// `custom_inference_enabled`) returns `false` for anonymous/logged-out users,
+/// which would short-circuit the custom-model resolution path we're testing.
+fn install_singletons_for_reconcile(app: &mut App) {
+    initialize_settings_for_tests(app);
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(SyncQueue::mock);
+    app.add_singleton_model(|_| NetworkStatus::new());
+    app.add_singleton_model(TeamTesterStatus::mock);
+    app.add_singleton_model(UpdateManager::mock);
+    app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+    app.add_singleton_model(PrivacySettings::mock);
+    app.add_singleton_model(UserWorkspaces::default_mock);
+}
+
+fn prefs_with_custom_model(custom_config_key: &str) -> LLMPreferences {
+    let keys = ai::api_keys::ApiKeys {
+        custom_endpoints: vec![endpoint(
+            "ep",
+            "https://a.io",
+            "k",
+            vec![model("custom", None, custom_config_key)],
+        )],
+        ..Default::default()
+    };
+    LLMPreferences {
+        models_by_feature: ModelsByFeature::default(),
+        last_update: None,
+        base_llm_for_terminal_view: HashMap::new(),
+        custom_llms: build_custom_llm_infos(&keys),
+    }
+}
+
+/// Regression test for #11564: reconciliation (which runs on startup and when
+/// BYOK keys change) must not clear a profile's saved custom/BYOK base model.
+/// The model getters resolve a saved id against both server models *and*
+/// `custom_llms`, but `reconcile_disabled_model_preferences` used to validate
+/// only against server `agent_mode` models — so a custom `config_key` id looked
+/// "unusable" and the default profile silently reverted to `auto` after restart.
+#[test]
+fn reconcile_preserves_custom_base_model_for_default_profile() {
+    App::test((), |mut app| async move {
+        install_singletons_for_reconcile(&mut app);
+        // Custom inference is gated behind this flag; without it,
+        // `custom_inference_enabled` is false and custom models are never resolved.
+        let _flag = FeatureFlag::CustomInferenceEndpoints.override_enabled(true);
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let llm_prefs = app.add_singleton_model(|_| prefs_with_custom_model("custom-uuid"));
+
+        let default_id = profile_model.read(&app, |model, _| model.default_profile_id());
+
+        // Save the custom model as the default profile's base model, mirroring
+        // a user picking a BYOK model in the profile editor.
+        profile_model.update(&mut app, |model, ctx| {
+            model.set_base_model(default_id, Some("custom-uuid".into()), ctx);
+        });
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.get_profile_by_id(default_id, ctx).unwrap().data().base_model,
+                Some("custom-uuid".into()),
+                "precondition: custom base model should be saved",
+            );
+        });
+
+        // Run reconciliation, as happens on startup / BYOK-key changes.
+        llm_prefs.update(&mut app, |me, ctx| {
+            me.reconcile_disabled_model_preferences(ctx);
+        });
+
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.get_profile_by_id(default_id, ctx).unwrap().data().base_model,
+                Some("custom-uuid".into()),
+                "custom base model was cleared by reconciliation (the #11564 bug)",
+            );
+        });
+    })
+}
+
+/// Guards against over-correcting the fix above: reconciliation must still clear
+/// a saved base model whose id matches neither a server model nor a known custom
+/// endpoint model (e.g. a stale id left over from a removed endpoint).
+#[test]
+fn reconcile_clears_unknown_base_model_for_default_profile() {
+    App::test((), |mut app| async move {
+        install_singletons_for_reconcile(&mut app);
+        let _flag = FeatureFlag::CustomInferenceEndpoints.override_enabled(true);
+
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        // custom_llms only knows about "custom-uuid"; the profile points elsewhere.
+        let llm_prefs = app.add_singleton_model(|_| prefs_with_custom_model("custom-uuid"));
+
+        let default_id = profile_model.read(&app, |model, _| model.default_profile_id());
+
+        profile_model.update(&mut app, |model, ctx| {
+            model.set_base_model(default_id, Some("not-a-real-model".into()), ctx);
+        });
+
+        llm_prefs.update(&mut app, |me, ctx| {
+            me.reconcile_disabled_model_preferences(ctx);
+        });
+
+        profile_model.read(&app, |model, ctx| {
+            assert_eq!(
+                model.get_profile_by_id(default_id, ctx).unwrap().data().base_model,
+                None,
+                "an unresolvable base model should still be cleared by reconciliation",
+            );
+        });
+    })
+}


### PR DESCRIPTION
## Summary

Fixes #11564 — the default AI profile's selected model (especially custom/BYOK models) silently reverts to `auto`.

## Root cause

`LLMPreferences::reconcile_disabled_model_preferences()` (`app/src/ai/llms.rs`) clears any saved profile model it considers unusable. It validated the saved id **only against the server-provided model lists** (`models_by_feature.{agent_mode,coding,cli_agent}`):

```rust
self.models_by_feature.agent_mode.usable_info_for_id(effective_base_model_id, ctx)
```

Custom/BYOK models don't live there — they're built separately into `custom_llms`, keyed by a `config_key` UUID that never appears in the server `choices`. Every model **getter** resolves against both collections (e.g. `get_preferred_base_model` does `.info_for_id(&id).or_else(|| self.custom_llm_info_for_id_if_enabled(&id, app))`), but reconciliation did not. So a valid custom selection looked "unusable," reconciliation called `set_base_model(profile_id, None, ...)`, and the profile fell back to the default `auto` model.

This explains why the revert was intermittent and not restart-only: `reconcile_disabled_model_preferences` runs on **startup, server model-list refresh, auth-complete, network-online, teams-change, and BYOK-key updates** — any of which mid-session would wipe the custom selection (matching reports of reverts with no restart, on new agent sessions, and after a usage/credits refresh).

## Fix

Make reconciliation's usability check symmetric with the getters: a saved id is usable if it resolves to a usable server model **or** an enabled custom/BYOK model. Applied to the `base`, `coding`, and `cli_agent` fields. Computer-use is intentionally left unchanged — its getter has no custom-model resolution path, so a custom id can't be stored there.

## Tests

Added two GPUI regression tests in `app/src/ai/llms_tests.rs`:

- `reconcile_preserves_custom_base_model_for_default_profile` — a saved custom/BYOK base model survives reconciliation (would have failed before this fix).
- `reconcile_clears_unknown_base_model_for_default_profile` — guards against over-correcting: an id matching neither a server model nor a known custom endpoint is still cleared.

Both pass (`cargo test -p warp --lib reconcile_`).

## Manual verification

Built and ran the patched client (`./script/run`, WarpOss/`Channel::Oss`). Set a custom/BYOK base model on the default profile and exercised the reconcile triggers (restart, new agent session, network toggle); the selection now persists instead of reverting to `auto`.
