### PR TITLE
Add `./script/format` for customized `cargo fmt` invocation.

### DIFF
--- a/.agents/skills/promote-feature/SKILL.md
+++ b/.agents/skills/promote-feature/SKILL.md
@@ -81,7 +81,7 @@ pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
 ### Validate
 
 ```bash
-cargo fmt
+./script/format
 cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
 ```
 

--- a/.agents/skills/remove-feature-flag/SKILL.md
+++ b/.agents/skills/remove-feature-flag/SKILL.md
@@ -116,7 +116,7 @@ After removing the flag:
 
 ```bash
 # Format and lint
-cargo fmt
+./script/format
 cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
 
 # Run tests

--- a/.agents/skills/rust-unit-tests/SKILL.md
+++ b/.agents/skills/rust-unit-tests/SKILL.md
@@ -106,7 +106,7 @@ cargo test --doc
 ## Linting and formatting
 Run before submitting changes:
 ```bash
-cargo fmt
+./script/format
 cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,6 +614,7 @@ jobs:
           cargo metadata --locked --format-version=1 > ${{ matrix.null_device }} || (echo "::error::Cargo.lock is out-of-date with Cargo.toml. Run 'cargo check' to update." && exit 1)
 
       - name: Run ./script/format
+        shell: bash
         run: ./script/format --check
 
       - name: Run cargo clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,8 +613,8 @@ jobs:
         run:
           cargo metadata --locked --format-version=1 > ${{ matrix.null_device }} || (echo "::error::Cargo.lock is out-of-date with Cargo.toml. Run 'cargo check' to update." && exit 1)
 
-      - name: Run cargo fmt
-        run: cargo fmt --check
+      - name: Run ./script/format
+        run: ./script/format --check
 
       - name: Run cargo clippy
         shell: bash
@@ -724,8 +724,8 @@ jobs:
         run:
           cargo metadata --locked --format-version=1 >/dev/null || (echo "::error::Cargo.lock is out-of-date with Cargo.toml. Run 'cargo check' to update." && exit 1)
 
-      - name: Run cargo fmt
-        run: cargo fmt --check
+      - name: Run ./script/format
+        run: ./script/format --check
 
       - name: Run cargo clippy
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,8 +725,15 @@ jobs:
         run:
           cargo metadata --locked --format-version=1 >/dev/null || (echo "::error::Cargo.lock is out-of-date with Cargo.toml. Run 'cargo check' to update." && exit 1)
 
-      - name: Run ./script/format
-        run: ./script/format --check
+      - name: Check Rust formatting
+        shell: bash
+        run: |
+          # TODO(vorporeal): Once people have gotten used to ./script/format, in a week or so,
+          # we can have CI enforce the new formatting.
+          #./script/format --check
+
+          # Until then, we'll keep running the traditional formatting check.
+          cargo fmt --check
 
       - name: Run cargo clippy
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ Run unit tests with `cargo nextest run`.
 
 ## Code Style
 
-- `cargo fmt` and `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` must pass.
+- `./script/format --check` and `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` must pass.
 - Prefer imports over path qualifiers, inline format args (`println!("{x}")`), and exhaustive `match` over `_` wildcards.
 - See [WARP.md](WARP.md) for the full style guide, including WarpUI patterns and terminal model locking rules.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -80,7 +80,7 @@ No. Contributing by hand or with your own agent is free. Oz runs on Warp's credi
 
 ### Are agent-generated PRs held to the same bar as human ones?
 
-Yes. The same Oz + SME review, the same tests, and the same `cargo fmt` / `cargo clippy` / presubmit checks apply regardless of who (or what) wrote the code. Whether a PR is hand-written or agent-written doesn't change the quality bar — it changes how quickly you can iterate to meet it.
+Yes. The same Oz + SME review, the same tests, and the same `./script/format` / `cargo clippy` / presubmit checks apply regardless of who (or what) wrote the code. Whether a PR is hand-written or agent-written doesn't change the quality bar — it changes how quickly you can iterate to meet it.
 
 ### Will my issues, comments, or code be used to train models?
 

--- a/WARP.md
+++ b/WARP.md
@@ -31,7 +31,7 @@ Environment variables:
 
 ### Linting and Formatting
 - `./script/presubmit` - Run all presubmit checks (fmt, clippy, tests)
-- `cargo fmt` - Format code
+- `./script/format` - Format code
 - `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` - Run clippy
 - `./script/run-clang-format.py -r --extensions 'c,h,cpp,m' ./crates/warpui/src/ ./app/src/` - Format C/C++/Obj-C code
 - `find . -name "*.wgsl" -exec wgslfmt --check {} +` - Check WGSL shader formatting
@@ -129,9 +129,9 @@ This is a Rust-based terminal emulator with a custom UI framework called **WarpU
   ```
 
 **Pull Request Workflow**:
-- **ALWAYS** run cargo fmt and cargo clippy (the versions specified in ./script/presubmit) before opening a PR or pushing updates to an existing PR branch
+- **ALWAYS** run `./script/format` and `cargo clippy` (the versions specified in ./script/presubmit) before opening a PR or pushing updates to an existing PR branch
 - Those commands must pass completely before creating or updating a pull request
-- Specifically, ensure `cargo fmt` and `cargo clippy` checks pass
+- Specifically, ensure `./script/format` and `cargo clippy` checks pass
 - If they fail, fix all issues before proceeding with the PR
 - This applies to:
   - Opening new pull requests

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -2,8 +2,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use ai::agent::action::LifecycleEventType as StartAgentLifecycleEventType;
-use ai::agent::action::ReadSkillRequest;
+use ai::agent::action::{LifecycleEventType as StartAgentLifecycleEventType, ReadSkillRequest};
 use ai::agent::action_result::StartAgentVersion;
 use ai::agent::convert::ToolToAIAgentActionError;
 use ai::agent::UnknownCitationTypeError;

--- a/app/src/ai/agent/api/convert_from_tests.rs
+++ b/app/src/ai/agent/api/convert_from_tests.rs
@@ -1,6 +1,7 @@
+use std::path::PathBuf;
+
 use ai::agent::action::AskUserQuestionType;
 use ai::skills::{SkillPathOrigin, SkillReference};
-use std::path::PathBuf;
 use warp_multi_agent_api as api;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -1,6 +1,6 @@
-use ai::api_keys::ApiKeyManager;
 use std::collections::HashMap;
 
+use ai::api_keys::ApiKeyManager;
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
 use warpui::{App, SingletonEntity};
@@ -11,7 +11,8 @@ use super::{
 };
 use crate::ai::artifacts::Artifact;
 use crate::ai::llms::LLMPreferences;
-use crate::auth::{auth_manager::AuthManager, AuthStateProvider};
+use crate::auth::auth_manager::AuthManager;
+use crate::auth::AuthStateProvider;
 use crate::network::NetworkStatus;
 use crate::persistence::model::AgentConversationData;
 use crate::server::server_api::ServerApiProvider;

--- a/app/src/ai/blocklist/block_tests.rs
+++ b/app/src/ai/blocklist/block_tests.rs
@@ -4,6 +4,7 @@ use ai::agent::action::{RunAgentsAgentRunConfig, RunAgentsExecutionMode};
 use ai::agent::action_result::StartAgentVersion;
 use ai::skills::SkillReference;
 use settings::Setting;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{App, SingletonEntity};
 
 use super::{
@@ -16,7 +17,6 @@ use crate::ai::blocklist::action_model::{
 };
 use crate::settings::AISettings;
 use crate::test_util::settings::initialize_settings_for_tests;
-use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 #[test]
 fn reasoning_auto_collapses_when_user_has_not_manually_toggled() {

--- a/app/src/ai/blocklist/context_model_tests.rs
+++ b/app/src/ai/blocklist/context_model_tests.rs
@@ -17,8 +17,7 @@ use warpui::r#async::executor::Background;
 use warpui::{App, EntityId, ModelHandle};
 
 use super::{BlocklistAIContextModel, PendingAttachment, PendingFile};
-use crate::ai::agent::AIAgentContext;
-use crate::ai::agent::ImageContext;
+use crate::ai::agent::{AIAgentContext, ImageContext};
 use crate::ai::blocklist::agent_view::{AgentViewController, EphemeralMessageModel};
 #[cfg(feature = "local_fs")]
 use crate::code_review::git_status_update::GitRepoStatusModel;

--- a/app/src/ai/blocklist/controller/input_context.rs
+++ b/app/src/ai/blocklist/controller/input_context.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
 use chrono::Local;

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -23,6 +23,7 @@
 //! that aren't relevant to the handler's correctness).
 
 use std::collections::HashMap;
+
 use warp_core::ui::appearance::Appearance;
 use warpui::platform::WindowStyle;
 use warpui::App;

--- a/app/src/ai/get_relevant_files/remote_search/native.rs
+++ b/app/src/ai/get_relevant_files/remote_search/native.rs
@@ -1,6 +1,13 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use ::ai::index::full_source_code_embedding::search_shaping::{
+    build_fragments_from_file_contents, fragments_to_context_locations,
+};
+use ::ai::index::full_source_code_embedding::store_client::StoreClient;
 use ::ai::index::full_source_code_embedding::{
-    search_shaping::{build_fragments_from_file_contents, fragments_to_context_locations},
-    store_client::StoreClient,
     ContentHash, FragmentMetadata as AiFragmentMetadata, FragmentMetadataLocation, RepoMetadata,
 };
 use ::ai::index::locations::CodeContextLocation;
@@ -8,12 +15,6 @@ use itertools::Itertools;
 use remote_server::proto::{
     file_context_proto, FragmentMetadata as ProtoFragmentMetadata, LineRange, ReadFileContextFile,
     ReadFileContextRequest, ReadFileContextResponse,
-};
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-    str::FromStr,
-    sync::Arc,
 };
 use string_offset::ByteOffset;
 use warpui::{AppContext, ModelContext, SingletonEntity};

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -1,7 +1,6 @@
-use super::*;
-
 use warpui::App;
 
+use super::*;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::auth::auth_manager::AuthManager;

--- a/app/src/ai/local_harness_setup.rs
+++ b/app/src/ai/local_harness_setup.rs
@@ -1,6 +1,7 @@
+use warp_cli::agent::Harness;
+
 #[cfg(not(target_family = "wasm"))]
 use crate::util::path::resolve_executable;
-use warp_cli::agent::Harness;
 
 /// Tooltip shown when a local harness is product-enabled but its CLI is missing.
 pub(crate) const LOCAL_HARNESS_INSTALLATION_REQUIRED_TOOLTIP: &str =

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -2,12 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
-use super::super::subscribers::SkillRepositoryMessage;
-use super::{
-    parse_project_skill_contents, read_remote_project_skill_contents, remote_skill_read_request,
-    SkillWatcher, REMOTE_SKILL_MAX_BATCH_BYTES, REMOTE_SKILL_MAX_FILE_BYTES,
-};
-use crate::ai::skills::skill_manager::SkillWatcherEvent;
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
 use remote_server::proto::{file_context_proto, FileContextProto};
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
@@ -17,11 +11,18 @@ use repo_metadata::{
     DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate, TargetFile,
 };
 use tempfile::TempDir;
-use warp_util::{
-    host_id::HostId, local_or_remote_path::LocalOrRemotePath, remote_path::RemotePath,
-    standardized_path::StandardizedPath,
-};
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
+
+use super::super::subscribers::SkillRepositoryMessage;
+use super::{
+    parse_project_skill_contents, read_remote_project_skill_contents, remote_skill_read_request,
+    SkillWatcher, REMOTE_SKILL_MAX_BATCH_BYTES, REMOTE_SKILL_MAX_FILE_BYTES,
+};
+use crate::ai::skills::skill_manager::SkillWatcherEvent;
 
 /// Helper function for creating a single skill file
 fn create_skill_file(dir: &TempDir, name: &str, description: &str, content: &str) -> ParsedSkill {

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -5,14 +5,12 @@ use ai::skills::{
     SKILL_PROVIDER_DEFINITIONS,
 };
 use anyhow::Error;
-use repo_metadata::{
-    local_model::GetContentsArgs, RepoContent, RepoMetadataModel, RepositoryIdentifier,
-};
+use repo_metadata::local_model::GetContentsArgs;
+use repo_metadata::{RepoContent, RepoMetadataModel, RepositoryIdentifier};
 use walkdir::{DirEntry, WalkDir};
-use warp_util::{
-    local_or_remote_path::LocalOrRemotePath, remote_path::RemotePath,
-    standardized_path::StandardizedPath,
-};
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::AppContext;
 
 use crate::warp_managed_paths_watcher::warp_managed_skill_dirs;

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -1,17 +1,17 @@
+use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
+use repo_metadata::file_tree_store::FileTreeState;
+use repo_metadata::file_tree_update::{
+    DirectoryNodeMetadata, FileNodeMetadata, FileTreeEntryUpdate, RepoNodeMetadata,
+};
+use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{
-    entry::{DirectoryEntry, Entry, FileMetadata},
-    file_tree_store::FileTreeState,
-    file_tree_update::{
-        DirectoryNodeMetadata, FileNodeMetadata, FileTreeEntryUpdate, RepoNodeMetadata,
-    },
-    repositories::DetectedRepositories,
     DirectoryWatcher, RepoMetadataModel, RepoMetadataUpdate, RepositoryIdentifier,
 };
 use virtual_fs::{Stub, VirtualFS};
-use warp_util::{
-    host_id::HostId, local_or_remote_path::LocalOrRemotePath, remote_path::RemotePath,
-    standardized_path::StandardizedPath,
-};
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
 use super::{

--- a/app/src/ai/skills/global_skills.rs
+++ b/app/src/ai/skills/global_skills.rs
@@ -1,10 +1,8 @@
 //! Helpers for resolving per-agent "global" skill specs into repos to
 //! ensure are available on disk before the agent runs.
 
-use std::{
-    collections::{BTreeSet, HashMap, HashSet},
-    str::FromStr,
-};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::str::FromStr;
 
 use ai::skills::{provider_rank, ParsedSkill};
 use warp_cli::skill::SkillSpec;

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -1,14 +1,15 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+
 use ai::skills::{get_provider_for_path, ParsedSkill, SkillProvider, SkillReference, SkillScope};
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel};
-use std::collections::{HashMap, HashSet};
-use std::fs;
 use tempfile::TempDir;
 use warp_core::channel::ChannelState;
-use warp_util::{
-    host_id::HostId, local_or_remote_path::LocalOrRemotePath, remote_path::RemotePath,
-    standardized_path::StandardizedPath,
-};
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 use watcher::HomeDirectoryWatcher;
 

--- a/app/src/ai/skills/skill_utils_tests.rs
+++ b/app/src/ai/skills/skill_utils_tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
-use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 use super::*;
 

--- a/app/src/cloud_object/model/model_tests.rs
+++ b/app/src/cloud_object/model/model_tests.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Utc;
+use cloud_object_client::MockObjectClient;
 use lazy_static::lazy_static;
 use mockall::Sequence;
 use rand::Rng;
@@ -43,7 +44,6 @@ use crate::workspaces::user_profiles::UserProfiles;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::workspaces::workspace::{Workspace, WorkspaceUid};
 use crate::{NetworkStatus, UpdateManager};
-use cloud_object_client::MockObjectClient;
 
 fn create_cloud_model(
     app: &mut App,

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -22,6 +22,7 @@ use num_traits::SaturatingSub;
 use pathfinder_color::ColorU;
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
+use remote_server::manager::RemoteServerManager;
 #[cfg(feature = "local_fs")]
 use repo_metadata::repositories::DetectedRepositories;
 use string_offset::CharOffset;
@@ -56,8 +57,6 @@ use warpui::{
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle, WindowId,
 };
-
-use remote_server::manager::RemoteServerManager;
 
 use crate::ai::persisted_workspace::{PersistedWorkspace, PersistedWorkspaceEvent};
 use crate::code::buffer_location::LocalOrRemotePath as BufferFileLocation;

--- a/app/src/code_review/file_invalidation_queue.rs
+++ b/app/src/code_review/file_invalidation_queue.rs
@@ -2,8 +2,8 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use warp_core::errors::{AnyhowErrorExt as _, ErrorExt};
 
+use warp_core::errors::{AnyhowErrorExt as _, ErrorExt};
 use warp_core::sync_queue::{IsTransientError, SyncQueueTaskTrait};
 
 use super::diff_state::{DiffMode, FileDiffAndContent, LocalDiffStateModel};

--- a/app/src/code_review/git_status_update.rs
+++ b/app/src/code_review/git_status_update.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "local_fs")]
 use std::path::{Path, PathBuf};
 
-use crate::util::git::{PrInfo, RepositoryInfo};
 #[cfg(feature = "local_fs")]
 use settings::Setting as _;
 #[cfg(feature = "local_fs")]
@@ -31,6 +30,7 @@ use {
 
 #[cfg(feature = "local_fs")]
 use super::diff_state::{diff_metadata_against_head, DiffStats};
+use crate::util::git::{PrInfo, RepositoryInfo};
 #[cfg(feature = "local_fs")]
 const PR_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(feature = "local_fs")]

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -2,13 +2,6 @@ use std::cell::OnceCell;
 use std::sync::Arc;
 use std::{fmt, vec};
 
-use crate::safe_triangle::SafeTriangle;
-use crate::themes::theme::Fill;
-use crate::util::time_format::format_approx_duration_from_now_sentence_case;
-use crate::{
-    appearance::Appearance,
-    ui_components::{buttons::icon_button_with_color, icons},
-};
 use chrono::{DateTime, Local};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::rect::RectF;
@@ -33,6 +26,13 @@ use warpui::ui_components::components::UiComponent;
 use warpui::{
     Action, AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, WindowId,
 };
+
+use crate::appearance::Appearance;
+use crate::safe_triangle::SafeTriangle;
+use crate::themes::theme::Fill;
+use crate::ui_components::buttons::icon_button_with_color;
+use crate::ui_components::icons;
+use crate::util::time_format::format_approx_duration_from_now_sentence_case;
 
 pub const CHEVRON_RIGHT_ALIGN_SVG_PATH: &str = "bundled/svg/chevron-right-align.svg";
 

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use pathfinder_geometry::vector::vec2f;
+#[cfg(not(target_family = "wasm"))]
+use remote_server::manager::RemoteServerManager;
 use warp_core::ui::icons::ICON_DIMENSIONS;
 use warp_editor::model::CoreEditorModel;
 #[cfg(feature = "local_fs")]
@@ -28,9 +30,6 @@ use warpui::{
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle,
 };
-
-#[cfg(not(target_family = "wasm"))]
-use remote_server::manager::RemoteServerManager;
 
 use super::context_menu::{show_rich_editor_context_menu, ContextMenuAction, ContextMenuState};
 use super::editor::view::{EditorViewEvent, RichTextEditorConfig, RichTextEditorView};

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -20,8 +20,9 @@ use crate::ai::ambient_agents::task::{
 use crate::ai::ambient_agents::{AgentConfigSnapshot, AmbientAgentTaskId};
 use crate::ai::local_harness_setup::local_harness_product_disabled_message;
 use crate::server::server_api::ai::AIClient;
-use crate::terminal::cli_agent_sessions::plugin_manager::plugin_manager_for;
-use crate::terminal::cli_agent_sessions::plugin_manager::CliAgentPluginManager;
+use crate::terminal::cli_agent_sessions::plugin_manager::{
+    plugin_manager_for, CliAgentPluginManager,
+};
 use crate::terminal::shell::ShellType;
 
 #[derive(Clone)]

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -1,6 +1,13 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use ai::index::full_source_code_embedding::NodeHash;
+use remote_server::codebase_index_proto::{RemoteCodebaseIndexState, RemoteCodebaseIndexStatus};
+use warp_core::{HostId, SessionId};
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
 use super::manager::{
     RemoteCodebaseIndexStatusWithPath, RemoteCodebaseIndexUpdateOperation, RemoteServerManager,
     RemoteServerManagerEvent,
@@ -15,12 +22,6 @@ use crate::server::telemetry::{
 };
 use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 use crate::{send_telemetry_from_ctx, TelemetryEvent};
-use ai::index::full_source_code_embedding::NodeHash;
-use remote_server::codebase_index_proto::{RemoteCodebaseIndexState, RemoteCodebaseIndexStatus};
-use warp_core::{HostId, SessionId};
-use warp_util::remote_path::RemotePath;
-use warp_util::standardized_path::StandardizedPath;
-use warpui::{Entity, ModelContext, SingletonEntity};
 
 #[derive(Clone, Debug)]
 pub struct RemoteCodebaseSearchContext {

--- a/app/src/search/action/data_source.rs
+++ b/app/src/search/action/data_source.rs
@@ -184,6 +184,7 @@ mod full_text_searcher {
     use std::sync::Arc;
 
     use fuzzy_match::FuzzyMatchResult;
+    use warp_search_core::define_search_schema;
     use warpui::keymap::{BindingId, DescriptionContext};
 
     use crate::search::action::data_source::{is_excluded_binding, ActionSearcher, SearcherAction};
@@ -193,7 +194,6 @@ mod full_text_searcher {
         SimpleFullTextSearcher, DEFAULT_MEMORY_BUDGET, SCORE_CONVERSION_FACTOR,
     };
     use crate::util::bindings::CommandBinding;
-    use warp_search_core::define_search_schema;
 
     define_search_schema!(
         schema_name: ACTION_SEARCH_SCHEMA,

--- a/app/src/search/mod.rs
+++ b/app/src/search/mod.rs
@@ -18,12 +18,11 @@ pub mod slash_command_menu;
 pub mod welcome_palette;
 mod workflows;
 
-// Re-export core search types.
-pub use warp_search_core::*;
-
 pub use data_source::QueryFilter;
 use filter_chip_renderer::FilterChipRenderer;
 pub use item::SearchItem;
 pub use mixer::SyncDataSource;
 pub use result_renderer::ItemHighlightState;
+// Re-export core search types.
+pub use warp_search_core::*;
 pub use workflows::fuzzy_match::FuzzyMatchWorkflowResult;

--- a/app/src/server/graphql/schema/mod.rs
+++ b/app/src/server/graphql/schema/mod.rs
@@ -1,7 +1,6 @@
 pub mod util;
-pub use util::{action_type_to_gql_action_type, object_action_history_from_gql};
-
 use anyhow::{bail, Result};
+pub use util::{action_type_to_gql_action_type, object_action_history_from_gql};
 use warp_graphql::generic_string_object::GenericStringObjectFormat;
 use warp_graphql::mutations::update_generic_string_object::{
     GenericStringObjectUpdate, UpdateGenericStringObjectResult,

--- a/app/src/server/sync_queue.rs
+++ b/app/src/server/sync_queue.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+// Re-exported from cloud_objects.
+pub use cloud_objects::cloud_object::SerializedModel;
 use derivative::Derivative;
 use http::StatusCode;
 use lazy_static::lazy_static;
 use uuid::Uuid;
 use warp_graphql::scalars::time::ServerTimestamp;
-// Re-exported from cloud_objects.
-pub use cloud_objects::cloud_object::SerializedModel;
 use warpui::r#async::FutureId;
 use warpui::{Entity, ModelContext, RequestState, RetryOption, SingletonEntity};
 

--- a/app/src/settings/theme_tests.rs
+++ b/app/src/settings/theme_tests.rs
@@ -1,6 +1,8 @@
-use super::*;
-use crate::{themes::theme::CustomTheme, user_config};
 use std::path::PathBuf;
+
+use super::*;
+use crate::themes::theme::CustomTheme;
+use crate::user_config;
 
 fn custom(path: PathBuf) -> ThemeKind {
     ThemeKind::Custom(CustomTheme::new("Custom".to_string(), path))

--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -1,8 +1,9 @@
+use std::sync::{Arc, Mutex};
+
 use ::settings::{Setting, ToggleableSetting};
 use lazy_static::lazy_static;
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
-use std::sync::{Arc, Mutex};
 use warp_core::channel::ChannelState;
 use warp_core::context_flag::ContextFlag;
 use warp_core::features::FeatureFlag;

--- a/app/src/settings_view/mcp_servers/installation_modal.rs
+++ b/app/src/settings_view/mcp_servers/installation_modal.rs
@@ -1,43 +1,37 @@
 use std::collections::HashMap;
 
+use markdown_parser::parse_markdown;
+use warp_core::ui::external_product_icon::ExternalProductIcon;
+use warp_core::ui::icons::Icon;
+use warpui::elements::{
+    Align, Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
+    Flex, FormattedTextElement, HighlightedHyperlink, Hoverable, MainAxisAlignment,
+    MouseStateHandle, Padding, ParentElement, Radius, Shrinkable, Text,
+};
+use warpui::fonts::{Properties, Weight};
+use warpui::keymap::Keystroke;
+use warpui::platform::Cursor;
+use warpui::ui_components::components::{UiComponent, UiComponentStyles};
+use warpui::{
+    AppContext, Element, Entity, FocusContext, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
+};
+
 use crate::ai::mcp::templatable_installation::{VariableType, VariableValue};
+use crate::ai::mcp::{TemplatableMCPServer, TemplatableMCPServerManager, TemplateVariable};
 use crate::appearance::Appearance;
-use crate::editor::Event as EditorEvent;
-use crate::editor::{EditorView, SingleLineEditorOptions};
+use crate::editor::{EditorView, Event as EditorEvent, SingleLineEditorOptions};
 use crate::settings_view::mcp_servers::style::{
     INSTALLATION_MODAL_BUTTON_GAP, INSTALLATION_MODAL_BUTTON_PADDING,
     INSTALLATION_MODAL_INPUT_VERTICAL_SPACING, INSTALLATION_MODAL_LABEL_VERTICAL_SPACING,
     INSTALLATION_MODAL_PADDING, INSTALLATION_MODAL_TITLE_VERTICAL_SPACING,
 };
+use crate::ui_components::avatar::{Avatar, AvatarContent};
+use crate::ui_components::blended_colors;
 use crate::view_components::action_button::{
     ActionButton, KeystrokeSource, NakedTheme, PrimaryTheme,
 };
 use crate::view_components::dropdown::{Dropdown, DropdownItem};
-use markdown_parser::parse_markdown;
-use warpui::elements::Shrinkable;
-use warpui::fonts::{Properties, Weight};
-use warpui::keymap::Keystroke;
-use warpui::ui_components::components::{UiComponent, UiComponentStyles};
-use warpui::{
-    elements::{
-        Align, Border, ChildView, ConstrainedBox, Container, CrossAxisAlignment, Empty, Flex,
-        FormattedTextElement, HighlightedHyperlink, Hoverable, MainAxisAlignment, MouseStateHandle,
-        ParentElement, Text,
-    },
-    platform::Cursor,
-    AppContext, Element, Entity, FocusContext, TypedActionView, View, ViewHandle,
-};
-use warpui::{SingletonEntity, ViewContext};
-
-use crate::ai::mcp::{TemplatableMCPServer, TemplatableMCPServerManager, TemplateVariable};
-
-use crate::ui_components::{
-    avatar::{Avatar, AvatarContent},
-    blended_colors,
-};
-use warpui::elements::{CornerRadius, Padding, Radius};
-
-use warp_core::ui::{external_product_icon::ExternalProductIcon, icons::Icon};
 
 pub enum InstallationModalBodyEvent {
     Cancel,

--- a/app/src/settings_view/mcp_servers/update_modal.rs
+++ b/app/src/settings_view/mcp_servers/update_modal.rs
@@ -1,3 +1,21 @@
+use chrono::{Local, TimeZone};
+use uuid::Uuid;
+use warp_core::ui::external_product_icon::ExternalProductIcon;
+use warp_core::ui::icons::Icon;
+use warp_core::ui::theme::color::internal_colors;
+use warpui::elements::{
+    Align, Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
+    Flex, Hoverable, MainAxisAlignment, MouseStateHandle, Padding, ParentElement, Radius,
+    Shrinkable, Text,
+};
+use warpui::fonts::{Properties, Weight};
+use warpui::keymap::Keystroke;
+use warpui::platform::Cursor;
+use warpui::ui_components::components::{UiComponent, UiComponentStyles};
+use warpui::{
+    AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
+};
+
 use crate::ai::mcp::{Author, MCPServerUpdate};
 use crate::appearance::Appearance;
 use crate::settings_view::mcp_servers::style::{
@@ -8,24 +26,6 @@ use crate::ui_components::blended_colors;
 use crate::util::time_format::format_approx_duration_from_now;
 use crate::view_components::action_button::{
     ActionButton, KeystrokeSource, NakedTheme, PrimaryTheme,
-};
-use chrono::{Local, TimeZone};
-use uuid::Uuid;
-use warp_core::ui::external_product_icon::ExternalProductIcon;
-use warp_core::ui::icons::Icon;
-use warp_core::ui::theme::color::internal_colors;
-use warpui::elements::{Align, Empty, Padding, Shrinkable};
-use warpui::fonts::{Properties, Weight};
-use warpui::keymap::Keystroke;
-use warpui::ui_components::components::{UiComponent, UiComponentStyles};
-use warpui::SingletonEntity;
-use warpui::{
-    elements::{
-        Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex,
-        Hoverable, MainAxisAlignment, MouseStateHandle, ParentElement, Radius, Text,
-    },
-    platform::Cursor,
-    AppContext, Element, Entity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
 pub enum UpdateModalBodyEvent {

--- a/app/src/settings_view/platform_page_tests.rs
+++ b/app/src/settings_view/platform_page_tests.rs
@@ -1,3 +1,5 @@
+use chrono::Utc;
+
 use super::{
     api_key_table_min_non_resizable_columns_width, compute_api_key_name_column_max_width,
     APIKeyProperties, ApiKeyScope, API_KEY_KEY_COLUMN_WIDTH, API_KEY_NAME_COLUMN_MIN_WIDTH,
@@ -5,7 +7,6 @@ use super::{
     SETTINGS_PAGE_HORIZONTAL_PADDING, SETTINGS_PAGE_MAX_CONTENT_WIDTH,
     SETTINGS_SECTION_BORDER_WIDTH, SETTINGS_SIDEBAR_WIDTH_DEFAULT,
 };
-use chrono::Utc;
 
 fn table_width_chrome() -> f32 {
     SETTINGS_SIDEBAR_WIDTH_DEFAULT

--- a/app/src/settings_view/warp_drive_page.rs
+++ b/app/src/settings_view/warp_drive_page.rs
@@ -5,13 +5,12 @@ use warpui::elements::{
     Container, Element, Flex, MouseStateHandle, ParentElement, Shrinkable, Text,
 };
 use warpui::fonts::Weight;
-use warpui::id;
 use warpui::keymap::ContextPredicate;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::ui_components::switch::SwitchStateHandle;
 use warpui::{
-    Action, AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
+    id, Action, AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
 use super::settings_page::{

--- a/app/src/terminal/focus_env.rs
+++ b/app/src/terminal/focus_env.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, ffi::OsString};
+use std::collections::HashMap;
+use std::ffi::OsString;
 
 use crate::channel::ChannelState;
 

--- a/app/src/terminal/focus_env_tests.rs
+++ b/app/src/terminal/focus_env_tests.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, ffi::OsString};
-
-use crate::channel::ChannelState;
+use std::collections::HashMap;
+use std::ffi::OsString;
 
 use super::{add_session_focus_env_vars, FOCUS_URL_ENV, TERMINAL_SESSION_UUID_ENV};
+use crate::channel::ChannelState;
 
 #[test]
 fn focus_env_vars_point_at_session_deeplink() {

--- a/app/src/terminal/input/skills/data_source.rs
+++ b/app/src/terminal/input/skills/data_source.rs
@@ -3,6 +3,7 @@ use fuzzy_match::{match_indices_case_insensitive, FuzzyMatchResult};
 use ordered_float::OrderedFloat;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::Fill;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{
     ConstrainedBox, Container, CrossAxisAlignment, Flex, Highlight, ParentElement, Shrinkable, Text,
 };
@@ -27,7 +28,6 @@ use crate::terminal::input::inline_menu::{
 };
 use crate::terminal::input::message_bar::{Message, MessageItem};
 use crate::terminal::model::session::active_session::{ActiveSession, ActiveSessionEvent};
-use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 #[derive(Clone, Debug)]
 pub struct AcceptSkill {

--- a/app/src/terminal/input/slash_commands/cloud_mode_v2_view.rs
+++ b/app/src/terminal/input/slash_commands/cloud_mode_v2_view.rs
@@ -22,8 +22,7 @@ use crate::search::mixer::{AddAsyncSourceOptions, SearchMixer, SearchMixerEvent}
 use crate::search::result_renderer::{QueryResultRenderer, QueryResultRendererStyles};
 use crate::search::slash_command_menu::static_commands::commands::COMMAND_REGISTRY;
 use crate::terminal::input::buffer_model::{InputBufferModel, InputBufferUpdateEvent};
-use crate::terminal::input::inline_menu::styles as inline_styles;
-use crate::terminal::input::inline_menu::QueryResultRendererExt as _;
+use crate::terminal::input::inline_menu::{styles as inline_styles, QueryResultRendererExt as _};
 use crate::terminal::input::slash_command_model::{SlashCommandEntryState, SlashCommandModel};
 use crate::terminal::input::slash_commands::view::{slash_command_query, CloseReason};
 use crate::terminal::input::slash_commands::{

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -1715,9 +1715,10 @@ fn viewer_model_retries_consumer_registration_on_set_active_conversation() {
     // `parent_conversation_id` (children get one through
     // `start_new_child_conversation`). The discriminator in
     // `register_viewer_mode_consumer_if_possible` must accept this shape.
-    use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
     use warp_core::features::FeatureFlag;
     use warpui::SingletonEntity;
+
+    use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 
     App::test((), |mut app| async move {
         let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);
@@ -1781,9 +1782,10 @@ fn viewer_model_does_not_register_when_active_conversation_is_a_child_placeholde
     // `SwapPaneToConversation` before the orchestrator placeholder is
     // activated — which would persist the orchestration cursor on the
     // wrong row.
-    use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
     use warp_core::features::FeatureFlag;
     use warpui::SingletonEntity;
+
+    use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 
     App::test((), |mut app| async move {
         let _v2_guard = FeatureFlag::OrchestrationV2.override_enabled(true);

--- a/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
@@ -10,11 +10,10 @@
 //! `DetachType::Closed`, while deliberately preserving it on
 //! `HiddenForClose` (undo-close grace window) and `Moved`.
 
-use super::*;
-
 use async_broadcast::broadcast;
 use warpui::App;
 
+use super::*;
 use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 // Bring the `TerminalManager` trait into scope (named under a different alias
 // since the local `TerminalManager` struct shadows it) so the trait method

--- a/app/src/terminal/view/ambient_agent/delete_auth_secret_confirmation_dialog.rs
+++ b/app/src/terminal/view/ambient_agent/delete_auth_secret_confirmation_dialog.rs
@@ -2,17 +2,15 @@ use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use warp_cli::agent::Harness;
 use warp_managed_secrets::client::SecretOwner;
+use warpui::elements::{Align, ChildView, Container, Dismiss, DropShadow, Empty};
+use warpui::ui_components::components::UiComponent;
 use warpui::{
-    elements::{Align, ChildView, Container, Dismiss, DropShadow, Empty},
-    ui_components::components::UiComponent,
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
-use crate::{
-    appearance::Appearance,
-    ui_components::dialog::{dialog_styles, Dialog},
-    view_components::action_button::{ActionButton, DangerPrimaryTheme, NakedTheme},
-};
+use crate::appearance::Appearance;
+use crate::ui_components::dialog::{dialog_styles, Dialog};
+use crate::view_components::action_button::{ActionButton, DangerPrimaryTheme, NakedTheme};
 
 const DIALOG_WIDTH: f32 = 450.;
 

--- a/app/src/terminal/view/docker_sandbox/mod.rs
+++ b/app/src/terminal/view/docker_sandbox/mod.rs
@@ -1,6 +1,18 @@
 #[cfg(feature = "local_tty")]
 use std::sync::mpsc::SyncSender;
 
+#[cfg(not(target_family = "wasm"))]
+use warp_cli::agent::Harness;
+#[cfg(feature = "local_tty")]
+use warpui::geometry::vector::Vector2F;
+#[cfg(not(target_family = "wasm"))]
+use warpui::r#async::FutureExt;
+#[cfg(feature = "local_tty")]
+use warpui::ModelHandle;
+use warpui::ViewContext;
+#[cfg(not(target_family = "wasm"))]
+use warpui::{SingletonEntity, View, ViewHandle};
+
 use super::TerminalView;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_sdk::driver::{
@@ -28,17 +40,6 @@ use crate::terminal::local_tty::docker_sandbox::DOCKER_SANDBOX_HOME_DIR;
 use crate::terminal::remote_tty::TerminalManager as RemoteTtyTerminalManager;
 #[cfg(feature = "local_tty")]
 use crate::terminal::TerminalManager;
-#[cfg(not(target_family = "wasm"))]
-use warp_cli::agent::Harness;
-#[cfg(feature = "local_tty")]
-use warpui::geometry::vector::Vector2F;
-#[cfg(not(target_family = "wasm"))]
-use warpui::r#async::FutureExt;
-#[cfg(feature = "local_tty")]
-use warpui::ModelHandle;
-use warpui::ViewContext;
-#[cfg(not(target_family = "wasm"))]
-use warpui::{SingletonEntity, View, ViewHandle};
 
 /// Default base Docker image used for newly created sandbox shells.
 ///

--- a/app/src/themes/theme_tests.rs
+++ b/app/src/themes/theme_tests.rs
@@ -1,6 +1,8 @@
-use super::*;
-use crate::{user_config, util::color::OPAQUE};
 use settings_value::SettingsValue as _;
+
+use super::*;
+use crate::user_config;
+use crate::util::color::OPAQUE;
 
 fn custom_theme_json(path: &str) -> serde_json::Value {
     serde_json::json!({

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -1377,10 +1377,8 @@ fn open_file_editor(
     {
         use crate::code::editor_management::CodeSource;
         use crate::root_view::{open_new_with_workspace_source, NewWorkspaceSource};
-        use crate::util::{
-            file::external_editor::EditorSettings,
-            openable_file_type::resolve_file_target_to_open_in_warp,
-        };
+        use crate::util::file::external_editor::EditorSettings;
+        use crate::util::openable_file_type::resolve_file_target_to_open_in_warp;
 
         if !can_open_file_editor_path(&path) {
             log::warn!("open_file_editor action rejected non-openable path: {path:?}");

--- a/app/src/view_components/compact_dropdown.rs
+++ b/app/src/view_components/compact_dropdown.rs
@@ -1,5 +1,6 @@
-use pathfinder_geometry::vector::vec2f;
 use std::marker::PhantomData;
+
+use pathfinder_geometry::vector::vec2f;
 use warpui::elements::{
     Border, ChildAnchor, ConstrainedBox, CornerRadius, CrossAxisAlignment, Flex,
     Icon as WarpUiIcon, MainAxisAlignment, MouseStateHandle, OffsetPositioning, ParentElement,

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+
 use warp_editor::editor::NavigationKey;
 use warpui::elements::{
     Align, Border, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container, CornerRadius,

--- a/app/src/workspaces/user_profiles.rs
+++ b/app/src/workspaces/user_profiles.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
+pub use cloud_object_models::UserProfileWithUID;
 use warpui::{Entity, SingletonEntity};
 
 use crate::auth::UserUid;
-pub use cloud_object_models::UserProfileWithUID;
 
 pub enum UserProfilesEvent {}
 

--- a/crates/ai/src/index/full_source_code_embedding/search_shaping.rs
+++ b/crates/ai/src/index/full_source_code_embedding/search_shaping.rs
@@ -1,12 +1,9 @@
-use std::{
-    collections::{HashMap, HashSet},
-    ops::Range,
-    path::PathBuf,
-};
-
-use crate::index::locations::{CodeContextLocation, FileFragmentLocation};
+use std::collections::{HashMap, HashSet};
+use std::ops::Range;
+use std::path::PathBuf;
 
 use super::{ContentHash, Fragment, FragmentLocation, FragmentMetadata};
+use crate::index::locations::{CodeContextLocation, FileFragmentLocation};
 
 #[derive(Default)]
 pub struct ReadFragmentResult {
@@ -178,11 +175,9 @@ pub fn fragments_to_context_locations<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::{HashMap, HashSet},
-        ops::Range,
-        path::PathBuf,
-    };
+    use std::collections::{HashMap, HashSet};
+    use std::ops::Range;
+    use std::path::PathBuf;
 
     use string_offset::ByteOffset;
 

--- a/crates/ai/src/skills/conversion.rs
+++ b/crates/ai/src/skills/conversion.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use thiserror::Error;
 use warp_multi_agent_api as api;
 use warp_util::host_id::HostId;

--- a/crates/ai/src/skills/mod.rs
+++ b/crates/ai/src/skills/mod.rs
@@ -8,7 +8,6 @@ pub use conversion::{
     skill_reference_from_api_skill_ref, skill_reference_from_read_skill_ref, SkillConversionError,
     SkillPathOrigin,
 };
-
 pub use parse_skill::{
     parse_bundled_skill, parse_skill, parse_skill_content_at_location, ParsedSkill,
 };

--- a/crates/ai/src/skills/parse_skill.rs
+++ b/crates/ai/src/skills/parse_skill.rs
@@ -3,13 +3,14 @@ use std::fs;
 use std::ops::Range;
 use std::path::Path;
 
-use super::parser::parse_markdown_content;
-use super::skill_provider::{get_provider_for_path, get_scope_for_path, SkillProvider, SkillScope};
 use anyhow::Result;
 use lazy_static::lazy_static;
 use regex::Regex;
 use thiserror::Error;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+
+use super::parser::parse_markdown_content;
+use super::skill_provider::{get_provider_for_path, get_scope_for_path, SkillProvider, SkillScope};
 
 const MAX_SKILL_DESCRIPTION_CHARS: usize = 512;
 

--- a/crates/ai/src/skills/skill_provider.rs
+++ b/crates/ai/src/skills/skill_provider.rs
@@ -219,13 +219,14 @@ pub fn get_scope_for_path(path: &Path) -> SkillScope {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        get_provider_for_path, get_scope_for_path, home_skills_path, SkillProvider, SkillScope,
-    };
     use warp_util::host_id::HostId;
     use warp_util::local_or_remote_path::LocalOrRemotePath;
     use warp_util::remote_path::RemotePath;
     use warp_util::standardized_path::StandardizedPath;
+
+    use super::{
+        get_provider_for_path, get_scope_for_path, home_skills_path, SkillProvider, SkillScope,
+    };
 
     #[test]
     fn warp_home_skills_path_uses_warp_home_path() {

--- a/crates/cloud_object_client/src/lib.rs
+++ b/crates/cloud_object_client/src/lib.rs
@@ -4,16 +4,16 @@ use anyhow::Result;
 use async_channel::Sender;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use cloud_objects::{
-    drive::sharing::SharingAccessLevel,
-    ids::{FolderId, GenericStringObjectId, HashedSqliteId, ObjectUid, ServerId, SyncId},
+pub use cloud_object_models::*;
+pub use cloud_objects::cloud_object::*;
+use cloud_objects::drive::sharing::SharingAccessLevel;
+use cloud_objects::ids::{
+    FolderId, GenericStringObjectId, HashedSqliteId, ObjectUid, ServerId, SyncId,
 };
 #[cfg(any(test, feature = "test-util"))]
 use mockall::automock;
-use warp_graphql::{mcp_gallery_template::MCPGalleryTemplate, object_permissions::AccessLevel};
-
-pub use cloud_object_models::*;
-pub use cloud_objects::cloud_object::*;
+use warp_graphql::mcp_gallery_template::MCPGalleryTemplate;
+use warp_graphql::object_permissions::AccessLevel;
 
 /// Identifies a guest to remove from an object.
 #[derive(Clone, Debug)]

--- a/crates/cloud_object_models/src/ai_execution_profile.rs
+++ b/crates/cloud_object_models/src/ai_execution_profile.rs
@@ -1,14 +1,15 @@
 use std::path::PathBuf;
 
 use ai::LLMId;
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use warp_core::{channel::ChannelState, features::FeatureFlag};
+use warp_core::channel::ChannelState;
+use warp_core::features::FeatureFlag;
 
 use crate::{JsonModel, JsonSerializer};
 

--- a/crates/cloud_object_models/src/ai_fact.rs
+++ b/crates/cloud_object_models/src/ai_fact.rs
@@ -1,9 +1,10 @@
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
-};
-use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
+};
+use cloud_objects::ids::GenericStringObjectId;
+use serde::{Deserialize, Serialize};
 
 use crate::{JsonModel, JsonSerializer};
 

--- a/crates/cloud_object_models/src/cloud_agent_config.rs
+++ b/crates/cloud_object_models/src/cloud_agent_config.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use serde::{Deserialize, Serialize};
 
 use crate::{AgentConfigSnapshot, JsonModel, JsonSerializer};

--- a/crates/cloud_object_models/src/cloud_environment.rs
+++ b/crates/cloud_object_models/src/cloud_environment.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use serde::{Deserialize, Serialize};
 
 use crate::{JsonModel, JsonSerializer};

--- a/crates/cloud_object_models/src/env_vars.rs
+++ b/crates/cloud_object_models/src/env_vars.rs
@@ -1,7 +1,7 @@
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use serde::{Deserialize, Serialize};
 use warp_util::path::ShellFamily;
 

--- a/crates/cloud_object_models/src/folder.rs
+++ b/crates/cloud_object_models/src/folder.rs
@@ -1,7 +1,7 @@
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, ObjectType, ServerObjectModel},
-    ids::FolderId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, ObjectType, ServerObjectModel,
 };
+use cloud_objects::ids::FolderId;
 
 /// The model for a `CloudFolder`.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/cloud_object_models/src/json_model.rs
+++ b/crates/cloud_object_models/src/json_model.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use cloud_objects::cloud_object::{
     GenericStringObjectFormat, JsonObjectType, SerializedModel, Serializer,
 };
-use serde::{Serialize, de::DeserializeOwned};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 /// A JSON-backed cloud object payload.
 pub trait JsonModel: Clone + Debug + Send + Sync + Serialize + DeserializeOwned + 'static {

--- a/crates/cloud_object_models/src/mcp.rs
+++ b/crates/cloud_object_models/src/mcp.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use chrono::Utc;
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use handlebars::get_arguments;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/crates/cloud_object_models/src/notebook.rs
+++ b/crates/cloud_object_models/src/notebook.rs
@@ -1,8 +1,8 @@
 use ai::document::AIDocumentId;
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, ObjectType, ServerObjectModel},
-    ids::{ServerId, SyncId},
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, ObjectType, ServerObjectModel,
 };
+use cloud_objects::ids::{ServerId, SyncId};
 use serde::{Deserialize, Serialize};
 
 /// Serialized representation of a notebook for sync queue

--- a/crates/cloud_object_models/src/preference.rs
+++ b/crates/cloud_object_models/src/preference.rs
@@ -1,8 +1,8 @@
 use anyhow::{Result, anyhow};
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use settings::SyncToCloud;

--- a/crates/cloud_object_models/src/scheduled_ambient_agent.rs
+++ b/crates/cloud_object_models/src/scheduled_ambient_agent.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use warp_cli::agent::Harness;
 

--- a/crates/cloud_object_models/src/server_cloud_object.rs
+++ b/crates/cloud_object_models/src/server_cloud_object.rs
@@ -1,10 +1,10 @@
 use std::any::Any;
 
 use anyhow::Result;
-use cloud_objects::{
-    cloud_object::{GenericServerObject, GenericStringModel, Serializer, ServerMetadata},
-    ids::{GenericStringObjectId, ObjectUid, ServerId, SyncId},
+use cloud_objects::cloud_object::{
+    GenericServerObject, GenericStringModel, Serializer, ServerMetadata,
 };
+use cloud_objects::ids::{GenericStringObjectId, ObjectUid, ServerId, SyncId};
 use warp_graphql::object::CloudObjectWithDescendants;
 
 use crate::{

--- a/crates/cloud_object_models/src/user_profile.rs
+++ b/crates/cloud_object_models/src/user_profile.rs
@@ -1,4 +1,5 @@
-use cloud_objects::{UserUid, ids::ServerId};
+use cloud_objects::UserUid;
+use cloud_objects::ids::ServerId;
 use session_sharing_protocol::common::ProfileData;
 
 /// Public struct for storing all the UserProfile data that's fed in from either sqlite or the server.

--- a/crates/cloud_object_models/src/workflow.rs
+++ b/crates/cloud_object_models/src/workflow.rs
@@ -1,7 +1,7 @@
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, ObjectType, ServerObjectModel},
-    ids::{GenericStringObjectId, ServerId, SyncId},
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, ObjectType, ServerObjectModel,
 };
+use cloud_objects::ids::{GenericStringObjectId, ServerId, SyncId};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 

--- a/crates/cloud_object_models/src/workflow_enum.rs
+++ b/crates/cloud_object_models/src/workflow_enum.rs
@@ -1,7 +1,7 @@
-use cloud_objects::{
-    cloud_object::{GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType},
-    ids::GenericStringObjectId,
+use cloud_objects::cloud_object::{
+    GenericCloudObject, GenericServerObject, GenericStringModel, JsonObjectType,
 };
+use cloud_objects::ids::GenericStringObjectId;
 use serde::{Deserialize, Serialize};
 
 use crate::{JsonModel, JsonSerializer};

--- a/crates/cloud_objects/src/auth/user_uid.rs
+++ b/crates/cloud_objects/src/auth/user_uid.rs
@@ -1,4 +1,5 @@
-use std::{fmt, sync::LazyLock};
+use std::fmt;
+use std::sync::LazyLock;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/crates/cloud_objects/src/cloud_object/generic_cloud_object.rs
+++ b/crates/cloud_objects/src/cloud_object/generic_cloud_object.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
-use crate::ids::{ClientId, SyncId};
-
 use super::{
     CloudObjectMetadata, CloudObjectPermissions, CloudObjectStatuses, CloudObjectSyncStatus,
     ConflictStatus, GenericServerObject, NumInFlightRequests, ObjectType, Owner,
 };
+use crate::ids::{ClientId, SyncId};
 
 /// A portable payload for persisting or otherwise upserting a cloud object without app-local event types.
 #[derive(Clone, Debug)]

--- a/crates/cloud_objects/src/cloud_object/generic_string_model.rs
+++ b/crates/cloud_objects/src/cloud_object/generic_string_model.rs
@@ -1,4 +1,5 @@
-use std::{fmt::Debug, marker::PhantomData};
+use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use anyhow::Result;
 

--- a/crates/cloud_objects/src/cloud_object/server_object.rs
+++ b/crates/cloud_objects/src/cloud_object/server_object.rs
@@ -1,13 +1,10 @@
-use std::{
-    any::Any,
-    fmt::{self, Debug},
-    marker::PhantomData,
-    sync::Arc,
-};
-
-use crate::ids::SyncId;
+use std::any::Any;
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+use std::sync::Arc;
 
 use super::{ObjectType, ServerMetadata, ServerPermissions};
+use crate::ids::SyncId;
 
 #[derive(Clone, Debug, Default)]
 pub enum ConflictStatus<T> {

--- a/crates/warp_core/src/lib.rs
+++ b/crates/warp_core/src/lib.rs
@@ -29,7 +29,6 @@ pub mod user_preferences;
 pub use app_id::AppId;
 pub use session_id::SessionId;
 pub use warp_util::host_id::HostId;
-
 // Re-export warpui so that it can be referenced safely from the
 // telemetry macros.
 pub use warpui;

--- a/crates/warp_logging/src/rotation.rs
+++ b/crates/warp_logging/src/rotation.rs
@@ -174,8 +174,9 @@ pub(crate) fn wrap_for_rotation(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Read;
+
+    use super::*;
 
     fn read(path: &Path) -> String {
         let mut s = String::new();

--- a/crates/warp_search_core/src/telemetry.rs
+++ b/crates/warp_search_core/src/telemetry.rs
@@ -2,10 +2,8 @@ use std::collections::HashSet;
 
 use serde_json::{Value, json};
 use strum_macros::{EnumDiscriminants, EnumIter};
-use warp_core::{
-    register_telemetry_event,
-    telemetry::{EnablementState, TelemetryEventDesc},
-};
+use warp_core::register_telemetry_event;
+use warp_core::telemetry::{EnablementState, TelemetryEventDesc};
 
 #[derive(Clone, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumIter))]

--- a/script/format
+++ b/script/format
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script to format (Rust) code.
+
+set -e
+cd "$(dirname "$0")/.."
+
+EXTRA_ARGS=()
+
+while (( "$#" )); do
+  case "$1" in
+    --check)
+      EXTRA_ARGS+=("--check")
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# Format with specific configuration around how module imports are formatted.
+#
+# We need to set RUSTC_BOOTSTRAP to allow using unstable features on a stable toolchain.
+RUSTC_BOOTSTRAP=1 cargo fmt -- --config imports_granularity=Module --config group_imports=StdExternalCrate "${EXTRA_ARGS[@]}"

--- a/script/presubmit
+++ b/script/presubmit
@@ -6,17 +6,17 @@
 set -e
 cd "$(dirname "$0")/.."
 
-FMT_COMMAND="cargo fmt"
+FMT_COMMAND="./script/format"
 echo "Running $FMT_COMMAND..."
 set -e
 EXIT_CODE=0
-$FMT_COMMAND -- --check || EXIT_CODE=$?
+$FMT_COMMAND --check || EXIT_CODE=$?
 if [[ $EXIT_CODE -ne 0 ]]; then
     echo 'Run `'"$FMT_COMMAND"'` to fix.'
     exit $EXIT_CODE
 fi
 
-echo "Cargo fmt succeeded..."
+echo "Rust formatting succeeded..."
 
 echo "Running clippy..."
 # Exclude warp_completer because we run clippy on it with default features (rather than all features) below.


### PR DESCRIPTION
## Description

This adds a formatting script at `./script/format` that invokes `cargo fmt` with the options we want for our codebase.

Due to the fact that we're using some unstable formatter options, we need to pass `RUSTC_BOOTSTRAP=1` to enable use of unstable options with a stable toolchain, and that requires us to put together a small script like this.

This PR updates existing formatting using the new script, and modifies both `./script/presubmit` ~and CI to enforce formatting against this new configuration~.

EDIT: Realized we probably want `./script/format` to soak for a week or so before we start enforcement, due to us not using a merge queue.  Otherwise, we'll probably end up with non-conforming formatting changes being merged into `master` and causing issues.