### PR TITLE
Basic vertical tab grouping

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -44,6 +44,7 @@ use crate::util::color::{coloru_with_opacity, Opacity};
 use crate::util::truncation::truncate_from_end;
 use crate::window_settings::WindowSettings;
 use crate::workspace::sync_inputs::SyncedInputState;
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspace::tab_settings::{
     TabCloseButtonPosition, TabSettings, VerticalTabsDisplayGranularity,
 };
@@ -147,6 +148,8 @@ pub struct TabData {
     pub indicator_hover_state: MouseStateHandle,
     // Used by a later drag-tab branch to distinguish tabs that have moved into detached windows.
     pub detached: bool,
+    /// Tab group this tab belongs to, if any
+    pub group_id: Option<TabGroupId>,
 }
 
 const TAB_COLOR_ICON_PATH: &str = "bundled/svg/ellipse.svg";
@@ -164,6 +167,7 @@ impl TabData {
             selected_color: SelectedTabColor::Unset,
             indicator_hover_state: Default::default(),
             detached: false,
+            group_id: None,
         }
     }
 

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -41,6 +41,7 @@ use crate::terminal::view::inline_banner::ZeroStatePromptSuggestionType;
 use crate::themes::theme::AnsiColorIdentifier;
 use crate::themes::theme_chooser::ThemeChooserMode;
 use crate::workflows::{WorkflowSelectionSource, WorkflowSource, WorkflowType};
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspace::PaneViewLocator;
 
 /// This enum determines how the search query is initialized when opening command search.
@@ -169,6 +170,10 @@ pub enum WorkspaceAction {
     CloseNonActiveTabs,
     CloseTabsRight(usize),
     CloseTabsRightActiveTab,
+    /// Close every tab that belongs to the given tab group.
+    CloseTabGroup(TabGroupId),
+    /// Toggle collapsed state for the given tab group.
+    ToggleTabGroupCollapsed(TabGroupId),
     AddDefaultTab,
     AddTerminalTab {
         hide_homepage: bool,
@@ -790,6 +795,8 @@ impl WorkspaceAction {
             | CloseNonActiveTabs
             | CloseTabsRight(_)
             | CloseTabsRightActiveTab
+            | CloseTabGroup(_)
+            | ToggleTabGroupCollapsed(_)
             | ToggleTabColor { .. }
             | AddDefaultTab
             | AddTerminalTab { .. }

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -18,6 +18,7 @@ mod one_time_modal_model;
 mod registry;
 pub mod rewind_confirmation_dialog;
 pub mod sync_inputs;
+pub mod tab_group;
 pub mod tab_settings;
 mod toast_stack;
 pub mod util;

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -1,0 +1,22 @@
+//! Tab group data model. Gated at runtime by `FeatureFlag::GroupedTabs`.
+
+use uuid::Uuid;
+
+/// Stable identity for a tab group.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TabGroupId(pub Uuid);
+
+impl TabGroupId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+/// A group of tabs. Member tabs point to their
+/// group via `TabData::group_id`.
+#[derive(Clone)]
+pub struct TabGroup {
+    pub id: TabGroupId,
+    pub name: Option<String>,
+    pub collapsed: bool,
+}

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -12,6 +12,12 @@ impl TabGroupId {
     }
 }
 
+impl Default for TabGroupId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A group of tabs. Member tabs point to their
 /// group via `TabData::group_id`.
 #[derive(Clone)]

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -26,3 +26,20 @@ pub struct TabGroup {
     pub name: Option<String>,
     pub collapsed: bool,
 }
+
+impl TabGroup {
+    /// Creates a new, untitled, expanded tab group with a fresh id.
+    pub fn new() -> Self {
+        Self {
+            id: TabGroupId::new(),
+            name: None,
+            collapsed: false,
+        }
+    }
+}
+
+impl Default for TabGroup {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -467,6 +467,7 @@ use crate::workspace::header_toolbar_editor::{HeaderToolbarEditorEvent, HeaderTo
 use crate::workspace::header_toolbar_item::HeaderToolbarItemKind;
 use crate::workspace::one_time_modal_model::OneTimeModalModel;
 use crate::workspace::sync_inputs::SyncedInputState;
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::TabCloseButtonPosition;
 use crate::workspace::toast_stack::{
     ToastStack, ToastStack as WorkspaceToastStack, ToastStackEvent as WorkspaceToastStackEvent,
@@ -933,6 +934,8 @@ pub struct Workspace {
     tab_bar_hover_state: MouseStateHandle,
     tab_fixed_width: Option<f32>,
     traffic_light_mouse_states: TrafficLightMouseStates,
+    /// Tab groups in this workspace, keyed by id.
+    pub(crate) tab_groups: HashMap<TabGroupId, TabGroup>,
     tab_rename_editor: ViewHandle<EditorView>,
     pane_rename_editor: ViewHandle<EditorView>,
     vertical_tabs_search_input: ViewHandle<EditorView>,
@@ -3085,6 +3088,7 @@ impl Workspace {
             hovered_tab_index: None,
             tab_bar_hover_state: Default::default(),
             traffic_light_mouse_states: Default::default(),
+            tab_groups: HashMap::new(),
             tab_rename_editor: Self::tab_rename_editor(ctx),
             pane_rename_editor: Self::pane_rename_editor(ctx),
             vertical_tabs_search_input: Self::vertical_tabs_search_input(ctx),
@@ -6481,7 +6485,7 @@ impl Workspace {
             #[cfg(not(feature = "local_fs"))]
             NewSessionMenuItem::CreateNewTabConfig => {}
             NewSessionMenuItem::CreateNewTabGroup => {
-                // TODO(johnturcoo): implement tab group creation.
+                self.create_new_tab_group(ctx);
             }
         }
     }
@@ -6634,6 +6638,98 @@ impl Workspace {
 
     #[cfg(not(feature = "local_fs"))]
     fn save_current_tab_as_new_config(&mut self, _tab_index: usize, _ctx: &mut ViewContext<Self>) {}
+
+    /// Creates a new tab group containing a single new tab. 
+    fn create_new_tab_group(&mut self, ctx: &mut ViewContext<Self>) {
+        let group_id = TabGroupId::new();
+        self.tab_groups.insert(
+            group_id,
+            TabGroup {
+                id: group_id,
+                name: None,
+                collapsed: false,
+            },
+        );
+        self.add_new_session_tab_with_default_mode(
+            NewSessionSource::Tab,
+            Some(ctx.window_id()),
+            None,
+            None,
+            false,
+            ctx,
+        );
+        let new_tab_index = self.active_tab_index;
+        if let Some(tab) = self.tabs.get_mut(new_tab_index) {
+            tab.group_id = Some(group_id);
+        }
+
+        // Cluster the new group after the last existing grouped tab.
+        let target_index = self
+            .tabs
+            .iter()
+            .enumerate()
+            .filter(|(idx, tab)| *idx != new_tab_index && tab.group_id.is_some())
+            .map(|(idx, _)| idx)
+            .max()
+            .map(|max_idx| max_idx + 1)
+            .unwrap_or(0);
+
+        if new_tab_index != target_index {
+            let tab = self.tabs.remove(new_tab_index);
+            let insert_index = if new_tab_index < target_index {
+                target_index - 1
+            } else {
+                target_index
+            };
+            self.tabs.insert(insert_index, tab);
+            self.active_tab_index = insert_index;
+        }
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Closes every tab in the given group and removes the group.
+    pub fn close_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
+        let indices: Vec<usize> = self
+            .tabs
+            .iter()
+            .enumerate()
+            .filter(|(_, tab)| tab.group_id == Some(group_id))
+            .map(|(idx, _)| idx)
+            .collect();
+        if indices.is_empty() {
+            self.tab_groups.remove(&group_id);
+            ctx.notify();
+            return;
+        }
+        let first_index = indices[0];
+        let closed = self.close_tabs(
+            indices.into_iter(),
+            OpenDialogSource::CloseOtherTabs {
+                tab_index: first_index,
+            },
+            false,
+            true,
+            ctx,
+        );
+        if closed {
+            self.tab_groups.remove(&group_id);
+            ctx.notify();
+        }
+    }
+
+    /// Toggles the collapsed state of the given tab group.
+    pub fn toggle_tab_group_collapsed(
+        &mut self,
+        group_id: TabGroupId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(group) = self.tab_groups.get_mut(&group_id) {
+            group.collapsed = !group.collapsed;
+            ctx.notify();
+        }
+    }
 
     pub fn toggle_tab_right_click_menu(
         &mut self,
@@ -11053,6 +11149,12 @@ impl Workspace {
 
         let is_new_terminal = matches!(panes_layout, PanesLayout::SingleTerminal(_));
         let is_restoration = matches!(panes_layout, PanesLayout::Snapshot(_));
+        // Capture the active tab's group membership so the new tab can inherit it.
+        let active_tab_group_id = if FeatureFlag::GroupedTabs.is_enabled() && !is_restoration {
+            active_tab.and_then(|tab| tab.group_id)
+        } else {
+            None
+        };
         let new_pane_group = ctx.add_typed_action_view(|ctx| {
             let mut pane_group = PaneGroup::new_with_panes_layout(
                 self.tips_completed.clone(),
@@ -11078,10 +11180,24 @@ impl Workspace {
 
         match new_tab_placement_setting {
             NewTabPlacement::AfterAllTabs => {
-                self.tabs.push(TabData::new(new_pane_group));
+                // When inheriting a group, land at the end of the group's
+                // contiguous run instead of past it so the setting is
+                // honored within the group's bounds.
+                let insert_idx = active_tab_group_id
+                    .and_then(|gid| {
+                        self.tabs
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, tab)| tab.group_id == Some(gid))
+                            .map(|(idx, _)| idx)
+                            .max()
+                            .map(|max_idx| max_idx + 1)
+                    })
+                    .unwrap_or(self.tabs.len());
+                self.tabs.insert(insert_idx, TabData::new(new_pane_group));
                 self.tab_mru_order
-                    .push(self.tabs.last().unwrap().pane_group.id());
-                self.activate_tab_internal(self.tab_count() - 1, ctx);
+                    .push(self.tabs[insert_idx].pane_group.id());
+                self.activate_tab_internal(insert_idx, ctx);
             }
             // Add tab after current tab
             _ => {
@@ -11097,6 +11213,14 @@ impl Workspace {
                         .push(self.tabs[insert_idx].pane_group.id());
                     self.activate_tab_internal(insert_idx, ctx);
                 }
+            }
+        }
+
+        // Inherit the active tab's group membership. D
+        if let Some(group_id) = active_tab_group_id {
+            let new_idx = self.active_tab_index;
+            if let Some(new_tab) = self.tabs.get_mut(new_idx) {
+                new_tab.group_id = Some(group_id);
             }
         }
 
@@ -21127,6 +21251,8 @@ impl TypedActionView for Workspace {
             CloseTabsRightActiveTab => {
                 self.close_tabs_direction(self.active_tab_index, TabMovement::Right, false, ctx)
             }
+            CloseTabGroup(group_id) => self.close_tab_group(*group_id, ctx),
+            ToggleTabGroupCollapsed(group_id) => self.toggle_tab_group_collapsed(*group_id, ctx),
             AddDefaultTab => {
                 let effective_mode = AISettings::as_ref(ctx).default_session_mode(ctx);
                 match effective_mode {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6641,15 +6641,9 @@ impl Workspace {
 
     /// Creates a new tab group containing a single new tab.
     fn create_new_tab_group(&mut self, ctx: &mut ViewContext<Self>) {
-        let group_id = TabGroupId::new();
-        self.tab_groups.insert(
-            group_id,
-            TabGroup {
-                id: group_id,
-                name: None,
-                collapsed: false,
-            },
-        );
+        let group = TabGroup::new();
+        let group_id = group.id;
+        self.tab_groups.insert(group_id, group);
         self.add_new_session_tab_with_default_mode(
             NewSessionSource::Tab,
             Some(ctx.window_id()),
@@ -6663,26 +6657,11 @@ impl Workspace {
             tab.group_id = Some(group_id);
         }
 
-        // Cluster the new group after the last existing grouped tab.
-        let target_index = self
-            .tabs
-            .iter()
-            .enumerate()
-            .filter(|(idx, tab)| *idx != new_tab_index && tab.group_id.is_some())
-            .map(|(idx, _)| idx)
-            .max()
-            .map(|max_idx| max_idx + 1)
-            .unwrap_or(0);
-
-        if new_tab_index != target_index {
+        // New tab groups always land at the top of the tab list.
+        if new_tab_index != 0 {
             let tab = self.tabs.remove(new_tab_index);
-            let insert_index = if new_tab_index < target_index {
-                target_index - 1
-            } else {
-                target_index
-            };
-            self.tabs.insert(insert_index, tab);
-            self.active_tab_index = insert_index;
+            self.tabs.insert(0, tab);
+            self.active_tab_index = 0;
         }
 
         ctx.dispatch_global_action("workspace:save_app", ());
@@ -6691,13 +6670,7 @@ impl Workspace {
 
     /// Closes every tab in the given group and removes the group.
     pub fn close_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
-        let indices: Vec<usize> = self
-            .tabs
-            .iter()
-            .enumerate()
-            .filter(|(_, tab)| tab.group_id == Some(group_id))
-            .map(|(idx, _)| idx)
-            .collect();
+        let indices: Vec<usize> = group_member_indices(&self.tabs, group_id).collect();
         if indices.is_empty() {
             self.tab_groups.remove(&group_id);
             ctx.notify();
@@ -11185,13 +11158,9 @@ impl Workspace {
                 // honored within the group's bounds.
                 let insert_idx = active_tab_group_id
                     .and_then(|gid| {
-                        self.tabs
-                            .iter()
-                            .enumerate()
-                            .filter(|(_, tab)| tab.group_id == Some(gid))
-                            .map(|(idx, _)| idx)
-                            .max()
-                            .map(|max_idx| max_idx + 1)
+                        group_member_indices(&self.tabs, gid)
+                            .last()
+                            .map(|last| last + 1)
                     })
                     .unwrap_or(self.tabs.len());
                 self.tabs.insert(insert_idx, TabData::new(new_pane_group));
@@ -25402,6 +25371,18 @@ impl Workspace {
 
 fn should_reserve_traffic_light_space_in_tab_bar(side: TrafficLightSide) -> bool {
     side == TrafficLightSide::Right
+}
+
+/// Returns the indices of every tab in `tabs` that belongs to `group_id`,
+/// in ascending order.
+fn group_member_indices(
+    tabs: &[TabData],
+    group_id: TabGroupId,
+) -> impl Iterator<Item = usize> + '_ {
+    tabs.iter()
+        .enumerate()
+        .filter(move |(_, tab)| tab.group_id == Some(group_id))
+        .map(|(idx, _)| idx)
 }
 
 /// Returns every tab-bar-equivalent rect laid out in `window_id` (horizontal

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6639,7 +6639,7 @@ impl Workspace {
     #[cfg(not(feature = "local_fs"))]
     fn save_current_tab_as_new_config(&mut self, _tab_index: usize, _ctx: &mut ViewContext<Self>) {}
 
-    /// Creates a new tab group containing a single new tab. 
+    /// Creates a new tab group containing a single new tab.
     fn create_new_tab_group(&mut self, ctx: &mut ViewContext<Self>) {
         let group_id = TabGroupId::new();
         self.tab_groups.insert(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6485,7 +6485,9 @@ impl Workspace {
             #[cfg(not(feature = "local_fs"))]
             NewSessionMenuItem::CreateNewTabConfig => {}
             NewSessionMenuItem::CreateNewTabGroup => {
-                self.create_new_tab_group(ctx);
+                if FeatureFlag::GroupedTabs.is_enabled() {
+                    self.create_new_tab_group(ctx);
+                }
             }
         }
     }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -70,6 +70,7 @@ use crate::util::color::Opacity;
 use crate::workspace::action::{NewSessionMenuAnchor, WorkspaceAction};
 use crate::workspace::cross_window_tab_drag::CrossWindowTabDrag;
 use crate::workspace::hoa_onboarding::HoaOnboardingStep;
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::{
     TabSettings, VerticalTabsCompactSubtitle, VerticalTabsDisplayGranularity,
     VerticalTabsPrimaryInfo, VerticalTabsTabItemMode, VerticalTabsViewMode,
@@ -94,9 +95,13 @@ const GROUP_BODY_BOTTOM_PADDING: f32 = 8.;
 const GROUP_ITEM_SPACING: f32 = 4.;
 const TABS_MODE_ITEM_SPACING: f32 = 4.;
 const GROUP_ACTION_BUTTON_ICON_SIZE: f32 = 12.;
+const TAB_GROUP_HEADER_ACTION_ICON_SIZE: f32 = 14.;
 const GROUP_ACTION_BUTTON_PADDING: f32 = 2.;
 const GROUP_ACTION_BUTTON_GAP: f32 = 2.;
 const ROW_CORNER_RADIUS: f32 = 4.;
+const TAB_GROUP_MEMBER_INDENT: f32 = 12.;
+const TAB_GROUP_ICON_SIZE: f32 = 16.;
+const TAB_GROUP_CONTENT_INSET: f32 = 4.;
 const BADGE_ICON_SIZE: f32 = 12.;
 const DETAIL_SIDECAR_DEFAULT_WIDTH: f32 = 320.;
 const DETAIL_SIDECAR_MIN_WIDTH: f32 = 240.;
@@ -267,6 +272,16 @@ struct PaneGroupStateHandles {
     kebab: MouseStateHandle,
     close: MouseStateHandle,
     action_buttons: MouseStateHandle,
+}
+
+/// Hover states for a tab group's container, header, chevron, kebab, and close button.
+#[derive(Clone, Default)]
+struct TabGroupMouseStates {
+    container: MouseStateHandle,
+    header: MouseStateHandle,
+    chevron: MouseStateHandle,
+    kebab: MouseStateHandle,
+    close: MouseStateHandle,
 }
 
 fn pane_row_background(
@@ -556,6 +571,8 @@ pub(super) struct VerticalTabsPanelState {
     scroll_state: ClippedScrollStateHandle,
     resizable_state: ResizableStateHandle,
     group_mouse_states: RefCell<HashMap<EntityId, PaneGroupStateHandles>>,
+    /// Hover states per tab group, keyed by `TabGroupId`.
+    tab_group_mouse_states: RefCell<HashMap<TabGroupId, TabGroupMouseStates>>,
     pane_row_mouse_states: RefCell<HashMap<PaneId, MouseStateHandle>>,
     pane_title_mouse_states: RefCell<HashMap<PaneId, MouseStateHandle>>,
     pane_badge_mouse_states: RefCell<HashMap<PaneId, PaneRowBadgeMouseStates>>,
@@ -592,6 +609,7 @@ impl Default for VerticalTabsPanelState {
             scroll_state: ClippedScrollStateHandle::default(),
             resizable_state: resizable_state_handle(PANEL_WIDTH),
             group_mouse_states: RefCell::default(),
+            tab_group_mouse_states: RefCell::default(),
             pane_row_mouse_states: RefCell::default(),
             pane_title_mouse_states: RefCell::default(),
             pane_badge_mouse_states: RefCell::default(),
@@ -818,6 +836,13 @@ struct TabGroupDragState {
     is_any_pane_dragging: bool,
     insert_before_index: usize,
     insert_after_index: Option<usize>,
+}
+
+/// One visible member of a tab group, captured during the render walk.
+struct TabGroupMember<'a> {
+    tab_index: usize,
+    filtered_pane_ids: Option<&'a [PaneId]>,
+    is_last_visible: bool,
 }
 
 fn resolve_vertical_tabs_mode(app: &AppContext) -> VerticalTabsResolvedMode {
@@ -1724,27 +1749,67 @@ fn render_groups(
         groups = groups.with_spacing(TABS_MODE_ITEM_SPACING);
     }
 
-    for (visible_tab_index, (tab_index, filtered_pane_ids)) in visible_tabs.iter().enumerate() {
-        // Insert ghost slot before this tab group if the drop would land here.
-        if ghost_insertion_index == Some(*tab_index) {
+    // Consecutive tabs sharing a group_id collapse into a single group container.
+    let total_visible = visible_tabs.len();
+    let mut i = 0;
+    while i < total_visible {
+        let (tab_index, ref filtered_pane_ids) = visible_tabs[i];
+        if ghost_insertion_index == Some(tab_index) {
             groups.add_child(render_ghost_vertical_tab_slot(workspace, app));
         }
-        let insert_before_index = *tab_index;
-        let insert_after_index =
-            (visible_tab_index == visible_tabs.len() - 1).then_some(tab_index + 1);
-        groups.add_child(render_tab_group(
-            state,
-            workspace,
-            *tab_index,
-            &workspace.tabs[*tab_index],
-            filtered_pane_ids.as_deref(),
-            TabGroupDragState {
-                is_any_pane_dragging,
-                insert_before_index,
-                insert_after_index,
-            },
-            app,
-        ));
+        let tab = &workspace.tabs[tab_index];
+        match tab.group_id.and_then(|gid| {
+            workspace
+                .tab_groups
+                .get(&gid)
+                .map(|group| (gid, group.clone()))
+        }) {
+            Some((group_id, group)) => {
+                // Collect consecutive member tabs belonging to the same group.
+                let mut members: Vec<TabGroupMember<'_>> = Vec::new();
+                let mut j = i;
+                while j < total_visible {
+                    let (next_tab_index, ref next_filtered_pane_ids) = visible_tabs[j];
+                    if workspace.tabs[next_tab_index].group_id != Some(group_id) {
+                        break;
+                    }
+                    members.push(TabGroupMember {
+                        tab_index: next_tab_index,
+                        filtered_pane_ids: next_filtered_pane_ids.as_deref(),
+                        is_last_visible: j == total_visible - 1,
+                    });
+                    j += 1;
+                }
+                groups.add_child(render_grouped_tab_container(
+                    state,
+                    workspace,
+                    &group,
+                    &members,
+                    is_any_pane_dragging,
+                    app,
+                ));
+                i = j;
+            }
+            None => {
+                let insert_before_index = tab_index;
+                let insert_after_index = (i == total_visible - 1).then_some(tab_index + 1);
+                groups.add_child(render_tab_group(
+                    state,
+                    workspace,
+                    tab_index,
+                    tab,
+                    filtered_pane_ids.as_deref(),
+                    TabGroupDragState {
+                        is_any_pane_dragging,
+                        insert_before_index,
+                        insert_after_index,
+                    },
+                    false, // in_tab_group
+                    app,
+                ));
+                i += 1;
+            }
+        }
     }
     // Ghost after all tab groups (fencepost).
     if ghost_insertion_index == Some(workspace.tabs.len()) {
@@ -1780,6 +1845,7 @@ fn render_groups(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_tab_group(
     state: &VerticalTabsPanelState,
     workspace: &Workspace,
@@ -1787,6 +1853,7 @@ fn render_tab_group(
     tab: &TabData,
     filtered_pane_ids: Option<&[PaneId]>,
     drag_state: TabGroupDragState,
+    in_tab_group: bool,
     app: &AppContext,
 ) -> Box<dyn Element> {
     render_tab_group_internal(
@@ -1797,6 +1864,7 @@ fn render_tab_group(
         filtered_pane_ids,
         drag_state,
         false,
+        in_tab_group,
         app,
     )
 }
@@ -1810,6 +1878,7 @@ fn render_tab_group_internal(
     filtered_pane_ids: Option<&[PaneId]>,
     drag_state: TabGroupDragState,
     for_drag_ghost: bool,
+    in_tab_group: bool,
     app: &AppContext,
 ) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
@@ -1824,7 +1893,9 @@ fn render_tab_group_internal(
             VerticalTabsDisplayGranularity::Tabs
         }
     };
-    let uses_outer_group_container = uses_outer_group_container(display_granularity);
+    // Tabs inside a group skip the per-tab outer container; the group provides it.
+    let uses_outer_group_container =
+        !in_tab_group && uses_outer_group_container(display_granularity);
     let representative_pane_ids = pane_ids_for_display_granularity(
         &visible_pane_ids,
         pane_group.focused_pane_id(app),
@@ -2060,14 +2131,28 @@ fn render_tab_group_internal(
             }
             container.finish()
         } else {
+            // Inside a tab group the surrounding container already paints
+            // hover/active state for the whole group, so suppress the
+            // per-tab background here and let each row show its own
+            // selected/hovered state.
             let background = if is_drag_target {
                 internal_colors::fg_overlay_2(theme)
-            } else if is_active || group_state.is_hovered() {
+            } else if !in_tab_group && (is_active || group_state.is_hovered()) {
                 internal_colors::fg_overlay_1(theme)
             } else {
                 ThemeFill::Solid(ColorU::transparent_black())
             };
+            // Pane view inside a tab group: reserve a top band so the action
+            // buttons (anchored to this wrapper's top-right) sit above the
+            // first pane row instead of overlaying its content, matching how
+            // regular pane view places them in the body's top padding.
+            let needs_action_button_band = in_tab_group
+                && matches!(display_granularity, VerticalTabsDisplayGranularity::Panes);
             let mut container = Container::new(build_rows()).with_background(background);
+            if needs_action_button_band {
+                container = container
+                    .with_padding(Padding::uniform(0.).with_top(GROUP_BODY_BOTTOM_PADDING));
+            }
             if is_drag_target {
                 container = container.with_border(
                     Border::all(1.).with_border_fill(ThemeFill::Solid(theme.accent().into())),
@@ -2120,10 +2205,23 @@ fn render_tab_group_internal(
                 );
             }
         }
+        // Pane view inside a tab group: the group container adds
+        // `GROUP_HORIZONTAL_PADDING` of right padding and the member wrapper
+        // around this `Stack` adds another `TAB_GROUP_CONTENT_INSET`, so the
+        // `Stack`'s right edge sits that much further inside the panel than
+        // it does in regular pane view. Push the buttons back out by the
+        // same amount so they land at the same panel-relative offset.
+        let action_button_x_offset = if in_tab_group
+            && matches!(display_granularity, VerticalTabsDisplayGranularity::Panes)
+        {
+            GROUP_HORIZONTAL_PADDING + TAB_GROUP_CONTENT_INSET - 4.
+        } else {
+            -4.
+        };
         stack.add_positioned_overlay_child(
             action_buttons,
             OffsetPositioning::offset_from_parent(
-                vec2f(-4., GROUP_HEADER_VERTICAL_PADDING),
+                vec2f(action_button_x_offset, GROUP_HEADER_VERTICAL_PADDING),
                 ParentOffsetBounds::WindowByPosition,
                 ParentAnchor::TopRight,
                 ChildAnchor::TopRight,
@@ -2304,9 +2402,295 @@ pub(crate) fn render_tab_group_for_drag_ghost(
         tab,
         None,
         drag_state,
-        true, // for_drag_ghost
+        true,  // for_drag_ghost
+        false, // in_tab_group
         app,
     )
+}
+
+/// Small icon button for the tab-group header; consumes clicks so they don't bubble.
+fn render_tab_group_header_icon_button(
+    icon: WarpIcon,
+    icon_size: f32,
+    icon_color: WarpThemeFill,
+    hover_background: WarpThemeFill,
+    mouse_state: MouseStateHandle,
+    on_click_action: Option<WorkspaceAction>,
+) -> Box<dyn Element> {
+    Hoverable::new(mouse_state, move |button_state| {
+        let mut container = Container::new(
+            ConstrainedBox::new(icon.to_warpui_icon(icon_color).finish())
+                .with_width(icon_size)
+                .with_height(icon_size)
+                .finish(),
+        )
+        .with_padding(Padding::uniform(GROUP_ACTION_BUTTON_PADDING))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
+        if button_state.is_hovered() {
+            container = container.with_background(hover_background);
+        }
+        container.finish()
+    })
+    .with_cursor(Cursor::PointingHand)
+    .on_click(move |ctx, _, _| {
+        if let Some(action) = on_click_action.clone() {
+            ctx.dispatch_typed_action(action);
+        }
+    })
+    .finish()
+}
+
+/// Renders the header row for a tab group: chevron, title + "N tabs", and (on hover)
+/// kebab + close buttons. Single-clicking outside the per-button regions toggles collapse.
+fn render_grouped_tabs_header(
+    group: &TabGroup,
+    member_count: usize,
+    mouse_states: &TabGroupMouseStates,
+    is_collapsed: bool,
+    is_header_selected: bool,
+    show_action_buttons: bool,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    let font_family = appearance.ui_font_family();
+    let main_text_color = theme.main_text_color(theme.background());
+    let sub_text_color = theme.sub_text_color(theme.background());
+    let group_id = group.id;
+
+    let chevron_icon = if is_collapsed {
+        WarpIcon::ChevronRight
+    } else {
+        WarpIcon::ChevronDown
+    };
+    let chevron_button = render_tab_group_header_icon_button(
+        chevron_icon,
+        TAB_GROUP_ICON_SIZE,
+        main_text_color,
+        internal_colors::fg_overlay_2(theme),
+        mouse_states.chevron.clone(),
+        Some(WorkspaceAction::ToggleTabGroupCollapsed(group_id)),
+    );
+    // Center the chevron in a `VERTICAL_TABS_ICON_SIZE` slot so the title aligns with member rows.
+    let chevron_slot = ConstrainedBox::new(
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::Center)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(chevron_button)
+            .finish(),
+    )
+    .with_width(VERTICAL_TABS_ICON_SIZE)
+    .with_height(VERTICAL_TABS_ICON_SIZE)
+    .finish();
+
+    let title_text = group.name.clone().unwrap_or_else(|| "New Group".to_string());
+    let title_element: Box<dyn Element> = Text::new_inline(title_text, font_family, 12.)
+        .with_clip(ClipConfig::ellipsis())
+        .with_color(main_text_color.into())
+        .finish();
+    let subtitle_text = if member_count == 1 {
+        "1 tab".to_string()
+    } else {
+        format!("{member_count} tabs")
+    };
+    let subtitle = Text::new_inline(subtitle_text, font_family, 10.)
+        .with_clip(ClipConfig::ellipsis())
+        .with_color(sub_text_color.into())
+        .finish();
+    let text_column: Box<dyn Element> = Flex::column()
+        .with_main_axis_size(MainAxisSize::Min)
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_spacing(1.)
+        .with_child(title_element)
+        .with_child(subtitle)
+        .finish();
+
+    let action_buttons = if show_action_buttons {
+        let kebab_button = render_tab_group_header_icon_button(
+            WarpIcon::DotsVertical,
+            TAB_GROUP_HEADER_ACTION_ICON_SIZE,
+            sub_text_color,
+            internal_colors::fg_overlay_2(theme),
+            mouse_states.kebab.clone(),
+            // No-op for now; TODO(johnturcoo) add tab group more-options menu.
+            None,
+        );
+        let close_button = render_tab_group_header_icon_button(
+            WarpIcon::X,
+            TAB_GROUP_HEADER_ACTION_ICON_SIZE,
+            sub_text_color,
+            internal_colors::fg_overlay_3(theme),
+            mouse_states.close.clone(),
+            Some(WorkspaceAction::CloseTabGroup(group_id)),
+        );
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(GROUP_ACTION_BUTTON_GAP)
+            .with_child(kebab_button)
+            .with_child(close_button)
+            .finish()
+    } else {
+        Empty::new().finish()
+    };
+
+    let row = Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(
+            Shrinkable::new(
+                1.,
+                Flex::row()
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(ICON_WITH_STATUS_GAP)
+                    .with_child(chevron_slot)
+                    .with_child(Shrinkable::new(1., text_column).finish())
+                    .finish(),
+            )
+            .finish(),
+        )
+        .with_child(action_buttons)
+        .finish();
+
+    let mut hoverable = Hoverable::new(mouse_states.header.clone(), move |state| {
+        let border_fill = if is_header_selected {
+            internal_colors::fg_overlay_3(theme)
+        } else {
+            WarpThemeFill::Solid(ColorU::transparent_black())
+        };
+        let mut container = Container::new(row)
+            .with_padding(Padding::uniform(GROUP_HORIZONTAL_PADDING))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
+            .with_border(Border::all(1.).with_border_fill(border_fill));
+        if is_header_selected || state.is_hovered() {
+            container = container.with_background(internal_colors::fg_overlay_2(theme));
+        }
+        container.finish()
+    })
+    .with_cursor(Cursor::PointingHand)
+    .with_defer_events_to_children();
+
+    // Single-click toggles collapse; no-op `on_right_click` keeps right-clicks from bubbling
+    // up to the panel's new-session menu handler.
+    hoverable = hoverable.on_click(move |ctx, _, _| {
+        ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupCollapsed(group_id));
+    });
+    hoverable = hoverable.on_right_click(|_, _, _| {});
+    hoverable.finish()
+}
+
+/// Renders a tab group: pane-like header followed by indented member rows. Background only paints
+/// on hover or when a member is active.
+fn render_grouped_tab_container(
+    state: &VerticalTabsPanelState,
+    workspace: &Workspace,
+    group: &TabGroup,
+    members: &[TabGroupMember<'_>],
+    is_any_pane_dragging: bool,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+
+    let mouse_states = state
+        .tab_group_mouse_states
+        .borrow_mut()
+        .entry(group.id)
+        .or_default()
+        .clone();
+
+    let member_count = members.len();
+    let group = group.clone();
+    let any_member_active = members
+        .iter()
+        .any(|m| m.tab_index == workspace.active_tab_index);
+    let is_collapsed = group.collapsed;
+
+    let resolved_mode = resolve_vertical_tabs_mode(app);
+    let needs_outer_horizontal_padding = uses_outer_group_container(match resolved_mode {
+        VerticalTabsResolvedMode::Panes => VerticalTabsDisplayGranularity::Panes,
+        _ => VerticalTabsDisplayGranularity::Tabs,
+    });
+
+    Hoverable::new(mouse_states.container.clone(), |hover_state| {
+        let mut content = Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(TABS_MODE_ITEM_SPACING);
+
+        // Collapsed group + active member: highlight the header instead of the (now hidden) member row.
+        let is_header_selected = is_collapsed && any_member_active;
+        content.add_child(render_grouped_tabs_header(
+            &group,
+            member_count,
+            &mouse_states,
+            is_collapsed,
+            is_header_selected,
+            hover_state.is_hovered(),
+            app,
+        ));
+
+        // Collapsed groups hide member rows in the panel chrome; the members remain in `workspace.tabs`.
+        if !is_collapsed {
+            for member in members {
+                let tab = &workspace.tabs[member.tab_index];
+                let insert_before_index = member.tab_index;
+                let insert_after_index = member.is_last_visible.then_some(member.tab_index + 1);
+                let drag_state = TabGroupDragState {
+                    is_any_pane_dragging,
+                    insert_before_index,
+                    insert_after_index,
+                };
+                let tab_element = render_tab_group(
+                    state,
+                    workspace,
+                    member.tab_index,
+                    tab,
+                    member.filtered_pane_ids,
+                    drag_state,
+                    true, 
+                    app,
+                );
+                content.add_child(
+                    Container::new(tab_element)
+                        .with_padding(
+                            Padding::uniform(0.)
+                                .with_left(TAB_GROUP_MEMBER_INDENT)
+                                .with_right(TAB_GROUP_CONTENT_INSET),
+                        )
+                        .finish(),
+                );
+            }
+        }
+
+        let background = if hover_state.is_hovered() || any_member_active {
+            internal_colors::fg_overlay_1(theme)
+        } else {
+            ThemeFill::Solid(ColorU::transparent_black())
+        };
+
+        // Pane view: uniform `GROUP_HORIZONTAL_PADDING` matches ungrouped-tab body padding.
+        // Tab view: only apply bottom padding when expanded so a collapsed group has no trailing band.
+        let mut padding = Padding::uniform(0.);
+        if needs_outer_horizontal_padding {
+            padding = Padding::uniform(GROUP_HORIZONTAL_PADDING);
+        } else if !is_collapsed {
+            padding = padding.with_bottom(TAB_GROUP_CONTENT_INSET);
+        }
+
+        Container::new(content.finish())
+            .with_padding(padding)
+            .with_background(background)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
+            .finish()
+    })
+    // Consume right-clicks so they don't bubble to the panel's new-session menu handler.
+    .on_right_click(|_, _, _| {})
+    .with_defer_events_to_children()
+    .finish()
 }
 
 fn render_group_header(props: GroupHeaderProps<'_>, app: &AppContext) -> Box<dyn Element> {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -838,13 +838,6 @@ struct TabGroupDragState {
     insert_after_index: Option<usize>,
 }
 
-/// One visible member of a tab group, captured during the render walk.
-struct TabGroupMember<'a> {
-    tab_index: usize,
-    filtered_pane_ids: Option<&'a [PaneId]>,
-    is_last_visible: bool,
-}
-
 fn resolve_vertical_tabs_mode(app: &AppContext) -> VerticalTabsResolvedMode {
     let settings = TabSettings::as_ref(app);
     match *settings.vertical_tabs_display_granularity.value() {
@@ -1765,30 +1758,26 @@ fn render_groups(
                 .map(|group| (gid, group.clone()))
         }) {
             Some((group_id, group)) => {
-                // Collect consecutive member tabs belonging to the same group.
-                let mut members: Vec<TabGroupMember<'_>> = Vec::new();
-                let mut j = i;
-                while j < total_visible {
-                    let (next_tab_index, ref next_filtered_pane_ids) = visible_tabs[j];
-                    if workspace.tabs[next_tab_index].group_id != Some(group_id) {
-                        break;
-                    }
-                    members.push(TabGroupMember {
-                        tab_index: next_tab_index,
-                        filtered_pane_ids: next_filtered_pane_ids.as_deref(),
-                        is_last_visible: j == total_visible - 1,
-                    });
-                    j += 1;
-                }
+                // Members are a contiguous subslice of `visible_tabs`.
+                let run_len = visible_tabs[i..]
+                    .iter()
+                    .take_while(|(idx, _)| workspace.tabs[*idx].group_id == Some(group_id))
+                    .count();
+                let members = &visible_tabs[i..i + run_len];
+                // The group's last member needs an "after" drop target only when
+                // it's also the absolute last visible tab.
+                let last_member_after_index = (i + run_len == total_visible)
+                    .then(|| members.last().unwrap().0 + 1);
                 groups.add_child(render_grouped_tab_container(
                     state,
                     workspace,
                     &group,
-                    &members,
+                    members,
+                    last_member_after_index,
                     is_any_pane_dragging,
                     app,
                 ));
-                i = j;
+                i += run_len;
             }
             None => {
                 let insert_before_index = tab_index;
@@ -2591,7 +2580,8 @@ fn render_grouped_tab_container(
     state: &VerticalTabsPanelState,
     workspace: &Workspace,
     group: &TabGroup,
-    members: &[TabGroupMember<'_>],
+    members: &[(usize, Option<Vec<PaneId>>)],
+    last_member_after_index: Option<usize>,
     is_any_pane_dragging: bool,
     app: &AppContext,
 ) -> Box<dyn Element> {
@@ -2609,7 +2599,7 @@ fn render_grouped_tab_container(
     let group = group.clone();
     let any_member_active = members
         .iter()
-        .any(|m| m.tab_index == workspace.active_tab_index);
+        .any(|(tab_index, _)| *tab_index == workspace.active_tab_index);
     let is_collapsed = group.collapsed;
 
     let resolved_mode = resolve_vertical_tabs_mode(app);
@@ -2638,21 +2628,25 @@ fn render_grouped_tab_container(
 
         // Collapsed groups hide member rows in the panel chrome; the members remain in `workspace.tabs`.
         if !is_collapsed {
-            for member in members {
-                let tab = &workspace.tabs[member.tab_index];
-                let insert_before_index = member.tab_index;
-                let insert_after_index = member.is_last_visible.then_some(member.tab_index + 1);
+            let last_member_idx = members.len().saturating_sub(1);
+            for (i, (tab_index, filtered_pane_ids)) in members.iter().enumerate() {
+                let tab = &workspace.tabs[*tab_index];
+                let insert_after_index = if i == last_member_idx {
+                    last_member_after_index
+                } else {
+                    None
+                };
                 let drag_state = TabGroupDragState {
                     is_any_pane_dragging,
-                    insert_before_index,
+                    insert_before_index: *tab_index,
                     insert_after_index,
                 };
                 let tab_element = render_tab_group(
                     state,
                     workspace,
-                    member.tab_index,
+                    *tab_index,
                     tab,
-                    member.filtered_pane_ids,
+                    filtered_pane_ids.as_deref(),
                     drag_state,
                     true,
                     app,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1766,8 +1766,8 @@ fn render_groups(
                 let members = &visible_tabs[i..i + run_len];
                 // The group's last member needs an "after" drop target only when
                 // it's also the absolute last visible tab.
-                let last_member_after_index = (i + run_len == total_visible)
-                    .then(|| members.last().unwrap().0 + 1);
+                let last_member_after_index =
+                    (i + run_len == total_visible).then(|| members.last().unwrap().0 + 1);
                 groups.add_child(render_grouped_tab_container(
                     state,
                     workspace,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2484,7 +2484,10 @@ fn render_grouped_tabs_header(
     .with_height(VERTICAL_TABS_ICON_SIZE)
     .finish();
 
-    let title_text = group.name.clone().unwrap_or_else(|| "New Group".to_string());
+    let title_text = group
+        .name
+        .clone()
+        .unwrap_or_else(|| "New Group".to_string());
     let title_element: Box<dyn Element> = Text::new_inline(title_text, font_family, 12.)
         .with_clip(ClipConfig::ellipsis())
         .with_color(main_text_color.into())
@@ -2651,7 +2654,7 @@ fn render_grouped_tab_container(
                     tab,
                     member.filtered_pane_ids,
                     drag_state,
-                    true, 
+                    true,
                     app,
                 );
                 content.add_child(

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3205,3 +3205,275 @@ fn test_tab_mru_order() {
         });
     });
 }
+
+#[test]
+fn test_create_new_tab_group_groups_active_tab() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Workspace starts with one tab from `Empty` source. Create a tab
+            // group and verify the active tab is assigned to it.
+            assert_eq!(workspace.tab_count(), 1);
+            assert!(workspace.tabs[0].group_id.is_none());
+            assert!(workspace.tab_groups.is_empty());
+
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+
+            assert_eq!(workspace.tab_groups.len(), 1);
+            let group_id = workspace.tabs[0]
+                .group_id
+                .expect("active tab should be assigned to the new group");
+            assert!(workspace.tab_groups.contains_key(&group_id));
+            // New groups start expanded so members are visible.
+            assert!(!workspace.tab_groups[&group_id].collapsed);
+        });
+    });
+}
+
+#[test]
+fn test_toggle_tab_group_collapsed_flips_state() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[0]
+                .group_id
+                .expect("active tab should be in a group");
+            assert!(!workspace.tab_groups[&group_id].collapsed);
+
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(workspace.tab_groups[&group_id].collapsed);
+
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(!workspace.tab_groups[&group_id].collapsed);
+        });
+    });
+}
+
+#[test]
+fn test_close_tab_group_removes_group_and_members() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group, then add another tab which inherits the
+            // active tab's group_id via `add_tab_with_pane_layout`.
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+
+            workspace.add_terminal_tab(false, ctx);
+
+            let group_members: Vec<usize> = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, tab)| tab.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .collect();
+            assert_eq!(
+                group_members.len(),
+                2,
+                "new tab should inherit the active tab's group_id"
+            );
+
+            workspace.handle_action(&WorkspaceAction::CloseTabGroup(group_id), ctx);
+
+            // All group members are closed and the group entry is removed.
+            assert!(!workspace.tab_groups.contains_key(&group_id));
+            assert!(
+                workspace
+                    .tabs
+                    .iter()
+                    .all(|tab| tab.group_id != Some(group_id))
+            );
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_with_after_all_tabs_setting_lands_at_group_end() {
+    // With `new_tab_placement = AfterAllTabs` and the active tab in a
+    // group, a new tab should land at the end of the group's contiguous
+    // run instead of at the workspace's global end so group contiguity
+    // is preserved while honoring the user's "end" placement preference.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(
+                    settings
+                        .new_tab_placement
+                        .set_value(NewTabPlacement::AfterAllTabs, ctx)
+                );
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group and add a second tab so the group has two
+            // contiguous members.
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+            workspace.add_terminal_tab(false, ctx);
+
+            // Add an ungrouped tab past the end of the group by first
+            // activating the trailing ungrouped tab.
+            let ungrouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id.is_none())
+                .expect("expected at least one ungrouped tab");
+            workspace.activate_tab(ungrouped_idx, ctx);
+            workspace.add_terminal_tab(false, ctx);
+
+            // Now activate the first grouped tab and add a new tab. With
+            // `AfterAllTabs`, the new tab must land at the end of the
+            // group's contiguous run rather than past the trailing
+            // ungrouped tabs.
+            let first_grouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id == Some(group_id))
+                .expect("expected at least one grouped tab");
+            workspace.activate_tab(first_grouped_idx, ctx);
+
+            let group_run_end_before = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .max()
+                .expect("group should be non-empty")
+                + 1;
+
+            workspace.add_terminal_tab(false, ctx);
+
+            // The new tab lands at the prior group-run end, inherits the
+            // group_id, and keeps the group's run contiguous.
+            assert_eq!(workspace.active_tab_index(), group_run_end_before);
+            assert_eq!(
+                workspace.tabs[group_run_end_before].group_id,
+                Some(group_id)
+            );
+
+            let group_indices: Vec<usize> = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .collect();
+            assert!(
+                group_indices.windows(2).all(|w| w[1] == w[0] + 1),
+                "group's tab indices should be contiguous, got {group_indices:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_with_after_current_tab_setting_lands_after_active_tab_in_group() {
+    // With `new_tab_placement = AfterCurrentTab` and the active tab in the
+    // middle of a group, a new tab should land immediately after the active
+    // tab and inherit the group_id, preserving group contiguity rather than
+    // jumping to the end of the group or past it.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(
+                    settings
+                        .new_tab_placement
+                        .set_value(NewTabPlacement::AfterCurrentTab, ctx)
+                );
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group and grow it to two contiguous members so we can
+            // activate the first one (i.e. a member that isn't at the end of
+            // the group's run).
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+            workspace.add_terminal_tab(false, ctx);
+
+            // Activate the first grouped tab so the next insertion happens in
+            // the middle of the group's contiguous run.
+            let first_grouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id == Some(group_id))
+                .expect("expected at least one grouped tab");
+            workspace.activate_tab(first_grouped_idx, ctx);
+
+            let expected_new_idx = first_grouped_idx + 1;
+
+            workspace.add_terminal_tab(false, ctx);
+
+            // The new tab lands immediately after the previously-active
+            // grouped tab, inherits its group_id, and keeps the group's run
+            // contiguous.
+            assert_eq!(workspace.active_tab_index(), expected_new_idx);
+            assert_eq!(
+                workspace.tabs[expected_new_idx].group_id,
+                Some(group_id),
+                "new tab should inherit the active tab's group_id"
+            );
+
+            let group_indices: Vec<usize> = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .collect();
+            assert_eq!(
+                group_indices.len(),
+                3,
+                "group should have grown to three members"
+            );
+            assert!(
+                group_indices.windows(2).all(|w| w[1] == w[0] + 1),
+                "group's tab indices should be contiguous, got {group_indices:?}"
+            );
+        });
+    });
+}

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3302,12 +3302,10 @@ fn test_close_tab_group_removes_group_and_members() {
 
             // All group members are closed and the group entry is removed.
             assert!(!workspace.tab_groups.contains_key(&group_id));
-            assert!(
-                workspace
-                    .tabs
-                    .iter()
-                    .all(|tab| tab.group_id != Some(group_id))
-            );
+            assert!(workspace
+                .tabs
+                .iter()
+                .all(|tab| tab.group_id != Some(group_id)));
         });
     });
 }
@@ -3324,11 +3322,9 @@ fn test_new_tab_with_after_all_tabs_setting_lands_at_group_end() {
         initialize_app(&mut app);
         app.update(|ctx| {
             TabSettings::handle(ctx).update(ctx, |settings, ctx| {
-                report_if_error!(
-                    settings
-                        .new_tab_placement
-                        .set_value(NewTabPlacement::AfterAllTabs, ctx)
-                );
+                report_if_error!(settings
+                    .new_tab_placement
+                    .set_value(NewTabPlacement::AfterAllTabs, ctx));
             });
         });
 
@@ -3413,11 +3409,9 @@ fn test_new_tab_with_after_current_tab_setting_lands_after_active_tab_in_group()
         initialize_app(&mut app);
         app.update(|ctx| {
             TabSettings::handle(ctx).update(ctx, |settings, ctx| {
-                report_if_error!(
-                    settings
-                        .new_tab_placement
-                        .set_value(NewTabPlacement::AfterCurrentTab, ctx)
-                );
+                report_if_error!(settings
+                    .new_tab_placement
+                    .set_value(NewTabPlacement::AfterCurrentTab, ctx));
             });
         });
 


### PR DESCRIPTION
## Description

Basic functionality for vertical tab grouping. Tabs in the vertical tabs panel can now be organized into collapsible groups with their own header, chevron, and action buttons. All behavior is gated behind `FeatureFlag::GroupedTabs` — with the flag off this PR is a no-op.

## Features supported
- **New "New tab group" entry in the unified new-session menu** (the `+` button dropdown in the vertical tabs panel). Selecting it creates a fresh group containing one new tab.
- **Group container rendering** in the vertical tabs panel:
  - Header with chevron + group name + `N tabs` subtitle
  - Single-click anywhere on the header (or the chevron) toggles collapse/expand
  - Kebab + close action buttons appear on header hover
  - Closing a group closes all of its member tabs
- **Member tabs render indented** inside the group container, with the group's hover/active background painting across the whole group instead of per-tab
- **Group-aware new tab placement**: when the active tab is in a group, new tabs inherit the group's `group_id` and stay clustered with it. The user's `NewTabPlacement` setting is honored within the group's bounds — `AfterCurrentTab` lands immediately after the active member, and `AfterAllTabs` lands at the end of the group's contiguous run (not at the end of the panel)

Other features such as group renaming, dragging tabs into/out of groups, dragging groups, moving tabs between groups, and other menu options will be implemented in a follow up PR.

Figma designs: https://www.figma.com/design/yTHUBNWdYjQquFugM4qjA5/Tab-grouping?node-id=6001-10704&m=dev

Note there are some minor UI changes that are not completely up to spec, still reaching alignment and will update in follow up PR.

## Linked Issue
https://linear.app/warpdotdev/issue/APP-4609/vertical-tab-grouping-basic-functionality

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`
- [x] Creating a new tab group from the `+` menu creates the group + one member tab
- [x] Adding new tabs from within the group keeps the group contiguous
- [x] Single-click on the header toggles collapse; the chevron icon flips
- [x] Closing the group (via the `X`) closes every member tab
- [x] Confirmed flag-off behavior is unchanged (menu item hidden, no group rendering)


### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/dfb13128f5f34585bb54880274cbb84b

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
