### PR TITLE
Use searchable dropdown for run_agents model picker

### DIFF
--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -336,7 +336,7 @@ impl OrchestrationEditState {
 /// block. Generic over the action type `A`.
 #[derive(Clone)]
 pub struct OrchestrationPickerHandles<A: OrchestrationControlAction> {
-    pub model_picker: Option<ViewHandle<Dropdown<A>>>,
+    pub model_picker: Option<ViewHandle<FilterableDropdown<A>>>,
     pub harness_picker: Option<ViewHandle<Dropdown<A>>>,
     pub environment_picker: Option<ViewHandle<FilterableDropdown<A>>>,
     pub host_picker: Option<ViewHandle<HostPicker>>,
@@ -438,6 +438,26 @@ pub fn new_standard_picker_dropdown<A: OrchestrationControlAction, V: View>(
     })
 }
 
+/// Creates a searchable dropdown with the shared orchestration picker
+/// chrome (border, radius, background, font).
+pub fn new_standard_filterable_picker_dropdown<A: OrchestrationControlAction, V: View>(
+    styles: &UiComponentStyles,
+    ctx: &mut ViewContext<V>,
+) -> ViewHandle<FilterableDropdown<A>> {
+    let styles = *styles;
+    ctx.add_typed_action_view(move |ctx_dropdown| {
+        let mut dropdown = FilterableDropdown::<A>::new(ctx_dropdown);
+        dropdown.set_use_overlay_layer(false, ctx_dropdown);
+        dropdown.set_match_menu_width_to_top_bar(true, ctx_dropdown);
+        dropdown.set_main_axis_size(MainAxisSize::Max, ctx_dropdown);
+        dropdown.set_button_variant(ButtonVariant::Secondary);
+        dropdown.set_style(styles);
+        dropdown.set_top_bar_height(ORCHESTRATION_PICKER_HEIGHT, ctx_dropdown);
+        dropdown.set_top_bar_max_width(f32::INFINITY);
+        dropdown
+    })
+}
+
 /// Returns Warp base-model choices for orchestration.
 fn get_base_model_choices<'a>(
     llm_prefs: &'a LLMPreferences,
@@ -457,7 +477,7 @@ fn get_base_model_choices<'a>(
 ///   by the server-provided harness model catalog from
 ///   `HarnessAvailabilityModel::models_for()`.
 pub fn populate_model_picker_for_harness<A: OrchestrationControlAction, V: View>(
-    dropdown: &ViewHandle<Dropdown<A>>,
+    dropdown: &ViewHandle<FilterableDropdown<A>>,
     initial_model_id: &str,
     harness_type: &str,
     is_local: bool,

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -730,8 +730,8 @@ impl RunAgentsCardView {
                 state.orch.model_id.clone()
             };
             let is_local = !state.orch.execution_mode.is_remote();
-            let handle = oc::new_standard_picker_dropdown(&colors, ctx);
-            Self::set_upward_menu_position(&handle, ctx);
+            let handle = oc::new_standard_filterable_picker_dropdown(&styles, ctx);
+            Self::set_upward_filterable_menu_position(&handle, ctx);
             oc::populate_model_picker_for_harness(
                 &handle,
                 &initial_model_id,
@@ -739,7 +739,7 @@ impl RunAgentsCardView {
                 is_local,
                 ctx,
             );
-            Self::subscribe_picker_close(&handle, ctx);
+            Self::subscribe_filterable_picker_close(&handle, ctx);
             self.handles.pickers.model_picker = Some(handle);
         }
 
@@ -852,6 +852,17 @@ impl RunAgentsCardView {
         });
     }
 
+    fn set_upward_filterable_menu_position(
+        dropdown_handle: &ViewHandle<
+            crate::view_components::FilterableDropdown<RunAgentsCardViewAction>,
+        >,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        dropdown_handle.update(ctx, |dropdown, _| {
+            dropdown.set_orientation(FilterableDropdownOrientation::Up)
+        });
+    }
+
     fn subscribe_picker_close(
         dropdown_handle: &ViewHandle<
             crate::view_components::dropdown::Dropdown<RunAgentsCardViewAction>,
@@ -860,6 +871,19 @@ impl RunAgentsCardView {
     ) {
         ctx.subscribe_to_view(dropdown_handle, move |me, _, event, ctx| {
             if let DropdownEvent::Close = event {
+                me.refocus_after_picker_close(ctx);
+            }
+        });
+    }
+
+    fn subscribe_filterable_picker_close(
+        dropdown_handle: &ViewHandle<
+            crate::view_components::FilterableDropdown<RunAgentsCardViewAction>,
+        >,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        ctx.subscribe_to_view(dropdown_handle, move |me, _, event, ctx| {
+            if let FilterableDropdownEvent::Close = event {
                 me.refocus_after_picker_close(ctx);
             }
         });

--- a/app/src/ai/document/orchestration_config_block.rs
+++ b/app/src/ai/document/orchestration_config_block.rs
@@ -437,7 +437,7 @@ impl OrchestrationConfigBlockView {
             self.edit_state.model_id.clone()
         };
         let is_local = !self.edit_state.execution_mode.is_remote();
-        let model_handle = oc::new_standard_picker_dropdown(&colors, ctx);
+        let model_handle = oc::new_standard_filterable_picker_dropdown(&styles, ctx);
         model_handle.update(ctx, |d, c| d.set_use_overlay_layer(true, c));
         oc::populate_model_picker_for_harness(
             &model_handle,


### PR DESCRIPTION
## Description
Use the searchable dropdown component for the run_agents orchestration Base model picker. The Environment picker already used the searchable component, and the shared orchestration picker plumbing now uses the same component type for model selection while preserving the existing model catalog population and selection sync behavior.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Slack feedback: model/environment selectors in the run_agents tool card should have search.

## Testing
- `cargo fmt`
- `cargo test -p warp --lib run_agents_card_view_tests --no-run`
- `cargo test -p warp --lib run_agents_card_view_tests` (filter matched 0 tests; compile/test harness succeeded)
- `cargo clippy -p warp --lib --tests --all-features -- -D warnings`
- Attempted `cargo clippy -p warp --all-targets --all-features --tests -- -D warnings`, but binary target compilation failed before this change due missing generated channel config files in `OUT_DIR` (`dev_config.json`, `stable_config.json`, `preview_config.json`).

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not captured in this sandboxed environment.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/84154cc7-cb5c-4bd9-b551-cb7925474b65_
_Run: https://oz.staging.warp.dev/runs/019e69ef-51b4-79c4-a365-eaeb1bb87a37_

_This PR was generated with [Oz](https://warp.dev/oz)._
