### PR TITLE
Open orchestration pill menu on right click

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -2009,6 +2009,16 @@ fn render_pill(
             pill_kind: kind,
         });
     })
+    .on_right_click(move |ctx, _app, _| {
+        // Right-clicking a child pill should expose the same overflow
+        // actions as clicking the trailing 3-dot button. The menu is still
+        // anchored to that button's saved position: opening the menu forces
+        // `show_dots`, so the next render creates the anchor before the menu
+        // overlay is positioned.
+        if show_overflow_button {
+            ctx.dispatch_typed_action(OrchestrationPillBarAction::OpenMenu(conversation_id));
+        }
+    })
     .finish();
 
     // Cache the painted rect of this pill body under a stable id so the


### PR DESCRIPTION
## Description
Right-clicking a child agent pill in the orchestration pill bar now dispatches the same `OpenMenu` action as clicking the pill's three-dot overflow button.

This reuses the existing overflow menu construction and anchoring behavior, so menu contents stay consistent across both entry points.

## Linked Issue
Slack feedback: right-clicking orchestration child-agent pills should bring up the overflow context menu.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `rustfmt app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs`
- `cargo fmt --manifest-path /workspace/warp/app/Cargo.toml --check`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp orchestration_pill_bar --lib`
- Attempted `cargo clippy --manifest-path /workspace/warp/app/Cargo.toml --lib --tests -- -D warnings`, but it is currently blocked by existing `warpui_core` clippy errors unrelated to this diff.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; this sandbox does not have a local Warp GUI session for manual verification.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Fixed right-clicking child agent pills in the orchestration pill bar to open their overflow menu.

_Co-Authored-By: Oz <oz-agent@warp.dev>_

_Conversation: https://staging.warp.dev/conversation/bcae4c00-6c49-4287-b9ab-9a75b398fc0a_
_Run: https://oz.staging.warp.dev/runs/019e6a04-4787-7dc1-9f53-b4391a28f9ec_
_This PR was generated with [Oz](https://warp.dev/oz)._
