### PR TITLE
Render AIBlock queries as markdown

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -30,6 +30,7 @@ use cli_controller::{CLISubagentController, CLISubagentEvent};
 use find::FindState;
 use indexmap::IndexMap;
 use itertools::Itertools;
+use markdown_parser::parse_markdown;
 use model::AIBlockOutputStatus;
 use parking_lot::{FairMutex, Mutex, RwLock};
 use pathfinder_color::ColorU;
@@ -270,6 +271,7 @@ pub enum TextLocation {
     },
     Query {
         input_index: usize,
+        line_index: usize,
     },
     Action {
         action_index: usize,
@@ -1509,10 +1511,28 @@ impl AIBlock {
             let Some(query) = input.display_user_query(initial_conversation_query.as_ref()) else {
                 continue;
             };
-            if secret_redaction_mode.should_redact_secret() {
+            if !secret_redaction_mode.should_redact_secret() {
+                continue;
+            }
+
+            if let Ok(formatted_query) = parse_markdown(&query) {
+                for (line_index, line) in formatted_query.lines.iter().enumerate() {
+                    self.secret_redaction_state.run_redaction_for_location(
+                        &line.raw_text(),
+                        TextLocation::Query {
+                            input_index,
+                            line_index,
+                        },
+                        secret_redaction_mode.is_visually_obfuscated(),
+                    );
+                }
+            } else {
                 self.secret_redaction_state.run_redaction_for_location(
                     &query,
-                    TextLocation::Query { input_index },
+                    TextLocation::Query {
+                        input_index,
+                        line_index: 0,
+                    },
                     secret_redaction_mode.is_visually_obfuscated(),
                 );
             }
@@ -1535,7 +1555,7 @@ impl AIBlock {
         let output_guard = shared_output.as_ref().map(|o| o.get());
         let output = output_guard.as_deref();
 
-        let (mut texts, hyperlinks) = match output {
+        let (mut texts, mut hyperlinks) = match output {
             Some(output) => collect_output_data_for_link_detection(
                 output,
                 self.current_working_directory.as_ref(),
@@ -1550,7 +1570,32 @@ impl AIBlock {
             .and_then(|conversation| conversation.initial_user_query());
         for (input_index, input) in self.model.inputs_to_render(ctx).iter().enumerate() {
             if let Some(query) = input.display_user_query(initial_conversation_query.as_ref()) {
-                texts.push((query, TextLocation::Query { input_index }));
+                if let Ok(formatted_query) = parse_markdown(&query) {
+                    for (line_index, line) in formatted_query.lines.iter().enumerate() {
+                        let location = TextLocation::Query {
+                            input_index,
+                            line_index,
+                        };
+                        texts.push((line.raw_text().to_owned(), location));
+
+                        let url_hyperlinks = line
+                            .hyperlinks(true)
+                            .into_iter()
+                            .filter_map(|(range, hyperlink)| hyperlink.url().map(|url| (range, url)))
+                            .collect::<Vec<_>>();
+                        if !url_hyperlinks.is_empty() {
+                            hyperlinks.push((location, url_hyperlinks));
+                        }
+                    }
+                } else {
+                    texts.push((
+                        query,
+                        TextLocation::Query {
+                            input_index,
+                            line_index: 0,
+                        },
+                    ));
+                }
             }
         }
 

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use lazy_static::lazy_static;
-use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
+use markdown_parser::{parse_markdown, FormattedText, FormattedTextFragment, FormattedTextLine};
 use parking_lot::{FairMutex, RwLock};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
@@ -27,7 +27,7 @@ use warpui::elements::{
     PositionedElementAnchor, PositionedElementOffsetBounds, Radius, SavePosition, SelectableArea,
     SelectionHandle, Shrinkable, SizeConstraintCondition, SizeConstraintSwitch, Stack, Text,
 };
-use warpui::fonts::{Properties, Style, Weight};
+use warpui::fonts::{Properties, Style};
 use warpui::keymap::{EditableBinding, Keystroke};
 use warpui::platform::{Cursor, OperatingSystem};
 use warpui::r#async::{SpawnedFutureHandle, Timer};
@@ -84,7 +84,7 @@ use crate::terminal::safe_mode_settings::get_secret_obfuscation_mode;
 use crate::terminal::{ShellLaunchData, TerminalModel};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
-use crate::util::link_detection::{detect_links, DetectedLinksState};
+use crate::util::link_detection::{detect_all_links, DetectedLinksState};
 use crate::view_components::action_button::{
     ButtonSize, KeystrokeSource, NakedTheme, PrimaryTheme,
 };
@@ -844,34 +844,66 @@ impl CLISubagentView {
     }
 
     fn set_state_from_updated_inputs(&mut self, ctx: &mut ViewContext<Self>) {
-        // Clear existing link detection state
+        self.secret_redaction_state.clear_user_query_locations();
         self.link_detection_state.detected_links_by_location.clear();
 
         self.reset_input_dismiss_timer(ctx);
 
-        // Detect links in all user queries
+        let mut texts = vec![];
+        let mut hyperlinks = vec![];
         for (input_index, input) in self.model.inputs_to_render(ctx).iter().enumerate() {
             if let AIAgentInput::UserQuery { query, .. } = input {
-                detect_links(
-                    &mut self.link_detection_state,
-                    query,
-                    TextLocation::Query { input_index },
-                    self.current_working_directory.as_ref(),
-                    self.shell_launch_data.as_ref(),
-                );
-
-                // Run secret redaction on user queries
                 let secret_redaction_mode = get_secret_obfuscation_mode(ctx);
-                if secret_redaction_mode.should_redact_secret() {
-                    let should_obfuscate = secret_redaction_mode.is_visually_obfuscated();
-                    self.secret_redaction_state.run_redaction_for_location(
-                        query,
-                        TextLocation::Query { input_index },
-                        should_obfuscate,
-                    );
+                if let Ok(formatted_query) = parse_markdown(query) {
+                    for (line_index, line) in formatted_query.lines.iter().enumerate() {
+                        let location = TextLocation::Query {
+                            input_index,
+                            line_index,
+                        };
+                        let raw_text = line.raw_text().to_owned();
+                        texts.push((raw_text.clone(), location));
+
+                        let url_hyperlinks = line
+                            .hyperlinks(true)
+                            .into_iter()
+                            .filter_map(|(range, hyperlink)| hyperlink.url().map(|url| (range, url)))
+                            .collect::<Vec<_>>();
+                        if !url_hyperlinks.is_empty() {
+                            hyperlinks.push((location, url_hyperlinks));
+                        }
+
+                        if secret_redaction_mode.should_redact_secret() {
+                            self.secret_redaction_state.run_redaction_for_location(
+                                &raw_text,
+                                location,
+                                secret_redaction_mode.is_visually_obfuscated(),
+                            );
+                        }
+                    }
+                } else {
+                    let location = TextLocation::Query {
+                        input_index,
+                        line_index: 0,
+                    };
+                    texts.push((query.to_owned(), location));
+
+                    if secret_redaction_mode.should_redact_secret() {
+                        self.secret_redaction_state.run_redaction_for_location(
+                            query,
+                            location,
+                            secret_redaction_mode.is_visually_obfuscated(),
+                        );
+                    }
                 }
             }
         }
+        let all_links = detect_all_links(
+            &texts,
+            hyperlinks,
+            self.current_working_directory.as_ref(),
+            self.shell_launch_data.as_ref(),
+        );
+        self.link_detection_state.replace_all_links(all_links);
     }
 
     /// Clears text selections at the `CLISubagentView` level (e.g. user query text).
@@ -976,10 +1008,6 @@ impl View for CLISubagentView {
                         is_selecting: self.state_handles.query_selection_handle.is_selecting(),
                         is_ai_input_enabled: false,
                         find_context: None,
-                        font_properties: &Properties {
-                            style: Style::Normal,
-                            weight: Weight::Normal,
-                        },
                     },
                     app,
                 );
@@ -1000,7 +1028,7 @@ impl View for CLISubagentView {
                             ctx.dispatch_typed_action(CLISubagentAction::SelectText);
                         }
                     },
-                    text.finish(),
+                    text,
                 )
                 .with_word_boundaries_policy(semantic_selection.word_boundary_policy())
                 .with_smart_select_fn(semantic_selection.smart_select_fn());

--- a/app/src/ai/blocklist/block/find.rs
+++ b/app/src/ai/blocklist/block/find.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 use itertools::Itertools;
+use markdown_parser::parse_markdown;
 use regex::RegexBuilder;
 
 use super::{AIBlock, TextLocation};
@@ -51,17 +52,31 @@ impl FindableRichContentView for AIBlock {
         let mut new_match_ids = vec![];
         for (i, input) in self.model.inputs_to_render(ctx).iter().enumerate() {
             if let Some(query) = input.user_query() {
-                for find_match_range in compute_find_matches(&query, options).into_iter() {
-                    let id = RichContentMatchId::default();
-                    new_match_ids.push(id);
-                    self.find_state.matches.insert(
-                        id,
-                        FindMatchLocation {
-                            text_location: TextLocation::Query { input_index: i },
-                            char_range: find_match_range,
-                            message_id: None,
-                        },
-                    );
+                let query_matches = match parse_markdown(&query) {
+                    Ok(formatted_query) => formatted_query
+                        .lines
+                        .iter()
+                        .map(|line| compute_find_matches(&line.raw_text(), options))
+                        .collect_vec(),
+                    Err(_) => vec![compute_find_matches(&query, options)],
+                };
+
+                for (line_index, line_matches) in query_matches.into_iter().enumerate() {
+                    for find_match_range in line_matches {
+                        let id = RichContentMatchId::default();
+                        new_match_ids.push(id);
+                        self.find_state.matches.insert(
+                            id,
+                            FindMatchLocation {
+                                text_location: TextLocation::Query {
+                                    input_index: i,
+                                    line_index,
+                                },
+                                char_range: find_match_range,
+                                message_id: None,
+                            },
+                        );
+                    }
                 }
             }
         }

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -147,6 +147,89 @@ fn add_slash_command_highlight(
     }
 }
 
+fn add_slash_command_prefix_highlights(
+    merged_highlighted_ranges: Vec<HighlightedRange>,
+    slash_command_prefix_len: Option<usize>,
+    app: &AppContext,
+) -> Vec<HighlightedRange> {
+    let Some(slash_command_prefix_len) = slash_command_prefix_len else {
+        return merged_highlighted_ranges;
+    };
+    let appearance = Appearance::as_ref(app);
+    let mut unhandled_prefix_indices: HashSet<usize> = (0..slash_command_prefix_len).collect();
+    let mut result = vec![];
+
+    for range in merged_highlighted_ranges {
+        let range_start = range.highlight_indices.first().cloned().unwrap_or(0);
+        let range_end = range
+            .highlight_indices
+            .last()
+            .cloned()
+            .unwrap_or(range_start);
+
+        if range_end < slash_command_prefix_len {
+            for &idx in &range.highlight_indices {
+                unhandled_prefix_indices.remove(&idx);
+            }
+            result.push(HighlightedRange {
+                highlight: add_slash_command_highlight(appearance, Some(range.highlight)),
+                highlight_indices: range.highlight_indices,
+            });
+        } else if range_start >= slash_command_prefix_len {
+            result.push(range);
+        } else {
+            let mut prefix_part_indices = vec![];
+            let mut after_part_indices = vec![];
+
+            for idx in range.highlight_indices {
+                if idx < slash_command_prefix_len {
+                    prefix_part_indices.push(idx);
+                    unhandled_prefix_indices.remove(&idx);
+                } else {
+                    after_part_indices.push(idx);
+                }
+            }
+
+            if !prefix_part_indices.is_empty() {
+                result.push(HighlightedRange {
+                    highlight: add_slash_command_highlight(appearance, Some(range.highlight)),
+                    highlight_indices: prefix_part_indices,
+                });
+            }
+            if !after_part_indices.is_empty() {
+                result.push(HighlightedRange {
+                    highlight: range.highlight,
+                    highlight_indices: after_part_indices,
+                });
+            }
+        }
+    }
+
+    if !unhandled_prefix_indices.is_empty() {
+        let mut sorted_indices: Vec<usize> = unhandled_prefix_indices.into_iter().collect();
+        sorted_indices.sort_unstable();
+
+        let mut current_group = vec![sorted_indices[0]];
+        for &idx in &sorted_indices[1..] {
+            if idx == current_group.last().unwrap() + 1 {
+                current_group.push(idx);
+            } else {
+                result.push(HighlightedRange {
+                    highlight: add_slash_command_highlight(appearance, None),
+                    highlight_indices: current_group,
+                });
+                current_group = vec![idx];
+            }
+        }
+        result.push(HighlightedRange {
+            highlight: add_slash_command_highlight(appearance, None),
+            highlight_indices: current_group,
+        });
+    }
+
+    result
+}
+
 /// Adds the appropriate highlighting for secrets and links to the given text element.
 #[allow(clippy::too_many_arguments)]
 fn add_highlights_to_text(
@@ -403,11 +486,11 @@ pub(crate) fn add_highlights_to_rich_text(
     detected_links_state: Option<&DetectedLinksState>,
     secret_redaction_state: &SecretRedactionState,
     find_context: Option<FindContext<'_>>,
-    location_index: usize,
+    location_for_line: impl Fn(usize) -> TextLocation,
     line_count: usize,
     theme: &WarpTheme,
     is_selecting: bool,
-    is_action: bool,
+    slash_command_prefix_len: Option<usize>,
     app: &AppContext,
 ) -> FormattedTextElement {
     let ansi_blue = theme.terminal_colors().normal.blue;
@@ -427,17 +510,7 @@ pub(crate) fn add_highlights_to_rich_text(
         Highlight::new().with_text_style(TextStyle::new().with_foreground_color(ansi_blue.into()));
 
     for i in 0..line_count {
-        let location = if is_action {
-            TextLocation::Action {
-                action_index: location_index,
-                line_index: i,
-            }
-        } else {
-            TextLocation::Output {
-                section_index: location_index,
-                line_index: i,
-            }
-        };
+        let location = location_for_line(i);
 
         let mut style_ranges = vec![];
         if let Some(detected_links_state) = detected_links_state {
@@ -590,7 +663,11 @@ pub(crate) fn add_highlights_to_rich_text(
             ));
         }
 
-        let merged_range = HighlightedRange::merge_overlapping_ranges(style_ranges);
+        let merged_range = add_slash_command_prefix_highlights(
+            HighlightedRange::merge_overlapping_ranges(style_ranges),
+            (i == 0).then_some(slash_command_prefix_len).flatten(),
+            app,
+        );
         let sorted_range = merged_range
             .into_iter()
             .sorted_by_key(|range| range.highlight_indices[0]);

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use markdown_parser::{FormattedText, FormattedTextInline, TableAlignment};
+use markdown_parser::{parse_markdown, FormattedText, FormattedTextInline, TableAlignment};
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use warp_core::channel::ChannelState;
@@ -1566,11 +1566,14 @@ pub(super) fn render_rich_text_output_text_section(
         props.detected_links,
         props.secret_redaction_state,
         props.find_context,
-        props.section_index,
+        |line_index| TextLocation::Output {
+            section_index: props.section_index,
+            line_index,
+        },
         line_count,
         appearance.theme(),
         props.is_selecting_text,
-        false,
+        None,
         app,
     );
 
@@ -3396,7 +3399,6 @@ pub struct UserQueryProps<'a> {
     pub is_selecting: bool,
     pub is_ai_input_enabled: bool,
     pub find_context: Option<FindContext<'a>>,
-    pub font_properties: &'a Properties,
 }
 pub(crate) fn user_query_mode_prefix_highlight_len(mode: UserQueryMode) -> Option<usize> {
     match mode {
@@ -3449,23 +3451,96 @@ pub(super) fn query_prefix_highlight_len(
     }
 }
 
-/// Renders query text with all interactive features: link detection, secret redaction, and highlights.
-/// Returns a text element ready to be placed in a layout.
-pub fn render_query_text(props: UserQueryProps<'_>, app: &AppContext) -> Text {
+pub fn render_query_text(props: UserQueryProps<'_>, app: &AppContext) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
+    let text_color = blended_colors::text_main(theme, theme.surface_1());
+
+    if let Ok(formatted_text) = parse_markdown(&props.text) {
+        let inline_code_bg_color = theme.background().into_solid();
+        let inline_code_text_color = theme.terminal_colors().normal.green.into();
+        let line_count = formatted_text.lines.len();
+        let mut rich_text_element = FormattedTextElement::new(
+            formatted_text,
+            appearance.monospace_font_size(),
+            appearance.ai_font_family(),
+            appearance.monospace_font_family(),
+            text_color,
+            Default::default(),
+        )
+        .with_selection_color(if props.is_ai_input_enabled {
+            theme.text_selection_as_context_color().into_solid()
+        } else {
+            theme.text_selection_color().into_solid()
+        })
+        .with_line_height_ratio(1.2)
+        .with_heading_to_font_size_multipliers(HeadingFontSizeMultipliers {
+            h1: 1.55,
+            h2: 1.4,
+            h3: 1.2,
+            ..Default::default()
+        })
+        .with_inline_code_properties(Some(inline_code_text_color), Some(inline_code_bg_color))
+        .set_selectable(true);
+
+        rich_text_element.register_handlers(|mut frame, (line_index, _)| {
+            let location = TextLocation::Query {
+                input_index: props.input_index,
+                line_index,
+            };
+            frame = add_link_detection_mouse_interactions(
+                frame,
+                props.detected_links_state,
+                LinkActionConstructors::<AIBlockAction>::build_ai_block_action(),
+                location,
+            );
+
+            let secret_redaction = get_secret_obfuscation_mode(app);
+            if secret_redaction.should_redact_secret() {
+                if let Some(secrets) = props.secret_redaction_state.secrets_for_location(&location)
+                {
+                    frame = redact_secrets_in_element(
+                        frame,
+                        secrets,
+                        location,
+                        secret_redaction.is_visually_obfuscated(),
+                    );
+                }
+            }
+            frame
+        });
+
+        rich_text_element = add_highlights_to_rich_text(
+            rich_text_element,
+            Some(props.detected_links_state),
+            props.secret_redaction_state,
+            props.find_context,
+            |line_index| TextLocation::Query {
+                input_index: props.input_index,
+                line_index,
+            },
+            line_count,
+            theme,
+            props.is_selecting,
+            props.query_prefix_highlight_len,
+            app,
+        );
+
+        return rich_text_element.finish();
+    }
 
     let location = TextLocation::Query {
         input_index: props.input_index,
+        line_index: 0,
     };
 
     let mut text_element = Text::new(
         props.text,
-        appearance.monospace_font_family(),
+        appearance.ai_font_family(),
         appearance.monospace_font_size(),
     )
-    .with_style(*props.font_properties)
-    .with_color(blended_colors::text_main(theme, theme.surface_1()))
+    .with_style(Properties::default().weight(appearance.monospace_font_weight()))
+    .with_color(text_color)
     .with_selection_color(if props.is_ai_input_enabled {
         theme.text_selection_as_context_color().into_solid()
     } else {
@@ -3497,12 +3572,11 @@ pub fn render_query_text(props: UserQueryProps<'_>, app: &AppContext) -> Text {
         props.find_context,
         location,
         props.is_selecting,
-        Some(*props.font_properties),
+        None,
         props.query_prefix_highlight_len,
         app,
     );
-
-    text_element
+    text_element.finish()
 }
 
 /// Renders a scrollable collapsible content area with auto-scroll-to-bottom

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1701,11 +1701,14 @@ pub fn render_read_files_text<A: Action>(
         Some(render_read_file_args.render_context.detected_links_state),
         render_read_file_args.render_context.secret_redaction_state,
         render_read_file_args.find_context,
-        action_index,
+        |line_index| TextLocation::Action {
+            action_index,
+            line_index,
+        },
         file_names.lines().count(),
         theme,
         render_read_file_args.is_selecting_text,
-        true,
+        None,
         app,
     );
     formatted_files

--- a/app/src/ai/blocklist/block/view_impl/query.rs
+++ b/app/src/ai/blocklist/block/view_impl/query.rs
@@ -9,7 +9,6 @@ use warpui::elements::{
     Container, CornerRadius, DispatchEventResult, EventHandler, Flex, MainAxisAlignment,
     MainAxisSize, ParentElement, Radius, Shrinkable, Wrap,
 };
-use warpui::fonts::{Properties, Style, Weight};
 use warpui::ui_components::chip::Chip;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{AppContext, Element, SingletonEntity};
@@ -83,10 +82,6 @@ pub(crate) fn render_query(
     .with_margin_right(16.)
     .finish();
 
-    let properties = Properties {
-        style: Style::Normal,
-        weight: Weight::Bold,
-    };
     // The query already includes the /plan prefix when in plan mode via display_user_query()
     let text_element = render_query_text(
         UserQueryProps {
@@ -98,13 +93,12 @@ pub(crate) fn render_query(
             is_selecting,
             is_ai_input_enabled,
             find_context,
-            font_properties: &properties,
         },
         app,
     );
 
     let appearance = Appearance::as_ref(app);
-    let mut query = Flex::column().with_child(text_element.finish());
+    let mut query = Flex::column().with_child(text_element);
 
     if FeatureFlag::ImageAsContext.is_enabled() {
         query = query.with_child(render_attachments(attachments, appearance));


### PR DESCRIPTION
## Description
Render AIBlock user queries with markdown formatting through the same rich text path used for agent output, instead of applying uniform bold styling to the whole query.

This also keeps query interactions working across parsed markdown lines:
- link detection and hover/click affordances
- secret redaction
- find-in-block matches
- slash command prefix highlighting

## Linked Issue
Slack request from #feedback-app.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --all-targets --all-features --tests -- -D warnings`
- `git --no-pager -C /workspace/warp diff --check`
- Computer use / local app verification with `./script/run`: submitted an Agent query containing `**bold** _italic_ \`code\` [example](https://example.com) # heading`; observed bold, italic, inline code, and link styling in the rendered user query block, with the link underlining on hover.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Computer-use verification observed the rendered AIBlock query in the local app. No screenshot file is attached to this PR.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: AIBlock user queries now render markdown formatting instead of showing raw markdown markers or using uniform bold styling.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/3feacd87-d075-41cb-a6af-babe1005a968_
_Run: https://oz.staging.warp.dev/runs/019e69e7-bf89-764d-8f22-5919a22a7451_
_This PR was generated with [Oz](https://warp.dev/oz)._
