### PR TITLE
Update code review file tree toggle icon

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -295,6 +295,14 @@ fn file_nav_button_tooltip(is_sidebar_expanded: bool, app: &AppContext) -> Strin
     }
 }
 
+fn file_nav_button_icon(is_sidebar_expanded: bool) -> Icon {
+    if is_sidebar_expanded {
+        Icon::LeftSidebarClose
+    } else {
+        Icon::LeftSidebarOpen
+    }
+}
+
 /// Returns true if the file status changed between Deleted and non-Deleted states,
 /// which requires rebuilding the editor state because we can't use global buffer
 /// for files that don't exist on the file system.
@@ -1128,7 +1136,7 @@ impl CodeReviewView {
 
         let file_nav_button = ctx.add_typed_action_view(|ctx| {
             ActionButton::new("", NakedTheme)
-                .with_icon(Icon::FileCopy)
+                .with_icon(file_nav_button_icon(false))
                 .with_tooltip(file_nav_button_tooltip(false, ctx))
                 .on_click(|ctx| ctx.dispatch_typed_action(CodeReviewAction::ToggleFileSidebar))
         });
@@ -1403,9 +1411,11 @@ impl CodeReviewView {
         });
     }
 
-    fn update_file_nav_button_tooltip(&self, ctx: &mut ViewContext<Self>) {
+    fn update_file_nav_button_state(&self, ctx: &mut ViewContext<Self>) {
         let tooltip = file_nav_button_tooltip(self.file_sidebar_expanded, ctx);
+        let icon = file_nav_button_icon(self.file_sidebar_expanded);
         self.file_nav_button.update(ctx, |button, ctx| {
+            button.set_icon(Some(icon), ctx);
             button.set_tooltip(Some(tooltip), ctx);
         });
     }
@@ -1433,7 +1443,7 @@ impl CodeReviewView {
             self.file_sidebar_expanded_before_maximize = Some(self.file_sidebar_expanded);
             if !self.file_sidebar_expanded {
                 self.open_file_sidebar(ctx);
-                self.update_file_nav_button_tooltip(ctx);
+                self.update_file_nav_button_state(ctx);
                 ctx.notify();
             }
         } else if !is_maximized {
@@ -1441,7 +1451,7 @@ impl CodeReviewView {
                 // Transitioning to minimized: restore saved sidebar state
                 if self.file_sidebar_expanded != was_expanded {
                     self.file_sidebar_expanded = was_expanded;
-                    self.update_file_nav_button_tooltip(ctx);
+                    self.update_file_nav_button_state(ctx);
                     ctx.notify();
                 }
             }
@@ -7176,7 +7186,7 @@ impl TypedActionView for CodeReviewView {
                 } else {
                     self.open_file_sidebar(ctx);
                 }
-                self.update_file_nav_button_tooltip(ctx);
+                self.update_file_nav_button_state(ctx);
                 ctx.notify();
             }
             CodeReviewAction::FileSelected(file_index) => {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Updates the code review file navigation toggle in the git-operations-enabled header to use the sidebar/panel toggle icon instead of the file-copy icon.

The button now derives its icon from the current file navigation sidebar state, matching the existing `LeftSidebarOpen` / `LeftSidebarClose` icon pair used elsewhere for this control.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
Closes #11750

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] `cargo fmt --manifest-path /workspace/warp/Cargo.toml --package warp`
- [x] `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib --features local_fs,gui`
- [x] `cargo build --manifest-path /workspace/warp/Cargo.toml -p warp --bin warp-oss --features local_fs,gui,skip_login`
- [x] Manual GUI verification with the built `warp-oss` binary in a disposable git repo with local changes
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Computer-use verification observations:
- Before clicking, the code review header toggle showed the tooltip `Show file navigation (F)` and rendered as a sidebar/panel toggle icon with two outlined rectangles, not a document/file-copy icon.
- The button appeared in the header row next to the git operation controls.
- After clicking, the file navigation sidebar opened and listed changed files from the demo repo; the tooltip changed to `Hide file navigation (F)`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/8590c6f0-b86e-486e-a8ef-7d24d8e77868_
_Run: https://oz.staging.warp.dev/runs/019e6a06-ebc9-77d2-bde1-12fba51db76c_
_This PR was generated with [Oz](https://warp.dev/oz)._
