### PR TITLE
Vertical tab grouping additional actions + dragging

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -44,6 +44,7 @@ use crate::util::color::{coloru_with_opacity, Opacity};
 use crate::util::truncation::truncate_from_end;
 use crate::window_settings::WindowSettings;
 use crate::workspace::sync_inputs::SyncedInputState;
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspace::tab_settings::{
     TabCloseButtonPosition, TabSettings, VerticalTabsDisplayGranularity,
 };
@@ -147,6 +148,8 @@ pub struct TabData {
     pub indicator_hover_state: MouseStateHandle,
     // Used by a later drag-tab branch to distinguish tabs that have moved into detached windows.
     pub detached: bool,
+    /// Tab group this tab belongs to, if any
+    pub group_id: Option<TabGroupId>,
 }
 
 const TAB_COLOR_ICON_PATH: &str = "bundled/svg/ellipse.svg";
@@ -164,6 +167,7 @@ impl TabData {
             selected_color: SelectedTabColor::Unset,
             indicator_hover_state: Default::default(),
             detached: false,
+            group_id: None,
         }
     }
 

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -44,7 +45,7 @@ use crate::util::color::{coloru_with_opacity, Opacity};
 use crate::util::truncation::truncate_from_end;
 use crate::window_settings::WindowSettings;
 use crate::workspace::sync_inputs::SyncedInputState;
-use crate::workspace::tab_group::TabGroupId;
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::{
     TabCloseButtonPosition, TabSettings, VerticalTabsDisplayGranularity,
 };
@@ -55,6 +56,21 @@ use crate::BlocklistAIHistoryModel;
 
 pub const TAB_BAR_BORDER_HEIGHT: f32 = 1.0;
 const TAB_INDICATOR_HEIGHT: f32 = 14.0;
+
+const UNTITLED_TAB_GROUP_DISPLAY_NAME: &str = "Untitled group";
+
+/// Shared between `tab_group_menu_items` and the sidecar overlay in `view.rs`
+/// (used as the `SavePosition` anchor key) so the lookup matches the label.
+pub const MOVE_TO_GROUP_LABEL: &str = "Move to group";
+
+fn tab_group_display_name(group: &TabGroup) -> String {
+    group
+        .name
+        .as_ref()
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| UNTITLED_TAB_GROUP_DISPLAY_NAME.to_string())
+}
 
 /// True when the user has opted into vertical tabs and the feature flag is on.
 /// Exposed so binding-description overrides in `workspace/mod.rs` and context-
@@ -181,9 +197,10 @@ impl TabData {
         &self,
         index: usize,
         tabs_len: usize,
+        tab_groups: &HashMap<TabGroupId, TabGroup>,
         ctx: &AppContext,
     ) -> Vec<MenuItem<WorkspaceAction>> {
-        self.menu_items_with_pane_name_target(index, tabs_len, None, ctx)
+        self.menu_items_with_pane_name_target(index, tabs_len, None, tab_groups, ctx)
     }
 
     pub fn menu_items_with_pane_name_target(
@@ -191,6 +208,7 @@ impl TabData {
         index: usize,
         tabs_len: usize,
         pane_name_target: Option<PaneNameMenuTarget>,
+        tab_groups: &HashMap<TabGroupId, TabGroup>,
         ctx: &AppContext,
     ) -> Vec<MenuItem<WorkspaceAction>> {
         let appearance = Appearance::as_ref(ctx);
@@ -198,7 +216,7 @@ impl TabData {
         let mut menu_items = vec![];
 
         for section_items in [
-            Self::tab_group_menu_items(),
+            self.tab_group_menu_items(index, tab_groups),
             self.session_sharing_menu_items(index, ctx),
             self.copy_metadata_menu_items(pane_name_target, ctx),
             self.modify_tab_menu_items(index, tabs_len, pane_name_target, ctx),
@@ -534,15 +552,73 @@ impl TabData {
             .into_item()]
     }
 
-    /// Returns the tab-group related entries, TODO(johnturcoo) add group actions.
-    fn tab_group_menu_items() -> Vec<MenuItem<WorkspaceAction>> {
+    /// "New group with tab" plus an optional "Move to group" submenu marker.
+    fn tab_group_menu_items(
+        &self,
+        index: usize,
+        tab_groups: &HashMap<TabGroupId, TabGroup>,
+    ) -> Vec<MenuItem<WorkspaceAction>> {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return vec![];
         }
-        vec![
-            MenuItemFields::new("New group with tab").into_item(),
-            MenuItemFields::new_submenu("Move to group").into_item(),
-        ]
+        let mut items = vec![MenuItemFields::new("New group with tab")
+            .with_on_select_action(WorkspaceAction::NewTabGroupFromTab(index))
+            .into_item()];
+
+        if self.group_sidecar_menu_items(index, tab_groups).is_empty() {
+            return items;
+        }
+
+        items.push(
+            MenuItemFields::new_submenu(MOVE_TO_GROUP_LABEL)
+                .with_tooltip(MOVE_TO_GROUP_LABEL.to_string())
+                .into_item(),
+        );
+        items
+    }
+
+    /// Sidecar entries for "Move to group": every other group, plus
+    /// "Remove from group" when this tab belongs to one.
+    pub fn group_sidecar_menu_items(
+        &self,
+        index: usize,
+        tab_groups: &HashMap<TabGroupId, TabGroup>,
+    ) -> Vec<MenuItem<WorkspaceAction>> {
+        let current_group_id = self.group_id;
+        // Group ids are random UUIDs; sort by display name for stable order.
+        let mut group_entries: Vec<(&TabGroupId, &TabGroup)> = tab_groups.iter().collect();
+        group_entries.sort_by(|(_, a), (_, b)| {
+            tab_group_display_name(a)
+                .to_lowercase()
+                .cmp(&tab_group_display_name(b).to_lowercase())
+        });
+
+        let mut items: Vec<MenuItem<WorkspaceAction>> = group_entries
+            .into_iter()
+            .filter(|(gid, _)| Some(**gid) != current_group_id)
+            .map(|(gid, group)| {
+                MenuItemFields::new(tab_group_display_name(group))
+                    .with_on_select_action(WorkspaceAction::AssignTabToGroup {
+                        tab_index: index,
+                        group_id: Some(*gid),
+                    })
+                    .into_item()
+            })
+            .collect();
+        if current_group_id.is_some() {
+            if !items.is_empty() {
+                items.push(MenuItem::Separator);
+            }
+            items.push(
+                MenuItemFields::new("Remove from group")
+                    .with_on_select_action(WorkspaceAction::AssignTabToGroup {
+                        tab_index: index,
+                        group_id: None,
+                    })
+                    .into_item(),
+            );
+        }
+        items
     }
 
     fn color_option_menu_items(

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -41,6 +41,7 @@ use crate::terminal::view::inline_banner::ZeroStatePromptSuggestionType;
 use crate::themes::theme::AnsiColorIdentifier;
 use crate::themes::theme_chooser::ThemeChooserMode;
 use crate::workflows::{WorkflowSelectionSource, WorkflowSource, WorkflowType};
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspace::PaneViewLocator;
 
 /// This enum determines how the search query is initialized when opening command search.
@@ -169,6 +170,10 @@ pub enum WorkspaceAction {
     CloseNonActiveTabs,
     CloseTabsRight(usize),
     CloseTabsRightActiveTab,
+    /// Close every tab that belongs to the given tab group.
+    CloseTabGroup(TabGroupId),
+    /// Toggle collapsed state for the given tab group.
+    ToggleTabGroupCollapsed(TabGroupId),
     AddDefaultTab,
     AddTerminalTab {
         hide_homepage: bool,
@@ -794,6 +799,8 @@ impl WorkspaceAction {
             | CloseNonActiveTabs
             | CloseTabsRight(_)
             | CloseTabsRightActiveTab
+            | CloseTabGroup(_)
+            | ToggleTabGroupCollapsed(_)
             | ToggleTabColor { .. }
             | AddDefaultTab
             | AddTerminalTab { .. }

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -296,6 +296,20 @@ pub enum WorkspaceAction {
         tab_position: RectF,
     },
     DropTab,
+    /// Begins a drag of an entire tab group via its header.
+    /// Mirrors `StartTabDrag` but for the group's contiguous run of member
+    /// tabs. Gated at runtime by `FeatureFlag::GroupedTabs`.
+    StartGroupDrag(TabGroupId),
+    /// In-progress drag of an entire tab group. Forwarded to
+    /// `Workspace::on_group_drag`, which decides whether to swap the group's
+    /// block with an adjacent neighbor block based on the dragged header's
+    /// current Y position. Mirrors `DragTab` but for groups.
+    DragGroup {
+        group_id: TabGroupId,
+        position: RectF,
+    },
+    /// Finalizes a group drag. Persists via `should_save_app_state_on_action`.
+    DropGroup(TabGroupId),
     /// Toggles the left panel. In Code Mode V1 this toggles Warp Drive.
     /// In Code Mode V2 this toggles the left panel which contains both the project explorer and
     /// Warp Drive. This happens as explicit action from the user.
@@ -801,6 +815,7 @@ impl WorkspaceAction {
             | MoveTabLeft(_)
             | MoveTabRight(_)
             | DropTab
+            | DropGroup(_)
             | RenameTab(_)
             | ResetTabName(_)
             | RenamePane(_)
@@ -915,6 +930,8 @@ impl WorkspaceAction {
             | OpenInExplorer { .. }
             | DragTab { .. }
             | StartTabDrag
+            | DragGroup { .. }
+            | StartGroupDrag(_)
             | ToggleLeftPanel
             | ToggleWarpDrive
             | OpenWarpDrive

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -174,6 +174,22 @@ pub enum WorkspaceAction {
     CloseTabGroup(TabGroupId),
     /// Toggle collapsed state for the given tab group.
     ToggleTabGroupCollapsed(TabGroupId),
+    /// Enter rename mode for the given tab group. Focuses the inline header
+    /// editor and seeds it with the existing name (or a placeholder when the
+    /// group is unnamed).
+    RenameTabGroup(TabGroupId),
+    /// Commit any in-progress tab-group rename. Dispatched by header click /
+    /// editor blur. No-op when no group is being renamed.
+    FinishTabGroupRename,
+    /// Create a new tab group containing the existing tab at `tab_index` and
+    /// immediately enter rename mode on the new group.
+    NewTabGroupFromTab(usize),
+    /// Move the tab at `tab_index` into the given group, or remove it from
+    /// its current group when `group_id` is `None`.
+    AssignTabToGroup {
+        tab_index: usize,
+        group_id: Option<TabGroupId>,
+    },
     AddDefaultTab,
     AddTerminalTab {
         hide_homepage: bool,
@@ -801,6 +817,10 @@ impl WorkspaceAction {
             | CloseTabsRightActiveTab
             | CloseTabGroup(_)
             | ToggleTabGroupCollapsed(_)
+            | RenameTabGroup(_)
+            | FinishTabGroupRename
+            | NewTabGroupFromTab(_)
+            | AssignTabToGroup { .. }
             | ToggleTabColor { .. }
             | AddDefaultTab
             | AddTerminalTab { .. }

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -18,6 +18,7 @@ mod one_time_modal_model;
 mod registry;
 pub mod rewind_confirmation_dialog;
 pub mod sync_inputs;
+pub mod tab_group;
 pub mod tab_settings;
 mod toast_stack;
 pub mod util;

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -1,0 +1,22 @@
+//! Tab group data model. Gated at runtime by `FeatureFlag::GroupedTabs`.
+
+use uuid::Uuid;
+
+/// Stable identity for a tab group.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TabGroupId(pub Uuid);
+
+impl TabGroupId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+/// A group of tabs. Member tabs point to their
+/// group via `TabData::group_id`.
+#[derive(Clone)]
+pub struct TabGroup {
+    pub id: TabGroupId,
+    pub name: Option<String>,
+    pub collapsed: bool,
+}

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -1,9 +1,11 @@
 //! Tab group data model. Gated at runtime by `FeatureFlag::GroupedTabs`.
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use warpui::elements::DraggableState;
 
 /// Stable identity for a tab group.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct TabGroupId(pub Uuid);
 
 impl TabGroupId {
@@ -18,11 +20,32 @@ impl Default for TabGroupId {
     }
 }
 
-/// A group of tabs. Member tabs point to their
-/// group via `TabData::group_id`.
-#[derive(Clone)]
+/// A group of tabs the user has clustered together. Member tabs point to
+/// their group via `TabData::group_id`; `Workspace::tab_groups` is the source
+/// of truth for the group's metadata.
+///
+/// `Debug` is implemented manually so that `draggable_state` (which doesn't
+/// implement `Debug`) can be skipped.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TabGroup {
     pub id: TabGroupId,
     pub name: Option<String>,
     pub collapsed: bool,
+    /// Transient drag state for the group header. Bound to a `Draggable`
+    /// in the vertical tabs panel so the entire group's contiguous run of
+    /// member tabs can be reordered as a single block. Not persisted: drag
+    /// state is meaningful only during an in-flight drag, so the field is
+    /// skipped on serialize/deserialize and reinitialized to its default.
+    #[serde(skip)]
+    pub draggable_state: DraggableState,
+}
+
+impl std::fmt::Debug for TabGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TabGroup")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("collapsed", &self.collapsed)
+            .finish_non_exhaustive()
+    }
 }

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -12,6 +12,12 @@ impl TabGroupId {
     }
 }
 
+impl Default for TabGroupId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A group of tabs. Member tabs point to their
 /// group via `TabData::group_id`.
 #[derive(Clone)]

--- a/app/src/workspace/util.rs
+++ b/app/src/workspace/util.rs
@@ -7,6 +7,7 @@ use crate::appearance::Appearance;
 use crate::pane_group::PaneId;
 use crate::terminal::TerminalView;
 use crate::window_settings::WindowSettings;
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspace::Workspace;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -128,6 +129,10 @@ pub struct WorkspaceState {
     pub is_transcript_details_panel_open: bool,
     tab_being_renamed: Option<usize>, // The index of the tab being renamed
     pane_being_renamed: Option<PaneViewLocator>,
+    /// The tab group currently in inline-rename mode, if any. Mirrors
+    /// `tab_being_renamed` but keyed by `TabGroupId` so the rename UI
+    /// can survive reorders / membership changes.
+    tab_group_being_renamed: Option<TabGroupId>,
 }
 
 impl WorkspaceState {
@@ -145,6 +150,7 @@ impl WorkspaceState {
             || self.is_changelog_modal_open
             || self.tab_being_renamed.is_some()
             || self.pane_being_renamed.is_some()
+            || self.tab_group_being_renamed.is_some()
             || self.is_reward_modal_open
             || self.is_launch_config_save_modal_open
             || self.is_command_search_open
@@ -186,6 +192,7 @@ impl WorkspaceState {
         self.is_changelog_modal_open = false;
         self.tab_being_renamed = None;
         self.pane_being_renamed = None;
+        self.tab_group_being_renamed = None;
         self.is_reward_modal_open = false;
         self.is_launch_config_save_modal_open = false;
         self.is_command_search_open = false;
@@ -258,6 +265,28 @@ impl WorkspaceState {
 
     pub fn pane_being_renamed(&self) -> Option<PaneViewLocator> {
         self.pane_being_renamed
+    }
+
+    pub fn is_tab_group_being_renamed(&self, group_id: TabGroupId) -> bool {
+        self.tab_group_being_renamed == Some(group_id)
+    }
+
+    pub fn is_any_tab_group_being_renamed(&self) -> bool {
+        self.tab_group_being_renamed.is_some()
+    }
+
+    pub fn set_tab_group_being_renamed(&mut self, group_id: TabGroupId) {
+        self.tab_group_being_renamed = Some(group_id);
+        self.tab_being_renamed = None;
+        self.pane_being_renamed = None;
+    }
+
+    pub fn clear_tab_group_being_renamed(&mut self) {
+        self.tab_group_being_renamed = None;
+    }
+
+    pub fn tab_group_being_renamed(&self) -> Option<TabGroupId> {
+        self.tab_group_being_renamed
     }
 }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -467,6 +467,7 @@ use crate::workspace::header_toolbar_editor::{HeaderToolbarEditorEvent, HeaderTo
 use crate::workspace::header_toolbar_item::HeaderToolbarItemKind;
 use crate::workspace::one_time_modal_model::OneTimeModalModel;
 use crate::workspace::sync_inputs::SyncedInputState;
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::TabCloseButtonPosition;
 use crate::workspace::toast_stack::{
     ToastStack, ToastStack as WorkspaceToastStack, ToastStackEvent as WorkspaceToastStackEvent,
@@ -933,6 +934,8 @@ pub struct Workspace {
     tab_bar_hover_state: MouseStateHandle,
     tab_fixed_width: Option<f32>,
     traffic_light_mouse_states: TrafficLightMouseStates,
+    /// Tab groups in this workspace, keyed by id.
+    pub(crate) tab_groups: HashMap<TabGroupId, TabGroup>,
     tab_rename_editor: ViewHandle<EditorView>,
     pane_rename_editor: ViewHandle<EditorView>,
     vertical_tabs_search_input: ViewHandle<EditorView>,
@@ -3085,6 +3088,7 @@ impl Workspace {
             hovered_tab_index: None,
             tab_bar_hover_state: Default::default(),
             traffic_light_mouse_states: Default::default(),
+            tab_groups: HashMap::new(),
             tab_rename_editor: Self::tab_rename_editor(ctx),
             pane_rename_editor: Self::pane_rename_editor(ctx),
             vertical_tabs_search_input: Self::vertical_tabs_search_input(ctx),
@@ -6481,7 +6485,7 @@ impl Workspace {
             #[cfg(not(feature = "local_fs"))]
             NewSessionMenuItem::CreateNewTabConfig => {}
             NewSessionMenuItem::CreateNewTabGroup => {
-                // TODO(johnturcoo): implement tab group creation.
+                self.create_new_tab_group(ctx);
             }
         }
     }
@@ -6634,6 +6638,98 @@ impl Workspace {
 
     #[cfg(not(feature = "local_fs"))]
     fn save_current_tab_as_new_config(&mut self, _tab_index: usize, _ctx: &mut ViewContext<Self>) {}
+
+    /// Creates a new tab group containing a single new tab. 
+    fn create_new_tab_group(&mut self, ctx: &mut ViewContext<Self>) {
+        let group_id = TabGroupId::new();
+        self.tab_groups.insert(
+            group_id,
+            TabGroup {
+                id: group_id,
+                name: None,
+                collapsed: false,
+            },
+        );
+        self.add_new_session_tab_with_default_mode(
+            NewSessionSource::Tab,
+            Some(ctx.window_id()),
+            None,
+            None,
+            false,
+            ctx,
+        );
+        let new_tab_index = self.active_tab_index;
+        if let Some(tab) = self.tabs.get_mut(new_tab_index) {
+            tab.group_id = Some(group_id);
+        }
+
+        // Cluster the new group after the last existing grouped tab.
+        let target_index = self
+            .tabs
+            .iter()
+            .enumerate()
+            .filter(|(idx, tab)| *idx != new_tab_index && tab.group_id.is_some())
+            .map(|(idx, _)| idx)
+            .max()
+            .map(|max_idx| max_idx + 1)
+            .unwrap_or(0);
+
+        if new_tab_index != target_index {
+            let tab = self.tabs.remove(new_tab_index);
+            let insert_index = if new_tab_index < target_index {
+                target_index - 1
+            } else {
+                target_index
+            };
+            self.tabs.insert(insert_index, tab);
+            self.active_tab_index = insert_index;
+        }
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Closes every tab in the given group and removes the group.
+    pub fn close_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
+        let indices: Vec<usize> = self
+            .tabs
+            .iter()
+            .enumerate()
+            .filter(|(_, tab)| tab.group_id == Some(group_id))
+            .map(|(idx, _)| idx)
+            .collect();
+        if indices.is_empty() {
+            self.tab_groups.remove(&group_id);
+            ctx.notify();
+            return;
+        }
+        let first_index = indices[0];
+        let closed = self.close_tabs(
+            indices.into_iter(),
+            OpenDialogSource::CloseOtherTabs {
+                tab_index: first_index,
+            },
+            false,
+            true,
+            ctx,
+        );
+        if closed {
+            self.tab_groups.remove(&group_id);
+            ctx.notify();
+        }
+    }
+
+    /// Toggles the collapsed state of the given tab group.
+    pub fn toggle_tab_group_collapsed(
+        &mut self,
+        group_id: TabGroupId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(group) = self.tab_groups.get_mut(&group_id) {
+            group.collapsed = !group.collapsed;
+            ctx.notify();
+        }
+    }
 
     pub fn toggle_tab_right_click_menu(
         &mut self,
@@ -11053,6 +11149,12 @@ impl Workspace {
 
         let is_new_terminal = matches!(panes_layout, PanesLayout::SingleTerminal(_));
         let is_restoration = matches!(panes_layout, PanesLayout::Snapshot(_));
+        // Capture the active tab's group membership so the new tab can inherit it.
+        let active_tab_group_id = if FeatureFlag::GroupedTabs.is_enabled() && !is_restoration {
+            active_tab.and_then(|tab| tab.group_id)
+        } else {
+            None
+        };
         let new_pane_group = ctx.add_typed_action_view(|ctx| {
             let mut pane_group = PaneGroup::new_with_panes_layout(
                 self.tips_completed.clone(),
@@ -11078,10 +11180,24 @@ impl Workspace {
 
         match new_tab_placement_setting {
             NewTabPlacement::AfterAllTabs => {
-                self.tabs.push(TabData::new(new_pane_group));
+                // When inheriting a group, land at the end of the group's
+                // contiguous run instead of past it so the setting is
+                // honored within the group's bounds.
+                let insert_idx = active_tab_group_id
+                    .and_then(|gid| {
+                        self.tabs
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, tab)| tab.group_id == Some(gid))
+                            .map(|(idx, _)| idx)
+                            .max()
+                            .map(|max_idx| max_idx + 1)
+                    })
+                    .unwrap_or(self.tabs.len());
+                self.tabs.insert(insert_idx, TabData::new(new_pane_group));
                 self.tab_mru_order
-                    .push(self.tabs.last().unwrap().pane_group.id());
-                self.activate_tab_internal(self.tab_count() - 1, ctx);
+                    .push(self.tabs[insert_idx].pane_group.id());
+                self.activate_tab_internal(insert_idx, ctx);
             }
             // Add tab after current tab
             _ => {
@@ -11097,6 +11213,14 @@ impl Workspace {
                         .push(self.tabs[insert_idx].pane_group.id());
                     self.activate_tab_internal(insert_idx, ctx);
                 }
+            }
+        }
+
+        // Inherit the active tab's group membership. D
+        if let Some(group_id) = active_tab_group_id {
+            let new_idx = self.active_tab_index;
+            if let Some(new_tab) = self.tabs.get_mut(new_idx) {
+                new_tab.group_id = Some(group_id);
             }
         }
 
@@ -21127,6 +21251,8 @@ impl TypedActionView for Workspace {
             CloseTabsRightActiveTab => {
                 self.close_tabs_direction(self.active_tab_index, TabMovement::Right, false, ctx)
             }
+            CloseTabGroup(group_id) => self.close_tab_group(*group_id, ctx),
+            ToggleTabGroupCollapsed(group_id) => self.toggle_tab_group_collapsed(*group_id, ctx),
             AddDefaultTab => {
                 let effective_mode = AISettings::as_ref(ctx).default_session_mode(ctx);
                 match effective_mode {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -108,7 +108,7 @@ use warpui::{
 
 use self::vertical_tabs::telemetry::{VerticalTabsDisplayOption, VerticalTabsTelemetryEvent};
 use self::vertical_tabs::{
-    render_detail_sidecar, render_settings_popup, VerticalTabsPanelState,
+    render_detail_sidecar, render_settings_popup, vtab_group_position_id, VerticalTabsPanelState,
     VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -940,6 +940,12 @@ pub struct Workspace {
     traffic_light_mouse_states: TrafficLightMouseStates,
     /// Tab groups in this workspace, keyed by id.
     pub(crate) tab_groups: HashMap<TabGroupId, TabGroup>,
+    /// While a tab drag is hovering over a collapsed group's container,
+    /// holds that group's id so the vertical tabs renderer transiently
+    /// displays the group as expanded. Cleared on drop / drag end.
+    /// Distinct from `TabGroup::collapsed`, which is the user's persistent
+    /// intent and is not mutated by the drag.
+    pub(crate) drag_force_expanded_group: Option<TabGroupId>,
     tab_rename_editor: ViewHandle<EditorView>,
     pane_rename_editor: ViewHandle<EditorView>,
     vertical_tabs_search_input: ViewHandle<EditorView>,
@@ -1552,6 +1558,7 @@ impl Workspace {
                 id: group_id,
                 name: None,
                 collapsed: false,
+                draggable_state: Default::default(),
             },
         );
         // Detach from any prior group; a tab can only belong to one group.
@@ -1617,6 +1624,16 @@ impl Workspace {
 
         let previous_group_id = self.tabs[tab_index].group_id;
         self.tabs[tab_index].group_id = group_id;
+
+        // If the tab is joining a collapsed group, expand it so the user can
+        // see where the tab landed. Applies to both drag-into and the
+        // right-click "Move to group" path. The user's persistent collapse
+        // intent only sticks until the next time membership changes.
+        if let Some(gid) = group_id {
+            if let Some(group) = self.tab_groups.get_mut(&gid) {
+                group.collapsed = false;
+            }
+        }
 
         // Destination index: after the group's last member when joining, or
         // after the last grouped tab when leaving (so the cluster stays
@@ -3343,6 +3360,7 @@ impl Workspace {
             tab_bar_hover_state: Default::default(),
             traffic_light_mouse_states: Default::default(),
             tab_groups: HashMap::new(),
+            drag_force_expanded_group: None,
             tab_rename_editor: Self::tab_rename_editor(ctx),
             pane_rename_editor: Self::pane_rename_editor(ctx),
             vertical_tabs_search_input: Self::vertical_tabs_search_input(ctx),
@@ -6906,6 +6924,7 @@ impl Workspace {
                 id: group_id,
                 name: None,
                 collapsed: false,
+                draggable_state: Default::default(),
             },
         );
         self.add_new_session_tab_with_default_mode(
@@ -11551,10 +11570,13 @@ impl Workspace {
         let active_tab = self.tabs.get(self.active_tab_index);
         let active_tab_selected_color = active_tab.map(|tab| tab.selected_color);
         let active_tab_default_color = active_tab.and_then(|tab| tab.default_directory_color);
-
         let is_new_terminal = matches!(panes_layout, PanesLayout::SingleTerminal(_));
         let is_restoration = matches!(panes_layout, PanesLayout::Snapshot(_));
-        // Capture the active tab's group membership so the new tab can inherit it.
+        // Capture the active tab's group membership so the new tab can
+        // inherit it. Picked up only when grouped tabs are enabled and we
+        // are not restoring a tab (restored tabs come with their own
+        // persisted `group_id` and shouldn't be retroactively re-grouped
+        // based on whichever tab happens to be active during restoration).
         let active_tab_group_id = if FeatureFlag::GroupedTabs.is_enabled() && !is_restoration {
             active_tab.and_then(|tab| tab.group_id)
         } else {
@@ -11583,7 +11605,19 @@ impl Workspace {
 
         let new_tab_placement_setting = TabSettings::as_ref(ctx).new_tab_placement;
 
-        match new_tab_placement_setting {
+        // When the active tab belongs to a tab group, the user's
+        // `new_tab_placement` is overridden to `AfterCurrentTab` so the new
+        // tab lands adjacent to the active tab inside the group's
+        // contiguous run. Without this, an `AfterAllTabs` setting would
+        // push the new tab past the group, breaking contiguity and
+        // requiring an immediate reclustering step.
+        let effective_placement = if active_tab_group_id.is_some() {
+            NewTabPlacement::AfterCurrentTab
+        } else {
+            new_tab_placement_setting
+        };
+
+        match effective_placement {
             NewTabPlacement::AfterAllTabs => {
                 // When inheriting a group, land at the end of the group's
                 // contiguous run instead of past it so the setting is
@@ -11621,7 +11655,14 @@ impl Workspace {
             }
         }
 
-        // Inherit the active tab's group membership. D
+        // Inherit the active tab's group membership. Done after the
+        // placement match so the new tab is already at
+        // `self.active_tab_index`. Because we forced `AfterCurrentTab`
+        // placement above when the active tab is grouped, the new tab is
+        // always inserted somewhere inside the group's contiguous run
+        // (immediately after the active member), so simply tagging it
+        // with the same `group_id` preserves contiguity without a
+        // reclustering step.
         if let Some(group_id) = active_tab_group_id {
             let new_idx = self.active_tab_index;
             if let Some(new_tab) = self.tabs.get_mut(new_idx) {
@@ -22215,6 +22256,27 @@ impl TypedActionView for Workspace {
                 self.finish_tab_rename(ctx);
                 self.current_workspace_state.is_tab_being_dragged = true;
             }
+            StartGroupDrag(_group_id) => {
+                // Mirrors `StartTabDrag` so the rest of the workspace knows a
+                // drag is in flight (e.g. action-button overlays hide). The
+                // group's `draggable_state` is managed by the `Draggable`
+                // element itself; we only need to flip the workspace-level
+                // "is dragging" flag here and finish any in-progress rename.
+                self.finish_tab_rename(ctx);
+                self.finish_tab_group_rename(ctx);
+                self.current_workspace_state.is_tab_being_dragged = true;
+            }
+            DragGroup { group_id, position } => {
+                self.on_group_drag(*group_id, *position, ctx);
+            }
+            DropGroup(_group_id) => {
+                // Symmetric to `DropTab`: clear the shared drag flag so
+                // overlays reappear. Persistence runs via
+                // `should_save_app_state_on_action`.
+                self.current_workspace_state.is_tab_being_dragged = false;
+                send_telemetry_from_ctx!(TelemetryEvent::DragAndDropTab, ctx);
+                ctx.notify();
+            }
             OpenWarpDrive => {
                 if WarpDriveSettings::is_warp_drive_enabled(ctx) {
                     self.open_left_panel_view(&LeftPanelAction::WarpDrive, ctx);
@@ -22599,6 +22661,12 @@ impl TypedActionView for Workspace {
                 tab_position,
             } => self.on_tab_drag(*tab_index, *tab_position, ctx),
             DropTab => {
+                // Clear the transient "force-expand group under cursor"
+                // marker so the persisted `TabGroup::collapsed` state takes
+                // over again on the next render.
+                if self.drag_force_expanded_group.take().is_some() {
+                    ctx.notify();
+                }
                 let is_cross_window = CrossWindowTabDrag::as_ref(ctx).is_active();
                 let handed_off_tab_index =
                     CrossWindowTabDrag::as_ref(ctx)
@@ -25703,15 +25771,95 @@ impl Workspace {
             return;
         }
 
-        let new_index = if FeatureFlag::VerticalTabs.is_enabled()
-            && *TabSettings::as_ref(ctx).use_vertical_tabs
-        {
+        let use_vertical_tabs =
+            FeatureFlag::VerticalTabs.is_enabled() && *TabSettings::as_ref(ctx).use_vertical_tabs;
+        let groups_enabled = FeatureFlag::GroupedTabs.is_enabled();
+
+        // Group-aware path: only meaningful in the vertical tabs panel, where
+        // each group container has a `SavePosition` we can hit-test against.
+        if use_vertical_tabs && groups_enabled {
+            let cursor_y = position.center().y();
+            // Collapsed groups are intentionally excluded as drop targets:
+            // assigning a tab into a collapsed group triggers a transient
+            // layout shift (the group expands mid-drag) that interacts
+            // badly with the dispatched `DragTab` action's stale
+            // `tab_index` between renders — subsequent events can end up
+            // operating on the wrong tab and split the group's contiguous
+            // run. To drop a tab into a group, expand it first.
+            let target_group = self
+                .target_group_at_y(cursor_y, ctx)
+                .filter(|gid| !self.tab_groups.get(gid).is_some_and(|g| g.collapsed));
+            let source_group = self.tabs[current_index].group_id;
+
+            // `drag_force_expanded_group` stays unused while we disallow
+            // drag-into-collapsed (the filter above ensures `target_group`
+            // is never a collapsed group). The field/clear-on-drop wiring
+            // remains in place so we can re-enable the auto-expand UX
+            // later by removing just the filter, once the underlying
+            // stale-`tab_index` race is fixed.
+            if self.drag_force_expanded_group.take().is_some() {
+                ctx.notify();
+            }
+
+            // Cursor crossed a group boundary (or moved between two
+            // different groups). Delegate to `assign_tab_to_group`, which
+            // updates `group_id`, slots the tab adjacent to the target
+            // group's existing members to preserve contiguity, prunes an
+            // emptied source group, and adjusts `active_tab_index`.
+            if target_group != source_group {
+                self.assign_tab_to_group(current_index, target_group, ctx);
+                return;
+            }
+        }
+
+        let new_index = if use_vertical_tabs {
             self.calculate_updated_tab_index_vertical(current_index, position, ctx)
         } else {
             self.calculate_updated_tab_index(current_index, position, ctx)
         };
 
+        // Within-group reorder: clamp the swap destination to the dragged
+        // tab's group so a grouped tab can't be swapped past an ungrouped
+        // neighbor (which would break the group's contiguous run). The
+        // group-boundary case above already handled cross-group transitions
+        // via `assign_tab_to_group`.
+        let new_index = if let Some(group_id) = self.tabs[current_index].group_id {
+            if let Some((first, last)) = group_member_index_range(&self.tabs, group_id) {
+                new_index.clamp(first, last)
+            } else {
+                new_index
+            }
+        } else {
+            new_index
+        };
+
         if new_index != current_index {
+            // When the neighbor we would swap with is a member of a
+            // collapsed group that the dragged tab does not belong to,
+            // a plain `tabs.swap(new_index, current_index)` would land
+            // the dragged tab between the group's first member and the
+            // rest, breaking the group's contiguous run (the renderer
+            // walks runs of equal `group_id` so the group would split
+            // into two disjoint runs). Hop past the entire collapsed
+            // group block with `remove` + `insert` instead so the
+            // members keep their order and stay contiguous.
+            let dragged_group = self.tabs[current_index].group_id;
+            let neighbor_collapsed_group = self
+                .tabs
+                .get(new_index)
+                .and_then(|t| t.group_id)
+                .filter(|gid| {
+                    Some(*gid) != dragged_group
+                        && self.tab_groups.get(gid).is_some_and(|g| g.collapsed)
+                });
+            if let Some(group_id) = neighbor_collapsed_group {
+                if let Some((first, last)) = group_member_index_range(&self.tabs, group_id) {
+                    let insert_at = if current_index < first { last } else { first };
+                    self.hop_tab_to_index(current_index, insert_at, ctx);
+                    return;
+                }
+            }
+
             self.tabs.swap(new_index, current_index);
 
             if current_index == self.active_tab_index {
@@ -25722,6 +25870,63 @@ impl Workspace {
 
             ctx.notify();
         }
+    }
+
+    /// Removes the tab at `from_index` and re-inserts it at `to_index` in
+    /// the resulting list, shifting intervening tabs to preserve their
+    /// relative order. Used by `on_tab_drag` to hop an ungrouped tab past
+    /// a collapsed tab group's contiguous block in a single motion,
+    /// keeping the group's members intact. `active_tab_index` is adjusted
+    /// directly (without `set_active_tab_index`) to avoid the MRU and
+    /// focus side effects that aren't appropriate for a transient drag
+    /// reorder.
+    fn hop_tab_to_index(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if from_index == to_index
+            || from_index >= self.tabs.len()
+            || to_index >= self.tabs.len()
+        {
+            return;
+        }
+        let tab = self.tabs.remove(from_index);
+        self.tabs.insert(to_index, tab);
+
+        let old_active = self.active_tab_index;
+        self.active_tab_index = if old_active == from_index {
+            to_index
+        } else if from_index < to_index {
+            if old_active > from_index && old_active <= to_index {
+                old_active - 1
+            } else {
+                old_active
+            }
+        } else if old_active >= to_index && old_active < from_index {
+            old_active + 1
+        } else {
+            old_active
+        };
+
+        ctx.notify();
+    }
+
+    /// Returns the tab group whose vertical container rect contains
+    /// `cursor_y`, if any. Used during `on_tab_drag` to decide whether the
+    /// dragged tab should join, leave, or move between groups based on
+    /// where the cursor currently sits. Reads each group's saved rect via
+    /// `element_position_by_id_at_last_frame`, so it returns `None` until
+    /// the renderer has emitted at least one frame for the group.
+    fn target_group_at_y(&self, cursor_y: f32, ctx: &AppContext) -> Option<TabGroupId> {
+        self.tab_groups.keys().copied().find(|group_id| {
+            ctx.element_position_by_id_at_last_frame(
+                self.window_id,
+                &vtab_group_position_id(*group_id),
+            )
+            .is_some_and(|rect| rect.min_y() <= cursor_y && cursor_y <= rect.max_y())
+        })
     }
 
     /// Performs the source-workspace cleanup indicated by `DropResult`.
@@ -25843,7 +26048,7 @@ impl Workspace {
         let midpoint_drag_y = (drag_position.min_y() + drag_position.max_y()) / 2.;
 
         let maybe_above_tab = if current_index > 0 {
-            ctx.element_position_by_id(tab_position_id(current_index - 1))
+            self.neighbor_drag_rect(current_index - 1, ctx)
         } else {
             None
         };
@@ -25855,7 +26060,7 @@ impl Workspace {
         }
 
         let maybe_below_tab = if current_index < self.tabs.len() - 1 {
-            ctx.element_position_by_id(tab_position_id(current_index + 1))
+            self.neighbor_drag_rect(current_index + 1, ctx)
         } else {
             None
         };
@@ -25868,10 +26073,151 @@ impl Workspace {
 
         current_index
     }
+
+    /// Returns the rect to compare a vertical-tab drag against for the
+    /// neighbor at `neighbor_index`. Normally this is the tab's own rect,
+    /// but when the neighbor is a member of a collapsed group its row is
+    /// not rendered (so `tab_position_id` isn't saved). In that case we
+    /// fall back to the group container's rect, which treats the whole
+    /// collapsed group as a single block the dragged tab can swap past.
+    fn neighbor_drag_rect(
+        &self,
+        neighbor_index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<RectF> {
+        ctx.element_position_by_id(tab_position_id(neighbor_index))
+            .or_else(|| {
+                let gid = self.tabs.get(neighbor_index)?.group_id?;
+                ctx.element_position_by_id_at_last_frame(
+                    self.window_id,
+                    &vtab_group_position_id(gid),
+                )
+            })
+    }
+
+    /// Handles a drag of an entire tab group from the `Draggable` wrapped
+    /// around the group header. Mirrors `on_tab_drag`'s within-window
+    /// reorder logic but treats the group's contiguous run of member tabs
+    /// as a single block: swaps the block with the adjacent neighbor
+    /// block (another group or an ungrouped tab) when the dragged
+    /// header's Y midpoint crosses the neighbor's midpoint. Neighbor
+    /// blocks are looked up via `vtab_group_position_id` when the
+    /// neighbor is itself grouped, otherwise via `tab_position_id`, so
+    /// the dragged group never lands inside another group (no nesting).
+    pub(crate) fn on_group_drag(
+        &mut self,
+        group_id: TabGroupId,
+        position: RectF,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some((first, last)) = group_member_index_range(&self.tabs, group_id) else {
+            return;
+        };
+        let midpoint_drag_y = (position.min_y() + position.max_y()) / 2.;
+        let block_size = last - first + 1;
+
+        // Swap up: check the neighbor directly above the group's first
+        // member. Find the start of that neighbor's block (its group's
+        // first member when grouped, else its own index) and move our
+        // block to land there.
+        if first > 0 {
+            let above_index = first - 1;
+            if let Some(rect) = self.neighbor_drag_rect(above_index, ctx) {
+                let neighbor_midpoint = (rect.min_y() + rect.max_y()) / 2.;
+                if midpoint_drag_y < neighbor_midpoint {
+                    let new_first = if let Some(other_gid) = self.tabs[above_index].group_id {
+                        group_member_index_range(&self.tabs, other_gid)
+                            .map(|(f, _)| f)
+                            .unwrap_or(above_index)
+                    } else {
+                        above_index
+                    };
+                    self.move_group_block(group_id, new_first, ctx);
+                    return;
+                }
+            }
+        }
+
+        // Swap down: check the neighbor directly below the group's last
+        // member. After the move the dragged block should land such that
+        // its last member sits at `below_block_last`, so its first member
+        // ends up at `below_block_last + 1 - block_size`.
+        if last + 1 < self.tabs.len() {
+            let below_index = last + 1;
+            if let Some(rect) = self.neighbor_drag_rect(below_index, ctx) {
+                let neighbor_midpoint = (rect.min_y() + rect.max_y()) / 2.;
+                if midpoint_drag_y > neighbor_midpoint {
+                    let below_block_last = if let Some(other_gid) = self.tabs[below_index].group_id
+                    {
+                        group_member_index_range(&self.tabs, other_gid)
+                            .map(|(_, l)| l)
+                            .unwrap_or(below_index)
+                    } else {
+                        below_index
+                    };
+                    let new_first = below_block_last + 1 - block_size;
+                    self.move_group_block(group_id, new_first, ctx);
+                }
+            }
+        }
+    }
+
+    /// Moves the contiguous run of tabs belonging to `group_id` so its
+    /// first member ends up at `new_first` in the resulting tab list.
+    /// Uses `Vec::drain` + `Vec::splice` so the relative order of the
+    /// member tabs is preserved through the move. The active tab index is
+    /// re-derived by tracking the active tab's `pane_group` id across
+    /// the mutation, so the in-app focus follows the moved tab when the
+    /// user is dragging the group that contains it.
+    fn move_group_block(
+        &mut self,
+        group_id: TabGroupId,
+        new_first: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some((first, last)) = group_member_index_range(&self.tabs, group_id) else {
+            return;
+        };
+        if new_first == first {
+            return;
+        }
+
+        let active_pane_group_id = self
+            .tabs
+            .get(self.active_tab_index)
+            .map(|tab| tab.pane_group.id());
+
+        let drained: Vec<TabData> = self.tabs.drain(first..=last).collect();
+        self.tabs.splice(new_first..new_first, drained);
+
+        if let Some(active_id) = active_pane_group_id {
+            if let Some(new_idx) = self
+                .tabs
+                .iter()
+                .position(|tab| tab.pane_group.id() == active_id)
+            {
+                self.active_tab_index = new_idx;
+            }
+        }
+
+        ctx.notify();
+    }
 }
 
 fn should_reserve_traffic_light_space_in_tab_bar(side: TrafficLightSide) -> bool {
     side == TrafficLightSide::Right
+}
+
+/// Returns `(first, last)` indices of `tabs` belonging to `group_id`, or
+/// `None` when the group has no members. Members of a group are always
+/// contiguous (enforced on every membership change), so the first and last
+/// matching indices fully describe the group's block.
+fn group_member_index_range(tabs: &[TabData], group_id: TabGroupId) -> Option<(usize, usize)> {
+    let first = tabs.iter().position(|tab| tab.group_id == Some(group_id))?;
+    let last = tabs
+        .iter()
+        .rposition(|tab| tab.group_id == Some(group_id))?;
+    Some((first, last))
 }
 
 /// Returns every tab-bar-equivalent rect laid out in `window_id` (horizontal

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -337,7 +337,8 @@ use crate::settings_view::{flags, SettingsSection, SettingsView, SettingsViewEve
 use crate::shell_indicator::ShellIndicatorType;
 use crate::tab::{
     tab_position_id, uses_vertical_tabs, NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor,
-    TabBarState, TabComponent, TabData, TabTelemetryAction, TAB_BAR_BORDER_HEIGHT,
+    TabBarState, TabComponent, TabData, TabTelemetryAction, MOVE_TO_GROUP_LABEL,
+    TAB_BAR_BORDER_HEIGHT,
 };
 use crate::tab_configs::action_sidecar::SidecarItemKind;
 use crate::tab_configs::remove_confirmation_dialog::{
@@ -571,6 +572,9 @@ const TOGGLE_RESOURCE_CENTER_KEYBINDING_NAME: &str = "workspace:toggle_resource_
 /// `SavePosition` wrapper and the safe-zone rect lookup.
 const NEW_SESSION_SIDECAR_POSITION_ID: &str = "new_session_sidecar";
 const NEW_SESSION_SIDECAR_WIDTH: f32 = 300.;
+
+const TAB_GROUPS_SIDECAR_POSITION_ID: &str = "tab_groups_sidecar";
+const TAB_GROUPS_SIDECAR_WIDTH: f32 = 200.;
 const NEW_SESSION_SIDECAR_SEARCH_BOX_HEIGHT: f32 = 32.;
 const NEW_SESSION_SIDECAR_SEARCH_BOX_HORIZONTAL_PADDING: f32 = 12.;
 const NEW_SESSION_SIDECAR_SEARCH_BOX_VERTICAL_PADDING: f32 = 6.;
@@ -1088,6 +1092,10 @@ pub struct Workspace {
     new_session_sidecar_add_repo_mouse_state: MouseStateHandle,
     tab_config_action_sidecar_item: Option<SidecarItemKind>,
     tab_config_action_sidecar_mouse_states: crate::tab_configs::action_sidecar::SidecarMouseStates,
+    tab_group_rename_editor: ViewHandle<EditorView>,
+    tab_groups_sidecar_menu: ViewHandle<Menu<WorkspaceAction>>,
+    show_tab_groups_sidecar: bool,
+    tab_groups_sidecar_tab_index: Option<usize>,
     remove_tab_config_confirmation_dialog: ViewHandle<RemoveTabConfigConfirmationDialog>,
     handoff_environment_creation_modal: Option<ViewHandle<HandoffEnvironmentCreationModal>>,
     /// Workspace-level modal hosting `AuthSecretFtuxView` for the
@@ -1325,6 +1333,38 @@ impl Workspace {
         editor
     }
 
+    fn tab_group_rename_editor(ctx: &mut ViewContext<Self>) -> ViewHandle<EditorView> {
+        let editor = ctx.add_typed_action_view(|ctx| {
+            let appearance = Appearance::as_ref(ctx);
+            let options = SingleLineEditorOptions {
+                text: TextOptions::ui_text(Some(12.), appearance),
+                ..Default::default()
+            };
+            EditorView::single_line(options, ctx)
+        });
+        ctx.subscribe_to_view(&editor, move |me, _, event, ctx| {
+            me.handle_tab_group_rename_editor_event(event, ctx);
+        });
+        editor
+    }
+
+    /// Sidecar menu for the "Move to group" submenu. Item dispatch is
+    /// suppressed so we can close the parent menu before dispatching.
+    fn build_tab_groups_sidecar_menu(
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<Menu<WorkspaceAction>> {
+        let sidecar = ctx.add_typed_action_view(|_| {
+            Menu::new()
+                .without_item_action_dispatch()
+                .with_width(TAB_GROUPS_SIDECAR_WIDTH)
+                .prevent_interaction_with_other_elements()
+        });
+        ctx.subscribe_to_view(&sidecar, move |me, _, event, ctx| {
+            me.handle_tab_groups_sidecar_event(event, ctx);
+        });
+        sidecar
+    }
+
     pub fn handle_tab_rename_editor_event(
         &mut self,
         event: &EditorEvent,
@@ -1355,6 +1395,27 @@ impl Workspace {
                 }
                 EditorEvent::Escape => {
                     self.cancel_pane_rename(ctx);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    pub fn handle_tab_group_rename_editor_event(
+        &mut self,
+        event: &EditorEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self
+            .current_workspace_state
+            .is_any_tab_group_being_renamed()
+        {
+            match event {
+                EditorEvent::Blurred | EditorEvent::Enter => {
+                    self.finish_tab_group_rename(ctx);
+                }
+                EditorEvent::Escape => {
+                    self.cancel_tab_group_rename(ctx);
                 }
                 _ => {}
             }
@@ -1412,6 +1473,199 @@ impl Workspace {
             self.clear_pane_name_editor(ctx);
             self.focus_pane(locator, ctx);
             ctx.notify();
+        }
+    }
+
+    fn clear_tab_group_name_editor(&mut self, ctx: &mut ViewContext<Self>) {
+        self.tab_group_rename_editor
+            .update(ctx, move |editor, ctx| {
+                editor.clear_buffer_and_reset_undo_stack(ctx);
+            });
+    }
+
+    /// Enters rename mode for the given tab group. Seeds the editor with the
+    /// existing name (or "New group" placeholder when unnamed) and selects it
+    /// so the user can either keep it or type to replace.
+    pub fn rename_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
+        let existing_name = self
+            .tab_groups
+            .get(&group_id)
+            .and_then(|g| g.name.clone())
+            .unwrap_or_default();
+        let seed_text = if existing_name.is_empty() {
+            "New group".to_string()
+        } else {
+            existing_name
+        };
+
+        self.current_workspace_state
+            .set_tab_group_being_renamed(group_id);
+        self.clear_tab_group_name_editor(ctx);
+        self.tab_group_rename_editor
+            .update(ctx, move |editor, ctx| {
+                editor.insert_selected_text(&seed_text, ctx);
+            });
+        ctx.focus(&self.tab_group_rename_editor);
+        ctx.notify();
+    }
+
+    fn finish_tab_group_rename(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(group_id) = self.current_workspace_state.tab_group_being_renamed() {
+            self.current_workspace_state.clear_tab_group_being_renamed();
+            let title = self.tab_group_rename_editor.as_ref(ctx).buffer_text(ctx);
+            let trimmed = title.trim();
+            if let Some(group) = self.tab_groups.get_mut(&group_id) {
+                group.name = (!trimmed.is_empty()).then(|| trimmed.to_string());
+            }
+            self.clear_tab_group_name_editor(ctx);
+            self.focus_active_tab(ctx);
+            ctx.notify();
+        }
+    }
+
+    fn cancel_tab_group_rename(&mut self, ctx: &mut ViewContext<Self>) {
+        if self
+            .current_workspace_state
+            .is_any_tab_group_being_renamed()
+        {
+            self.current_workspace_state.clear_tab_group_being_renamed();
+            self.clear_tab_group_name_editor(ctx);
+            self.focus_active_tab(ctx);
+            ctx.notify();
+        }
+    }
+
+    /// Creates a new tab group containing `tab_index`, clusters it next to
+    /// other grouped tabs, and enters rename mode on the new group.
+    pub fn new_tab_group_from_tab(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
+        if tab_index >= self.tabs.len() {
+            log::warn!(
+                "Tried to create a tab group from tab {tab_index} but only {} tabs exist",
+                self.tabs.len()
+            );
+            return;
+        }
+        let group_id = TabGroupId::new();
+        self.tab_groups.insert(
+            group_id,
+            TabGroup {
+                id: group_id,
+                name: None,
+                collapsed: false,
+            },
+        );
+        // Detach from any prior group; a tab can only belong to one group.
+        self.tabs[tab_index].group_id = Some(group_id);
+
+        // Land one slot after the last grouped tab so groups stay clustered.
+        let target_index = self
+            .tabs
+            .iter()
+            .enumerate()
+            .filter(|(idx, tab)| *idx != tab_index && tab.group_id.is_some())
+            .map(|(idx, _)| idx)
+            .max()
+            .map(|max_idx| max_idx + 1)
+            .unwrap_or(0);
+
+        let mut active_tab_index = tab_index;
+        if tab_index != target_index {
+            let tab = self.tabs.remove(tab_index);
+            let insert_index = if tab_index < target_index {
+                target_index - 1
+            } else {
+                target_index
+            };
+            self.tabs.insert(insert_index, tab);
+            active_tab_index = insert_index;
+        }
+        self.set_active_tab_index(active_tab_index, ctx);
+
+        ctx.notify();
+
+        // Deferred so the inline editor mounts on the next render.
+        ctx.dispatch_typed_action_deferred(WorkspaceAction::RenameTabGroup(group_id));
+    }
+
+    /// Assigns `tab_index` to `group_id` (or removes it from its group when
+    /// `None`), then reorders to keep group members adjacent. Prunes the
+    /// previous group if it becomes empty.
+    pub fn assign_tab_to_group(
+        &mut self,
+        tab_index: usize,
+        group_id: Option<TabGroupId>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if tab_index >= self.tabs.len() {
+            log::warn!(
+                "Tried to assign tab {tab_index} to a group but only {} tabs exist",
+                self.tabs.len()
+            );
+            return;
+        }
+        if let Some(gid) = group_id {
+            if !self.tab_groups.contains_key(&gid) {
+                log::warn!("Tried to assign tab {tab_index} to unknown group {gid:?}");
+                return;
+            }
+        }
+
+        // Short-circuit no-op assignments.
+        if self.tabs[tab_index].group_id == group_id {
+            return;
+        }
+
+        let previous_group_id = self.tabs[tab_index].group_id;
+        self.tabs[tab_index].group_id = group_id;
+
+        // Destination index: after the group's last member when joining, or
+        // after the last grouped tab when leaving (so the cluster stays
+        // contiguous). `None` keeps the tab in place.
+        let target_index = match group_id {
+            Some(gid) => self
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(idx, tab)| *idx != tab_index && tab.group_id == Some(gid))
+                .map(|(idx, _)| idx)
+                .max()
+                .map(|max_idx| max_idx + 1),
+            None => self
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(idx, tab)| *idx != tab_index && tab.group_id.is_some())
+                .map(|(idx, _)| idx)
+                .max()
+                .map(|max_idx| max_idx + 1),
+        };
+
+        if let Some(target_index) = target_index {
+            if tab_index != target_index {
+                let tab = self.tabs.remove(tab_index);
+                let insert_index = if tab_index < target_index {
+                    target_index - 1
+                } else {
+                    target_index
+                };
+                self.tabs.insert(insert_index, tab);
+                if self.active_tab_index == tab_index {
+                    self.set_active_tab_index(insert_index, ctx);
+                }
+            }
+        }
+
+        if let Some(previous_group_id) = previous_group_id {
+            self.prune_empty_tab_group(previous_group_id);
+        }
+
+        ctx.notify();
+    }
+
+    fn prune_empty_tab_group(&mut self, group_id: TabGroupId) {
+        let has_member = self.tabs.iter().any(|tab| tab.group_id == Some(group_id));
+        if !has_member {
+            self.tab_groups.remove(&group_id);
         }
     }
 
@@ -3215,6 +3469,10 @@ impl Workspace {
             new_session_sidecar_add_repo_mouse_state: Default::default(),
             tab_config_action_sidecar_item: None,
             tab_config_action_sidecar_mouse_states: Default::default(),
+            tab_group_rename_editor: Self::tab_group_rename_editor(ctx),
+            tab_groups_sidecar_menu: Self::build_tab_groups_sidecar_menu(ctx),
+            show_tab_groups_sidecar: false,
+            tab_groups_sidecar_tab_index: None,
             remove_tab_config_confirmation_dialog:
                 Self::build_remove_tab_config_confirmation_dialog(ctx),
             handoff_environment_creation_modal: None,
@@ -6687,6 +6945,11 @@ impl Workspace {
 
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
+
+        // Defer entering rename mode to the next event-loop turn so the new
+        // tab group renders first; the inline rename editor anchors to a
+        // header element that only exists after the next render.
+        ctx.dispatch_typed_action_deferred(WorkspaceAction::RenameTabGroup(group_id));
     }
 
     /// Closes every tab in the given group and removes the group.
@@ -6744,7 +7007,7 @@ impl Workspace {
         }
 
         let tab = &self.tabs[tab_index];
-        let menu_items = tab.menu_items(tab_index, self.tabs.len(), ctx);
+        let menu_items = tab.menu_items(tab_index, self.tabs.len(), &self.tab_groups, ctx);
         ctx.update_view(&self.tab_right_click_menu, |context_menu, view_ctx| {
             context_menu.set_items(menu_items, view_ctx);
         });
@@ -6792,6 +7055,7 @@ impl Workspace {
             tab_index,
             self.tabs.len(),
             Some(pane_name_target),
+            &self.tab_groups,
             ctx,
         );
 
@@ -8772,10 +9036,151 @@ impl Workspace {
         event: &MenuEvent,
         ctx: &mut ViewContext<Self>,
     ) {
-        if let MenuEvent::Close { via_select_item: _ } = event {
-            self.show_tab_right_click_menu = None;
+        match event {
+            MenuEvent::Close { .. } => {
+                self.show_tab_right_click_menu = None;
+                self.clear_tab_groups_sidecar_state(ctx);
+                self.tab_right_click_menu.update(ctx, |menu, _| {
+                    menu.set_safe_zone_target(None);
+                    menu.set_submenu_being_shown_for_item_index(None);
+                });
+                ctx.notify();
+            }
+            // Submenu-parent items emit `ItemSelected` via
+            // `HoverSubmenuWithChildren` instead of `ItemHovered`, so handle
+            // both to keep the sidecar in sync with the cursor.
+            MenuEvent::ItemHovered | MenuEvent::ItemSelected => {
+                self.update_tab_groups_sidecar(ctx);
+            }
+        }
+    }
+
+    fn update_tab_groups_sidecar(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some((tab_index, _)) = self.show_tab_right_click_menu else {
+            return;
+        };
+
+        let hovered = self.tab_right_click_menu.read(ctx, |menu, _| {
+            menu.hovered_index().and_then(|idx| {
+                menu.items().get(idx).and_then(|item| match item {
+                    MenuItem::Item(fields) => Some((idx, fields.label().to_string())),
+                    _ => None,
+                })
+            })
+        });
+        let Some((hovered_index, hovered_label)) = hovered else {
+            return;
+        };
+
+        if hovered_label == MOVE_TO_GROUP_LABEL {
+            self.configure_tab_groups_sidecar(tab_index, hovered_index, ctx);
+        } else if self.show_tab_groups_sidecar {
+            self.clear_tab_groups_sidecar_state(ctx);
+            self.tab_right_click_menu.update(ctx, |menu, _| {
+                menu.set_safe_zone_target(None);
+                menu.set_submenu_being_shown_for_item_index(None);
+            });
             ctx.notify();
         }
+    }
+
+    fn configure_tab_groups_sidecar(
+        &mut self,
+        tab_index: usize,
+        hovered_index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(tab) = self.tabs.get(tab_index) else {
+            return;
+        };
+        let items = tab.group_sidecar_menu_items(tab_index, &self.tab_groups);
+        if items.is_empty() {
+            self.clear_tab_groups_sidecar_state(ctx);
+            self.tab_right_click_menu.update(ctx, |menu, _| {
+                menu.set_safe_zone_target(None);
+                menu.set_submenu_being_shown_for_item_index(None);
+            });
+            return;
+        }
+
+        self.tab_groups_sidecar_menu.update(ctx, |menu, view_ctx| {
+            menu.set_items(items, view_ctx);
+            menu.reset_selection(view_ctx);
+        });
+        self.show_tab_groups_sidecar = true;
+        self.tab_groups_sidecar_tab_index = Some(tab_index);
+
+        let sidecar_rect = ctx
+            .element_position_by_id_at_last_frame(self.window_id, TAB_GROUPS_SIDECAR_POSITION_ID);
+        self.tab_right_click_menu.update(ctx, |menu, _| {
+            menu.set_safe_zone_target(sidecar_rect);
+            menu.set_submenu_being_shown_for_item_index(Some(hovered_index));
+        });
+        ctx.notify();
+    }
+
+    /// Hides the sidecar and resets its selection. Callers handle the parent
+    /// menu's safe-zone state separately.
+    fn clear_tab_groups_sidecar_state(&mut self, ctx: &mut ViewContext<Self>) {
+        self.show_tab_groups_sidecar = false;
+        self.tab_groups_sidecar_tab_index = None;
+        self.tab_groups_sidecar_menu.update(ctx, |menu, view_ctx| {
+            menu.reset_selection(view_ctx);
+        });
+    }
+
+    fn selected_tab_groups_sidecar_action(&self, ctx: &AppContext) -> Option<WorkspaceAction> {
+        self.tab_groups_sidecar_menu.read(ctx, |menu, _| {
+            menu.selected_item().and_then(|item| match item {
+                MenuItem::Item(fields) => fields.on_select_action().cloned(),
+                _ => None,
+            })
+        })
+    }
+
+    fn handle_tab_groups_sidecar_event(&mut self, event: &MenuEvent, ctx: &mut ViewContext<Self>) {
+        match event {
+            MenuEvent::Close { via_select_item } => {
+                let action = via_select_item
+                    .then(|| self.selected_tab_groups_sidecar_action(ctx))
+                    .flatten();
+                if *via_select_item {
+                    // Sidecar item clicked: close the parent menu too.
+                    self.show_tab_right_click_menu = None;
+                    self.tab_right_click_menu.update(ctx, |menu, _| {
+                        menu.set_safe_zone_target(None);
+                        menu.set_submenu_being_shown_for_item_index(None);
+                    });
+                }
+                self.clear_tab_groups_sidecar_state(ctx);
+                if let Some(action) = action {
+                    // Deferred so the workspace view handler is reachable
+                    // after `flush_effects` reinserts the view post-close.
+                    ctx.dispatch_typed_action_deferred(action);
+                }
+                ctx.notify();
+            }
+            MenuEvent::ItemSelected => {}
+            MenuEvent::ItemHovered => {
+                self.sync_tab_groups_sidecar_selection_to_hover(ctx);
+            }
+        }
+    }
+
+    fn sync_tab_groups_sidecar_selection_to_hover(&mut self, ctx: &mut ViewContext<Self>) {
+        self.tab_groups_sidecar_menu.update(ctx, |menu, view_ctx| {
+            let Some(hovered_index) = menu.hovered_index() else {
+                return;
+            };
+            let hovered_item_has_action = menu
+                .items()
+                .get(hovered_index)
+                .and_then(MenuItem::item_on_select_action)
+                .is_some();
+            if hovered_item_has_action && menu.selected_index() != Some(hovered_index) {
+                menu.set_selected_by_index(hovered_index, view_ctx);
+            }
+        });
     }
 
     fn handle_new_session_menu_event(&mut self, event: &MenuEvent, ctx: &mut ViewContext<Self>) {
@@ -21253,6 +21658,13 @@ impl TypedActionView for Workspace {
             }
             CloseTabGroup(group_id) => self.close_tab_group(*group_id, ctx),
             ToggleTabGroupCollapsed(group_id) => self.toggle_tab_group_collapsed(*group_id, ctx),
+            RenameTabGroup(group_id) => self.rename_tab_group(*group_id, ctx),
+            FinishTabGroupRename => self.finish_tab_group_rename(ctx),
+            NewTabGroupFromTab(tab_index) => self.new_tab_group_from_tab(*tab_index, ctx),
+            AssignTabToGroup {
+                tab_index,
+                group_id,
+            } => self.assign_tab_to_group(*tab_index, *group_id, ctx),
             AddDefaultTab => {
                 let effective_mode = AISettings::as_ref(ctx).default_session_mode(ctx);
                 match effective_mode {
@@ -23820,6 +24232,46 @@ impl View for Workspace {
                     stack.add_positioned_overlay_child(
                         ChildView::new(&self.tab_right_click_menu).finish(),
                         positioning,
+                    );
+                }
+
+                // "Move to group" sidecar, anchored to the per-label
+                // `SavePosition` set up in tab.rs.
+                if self.show_tab_groups_sidecar {
+                    let sidecar_element = SavePosition::new(
+                        ChildView::new(&self.tab_groups_sidecar_menu).finish(),
+                        TAB_GROUPS_SIDECAR_POSITION_ID,
+                    )
+                    .finish();
+
+                    let render_left = self.should_render_sidecar_left(
+                        MOVE_TO_GROUP_LABEL,
+                        TAB_GROUPS_SIDECAR_WIDTH,
+                        app,
+                    );
+                    let (offset, parent_anchor, child_anchor) = if render_left {
+                        (
+                            vec2f(-4., 0.),
+                            PositionedElementAnchor::TopLeft,
+                            ChildAnchor::TopRight,
+                        )
+                    } else {
+                        (
+                            vec2f(4., 0.),
+                            PositionedElementAnchor::TopRight,
+                            ChildAnchor::TopLeft,
+                        )
+                    };
+
+                    stack.add_positioned_overlay_child(
+                        sidecar_element,
+                        OffsetPositioning::offset_from_save_position_element(
+                            MOVE_TO_GROUP_LABEL,
+                            offset,
+                            PositionedElementOffsetBounds::WindowByPosition,
+                            parent_anchor,
+                            child_anchor,
+                        ),
                     );
                 }
             }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6639,7 +6639,7 @@ impl Workspace {
     #[cfg(not(feature = "local_fs"))]
     fn save_current_tab_as_new_config(&mut self, _tab_index: usize, _ctx: &mut ViewContext<Self>) {}
 
-    /// Creates a new tab group containing a single new tab. 
+    /// Creates a new tab group containing a single new tab.
     fn create_new_tab_group(&mut self, ctx: &mut ViewContext<Self>) {
         let group_id = TabGroupId::new();
         self.tab_groups.insert(

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -70,6 +70,7 @@ use crate::util::color::Opacity;
 use crate::workspace::action::{NewSessionMenuAnchor, WorkspaceAction};
 use crate::workspace::cross_window_tab_drag::CrossWindowTabDrag;
 use crate::workspace::hoa_onboarding::HoaOnboardingStep;
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::{
     TabSettings, VerticalTabsCompactSubtitle, VerticalTabsDisplayGranularity,
     VerticalTabsPrimaryInfo, VerticalTabsTabItemMode, VerticalTabsViewMode,
@@ -94,9 +95,13 @@ const GROUP_BODY_BOTTOM_PADDING: f32 = 8.;
 const GROUP_ITEM_SPACING: f32 = 4.;
 const TABS_MODE_ITEM_SPACING: f32 = 4.;
 const GROUP_ACTION_BUTTON_ICON_SIZE: f32 = 12.;
+const TAB_GROUP_HEADER_ACTION_ICON_SIZE: f32 = 14.;
 const GROUP_ACTION_BUTTON_PADDING: f32 = 2.;
 const GROUP_ACTION_BUTTON_GAP: f32 = 2.;
 const ROW_CORNER_RADIUS: f32 = 4.;
+const TAB_GROUP_MEMBER_INDENT: f32 = 12.;
+const TAB_GROUP_ICON_SIZE: f32 = 16.;
+const TAB_GROUP_CONTENT_INSET: f32 = 4.;
 const BADGE_ICON_SIZE: f32 = 12.;
 const DETAIL_SIDECAR_DEFAULT_WIDTH: f32 = 320.;
 const DETAIL_SIDECAR_MIN_WIDTH: f32 = 240.;
@@ -267,6 +272,16 @@ struct PaneGroupStateHandles {
     kebab: MouseStateHandle,
     close: MouseStateHandle,
     action_buttons: MouseStateHandle,
+}
+
+/// Hover states for a tab group's container, header, chevron, kebab, and close button.
+#[derive(Clone, Default)]
+struct TabGroupMouseStates {
+    container: MouseStateHandle,
+    header: MouseStateHandle,
+    chevron: MouseStateHandle,
+    kebab: MouseStateHandle,
+    close: MouseStateHandle,
 }
 
 fn pane_row_background(
@@ -556,6 +571,8 @@ pub(super) struct VerticalTabsPanelState {
     scroll_state: ClippedScrollStateHandle,
     resizable_state: ResizableStateHandle,
     group_mouse_states: RefCell<HashMap<EntityId, PaneGroupStateHandles>>,
+    /// Hover states per tab group, keyed by `TabGroupId`.
+    tab_group_mouse_states: RefCell<HashMap<TabGroupId, TabGroupMouseStates>>,
     pane_row_mouse_states: RefCell<HashMap<PaneId, MouseStateHandle>>,
     pane_title_mouse_states: RefCell<HashMap<PaneId, MouseStateHandle>>,
     pane_badge_mouse_states: RefCell<HashMap<PaneId, PaneRowBadgeMouseStates>>,
@@ -592,6 +609,7 @@ impl Default for VerticalTabsPanelState {
             scroll_state: ClippedScrollStateHandle::default(),
             resizable_state: resizable_state_handle(PANEL_WIDTH),
             group_mouse_states: RefCell::default(),
+            tab_group_mouse_states: RefCell::default(),
             pane_row_mouse_states: RefCell::default(),
             pane_title_mouse_states: RefCell::default(),
             pane_badge_mouse_states: RefCell::default(),
@@ -818,6 +836,13 @@ struct TabGroupDragState {
     is_any_pane_dragging: bool,
     insert_before_index: usize,
     insert_after_index: Option<usize>,
+}
+
+/// One visible member of a tab group, captured during the render walk.
+struct TabGroupMember<'a> {
+    tab_index: usize,
+    filtered_pane_ids: Option<&'a [PaneId]>,
+    is_last_visible: bool,
 }
 
 fn resolve_vertical_tabs_mode(app: &AppContext) -> VerticalTabsResolvedMode {
@@ -1724,27 +1749,67 @@ fn render_groups(
         groups = groups.with_spacing(TABS_MODE_ITEM_SPACING);
     }
 
-    for (visible_tab_index, (tab_index, filtered_pane_ids)) in visible_tabs.iter().enumerate() {
-        // Insert ghost slot before this tab group if the drop would land here.
-        if ghost_insertion_index == Some(*tab_index) {
+    // Consecutive tabs sharing a group_id collapse into a single group container.
+    let total_visible = visible_tabs.len();
+    let mut i = 0;
+    while i < total_visible {
+        let (tab_index, ref filtered_pane_ids) = visible_tabs[i];
+        if ghost_insertion_index == Some(tab_index) {
             groups.add_child(render_ghost_vertical_tab_slot(workspace, app));
         }
-        let insert_before_index = *tab_index;
-        let insert_after_index =
-            (visible_tab_index == visible_tabs.len() - 1).then_some(tab_index + 1);
-        groups.add_child(render_tab_group(
-            state,
-            workspace,
-            *tab_index,
-            &workspace.tabs[*tab_index],
-            filtered_pane_ids.as_deref(),
-            TabGroupDragState {
-                is_any_pane_dragging,
-                insert_before_index,
-                insert_after_index,
-            },
-            app,
-        ));
+        let tab = &workspace.tabs[tab_index];
+        match tab.group_id.and_then(|gid| {
+            workspace
+                .tab_groups
+                .get(&gid)
+                .map(|group| (gid, group.clone()))
+        }) {
+            Some((group_id, group)) => {
+                // Collect consecutive member tabs belonging to the same group.
+                let mut members: Vec<TabGroupMember<'_>> = Vec::new();
+                let mut j = i;
+                while j < total_visible {
+                    let (next_tab_index, ref next_filtered_pane_ids) = visible_tabs[j];
+                    if workspace.tabs[next_tab_index].group_id != Some(group_id) {
+                        break;
+                    }
+                    members.push(TabGroupMember {
+                        tab_index: next_tab_index,
+                        filtered_pane_ids: next_filtered_pane_ids.as_deref(),
+                        is_last_visible: j == total_visible - 1,
+                    });
+                    j += 1;
+                }
+                groups.add_child(render_grouped_tab_container(
+                    state,
+                    workspace,
+                    &group,
+                    &members,
+                    is_any_pane_dragging,
+                    app,
+                ));
+                i = j;
+            }
+            None => {
+                let insert_before_index = tab_index;
+                let insert_after_index = (i == total_visible - 1).then_some(tab_index + 1);
+                groups.add_child(render_tab_group(
+                    state,
+                    workspace,
+                    tab_index,
+                    tab,
+                    filtered_pane_ids.as_deref(),
+                    TabGroupDragState {
+                        is_any_pane_dragging,
+                        insert_before_index,
+                        insert_after_index,
+                    },
+                    false, // in_tab_group
+                    app,
+                ));
+                i += 1;
+            }
+        }
     }
     // Ghost after all tab groups (fencepost).
     if ghost_insertion_index == Some(workspace.tabs.len()) {
@@ -1780,6 +1845,7 @@ fn render_groups(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_tab_group(
     state: &VerticalTabsPanelState,
     workspace: &Workspace,
@@ -1787,6 +1853,7 @@ fn render_tab_group(
     tab: &TabData,
     filtered_pane_ids: Option<&[PaneId]>,
     drag_state: TabGroupDragState,
+    in_tab_group: bool,
     app: &AppContext,
 ) -> Box<dyn Element> {
     render_tab_group_internal(
@@ -1797,6 +1864,7 @@ fn render_tab_group(
         filtered_pane_ids,
         drag_state,
         false,
+        in_tab_group,
         app,
     )
 }
@@ -1810,6 +1878,7 @@ fn render_tab_group_internal(
     filtered_pane_ids: Option<&[PaneId]>,
     drag_state: TabGroupDragState,
     for_drag_ghost: bool,
+    in_tab_group: bool,
     app: &AppContext,
 ) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
@@ -1824,7 +1893,9 @@ fn render_tab_group_internal(
             VerticalTabsDisplayGranularity::Tabs
         }
     };
-    let uses_outer_group_container = uses_outer_group_container(display_granularity);
+    // Tabs inside a group skip the per-tab outer container; the group provides it.
+    let uses_outer_group_container =
+        !in_tab_group && uses_outer_group_container(display_granularity);
     let representative_pane_ids = pane_ids_for_display_granularity(
         &visible_pane_ids,
         pane_group.focused_pane_id(app),
@@ -2060,14 +2131,28 @@ fn render_tab_group_internal(
             }
             container.finish()
         } else {
+            // Inside a tab group the surrounding container already paints
+            // hover/active state for the whole group, so suppress the
+            // per-tab background here and let each row show its own
+            // selected/hovered state.
             let background = if is_drag_target {
                 internal_colors::fg_overlay_2(theme)
-            } else if is_active || group_state.is_hovered() {
+            } else if !in_tab_group && (is_active || group_state.is_hovered()) {
                 internal_colors::fg_overlay_1(theme)
             } else {
                 ThemeFill::Solid(ColorU::transparent_black())
             };
+            // Pane view inside a tab group: reserve a top band so the action
+            // buttons (anchored to this wrapper's top-right) sit above the
+            // first pane row instead of overlaying its content, matching how
+            // regular pane view places them in the body's top padding.
+            let needs_action_button_band = in_tab_group
+                && matches!(display_granularity, VerticalTabsDisplayGranularity::Panes);
             let mut container = Container::new(build_rows()).with_background(background);
+            if needs_action_button_band {
+                container = container
+                    .with_padding(Padding::uniform(0.).with_top(GROUP_BODY_BOTTOM_PADDING));
+            }
             if is_drag_target {
                 container = container.with_border(
                     Border::all(1.).with_border_fill(ThemeFill::Solid(theme.accent().into())),
@@ -2120,10 +2205,23 @@ fn render_tab_group_internal(
                 );
             }
         }
+        // Pane view inside a tab group: the group container adds
+        // `GROUP_HORIZONTAL_PADDING` of right padding and the member wrapper
+        // around this `Stack` adds another `TAB_GROUP_CONTENT_INSET`, so the
+        // `Stack`'s right edge sits that much further inside the panel than
+        // it does in regular pane view. Push the buttons back out by the
+        // same amount so they land at the same panel-relative offset.
+        let action_button_x_offset = if in_tab_group
+            && matches!(display_granularity, VerticalTabsDisplayGranularity::Panes)
+        {
+            GROUP_HORIZONTAL_PADDING + TAB_GROUP_CONTENT_INSET - 4.
+        } else {
+            -4.
+        };
         stack.add_positioned_overlay_child(
             action_buttons,
             OffsetPositioning::offset_from_parent(
-                vec2f(-4., GROUP_HEADER_VERTICAL_PADDING),
+                vec2f(action_button_x_offset, GROUP_HEADER_VERTICAL_PADDING),
                 ParentOffsetBounds::WindowByPosition,
                 ParentAnchor::TopRight,
                 ChildAnchor::TopRight,
@@ -2304,9 +2402,295 @@ pub(crate) fn render_tab_group_for_drag_ghost(
         tab,
         None,
         drag_state,
-        true, // for_drag_ghost
+        true,  // for_drag_ghost
+        false, // in_tab_group
         app,
     )
+}
+
+/// Small icon button for the tab-group header; consumes clicks so they don't bubble.
+fn render_tab_group_header_icon_button(
+    icon: WarpIcon,
+    icon_size: f32,
+    icon_color: WarpThemeFill,
+    hover_background: WarpThemeFill,
+    mouse_state: MouseStateHandle,
+    on_click_action: Option<WorkspaceAction>,
+) -> Box<dyn Element> {
+    Hoverable::new(mouse_state, move |button_state| {
+        let mut container = Container::new(
+            ConstrainedBox::new(icon.to_warpui_icon(icon_color).finish())
+                .with_width(icon_size)
+                .with_height(icon_size)
+                .finish(),
+        )
+        .with_padding(Padding::uniform(GROUP_ACTION_BUTTON_PADDING))
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)));
+        if button_state.is_hovered() {
+            container = container.with_background(hover_background);
+        }
+        container.finish()
+    })
+    .with_cursor(Cursor::PointingHand)
+    .on_click(move |ctx, _, _| {
+        if let Some(action) = on_click_action.clone() {
+            ctx.dispatch_typed_action(action);
+        }
+    })
+    .finish()
+}
+
+/// Renders the header row for a tab group: chevron, title + "N tabs", and (on hover)
+/// kebab + close buttons. Single-clicking outside the per-button regions toggles collapse.
+fn render_grouped_tabs_header(
+    group: &TabGroup,
+    member_count: usize,
+    mouse_states: &TabGroupMouseStates,
+    is_collapsed: bool,
+    is_header_selected: bool,
+    show_action_buttons: bool,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+    let font_family = appearance.ui_font_family();
+    let main_text_color = theme.main_text_color(theme.background());
+    let sub_text_color = theme.sub_text_color(theme.background());
+    let group_id = group.id;
+
+    let chevron_icon = if is_collapsed {
+        WarpIcon::ChevronRight
+    } else {
+        WarpIcon::ChevronDown
+    };
+    let chevron_button = render_tab_group_header_icon_button(
+        chevron_icon,
+        TAB_GROUP_ICON_SIZE,
+        main_text_color,
+        internal_colors::fg_overlay_2(theme),
+        mouse_states.chevron.clone(),
+        Some(WorkspaceAction::ToggleTabGroupCollapsed(group_id)),
+    );
+    // Center the chevron in a `VERTICAL_TABS_ICON_SIZE` slot so the title aligns with member rows.
+    let chevron_slot = ConstrainedBox::new(
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::Center)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(chevron_button)
+            .finish(),
+    )
+    .with_width(VERTICAL_TABS_ICON_SIZE)
+    .with_height(VERTICAL_TABS_ICON_SIZE)
+    .finish();
+
+    let title_text = group.name.clone().unwrap_or_else(|| "New Group".to_string());
+    let title_element: Box<dyn Element> = Text::new_inline(title_text, font_family, 12.)
+        .with_clip(ClipConfig::ellipsis())
+        .with_color(main_text_color.into())
+        .finish();
+    let subtitle_text = if member_count == 1 {
+        "1 tab".to_string()
+    } else {
+        format!("{member_count} tabs")
+    };
+    let subtitle = Text::new_inline(subtitle_text, font_family, 10.)
+        .with_clip(ClipConfig::ellipsis())
+        .with_color(sub_text_color.into())
+        .finish();
+    let text_column: Box<dyn Element> = Flex::column()
+        .with_main_axis_size(MainAxisSize::Min)
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_spacing(1.)
+        .with_child(title_element)
+        .with_child(subtitle)
+        .finish();
+
+    let action_buttons = if show_action_buttons {
+        let kebab_button = render_tab_group_header_icon_button(
+            WarpIcon::DotsVertical,
+            TAB_GROUP_HEADER_ACTION_ICON_SIZE,
+            sub_text_color,
+            internal_colors::fg_overlay_2(theme),
+            mouse_states.kebab.clone(),
+            // No-op for now; TODO(johnturcoo) add tab group more-options menu.
+            None,
+        );
+        let close_button = render_tab_group_header_icon_button(
+            WarpIcon::X,
+            TAB_GROUP_HEADER_ACTION_ICON_SIZE,
+            sub_text_color,
+            internal_colors::fg_overlay_3(theme),
+            mouse_states.close.clone(),
+            Some(WorkspaceAction::CloseTabGroup(group_id)),
+        );
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(GROUP_ACTION_BUTTON_GAP)
+            .with_child(kebab_button)
+            .with_child(close_button)
+            .finish()
+    } else {
+        Empty::new().finish()
+    };
+
+    let row = Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(
+            Shrinkable::new(
+                1.,
+                Flex::row()
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(ICON_WITH_STATUS_GAP)
+                    .with_child(chevron_slot)
+                    .with_child(Shrinkable::new(1., text_column).finish())
+                    .finish(),
+            )
+            .finish(),
+        )
+        .with_child(action_buttons)
+        .finish();
+
+    let mut hoverable = Hoverable::new(mouse_states.header.clone(), move |state| {
+        let border_fill = if is_header_selected {
+            internal_colors::fg_overlay_3(theme)
+        } else {
+            WarpThemeFill::Solid(ColorU::transparent_black())
+        };
+        let mut container = Container::new(row)
+            .with_padding(Padding::uniform(GROUP_HORIZONTAL_PADDING))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
+            .with_border(Border::all(1.).with_border_fill(border_fill));
+        if is_header_selected || state.is_hovered() {
+            container = container.with_background(internal_colors::fg_overlay_2(theme));
+        }
+        container.finish()
+    })
+    .with_cursor(Cursor::PointingHand)
+    .with_defer_events_to_children();
+
+    // Single-click toggles collapse; no-op `on_right_click` keeps right-clicks from bubbling
+    // up to the panel's new-session menu handler.
+    hoverable = hoverable.on_click(move |ctx, _, _| {
+        ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupCollapsed(group_id));
+    });
+    hoverable = hoverable.on_right_click(|_, _, _| {});
+    hoverable.finish()
+}
+
+/// Renders a tab group: pane-like header followed by indented member rows. Background only paints
+/// on hover or when a member is active.
+fn render_grouped_tab_container(
+    state: &VerticalTabsPanelState,
+    workspace: &Workspace,
+    group: &TabGroup,
+    members: &[TabGroupMember<'_>],
+    is_any_pane_dragging: bool,
+    app: &AppContext,
+) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    let theme = appearance.theme();
+
+    let mouse_states = state
+        .tab_group_mouse_states
+        .borrow_mut()
+        .entry(group.id)
+        .or_default()
+        .clone();
+
+    let member_count = members.len();
+    let group = group.clone();
+    let any_member_active = members
+        .iter()
+        .any(|m| m.tab_index == workspace.active_tab_index);
+    let is_collapsed = group.collapsed;
+
+    let resolved_mode = resolve_vertical_tabs_mode(app);
+    let needs_outer_horizontal_padding = uses_outer_group_container(match resolved_mode {
+        VerticalTabsResolvedMode::Panes => VerticalTabsDisplayGranularity::Panes,
+        _ => VerticalTabsDisplayGranularity::Tabs,
+    });
+
+    Hoverable::new(mouse_states.container.clone(), |hover_state| {
+        let mut content = Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_spacing(TABS_MODE_ITEM_SPACING);
+
+        // Collapsed group + active member: highlight the header instead of the (now hidden) member row.
+        let is_header_selected = is_collapsed && any_member_active;
+        content.add_child(render_grouped_tabs_header(
+            &group,
+            member_count,
+            &mouse_states,
+            is_collapsed,
+            is_header_selected,
+            hover_state.is_hovered(),
+            app,
+        ));
+
+        // Collapsed groups hide member rows in the panel chrome; the members remain in `workspace.tabs`.
+        if !is_collapsed {
+            for member in members {
+                let tab = &workspace.tabs[member.tab_index];
+                let insert_before_index = member.tab_index;
+                let insert_after_index = member.is_last_visible.then_some(member.tab_index + 1);
+                let drag_state = TabGroupDragState {
+                    is_any_pane_dragging,
+                    insert_before_index,
+                    insert_after_index,
+                };
+                let tab_element = render_tab_group(
+                    state,
+                    workspace,
+                    member.tab_index,
+                    tab,
+                    member.filtered_pane_ids,
+                    drag_state,
+                    true, 
+                    app,
+                );
+                content.add_child(
+                    Container::new(tab_element)
+                        .with_padding(
+                            Padding::uniform(0.)
+                                .with_left(TAB_GROUP_MEMBER_INDENT)
+                                .with_right(TAB_GROUP_CONTENT_INSET),
+                        )
+                        .finish(),
+                );
+            }
+        }
+
+        let background = if hover_state.is_hovered() || any_member_active {
+            internal_colors::fg_overlay_1(theme)
+        } else {
+            ThemeFill::Solid(ColorU::transparent_black())
+        };
+
+        // Pane view: uniform `GROUP_HORIZONTAL_PADDING` matches ungrouped-tab body padding.
+        // Tab view: only apply bottom padding when expanded so a collapsed group has no trailing band.
+        let mut padding = Padding::uniform(0.);
+        if needs_outer_horizontal_padding {
+            padding = Padding::uniform(GROUP_HORIZONTAL_PADDING);
+        } else if !is_collapsed {
+            padding = padding.with_bottom(TAB_GROUP_CONTENT_INSET);
+        }
+
+        Container::new(content.finish())
+            .with_padding(padding)
+            .with_background(background)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
+            .finish()
+    })
+    // Consume right-clicks so they don't bubble to the panel's new-session menu handler.
+    .on_right_click(|_, _, _| {})
+    .with_defer_events_to_children()
+    .finish()
 }
 
 fn render_group_header(props: GroupHeaderProps<'_>, app: &AppContext) -> Box<dyn Element> {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2440,8 +2440,9 @@ fn render_tab_group_header_icon_button(
     .finish()
 }
 
-/// Renders the header row for a tab group: chevron, title + "N tabs", and (on hover)
-/// kebab + close buttons. Single-clicking outside the per-button regions toggles collapse.
+/// Header row for a tab group: chevron, title + "N tabs", and (on hover) kebab + close
+/// buttons. Single-clicking toggles collapse; double-click enters rename mode.
+#[allow(clippy::too_many_arguments)]
 fn render_grouped_tabs_header(
     group: &TabGroup,
     member_count: usize,
@@ -2449,6 +2450,8 @@ fn render_grouped_tabs_header(
     is_collapsed: bool,
     is_header_selected: bool,
     show_action_buttons: bool,
+    is_being_renamed: bool,
+    rename_editor: Option<ViewHandle<EditorView>>,
     app: &AppContext,
 ) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
@@ -2484,14 +2487,19 @@ fn render_grouped_tabs_header(
     .with_height(VERTICAL_TABS_ICON_SIZE)
     .finish();
 
-    let title_text = group
-        .name
-        .clone()
-        .unwrap_or_else(|| "New Group".to_string());
-    let title_element: Box<dyn Element> = Text::new_inline(title_text, font_family, 12.)
-        .with_clip(ClipConfig::ellipsis())
-        .with_color(main_text_color.into())
-        .finish();
+    let title_element: Box<dyn Element> =
+        if let (true, Some(editor)) = (is_being_renamed, rename_editor.as_ref()) {
+            render_inline_tab_rename_editor(editor, appearance, app)
+        } else {
+            let title_text = group
+                .name
+                .clone()
+                .unwrap_or_else(|| "New Group".to_string());
+            Text::new_inline(title_text, font_family, 12.)
+                .with_clip(ClipConfig::ellipsis())
+                .with_color(main_text_color.into())
+                .finish()
+        };
     let subtitle_text = if member_count == 1 {
         "1 tab".to_string()
     } else {
@@ -2573,20 +2581,30 @@ fn render_grouped_tabs_header(
         }
         container.finish()
     })
-    .with_cursor(Cursor::PointingHand)
+    .with_cursor(if is_being_renamed {
+        Cursor::Arrow
+    } else {
+        Cursor::PointingHand
+    })
     .with_defer_events_to_children();
 
-    // Single-click toggles collapse; no-op `on_right_click` keeps right-clicks from bubbling
-    // up to the panel's new-session menu handler.
-    hoverable = hoverable.on_click(move |ctx, _, _| {
-        ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupCollapsed(group_id));
-    });
+    // In rename mode we leave the click alone so it falls through to the inline editor.
+    // The double-click for rename does fire `on_click` for the first click, causing a
+    // brief collapse flash — accepted as a trade-off for snappy single-click toggle.
+    if !is_being_renamed {
+        hoverable = hoverable.on_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupCollapsed(group_id));
+        });
+        hoverable = hoverable.on_double_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(WorkspaceAction::RenameTabGroup(group_id));
+        });
+    }
+    // Swallow right-clicks so they don't bubble to the panel's new-session menu handler.
     hoverable = hoverable.on_right_click(|_, _, _| {});
     hoverable.finish()
 }
 
-/// Renders a tab group: pane-like header followed by indented member rows. Background only paints
-/// on hover or when a member is active.
+/// Renders a tab group: header followed by indented member rows.
 fn render_grouped_tab_container(
     state: &VerticalTabsPanelState,
     workspace: &Workspace,
@@ -2606,6 +2624,7 @@ fn render_grouped_tab_container(
         .clone();
 
     let member_count = members.len();
+    let group_id = group.id;
     let group = group.clone();
     let any_member_active = members
         .iter()
@@ -2618,7 +2637,12 @@ fn render_grouped_tab_container(
         _ => VerticalTabsDisplayGranularity::Tabs,
     });
 
-    Hoverable::new(mouse_states.container.clone(), |hover_state| {
+    let is_being_renamed = workspace
+        .current_workspace_state
+        .is_tab_group_being_renamed(group_id);
+    let rename_editor = is_being_renamed.then(|| workspace.tab_group_rename_editor.clone());
+
+    Hoverable::new(mouse_states.container.clone(), move |hover_state| {
         let mut content = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
@@ -2633,6 +2657,8 @@ fn render_grouped_tab_container(
             is_collapsed,
             is_header_selected,
             hover_state.is_hovered(),
+            is_being_renamed,
+            rename_editor.clone(),
             app,
         ));
 

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -128,6 +128,15 @@ fn vtab_pane_row_position_id(pane_group_id: EntityId, pane_id: PaneId) -> String
     format!("vertical_tabs:pane_row:{pane_group_id:?}:{pane_id}")
 }
 
+/// Save-position id for a tab group's full container rect (header + body).
+/// Read at drop time via `element_position_by_id_at_last_frame` to test
+/// whether `cursor.y` falls inside the group, which is how
+/// `Workspace::on_tab_drag` decides if a dragged tab should join, leave, or
+/// move between groups.
+pub(crate) fn vtab_group_position_id(group_id: TabGroupId) -> String {
+    format!("vertical_tabs:group:{group_id:?}")
+}
+
 fn terminal_title_fallback_font(agent_text: &TerminalAgentText) -> TerminalPrimaryLineFont {
     if agent_text.cli_agent.is_some() {
         TerminalPrimaryLineFont::Ui
@@ -2247,28 +2256,40 @@ fn render_tab_group_internal(
 
     let group_element = group_element.with_defer_events_to_children().finish();
 
-    let draggable = Draggable::new(tab.draggable_state.clone(), group_element)
-        .on_drag_start(|ctx, _, _| {
-            ctx.dispatch_typed_action(WorkspaceAction::StartTabDrag);
-        })
-        .on_drag(move |ctx, _, rect, _| {
-            ctx.dispatch_typed_action(WorkspaceAction::DragTab {
-                tab_index,
-                tab_position: rect,
-            });
-        })
-        .on_drop(|ctx, _, _, _| {
-            ctx.dispatch_typed_action(WorkspaceAction::DropTab);
-        });
-    // Only lock the drag to the vertical axis when cross-window tab drag is
-    // disabled. When it is enabled, the user needs to be able to drag
-    // horizontally out of the panel to detach the tab into a new window.
-    let draggable = if FeatureFlag::DragTabsToWindows.is_enabled() {
-        draggable
+    // Skip the per-tab `Draggable` while the tab's enclosing tab group is
+    // being dragged as a block, so the user can't simultaneously tear a
+    // member tab out of a group that is itself in flight.
+    let is_parent_group_dragging = tab
+        .group_id
+        .and_then(|gid| workspace.tab_groups.get(&gid))
+        .is_some_and(|group| group.draggable_state.is_dragging());
+
+    let draggable: Box<dyn Element> = if is_parent_group_dragging {
+        group_element
     } else {
-        draggable.with_drag_axis(DragAxis::VerticalOnly)
+        let draggable = Draggable::new(tab.draggable_state.clone(), group_element)
+            .on_drag_start(|ctx, _, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::StartTabDrag);
+            })
+            .on_drag(move |ctx, _, rect, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::DragTab {
+                    tab_index,
+                    tab_position: rect,
+                });
+            })
+            .on_drop(|ctx, _, _, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::DropTab);
+            });
+        // Only lock the drag to the vertical axis when cross-window tab drag
+        // is disabled. When it is enabled, the user needs to be able to drag
+        // horizontally out of the panel to detach the tab into a new window.
+        let draggable = if FeatureFlag::DragTabsToWindows.is_enabled() {
+            draggable
+        } else {
+            draggable.with_drag_axis(DragAxis::VerticalOnly)
+        };
+        draggable.finish()
     };
-    let draggable = draggable.finish();
 
     let draggable: Box<dyn Element> = if is_this_tab_dragging {
         Container::new(draggable)
@@ -2601,6 +2622,10 @@ fn render_grouped_tabs_header(
     }
     // Swallow right-clicks so they don't bubble to the panel's new-session menu handler.
     hoverable = hoverable.on_right_click(|_, _, _| {});
+    // The group-level `Draggable` is installed by
+    // `render_grouped_tab_container` so the floating drag ghost includes
+    // the whole group (header + member tabs). The header itself only
+    // needs hover / click / right-click behavior here.
     hoverable.finish()
 }
 
@@ -2625,11 +2650,19 @@ fn render_grouped_tab_container(
 
     let member_count = members.len();
     let group_id = group.id;
+    let group_draggable_state = group.draggable_state.clone();
     let group = group.clone();
     let any_member_active = members
         .iter()
         .any(|m| m.tab_index == workspace.active_tab_index);
-    let is_collapsed = group.collapsed;
+    // Render the group as expanded while a tab drag is hovering over its
+    // container so the user can drop into a specific member slot. The
+    // persisted `group.collapsed` state is restored on `DropTab`.
+    let is_collapsed = group.collapsed && workspace.drag_force_expanded_group != Some(group_id);
+    let is_being_renamed = workspace
+        .current_workspace_state
+        .is_tab_group_being_renamed(group_id);
+    let rename_editor = is_being_renamed.then(|| workspace.tab_group_rename_editor.clone());
 
     let resolved_mode = resolve_vertical_tabs_mode(app);
     let needs_outer_horizontal_padding = uses_outer_group_container(match resolved_mode {
@@ -2637,12 +2670,7 @@ fn render_grouped_tab_container(
         _ => VerticalTabsDisplayGranularity::Tabs,
     });
 
-    let is_being_renamed = workspace
-        .current_workspace_state
-        .is_tab_group_being_renamed(group_id);
-    let rename_editor = is_being_renamed.then(|| workspace.tab_group_rename_editor.clone());
-
-    Hoverable::new(mouse_states.container.clone(), move |hover_state| {
+    let container = Hoverable::new(mouse_states.container.clone(), move |hover_state| {
         let mut content = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
@@ -2719,7 +2747,54 @@ fn render_grouped_tab_container(
     // Consume right-clicks so they don't bubble to the panel's new-session menu handler.
     .on_right_click(|_, _, _| {})
     .with_defer_events_to_children()
-    .finish()
+    .finish();
+    // Wrap the whole group block in a `Draggable` so the user can grab
+    // the group from its header and move it as a unit. Per-tab
+    // `Draggable`s remain nested inside each member row; inside-out hit
+    // testing means clicks on a member tab activate the per-tab drag,
+    // while clicks on the header (which is not inside any inner
+    // `Draggable`) activate the group drag. The drag ghost is the entire
+    // container child here, so the user sees the whole group floating
+    // during the drag rather than just the header.
+    //
+    // Skip the wrap while a member tab is being dragged (the per-tab
+    // drag is already in flight and we don't want to also start a
+    // group drag), or while the group header is being renamed (we don't
+    // want drag-threshold tracking competing with the inline editor).
+    let skip_group_draggable = is_being_renamed || is_any_pane_dragging;
+    let positioned_container: Box<dyn Element> = if skip_group_draggable {
+        container
+    } else {
+        Draggable::new(group_draggable_state, container)
+            .on_drag_start(move |ctx, _, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::StartGroupDrag(group_id));
+            })
+            .on_drag(move |ctx, _, rect, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::DragGroup {
+                    group_id,
+                    position: rect,
+                });
+            })
+            .on_drop(move |ctx, _, _, _| {
+                ctx.dispatch_typed_action(WorkspaceAction::DropGroup(group_id));
+            })
+            .with_drag_axis(DragAxis::VerticalOnly)
+            // Defer to the per-tab `Draggable`s nested inside this group:
+            // clicks on a member tab should start a tab drag, not the
+            // outer group drag. Without this opt-in, mouse-down on a
+            // member tab puts both the inner and outer `Draggable` into
+            // `WaitingToDrag` and they then start dragging in lockstep
+            // when the user crosses the drag threshold.
+            .with_defer_to_handled_child_mouse_down()
+            .finish()
+    };
+
+    // Wrap the whole group container in a `SavePosition` so
+    // `Workspace::target_group_at_y` can read its bounding rect via
+    // `element_position_by_id_at_last_frame` and decide, on tab drop,
+    // whether the dragged tab should join, leave, or move between groups
+    // based on where the cursor is.
+    SavePosition::new(positioned_container, &vtab_group_position_id(group_id)).finish()
 }
 
 fn render_group_header(props: GroupHeaderProps<'_>, app: &AppContext) -> Box<dyn Element> {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2484,7 +2484,10 @@ fn render_grouped_tabs_header(
     .with_height(VERTICAL_TABS_ICON_SIZE)
     .finish();
 
-    let title_text = group.name.clone().unwrap_or_else(|| "New Group".to_string());
+    let title_text = group
+        .name
+        .clone()
+        .unwrap_or_else(|| "New Group".to_string());
     let title_element: Box<dyn Element> = Text::new_inline(title_text, font_family, 12.)
         .with_clip(ClipConfig::ellipsis())
         .with_color(main_text_color.into())
@@ -2651,7 +2654,7 @@ fn render_grouped_tab_container(
                     tab,
                     member.filtered_pane_ids,
                     drag_state,
-                    true, 
+                    true,
                     app,
                 );
                 content.add_child(

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3202,3 +3202,275 @@ fn test_tab_mru_order() {
         });
     });
 }
+
+#[test]
+fn test_create_new_tab_group_groups_active_tab() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Workspace starts with one tab from `Empty` source. Create a tab
+            // group and verify the active tab is assigned to it.
+            assert_eq!(workspace.tab_count(), 1);
+            assert!(workspace.tabs[0].group_id.is_none());
+            assert!(workspace.tab_groups.is_empty());
+
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+
+            assert_eq!(workspace.tab_groups.len(), 1);
+            let group_id = workspace.tabs[0]
+                .group_id
+                .expect("active tab should be assigned to the new group");
+            assert!(workspace.tab_groups.contains_key(&group_id));
+            // New groups start expanded so members are visible.
+            assert!(!workspace.tab_groups[&group_id].collapsed);
+        });
+    });
+}
+
+#[test]
+fn test_toggle_tab_group_collapsed_flips_state() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[0]
+                .group_id
+                .expect("active tab should be in a group");
+            assert!(!workspace.tab_groups[&group_id].collapsed);
+
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(workspace.tab_groups[&group_id].collapsed);
+
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(!workspace.tab_groups[&group_id].collapsed);
+        });
+    });
+}
+
+#[test]
+fn test_close_tab_group_removes_group_and_members() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group, then add another tab which inherits the
+            // active tab's group_id via `add_tab_with_pane_layout`.
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+
+            workspace.add_terminal_tab(false, ctx);
+
+            let group_members: Vec<usize> = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, tab)| tab.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .collect();
+            assert_eq!(
+                group_members.len(),
+                2,
+                "new tab should inherit the active tab's group_id"
+            );
+
+            workspace.handle_action(&WorkspaceAction::CloseTabGroup(group_id), ctx);
+
+            // All group members are closed and the group entry is removed.
+            assert!(!workspace.tab_groups.contains_key(&group_id));
+            assert!(
+                workspace
+                    .tabs
+                    .iter()
+                    .all(|tab| tab.group_id != Some(group_id))
+            );
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_with_after_all_tabs_setting_lands_at_group_end() {
+    // With `new_tab_placement = AfterAllTabs` and the active tab in a
+    // group, a new tab should land at the end of the group's contiguous
+    // run instead of at the workspace's global end so group contiguity
+    // is preserved while honoring the user's "end" placement preference.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(
+                    settings
+                        .new_tab_placement
+                        .set_value(NewTabPlacement::AfterAllTabs, ctx)
+                );
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group and add a second tab so the group has two
+            // contiguous members.
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+            workspace.add_terminal_tab(false, ctx);
+
+            // Add an ungrouped tab past the end of the group by first
+            // activating the trailing ungrouped tab.
+            let ungrouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id.is_none())
+                .expect("expected at least one ungrouped tab");
+            workspace.activate_tab(ungrouped_idx, ctx);
+            workspace.add_terminal_tab(false, ctx);
+
+            // Now activate the first grouped tab and add a new tab. With
+            // `AfterAllTabs`, the new tab must land at the end of the
+            // group's contiguous run rather than past the trailing
+            // ungrouped tabs.
+            let first_grouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id == Some(group_id))
+                .expect("expected at least one grouped tab");
+            workspace.activate_tab(first_grouped_idx, ctx);
+
+            let group_run_end_before = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .max()
+                .expect("group should be non-empty")
+                + 1;
+
+            workspace.add_terminal_tab(false, ctx);
+
+            // The new tab lands at the prior group-run end, inherits the
+            // group_id, and keeps the group's run contiguous.
+            assert_eq!(workspace.active_tab_index(), group_run_end_before);
+            assert_eq!(
+                workspace.tabs[group_run_end_before].group_id,
+                Some(group_id)
+            );
+
+            let group_indices: Vec<usize> = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .collect();
+            assert!(
+                group_indices.windows(2).all(|w| w[1] == w[0] + 1),
+                "group's tab indices should be contiguous, got {group_indices:?}"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_with_after_current_tab_setting_lands_after_active_tab_in_group() {
+    // With `new_tab_placement = AfterCurrentTab` and the active tab in the
+    // middle of a group, a new tab should land immediately after the active
+    // tab and inherit the group_id, preserving group contiguity rather than
+    // jumping to the end of the group or past it.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(
+                    settings
+                        .new_tab_placement
+                        .set_value(NewTabPlacement::AfterCurrentTab, ctx)
+                );
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group and grow it to two contiguous members so we can
+            // activate the first one (i.e. a member that isn't at the end of
+            // the group's run).
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+            workspace.add_terminal_tab(false, ctx);
+
+            // Activate the first grouped tab so the next insertion happens in
+            // the middle of the group's contiguous run.
+            let first_grouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id == Some(group_id))
+                .expect("expected at least one grouped tab");
+            workspace.activate_tab(first_grouped_idx, ctx);
+
+            let expected_new_idx = first_grouped_idx + 1;
+
+            workspace.add_terminal_tab(false, ctx);
+
+            // The new tab lands immediately after the previously-active
+            // grouped tab, inherits its group_id, and keeps the group's run
+            // contiguous.
+            assert_eq!(workspace.active_tab_index(), expected_new_idx);
+            assert_eq!(
+                workspace.tabs[expected_new_idx].group_id,
+                Some(group_id),
+                "new tab should inherit the active tab's group_id"
+            );
+
+            let group_indices: Vec<usize> = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.group_id == Some(group_id))
+                .map(|(idx, _)| idx)
+                .collect();
+            assert_eq!(
+                group_indices.len(),
+                3,
+                "group should have grown to three members"
+            );
+            assert!(
+                group_indices.windows(2).all(|w| w[1] == w[0] + 1),
+                "group's tab indices should be contiguous, got {group_indices:?}"
+            );
+        });
+    });
+}

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3299,12 +3299,10 @@ fn test_close_tab_group_removes_group_and_members() {
 
             // All group members are closed and the group entry is removed.
             assert!(!workspace.tab_groups.contains_key(&group_id));
-            assert!(
-                workspace
-                    .tabs
-                    .iter()
-                    .all(|tab| tab.group_id != Some(group_id))
-            );
+            assert!(workspace
+                .tabs
+                .iter()
+                .all(|tab| tab.group_id != Some(group_id)));
         });
     });
 }
@@ -3321,11 +3319,9 @@ fn test_new_tab_with_after_all_tabs_setting_lands_at_group_end() {
         initialize_app(&mut app);
         app.update(|ctx| {
             TabSettings::handle(ctx).update(ctx, |settings, ctx| {
-                report_if_error!(
-                    settings
-                        .new_tab_placement
-                        .set_value(NewTabPlacement::AfterAllTabs, ctx)
-                );
+                report_if_error!(settings
+                    .new_tab_placement
+                    .set_value(NewTabPlacement::AfterAllTabs, ctx));
             });
         });
 
@@ -3410,11 +3406,9 @@ fn test_new_tab_with_after_current_tab_setting_lands_after_active_tab_in_group()
         initialize_app(&mut app);
         app.update(|ctx| {
             TabSettings::handle(ctx).update(ctx, |settings, ctx| {
-                report_if_error!(
-                    settings
-                        .new_tab_placement
-                        .set_value(NewTabPlacement::AfterCurrentTab, ctx)
-                );
+                report_if_error!(settings
+                    .new_tab_placement
+                    .set_value(NewTabPlacement::AfterCurrentTab, ctx));
             });
         });
 

--- a/crates/warpui_core/src/elements/drag/draggable.rs
+++ b/crates/warpui_core/src/elements/drag/draggable.rs
@@ -251,6 +251,11 @@ pub struct Draggable {
     bounds_cache: Option<RectF>,
     /// If true, keeps the original element visible in its original position during drag.
     keep_original_visible: bool,
+    /// When true, this `Draggable` skips initiating its own drag on a
+    /// `LeftMouseDown` event that was already handled by a child element
+    /// (typically a nested `Draggable` that initiated its own drag). Lets
+    /// nested `Draggable`s take priority over their parents.
+    defer_to_handled_child_mouse_down: bool,
 
     start_handler: Option<Handler>,
     drag_handler: Option<DragDropHandler>,
@@ -273,6 +278,7 @@ impl Draggable {
             drag_bounds: DragBounds::None,
             bounds_cache: None,
             keep_original_visible: false,
+            defer_to_handled_child_mouse_down: false,
             start_handler: None,
             drag_handler: None,
             is_accepted_by_drop_target_handler: None,
@@ -303,6 +309,17 @@ impl Draggable {
     /// showing both the original and the dragged copy.
     pub fn with_keep_original_visible(mut self, keep_visible: bool) -> Self {
         self.keep_original_visible = keep_visible;
+        self
+    }
+
+    /// When set, this `Draggable` will not initiate its own drag on a
+    /// `LeftMouseDown` event that was already handled by a child element.
+    /// Use this on the *outer* `Draggable` when there are nested inner
+    /// `Draggable`s (e.g. a tab group whose member tabs are also each
+    /// individually draggable) so the inner drag takes priority — without
+    /// this, mouse-down would simultaneously start both drags.
+    pub fn with_defer_to_handled_child_mouse_down(mut self) -> Self {
+        self.defer_to_handled_child_mouse_down = true;
         self
     }
 
@@ -591,6 +608,18 @@ impl Element for Draggable {
 
         match event.raw_event() {
             Event::LeftMouseDown { position, .. } => {
+                // When opted in, defer to a nested `Draggable` that
+                // initiated its own drag for the same gesture so the
+                // inner drag takes priority. Reads a context flag set
+                // by the inner `Draggable` itself (see the
+                // `WaitingToDrag` transition below) so a plain
+                // `Hoverable` returning `true` for click tracking does
+                // NOT cause us to skip.
+                if self.defer_to_handled_child_mouse_down
+                    && ctx.descendant_draggable_initiated()
+                {
+                    return true;
+                }
                 let origin = self.origin().expect("origin should exist");
                 if let Some(rect) = ctx.visible_rect(origin, size) {
                     let max_z_index = self.child_max_z_index.expect("child z index should exist");
@@ -605,6 +634,10 @@ impl Element for Draggable {
                             mouse_down_position: *position,
                             mouse_down_offset,
                         });
+                        // Signal to any ancestor `Draggable` that we
+                        // have claimed this gesture so it can defer
+                        // when configured to do so.
+                        ctx.mark_descendant_draggable_initiated();
 
                         ctx.set_cursor(Cursor::PointingHand, max_z_index);
                         return true;

--- a/crates/warpui_core/src/presenter.rs
+++ b/crates/warpui_core/src/presenter.rs
@@ -236,6 +236,12 @@ pub struct EventContext<'a> {
     /// Flag indicating the soft keyboard should be shown.
     /// Used on mobile WASM to trigger the keyboard in user gesture context.
     soft_keyboard_requested: bool,
+    /// Set when any `Draggable` transitions into `WaitingToDrag` during the
+    /// current event dispatch. Read by ancestor `Draggable`s with
+    /// `defer_to_handled_child_mouse_down` so they can defer to a nested
+    /// inner drag instead of also initiating their own. Lives for the
+    /// duration of one dispatched event.
+    descendant_draggable_initiated: bool,
 }
 
 impl<'a> EventContext<'a> {
@@ -504,6 +510,7 @@ impl Presenter {
             notify_timers_to_clear: Default::default(),
             cursor_update: Default::default(),
             soft_keyboard_requested: false,
+            descendant_draggable_initiated: false,
         }
     }
 
@@ -753,6 +760,22 @@ impl EventContext<'_> {
     /// This is used on mobile WASM to trigger the keyboard when a text input area is tapped.
     pub fn request_soft_keyboard(&mut self) {
         self.soft_keyboard_requested = true;
+    }
+
+    /// Returns whether a descendant `Draggable` has initiated a drag
+    /// (transitioned to `WaitingToDrag`) during the current event
+    /// dispatch. Used by ancestor `Draggable`s with
+    /// `defer_to_handled_child_mouse_down` to skip initiating their own
+    /// drag when an inner drag has already started.
+    pub fn descendant_draggable_initiated(&self) -> bool {
+        self.descendant_draggable_initiated
+    }
+
+    /// Marks that a `Draggable` has initiated a drag during the current
+    /// event dispatch. Called by `Draggable` itself on the
+    /// `WaitingToDrag` transition.
+    pub fn mark_descendant_draggable_initiated(&mut self) {
+        self.descendant_draggable_initiated = true;
     }
 }
 


### PR DESCRIPTION
## Description

Combined preview branch stacking two features on top of the basic vertical tab grouping work in APP-4609. These features are: 

Group editing:
- Rename a group via inline editor (double-click header, Enter to commit, Esc to cancel)
- "New group with tab" tab-context menu entry — wraps an existing tab in a new group and auto-enters rename mode
- "Move to group" submenu sidecar — assigns a tab to another group or removes it from its current group

Dragging: 
- Drag a tab into/out of a group, or between groups, in the vertical tabs panel
- Drag an entire group as a single block to reorder it relative to other groups / ungrouped tabs
- Within-group reorder of member tabs 
-  Drag past a collapsed group as one unit instead of splitting it


## Changes
- `on_tab_drag` extended with: group-boundary detection (`target_group_at_y` → `assign_tab_to_group`), within-group clamp via `group_member_index_range`, and `hop_tab_to_index` for collapsed-group 
- `on_group_drag` + `move_group_block`: midpoint-crossing swap at the block level
- Nested Draggables: per-tab Draggable for tab drag, outer Draggable on the group container for group drag. New framework method `Draggable::with_defer_to_handled_child_mouse_down()` routes mouse-down to the inner Draggable when the click lands on a member row.



### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Demo video: https://www.loom.com/share/f41866e77f2b4ef29888b00fa1ee9081