### PR TITLE
Improve WASM UDI button tap targets

### DIFF
--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -86,6 +86,13 @@ const MODEL_PICKER_TOOLTIP: &str = "Choose an agent model";
 const MODEL_LOCKED_FOR_FOLLOWUP_TOOLTIP: &str = "Follow-ups use the original run's model";
 const MODEL_REQUIRES_EDIT_ACCESS_TOOLTIP: &str = "Request edit access to change model";
 const HARNESS_DEFAULT_MODEL_LABEL: &str = "default";
+fn udi_button_size() -> ButtonSize {
+    if cfg!(target_family = "wasm") {
+        ButtonSize::UDITouchButton
+    } else {
+        ButtonSize::UDIButton
+    }
+}
 
 pub fn calculate_scaled_font_size(appearance: &warp_core::ui::appearance::Appearance) -> f32 {
     if FeatureFlag::AgentView.is_enabled() {
@@ -268,7 +275,7 @@ impl ProfileModelSelector {
                 is_blurred: false,
             })
             .with_tooltip(PROFILE_PICKER_TOOLTIP)
-            .with_size(ButtonSize::UDIButton)
+            .with_size(udi_button_size())
             .with_icon(Icon::Psychology)
         });
 
@@ -296,14 +303,14 @@ impl ProfileModelSelector {
                 is_blurred: false,
             })
             .with_tooltip(MODEL_PICKER_TOOLTIP)
-            .with_size(ButtonSize::UDIButton)
+            .with_size(udi_button_size())
         });
 
         let profile_compact_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("", PromptIconButtonTheme::new(false))
                 .with_icon(Icon::Psychology)
                 .with_tooltip(PROFILE_PICKER_TOOLTIP)
-                .with_size(ButtonSize::UDIButton)
+                .with_size(udi_button_size())
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(ProfileModelSelectorAction::ToggleProfileMenu);
                 })
@@ -313,7 +320,7 @@ impl ProfileModelSelector {
             ActionButton::new("", PromptIconButtonTheme::new(false))
                 .with_icon(Icon::Neurology)
                 .with_tooltip(MODEL_PICKER_TOOLTIP)
-                .with_size(ButtonSize::UDIButton)
+                .with_size(udi_button_size())
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(ProfileModelSelectorAction::ToggleModelMenu);
                 })

--- a/app/src/terminal/universal_developer_input.rs
+++ b/app/src/terminal/universal_developer_input.rs
@@ -189,6 +189,13 @@ impl AtContextMenuDisabledReason {
 const AT_CONTEXT_TOOLTIP: &str = "Attach context";
 
 const BLURRED_OPACITY: Opacity = 50;
+fn udi_button_size() -> ButtonSize {
+    if cfg!(target_family = "wasm") {
+        ButtonSize::UDITouchButton
+    } else {
+        ButtonSize::UDIButton
+    }
+}
 
 // Threshold calculation that estimates the width needed for the profile/model selector
 // This is used for determining whether the selector should be rendered as full or compact
@@ -337,7 +344,7 @@ impl UniversalDeveloperInputButtonBar {
         terminal_model: std::sync::Arc<parking_lot::FairMutex<crate::terminal::TerminalModel>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let button_size = ButtonSize::UDIButton;
+        let button_size = udi_button_size();
 
         let mic_button_view = ctx.add_typed_action_view(|_ctx| {
             #[cfg_attr(not(feature = "voice_input"), allow(unused_mut))]
@@ -922,7 +929,11 @@ impl TypedActionView for UniversalDeveloperInputButtonBar {
 fn segmented_control_styles(app: &AppContext) -> UiComponentStyles {
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
-    let button_size = 5.0 + appearance.monospace_font_size();
+    let button_size = if cfg!(target_family = "wasm") {
+        udi_button_size().button_height(appearance, app)
+    } else {
+        5.0 + appearance.monospace_font_size()
+    };
     // Use a smaller base font size that scales properly
     let base_font_size = 10.0; // Start with smaller font
     let scaled_ui_font_size = base_font_size * appearance.monospace_ui_scalar();

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -177,6 +177,8 @@ pub enum ButtonSize {
     InputPrompt,
     /// Sizing for buttons at the bottom of the UDI.
     UDIButton,
+    /// Touch target sizing for UDI buttons in WASM/mobile surfaces.
+    UDITouchButton,
     /// Sizing for prompt chips in the UDI.
     UDIPromptChip,
     /// Sizing for buttons in the AgentView input, e.g. when `FeatureFlag::AgentView` is enabled.
@@ -1319,6 +1321,7 @@ impl ButtonSize {
             ButtonSize::InlineActionHeader => appearance.monospace_font_size(),
             ButtonSize::InputPrompt => appearance.monospace_font_size(),
             ButtonSize::UDIButton => appearance.monospace_font_size() - 1.0,
+            ButtonSize::UDITouchButton => 18.0,
             ButtonSize::UDIPromptChip => appearance.monospace_font_size() - 1.0,
             ButtonSize::AgentInputButton => app.font_cache().line_height(
                 appearance.monospace_font_size(),
@@ -1335,6 +1338,7 @@ impl ButtonSize {
             ButtonSize::InlineActionHeader => appearance.monospace_font_size() - 2.,
             ButtonSize::InputPrompt => appearance.monospace_font_size(),
             ButtonSize::UDIButton => appearance.monospace_font_size() - 1.0,
+            ButtonSize::UDITouchButton => appearance.monospace_font_size() - 1.0,
             ButtonSize::UDIPromptChip => appearance.monospace_font_size() - 1.0,
             ButtonSize::AgentInputButton => appearance.monospace_font_size() - 1.0,
         }
@@ -1348,6 +1352,7 @@ impl ButtonSize {
             ButtonSize::InlineActionHeader => Properties::default().weight(Weight::Semibold),
             ButtonSize::InputPrompt => Properties::default(),
             ButtonSize::UDIButton => Properties::default(),
+            ButtonSize::UDITouchButton => Properties::default(),
             ButtonSize::UDIPromptChip => Properties::default().weight(Weight::Semibold),
             ButtonSize::AgentInputButton => Properties::default(),
         }
@@ -1362,6 +1367,7 @@ impl ButtonSize {
             ButtonSize::InlineActionHeader => 6.,
             ButtonSize::InputPrompt => 5.,
             ButtonSize::UDIButton => 5.,
+            ButtonSize::UDITouchButton => 5.,
             ButtonSize::UDIPromptChip => 4.,
             ButtonSize::AgentInputButton => 4.,
         }
@@ -1426,6 +1432,13 @@ impl ButtonSize {
                 padding: Some(Coords::default()),
                 ..Default::default()
             },
+            ButtonSize::UDITouchButton => UiComponentStyles {
+                font_size: Some(appearance.monospace_font_size() - 4.),
+                width: Some(44.0),
+                height: Some(44.0),
+                padding: Some(Coords::default()),
+                ..Default::default()
+            },
             ButtonSize::UDIPromptChip => UiComponentStyles {
                 font_size: Some(appearance.monospace_font_size() - 4.),
                 width: Some(appearance.monospace_font_size()),
@@ -1457,6 +1470,7 @@ impl ButtonSize {
             // Should be 20px high at a 14px font size, and scale accordingly.
             ButtonSize::InputPrompt => 6. + appearance.monospace_font_size(),
             ButtonSize::UDIButton => 6. + appearance.monospace_font_size(),
+            ButtonSize::UDITouchButton => 44.0,
             ButtonSize::UDIPromptChip => {
                 // Add 1 to the vertical padding to account for the border.
                 let vertical_padding =
@@ -1484,6 +1498,7 @@ impl ButtonSize {
             ButtonSize::InlineActionHeader => None,
             ButtonSize::InputPrompt => Some(-2.),
             ButtonSize::UDIButton => None,
+            ButtonSize::UDITouchButton => None,
             ButtonSize::UDIPromptChip => None,
             ButtonSize::AgentInputButton => None,
         }
@@ -1498,6 +1513,7 @@ impl ButtonSize {
             ButtonSize::InlineActionHeader => 8.,
             ButtonSize::InputPrompt => 4.,
             ButtonSize::UDIButton => 4.,
+            ButtonSize::UDITouchButton => 8.,
             ButtonSize::UDIPromptChip | ButtonSize::AgentInputButton => {
                 crate::context_chips::spacing::UDI_CHIP_HORIZONTAL_PADDING
             }
@@ -1514,6 +1530,7 @@ impl ButtonSize {
             // Account for the negative margin on prompt buttons.
             ButtonSize::InputPrompt => -8.,
             ButtonSize::UDIButton => -8.,
+            ButtonSize::UDITouchButton => -10.,
             ButtonSize::UDIPromptChip | ButtonSize::AgentInputButton => -8.,
         }
     }
@@ -1527,6 +1544,7 @@ impl ButtonSize {
             ButtonSize::InlineActionHeader => Padding::uniform(2.),
             ButtonSize::InputPrompt => Padding::default().with_vertical(1.).with_horizontal(2.),
             ButtonSize::UDIButton => Padding::default().with_vertical(1.).with_horizontal(2.),
+            ButtonSize::UDITouchButton => Padding::default().with_vertical(1.).with_horizontal(2.),
             ButtonSize::UDIPromptChip | ButtonSize::AgentInputButton => {
                 Padding::default().with_vertical(1.).with_horizontal(2.)
             }


### PR DESCRIPTION
## Summary
- Add a touch-sized UDI button size for WASM/mobile surfaces with a 44px tap target.
- Use the larger WASM button size for the input-area mic, slash command, context, file, and profile/model selector controls.
- Match the input mode segmented control dimensions to the touch target on WASM while preserving existing native sizing.

## Validation
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib --features voice_input`
- `./script/wasm/bundle --debug --check-only --features release_bundle,gui`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/f0d32571-daeb-4486-95d9-11a1f01b4bf8_
_Run: https://oz.staging.warp.dev/runs/019e6a66-9aed-75a3-a2d5-1b9e0084fa0f_
_This PR was generated with [Oz](https://warp.dev/oz)._
