### PR TITLE
[Completions] Bump command-signatures to b3061096

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14572,7 +14572,7 @@ dependencies = [
 [[package]]
 name = "warp-command-signatures"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/command-signatures.git?rev=00a032b8ea0ee5711e2077e39a92dc9ca2051cd3#00a032b8ea0ee5711e2077e39a92dc9ca2051cd3"
+source = "git+https://github.com/warpdotdev/command-signatures.git?rev=b3061096d193bf4915eabb0d03b4e6b403c6ea45#b3061096d193bf4915eabb0d03b4e6b403c6ea45"
 dependencies = [
  "cfg-if",
  "itertools 0.10.5",
@@ -14590,7 +14590,7 @@ dependencies = [
 [[package]]
 name = "warp-completion-metadata"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/command-signatures.git?rev=00a032b8ea0ee5711e2077e39a92dc9ca2051cd3#00a032b8ea0ee5711e2077e39a92dc9ca2051cd3"
+source = "git+https://github.com/warpdotdev/command-signatures.git?rev=b3061096d193bf4915eabb0d03b4e6b403c6ea45#b3061096d193bf4915eabb0d03b4e6b403c6ea45"
 dependencies = [
  "html-escape",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,7 +351,7 @@ dirs = "6.0.0"
 rayon = "1.10.0"
 sha2 = "0.10"
 shellexpand = "3.1.1"
-warp-command-signatures = { git = "https://github.com/warpdotdev/command-signatures.git", rev = "00a032b8ea0ee5711e2077e39a92dc9ca2051cd3", default-features = false }
+warp-command-signatures = { git = "https://github.com/warpdotdev/command-signatures.git", rev = "b3061096d193bf4915eabb0d03b4e6b403c6ea45", default-features = false }
 winit = { git = "https://github.com/warpdotdev/winit.git", rev = "a4e0ecb5f9626ccac9445a73dc28354b52423abc" }
 x11rb = "0.13.0"
 mockito = "1.7.0"


### PR DESCRIPTION
## Description

Updates `warp-command-signatures` to b3061096.

### Merged PRs
- Move operation skills over (warpdotdev/command-signatures#269)
- Add missing gh pr merge flag completions (warpdotdev/command-signatures#274)

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Added missing flag completions for `gh pr merge`.

Co-Authored-By: Oz <oz-agent@warp.dev>
