### PR TITLE
[REMOTE-1790] Surface shared session size limit errors

### DIFF
--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -1160,7 +1160,15 @@ impl Network {
         let num_bytes = event_type.num_bytes();
         self.num_bytes_shared = self.num_bytes_shared.add(num_bytes).unwrap_or(Byte::MAX);
         if self.num_bytes_shared > self.max_session_size {
-            log::info!("Stopping shared session because max bytes exceeded.");
+            let shared_bytes = self
+                .num_bytes_shared
+                .get_appropriate_unit(UnitType::Decimal);
+            let max_session_size = self
+                .max_session_size
+                .get_appropriate_unit(UnitType::Decimal);
+            log::info!(
+                "Stopping shared session because max bytes exceeded: shared_bytes={shared_bytes}, max_session_size={max_session_size}."
+            );
             self.end_session(SessionEndedReason::ExceededSizeLimit);
             return;
         }

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -1046,6 +1046,9 @@ pub fn session_ended_reason_string(reason: &SessionEndedReason) -> String {
         SessionEndedReason::InactivityLimitReached => {
             "Sharing ended due to sharer inactivity".to_owned()
         }
+        SessionEndedReason::ExceededSizeLimit => {
+            "The shared session reached its size limit. Start a new session to continue.".to_owned()
+        }
         _ => "Session ended.".to_owned(),
     }
 }

--- a/app/src/terminal/shared_session/viewer/network_tests.rs
+++ b/app/src/terminal/shared_session/viewer/network_tests.rs
@@ -1,18 +1,17 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_channel::Sender;
-use async_io::Timer;
-use instant::Instant;
-use parking_lot::FairMutex;
-use session_sharing_protocol::viewer::UpstreamMessage;
-use warpui::{App, ModelHandle};
-
-use super::{Network, PtyBytesBatchStatus, Stage};
+use super::{session_ended_reason_string, Network, PtyBytesBatchStatus, Stage};
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::TerminalModel;
 use crate::test_util::add_window_with_terminal;
 use crate::test_util::terminal::initialize_app_for_terminal_view;
+use async_channel::Sender;
+use async_io::Timer;
+use instant::Instant;
+use parking_lot::FairMutex;
+use session_sharing_protocol::viewer::{SessionEndedReason, UpstreamMessage};
+use warpui::{App, ModelHandle};
 
 fn create_network(app: &mut App) -> (ModelHandle<Network>, Sender<Vec<u8>>) {
     initialize_app_for_terminal_view(app);
@@ -70,6 +69,14 @@ fn test_send_pty_write_event_advances_event_no() {
             assert_eq!(network.write_to_pty_event_no.as_usize(), 1);
         });
     });
+}
+
+#[test]
+fn test_exceeded_size_limit_session_end_has_user_facing_error() {
+    assert_eq!(
+        session_ended_reason_string(&SessionEndedReason::ExceededSizeLimit),
+        "The shared session reached its size limit. Start a new session to continue."
+    );
 }
 
 #[test]

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -870,8 +870,7 @@ impl TerminalManager {
                 view.update(ctx, |terminal_view, ctx| {
                     let reason_string = session_ended_reason_string(reason);
                     match reason {
-                        SessionEndedReason::EndedBySharer
-                        | SessionEndedReason::ExceededSizeLimit => {}
+                        SessionEndedReason::EndedBySharer => {}
                         SessionEndedReason::InactivityLimitReached => {
                             terminal_view.show_persistent_toast(
                                 reason_string,


### PR DESCRIPTION
## Summary
- Surface a specific viewer-facing error when a shared session ends because it exceeded the max byte limit.
- Stop suppressing `ExceededSizeLimit` end reasons for shared-session viewers, including cloud/ambient agent sessions.
- Add shared byte count and max session size to the sharer shutdown log for future diagnosis.

## Investigation
The cloud sharer enforces the team billing policy's max shared-session size while sending ordered terminal events. The default/self-serve policy is 100 MB, and the sharer ends the session with `SessionEndedReason::ExceededSizeLimit` when the terminal stream exceeds that cap. Viewers previously suppressed this end reason, so a cloud run/session-sharing viewer could see the session disappear without an explanatory error.

## Validation
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all -- --check`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp test_exceeded_size_limit_session_end_has_user_facing_error`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --tests -- -D warnings` *(fails on pre-existing `warpui_core` Clippy warnings unrelated to this change)*

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/1e0ca577-8382-431d-bc96-674333d0b25e_
_Run: https://oz.staging.warp.dev/runs/019e6ad4-36f0-7eb3-bc75-eedfa3849244_
_This PR was generated with [Oz](https://warp.dev/oz)._
