### PR TITLE
feat: add ambient session end diagnostics

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1899,6 +1899,10 @@ impl AgentDriver {
                     })?
                 };
 
+                log::info!(
+                    "Ambient agent Oz lifecycle: event=run_exit_received idle_on_complete_elapsed_or_not_configured=true next=terminal_teardown_after_flush"
+                );
+
                 // Pause before returning to make sure that all conversation events are transmitted before the session is closed.
                 // TODO: This is a bit of a bandaid fix, and it would be better if we explicitly waited for the session to end before terminating.
                 // The way we could do that is through having the driver wait for all in-flight streams to be finished before terminating
@@ -2605,6 +2609,10 @@ impl AgentDriver {
 
                     if conversation.status().is_in_progress() {
                         // Conversation resumed or a new one started; cancel any pending idle timeout.
+                        log::info!(
+                            "Ambient agent idle lifecycle: event=idle_timeout_cancel_requested task_id={:?} terminal_view_id={terminal_id:?} trigger=conversation_in_progress",
+                            me.task_id
+                        );
                         run_exit.cancel_idle_timeout();
                         return;
                     }
@@ -2635,8 +2643,16 @@ impl AgentDriver {
                                 // Whether to keep the process alive after completion is controlled by
                                 // the `warp agent run --idle-on-complete[=<DURATION>]` flag.
                                 if let Some(idle_timeout) = me.idle_on_complete {
+                                    log::info!(
+                                        "Ambient agent idle lifecycle: event=idle_timeout_scheduled task_id={:?} terminal_view_id={terminal_id:?} timeout={idle_timeout:?} outcome=non_error_completion",
+                                        me.task_id
+                                    );
                                     run_exit.end_run_after(idle_timeout, output_status);
                                 } else {
+                                    log::info!(
+                                        "Ambient agent idle lifecycle: event=run_completion_immediate task_id={:?} terminal_view_id={terminal_id:?} outcome=non_error_completion",
+                                        me.task_id
+                                    );
                                     run_exit.end_run_now(output_status);
                                 }
                             }
@@ -2648,10 +2664,18 @@ impl AgentDriver {
                                 // if the follow-up never arrives.
                                 if error.will_attempt_resume() {
                                     log::info!("Error occurred but automatic resume will be attempted; waiting up to {AUTO_RESUME_TIMEOUT:?} for retry");
+                                    log::info!(
+                                        "Ambient agent idle lifecycle: event=idle_timeout_scheduled task_id={:?} terminal_view_id={terminal_id:?} timeout={AUTO_RESUME_TIMEOUT:?} outcome=automatic_resume_pending",
+                                        me.task_id
+                                    );
                                     run_exit.end_run_after(AUTO_RESUME_TIMEOUT, output_status);
                                     return;
                                 }
 
+                                log::info!(
+                                    "Ambient agent idle lifecycle: event=run_completion_immediate task_id={:?} terminal_view_id={terminal_id:?} outcome=error",
+                                    me.task_id
+                                );
                                 run_exit.end_run_now(output_status);
                             }
                         }
@@ -2865,12 +2889,24 @@ impl AgentDriver {
                     match status {
                         CLIAgentSessionStatus::Success | CLIAgentSessionStatus::Blocked { .. } => {
                             if let Some(idle_timeout) = me.idle_on_complete {
+                                log::info!(
+                                    "Ambient agent CLI lifecycle: event=idle_timeout_scheduled task_id={:?} terminal_view_id={terminal_view_id:?} timeout={idle_timeout:?}",
+                                    me.task_id
+                                );
                                 harness_exit.end_run_after(idle_timeout, ());
                             } else {
+                                log::info!(
+                                    "Ambient agent CLI lifecycle: event=run_completion_immediate task_id={:?} terminal_view_id={terminal_view_id:?}",
+                                    me.task_id
+                                );
                                 harness_exit.end_run_now(());
                             }
                         }
                         CLIAgentSessionStatus::InProgress => {
+                            log::info!(
+                                "Ambient agent CLI lifecycle: event=idle_timeout_cancel_requested task_id={:?} terminal_view_id={terminal_view_id:?} trigger=session_in_progress",
+                                me.task_id
+                            );
                             harness_exit.cancel_idle_timeout();
                         }
                     }
@@ -2989,13 +3025,17 @@ impl AgentDriver {
 
     /// Perform cleanup after the agent has finished running.
     async fn cleanup(spawner: ModelSpawner<Self>) {
-        let Ok(providers) = spawner
-            .spawn(|me, _| std::mem::take(&mut me.cloud_providers))
+        let Ok((providers, task_id)) = spawner
+            .spawn(|me, _| (std::mem::take(&mut me.cloud_providers), me.task_id))
             .await
         else {
             log::error!("Unable to retrieve cloud providers for cleanup");
             return;
         };
+
+        log::info!(
+            "Ambient agent lifecycle: event=driver_cleanup_started task_id={task_id:?} next=terminal_process_exit"
+        );
 
         for provider in providers {
             if let Err(err) = provider.cleanup().await {

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -1358,6 +1358,13 @@ impl TerminalManager {
         // the orchestrator task id is discoverable regardless of which variant
         // the share is.
         model.lock().set_shared_session_source(source.clone());
+        Self::log_shared_session_lifecycle(
+            &terminal_view,
+            &model,
+            "start_requested",
+            "trigger=terminal_view_start_sharing",
+            ctx,
+        );
         if matches!(source.source_type, SessionSourceType::AmbientAgent { .. }) {
             let terminal_view_id = terminal_view.id();
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _ctx| {
@@ -1535,6 +1542,13 @@ impl TerminalManager {
                         controller.set_sharer_participant_id(sharer_id.clone());
                     });
                 });
+                Self::log_shared_session_lifecycle(
+                    &terminal_view,
+                    &model,
+                    "session_established",
+                    "outcome=active_sharer",
+                    ctx,
+                );
 
                 // Let the manager know the share is active with the relevant metadata.
                 Manager::handle(ctx).update(ctx, |manager, ctx| {
@@ -2182,6 +2196,35 @@ impl TerminalManager {
         *session_sharer = Some(network);
     }
 
+    fn log_shared_session_lifecycle(
+        terminal_view: &ViewHandle<TerminalView>,
+        model: &Arc<FairMutex<TerminalModel>>,
+        event: &'static str,
+        details: impl std::fmt::Display,
+        ctx: &AppContext,
+    ) {
+        let session_id = terminal_view.as_ref(ctx).shared_session_id().cloned();
+        let (source_type, source_task_id) = {
+            let model = model.lock();
+            match model.shared_session_source() {
+                Some(source) => {
+                    let source_type = match &source.source_type {
+                        SessionSourceType::User => "user",
+                        SessionSourceType::AmbientAgent { .. } => "ambient_agent",
+                    };
+                    (
+                        source_type,
+                        source.orchestrator_task_id().map(str::to_owned),
+                    )
+                }
+                None => ("unknown", None),
+            }
+        };
+        log::info!(
+            "Shared session local lifecycle: event={event} session_id={session_id:?} source_type={source_type} source_task_id={source_task_id:?} {details}"
+        );
+    }
+
     /// Contains necessary logic for stopping the current shared session.
     fn cleanup_shared_session(
         terminal_view: &ViewHandle<TerminalView>,
@@ -2234,6 +2277,13 @@ impl TerminalManager {
         model: Arc<FairMutex<TerminalModel>>,
         ctx: &mut AppContext,
     ) {
+        Self::log_shared_session_lifecycle(
+            terminal_view,
+            &model,
+            "end_requested",
+            format_args!("reason={reason:?}"),
+            ctx,
+        );
         Self::cleanup_shared_session(terminal_view, model, ctx);
 
         // Drop the ModelHandle<Network> and set session_sharer to None.
@@ -2622,11 +2672,18 @@ impl crate::terminal::TerminalManager for TerminalManager {
         // The detach type is intentionally ignored: a sharer always stops sharing immediately,
         // even on a reversible `HiddenForClose` detach. This is desirable for security — a sharer
         // should not continue accepting commands from viewers while the session is not visible.
-        _detach_type: crate::pane_group::pane::DetachType,
+        detach_type: crate::pane_group::pane::DetachType,
         app: &mut AppContext,
     ) {
         let shared_session_status = self.model.lock().shared_session_status().clone();
         if shared_session_status.is_sharer() {
+            Self::log_shared_session_lifecycle(
+                &self.view,
+                &self.model,
+                "view_detached",
+                format_args!("detach_type={detach_type:?}"),
+                app,
+            );
             let is_confirm_close_session =
                 *SessionSettings::as_ref(app).should_confirm_close_session;
             self.view.update(app, |terminal_view, ctx| {

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -27,8 +27,8 @@ use session_sharing_protocol::common::{
 use session_sharing_protocol::sharer::{
     AddGuestsResponse, DownstreamMessage, FailedToAddGuestsReason, FailedToInitializeSessionReason,
     LinkAccessLevelUpdateResponse, ReconnectPayload, ReconnectToken, RemoveGuestResponse,
-    RoleUpdateReason, SessionEndedReason, SessionTerminatedReason, TeamAccessLevelUpdateResponse,
-    UpdatePendingUserRoleResponse, UpstreamMessage,
+    RoleUpdateReason, SessionEndedReason, SessionSourceType, SessionTerminatedReason,
+    TeamAccessLevelUpdateResponse, UpdatePendingUserRoleResponse, UpstreamMessage,
 };
 use warp_core::features::FeatureFlag;
 use warpui::r#async::Timer;
@@ -36,7 +36,6 @@ use warpui::{Entity, ModelContext, ModelHandle, RequestState, RetryOption, Singl
 use websocket::{Message, Sink, Stream, WebSocket, WebsocketMessage as _};
 #[cfg(not(any(test, feature = "integration_tests")))]
 use {
-    crate::terminal::shared_session::SharedSessionSource,
     crate::{report_error, server::telemetry::telemetry_context},
     session_sharing_protocol::common::{Scrollback, TelemetryContext},
     session_sharing_protocol::sharer::{InitPayload, Lifetime},
@@ -49,7 +48,7 @@ use crate::terminal::model::block::BlockId;
 use crate::terminal::shared_session::network::heartbeat::{Event as HeartbeatEvent, Heartbeat};
 use crate::terminal::shared_session::{
     connect_endpoint, max_session_size, EventNumber, SharedSessionScrollbackType,
-    SELECTION_THROTTLE_PERIOD,
+    SharedSessionSource, SELECTION_THROTTLE_PERIOD,
 };
 use crate::terminal::TerminalModel;
 use crate::throttle::throttle;
@@ -135,6 +134,7 @@ pub struct Network {
     session_id: Option<SessionId>,
     reconnect_token: Option<ReconnectToken>,
     sharer_id: Option<ParticipantId>,
+    source: Option<SharedSessionSource>,
 
     /// HashMap from event_no to the event. We keep these in memory to support reconnections
     /// until the server acks that they have been processed and are safe to remove.
@@ -186,6 +186,7 @@ impl Network {
             session_id: None,
             reconnect_token: None,
             sharer_id: None,
+            source: None,
             unacked_terminal_events: HashMap::new(),
             next_buffer_seq_no: (init_block_id, InputOperationSeqNo::zero()),
         };
@@ -259,6 +260,7 @@ impl Network {
             session_id: None,
             reconnect_token: None,
             sharer_id: None,
+            source: Some(source.clone()),
             unacked_terminal_events: HashMap::new(),
             next_buffer_seq_no: (init_block_id.clone(), InputOperationSeqNo::zero()),
         };
@@ -273,6 +275,7 @@ impl Network {
 
         // We should validate the scrollback is under the limit before creating the Network, but check here just to be safe.
         if num_bytes_scrollback > network.max_session_size {
+            network.log_diagnostic("local_policy_rejected_start", "reason=scrollback_too_large");
             log::warn!("Session sharing scrollback exceeds max session size; failing startup");
             ctx.emit(NetworkEvent::FailedToCreateSharedSession {
                 reason: FailedToInitializeSessionReason::ScrollbackTooLarge {},
@@ -328,11 +331,41 @@ impl Network {
     pub fn max_session_size(&self) -> Byte {
         self.max_session_size
     }
+    fn diagnostic_source_context(&self) -> (&'static str, Option<&str>) {
+        match self.source.as_ref() {
+            Some(source) => {
+                let source_type = match &source.source_type {
+                    SessionSourceType::User => "user",
+                    SessionSourceType::AmbientAgent { .. } => "ambient_agent",
+                };
+                (source_type, source.orchestrator_task_id())
+            }
+            None => ("unknown", None),
+        }
+    }
+
+    fn diagnostic_stage(&self) -> &'static str {
+        match self.stage {
+            Stage::BeforeStarted => "before_started",
+            Stage::StartedSuccessfully => "started_successfully",
+            Stage::Reconnecting { .. } => "reconnecting",
+            Stage::Finished => "finished",
+        }
+    }
+
+    fn log_diagnostic(&self, event: &'static str, details: impl std::fmt::Display) {
+        let (source_type, source_task_id) = self.diagnostic_source_context();
+        log::info!(
+            "Shared session sharer lifecycle: event={event} session_id={:?} source_type={source_type} source_task_id={source_task_id:?} {details}",
+            self.session_id
+        );
+    }
 
     /// All attempts to end a shared session must go through this API!
     /// This is important to guarantee that we correctly close the socket and
     /// notify viewers with the session ended reason.
     pub fn end_session(&mut self, reason: SessionEndedReason) {
+        self.log_diagnostic("end_session_requested", format_args!("reason={reason:?}"));
         let message = UpstreamMessage::EndSession { reason };
         self.send_message_to_server(message);
         self.close_without_reconnection();
@@ -347,6 +380,7 @@ impl Network {
                 self.send_message_to_server(UpstreamMessage::Ping { data: vec![] });
             }
             HeartbeatEvent::Idle => {
+                self.log_diagnostic("reconnect_triggered", "trigger=heartbeat_idle_timeout");
                 log::info!("Sharer reconnecting: heartbeat idle timeout");
                 self.reconnect_websocket(ctx);
             }
@@ -657,6 +691,7 @@ impl Network {
                     network.on_websocket_connected(ws_proxy_rx, sink, stream, ctx);
                 }
                 Err(e) => {
+                    network.log_diagnostic("initial_websocket_connect_failed", "outcome=transport_error");
                     let cause = Arc::new(e.context("Failed to create shared session"));
                     report_error!(&*cause);
                     ctx.emit(NetworkEvent::FailedToCreateSharedSession {
@@ -690,13 +725,22 @@ impl Network {
             log::error!("This channel does not support session-sharing.");
             return;
         };
+        self.log_diagnostic(
+            "reconnect_initiated",
+            "outcome=attempting_transport_recovery",
+        );
 
         let auth_client = ServerApiProvider::as_ref(ctx).get_auth_client();
         let auth_state = AuthStateProvider::as_ref(ctx).get().clone();
+        let (source_type, source_task_id) = self.diagnostic_source_context();
+        let source_type = source_type.to_string();
+        let source_task_id = source_task_id.map(str::to_owned);
         let abort_handle = ctx
             .spawn_with_retry_on_error(
                 move || {
-                    log::info!("Attempting to reconnect to session sharing server");
+                    log::info!(
+                        "Shared session sharer lifecycle: event=reconnect_attempt session_id={session_id:?} source_type={source_type} source_task_id={source_task_id:?}"
+                    );
                     let reconnect_endpoint = reconnect_endpoint.clone();
                     let auth_state = auth_state.clone();
                     let auth_client = auth_client.clone();
@@ -716,6 +760,10 @@ impl Network {
                 RECONNECT_RETRY_STRATEGY,
                 move |network, res, ctx| match res {
                     RequestState::RequestSucceeded(((sink, stream), user_id)) => {
+                        network.log_diagnostic(
+                            "reconnect_transport_connected",
+                            "outcome=waiting_for_server_confirmation",
+                        );
                         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
                         let latest_block_id =
                             network.model.lock().block_list().active_block_id().clone();
@@ -744,9 +792,17 @@ impl Network {
                         network.on_websocket_connected(ws_proxy_rx, sink, stream, ctx);
                     }
                     RequestState::RequestFailedRetryPending(e) => {
+                        network.log_diagnostic(
+                            "reconnect_attempt_failed",
+                            "outcome=retry_pending",
+                        );
                         log::warn!("Failed to reconnect to shared session, will retry: {e}");
                     }
                     RequestState::RequestFailed(e) => {
+                        network.log_diagnostic(
+                            "reconnect_failed",
+                            "outcome=transport_retries_exhausted",
+                        );
                         log::warn!(
                             "Failed to reconnect to shared session, and retries exhausted: {e}"
                         );
@@ -785,10 +841,13 @@ impl Network {
                     network.process_websocket_message(message, ctx);
                 }
                 Err(e) => {
+                    network.log_diagnostic("websocket_error", "direction=downstream");
                     log::error!("Got error from shared session sharer websocket: {e}");
                 }
             },
             |network, ctx| {
+                let stage = network.diagnostic_stage();
+                network.log_diagnostic("websocket_closed", format_args!("stage={stage}"));
                 log::info!("Session sharing server closed websocket to sharer");
                 // Close our current websocket proxy, because we may try to reconnect and that will create a new websocket proxy.
                 // This must be done before trying to reconnect.
@@ -796,6 +855,7 @@ impl Network {
                 // The connection may have timed out or the server restarted.
                 // We don't emit this event if we haven't started successfully to avoid an infinite retry loop.
                 if matches!(network.stage, Stage::StartedSuccessfully) {
+                    network.log_diagnostic("reconnect_triggered", "trigger=websocket_closed");
                     log::info!("Sharer reconnecting: websocket closed by server");
                     network.reconnect_websocket(ctx);
                 } else if matches!(network.stage, Stage::BeforeStarted) {
@@ -863,6 +923,7 @@ impl Network {
                 self.sharer_id = Some(sharer_id.clone());
 
                 self.stage = Stage::StartedSuccessfully;
+                self.log_diagnostic("session_initialized", "outcome=active_sharer");
 
                 // Flush all events starting from the very first event 0, since events were buffered before the session was initialized.
                 self.flush_terminal_events_to_server(0);
@@ -891,6 +952,7 @@ impl Network {
                     log::warn!("Received unexpected SessionReconnected message when we weren't reconnecting");
                     return;
                 }
+                self.log_diagnostic("reconnect_succeeded", "outcome=session_resumed");
                 log::info!("Successfully reconnected to shared session server as sharer.");
                 self.stage = Stage::StartedSuccessfully;
 
@@ -904,15 +966,18 @@ impl Network {
                     participant_list,
                 )));
             }
-            DownstreamMessage::FailedToReconnect { reason } => {
-                log::warn!(
-                    "Failed to reconnect to shared session server as sharer due to {reason:?}"
-                );
+            DownstreamMessage::FailedToReconnect { reason: _ } => {
+                self.log_diagnostic("reconnect_failed", "outcome=server_rejected_resume");
+                log::warn!("Failed to reconnect to shared session server as sharer");
                 self.close_without_reconnection();
                 ctx.emit(NetworkEvent::FailedToReconnect);
             }
             DownstreamMessage::SessionTerminated { reason } => {
-                log::info!("Server terminated shared session due to reason={reason:?}");
+                let reason_label = session_terminated_reason_diagnostic_label(&reason);
+                self.log_diagnostic(
+                    "server_terminated_session",
+                    format_args!("reason={reason_label}"),
+                );
                 self.close_without_reconnection();
                 ctx.emit(NetworkEvent::SessionTerminated { reason });
             }
@@ -1160,6 +1225,7 @@ impl Network {
         let num_bytes = event_type.num_bytes();
         self.num_bytes_shared = self.num_bytes_shared.add(num_bytes).unwrap_or(Byte::MAX);
         if self.num_bytes_shared > self.max_session_size {
+            self.log_diagnostic("local_policy_end_session", "reason=exceeded_size_limit");
             log::info!("Stopping shared session because max bytes exceeded.");
             self.end_session(SessionEndedReason::ExceededSizeLimit);
             return;
@@ -1240,6 +1306,13 @@ impl Network {
 
 const NO_QUOTA_REMAINING_MESSAGE: &str =
     "Session sharing usage exceeded for the day. Please try again later.";
+fn session_terminated_reason_diagnostic_label(reason: &SessionTerminatedReason) -> &'static str {
+    match reason {
+        SessionTerminatedReason::NoUserQuotaRemaining {} => "no_user_quota_remaining",
+        SessionTerminatedReason::ExceededSizeLimit => "exceeded_size_limit",
+        SessionTerminatedReason::InternalServerError { .. } => "internal_server_error",
+    }
+}
 
 /// Converts [`SessionTerminatedReason`] to a user-facing string.
 pub fn session_terminated_reason_string(
@@ -1376,6 +1449,8 @@ impl Entity for Network {
 
 impl Drop for Network {
     fn drop(&mut self) {
+        let stage = self.diagnostic_stage();
+        self.log_diagnostic("network_dropped", format_args!("stage={stage}"));
         // This is needed to gracefully close the websocket when Network is dropped.
         self.close();
         // We keep the same selection_throttled_tx even if we reconnect and replace the internal ws_proxy_tx,

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -647,6 +647,15 @@ impl TerminalView {
         reason: SessionEndedReason,
         ctx: &mut ViewContext<Self>,
     ) {
+        let session_id = self.shared_session_id().cloned();
+        let source_task_id = self
+            .model
+            .lock()
+            .shared_session_source()
+            .and_then(|share_source| share_source.orchestrator_task_id().map(str::to_owned));
+        log::info!(
+            "Shared session view stop requested: session_id={session_id:?} source_task_id={source_task_id:?} action_source={source:?} reason={reason:?}"
+        );
         ctx.emit(Event::StopSharingCurrentSession { reason });
 
         send_telemetry_from_ctx!(


### PR DESCRIPTION
## Summary
- Add privacy-safe sharer network diagnostics correlated by shared session ID and safe ambient source/task metadata.
- Log explicit local stop and pane detach triggers, websocket/reconnect lifecycle, server/policy terminations, and network drop stage.
- Log native Oz and CLI idle-on-complete scheduling, resumption cancellation, completion, and cleanup boundaries.

## Validation
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all -- --check`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib` (passes; existing unrelated unused-variable warnings remain)
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib terminal::shared_session::sharer::network::tests` (13 passed)
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib idle_timeout_sender` (6 passed)

## Observable end/reconnect paths
- Explicit stop requests: action source and protocol reason from the view, then local end request handling.
- Pane detach: detach type before the forced sharer end path.
- Sharer transport: websocket error/closure, reconnect initiation/attempt/transport success/failure/exhaustion, and recovered session.
- Server and client policy: sanitized server termination reason labels and local maximum-bytes endings.
- Agent lifecycle: native Oz/CLI idle scheduling and cancellation, run exit, and driver cleanup.

No prompts, environment variables, tokens, serialized content, websocket payloads, or detailed server error text are added to logs.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/94be9e4f-ae12-49d1-8265-979cd5a420cb_
_Run: https://oz.staging.warp.dev/runs/019e6b1b-ab3a-7033-aeef-4198d6f085dc_
_Plans_:
- _[Instrument ambient shared-session end diagnostics](https://staging.warp.dev/drive/notebook/YlqBOxGICZByBqKqr74LDV)_
_This PR was generated with [Oz](https://warp.dev/oz)._
