### PR TITLE
[REMOTE-1809] fix: allow browser shortcuts in wasm sessions

### DIFF
--- a/crates/warpui/src/platform/wasm/mod.rs
+++ b/crates/warpui/src/platform/wasm/mod.rs
@@ -12,6 +12,7 @@ use wasm_bindgen::{JsCast, UnwrapThrowExt};
 
 use super::KEYS_TO_IGNORE;
 use crate::keymap::Keystroke;
+use crate::platform::OperatingSystem;
 // Re-export a couple winit types and modules as the concrete implementations
 // for the wasm platform.
 pub use crate::windowing::winit::app::App;
@@ -108,7 +109,8 @@ pub(crate) fn add_prevent_default_listener(canvas: &web_sys::HtmlCanvasElement) 
                     key: event.key(),
                 };
 
-                let allow_default_event = KEYS_TO_IGNORE.contains(&keystroke);
+                let allow_default_event =
+                    KEYS_TO_IGNORE.contains(&keystroke) || is_browser_shortcut(event);
                 if !allow_default_event {
                     event.prevent_default();
                 }
@@ -116,6 +118,54 @@ pub(crate) fn add_prevent_default_listener(canvas: &web_sys::HtmlCanvasElement) 
         ));
         Box::leak(prevent_default_listener);
     }
+}
+
+fn is_browser_shortcut(event: &web_sys::KeyboardEvent) -> bool {
+    let key = event.key().to_ascii_lowercase();
+
+    if !event.ctrl_key() && !event.alt_key() && !event.meta_key() {
+        return key == "f5";
+    }
+
+    if is_browser_history_shortcut(event, &key) {
+        return true;
+    }
+
+    if !has_browser_primary_modifier(event) || event.alt_key() {
+        return false;
+    }
+
+    // These are standard browser chrome shortcuts that should keep working in WASM sessions.
+    // This allowlist uses the browser's primary shortcut modifier for the current OS
+    // (Cmd on macOS, Ctrl elsewhere), so the behavior is not macOS-specific.
+    let browser_primary_shortcut_keys = [
+        "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "-", "=", "+", "[", "]", "l", "n", "r",
+        "t", "tab", "w", "pageup", "pagedown",
+    ];
+    let browser_shifted_primary_shortcut_keys = [
+        "-", "=", "+", "[", "]", "{", "}", "n", "r", "t", "tab", "w", "pageup", "pagedown",
+    ];
+
+    if event.shift_key() {
+        browser_shifted_primary_shortcut_keys.contains(&key.as_str())
+    } else {
+        browser_primary_shortcut_keys.contains(&key.as_str())
+    }
+}
+
+fn has_browser_primary_modifier(event: &web_sys::KeyboardEvent) -> bool {
+    match OperatingSystem::get() {
+        OperatingSystem::Mac => event.meta_key() && !event.ctrl_key(),
+        _ => event.ctrl_key() && !event.meta_key(),
+    }
+}
+
+fn is_browser_history_shortcut(event: &web_sys::KeyboardEvent, key: &str) -> bool {
+    if event.shift_key() || event.ctrl_key() || event.meta_key() {
+        return false;
+    }
+
+    event.alt_key() && matches!(key, "arrowleft" | "arrowright")
 }
 
 pub(crate) fn add_paste_listener(event_loop_proxy: winit::event_loop::EventLoopProxy<CustomEvent>) {


### PR DESCRIPTION
## Summary
- Let WASM/browser sessions pass browser-reserved keyboard shortcuts through instead of always calling preventDefault on canvas key events.
- Use a platform-aware browser primary modifier (Cmd on macOS, Ctrl elsewhere) for common browser chrome shortcuts like tab navigation, reload, address bar focus, browser zoom, new/close/reopen tab/window shortcuts, plus F5 and Alt+Left/Right history navigation.
- Keep existing Warp-owned keyboard handling and the existing paste passthrough behavior intact.

## Why
Browser sessions were hijacking shortcuts before Warp keybinding settings could matter. Disabling a Warp shortcut could stop the Warp action, but the WASM preventDefault listener still blocked the browser default.

## Validation
- `ASSET_TARGET_DIR=/workspace/warp/target/wasm32-unknown-unknown/dev-wasm/bundle/assets cargo check --target wasm32-unknown-unknown --profile dev-wasm --bin dev --features gui`

## Screenshot/Video

https://www.loom.com/share/e7eff81b0ece4393b63059d6ff68610b

_Conversation: https://staging.warp.dev/conversation/631c6c08-fd5f-4d56-8851-f7ecf90e85bb_
_Run: https://oz.staging.warp.dev/runs/019e6b3a-b4bb-7cc4-8bcb-0ede5f4a270d_
_This PR was generated with [Oz](https://warp.dev/oz)._
