### PR TITLE
Clarify BYOK / Custom Inference description copy

### DIFF
--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -7108,7 +7108,7 @@ impl ApiKeysWidget {
         let appearance = Appearance::as_ref(app);
         let text_fragments = vec![
             FormattedTextFragment::plain_text(
-                "Use your own API keys from model providers for Warp Agent. You can also add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored locally and are never synced to the cloud. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
+                "Use your own API keys from model providers for Warp Agent. You can also add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored only on your device, never on Warp's servers. They're used to make requests to your chosen model provider. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
             ),
             FormattedTextFragment::hyperlink("Learn more", CUSTOM_INFERENCE_LEARN_MORE_URL),
         ];


### PR DESCRIPTION
This PR replaces the single misleading sentence with two short ones that keep the privacy assurance ("stored only on your device, never on Warp's servers") and add a purpose statement ("They're used to make requests to your chosen model provider") so the description also conveys what the key actually does.

### Diff
```diff
- API keys are stored locally and are never synced to the cloud.
+ API keys are stored only on your device, never on Warp's servers. They're used to make requests to your chosen model provider.
```

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Pairs with [warpdotdev/docs#138](https://github.com/warpdotdev/docs/pull/138).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

This is a static settings-panel string change in `render_custom_inference_description` (`app/src/settings_view/ai_page.rs`). No code paths or behavior change; only the user-facing description text in the Custom inference section.

### Screenshots / Videos
N/A — visual change is purely the replacement of one sentence in the Custom inference description block.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Clarify BYOK / Custom inference settings copy: API keys are stored only on your device, never on Warp's servers, and used to make requests to your chosen model provider.

_Conversation: https://staging.warp.dev/conversation/12c60bdb-97b9-4fe4-8c1d-7082bcb57992_
_Run: https://oz.staging.warp.dev/runs/019e6a71-fc28-78c8-952c-f07a9c098ab2_

_This PR was generated with [Oz](https://warp.dev/oz)._
