### PR TITLE
feat: make /app redirect to cloud agent in wasm

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2431,6 +2431,14 @@ fn on_close_window_cancelled(
     }
 }
 
+fn is_cloud_agent_web_home_launch_url(url: &Url) -> bool {
+    url.scheme() == ChannelState::url_scheme()
+        && url.host_str() == Some("action")
+        && url.path() == "/new_cloud_agent_conversation"
+        && url
+            .query_pairs()
+            .any(|(key, value)| key == "source" && value == "web_home")
+}
 fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode: LaunchMode) {
     IntervalTimer::handle(ctx).update(ctx, |timer, _ctx| {
         timer.mark_interval_end("APP_LAUNCHED");
@@ -2448,6 +2456,12 @@ fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode
 
     match launch_mode {
         LaunchMode::App { .. } | LaunchMode::Test { .. } => {
+            let should_skip_restore = launch_mode
+                .args()
+                .urls
+                .iter()
+                .any(is_cloud_agent_web_home_launch_url);
+            let app_state = if should_skip_restore { None } else { app_state };
             // Attempt to restore windows from the persisted application state.
             let arg = OpenFromRestoredArg { app_state };
             ctx.dispatch_global_action("root_view:open_from_restored", &arg);

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -1497,6 +1497,8 @@ pub enum NewWorkspaceSource {
         options: Box<NewTerminalOptions>,
         initial_query: Option<String>,
     },
+    /// Starts the workspace with the Cloud Agent setup tab.
+    AmbientAgent,
     /// A tab is being transferred from another window via the transferable views framework.
     /// The workspace will create a placeholder tab, which will be replaced by the transferred
     /// PaneGroup after window creation.

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -26,7 +26,10 @@ use crate::drive::{OpenWarpDriveObjectArgs, OpenWarpDriveObjectSettings};
 use crate::features::FeatureFlag;
 use crate::launch_configs::launch_config::LaunchConfig;
 use crate::linear::{LinearAction, LinearIssueWork};
-use crate::root_view::{open_new_window_get_handles, OpenLaunchConfigArg};
+use crate::root_view::{
+    open_new_window_get_handles, open_new_with_workspace_source, NewWorkspaceSource,
+    OpenLaunchConfigArg,
+};
 use crate::server::ids::ServerId;
 use crate::server::telemetry::{LaunchConfigUiLocation, TelemetryEvent};
 use crate::settings_view::{OpenTeamsSettingsModalArgs, SettingsSection};
@@ -940,13 +943,8 @@ impl Action {
                 }
             }
             Action::NewCloudAgentConversation => {
-                let window_id =
-                    primary_window_id.or_else(|| Some(open_new_window_get_handles(None, ctx).0));
-
-                let Some(window_id) = window_id else {
-                    log::warn!(
-                        "unable to determine window for new cloud agent conversation action"
-                    );
+                let Some(window_id) = primary_window_id else {
+                    open_new_with_workspace_source(NewWorkspaceSource::AmbientAgent, ctx);
                     return;
                 };
 

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -944,9 +944,6 @@ impl Action {
             }
             Action::NewCloudAgentConversation => {
                 let Some(window_id) = primary_window_id else {
-                    if !Workspace::can_add_ambient_agent_tab(ctx) {
-                        return;
-                    }
                     open_new_with_workspace_source(NewWorkspaceSource::AmbientAgent, ctx);
                     return;
                 };

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -944,6 +944,9 @@ impl Action {
             }
             Action::NewCloudAgentConversation => {
                 let Some(window_id) = primary_window_id else {
+                    if !Workspace::can_add_ambient_agent_tab(ctx) {
+                        return;
+                    }
                     open_new_with_workspace_source(NewWorkspaceSource::AmbientAgent, ctx);
                     return;
                 };

--- a/app/src/uri/uri_tests.rs
+++ b/app/src/uri/uri_tests.rs
@@ -261,6 +261,19 @@ fn test_warp_web_link_failure() {
         None
     );
 }
+#[test]
+fn test_app_web_link_rewrites_to_new_cloud_agent_conversation() {
+    let url = Url::parse(&format!("{}/app", ChannelState::server_root_url())).unwrap();
+    let intent = web_intent_parser::maybe_rewrite_web_url_to_intent(&url).unwrap();
+
+    assert_eq!(
+        intent.as_str(),
+        format!(
+            "{}://action/new_cloud_agent_conversation?source=web_home",
+            ChannelState::url_scheme()
+        )
+    );
+}
 
 #[test]
 fn test_action_create_environment_parse() {

--- a/app/src/uri/web_intent_parser.rs
+++ b/app/src/uri/web_intent_parser.rs
@@ -16,6 +16,7 @@ pub enum WebIntent {
     DriveObject(Url),
     SettingsView(Url),
     Home(Url),
+    CloudAgentHome(Url),
     Action(Url),
 }
 
@@ -43,8 +44,8 @@ impl WebIntent {
             } else {
                 match segments[0] {
                     "app" => {
-                        return Ok(WebIntent::Home(Url::parse(&format!(
-                            "{url_scheme}://home"
+                        return Ok(WebIntent::CloudAgentHome(Url::parse(&format!(
+                            "{url_scheme}://action/new_cloud_agent_conversation?source=web_home"
                         ))?));
                     }
                     // For sessions, we expect the URL to be in the format: {scheme}/session/{session_id}
@@ -154,6 +155,7 @@ impl WebIntent {
             WebIntent::DriveObject(url) => url,
             WebIntent::SettingsView(url) => url,
             WebIntent::Home(url) => url,
+            WebIntent::CloudAgentHome(url) => url,
             WebIntent::Action(url) => url,
         }
     }
@@ -174,6 +176,7 @@ pub fn open_url_on_desktop(url: &Url) {
         Ok(WebIntent::ConversationView(intent))
         | Ok(WebIntent::DriveObject(intent))
         | Ok(WebIntent::SessionView(intent))
+        | Ok(WebIntent::CloudAgentHome(intent))
         | Ok(WebIntent::Action(intent)) => {
             crate::platform::wasm::emit_event(crate::platform::wasm::WarpEvent::OpenOnNative {
                 url: intent.into(),
@@ -193,6 +196,7 @@ fn set_context_flags_from_url(url: Url) {
         Ok(WebIntent::DriveObject(_)) => ContextFlag::set_warp_drive_link_only(),
         Ok(WebIntent::SettingsView(_)) => ContextFlag::set_settings_link_only(),
         Ok(WebIntent::Home(_)) => ContextFlag::set_warp_home_link_only(),
+        Ok(WebIntent::CloudAgentHome(_)) => {}
         Ok(WebIntent::Action(_)) => {} // No special context flag for actions
         _ => {}
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3693,6 +3693,15 @@ impl Workspace {
                 });
                 self.check_and_trigger_onboarding(ctx);
             }
+            NewWorkspaceSource::AmbientAgent => {
+                self.add_tab_with_pane_layout(
+                    PanesLayout::AmbientAgent,
+                    Arc::new(HashMap::new()),
+                    None,
+                    ctx,
+                );
+                self.check_and_trigger_onboarding(ctx);
+            }
             NewWorkspaceSource::NotebookFromFilePath { file_path } => {
                 self.add_tab_for_file_notebook(file_path, ctx);
             }
@@ -3802,6 +3811,7 @@ impl Workspace {
             | NewWorkspaceSource::FromTemplate { .. }
             | NewWorkspaceSource::Session { .. }
             | NewWorkspaceSource::AgentSession { .. }
+            | NewWorkspaceSource::AmbientAgent
             | NewWorkspaceSource::NotebookFromFilePath { .. } => should_default_open,
             #[cfg(not(target_family = "wasm"))]
             NewWorkspaceSource::SharedSessionAsViewer { .. }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3694,7 +3694,12 @@ impl Workspace {
                 self.check_and_trigger_onboarding(ctx);
             }
             NewWorkspaceSource::AmbientAgent => {
-                self.add_ambient_agent_tab(ctx);
+                self.add_tab_with_pane_layout(
+                    PanesLayout::AmbientAgent,
+                    Arc::new(HashMap::new()),
+                    None,
+                    ctx,
+                );
                 self.check_and_trigger_onboarding(ctx);
             }
             NewWorkspaceSource::NotebookFromFilePath { file_path } => {
@@ -10877,14 +10882,8 @@ impl Workspace {
         }
     }
 
-    pub(crate) fn can_add_ambient_agent_tab(ctx: &AppContext) -> bool {
-        AISettings::as_ref(ctx).is_any_ai_enabled(ctx)
-            && FeatureFlag::AgentView.is_enabled()
-            && FeatureFlag::CloudMode.is_enabled()
-    }
-
     fn add_ambient_agent_tab(&mut self, ctx: &mut ViewContext<Self>) {
-        if !Self::can_add_ambient_agent_tab(ctx) {
+        if !FeatureFlag::AgentView.is_enabled() || !FeatureFlag::CloudMode.is_enabled() {
             return;
         }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3694,12 +3694,7 @@ impl Workspace {
                 self.check_and_trigger_onboarding(ctx);
             }
             NewWorkspaceSource::AmbientAgent => {
-                self.add_tab_with_pane_layout(
-                    PanesLayout::AmbientAgent,
-                    Arc::new(HashMap::new()),
-                    None,
-                    ctx,
-                );
+                self.add_ambient_agent_tab(ctx);
                 self.check_and_trigger_onboarding(ctx);
             }
             NewWorkspaceSource::NotebookFromFilePath { file_path } => {
@@ -10882,8 +10877,14 @@ impl Workspace {
         }
     }
 
+    pub(crate) fn can_add_ambient_agent_tab(ctx: &AppContext) -> bool {
+        AISettings::as_ref(ctx).is_any_ai_enabled(ctx)
+            && FeatureFlag::AgentView.is_enabled()
+            && FeatureFlag::CloudMode.is_enabled()
+    }
+
     fn add_ambient_agent_tab(&mut self, ctx: &mut ViewContext<Self>) {
-        if !FeatureFlag::AgentView.is_enabled() || !FeatureFlag::CloudMode.is_enabled() {
+        if !Self::can_add_ambient_agent_tab(ctx) {
             return;
         }
 


### PR DESCRIPTION
## Description
Fix `/app` in Warp-on-Web so it opens the Cloud Agent start experience instead of a regular Agent tab or restored workspace state.

## Linked Issue
N/A

## Testing
- `cargo fmt -p warp`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo test -p warp uri::tests::test_app_web_link_rewrites_to_new_cloud_agent_conversation`

- [x] I have manually tested my changes locally with `./script/run`
https://www.loom.com/share/5c6aa6142e9a43e29519419de771104f

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed `/app` in Warp-on-Web opening the wrong Agent experience instead of the Cloud Agent start page.