### PR TITLE
Improve UX for the lightbox.

### DIFF
--- a/crates/ui_components/src/lightbox.rs
+++ b/crates/ui_components/src/lightbox.rs
@@ -193,18 +193,17 @@ impl Component for Lightbox {
             central_content
         };
 
-        let centered_content = Align::new(
-            Dismiss::new(content_with_description)
+        let centered_content = Align::new(content_with_description).finish();
+
+        let scrim = Container::new(
+            Dismiss::new(centered_content)
                 .prevent_interaction_with_other_elements()
                 .on_dismiss(move |ctx, app| on_dismiss(ctx, app))
                 .finish(),
         )
+        .with_background_color(scrim_color())
+        .with_uniform_padding(SCRIM_PADDING)
         .finish();
-
-        let scrim = Container::new(centered_content)
-            .with_background_color(scrim_color())
-            .with_uniform_padding(SCRIM_PADDING)
-            .finish();
 
         // Stack the scrim, close button, and optional navigation arrows.
         let mut content = Stack::new().with_child(scrim);

--- a/crates/ui_components/src/lightbox.rs
+++ b/crates/ui_components/src/lightbox.rs
@@ -5,7 +5,7 @@ use warp_core::ui::Icon;
 use warp_core::ui::appearance::Appearance;
 use warpui::assets::asset_cache::AssetSource;
 use warpui::elements::{
-    CacheOption, Dismiss, DispatchEventResult, EventHandler, Image, Shrinkable,
+    CacheOption, Debug, Dismiss, DispatchEventResult, EventHandler, Image, Shrinkable,
 };
 use warpui::keymap::Keystroke;
 use warpui::prelude::stack::*;
@@ -153,6 +153,7 @@ impl Component for Lightbox {
                     let image = ConstrainedBox::new(
                         Image::new(asset_source.clone(), CacheOption::Original)
                             .contain()
+                            .layout_using_paint_bounds()
                             .before_load(Align::new(loading_element(appearance)).finish())
                             .finish(),
                     )
@@ -192,17 +193,18 @@ impl Component for Lightbox {
             central_content
         };
 
-        let centered_content = Align::new(content_with_description).finish();
-
-        let scrim = Container::new(
-            Dismiss::new(centered_content)
+        let centered_content = Align::new(
+            Dismiss::new(content_with_description)
                 .prevent_interaction_with_other_elements()
                 .on_dismiss(move |ctx, app| on_dismiss(ctx, app))
                 .finish(),
         )
-        .with_background_color(scrim_color())
-        .with_uniform_padding(SCRIM_PADDING)
         .finish();
+
+        let scrim = Container::new(centered_content)
+            .with_background_color(scrim_color())
+            .with_uniform_padding(SCRIM_PADDING)
+            .finish();
 
         // Stack the scrim, close button, and optional navigation arrows.
         let mut content = Stack::new().with_child(scrim);

--- a/crates/ui_components/src/lightbox.rs
+++ b/crates/ui_components/src/lightbox.rs
@@ -5,7 +5,7 @@ use warp_core::ui::Icon;
 use warp_core::ui::appearance::Appearance;
 use warpui::assets::asset_cache::AssetSource;
 use warpui::elements::{
-    CacheOption, Debug, Dismiss, DispatchEventResult, EventHandler, Image, Shrinkable,
+    CacheOption, Dismiss, DispatchEventResult, EventHandler, Image, Shrinkable,
 };
 use warpui::keymap::Keystroke;
 use warpui::prelude::stack::*;
@@ -132,7 +132,7 @@ impl Component for Lightbox {
             appearance,
             button::Params {
                 content: button::Content::Icon(Icon::X),
-                theme: &button::themes::Secondary,
+                theme: &DismissButtonTheme,
                 options: button::Options {
                     size: button::Size::Small,
                     on_click: Some(Box::new(move |ctx, app, _| {
@@ -297,4 +297,39 @@ fn loading_element(appearance: &Appearance) -> Box<dyn Element> {
 
 fn lightbox_text_size(appearance: &Appearance) -> f32 {
     appearance.ui_font_size() + LIGHTBOX_TEXT_SIZE_DELTA
+}
+
+/// A custom button theme for the dismiss button to force colors to match
+/// a Dark theme button, as this button always appears on top of a near-black
+/// scrim, independent of application theme.
+struct DismissButtonTheme;
+
+impl button::Theme for DismissButtonTheme {
+    fn background(
+        &self,
+        button_state: button::State,
+        _appearance: &Appearance,
+    ) -> Option<warp_core::ui::theme::Fill> {
+        match button_state {
+            button::State::Default => None,
+            button::State::Hovered => Some(warp_core::ui::theme::Fill::white().with_opacity(10)),
+            button::State::Pressed => Some(warp_core::ui::theme::Fill::white().with_opacity(15)),
+        }
+    }
+
+    fn text_color(
+        &self,
+        _background: Option<warp_core::ui::theme::Fill>,
+        _appearance: &Appearance,
+    ) -> ColorU {
+        ColorU::new(255, 255, 255, 255)
+    }
+
+    fn border(&self, _appearance: &Appearance) -> Option<ColorU> {
+        Some(ColorU::new(51, 51, 51, 255))
+    }
+
+    fn keyboard_shortcut_background(&self, _appearance: &Appearance) -> Option<ColorU> {
+        Some(ColorU::new(38, 38, 38, 255))
+    }
 }

--- a/crates/ui_components/src/lightbox.rs
+++ b/crates/ui_components/src/lightbox.rs
@@ -132,7 +132,7 @@ impl Component for Lightbox {
             appearance,
             button::Params {
                 content: button::Content::Icon(Icon::X),
-                theme: &DismissButtonTheme,
+                theme: &ButtonTheme,
                 options: button::Options {
                     size: button::Size::Small,
                     on_click: Some(Box::new(move |ctx, app, _| {
@@ -228,7 +228,7 @@ impl Component for Lightbox {
                     appearance,
                     button::Params {
                         content: button::Content::Icon(Icon::ChevronLeft),
-                        theme: &button::themes::Secondary,
+                        theme: &ButtonTheme,
                         options: button::Options {
                             size: button::Size::Small,
                             on_click: Some(Box::new(move |ctx, app, _| {
@@ -256,7 +256,7 @@ impl Component for Lightbox {
                     appearance,
                     button::Params {
                         content: button::Content::Icon(Icon::ChevronRight),
-                        theme: &button::themes::Secondary,
+                        theme: &ButtonTheme,
                         options: button::Options {
                             size: button::Size::Small,
                             on_click: Some(Box::new(move |ctx, app, _| {
@@ -298,12 +298,12 @@ fn lightbox_text_size(appearance: &Appearance) -> f32 {
     appearance.ui_font_size() + LIGHTBOX_TEXT_SIZE_DELTA
 }
 
-/// A custom button theme for the dismiss button to force colors to match
-/// a Dark theme button, as this button always appears on top of a near-black
+/// A custom button theme for lightbox buttons to force colors to match
+/// a Dark theme button, as these buttons always appear on top of a near-black
 /// scrim, independent of application theme.
-struct DismissButtonTheme;
+struct ButtonTheme;
 
-impl button::Theme for DismissButtonTheme {
+impl button::Theme for ButtonTheme {
     fn background(
         &self,
         button_state: button::State,

--- a/crates/warpui_core/src/elements/image.rs
+++ b/crates/warpui_core/src/elements/image.rs
@@ -41,6 +41,7 @@ pub struct Image {
     size: Option<Vector2F>,
     origin: Option<Point>,
     fit_type: FitType,
+    layout_using_paint_bounds: bool,
     animated_image_behavior: AnimatedImageBehavior,
     cache_option: CacheOption,
     started_at: Option<Instant>,
@@ -91,6 +92,7 @@ impl Image {
             failed_to_load_element: None,
             load_timeout: None,
             requested_repaint_after_load: false,
+            layout_using_paint_bounds: false,
             #[cfg(debug_assertions)]
             constructor_location: Some(std::panic::Location::caller()),
         }
@@ -141,6 +143,16 @@ impl Image {
     /// and the empty space should appear on the left rather than being split on both sides.
     pub fn right_aligned(mut self) -> Self {
         self.right_aligned = true;
+        self
+    }
+
+    /// Uses the paint boundary of the image as the laid-out size.
+    ///
+    /// By default, the [`Image`] element bounds will be the incoming max constraint.
+    /// For some cases, we'd prefer for the element's laid-out size to match the painted
+    /// image size.
+    pub fn layout_using_paint_bounds(mut self) -> Self {
+        self.layout_using_paint_bounds = true;
         self
     }
 
@@ -393,7 +405,16 @@ impl Element for Image {
         ctx: &mut LayoutContext,
         app: &AppContext,
     ) -> Vector2F {
-        let size = constraint.max;
+        let mut size = constraint.max;
+        // If we want to lay out the image using the
+        if self.layout_using_paint_bounds {
+            let asset_cache = AssetCache::as_ref(app);
+            let image_size = ImageCache::as_ref(app).image_size(self.source.clone(), asset_cache);
+            if let Some(image_size) = image_size {
+                size = dimensions(image_size.to_f32(), size, self.fit_type);
+            }
+        }
+
         self.size = Some(size);
 
         if let Some(before_load_element) = self.before_load_element.as_mut() {

--- a/crates/warpui_core/src/elements/image.rs
+++ b/crates/warpui_core/src/elements/image.rs
@@ -41,6 +41,8 @@ pub struct Image {
     size: Option<Vector2F>,
     origin: Option<Point>,
     fit_type: FitType,
+    /// If true, layout will produce a size based on the bounds at which the image will
+    /// be painted instead of simply using the incoming max constraint.
     layout_using_paint_bounds: bool,
     animated_image_behavior: AnimatedImageBehavior,
     cache_option: CacheOption,
@@ -406,7 +408,7 @@ impl Element for Image {
         app: &AppContext,
     ) -> Vector2F {
         let mut size = constraint.max;
-        // If we want to lay out the image using the
+
         if self.layout_using_paint_bounds {
             let asset_cache = AssetCache::as_ref(app);
             let image_size = ImageCache::as_ref(app).image_size(self.source.clone(), asset_cache);

--- a/crates/warpui_core/src/image_cache.rs
+++ b/crates/warpui_core/src/image_cache.rs
@@ -952,6 +952,17 @@ impl ImageCache {
             }
         }
     }
+
+    pub fn image_size(
+        &self,
+        asset_source: AssetSource,
+        asset_cache: &AssetCache,
+    ) -> Option<Vector2I> {
+        let AssetState::Loaded { data } = asset_cache.load_asset::<ImageType>(asset_source) else {
+            return None;
+        };
+        data.image_size()
+    }
 }
 
 impl Entity for ImageCache {


### PR DESCRIPTION
## Description

This addresses some UX feedback from Erica:
1. Clicking too close to the image doesn't trigger the background scrim dismiss behavior.
2. When using a light theme, the buttons render oddly.

This fixes the feedback in the following ways:
1. Add opt-in support to `Image` to utilize the image size when doing layout, to ensure the bounding box for the element is tight to the actual rendered image bounds.
2. Define a custom button theme for lightbox buttons that is identical to the `Secondary` button theme when using the `Dark` application theme.

Fixes https://github.com/warpdotdev/warp/issues/11785.

### Screenshot

<img width="1390" height="912" alt="image" src="https://github.com/user-attachments/assets/ee5108b6-4dad-4c19-abf9-9cc19e71eff7" />

## Testing

- [x] Tested manually.