### PR TITLE
Fix working directories clean up

### DIFF
--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -78,6 +78,141 @@ impl DiffStateModelMap {
     }
 }
 
+/// Bidirectional map of pane groups to the repository roots they reference.
+///
+/// Maintains both a forward map (`pane_group_id -> ordered set of repo paths`)
+/// and a reverse map (`repo path -> set of pane group ids that reference it`)
+/// in lockstep, so callers can answer "is this repo still referenced by any
+/// pane group?" in O(1) without scanning every pane group's set.
+///
+/// All mutations go through methods on this wrapper to guarantee the two
+/// maps stay in sync.
+#[cfg(feature = "local_fs")]
+#[derive(Default)]
+struct PaneGroupRepositoryRoots {
+    /// Forward: per-pane-group ordered set of repository roots.
+    /// IndexSet maintains insertion order so most recently added repos appear later.
+    pane_group_to_paths: HashMap<EntityId, IndexSet<LocalOrRemotePath>>,
+    /// Reverse: which pane groups reference each repo path.
+    /// Maintained in lockstep with `pane_group_to_paths`.
+    path_to_pane_groups: HashMap<LocalOrRemotePath, HashSet<EntityId>>,
+}
+
+#[cfg(feature = "local_fs")]
+impl PaneGroupRepositoryRoots {
+    /// Read-only view of a pane group's repository roots, preserving the
+    /// existing `HashMap::get(&pane_group_id)` semantics.
+    fn get(&self, pane_group_id: EntityId) -> Option<&IndexSet<LocalOrRemotePath>> {
+        self.pane_group_to_paths.get(&pane_group_id)
+    }
+
+    /// Insert a single repo for a pane group. Returns `true` if it was newly
+    /// added to the pane group (matching `IndexSet::insert` semantics).
+    ///
+    /// Always keeps the reverse map in sync: if the path was newly added to
+    /// the pane group, the pane group is added to the path's reverse entry.
+    fn insert(&mut self, pane_group_id: EntityId, path: LocalOrRemotePath) -> bool {
+        let added = self
+            .pane_group_to_paths
+            .entry(pane_group_id)
+            .or_default()
+            .insert(path.clone());
+
+        if added {
+            self.path_to_pane_groups
+                .entry(path)
+                .or_default()
+                .insert(pane_group_id);
+        }
+
+        added
+    }
+
+    /// Set the full list of repository roots for a pane group,
+    /// preserving the insertion-order of the previous set.
+    ///
+    /// Returns the paths that left this pane group's set AND no longer have
+    /// any other pane group referencing them — i.e. the paths whose shared
+    /// `DiffStateModel` is now safe to drop. Any paths that were already referenced
+    /// by other pane groups are kept in their original order.
+    fn set_paths(
+        &mut self,
+        pane_group_id: EntityId,
+        new_paths: impl IntoIterator<Item = LocalOrRemotePath>,
+    ) -> Vec<LocalOrRemotePath> {
+        let new_paths: Vec<LocalOrRemotePath> = new_paths.into_iter().collect();
+        let new_set: HashSet<&LocalOrRemotePath> = new_paths.iter().collect();
+
+        // Update the forward map and capture which paths left this pane group
+        // (`removed`) and which were newly inserted into it (`newly_added`).
+        // Tracking `newly_added` separately lets us skip redundant reverse-map
+        // updates for paths the pane group already referenced.
+        let (removed, newly_added): (Vec<LocalOrRemotePath>, Vec<LocalOrRemotePath>) = {
+            let forward = self.pane_group_to_paths.entry(pane_group_id).or_default();
+            let removed: Vec<LocalOrRemotePath> = forward
+                .iter()
+                .filter(|item| !new_set.contains(*item))
+                .cloned()
+                .collect();
+            forward.retain(|item| new_set.contains(item));
+            let mut newly_added: Vec<LocalOrRemotePath> = Vec::new();
+            for item in &new_paths {
+                if forward.insert(item.clone()) {
+                    newly_added.push(item.clone());
+                }
+            }
+            (removed, newly_added)
+        };
+
+        // Add pane_group_id only for paths that are newly referenced by this
+        // pane group; paths it already referenced are already in the reverse
+        // entry by the invariant maintained on every mutation.
+        for path in newly_added {
+            self.path_to_pane_groups
+                .entry(path)
+                .or_default()
+                .insert(pane_group_id);
+        }
+
+        // Drop pane_group_id from the reverse map for paths it no longer
+        // references; collect the paths whose reverse entry became empty.
+        self.remove_pane_group_from_reverse(pane_group_id, removed)
+    }
+
+    /// Drop all entries for a pane group (used when a tab is closed or the
+    /// pane group becomes empty). Returns `Some(orphans)` when the pane group
+    /// had a `repository_roots` entry, where `orphans` are the paths that no
+    /// longer have any pane group referencing them. Returns `None` when the
+    /// pane group was not tracked, so callers can distinguish "present with
+    /// no orphans" from "not present" in a single call.
+    fn remove_pane_group(&mut self, pane_group_id: EntityId) -> Option<Vec<LocalOrRemotePath>> {
+        let paths = self.pane_group_to_paths.remove(&pane_group_id)?;
+        Some(self.remove_pane_group_from_reverse(pane_group_id, paths))
+    }
+
+    /// Helper: for each path in `paths`, remove `pane_group_id` from its
+    /// reverse-map entry. Returns the paths whose entry became empty (and
+    /// were removed from the reverse map entirely).
+    fn remove_pane_group_from_reverse(
+        &mut self,
+        pane_group_id: EntityId,
+        paths: impl IntoIterator<Item = LocalOrRemotePath>,
+    ) -> Vec<LocalOrRemotePath> {
+        let mut orphans = Vec::new();
+        for path in paths {
+            let became_empty = self.path_to_pane_groups.get_mut(&path).is_some_and(|set| {
+                set.remove(&pane_group_id);
+                set.is_empty()
+            });
+            if became_empty {
+                self.path_to_pane_groups.remove(&path);
+                orphans.push(path);
+            }
+        }
+        orphans
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkingDirectory {
     pub path: LocalOrRemotePath,
@@ -132,8 +267,7 @@ pub struct WorkingDirectoriesModel {
     pane_groups: HashMap<EntityId, IndexSet<LocalOrRemotePath>>,
     /// Per-pane-group tracking of active repository roots as a deduplicated, ordered set.
     /// Covers both local and remote repositories in a single map.
-    /// IndexSet maintains insertion order - most recently added repositories appear later.
-    repository_roots: HashMap<EntityId, IndexSet<LocalOrRemotePath>>,
+    repository_roots: PaneGroupRepositoryRoots,
     /// Per-pane-group mapping from root paths to a matching terminal view ID.
     /// This allows looking up which terminal is associated with each root path.
     /// Note, a single root path can be associated with multiple terminals.
@@ -212,7 +346,7 @@ impl WorkingDirectoriesModel {
         &self,
         pane_group_id: EntityId,
     ) -> Option<&IndexSet<LocalOrRemotePath>> {
-        self.repository_roots.get(&pane_group_id)
+        self.repository_roots.get(pane_group_id)
     }
 
     /// Get the unique repository roots for a specific pane group in most to least recently added order.
@@ -278,23 +412,15 @@ impl WorkingDirectoriesModel {
         Some(diff_state_model)
     }
 
-    /// DiffStateModels are shared across tabs. When you delete repos from one tab,
-    /// we should check if its still in use in any tab. If not, stop its watcher and delete it.
-    /// Drops diff state models and cached views for repos that are no longer
-    /// active in any pane group. Called from `refresh_working_directories`
-    /// when a repo leaves the computed set.
-    ///
-    /// The model is dropped unconditionally for the repos passed in — the
-    /// caller has already verified they are not in the new repo set. We do
-    /// NOT re-check `repository_roots` here because a racing side-channel
-    /// (e.g. `register_remote_repo`) may have re-added the repo, which
-    /// would prevent the stale model from being cleaned up.
+    /// Drops diff state models for repos that are no longer referenced by any
+    /// pane group. The input must already be pre-filtered to orphans, so this
+    /// method stops the watcher and removes stale model and view cache entries.
     fn drop_unused_diff_state_models(
         &mut self,
-        removed_repos: impl Iterator<Item = LocalOrRemotePath>,
+        orphaned_repos: impl IntoIterator<Item = LocalOrRemotePath>,
         ctx: &mut ModelContext<Self>,
     ) {
-        for repo_key in removed_repos {
+        for repo_key in orphaned_repos {
             if let Some(model) = self.diff_state_models.remove(&repo_key) {
                 model.update(ctx, |model, ctx| {
                     model.stop_active_watcher(ctx);
@@ -431,11 +557,11 @@ impl WorkingDirectoriesModel {
     fn handle_empty_pane_group(&mut self, pane_group_id: EntityId, ctx: &mut ModelContext<Self>) {
         let did_remove_dirs = self.pane_groups.remove(&pane_group_id).is_some();
         let did_remove_terminals = self.directory_to_terminal.remove(&pane_group_id).is_some();
-        let removed_repos = self.repository_roots.remove(&pane_group_id);
-        let did_remove_repos = removed_repos.is_some();
+        let orphaned_repos = self.repository_roots.remove_pane_group(pane_group_id);
+        let did_remove_repos = orphaned_repos.is_some();
 
-        if let Some(removed_repos) = removed_repos {
-            self.drop_unused_diff_state_models(removed_repos.into_iter(), ctx);
+        if let Some(orphaned_repos) = orphaned_repos {
+            self.drop_unused_diff_state_models(orphaned_repos, ctx);
         }
 
         if did_remove_dirs {
@@ -685,8 +811,9 @@ impl WorkingDirectoriesModel {
         });
         let _ = seen; // consumed by retain closure above
 
-        let pane_group_repos = self.repository_roots.entry(pane_group_id).or_default();
-        update_index_set(pane_group_repos, new_repo_roots_wrapped);
+        let orphaned_repos = self
+            .repository_roots
+            .set_paths(pane_group_id, new_repo_roots_wrapped);
 
         self.directory_to_terminal
             .insert(pane_group_id, new_root_to_terminal);
@@ -705,7 +832,7 @@ impl WorkingDirectoriesModel {
             .unwrap_or_default();
         let new_deduplicated_repos: Vec<LocalOrRemotePath> = self
             .repository_roots
-            .get(&pane_group_id)
+            .get(pane_group_id)
             .map(|repos| repos.iter().cloned().collect())
             .unwrap_or_default();
         if old_directories != new_directories {
@@ -713,12 +840,7 @@ impl WorkingDirectoriesModel {
         }
 
         if old_repos != new_deduplicated_repos {
-            self.drop_unused_diff_state_models(
-                old_repos
-                    .into_iter()
-                    .filter(|repo| !new_deduplicated_repos.contains(repo)),
-                ctx,
-            );
+            self.drop_unused_diff_state_models(orphaned_repos, ctx);
             self.emit_repositories_changed(pane_group_id, ctx);
         }
 
@@ -753,8 +875,7 @@ impl WorkingDirectoriesModel {
         repo_key: LocalOrRemotePath,
         ctx: &mut ModelContext<Self>,
     ) {
-        let repos = self.repository_roots.entry(pane_group_id).or_default();
-        if repos.insert(repo_key) {
+        if self.repository_roots.insert(pane_group_id, repo_key) {
             self.emit_repositories_changed(pane_group_id, ctx);
         }
     }

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -176,7 +176,10 @@ impl PaneGroupRepositoryRoots {
 
         // Drop pane_group_id from the reverse map for paths it no longer
         // references; collect the paths whose reverse entry became empty.
-        self.remove_pane_group_from_reverse(pane_group_id, removed)
+        removed
+            .into_iter()
+            .filter(|path| self.remove_path(pane_group_id, path))
+            .collect()
     }
 
     /// Drop all entries for a pane group (used when a tab is closed or the
@@ -187,29 +190,30 @@ impl PaneGroupRepositoryRoots {
     /// no orphans" from "not present" in a single call.
     fn remove_pane_group(&mut self, pane_group_id: EntityId) -> Option<Vec<LocalOrRemotePath>> {
         let paths = self.pane_group_to_paths.remove(&pane_group_id)?;
-        Some(self.remove_pane_group_from_reverse(pane_group_id, paths))
+        Some(
+            paths
+                .into_iter()
+                .filter(|path| self.remove_path(pane_group_id, path))
+                .collect(),
+        )
     }
 
-    /// Helper: for each path in `paths`, remove `pane_group_id` from its
-    /// reverse-map entry. Returns the paths whose entry became empty (and
-    /// were removed from the reverse map entirely).
-    fn remove_pane_group_from_reverse(
-        &mut self,
-        pane_group_id: EntityId,
-        paths: impl IntoIterator<Item = LocalOrRemotePath>,
-    ) -> Vec<LocalOrRemotePath> {
-        let mut orphans = Vec::new();
-        for path in paths {
-            let became_empty = self.path_to_pane_groups.get_mut(&path).is_some_and(|set| {
-                set.remove(&pane_group_id);
-                set.is_empty()
-            });
-            if became_empty {
-                self.path_to_pane_groups.remove(&path);
-                orphans.push(path);
-            }
+    /// Remove `pane_group_id` from the reverse-map entry for `path`.
+    /// Returns `true` if removing this reference left `path` with no pane groups
+    /// referencing it — i.e. the path is now globally orphaned.
+    ///
+    /// This only mutates the reverse map; callers are responsible for
+    /// removing `path` from `pane_group_id`'s forward entry before (or
+    /// after) calling this.
+    fn remove_path(&mut self, pane_group_id: EntityId, path: &LocalOrRemotePath) -> bool {
+        let became_empty = self.path_to_pane_groups.get_mut(path).is_some_and(|set| {
+            set.remove(&pane_group_id);
+            set.is_empty()
+        });
+        if became_empty {
+            self.path_to_pane_groups.remove(path);
         }
-        orphans
+        became_empty
     }
 }
 

--- a/app/src/pane_group/working_directories_tests.rs
+++ b/app/src/pane_group/working_directories_tests.rs
@@ -5,13 +5,19 @@ use std::fs;
 use std::path::PathBuf;
 
 use repo_metadata::repositories::DetectedRepositories;
+use repo_metadata::watcher::DirectoryWatcher;
 use warpui::{App, EntityId};
 
+use super::PaneGroupRepositoryRoots;
 use crate::code::buffer_location::LocalOrRemotePath;
 use crate::pane_group::WorkingDirectoriesModel;
 
 fn local(path: &std::path::Path) -> LocalOrRemotePath {
     LocalOrRemotePath::Local(path.to_path_buf())
+}
+
+fn local_str(path: &str) -> LocalOrRemotePath {
+    LocalOrRemotePath::Local(PathBuf::from(path))
 }
 
 #[test]
@@ -213,6 +219,348 @@ fn selected_review_repo_is_cleared_when_pane_group_is_removed() {
                 "removing a pane group must clear its saved review-panel selection"
             );
         });
+    });
+}
+
+// ── PaneGroupRepositoryRoots unit tests ──────────────────────────
+
+#[test]
+fn pane_group_repository_roots_insert_updates_both_maps() {
+    let mut roots = PaneGroupRepositoryRoots::default();
+    let pane_a = EntityId::new();
+    let path = local_str("/repos/x");
+
+    assert!(roots.insert(pane_a, path.clone()));
+    // Re-inserting the same (pane_group, path) is a no-op.
+    assert!(!roots.insert(pane_a, path.clone()));
+
+    let forward = roots.get(pane_a).expect("pane group registered");
+    assert!(forward.contains(&path), "forward map must contain the path");
+    assert_eq!(
+        roots.path_to_pane_groups.get(&path).cloned(),
+        Some(HashSet::from_iter([pane_a])),
+        "reverse map must reflect the inserted pane group"
+    );
+}
+
+#[test]
+fn pane_group_repository_roots_set_paths_returns_only_truly_orphaned_paths() {
+    let mut roots = PaneGroupRepositoryRoots::default();
+    let pane_a = EntityId::new();
+    let pane_b = EntityId::new();
+    let shared = local_str("/repos/shared");
+    let only_a = local_str("/repos/only-a");
+
+    // Both pane groups reference `shared`; only A references `only_a`.
+    let orphans_a = roots.set_paths(pane_a, vec![shared.clone(), only_a.clone()]);
+    assert!(orphans_a.is_empty(), "first insert never produces orphans");
+    let orphans_b = roots.set_paths(pane_b, vec![shared.clone()]);
+    assert!(orphans_b.is_empty());
+
+    // A drops both of its paths.
+    let orphans = roots.set_paths(pane_a, Vec::<LocalOrRemotePath>::new());
+
+    // `shared` is still referenced by B, so it must not be reported as orphaned.
+    // `only_a` was only referenced by A, so it must be.
+    assert_eq!(
+        orphans,
+        vec![only_a.clone()],
+        "shared paths must not appear in the orphan list"
+    );
+
+    // Reverse map: `shared` only references B; `only_a` is gone entirely.
+    assert_eq!(
+        roots.path_to_pane_groups.get(&shared).cloned(),
+        Some(HashSet::from_iter([pane_b])),
+    );
+    assert!(
+        !roots.path_to_pane_groups.contains_key(&only_a),
+        "orphaned path must be evicted from the reverse map"
+    );
+
+    // Forward map: A is now empty (entry retained), B still owns `shared`.
+    let a_forward = roots.get(pane_a).expect("pane group A entry retained");
+    assert!(a_forward.is_empty(), "A's forward set should be empty");
+    let b_forward = roots.get(pane_b).expect("pane group B entry retained");
+    assert!(b_forward.contains(&shared));
+}
+
+#[test]
+fn pane_group_repository_roots_set_paths_preserves_insertion_order() {
+    let mut roots = PaneGroupRepositoryRoots::default();
+    let pane = EntityId::new();
+    let x = local_str("/repos/x");
+    let y = local_str("/repos/y");
+    let z = local_str("/repos/z");
+
+    // Initial set in order x, y.
+    let _ = roots.set_paths(pane, vec![x.clone(), y.clone()]);
+
+    // Replace with y, z. y should keep its position; z is appended; x is removed.
+    let _ = roots.set_paths(pane, vec![y.clone(), z.clone()]);
+
+    let forward: Vec<LocalOrRemotePath> = roots
+        .get(pane)
+        .expect("pane group present")
+        .iter()
+        .cloned()
+        .collect();
+    assert_eq!(
+        forward,
+        vec![y, z],
+        "existing items must keep their order; new items appended after"
+    );
+}
+
+#[test]
+fn pane_group_repository_roots_remove_pane_group_returns_orphans() {
+    let mut roots = PaneGroupRepositoryRoots::default();
+    let pane_a = EntityId::new();
+    let pane_b = EntityId::new();
+    let shared = local_str("/repos/shared");
+    let only_a = local_str("/repos/only-a");
+
+    let _ = roots.set_paths(pane_a, vec![shared.clone(), only_a.clone()]);
+    let _ = roots.set_paths(pane_b, vec![shared.clone()]);
+
+    // Removing A while B still references `shared` only orphans `only_a`.
+    let orphans: HashSet<LocalOrRemotePath> = roots
+        .remove_pane_group(pane_a)
+        .expect("pane group A was present")
+        .into_iter()
+        .collect();
+    assert_eq!(orphans, HashSet::from_iter([only_a.clone()]));
+    assert!(roots.get(pane_a).is_none(), "pane group A entry is gone");
+
+    // Removing B now orphans `shared`.
+    let orphans = roots
+        .remove_pane_group(pane_b)
+        .expect("pane group B was present");
+    assert_eq!(orphans, vec![shared.clone()]);
+    assert!(roots.path_to_pane_groups.is_empty());
+    assert!(roots.pane_group_to_paths.is_empty());
+}
+
+#[test]
+fn pane_group_repository_roots_remove_unknown_pane_group_is_noop() {
+    let mut roots = PaneGroupRepositoryRoots::default();
+    let missing = EntityId::new();
+    assert!(roots.remove_pane_group(missing).is_none());
+}
+
+// ── End-to-end cleanup behavior tests ────────────────────────────
+
+/// Helper for end-to-end cleanup tests: registers the singletons required by
+/// `DiffStateModel::new_local` (the `DirectoryWatcher`), prepares a temp dir,
+/// seeds it as a detected repo root, and returns the canonical repo path along
+/// with a fresh `WorkingDirectoriesModel` handle.
+fn setup_repo(
+    app: &mut warpui::App,
+    detected_repos: &warpui::ModelHandle<DetectedRepositories>,
+) -> (
+    tempfile::TempDir,
+    PathBuf,
+    PathBuf,
+    warpui::ModelHandle<WorkingDirectoriesModel>,
+) {
+    app.add_singleton_model(DirectoryWatcher::new_for_testing);
+
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+    let repo_path = temp_dir.path().join("repo");
+    fs::create_dir_all(&repo_path).expect("create repo dir");
+    let canonical_repo = dunce::canonicalize(&repo_path).expect("canonical repo");
+
+    detected_repos.update(app, |repos, _ctx| {
+        let canonical = warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+            canonical_repo.as_path(),
+        )
+        .expect("canonicalized path");
+        repos.insert_test_repo_root(canonical);
+    });
+
+    let working_directories_handle = app.add_model(|_| WorkingDirectoriesModel::new());
+    (
+        temp_dir,
+        repo_path,
+        canonical_repo,
+        working_directories_handle,
+    )
+}
+
+/// Regression: closing pane group A while pane group B still references the
+/// same repo must NOT drop the shared `DiffStateModel`. Before the fix,
+/// `drop_unused_diff_state_models` removed the cache entry unconditionally for
+/// any repo that left A's set, even when B still relied on it.
+#[test]
+fn shared_diff_state_model_survives_when_other_pane_group_still_references_repo() {
+    App::test((), |mut app| async move {
+        let detected_repos = app.add_singleton_model(|_| DetectedRepositories::default());
+
+        let pane_group_a = EntityId::new();
+        let pane_group_b = EntityId::new();
+        let terminal_a = EntityId::new();
+        let terminal_b = EntityId::new();
+
+        let (_temp_dir, repo_path, canonical_repo, working_directories_handle) =
+            setup_repo(&mut app, &detected_repos);
+
+        // Both pane groups land in the same repo.
+        working_directories_handle.update(&mut app, |model, ctx| {
+            model.refresh_working_directories_for_pane_group(
+                pane_group_a,
+                vec![(terminal_a, LocalOrRemotePath::Local(repo_path.clone()))],
+                vec![],
+                Some(terminal_a),
+                ctx,
+            );
+            model.refresh_working_directories_for_pane_group(
+                pane_group_b,
+                vec![(terminal_b, LocalOrRemotePath::Local(repo_path.clone()))],
+                vec![],
+                Some(terminal_b),
+                ctx,
+            );
+        });
+
+        // Open the shared diff state model.
+        let initial_id = working_directories_handle.update(&mut app, |model, ctx| {
+            model
+                .get_or_create_diff_state_model(local(&canonical_repo), ctx)
+                .expect("local diff state model must be created")
+                .id()
+        });
+
+        // Pane group A's terminals go away (close the tab path).
+        working_directories_handle.update(&mut app, |model, ctx| {
+            model.refresh_working_directories_for_pane_group(
+                pane_group_a,
+                vec![],
+                vec![],
+                None,
+                ctx,
+            );
+        });
+
+        // Re-fetching should return the SAME cached model (no re-creation).
+        let after_id = working_directories_handle.update(&mut app, |model, ctx| {
+            model
+                .get_or_create_diff_state_model(local(&canonical_repo), ctx)
+                .expect("local diff state model must still be present")
+                .id()
+        });
+
+        assert_eq!(
+            initial_id, after_id,
+            "shared DiffStateModel must survive when another pane group still references the repo"
+        );
+    });
+}
+
+/// When the last pane group referencing a repo navigates away, the shared
+/// `DiffStateModel` is dropped from the cache, so a subsequent
+/// `get_or_create_diff_state_model` creates a fresh model.
+#[test]
+fn diff_state_model_is_dropped_when_no_pane_group_references_repo() {
+    App::test((), |mut app| async move {
+        let detected_repos = app.add_singleton_model(|_| DetectedRepositories::default());
+
+        let pane_group = EntityId::new();
+        let terminal = EntityId::new();
+
+        let (_temp_dir, repo_path, canonical_repo, working_directories_handle) =
+            setup_repo(&mut app, &detected_repos);
+
+        working_directories_handle.update(&mut app, |model, ctx| {
+            model.refresh_working_directories_for_pane_group(
+                pane_group,
+                vec![(terminal, LocalOrRemotePath::Local(repo_path.clone()))],
+                vec![],
+                Some(terminal),
+                ctx,
+            );
+        });
+
+        let initial_id = working_directories_handle.update(&mut app, |model, ctx| {
+            model
+                .get_or_create_diff_state_model(local(&canonical_repo), ctx)
+                .expect("local diff state model must be created")
+                .id()
+        });
+
+        // Only pane group leaves the repo → model is orphaned and dropped.
+        working_directories_handle.update(&mut app, |model, ctx| {
+            model.refresh_working_directories_for_pane_group(pane_group, vec![], vec![], None, ctx);
+        });
+
+        let after_id = working_directories_handle.update(&mut app, |model, ctx| {
+            model
+                .get_or_create_diff_state_model(local(&canonical_repo), ctx)
+                .expect("local diff state model must be re-created")
+                .id()
+        });
+
+        assert_ne!(
+            initial_id, after_id,
+            "DiffStateModel should be dropped and re-created when no pane group references the repo"
+        );
+    });
+}
+
+/// `remove_pane_group` (explicit tab teardown) must respect the same refcount
+/// semantics: pane group B's shared `DiffStateModel` survives when A is closed.
+#[test]
+fn remove_pane_group_does_not_drop_diff_state_model_shared_with_other_pane_group() {
+    App::test((), |mut app| async move {
+        let detected_repos = app.add_singleton_model(|_| DetectedRepositories::default());
+
+        let pane_group_a = EntityId::new();
+        let pane_group_b = EntityId::new();
+        let terminal_a = EntityId::new();
+        let terminal_b = EntityId::new();
+
+        let (_temp_dir, repo_path, canonical_repo, working_directories_handle) =
+            setup_repo(&mut app, &detected_repos);
+
+        working_directories_handle.update(&mut app, |model, ctx| {
+            model.refresh_working_directories_for_pane_group(
+                pane_group_a,
+                vec![(terminal_a, LocalOrRemotePath::Local(repo_path.clone()))],
+                vec![],
+                Some(terminal_a),
+                ctx,
+            );
+            model.refresh_working_directories_for_pane_group(
+                pane_group_b,
+                vec![(terminal_b, LocalOrRemotePath::Local(repo_path.clone()))],
+                vec![],
+                Some(terminal_b),
+                ctx,
+            );
+        });
+
+        let initial_id = working_directories_handle.update(&mut app, |model, ctx| {
+            model
+                .get_or_create_diff_state_model(local(&canonical_repo), ctx)
+                .expect("local diff state model must be created")
+                .id()
+        });
+
+        // Tear down pane group A.
+        working_directories_handle.update(&mut app, |model, ctx| {
+            model.remove_pane_group(pane_group_a, ctx);
+        });
+
+        let after_id = working_directories_handle.update(&mut app, |model, ctx| {
+            model
+                .get_or_create_diff_state_model(local(&canonical_repo), ctx)
+                .expect("local diff state model must still be present")
+                .id()
+        });
+
+        assert_eq!(
+            initial_id, after_id,
+            "removing pane group A must not drop a model that pane group B still references"
+        );
     });
 }
 


### PR DESCRIPTION
## Description
* Context: https://warpdev.slack.com/archives/C08KTPNQN65/p1779918765473719 
* We were dropping diffstatemodels on pane close despite other pane groups still relying on the model 
* The fix introduces a reverse map to keep track of all pane groups that reference a repo path - this helps ensure that on pane group close, we don't drop the diffstatemodel unless that was the only pane group referencing it 

## Testing
Repro steps: 
1. Open code review view in a repo in one tab
2. Open another code review view in the same repo in another tab
3. Close the first tab 
4. See that the code review view gets in a broken state (this repros on both local and remote sessions)
  
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
https://www.loom.com/share/893359883e684175a71f70170c46523b

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode