### PR TITLE
Remove session id from `RemoteDiffStateModel`

### DIFF
--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -358,9 +358,8 @@ impl DiffStateModel {
     /// session-agnostic and is keyed by `(host_id, repo, mode)`; the
     /// `RemoteServerManager` resolves a connected session for the host at
     /// every outbound RPC, so the wrapper does not need to thread a
-    /// `SessionId` through. If no session for the host is currently
-    /// connected, the underlying `RemoteDiffStateModel` starts in
-    /// `Disconnected` and self-heals once a session becomes available.
+    /// `SessionId` through. Callers must ensure a session for the host is
+    /// connected before constructing.
     pub fn new_remote(remote_path: RemotePath, ctx: &mut ModelContext<Self>) -> Self {
         let remote =
             ctx.add_model(|ctx| RemoteDiffStateModel::new(remote_path, DiffMode::default(), ctx));

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use warp_core::SessionId;
 use warp_util::remote_path::RemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::{AppContext, ModelContext, ModelHandle};
@@ -355,16 +354,16 @@ impl DiffStateModel {
         Self::Local(local)
     }
 
-    /// Creates a new remote-backed `DiffStateModel`. Requires a connected
-    /// `session_id` to anchor the initial `GetDiffState` subscription.
-    pub fn new_remote(
-        remote_path: RemotePath,
-        session_id: SessionId,
-        ctx: &mut ModelContext<Self>,
-    ) -> Self {
-        let remote = ctx.add_model(|ctx| {
-            RemoteDiffStateModel::new(remote_path, DiffMode::default(), session_id, ctx)
-        });
+    /// Creates a new remote-backed `DiffStateModel`. The model is
+    /// session-agnostic and is keyed by `(host_id, repo, mode)`; the
+    /// `RemoteServerManager` resolves a connected session for the host at
+    /// every outbound RPC, so the wrapper does not need to thread a
+    /// `SessionId` through. If no session for the host is currently
+    /// connected, the underlying `RemoteDiffStateModel` starts in
+    /// `Disconnected` and self-heals once a session becomes available.
+    pub fn new_remote(remote_path: RemotePath, ctx: &mut ModelContext<Self>) -> Self {
+        let remote =
+            ctx.add_model(|ctx| RemoteDiffStateModel::new(remote_path, DiffMode::default(), ctx));
         ctx.subscribe_to_model(&remote, Self::forward_event);
         Self::Remote(remote)
     }

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use instant::Instant;
 use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
-use warp_core::{send_telemetry_from_ctx, HostId, SessionId};
+use warp_core::{send_telemetry_from_ctx, HostId};
 use warp_util::remote_path::RemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::{ModelContext, SingletonEntity};
@@ -47,8 +47,6 @@ pub struct RemoteDiffStateModel {
     mode: DiffMode,
     state: InternalRemoteDiffState,
     metadata: Option<DiffMetadata>,
-    /// The session through which the current server-side subscription was established.
-    session_id: SessionId,
     /// Start time for the latest caller-tracked full diff snapshot request.
     tracked_diff_load_start_time: Option<Instant>,
 }
@@ -58,36 +56,44 @@ impl warpui::Entity for RemoteDiffStateModel {
 }
 
 impl RemoteDiffStateModel {
-    /// Creates a new remote diff state model and initiates the `GetDiffState`
-    /// request. The model starts in `Loading` state.
-    pub fn new(
-        remote_path: RemotePath,
-        mode: DiffMode,
-        session_id: SessionId,
-        ctx: &mut ModelContext<Self>,
-    ) -> Self {
+    /// Creates a new remote diff state model.
+    ///
+    /// Identity is `(host_id, repo_path, mode)`. The model is session-agnostic:
+    /// the manager picks a connected session for the host at every outbound
+    /// RPC, and host-level connect/disconnect events drive subscription
+    /// lifecycle. If no session for the host is currently connected the
+    /// model starts in `Disconnected` and self-heals once a session becomes
+    /// available; otherwise it starts in `Loading` and issues the initial
+    /// `GetDiffState` request.
+    pub fn new(remote_path: RemotePath, mode: DiffMode, ctx: &mut ModelContext<Self>) -> Self {
         // Subscribe to RemoteServerManager push events and filter by remote_path and diff_mode
         let mgr_handle = RemoteServerManager::handle(ctx);
         ctx.subscribe_to_model(&mgr_handle, Self::handle_manager_event);
 
-        // Send the initial GetDiffState request through the provided session.
-        let remote_path_clone = remote_path.clone();
-        let mode_clone = mode.clone();
-        mgr_handle.update(ctx, |mgr, ctx| {
-            mgr.get_diff_state(
-                session_id,
-                remote_path_clone,
-                proto::DiffMode::from(&mode_clone),
-                ctx,
-            );
-        });
+        // Decide initial state based on whether a session for this host is
+        // already connected. If so, kick off the GetDiffState request now;
+        // otherwise wait for HostConnected to arrive.
+        let host_connected = mgr_handle
+            .as_ref(ctx)
+            .client_for_host(&remote_path.host_id)
+            .is_some();
+        let state = if host_connected {
+            let host_id = remote_path.host_id.clone();
+            let repo_path = remote_path.path.clone();
+            let mode_clone = mode.clone();
+            mgr_handle.update(ctx, |mgr, ctx| {
+                mgr.get_diff_state(host_id, repo_path, proto::DiffMode::from(&mode_clone), ctx);
+            });
+            InternalRemoteDiffState::Loading
+        } else {
+            InternalRemoteDiffState::Disconnected
+        };
 
         Self {
             remote_path,
             mode,
-            state: InternalRemoteDiffState::Loading,
+            state,
             metadata: None,
-            session_id,
             tracked_diff_load_start_time: None,
         }
     }
@@ -168,18 +174,10 @@ impl RemoteDiffStateModel {
             {
                 self.mark_disconnected(ctx);
             }
-            RemoteServerManagerEvent::SessionDisconnected {
-                session_id,
-                host_id,
-                ..
-            } if *session_id == self.session_id && host_id == &self.remote_path.host_id => {
-                self.mark_disconnected(ctx);
-            }
-            RemoteServerManagerEvent::SessionReconnected {
-                session_id,
-                host_id,
-                ..
-            } if *session_id == self.session_id && host_id == &self.remote_path.host_id => {
+            RemoteServerManagerEvent::HostConnected { host_id }
+                if host_id == &self.remote_path.host_id
+                    && matches!(self.state, InternalRemoteDiffState::Disconnected) =>
+            {
                 self.resubscribe(false, ctx);
             }
             _ => {}
@@ -197,17 +195,18 @@ impl RemoteDiffStateModel {
         ctx.emit(DiffStateModelEvent::ConnectionLost);
     }
 
-    /// Re-sends `GetDiffState` through the model's existing `session_id`
-    /// and transitions to `Loading` while waiting for a fresh snapshot.
+    /// Re-sends `GetDiffState` for this model's `(host_id, repo, mode)` and
+    /// transitions to `Loading` while waiting for a fresh snapshot. The
+    /// manager chooses a connected session for the host at dispatch time.
     fn resubscribe(&mut self, track_load_duration: bool, ctx: &mut ModelContext<Self>) {
         // Always overwrite to avoid carrying a stale `Instant` from a prior
         // tracked load that was interrupted by a session blip.
         self.tracked_diff_load_start_time = track_load_duration.then(Instant::now);
-        let remote_path = self.remote_path.clone();
+        let host_id = self.remote_path.host_id.clone();
+        let repo_path = self.remote_path.path.clone();
         let mode = self.mode.clone();
-        let session_id = self.session_id;
         RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
-            mgr.get_diff_state(session_id, remote_path, proto::DiffMode::from(&mode), ctx);
+            mgr.get_diff_state(host_id, repo_path, proto::DiffMode::from(&mode), ctx);
         });
         self.state = InternalRemoteDiffState::Loading;
         ctx.emit(DiffStateModelEvent::NewDiffsComputed {
@@ -294,11 +293,11 @@ impl RemoteDiffStateModel {
         if track_load_duration {
             self.tracked_diff_load_start_time = Some(Instant::now());
         }
-        let remote_path = self.remote_path.clone();
+        let host_id = self.remote_path.host_id.clone();
+        let repo_path = self.remote_path.path.clone();
         let mode = self.mode.clone();
-        let session_id = self.session_id;
         RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
-            mgr.get_diff_state(session_id, remote_path, proto::DiffMode::from(&mode), ctx);
+            mgr.get_diff_state(host_id, repo_path, proto::DiffMode::from(&mode), ctx);
         });
     }
 
@@ -447,21 +446,18 @@ impl RemoteDiffStateModel {
 
     /// Sends `UnsubscribeDiffState` to the server. Call before dropping the
     /// model (the wrapper calls it during mode switch / pane close).
+    ///
+    /// The manager handles the "no connected client" case internally; the
+    /// server-side subscription is also cleaned up automatically when the
+    /// underlying connection drops, so this is a best-effort notification.
     pub fn unsubscribe(&self, ctx: &mut ModelContext<Self>) {
-        let mgr_handle = RemoteServerManager::handle(ctx);
-        let mgr = mgr_handle.as_ref(ctx);
-        if mgr.client_for_session(self.session_id).is_none() {
-            log::debug!(
-                "RemoteDiffStateModel::unsubscribe: subscription session is no longer connected: session={:?}",
-                self.session_id,
+        RemoteServerManager::handle(ctx)
+            .as_ref(ctx)
+            .unsubscribe_diff_state(
+                self.remote_path.host_id.clone(),
+                &self.remote_path.path,
+                proto::DiffMode::from(&self.mode),
             );
-            return;
-        }
-        mgr.unsubscribe_diff_state(
-            self.session_id,
-            &self.remote_path,
-            proto::DiffMode::from(&self.mode),
-        );
     }
 
     // ── Read API (matching LocalDiffStateModel interface) ────────────
@@ -538,13 +534,6 @@ impl RemoteDiffStateModel {
         self.remote_path.clone()
     }
 
-    /// Returns the session this model's subscription is anchored to. Set
-    /// once at construction and never changed by the model itself — see
-    /// the `session_id` field doc for the lifecycle contract.
-    pub fn session_id(&self) -> SessionId {
-        self.session_id
-    }
-
     // ── Write API ────────────────────────────────────────────────────
 
     pub fn set_diff_mode(
@@ -558,7 +547,8 @@ impl RemoteDiffStateModel {
         }
 
         // Unsubscribe from the old mode before switching, then re-send
-        // GetDiffState for the new mode through the same session.
+        // GetDiffState for the new mode. The manager resolves a connected
+        // session for the host at dispatch time.
         self.unsubscribe(ctx);
         self.mode = mode;
         self.resubscribe(track_load_duration, ctx);
@@ -568,10 +558,10 @@ impl RemoteDiffStateModel {
     /// The response is handled in `handle_manager_event` which emits
     /// `DiffStateModelEvent::BranchesReceived`.
     pub fn fetch_branches(&self, ctx: &mut ModelContext<Self>) {
-        let session_id = self.session_id;
-        let remote_path = self.remote_path.clone();
+        let host_id = self.remote_path.host_id.clone();
+        let repo_path = self.remote_path.path.clone();
         RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
-            mgr.get_branches(session_id, remote_path, None, false, ctx);
+            mgr.get_branches(host_id, repo_path, None, false, ctx);
         });
     }
 
@@ -584,14 +574,14 @@ impl RemoteDiffStateModel {
         branch_name: Option<String>,
         ctx: &mut ModelContext<Self>,
     ) {
-        let session_id = self.session_id;
-        let remote_path = self.remote_path.clone();
+        let host_id = self.remote_path.host_id.clone();
+        let repo_path = self.remote_path.path.clone();
         let mode = self.mode.clone();
         let proto_files = file_infos.iter().map(proto::FileStatusInfo::from).collect();
         RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
             mgr.discard_files(
-                session_id,
-                remote_path,
+                host_id,
+                repo_path,
                 proto_files,
                 should_stash,
                 branch_name,

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -61,38 +61,27 @@ impl RemoteDiffStateModel {
     /// Identity is `(host_id, repo_path, mode)`. The model is session-agnostic:
     /// the manager picks a connected session for the host at every outbound
     /// RPC, and host-level connect/disconnect events drive subscription
-    /// lifecycle. If no session for the host is currently connected the
-    /// model starts in `Disconnected` and self-heals once a session becomes
-    /// available; otherwise it starts in `Loading` and issues the initial
-    /// `GetDiffState` request.
+    /// lifecycle.
+    ///
+    /// A session for this host is required at construction time. The model starts in `Loading` and
+    /// issues the initial `GetDiffState` request. Runtime disconnects transition the model through
+    /// `mark_disconnected`; subsequent reconnects re-subscribe via the `HostConnected` event handler.
     pub fn new(remote_path: RemotePath, mode: DiffMode, ctx: &mut ModelContext<Self>) -> Self {
         // Subscribe to RemoteServerManager push events and filter by remote_path and diff_mode
         let mgr_handle = RemoteServerManager::handle(ctx);
         ctx.subscribe_to_model(&mgr_handle, Self::handle_manager_event);
 
-        // Decide initial state based on whether a session for this host is
-        // already connected. If so, kick off the GetDiffState request now;
-        // otherwise wait for HostConnected to arrive.
-        let host_connected = mgr_handle
-            .as_ref(ctx)
-            .client_for_host(&remote_path.host_id)
-            .is_some();
-        let state = if host_connected {
-            let host_id = remote_path.host_id.clone();
-            let repo_path = remote_path.path.clone();
-            let mode_clone = mode.clone();
-            mgr_handle.update(ctx, |mgr, ctx| {
-                mgr.get_diff_state(host_id, repo_path, proto::DiffMode::from(&mode_clone), ctx);
-            });
-            InternalRemoteDiffState::Loading
-        } else {
-            InternalRemoteDiffState::Disconnected
-        };
+        let host_id = remote_path.host_id.clone();
+        let repo_path = remote_path.path.clone();
+        let mode_clone = mode.clone();
+        mgr_handle.update(ctx, |mgr, ctx| {
+            mgr.get_diff_state(host_id, repo_path, proto::DiffMode::from(&mode_clone), ctx);
+        });
 
         Self {
             remote_path,
             mode,
-            state,
+            state: InternalRemoteDiffState::Loading,
             metadata: None,
             tracked_diff_load_start_time: None,
         }
@@ -446,10 +435,6 @@ impl RemoteDiffStateModel {
 
     /// Sends `UnsubscribeDiffState` to the server. Call before dropping the
     /// model (the wrapper calls it during mode switch / pane close).
-    ///
-    /// The manager handles the "no connected client" case internally; the
-    /// server-side subscription is also cleaned up automatically when the
-    /// underlying connection drops, so this is a best-effort notification.
     pub fn unsubscribe(&self, ctx: &mut ModelContext<Self>) {
         RemoteServerManager::handle(ctx)
             .as_ref(ctx)

--- a/app/src/code_review/diff_state/remote_tests.rs
+++ b/app/src/code_review/diff_state/remote_tests.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use warp_core::SessionId;
+use remote_server::manager::RemoteServerManagerEvent;
 use warp_util::remote_path::RemotePath;
 
 use super::InternalRemoteDiffState;
@@ -27,7 +27,6 @@ impl RemoteDiffStateModel {
                     .expect("test repo path should be valid and absolute"),
             ),
             mode,
-            session_id: SessionId::default(),
             state,
             metadata,
             tracked_diff_load_start_time: None,
@@ -773,4 +772,93 @@ fn empty_branch_names_become_none() {
     );
     assert_eq!(m.get_main_branch_name(), None);
     assert_eq!(m.get_current_branch_name(), None);
+}
+
+#[test]
+fn host_disconnected_for_matching_host_transitions_to_disconnected() {
+    warpui::App::test((), |mut app| async move {
+        let handle = app.add_model(|_ctx| {
+            RemoteDiffStateModel::new_for_test(
+                DiffMode::Head,
+                InternalRemoteDiffState::Loading,
+                None,
+            )
+        });
+        let connection_lost_count = Arc::new(Mutex::new(0));
+        {
+            let connection_lost_count = connection_lost_count.clone();
+            app.update(|ctx| {
+                ctx.subscribe_to_model(&handle, move |_, event, _| {
+                    if matches!(event, DiffStateModelEvent::ConnectionLost) {
+                        *connection_lost_count
+                            .lock()
+                            .expect("connection lost count mutex should not be poisoned") += 1;
+                    }
+                });
+            });
+        }
+
+        let event = RemoteServerManagerEvent::HostDisconnected {
+            host_id: remote_server::HostId::new("test-host".to_string()),
+        };
+        handle.update(&mut app, |m, ctx| m.handle_manager_event(&event, ctx));
+
+        handle.read(&app, |m, _| {
+            assert!(matches!(m.get(), DiffState::Disconnected));
+        });
+        assert_eq!(
+            *connection_lost_count
+                .lock()
+                .expect("connection lost count mutex should not be poisoned"),
+            1
+        );
+    });
+}
+
+#[test]
+fn host_disconnected_for_other_host_is_ignored() {
+    warpui::App::test((), |mut app| async move {
+        let handle = app.add_model(|_ctx| {
+            RemoteDiffStateModel::new_for_test(
+                DiffMode::Head,
+                InternalRemoteDiffState::Loading,
+                None,
+            )
+        });
+        let event = RemoteServerManagerEvent::HostDisconnected {
+            host_id: remote_server::HostId::new("other-host".to_string()),
+        };
+        handle.update(&mut app, |m, ctx| m.handle_manager_event(&event, ctx));
+
+        handle.read(&app, |m, _| {
+            assert!(matches!(m.get(), DiffState::Loading));
+        });
+    });
+}
+
+#[test]
+fn session_disconnected_is_ignored_by_session_agnostic_model() {
+    // Per-session lifecycle events are no longer the model's concern; the
+    // manager picks a connected client at RPC dispatch time and only
+    // host-level connect/disconnect drive state transitions.
+    warpui::App::test((), |mut app| async move {
+        let handle = app.add_model(|_ctx| {
+            RemoteDiffStateModel::new_for_test(
+                DiffMode::Head,
+                InternalRemoteDiffState::Loading,
+                None,
+            )
+        });
+        let event = RemoteServerManagerEvent::SessionDisconnected {
+            session_id: warp_core::SessionId::default(),
+            host_id: remote_server::HostId::new("test-host".to_string()),
+            exit_status: None,
+            was_reconnect_attempt: false,
+        };
+        handle.update(&mut app, |m, ctx| m.handle_manager_event(&event, ctx));
+
+        handle.read(&app, |m, _| {
+            assert!(matches!(m.get(), DiffState::Loading));
+        });
+    });
 }

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -9,8 +9,6 @@ use std::path::PathBuf;
 #[cfg(feature = "local_fs")]
 use indexmap::IndexSet;
 #[cfg(feature = "local_fs")]
-use remote_server::manager::RemoteServerManager;
-#[cfg(feature = "local_fs")]
 use repo_metadata::repositories::DetectedRepositories;
 #[cfg(feature = "local_fs")]
 use warp_util::remote_path::RemotePath;
@@ -375,9 +373,10 @@ impl WorkingDirectoriesModel {
 
     /// Get or create a DiffStateModel for a specific repository.
     ///
-    /// If the model doesn't exist, it will be created.
-    /// For remote file locations we require a connected session for the host.
-    /// If none exists, returns `None` and callers should retry once a session is established.
+    /// If the model doesn't exist, it will be created. For remote
+    /// repositories the model is created unconditionally; it starts in
+    /// `Disconnected` when no session for the host is connected yet and
+    /// self-heals once one becomes available via `HostConnected`.
     pub fn get_or_create_diff_state_model(
         &mut self,
         key: LocalOrRemotePath,
@@ -393,12 +392,8 @@ impl WorkingDirectoriesModel {
                 ctx.add_model(|ctx| DiffStateModel::new_local(path, ctx))
             }
             LocalOrRemotePath::Remote(remote_path) => {
-                let mgr_handle = RemoteServerManager::handle(ctx);
-                let session_id = mgr_handle
-                    .as_ref(ctx)
-                    .find_connected_session(&remote_path.host_id)?;
                 let remote_path = remote_path.clone();
-                ctx.add_model(|ctx| DiffStateModel::new_remote(remote_path, session_id, ctx))
+                ctx.add_model(|ctx| DiffStateModel::new_remote(remote_path, ctx))
             }
         };
 

--- a/app/src/pane_group/working_directories.rs
+++ b/app/src/pane_group/working_directories.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 #[cfg(feature = "local_fs")]
 use indexmap::IndexSet;
 #[cfg(feature = "local_fs")]
+use remote_server::manager::RemoteServerManager;
+#[cfg(feature = "local_fs")]
 use repo_metadata::repositories::DetectedRepositories;
 #[cfg(feature = "local_fs")]
 use warp_util::remote_path::RemotePath;
@@ -374,9 +376,9 @@ impl WorkingDirectoriesModel {
     /// Get or create a DiffStateModel for a specific repository.
     ///
     /// If the model doesn't exist, it will be created. For remote
-    /// repositories the model is created unconditionally; it starts in
-    /// `Disconnected` when no session for the host is connected yet and
-    /// self-heals once one becomes available via `HostConnected`.
+    /// repositories we require a connected session for the host; returns
+    /// `None` when none exists so callers treat the panel as unavailable
+    /// for that repo rather than producing a model that cannot subscribe.
     pub fn get_or_create_diff_state_model(
         &mut self,
         key: LocalOrRemotePath,
@@ -392,6 +394,10 @@ impl WorkingDirectoriesModel {
                 ctx.add_model(|ctx| DiffStateModel::new_local(path, ctx))
             }
             LocalOrRemotePath::Remote(remote_path) => {
+                let mgr_handle = RemoteServerManager::handle(ctx);
+                mgr_handle
+                    .as_ref(ctx)
+                    .client_for_host(&remote_path.host_id)?;
                 let remote_path = remote_path.clone();
                 ctx.add_model(|ctx| DiffStateModel::new_remote(remote_path, ctx))
             }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4626,6 +4626,17 @@ impl TerminalView {
                         DetectedRepositories::handle(ctx).update(ctx, |repos, _| {
                             repos.remove_roots_for_host(host_id);
                         });
+
+                        // Drop and broadcast the stale remote repo so downstream consumers
+                        // stop acting on a host with no live client.
+                        let matches_host = matches!(
+                            me.current_repo_path.as_ref(),
+                            Some(LocalOrRemotePath::Remote(rp)) if &rp.host_id == host_id,
+                        );
+                        if matches_host {
+                            me.current_repo_path = None;
+                            ctx.emit(Event::Pane(PaneEvent::RepoChanged));
+                        }
                     }
                     RemoteServerManagerEvent::SessionConnecting { .. }
                     | RemoteServerManagerEvent::HostConnected { .. }

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -1807,25 +1807,29 @@ impl RemoteServerManager {
     }
 
     /// Sends a `GetDiffState` request to the remote server for the given
-    /// session and emits the snapshot response as a manager event.
+    /// host and emits the snapshot response as a manager event.
+    ///
+    /// When no session is currently connected for the host the request is
+    /// silently dropped (logged) — the caller is a session-agnostic model
+    /// whose state machine self-heals on `HostConnected`, so emitting a
+    /// synthetic error here would clobber its `Disconnected` state and
+    /// defeat the recovery path. Callers will re-issue the request once
+    /// a session to the host is established.
     pub fn get_diff_state(
         &mut self,
-        session_id: SessionId,
-        remote_path: RemotePath,
+        host_id: HostId,
+        repo_path: StandardizedPath,
         mode: DiffMode,
         ctx: &mut ModelContext<Self>,
     ) {
-        let Some(client) = self.client_for_session(session_id).cloned() else {
-            log::warn!("Remote server get_diff_state: no connected client session={session_id:?}");
+        let Some(client) = self.client_for_host(&host_id).cloned() else {
+            log::warn!("Remote server get_diff_state: no connected client host={host_id}");
             return;
         };
 
-        let RemotePath {
-            host_id,
-            path: repo_path,
-        } = remote_path;
         let mode_for_event = mode.clone();
         let repo_path_for_event = repo_path.clone();
+        let host_id_for_event = host_id.clone();
         let spawner = self.spawner.clone();
         ctx.background_executor()
             .spawn(async move {
@@ -1837,7 +1841,7 @@ impl RemoteServerManager {
                         let _ = spawner
                             .spawn(move |_me, ctx| {
                                 ctx.emit(RemoteServerManagerEvent::DiffStateSnapshotReceived {
-                                    host_id,
+                                    host_id: host_id_for_event,
                                     repo_path: repo_path_for_event,
                                     mode: mode_for_event,
                                     snapshot,
@@ -1865,26 +1869,20 @@ impl RemoteServerManager {
                                 // by send_request via RequestFailedEvent.
                                 log::warn!(
                                     "Remote server get_diff_state failed: \
-                                     session={session_id:?} error={e}"
+                                     host={host_id_for_event} error={e}"
                                 );
                                 e.to_string()
                             }
                         };
-                        let error_snapshot = DiffStateSnapshot {
-                            repo_path: repo_path_for_event.to_string(),
-                            mode: Some(mode_for_event.clone()),
-                            metadata: None,
-                            state: Some(DiffState {
-                                state: Some(diff_state::State::Error(DiffStateErrorValue {
-                                    message: error_message,
-                                })),
-                            }),
-                            diffs: None,
-                        };
+                        let error_snapshot = Self::make_diff_state_error_snapshot(
+                            &repo_path_for_event,
+                            &mode_for_event,
+                            error_message,
+                        );
                         let _ = spawner
                             .spawn(move |_me, ctx| {
                                 ctx.emit(RemoteServerManagerEvent::DiffStateSnapshotReceived {
-                                    host_id,
+                                    host_id: host_id_for_event,
                                     repo_path: repo_path_for_event,
                                     mode: mode_for_event,
                                     snapshot: error_snapshot,
@@ -1897,22 +1895,49 @@ impl RemoteServerManager {
             .detach();
     }
 
+    /// Builds a `DiffStateSnapshot` carrying an `Error` state. Used by the
+    /// post-dispatch transport-error path so callers downstream of
+    /// `DiffStateSnapshotReceived` see a consistent error shape.
+    fn make_diff_state_error_snapshot(
+        repo_path: &StandardizedPath,
+        mode: &DiffMode,
+        message: String,
+    ) -> DiffStateSnapshot {
+        DiffStateSnapshot {
+            repo_path: repo_path.to_string(),
+            mode: Some(mode.clone()),
+            metadata: None,
+            state: Some(DiffState {
+                state: Some(diff_state::State::Error(DiffStateErrorValue { message })),
+            }),
+            diffs: None,
+        }
+    }
+
     /// Sends a `GetBranches` request to the remote server for the given
-    /// session and emits the result as a manager event.
+    /// host and emits the result as a manager event.
+    ///
+    /// When no session is currently connected for the host the request is
+    /// silently dropped (logged). Callers can re-issue once a session
+    /// becomes available; emitting a synthetic error response here would
+    /// only feed downstream models an empty `BranchesReceived` and isn't
+    /// useful for an event-driven state machine.
     pub fn get_branches(
         &mut self,
-        session_id: SessionId,
-        remote_path: RemotePath,
+        host_id: HostId,
+        repo_path: StandardizedPath,
         max_branch_count: Option<u32>,
         include_remotes: bool,
         ctx: &mut ModelContext<Self>,
     ) {
-        let Some(client) = self.client_for_session(session_id).cloned() else {
-            log::warn!("Remote server get_branches: no connected client session={session_id:?}");
+        let Some((session_id, client)) = self
+            .any_connected_session_for_host(&host_id)
+            .map(|(sid, client)| (sid, client.clone()))
+        else {
+            log::warn!("Remote server get_branches: no connected client host={host_id}");
             return;
         };
 
-        let repo_path = remote_path.path;
         let repo_path_for_event = repo_path.clone();
         let spawner = self.spawner.clone();
         ctx.background_executor()
@@ -1935,19 +1960,22 @@ impl RemoteServerManager {
     }
 
     /// Sends an `UnsubscribeDiffState` notification (fire-and-forget) to the
-    /// remote server for the given session.
+    /// remote server for the given host.
+    ///
+    /// Safe no-op when no session is connected: the server already cleans up
+    /// the corresponding `(repo, mode, conn_id)` subscription when the
+    /// connection drops (see `deregister_connection` in the daemon), so the
+    /// client doesn't need to retry.
     pub fn unsubscribe_diff_state(
         &self,
-        session_id: SessionId,
-        remote_path: &RemotePath,
+        host_id: HostId,
+        repo_path: &StandardizedPath,
         mode: DiffMode,
     ) {
-        if let Some(client) = self.client_for_session(session_id) {
-            client.unsubscribe_diff_state(&remote_path.path, mode);
+        if let Some(client) = self.client_for_host(&host_id) {
+            client.unsubscribe_diff_state(repo_path, mode);
         } else {
-            log::debug!(
-                "Remote server unsubscribe_diff_state: no client for session={session_id:?}"
-            );
+            log::debug!("Remote server unsubscribe_diff_state: no client for host={host_id}");
         }
     }
 
@@ -1956,20 +1984,19 @@ impl RemoteServerManager {
     #[allow(clippy::too_many_arguments)]
     pub fn discard_files(
         &mut self,
-        session_id: SessionId,
-        remote_path: RemotePath,
+        host_id: HostId,
+        repo_path: StandardizedPath,
         files: Vec<FileStatusInfo>,
         should_stash: bool,
         branch_name: Option<String>,
         mode: DiffMode,
         ctx: &mut ModelContext<Self>,
     ) {
-        let Some(client) = self.client_for_session(session_id).cloned() else {
-            log::warn!("Remote server discard_files: no connected client session={session_id:?}");
+        let Some(client) = self.client_for_host(&host_id).cloned() else {
+            log::warn!("Remote server discard_files: no connected client host={host_id}");
             return;
         };
 
-        let repo_path = remote_path.path;
         ctx.background_executor()
             .spawn(async move {
                 match client
@@ -1980,9 +2007,7 @@ impl RemoteServerManager {
                         log::info!("Remote server discard_files succeeded");
                     }
                     Err(e) => {
-                        log::warn!(
-                            "Remote server discard_files failed: session={session_id:?} error={e}"
-                        );
+                        log::warn!("Remote server discard_files failed: host={host_id} error={e}");
                         // Transport-level telemetry is emitted automatically
                         // by send_request via RequestFailedEvent.
                     }


### PR DESCRIPTION
## Description
* WISOTT 
* Some users were reporting stale diff states/code reviews while in a remote environment - this is due to the fact that the `RemoteDiffStateModel` stored a fixed `session_id` => this meant that on reconnections with new session ids, the diff model would not be able to properly recover and thus returns stale diffs 
* The fix is to remove session id from `RemoteDiffStateModel`, making it host-scoped/session-agnostic and letting the `RemoteServerManager` handle choosing a connected `RemoteServerClient` for each request 
* Related issue/fix: https://github.com/warpdotdev/warp/pull/11789 

## Testing
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
