### PR TITLE
Additional tab grouping actions

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -198,7 +198,7 @@ impl TabData {
         let mut menu_items = vec![];
 
         for section_items in [
-            Self::tab_group_menu_items(),
+            self.tab_group_menu_items(index),
             self.session_sharing_menu_items(index, ctx),
             self.copy_metadata_menu_items(pane_name_target, ctx),
             self.modify_tab_menu_items(index, tabs_len, pane_name_target, ctx),
@@ -534,15 +534,24 @@ impl TabData {
             .into_item()]
     }
 
-    /// Returns the tab-group related entries, TODO(johnturcoo) add group actions.
-    fn tab_group_menu_items() -> Vec<MenuItem<WorkspaceAction>> {
+    /// Returns the tab-group entries for the top-level right-click menu:
+    /// `New group with tab` (always available when the FF is on) and
+    /// `Remove from group` (only when the tab is currently in a group).
+    fn tab_group_menu_items(&self, index: usize) -> Vec<MenuItem<WorkspaceAction>> {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return vec![];
         }
-        vec![
-            MenuItemFields::new("New group with tab").into_item(),
-            MenuItemFields::new_submenu("Move to group").into_item(),
-        ]
+        let mut menu_items = vec![MenuItemFields::new("New group with tab")
+            .with_on_select_action(WorkspaceAction::NewTabGroupFromTab(index))
+            .into_item()];
+        if self.group_id.is_some() {
+            menu_items.push(
+                MenuItemFields::new("Remove from group")
+                    .with_on_select_action(WorkspaceAction::RemoveTabFromGroup(index))
+                    .into_item(),
+            );
+        }
+        menu_items
     }
 
     fn color_option_menu_items(

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -174,6 +174,16 @@ pub enum WorkspaceAction {
     CloseTabGroup(TabGroupId),
     /// Toggle collapsed state for the given tab group.
     ToggleTabGroupCollapsed(TabGroupId),
+    /// Creates a new tab group containing the tab at the given index.
+    NewTabGroupFromTab(usize),
+    /// Moves the tab at `tab_index` into `group_id`, appending it to the
+    /// end of the group's contiguous run.
+    MoveTabToGroup {
+        tab_index: usize,
+        group_id: TabGroupId,
+    },
+    /// Removes the tab at the given index from its current group.
+    RemoveTabFromGroup(usize),
     AddDefaultTab,
     AddTerminalTab {
         hide_homepage: bool,
@@ -797,6 +807,9 @@ impl WorkspaceAction {
             | CloseTabsRightActiveTab
             | CloseTabGroup(_)
             | ToggleTabGroupCollapsed(_)
+            | NewTabGroupFromTab(_)
+            | MoveTabToGroup { .. }
+            | RemoveTabFromGroup(_)
             | ToggleTabColor { .. }
             | AddDefaultTab
             | AddTerminalTab { .. }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6708,6 +6708,136 @@ impl Workspace {
         }
     }
 
+    /// Creates a new group containing the tab and moves it to the top of
+    /// the tab list.
+    fn new_tab_group_from_tab(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        let Some(tab) = self.tabs.get(tab_index) else {
+            return;
+        };
+        let previous_group_id = tab.group_id;
+
+        let group = TabGroup::new();
+        let group_id = group.id;
+        self.tab_groups.insert(group_id, group);
+
+        self.tabs[tab_index].group_id = Some(group_id);
+        self.move_tab_to_index(tab_index, 0, ctx);
+        self.activate_tab_internal(0, ctx);
+
+        if let Some(prev_group_id) = previous_group_id {
+            self.prune_empty_tab_group(prev_group_id, ctx);
+        }
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Moves the tab into `group_id`, appending it to the end of the
+    /// group's contiguous run.
+    fn move_tab_to_group(
+        &mut self,
+        tab_index: usize,
+        group_id: TabGroupId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        let Some(tab) = self.tabs.get(tab_index) else {
+            return;
+        };
+        if tab.group_id == Some(group_id) {
+            return;
+        }
+        let previous_group_id = tab.group_id;
+
+        self.tabs[tab_index].group_id = Some(group_id);
+
+        let target_index = group_member_indices(&self.tabs, group_id)
+            .last()
+            .map(|i| i + 1)
+            .unwrap_or(self.tabs.len());
+        self.move_tab_to_index(tab_index, target_index, ctx);
+
+        if let Some(prev) = previous_group_id {
+            self.prune_empty_tab_group(prev, ctx);
+        }
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Removes the tab from its current group and repositions it just past
+    /// the group's last remaining member.
+    fn remove_tab_from_group(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        let Some(tab) = self.tabs.get(tab_index) else {
+            return;
+        };
+        let Some(previous_group_id) = tab.group_id else {
+            return;
+        };
+
+        self.tabs[tab_index].group_id = None;
+
+        let target_index = group_member_indices(&self.tabs, previous_group_id)
+            .last()
+            .map(|i| i + 1)
+            .unwrap_or(self.tabs.len());
+        self.move_tab_to_index(tab_index, target_index, ctx);
+
+        self.prune_empty_tab_group(previous_group_id, ctx);
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Removes a tab group from the workspace if no tabs reference it.
+    fn prune_empty_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
+        let has_members = self.tabs.iter().any(|t| t.group_id == Some(group_id));
+        if !has_members {
+            self.tab_groups.remove(&group_id);
+            ctx.notify();
+        }
+    }
+
+    /// Moves the tab at `from` to position `to` (`Vec::insert` semantics).
+    /// The active-tab tracker follows the moved tab.
+    fn move_tab_to_index(&mut self, from: usize, to: usize, ctx: &mut ViewContext<Self>) {
+        if from >= self.tabs.len() {
+            return;
+        }
+        let adjusted_to = if to > from { to - 1 } else { to };
+        let adjusted_to = adjusted_to.min(self.tabs.len().saturating_sub(1));
+        if from == adjusted_to {
+            return;
+        }
+
+        let active_pane_group_id = self
+            .tabs
+            .get(self.active_tab_index)
+            .map(|tab| tab.pane_group.id());
+
+        let tab = self.tabs.remove(from);
+        self.tabs.insert(adjusted_to, tab);
+
+        if let Some(pane_group_id) = active_pane_group_id {
+            if let Some(new_active) = self
+                .tabs
+                .iter()
+                .position(|t| t.pane_group.id() == pane_group_id)
+            {
+                self.active_tab_index = new_active;
+            }
+        }
+        ctx.notify();
+    }
+
     pub fn toggle_tab_right_click_menu(
         &mut self,
         tab_index: usize,
@@ -21406,6 +21536,12 @@ impl TypedActionView for Workspace {
             }
             CloseTabGroup(group_id) => self.close_tab_group(*group_id, ctx),
             ToggleTabGroupCollapsed(group_id) => self.toggle_tab_group_collapsed(*group_id, ctx),
+            NewTabGroupFromTab(tab_index) => self.new_tab_group_from_tab(*tab_index, ctx),
+            MoveTabToGroup {
+                tab_index,
+                group_id,
+            } => self.move_tab_to_group(*tab_index, *group_id, ctx),
+            RemoveTabFromGroup(tab_index) => self.remove_tab_from_group(*tab_index, ctx),
             AddDefaultTab => {
                 let effective_mode = AISettings::as_ref(ctx).default_session_mode(ctx);
                 match effective_mode {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6725,7 +6725,7 @@ impl Workspace {
 
         self.tabs[tab_index].group_id = Some(group_id);
         self.move_tab_to_index(tab_index, 0, ctx);
-        self.activate_tab_internal(0, ctx);
+        self.set_active_tab_index(0, ctx);
 
         if let Some(prev_group_id) = previous_group_id {
             self.prune_empty_tab_group(prev_group_id, ctx);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6715,6 +6715,7 @@ impl Workspace {
             return;
         }
         let Some(tab) = self.tabs.get(tab_index) else {
+            log::debug!("new_tab_group_from_tab: tab_index {tab_index} out of bounds");
             return;
         };
         let previous_group_id = tab.group_id;
@@ -6747,8 +6748,10 @@ impl Workspace {
             return;
         }
         let Some(tab) = self.tabs.get(tab_index) else {
+            log::debug!("move_tab_to_group: tab_index {tab_index} out of bounds");
             return;
         };
+        // No-op when the tab already belongs to the target group.
         if tab.group_id == Some(group_id) {
             return;
         }
@@ -6796,7 +6799,7 @@ impl Workspace {
 
     /// Removes a tab group from the workspace if no tabs reference it.
     fn prune_empty_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
-        let has_members = self.tabs.iter().any(|t| t.group_id == Some(group_id));
+        let has_members = group_member_indices(&self.tabs, group_id).next().is_some();
         if !has_members {
             self.tab_groups.remove(&group_id);
             ctx.notify();
@@ -6807,10 +6810,15 @@ impl Workspace {
     /// The active-tab tracker follows the moved tab.
     fn move_tab_to_index(&mut self, from: usize, to: usize, ctx: &mut ViewContext<Self>) {
         if from >= self.tabs.len() {
+            log::debug!(
+                "move_tab_to_index: from {from} out of bounds (len {})",
+                self.tabs.len()
+            );
             return;
         }
         let adjusted_to = if to > from { to - 1 } else { to };
         let adjusted_to = adjusted_to.min(self.tabs.len().saturating_sub(1));
+        // No-op when the requested destination resolves to the tab's current slot.
         if from == adjusted_to {
             return;
         }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6754,12 +6754,11 @@ impl Workspace {
         }
         let previous_group_id = tab.group_id;
 
-        self.tabs[tab_index].group_id = Some(group_id);
-
         let target_index = group_member_indices(&self.tabs, group_id)
             .last()
             .map(|i| i + 1)
             .unwrap_or(self.tabs.len());
+        self.tabs[tab_index].group_id = Some(group_id);
         self.move_tab_to_index(tab_index, target_index, ctx);
 
         if let Some(prev) = previous_group_id {
@@ -6785,11 +6784,9 @@ impl Workspace {
 
         self.tabs[tab_index].group_id = None;
 
-        let target_index = group_member_indices(&self.tabs, previous_group_id)
-            .last()
-            .map(|i| i + 1)
-            .unwrap_or(self.tabs.len());
-        self.move_tab_to_index(tab_index, target_index, ctx);
+        if let Some(last) = group_member_indices(&self.tabs, previous_group_id).last() {
+            self.move_tab_to_index(tab_index, last + 1, ctx);
+        }
 
         self.prune_empty_tab_group(previous_group_id, ctx);
 


### PR DESCRIPTION
## Description
Adds tab grouping actions plumbing and two new tab right-click menu items behind the `GroupedTabs` feature flag
- New group with tab — creates a new `TabGroup`
- Remove from group — clears the tab's group_id and repositions it just past the previous group's last remaining member

## Changes

Action variants added to `WorkspaceAction`:

•  `NewTabGroupFromTab(usize)`
•  `MoveTabToGroup { tab_index, group_id }` (wired up but not yet exposed in UI)
•  `RemoveTabFromGroup(usize)`

## Linked Issue
https://linear.app/warpdotdev/issue/APP-4614/vertical-tab-grouping-additional-actions

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [X] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

[Demo video](https://www.loom.com/share/ef5118e223d64768b5f137a8d806780b)