### PR TITLE
fix: shell-escape generator-produced suggestion replacements

### DIFF
--- a/crates/warp_completer/src/completer/engine/argument/legacy.rs
+++ b/crates/warp_completer/src/completer/engine/argument/legacy.rs
@@ -726,10 +726,19 @@ async fn generate_suggestions_for_argument_type(
 
                     let results = generator.on_complete(&output_string);
 
+                    // Generators emit raw values; shell-escape so the buffer-insertion path
+                    // produces a single shell token (e.g. `new file test.csv` becomes
+                    // `new\ file\ test.csv` for POSIX shells).
+                    let shell_family = ctx.shell_family().unwrap_or(ShellFamily::Posix);
                     let internal_suggestions = results
                         .suggestions
                         .into_iter()
                         .map(Into::into)
+                        .map(|mut suggestion: Suggestion| {
+                            suggestion.replacement =
+                                shell_family.escape(&suggestion.replacement).into();
+                            suggestion
+                        })
                         .filter_map(|suggestion: Suggestion| {
                             let match_type = matcher
                                 .get_match_type(parsed_token.as_str(), suggestion.display.as_str());

--- a/crates/warp_completer/src/completer/engine/argument/v2.rs
+++ b/crates/warp_completer/src/completer/engine/argument/v2.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use smol_str::SmolStr;
+use warp_util::path::ShellFamily;
 
 use super::add_extra_positional;
 use crate::completer::context::call_js_function;
@@ -695,10 +696,19 @@ async fn generate_suggestions_for_argument_value(
                             }
                         }
                     };
+                    // Generators emit raw values; shell-escape so the buffer-insertion path
+                    // produces a single shell token (e.g. `new file test.csv` becomes
+                    // `new\ file\ test.csv` for POSIX shells). Mirrors the legacy code path.
+                    let shell_family = ctx.shell_family().unwrap_or(ShellFamily::Posix);
                     let internal_suggestions = results
                         .suggestions
                         .into_iter()
                         .map(Into::into)
+                        .map(|mut suggestion: Suggestion| {
+                            suggestion.replacement =
+                                shell_family.escape(&suggestion.replacement).into();
+                            suggestion
+                        })
                         .filter_map(|suggestion: Suggestion| {
                             let match_type = matcher
                                 .get_match_type(parsed_token.as_str(), suggestion.display.as_str());

--- a/crates/warp_completer/src/completer/suggest/test.rs
+++ b/crates/warp_completer/src/completer/suggest/test.rs
@@ -2297,3 +2297,91 @@ fn test_powershell_parser_directives_for_case_insensitivity() {
         vec!["-Force"]
     );
 }
+
+/// Suggestions produced by a Rust generator (`Generator::script` registered via the
+/// command-signatures crate) flow through `legacy.rs:From<warp_command_signatures::Suggestion>
+/// for Suggestion`, which today copies `exact_string` into `replacement` verbatim. Real-world
+/// trigger: `git add <tab>` after the command-signatures repo is fixed to return raw filenames
+/// — the generator produces `new file test.csv`, but the buffer-insertion path needs
+/// `new\ file\ test.csv` (POSIX) for the shell to parse it as one token. Without escaping at
+/// this boundary, picking the suggestion produces three shell tokens and `git add` fails.
+#[cfg(not(feature = "v2"))]
+#[test]
+fn test_generator_suggestion_replacement_is_shell_escaped() {
+    use std::collections::HashMap;
+    use warp_command_signatures::{
+        Argument, ArgumentType, CommandBuilder, CommandSignatureGenerators, Generator,
+        GeneratorName, GeneratorResults, IsArgumentOptional, Signature,
+        Suggestion as MetadataSuggestion,
+    };
+
+    use crate::signatures::CommandRegistry;
+
+    const FILE_NAME: &str = "new file test.csv";
+    const SHELL_CMD: &str = "echo file_with_spaces";
+
+    let generators = CommandSignatureGenerators::new("stage").add_generator(
+        "files",
+        Generator::script(
+            CommandBuilder::single_command(SHELL_CMD),
+            // Output is irrelevant to this test; the callback returns a fixed
+            // suggestion mirroring what the fixed command-signatures generator
+            // emits for `git status --short -z`.
+            |_| GeneratorResults {
+                suggestions: vec![MetadataSuggestion::new(FILE_NAME)],
+                is_ordered: false,
+            },
+        ),
+    );
+    let generators_map = HashMap::from([generators.into()]);
+
+    let signature = Signature {
+        name: "stage".to_owned(),
+        alias_generator: None,
+        description: None,
+        arguments: Some(vec![Argument {
+            display_name: Some("file".to_owned()),
+            description: None,
+            is_variadic: false,
+            is_command: false,
+            argument_types: vec![ArgumentType::Generator(GeneratorName("files".to_owned()))],
+            optional: IsArgumentOptional::Required,
+            skip_generator_validation: false,
+        }]),
+        subcommands: None,
+        options: None,
+        priority: warp_command_signatures::Priority::default(),
+        parser_directives: Default::default(),
+    };
+
+    let registry = CommandRegistry::new_for_test([signature], generators_map);
+    let generator_ctx = MockGeneratorContext::new().with_expected_command(SHELL_CMD, "");
+    let ctx = FakeCompletionContext::new(registry).with_generator_context(generator_ctx);
+
+    let results = suggestions_for_test(
+        "stage ",
+        "stage ".len(),
+        CompleterOptions {
+            match_strategy: MatchStrategy::CaseInsensitive,
+            fallback_strategy: CompletionsFallbackStrategy::FilePaths,
+            suggest_file_path_completions_only: false,
+            parse_quotes_as_literals: false,
+        },
+        &ctx,
+    )
+    .expect("expected suggestion results from generator");
+
+    let matched = results
+        .suggestions
+        .iter()
+        .find(|s| s.display() == FILE_NAME)
+        .expect("expected the generator's suggestion to surface");
+
+    assert_eq!(
+        matched.replacement(),
+        r"new\ file\ test.csv",
+        "Generator-produced replacement must be shell-escaped before insertion. \
+         Today it equals the unescaped `{FILE_NAME}`, which the shell would parse \
+         as three separate tokens."
+    );
+}


### PR DESCRIPTION
Suggestions produced by `Generator::script` (Rust generators registered via the command-signatures crate) and by v2 script generators flowed through `From<...::Suggestion> for Suggestion` impls that copied the raw value into `replacement` with no shell-escaping. Once the upstream command-signatures fix for `git add <tab>` lands, this gap becomes user-visible: selecting a suggestion for a path containing spaces inserts an unescaped string into the buffer, so the shell parses it as multiple tokens (`git add new file test.csv` instead of `git add new\ file\ test.csv`).

Apply `ShellFamily::escape` after the `From` conversion in both the legacy (`engine/argument/legacy.rs`) and v2 (`engine/argument/v2.rs`) generator pipelines so generator-backed suggestions match the escaping behavior the path completer (`engine/path.rs`) already provides for filesystem-backed completions.

Includes a failing-then-passing unit test for the legacy code path. A parallel v2 test is deferred because it would require introducing shared test infrastructure (TEST_GENERATOR_3 + JS callback wiring).

Refs warpdotdev/warp#11072, warpdotdev/command-signatures#271.

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
https://github.com/warpdotdev/warp/issues/11072
https://github.com/warpdotdev/command-signatures/issues/271
https://github.com/warpdotdev/command-signatures/pull/272
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
Current issue, in a git folder with a filename with spaces, e.g. 'new test file.csv':
<img width="455" height="240" alt="Screenshot from 2026-05-15 14-16-51" src="https://github.com/user-attachments/assets/19bdff16-81df-4899-88d8-d8f3b6eaf9f8" />
Fixed in command-signatures but not in warp:
<img width="839" height="268" alt="Screenshot from 2026-05-15 15-55-54" src="https://github.com/user-attachments/assets/1f3ff459-7474-411d-ae55-dc207c8982bc" />
Fixed in both:
<img width="859" height="286" alt="Screenshot from 2026-05-27 10-23-33" src="https://github.com/user-attachments/assets/ecf7862d-73fc-4c05-bea1-c8187223d45d" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable


The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
CHANGELOG-BUG-FIX: fix paths with whitespace not being escaped in autocomplete for git commands