### PR TITLE
Fix child agent harness in pill bar hover card

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -1479,14 +1479,18 @@ fn render_hover_card(
     // harness (always when known). Hidden entirely when no chip applies.
     let mut chips: Vec<Box<dyn Element>> = Vec::new();
 
-    // Harness chip: defaults to Warp Agent (Oz) when server metadata
-    // hasn't loaded yet so the chip slot stays useful for in-progress
-    // local conversations. The brand color matches `harness_display`
+    // Harness chip: defaults to Warp Agent (Oz) when nothing else is
+    // known so the chip slot stays useful for in-progress local
+    // conversations. The brand color matches `harness_display`
     // (e.g. orange for Claude Code, blue for Gemini CLI).
-    let harness = conversation
-        .server_metadata()
-        .map(|m| Harness::from(m.harness))
-        .unwrap_or(Harness::Oz);
+    //
+    // Use `orchestration_harness()` so child agents spawned with a
+    // specific harness (e.g. Claude Code via `run_agents`) report that
+    // harness immediately via the `orchestration_harness_type` field —
+    // `server_metadata` alone isn't reliable for local children because
+    // it's None until the cloud sync round-trips and otherwise reflects
+    // the parent conversation's harness rather than the child's.
+    let harness = conversation.orchestration_harness().unwrap_or(Harness::Oz);
     let harness_icon = harness_display::icon_for(harness);
     let harness_label = harness_display::display_name(harness).to_string();
     let harness_color = harness_display::brand_color(harness).unwrap_or(sub_text);

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -1479,17 +1479,9 @@ fn render_hover_card(
     // harness (always when known). Hidden entirely when no chip applies.
     let mut chips: Vec<Box<dyn Element>> = Vec::new();
 
-    // Harness chip: defaults to Warp Agent (Oz) when nothing else is
-    // known so the chip slot stays useful for in-progress local
-    // conversations. The brand color matches `harness_display`
-    // (e.g. orange for Claude Code, blue for Gemini CLI).
-    //
-    // Use `orchestration_harness()` so child agents spawned with a
-    // specific harness (e.g. Claude Code via `run_agents`) report that
-    // harness immediately via the `orchestration_harness_type` field —
-    // `server_metadata` alone isn't reliable for local children because
-    // it's None until the cloud sync round-trips and otherwise reflects
-    // the parent conversation's harness rather than the child's.
+    // Harness chip: prefer the spawn-time `orchestration_harness_type`
+    // so child agents report their harness immediately; fall back to
+    // Oz so the chip slot stays populated.
     let harness = conversation.orchestration_harness().unwrap_or(Harness::Oz);
     let harness_icon = harness_display::icon_for(harness);
     let harness_label = harness_display::display_name(harness).to_string();


### PR DESCRIPTION
Before:
<img width="309" height="119" alt="image" src="https://github.com/user-attachments/assets/4cf156c7-a226-4e85-8f76-b016b707c259" />


After:
<img width="303" height="109" alt="image" src="https://github.com/user-attachments/assets/c5545a3a-d243-4186-ab9b-334a7ca15cc7" />

## Description
The orchestration pill bar's hover card was reading the harness chip from `conversation.server_metadata()`, which for a freshly spawned local child agent is either `None` or reflects the parent's Warp harness — so a Claude Code (or any non-Oz) child agent always showed **'Warp'**.

Switch to `conversation.orchestration_harness()`, which prefers the spawn-time `orchestration_harness_type` field stamped by `start_new_child_conversation` and falls back to `server_metadata` only when that's not set. Now the chip matches the badge.

## Linked Issue
Fixes https://linear.app/warpdotdev/issue/QUALITY-725/orchestration-pill-bar-hover-card-shows-wrong-harness-for-claude-agent
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt` ✓
- `cargo clippy -p warp --bin warp --all-features --tests -- -D warnings` ✓
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed orchestration pill bar hover card showing the wrong harness for non-Warp child agents (e.g. Claude Code).

Co-Authored-By: Oz <oz-agent@warp.dev>