### PR TITLE
Disable Continue button styling when New API key form is incomplete

### DIFF
--- a/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
+++ b/app/src/terminal/view/ambient_agent/auth_secret_ftux_view.rs
@@ -107,6 +107,16 @@ struct SecretCreationState {
     pending_name: Option<String>,
 }
 
+/// Validated, ready-to-submit snapshot of the creation form.
+struct ValidatedForm {
+    harness: Harness,
+    info: &'static AuthSecretTypeInfo,
+    /// Trimmed; non-empty.
+    name: String,
+    /// One per `info.fields`. Required fields are non-empty after trimming.
+    field_values: Vec<String>,
+}
+
 pub struct AuthSecretFtuxView {
     harness: Harness,
     ftux_dropdown: ViewHandle<AuthSecretFtuxDropdown>,
@@ -136,7 +146,7 @@ impl AuthSecretFtuxView {
         let name_editor = make_single_line_editor(Some("e.g. My API Key"), false, ctx);
 
         ctx.subscribe_to_view(&name_editor, |me, _, event, ctx| {
-            me.handle_form_editor_nav(0, event, ctx);
+            me.handle_form_editor_event(0, event, ctx);
         });
 
         let ftux_dropdown =
@@ -500,7 +510,7 @@ impl AuthSecretFtuxView {
         }
     }
 
-    fn handle_form_editor_nav(
+    fn handle_form_editor_event(
         &self,
         editor_index: usize,
         event: &EditorEvent,
@@ -525,6 +535,8 @@ impl AuthSecretFtuxView {
                 }
                 _ => {}
             },
+            // Re-render so the Continue button restyles as the user types.
+            EditorEvent::Edited(_) => ctx.notify(),
             _other => {}
         }
     }
@@ -545,7 +557,7 @@ impl AuthSecretFtuxView {
             let editor = make_single_line_editor(Some(placeholder), field.sensitive, ctx);
             let editor_index = field_idx + 1;
             ctx.subscribe_to_view(&editor, move |me, _, event, ctx| {
-                me.handle_form_editor_nav(editor_index, event, ctx);
+                me.handle_form_editor_event(editor_index, event, ctx);
             });
             editors.push(editor);
         }
@@ -569,6 +581,50 @@ impl AuthSecretFtuxView {
         auth_secret_types_for_harness(state.harness).get(state.secret_type_index)
     }
 
+    /// Validated form snapshot; `None` if not ready to submit. Single
+    /// source of truth for both `can_submit_creation_form` and
+    /// `handle_continue`.
+    fn validated_form_snapshot(&self, ctx: &AppContext) -> Option<ValidatedForm> {
+        let state = self.creation_state.as_ref()?;
+        if state.is_saving {
+            return None;
+        }
+        let info = auth_secret_types_for_harness(state.harness).get(state.secret_type_index)?;
+        if self.field_editors.len() != info.fields.len() {
+            return None;
+        }
+        let name = self
+            .name_editor
+            .as_ref(ctx)
+            .buffer_text(ctx)
+            .trim()
+            .to_string();
+        if name.is_empty() {
+            return None;
+        }
+        let field_values: Vec<String> = self
+            .field_editors
+            .iter()
+            .map(|e| e.as_ref(ctx).buffer_text(ctx))
+            .collect();
+        for (field, value) in info.fields.iter().zip(field_values.iter()) {
+            if !field.optional && value.trim().is_empty() {
+                return None;
+            }
+        }
+        Some(ValidatedForm {
+            harness: state.harness,
+            info,
+            name,
+            field_values,
+        })
+    }
+
+    /// Whether the Continue button should be enabled.
+    fn can_submit_creation_form(&self, ctx: &AppContext) -> bool {
+        self.validated_form_snapshot(ctx).is_some()
+    }
+
     fn handle_skip(&mut self, ctx: &mut ViewContext<Self>) {
         if self.skip_hidden {
             return;
@@ -589,39 +645,23 @@ impl AuthSecretFtuxView {
     }
 
     fn handle_continue(&mut self, ctx: &mut ViewContext<Self>) {
-        let Some(state) = self.creation_state.as_ref() else {
+        // The button is disabled when the form isn't ready; no-op if we
+        // got dispatched anyway.
+        let Some(form) = self.validated_form_snapshot(ctx) else {
             return;
         };
-        if state.is_saving {
-            return;
-        }
-        let harness = state.harness;
-        let type_index = state.secret_type_index;
-        let Some(info) = auth_secret_types_for_harness(harness).get(type_index) else {
-            return;
-        };
-
-        let name = self.name_editor.as_ref(ctx).buffer_text(ctx);
-        let trimmed_name = name.trim();
-        if trimmed_name.is_empty() {
-            HarnessAvailabilityModel::handle(ctx).update(ctx, |_model, ctx| {
-                ctx.emit(HarnessAvailabilityEvent::AuthSecretCreationFailed {
-                    error: "Please enter a name for the secret.".to_string(),
-                });
-            });
-            return;
-        }
-        let name = trimmed_name.to_string();
-
-        let field_values: Vec<String> = self
-            .field_editors
-            .iter()
-            .map(|e| e.as_ref(ctx).buffer_text(ctx))
-            .collect();
+        let ValidatedForm {
+            harness,
+            info,
+            name,
+            field_values,
+        } = form;
 
         let value = match build_managed_secret_value(info, &field_values) {
             Ok(v) => v,
             Err(err) => {
+                // Defensive: `validated_form_snapshot` already enforces
+                // the same required-field rules.
                 let msg = err.to_string();
                 HarnessAvailabilityModel::handle(ctx).update(ctx, |_model, ctx| {
                     ctx.emit(HarnessAvailabilityEvent::AuthSecretCreationFailed { error: msg });
@@ -890,24 +930,35 @@ impl AuthSecretFtuxView {
         mouse_state: MouseStateHandle,
         background: Option<Fill>,
         action: AuthSecretFtuxAction,
+        disabled: bool,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let font_family = appearance.ui_font_family();
-        let text_color = theme.foreground();
+        // Mirrors the design system's `DisabledTheme`.
+        let text_color = if disabled {
+            internal_colors::neutral_5(theme)
+        } else {
+            theme.foreground().into()
+        };
+        let effective_background = if disabled {
+            background.map(|_| Fill::from(internal_colors::neutral_4(theme)))
+        } else {
+            background
+        };
         Hoverable::new(mouse_state, move |_| {
             let inner = Container::new(
                 Text::new_inline(label.to_string(), font_family, BUTTON_FONT_SIZE)
                     .with_style(Properties::default().weight(Weight::Semibold))
-                    .with_color(text_color.into())
+                    .with_color(text_color)
                     .finish(),
             )
             .with_padding_left(BUTTON_PADDING * 2.)
             .with_padding_right(BUTTON_PADDING * 2.)
             .with_padding_top(BUTTON_PADDING)
             .with_padding_bottom(BUTTON_PADDING);
-            let inner = if let Some(background) = background {
+            let inner = if let Some(background) = effective_background {
                 inner
                     .with_background(background)
                     .with_corner_radius(CornerRadius::with_all(Radius::Pixels(CORNER_RADIUS)))
@@ -916,8 +967,15 @@ impl AuthSecretFtuxView {
             };
             inner.finish()
         })
-        .with_cursor(warpui::platform::Cursor::PointingHand)
+        .with_cursor(if disabled {
+            warpui::platform::Cursor::Arrow
+        } else {
+            warpui::platform::Cursor::PointingHand
+        })
         .on_click(move |ctx, _, _| {
+            if disabled {
+                return;
+            }
             ctx.dispatch_typed_action(action.clone());
         })
         .finish()
@@ -937,15 +995,18 @@ impl AuthSecretFtuxView {
             self.back_button_mouse_state.clone(),
             None,
             action,
+            false,
             app,
         ));
 
         let accent_fill = Appearance::as_ref(app).theme().accent();
+        let continue_disabled = !self.can_submit_creation_form(app);
         row.add_child(self.render_button(
             "Continue",
             self.continue_mouse_state.clone(),
             Some(accent_fill),
             AuthSecretFtuxAction::Continue,
+            continue_disabled,
             app,
         ));
 


### PR DESCRIPTION
Before:
<img width="503" height="379" alt="image" src="https://github.com/user-attachments/assets/0f1e7951-b2b3-40c4-888c-933884b36f84" />


After:
<img width="546" height="418" alt="image" src="https://github.com/user-attachments/assets/53c10541-355e-4c94-86a2-aecfbb2ae7e2" />


## Description
The Continue button in the "New API key" dialog (orchestration API key dropdown → `+ New API key…`) was already non-functional when required fields were empty (`handle_continue` early-returns), but it always rendered with the accent blue fill and a pointing-hand cursor, so visually it looked clickable. This PR adds proper disabled styling so the affordance matches the behavior.

**Before:** button looks active even when name / API key are empty.
**After:** button renders with the design system's disabled palette (`internal_colors::neutral_4` background, `neutral_5` text, arrow cursor) until the form is ready to submit.

### How
- Add `validated_form_snapshot` as a single source of truth for "is this form ready to submit". Both the Continue button's disabled-state check (`can_submit_creation_form`) and `handle_continue` consume it, so they can't drift.
- `render_button` gains a `disabled: bool` param that swaps fill/text colors, switches cursor to `Arrow`, and short-circuits the click handler. Mirrors `DisabledTheme` in `view_components/action_button.rs`.
- Subscribe to `EditorEvent::Edited` on the name + field editors so the button restyles live as the user types.

Continue is disabled when:
- No creation form is open
- A save is already in flight (`is_saving`)
- The trimmed name is empty
- Any non-optional field is empty after trimming

## Linked Issue
Fixes https://linear.app/warpdotdev/issue/QUALITY-752/continue-button-should-be-disabled-in-secrets-popup-if-fields-not

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- `cargo check -p warp` ✓
- `cargo clippy -p warp --all-targets --tests` ✓ (no new warnings)
- `cargo fmt` ✓


Co-Authored-By: Oz <oz-agent@warp.dev>
