### PR TITLE
Fix crash if context window limit is crashed

### DIFF
--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -621,7 +621,10 @@ impl AIExecutionProfilesModel {
             ctx,
         );
 
-        if changed {
+        // Gate on the limit being non-empty. The limit is cleared during
+        // reconciliation, which runs inside an `LLMPreferences` update where the
+        // `LLMPreferences::as_ref` read below would panic.
+        if changed && limit.is_some() {
             let Some(profile) = self.get_profile_by_id(profile_id, ctx) else {
                 return;
             };


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fix a crash that occurs when the context window limit is cleared after model choices are updated and model reconciliation happens.

The crash occurs when:
-  TeamUpdateManager update → LLMPreferences.update(...) → update_feature_model_choices → on_server_update → reconcile_disabled_model_preferences (frames 13–19). At this point the LLMPreferences model is taken out of ctx.models for the duration of its own update.
-  Inside that, reconcile does a nested AIExecutionProfilesModel.update(...) and calls profiles.set_context_window_limit(profile_id, None, ctx) (frame 8, llms.rs:1206).
-  set_context_window_limit then calls LLMPreferences::as_ref(ctx) for its telemetry tail (frame 7, profiles.rs:628). Because LLMPreferences is mid-update, ctx.models no longer contains it, so downcast_ref returns None and the .expect("downcast should be type safe") aborts.

I don't think this is a common crash. I ran into this when testing what happens when an admin disables all of the available models for a model config (I disabled all of the possible computer use models).

The fix is to avoid sending telemetry if `limit == None`, since that avoids the errant `LLMPreferences` read. This matches the pattern when we set a model in the config, which also skips sending telemetry if the model is `None`.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

Manually tested that the crash doesn't repro anymore.

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
