### PR TITLE
Fix optimistic-root persistence breaking conversation restore (QUALITY-774)

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -377,78 +377,123 @@ impl AIConversation {
         }
     }
 
-    // TODO: derive todo list state from tasks instead of taking args.
-    //
-    // This would make it possible to fully restore a convo from tasks, instead of having to persist this additional data.
+    /// Strict restore: returns `Err(NoRootTask)` if `tasks` is empty. Use
+    /// for cloud-restore and fork-insert paths, where an empty payload is
+    /// malformed input rather than a not-yet-populated child.
     pub fn new_restored(
         id: AIConversationId,
         tasks: Vec<api::Task>,
         conversation_data: Option<AgentConversationData>,
     ) -> Result<Self, RestoreConversationError> {
-        let root_task_is_optimistic = conversation_data
-            .as_ref()
-            .and_then(|data| data.root_task_is_optimistic)
-            .unwrap_or_default();
-        let api_tasks_by_id: HashMap<String, api::Task> =
-            tasks.into_iter().map(|t| (t.id.clone(), t)).collect();
-
-        // To process a task, we need to reference some of the data in its parent task.  To
-        // avoid cloning, we process the task tree from deepest tasks to shallowest tasks.  This
-        // ensures that children are always processed before their parents, avoiding any need to
-        // clone task data to ensure the parent is available when processing the child.
-        let depths = compute_task_depths(&api_tasks_by_id);
-        let mut task_ids: Vec<String> = api_tasks_by_id.keys().cloned().collect();
-        task_ids.sort_by(|a, b| {
-            depths
-                .get(b.as_str())
-                .unwrap_or(&0)
-                .cmp(depths.get(a.as_str()).unwrap_or(&0))
-        });
-
-        let mut api_tasks_and_exchanges_by_id: HashMap<_, _> = api_tasks_by_id
-            .into_iter()
-            .map(|(id, task)| {
-                let exchanges = task.into_exchanges();
-                (id, (task, exchanges))
-            })
-            .collect();
-
-        let mut tasks_by_id = HashMap::new();
-        let mut root_task = None;
-        for task_id in task_ids {
-            let Some((task, exchanges)) = api_tasks_and_exchanges_by_id.remove(&task_id) else {
-                continue;
-            };
-
-            if let Some(parent_id) = task.parent_id() {
-                if let Some((parent_task, _)) = api_tasks_and_exchanges_by_id.get(parent_id) {
-                    tasks_by_id.insert(
-                        TaskId::new(task.id.clone()),
-                        Task::new_restored_subtask(task, parent_task, exchanges),
-                    );
-                } else {
-                    log::error!(
-                        "Could not find parent task (id: {}) for task (id: {})",
-                        parent_id,
-                        task.id
-                    );
-                }
-            } else if root_task.is_none() {
-                root_task = Some(if root_task_is_optimistic {
-                    Task::new_restored_optimistic_root(task.id.clone(), exchanges.into_iter())
-                } else {
-                    Task::new_restored_root(task, exchanges.into_iter())
-                });
-            }
-        }
-
-        let Some(root_task) = root_task else {
+        if tasks.is_empty() {
             return Err(RestoreConversationError::NoRootTask);
+        }
+        Self::new_restored_synthesizing_on_empty(id, tasks, conversation_data)
+    }
+
+    // TODO: derive todo list state from tasks instead of taking args. This
+    // would make it possible to fully restore a convo from tasks, instead of
+    // having to persist this additional data.
+    /// Lenient restore: when `tasks` is empty, synthesizes a fresh in-memory
+    /// conversation with a new `Optimistic(Root)` root task and the persisted
+    /// overlay metadata applied (mirroring the shape `AIConversation::new()`
+    /// produces). Use for the local-DB restore path, where an empty
+    /// `agent_tasks` set is the normal shape of a child conversation
+    /// persisted before its first server response.
+    pub fn new_restored_synthesizing_on_empty(
+        id: AIConversationId,
+        tasks: Vec<api::Task>,
+        conversation_data: Option<AgentConversationData>,
+    ) -> Result<Self, RestoreConversationError> {
+        let (task_store, todo_lists, status) = if tasks.is_empty() {
+            // Bypass `derive_status_from_root_task`: it would return `Success`
+            // for a root with no exchanges, silently misclassifying a restored
+            // "child waiting on server response" as done.
+            let root_task = Task::new_optimistic_root();
+            let task_store = TaskStore::with_root_task(root_task);
+            (task_store, Vec::new(), ConversationStatus::InProgress)
+        } else {
+            let api_tasks_by_id: HashMap<String, api::Task> =
+                tasks.into_iter().map(|t| (t.id.clone(), t)).collect();
+
+            // To process a task, we need to reference some of the data in its parent task.  To
+            // avoid cloning, we process the task tree from deepest tasks to shallowest tasks.  This
+            // ensures that children are always processed before their parents, avoiding any need to
+            // clone task data to ensure the parent is available when processing the child.
+            let depths = compute_task_depths(&api_tasks_by_id);
+            let mut task_ids: Vec<String> = api_tasks_by_id.keys().cloned().collect();
+            task_ids.sort_by(|a, b| {
+                depths
+                    .get(b.as_str())
+                    .unwrap_or(&0)
+                    .cmp(depths.get(a.as_str()).unwrap_or(&0))
+            });
+
+            let mut api_tasks_and_exchanges_by_id: HashMap<_, _> = api_tasks_by_id
+                .into_iter()
+                .map(|(id, task)| {
+                    let exchanges = task.into_exchanges();
+                    (id, (task, exchanges))
+                })
+                .collect();
+
+            let mut tasks_by_id = HashMap::new();
+            // Defer root selection until we've seen every parentless task so
+            // we can deterministically prefer a candidate with non-empty
+            // messages. Heals legacy DB rows that contain an orphan
+            // optimistic-UUID stub alongside the real server root; without
+            // this dedupe, `HashMap` iteration order picks between them
+            // non-deterministically. See QUALITY-774.
+            let mut parentless_candidates: Vec<(api::Task, Vec<AIAgentExchange>)> = Vec::new();
+            for task_id in task_ids {
+                let Some((task, exchanges)) = api_tasks_and_exchanges_by_id.remove(&task_id) else {
+                    continue;
+                };
+
+                if let Some(parent_id) = task.parent_id() {
+                    if let Some((parent_task, _)) = api_tasks_and_exchanges_by_id.get(parent_id) {
+                        tasks_by_id.insert(
+                            TaskId::new(task.id.clone()),
+                            Task::new_restored_subtask(task, parent_task, exchanges),
+                        );
+                    } else {
+                        log::error!(
+                            "Could not find parent task (id: {}) for task (id: {})",
+                            parent_id,
+                            task.id
+                        );
+                    }
+                } else {
+                    parentless_candidates.push((task, exchanges));
+                }
+            }
+
+            // Prefer the parentless candidate with non-empty messages (the
+            // real server root) over an empty stub. If multiple have messages
+            // or none have messages, fall back to the first-encountered
+            // candidate.
+            let root_task_pick = parentless_candidates
+                .iter()
+                .position(|(task, _)| !task.messages.is_empty())
+                .or_else(|| (!parentless_candidates.is_empty()).then_some(0))
+                .map(|idx| parentless_candidates.swap_remove(idx));
+
+            let Some((root_api_task, root_exchanges)) = root_task_pick else {
+                return Err(RestoreConversationError::NoRootTask);
+            };
+            let root_task = Task::new_restored_root(root_api_task, root_exchanges.into_iter());
+
+            // Derive todo lists from tasks by replaying UpdateTodos operations
+            let todo_lists = derive_todo_lists_from_root_task(&root_task);
+            let root_task_id = root_task.id().clone();
+            tasks_by_id.insert(root_task.id().clone(), root_task);
+
+            // Determine the correct status based on the exchanges before constructing
+            let status = Self::derive_status_from_root_task(&tasks_by_id.get(&root_task_id));
+
+            let task_store = TaskStore::from_tasks(tasks_by_id, root_task_id);
+            (task_store, todo_lists, status)
         };
-        // Derive todo lists from tasks by replaying UpdateTodos operations
-        let todo_lists = derive_todo_lists_from_root_task(&root_task);
-        let root_task_id = root_task.id().clone();
-        tasks_by_id.insert(root_task.id().clone(), root_task);
 
         let (
             server_conversation_token,
@@ -470,11 +515,16 @@ impl AIConversation {
                 .server_conversation_token
                 .map(ServerConversationToken::new);
             let conversation_usage_metadata = data.conversation_usage_metadata.unwrap_or_default();
-            let reverted_action_ids = data.reverted_action_ids.unwrap_or_default();
+            let reverted_action_ids: HashSet<AIAgentActionId> = data
+                .reverted_action_ids
+                .unwrap_or_default()
+                .into_iter()
+                .map_into()
+                .collect();
             let forked_from_server_conversation_token = data
                 .forked_from_server_conversation_token
                 .map(ServerConversationToken::new);
-            let artifacts = data
+            let artifacts: Vec<Artifact> = data
                 .artifacts_json
                 .and_then(|json| {
                     serde_json::from_str(&json)
@@ -482,14 +532,9 @@ impl AIConversation {
                         .ok()
                 })
                 .unwrap_or_default();
-            let parent_agent_id = data.parent_agent_id;
-            let agent_name = data.agent_name;
-            let orchestration_harness_type = data.orchestration_harness_type;
             let parent_conversation_id = data
                 .parent_conversation_id
                 .and_then(|id| AIConversationId::try_from(id).ok());
-            let is_remote_child = data.is_remote_child;
-            let run_id = data.run_id;
             let autoexecute_override = if FeatureFlag::RememberFastForwardState.is_enabled() {
                 data.autoexecute_override
                     .map(Into::into)
@@ -497,31 +542,28 @@ impl AIConversation {
             } else {
                 AIConversationAutoexecuteMode::default()
             };
-            let last_event_sequence = data.last_event_sequence;
-            let pinned = data.pinned;
-
             (
                 server_conversation_token,
                 forked_from_server_conversation_token,
                 conversation_usage_metadata,
                 reverted_action_ids,
                 artifacts,
-                parent_agent_id,
-                agent_name,
-                orchestration_harness_type,
+                data.parent_agent_id,
+                data.agent_name,
+                data.orchestration_harness_type,
                 parent_conversation_id,
-                is_remote_child,
-                run_id,
+                data.is_remote_child,
+                data.run_id,
                 autoexecute_override,
-                last_event_sequence,
-                pinned,
+                data.last_event_sequence,
+                data.pinned,
             )
         } else {
             (
                 None,
                 None,
                 ConversationUsageMetadata::default(),
-                Default::default(),
+                HashSet::new(),
                 Vec::new(),
                 None,
                 None,
@@ -534,14 +576,6 @@ impl AIConversation {
                 false,
             )
         };
-
-        // Convert these from the persistence type to the runtime one.
-        let reverted_action_ids = reverted_action_ids.into_iter().map_into().collect();
-
-        // Determine the correct status based on the exchanges before constructing
-        let status = Self::derive_status_from_root_task(&tasks_by_id.get(&root_task_id));
-
-        let task_store = TaskStore::from_tasks(tasks_by_id, root_task_id);
 
         Ok(Self {
             id,
@@ -628,6 +662,31 @@ impl AIConversation {
     #[cfg(test)]
     pub(crate) fn set_credits_spent_for_test(&mut self, credits: f32) {
         self.conversation_usage_metadata.credits_spent = credits;
+    }
+
+    /// Test-only helper that simulates the root-task upgrade performed by the
+    /// `Action::CreateTask` branch of `apply_client_action` when the server
+    /// confirms the root for a newly started conversation. Replaces the
+    /// in-memory `Optimistic(Root)` root with a server-backed `Task` carrying
+    /// `server_task`'s id.
+    ///
+    /// Unlike the production `Action::CreateTask` path, this helper does NOT
+    /// update `added_exchanges_by_response`; it is only safe to call when no
+    /// in-flight response stream references the optimistic root.
+    #[cfg(test)]
+    pub(crate) fn upgrade_optimistic_root_to_server_task_for_test(
+        &mut self,
+        server_task: api::Task,
+    ) {
+        let root_task_id = self.task_store.root_task_id().clone();
+        let root_task = self
+            .task_store
+            .remove(&root_task_id)
+            .expect("root task should exist for upgrade-in-place test helper");
+        let server_root = root_task
+            .into_server_created_task(server_task, None, None, None)
+            .expect("upgrading optimistic root to a server-backed task should succeed");
+        self.task_store.set_root_task(server_root);
     }
 
     // Credits spent over the last block, where the block comprises
@@ -3085,8 +3144,6 @@ impl AIConversation {
             }
         };
 
-        let root_task_is_optimistic = self.get_root_task().map(Task::is_optimistic_root_task);
-
         let event = ModelEvent::UpdateMultiAgentConversation {
             conversation_id: self.id.to_string(),
             updated_tasks: self
@@ -3110,7 +3167,11 @@ impl AIConversation {
                 orchestration_harness_type: self.orchestration_harness_type.clone(),
                 parent_conversation_id: self.parent_conversation_id.map(|id| id.to_string()),
                 is_remote_child: self.is_remote_child,
-                root_task_is_optimistic,
+                // Legacy field; retained for backward-compatible
+                // deserialization but no longer written. The optimistic-root
+                // case is now handled by `Task::source_for_persistence`
+                // (returns `None`) and `new_restored_synthesizing_on_empty`.
+                root_task_is_optimistic: None,
                 run_id: self.task_id.map(|id| id.to_string()),
                 autoexecute_override: Some(self.autoexecute_override.into()),
                 last_event_sequence: self.last_event_sequence,

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -7,7 +7,7 @@ use warpui::{App, SingletonEntity};
 
 use super::{
     artifact_from_fork_proto, footer_model_token_usage, AIConversation,
-    AIConversationAutoexecuteMode, AIConversationId,
+    AIConversationAutoexecuteMode, AIConversationId, ConversationStatus, RestoreConversationError,
 };
 use crate::ai::artifacts::Artifact;
 use crate::ai::llms::LLMPreferences;
@@ -201,6 +201,32 @@ fn child_conversation_detection_uses_parent_agent_id() {
     assert_eq!(conversation.parent_conversation_id(), None);
 }
 
+/// When the persisted task list is empty (e.g. a child conversation persisted
+/// before any server response), restoring via `new_restored_synthesizing_on_empty`
+/// must produce a fresh in-progress optimistic root, mirroring
+/// `AIConversation::new()`.
+#[test]
+fn restored_conversation_with_empty_task_list_creates_in_progress_optimistic_root() {
+    let conversation =
+        AIConversation::new_restored_synthesizing_on_empty(AIConversationId::new(), vec![], None)
+            .expect("empty task list must synthesize an optimistic root");
+
+    let root_task = conversation
+        .get_root_task()
+        .expect("synthesized root task should exist");
+    assert!(root_task.is_root_task());
+    assert!(
+        root_task.source().is_none(),
+        "synthesized root is optimistic and has no api::Task source"
+    );
+    assert!(
+        !root_task.id().to_string().is_empty(),
+        "synthesized optimistic root must have a non-empty UUID id"
+    );
+    assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+    assert!(conversation.status_error_message().is_none());
+}
+
 #[test]
 fn update_cost_and_usage_resolves_custom_endpoint_alias_for_footer_usage() {
     App::test((), |mut app| async move {
@@ -359,6 +385,7 @@ fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_label
         assert_eq!(custom_usage.byok_tokens, 0);
     });
 }
+
 #[allow(deprecated)]
 #[test]
 fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fallback_label() {
@@ -407,8 +434,11 @@ fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fall
     });
 }
 
+/// The legacy `AgentConversationData.root_task_is_optimistic` flag must be
+/// ignored on restore. A non-empty task list always produces a real
+/// server-backed root regardless of whether the flag is set.
 #[test]
-fn restored_conversation_uses_persisted_optimistic_root_task() {
+fn restored_conversation_ignores_legacy_root_task_is_optimistic_flag_with_non_empty_tasks() {
     let conversation_data: AgentConversationData = serde_json::from_str(
         r#"{"server_conversation_token":null,"root_task_is_optimistic":true}"#,
     )
@@ -421,8 +451,118 @@ fn restored_conversation_uses_persisted_optimistic_root_task() {
 
     assert_eq!(root_task.id().to_string(), "root-task");
     assert!(root_task.is_root_task());
-    assert!(root_task.is_optimistic_root_task());
+    assert!(
+        root_task.source().is_some(),
+        "with a real task list, the legacy optimistic flag must be ignored",
+    );
+}
+
+/// The legacy `root_task_is_optimistic` flag is ignored when restoring an
+/// empty task list via `new_restored_synthesizing_on_empty`.
+#[test]
+fn restored_conversation_ignores_legacy_root_task_is_optimistic_flag_with_empty_tasks() {
+    let conversation_data: AgentConversationData = serde_json::from_str(
+        r#"{"server_conversation_token":null,"root_task_is_optimistic":true}"#,
+    )
+    .unwrap();
+
+    let conversation = AIConversation::new_restored_synthesizing_on_empty(
+        AIConversationId::new(),
+        vec![],
+        Some(conversation_data),
+    )
+    .expect("empty task list must synthesize an optimistic root regardless of legacy flag");
+
+    let root_task = conversation
+        .get_root_task()
+        .expect("synthesized root task should exist");
+    assert!(root_task.is_root_task());
     assert!(root_task.source().is_none());
+    assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+}
+
+/// Strict `new_restored` returns `NoRootTask` for an empty task list.
+#[test]
+fn new_restored_with_empty_task_list_returns_no_root_task_error() {
+    let result = AIConversation::new_restored(AIConversationId::new(), vec![], None);
+    assert!(
+        matches!(result, Err(RestoreConversationError::NoRootTask)),
+        "empty task list via strict new_restored must return NoRootTask; got {result:?}",
+    );
+}
+
+/// When multiple parentless tasks exist (e.g. a legacy orphan optimistic
+/// stub alongside the real server root), `new_restored` must prefer the
+/// candidate whose `messages` is non-empty. Each ordering runs in a loop to
+/// surface any nondeterminism in candidate selection.
+#[test]
+fn test_new_restored_prefers_parentless_task_with_messages_over_empty_stub() {
+    let stub = api::Task {
+        id: "optimistic-stub-uuid".to_string(),
+        messages: vec![],
+        dependencies: None,
+        description: String::new(),
+        summary: String::new(),
+        server_data: String::new(),
+    };
+    let real = api::Task {
+        id: "server-root-id".to_string(),
+        messages: vec![user_query_message("user-msg", "request-1", "real query")],
+        dependencies: None,
+        description: String::new(),
+        summary: String::new(),
+        server_data: String::new(),
+    };
+
+    // Stub appears first in the vec.
+    for _ in 0..50 {
+        let conversation = AIConversation::new_restored(
+            AIConversationId::new(),
+            vec![stub.clone(), real.clone()],
+            None,
+        )
+        .expect("restore with stub + real parentless tasks must succeed");
+        let root_task = conversation
+            .get_root_task()
+            .expect("restored conversation must have a root task");
+        assert_eq!(
+            root_task.id().to_string(),
+            "server-root-id",
+            "expected the real (non-empty) parentless task to win when stub is first",
+        );
+        let source = root_task
+            .source()
+            .expect("chosen root must have api::Task source");
+        assert!(
+            !source.messages.is_empty(),
+            "chosen root must have non-empty messages",
+        );
+    }
+
+    // Real appears first in the vec.
+    for _ in 0..50 {
+        let conversation = AIConversation::new_restored(
+            AIConversationId::new(),
+            vec![real.clone(), stub.clone()],
+            None,
+        )
+        .expect("restore with real + stub parentless tasks must succeed");
+        let root_task = conversation
+            .get_root_task()
+            .expect("restored conversation must have a root task");
+        assert_eq!(
+            root_task.id().to_string(),
+            "server-root-id",
+            "expected the real (non-empty) parentless task to win when real is first",
+        );
+        let source = root_task
+            .source()
+            .expect("chosen root must have api::Task source");
+        assert!(
+            !source.messages.is_empty(),
+            "chosen root must have non-empty messages",
+        );
+    }
 }
 
 #[test]

--- a/app/src/ai/agent/task.rs
+++ b/app/src/ai/agent/task.rs
@@ -267,20 +267,6 @@ impl Task {
         }
     }
 
-    pub(super) fn new_restored_optimistic_root(
-        task_id: String,
-        restored_exchanges: impl Iterator<Item = AIAgentExchange>,
-    ) -> Self {
-        let mut restored_exchanges = restored_exchanges.collect_vec();
-        restored_exchanges.sort_by_key(|exchange| exchange.start_time);
-
-        Self {
-            id: TaskId::new(task_id),
-            data: TaskImpl::Optimistic(optimistic::Task::Root),
-            exchanges: restored_exchanges,
-        }
-    }
-
     pub(super) fn new_subtask(
         subtask: api::Task,
         parent_task: &api::Task,
@@ -483,10 +469,6 @@ impl Task {
         }
     }
 
-    pub(super) fn is_optimistic_root_task(&self) -> bool {
-        matches!(&self.data, TaskImpl::Optimistic(optimistic::Task::Root))
-    }
-
     pub fn is_cli_subagent(&self) -> bool {
         match &self.data {
             TaskImpl::Server(server_data) => server_data
@@ -581,14 +563,12 @@ impl Task {
     pub(super) fn source_for_persistence(&self) -> Option<api::Task> {
         match &self.data {
             TaskImpl::Server(server_data) => Some(server_data.source.clone()),
-            TaskImpl::Optimistic(optimistic::Task::Root) => Some(api::Task {
-                id: self.id.to_string(),
-                messages: vec![],
-                dependencies: None,
-                description: String::new(),
-                summary: String::new(),
-                server_data: String::new(),
-            }),
+            // Optimistic root tasks have a client-generated UUID and no
+            // server-side identity yet. Persisting a stub `api::Task` for them
+            // produces an orphan row in `agent_tasks` that survives the later
+            // server-side upgrade and breaks restore by competing with the
+            // real server root for parentless-task selection. See QUALITY-774.
+            TaskImpl::Optimistic(optimistic::Task::Root) => None,
             TaskImpl::Optimistic(optimistic::Task::CLIAgent(_)) => None,
         }
     }

--- a/app/src/ai/agent/task_tests.rs
+++ b/app/src/ai/agent/task_tests.rs
@@ -378,20 +378,6 @@ fn test_splice_messages_optimistic_task_not_initialized() {
 }
 
 #[test]
-fn test_restored_optimistic_root_can_upgrade_to_server_created_task() {
-    let task =
-        Task::new_restored_optimistic_root("optimistic-root".to_string(), std::iter::empty());
-
-    let task = task
-        .into_server_created_task(create_api_task("server-root", vec![]), None, None, None)
-        .expect("restored optimistic root should upgrade");
-
-    assert_eq!(task.id().to_string(), "server-root");
-    assert!(!task.is_optimistic_root_task());
-    assert!(task.source().is_some());
-}
-
-#[test]
 fn test_splice_messages_from_beginning() {
     let task_id = "task1";
     let api_task = create_api_task(

--- a/app/src/ai/blocklist/history_model/conversation_loader.rs
+++ b/app/src/ai/blocklist/history_model/conversation_loader.rs
@@ -85,7 +85,14 @@ pub fn convert_persisted_conversation_to_ai_conversation_with_metadata(
 
     let conversation_data = serde_json::from_str::<AgentConversationData>(&conversation_data).ok();
 
-    match AIConversation::new_restored(conversation_id, tasks, conversation_data) {
+    // Local-DB restore: an empty `agent_tasks` row is the normal shape of a
+    // child conversation persisted before its first server response, so
+    // synthesize a fresh optimistic root rather than failing the restore.
+    match AIConversation::new_restored_synthesizing_on_empty(
+        conversation_id,
+        tasks,
+        conversation_data,
+    ) {
         Ok(conversation) => Some(conversation),
         Err(e) => {
             log::warn!("Failed to convert persisted conversation to AIConversation: {e:?}");

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1505,6 +1505,525 @@ fn test_mark_conversation_as_remote_child_persists_updated_conversation_state() 
     });
 }
 
+/// Persisting a conversation whose root is still `Optimistic(Root)` (i.e.
+/// the server has not yet upgraded it via a `CreateTask` action) must NOT
+/// emit a stub `api::Task` in `updated_tasks`.
+///
+/// Previously, `Task::source_for_persistence` returned a synthetic empty
+/// `api::Task` keyed by the client-generated optimistic UUID, which
+/// accumulated as an orphan row in `agent_tasks` and broke later restores
+/// via `HashMap` iteration non-determinism in `AIConversation::new_restored`
+/// (when two parentless tasks — the stub and the real server root —
+/// co-existed and the stub randomly won).
+#[test]
+fn test_persist_with_optimistic_root_emits_event_with_no_task_rows() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        // Create a fresh conversation. Its root is `Optimistic(Root)` with a
+        // client-generated UUID; no server response has been received.
+        let conversation_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        // Force a persist while the root is still optimistic.
+        // `mark_conversation_as_remote_child` is one of several early-persist
+        // sites; any of them would exhibit the same writer behavior.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.mark_conversation_as_remote_child(conversation_id, ctx);
+        });
+
+        let event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("optimistic-root persist should emit an UpdateMultiAgentConversation event");
+
+        let ModelEvent::UpdateMultiAgentConversation {
+            updated_tasks,
+            conversation_data,
+            ..
+        } = event
+        else {
+            panic!("expected UpdateMultiAgentConversation event");
+        };
+
+        // The fix: optimistic-root tasks must not produce any persisted task rows.
+        assert!(
+            updated_tasks.is_empty(),
+            "Persisting a conversation whose root is still Optimistic(Root) must emit zero \
+             task rows; got {} task(s) with ids: {:?}",
+            updated_tasks.len(),
+            updated_tasks
+                .iter()
+                .map(|t| t.id.as_str())
+                .collect::<Vec<_>>(),
+        );
+
+        // The legacy `root_task_is_optimistic` flag must no longer be written.
+        assert!(
+            conversation_data.root_task_is_optimistic.is_none(),
+            "conversation_data.root_task_is_optimistic must not be written (legacy field); \
+             got {:?}",
+            conversation_data.root_task_is_optimistic,
+        );
+    });
+}
+
+/// Once the in-memory root has been upgraded from `Optimistic(Root)` to a
+/// server-backed `Task`, the next `persist_conversation_state` must emit
+/// exactly one task row with the server-assigned id and no dependencies.
+/// Previously, the persist also retained the original optimistic stub row,
+/// producing two parentless rows that broke restore.
+#[test]
+fn test_optimistic_root_upgrade_then_persist_emits_event_with_single_server_task_row() {
+    use crate::test_util::ai_agent_tasks::create_api_task;
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        let (sender, receiver) = std::sync::mpsc::sync_channel(2);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        // First persist: while the root is still Optimistic(Root).
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.mark_conversation_as_remote_child(conversation_id, ctx);
+        });
+        let first_event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first persist event must arrive");
+        let ModelEvent::UpdateMultiAgentConversation {
+            updated_tasks: first_updated_tasks,
+            ..
+        } = first_event
+        else {
+            panic!("expected UpdateMultiAgentConversation event");
+        };
+        assert!(
+            first_updated_tasks.is_empty(),
+            "precondition: optimistic-root persist must emit zero task rows",
+        );
+
+        // Drive the optimistic→server upgrade in-place and trigger another
+        // persist via mark_conversation_as_remote_child (idempotent setter +
+        // unconditional persist) to keep this test isolated from the full
+        // response-stream/CreateTask plumbing.
+        let server_root_id = "server-root-task-id".to_string();
+        history_model.update(&mut app, |history_model, ctx| {
+            let conversation = history_model
+                .conversation_mut(&conversation_id)
+                .expect("conversation should still exist");
+            conversation.upgrade_optimistic_root_to_server_task_for_test(create_api_task(
+                &server_root_id,
+                vec![],
+            ));
+            history_model.mark_conversation_as_remote_child(conversation_id, ctx);
+        });
+
+        let second_event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("post-upgrade persist event must arrive");
+        let ModelEvent::UpdateMultiAgentConversation {
+            updated_tasks: second_updated_tasks,
+            ..
+        } = second_event
+        else {
+            panic!("expected UpdateMultiAgentConversation event");
+        };
+
+        assert_eq!(
+            second_updated_tasks.len(),
+            1,
+            "post-upgrade persist must emit exactly one task row (the server root); got {} task(s) with ids {:?}",
+            second_updated_tasks.len(),
+            second_updated_tasks.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
+        );
+        let only_task = &second_updated_tasks[0];
+        assert_eq!(
+            only_task.id, server_root_id,
+            "post-upgrade persist row id must match the server-assigned id",
+        );
+        assert!(
+            only_task.dependencies.is_none(),
+            "the server root must be parentless (no dependencies); got {:?}",
+            only_task.dependencies,
+        );
+    });
+}
+
+/// Round-trip: take the persist event emitted while the root is still
+/// optimistic, build an `AgentConversation` from it (with the expected empty
+/// `tasks` list), feed it through the local-DB restore path, and confirm we
+/// get back an `InProgress` conversation with a fresh optimistic root and all
+/// linkage metadata preserved.
+#[test]
+fn test_optimistic_root_restore_round_trip_yields_in_progress_optimistic_root() {
+    use crate::ai::agent::conversation::ConversationStatus;
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let _orchestration_v2 = FeatureFlag::OrchestrationV2.override_enabled(true);
+
+        let (sender, receiver) = std::sync::mpsc::sync_channel(2);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        // Set up a parent conversation so the child has a real parent_agent_id.
+        let (child_conversation_id, expected_parent_agent_id) =
+            history_model.update(&mut app, |history_model, ctx| {
+                let parent_id = history_model.start_new_conversation(
+                    terminal_view_id,
+                    false,
+                    false,
+                    false,
+                    ctx,
+                );
+                let parent_run_id = Uuid::new_v4().to_string();
+                history_model
+                    .conversation_mut(&parent_id)
+                    .expect("parent conversation should exist")
+                    .set_run_id(parent_run_id.clone());
+                // Drain any persist event from parent setup. start_new_conversation
+                // itself does not persist; nothing should be enqueued yet.
+                let child_id = history_model.start_new_child_conversation(
+                    terminal_view_id,
+                    "Round-trip child".to_string(),
+                    parent_id,
+                    Some(Harness::Claude),
+                    ctx,
+                );
+                let expected_parent_agent_id = history_model
+                    .conversation(&child_id)
+                    .and_then(|c| c.parent_agent_id().map(|s| s.to_string()))
+                    .expect("child conversation should have its parent_agent_id stamped");
+                (child_id, expected_parent_agent_id)
+            });
+
+        // The child-creation call site is itself one of the early-persist
+        // sites; consume that first event for the assertion below.
+        let first_event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("child creation should persist conversation state");
+        let ModelEvent::UpdateMultiAgentConversation {
+            conversation_id: child_id_str,
+            updated_tasks,
+            conversation_data,
+        } = first_event
+        else {
+            panic!("expected UpdateMultiAgentConversation event");
+        };
+        assert_eq!(child_id_str, child_conversation_id.to_string());
+        assert!(
+            updated_tasks.is_empty(),
+            "child conversation persisted while root is optimistic must emit zero task rows",
+        );
+
+        // Round-trip via the local-DB loader.
+        let persisted = AgentConversation {
+            conversation: AgentConversationRecord {
+                id: 0,
+                conversation_id: child_id_str.clone(),
+                conversation_data: serde_json::to_string(&conversation_data)
+                    .expect("conversation data should serialize"),
+                last_modified_at: Utc::now().naive_utc(),
+            },
+            tasks: updated_tasks,
+        };
+        let restored = convert_persisted_conversation_to_ai_conversation_with_metadata(persisted)
+            .expect("empty-tasks restore must succeed");
+
+        assert_eq!(restored.id(), child_conversation_id);
+        let root_task = restored.get_root_task().expect("root task should exist");
+        assert!(root_task.is_root_task());
+        assert!(
+            root_task.source().is_none(),
+            "the synthesized restored root must be optimistic (no api::Task source)",
+        );
+        assert_eq!(restored.status(), &ConversationStatus::InProgress);
+        assert!(restored.status_error_message().is_none());
+
+        // All persisted linkage metadata must round-trip.
+        assert_eq!(
+            restored.parent_agent_id(),
+            Some(expected_parent_agent_id.as_str()),
+        );
+        assert_eq!(restored.agent_name(), Some("Round-trip child"));
+        assert_eq!(restored.orchestration_harness(), Some(Harness::Claude));
+    });
+}
+
+/// `AIConversation::truncate_from_exchange` resets the root to
+/// `Optimistic(Root)` when all exchanges are removed and then calls
+/// `write_updated_conversation_state`. That persist must emit zero task rows
+/// (the synthesized optimistic root no longer produces a stub).
+#[test]
+fn test_truncate_from_exchange_to_empty_persist_event_has_empty_updated_tasks() {
+    use crate::test_util::ai_agent_tasks::create_api_task;
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        let (sender, receiver) = std::sync::mpsc::sync_channel(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+        let now = Local::now();
+
+        let conversation_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        // Upgrade the root to a server-backed task so the truncate path
+        // ("all exchanges removed → reset to optimistic") actually involves a
+        // real server root being torn down.
+        let server_root_id = "truncate-server-root".to_string();
+        history_model.update(&mut app, |history_model, _ctx| {
+            let conversation = history_model
+                .conversation_mut(&conversation_id)
+                .expect("conversation should exist");
+            conversation.upgrade_optimistic_root_to_server_task_for_test(create_api_task(
+                &server_root_id,
+                vec![],
+            ));
+        });
+
+        // Append an exchange tied to the now server-backed root, then
+        // truncate from it. The exchange add path does not persist; the
+        // truncate call does. `update_for_new_request_input` allocates a
+        // fresh exchange id internally, so we look the freshly-assigned id
+        // up on the conversation rather than reusing the dummy exchange's
+        // id from `create_exchange_with_query`.
+        let stream_id = ResponseStreamId::new_for_test();
+        history_model.update(&mut app, |history_model, ctx| {
+            let exchange = create_exchange_with_query("truncate me", now, None);
+            let request_input = RequestInput {
+                conversation_id,
+                input_messages: std::collections::HashMap::from([(
+                    crate::ai::agent::task::TaskId::new(server_root_id.clone()),
+                    exchange.input,
+                )]),
+                working_directory: exchange.working_directory,
+                model_id: exchange.model_id,
+                coding_model_id: exchange.coding_model_id,
+                cli_agent_model_id: exchange.cli_agent_model_id,
+                computer_use_model_id: exchange.computer_use_model_id,
+                shared_session_response_initiator: exchange.response_initiator,
+                request_start_ts: exchange.start_time,
+                supported_tools_override: None,
+            };
+            history_model
+                .update_conversation_for_new_request_input(
+                    request_input,
+                    stream_id,
+                    terminal_view_id,
+                    ctx,
+                )
+                .expect("update_for_new_request_input must succeed on server-backed root");
+        });
+        let exchange_id = history_model.read(&app, |model, _| {
+            model
+                .conversation(&conversation_id)
+                .expect("conversation should exist")
+                .get_root_task()
+                .expect("root task should exist")
+                .exchanges()
+                .last()
+                .map(|e| e.id)
+                .expect("a freshly-appended exchange must exist on the root task")
+        });
+
+        history_model.update(&mut app, |history_model, ctx| {
+            let conversation = history_model
+                .conversation_mut(&conversation_id)
+                .expect("conversation should exist");
+            conversation
+                .truncate_from_exchange(exchange_id, ctx)
+                .expect("truncating from an existing exchange must succeed");
+        });
+
+        let event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("truncate-to-empty must emit an UpdateMultiAgentConversation event");
+        let ModelEvent::UpdateMultiAgentConversation { updated_tasks, .. } = event else {
+            panic!("expected UpdateMultiAgentConversation event");
+        };
+        assert!(
+            updated_tasks.is_empty(),
+            "truncate-to-empty resets the root to optimistic; the persist must emit zero task rows, got {} row(s) with ids {:?}",
+            updated_tasks.len(),
+            updated_tasks.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
+        );
+    });
+}
+
+/// End-to-end happy path: start → early persist → upgrade → persist → restart
+/// → post-restore persist → restart. After two restart cycles, the final
+/// restored conversation must contain exactly one server-backed root task
+/// with the server id and no orphan optimistic tasks.
+#[test]
+fn test_two_restart_cycles_keep_exactly_one_server_root_task_row() {
+    use crate::test_util::ai_agent_tasks::create_api_task;
+
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        let (sender, receiver) = std::sync::mpsc::sync_channel(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        // Early persist while the root is still optimistic.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.mark_conversation_as_remote_child(conversation_id, ctx);
+        });
+        let early_event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("early persist event must arrive");
+        let ModelEvent::UpdateMultiAgentConversation {
+            updated_tasks: early_updated_tasks,
+            ..
+        } = early_event
+        else {
+            panic!("expected UpdateMultiAgentConversation event");
+        };
+        assert!(
+            early_updated_tasks.is_empty(),
+            "early persist must not write any optimistic-stub task rows",
+        );
+
+        // Drive the optimistic→server upgrade and trigger another persist.
+        let server_root_id = "server-root".to_string();
+        history_model.update(&mut app, |history_model, ctx| {
+            let conversation = history_model
+                .conversation_mut(&conversation_id)
+                .expect("conversation should exist");
+            conversation.upgrade_optimistic_root_to_server_task_for_test(create_api_task(
+                &server_root_id,
+                vec![],
+            ));
+            history_model.mark_conversation_as_remote_child(conversation_id, ctx);
+        });
+        let post_upgrade_event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("post-upgrade persist event must arrive");
+        let post_upgrade_persisted =
+            persisted_agent_conversation_from_update_event(post_upgrade_event);
+        assert_eq!(
+            post_upgrade_persisted.tasks.len(),
+            1,
+            "post-upgrade persist must emit exactly one task row (the real server root)",
+        );
+        assert_eq!(post_upgrade_persisted.tasks[0].id, server_root_id);
+
+        // Simulate quit/restart #1: feed the persisted event through the
+        // local-DB restore helper.
+        let restored_after_restart_1 =
+            convert_persisted_conversation_to_ai_conversation_with_metadata(post_upgrade_persisted)
+                .expect("first simulated restart must restore cleanly");
+        let restart_1_root = restored_after_restart_1
+            .get_root_task()
+            .expect("root task must exist after restart 1");
+        assert!(
+            restart_1_root.source().is_some(),
+            "restart 1 root must be server-backed"
+        );
+        assert_eq!(
+            restart_1_root.id().to_string(),
+            server_root_id,
+            "restart 1 root must use the server-assigned id",
+        );
+        assert_eq!(
+            restored_after_restart_1.all_tasks().count(),
+            1,
+            "restart 1 must produce exactly one task (no orphan optimistic stub)",
+        );
+
+        // "Reload" the restored conversation into the in-memory model and
+        // trigger another post-restore persist site. `restore_conversations`
+        // uses `conversations_by_id.insert(...)` which overwrites the existing
+        // in-memory entry under the same id, so we do NOT delete first
+        // (`delete_conversation` would enqueue two model events that would
+        // race the persist event we want to recv below).
+        let restart_1_terminal_view_id = EntityId::new();
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.restore_conversations(
+                restart_1_terminal_view_id,
+                vec![restored_after_restart_1],
+                ctx,
+            );
+            history_model.mark_conversation_as_remote_child(conversation_id, ctx);
+        });
+
+        let post_restart_event = receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("post-restore persist event must arrive");
+        let post_restart_persisted =
+            persisted_agent_conversation_from_update_event(post_restart_event);
+        assert_eq!(
+            post_restart_persisted.tasks.len(),
+            1,
+            "post-restore persist must still emit exactly one task row (no accumulated stubs)",
+        );
+        assert_eq!(post_restart_persisted.tasks[0].id, server_root_id);
+
+        // Simulate quit/restart #2.
+        let restored_after_restart_2 =
+            convert_persisted_conversation_to_ai_conversation_with_metadata(post_restart_persisted)
+                .expect("second simulated restart must restore cleanly");
+
+        // Still exactly one server-backed root with the server id, no orphan
+        // optimistic tasks anywhere in the task store.
+        let restart_2_tasks: Vec<_> = restored_after_restart_2.all_tasks().collect();
+        assert_eq!(
+            restart_2_tasks.len(),
+            1,
+            "final restored conversation must have exactly one task; got {}",
+            restart_2_tasks.len(),
+        );
+        let restart_2_root = restored_after_restart_2
+            .get_root_task()
+            .expect("root task must exist after restart 2");
+        assert!(
+            restart_2_root.source().is_some(),
+            "restart 2 root must be server-backed",
+        );
+        assert_eq!(
+            restart_2_root.id().to_string(),
+            server_root_id,
+            "restart 2 root id must still match the server-assigned id",
+        );
+    });
+}
+
 #[test]
 fn test_initialize_output_for_response_stream_persists_updated_conversation_state() {
     App::test((), |mut app| async move {

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -940,6 +940,9 @@ impl TerminalView {
             pinned: false,
         };
 
+        // We already early-return for empty `tasks` above, so the strict
+        // constructor is safe here and matches the other cloud-style entry
+        // points.
         match AIConversation::new_restored(conversation_id, tasks, Some(conversation_data)) {
             Ok(conversation) => {
                 // Use live appearance for cloud conversation viewer

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1045,7 +1045,13 @@ pub struct AgentConversationData {
     /// agent executing on a remote worker.
     #[serde(default, skip_serializing_if = "is_false")]
     pub is_remote_child: bool,
-    /// Whether the root task was still optimistic when this conversation was persisted.
+    /// Legacy marker that previously recorded whether the root task was still
+    /// optimistic when this conversation was persisted. Retained on the struct
+    /// for backward-compatible deserialization of rows written by older builds;
+    /// new writes always emit `None` and restore code ignores the value.
+    ///
+    // TODO: Remove this field once no live local DBs still contain
+    // `Some(true)` rows that legacy code paths might trip over.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub root_task_is_optimistic: Option<bool>,
     /// The server-assigned run identifier (`ai_tasks.id`) for v2 orchestration.

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -943,13 +943,24 @@ impl AgentConversation {
     ///
     /// A conversation is restorable if:
     /// - It contains a single task or fewer, OR
-    /// - It contains multiple tasks where every task other than the root task has a parent task ID.
+    /// - It has exactly one parentless (root) task, OR
+    /// - It has multiple parentless tasks but exactly one of them has
+    ///   non-empty `messages`. This permits restoring conversations whose
+    ///   persisted state was corrupted by the pre-QUALITY-774 optimistic-root
+    ///   writer bug, where a stub root row co-existed with the real server
+    ///   root row. `AIConversation::new_restored` deterministically picks
+    ///   the real root in that shape via its restore-side dedupe.
+    ///
+    /// Non-root tasks need not be validated here: any task that does not
+    /// match the parentless predicate has, by construction, a non-empty
+    /// `parent_task_id`.
     pub fn is_restorable(&self) -> bool {
         if self.tasks.len() <= 1 {
             return true;
         }
 
-        // Find the root task(s) - tasks with no parent_task_id or empty parent_task_id
+        // Find parentless (root) tasks - tasks with no dependencies or with an
+        // empty parent_task_id.
         let root_tasks: Vec<_> = self
             .tasks
             .iter()
@@ -961,28 +972,18 @@ impl AgentConversation {
             })
             .collect();
 
-        // Must have exactly one root task
-        if root_tasks.len() != 1 {
-            return false;
+        match root_tasks.len() {
+            // Malformed: no parentless task means no root to anchor restore on.
+            0 => false,
+            // Single root: the normal happy path.
+            1 => true,
+            // Multi-root: only permit the specific [stub + real] shape
+            // produced by the pre-QUALITY-774 optimistic-root writer bug,
+            // where exactly one parentless row carries the real conversation
+            // content. The restore-side dedupe in
+            // `AIConversation::new_restored` will pick that real root.
+            _ => root_tasks.iter().filter(|t| !t.messages.is_empty()).count() == 1,
         }
-
-        // All non-root tasks must have a non-empty parent_task_id
-        self.tasks.iter().all(|task| {
-            // Root task is always valid
-            if task
-                .dependencies
-                .as_ref()
-                .map(|deps| deps.parent_task_id.is_empty())
-                .unwrap_or(true)
-            {
-                return true;
-            }
-
-            // Non-root tasks must have a non-empty parent_task_id
-            task.dependencies
-                .as_ref()
-                .is_some_and(|deps| !deps.parent_task_id.is_empty())
-        })
     }
 }
 
@@ -1394,7 +1395,106 @@ pub struct NewMCPServerInstallation {
 mod tests {
     use std::collections::HashMap;
 
-    use super::{AgentConversationData, ModelTokenUsage};
+    use warp_multi_agent_api as api;
+
+    use super::{AgentConversation, AgentConversationData, ModelTokenUsage};
+
+    fn parentless_task(id: &str, message_count: usize) -> api::Task {
+        api::Task {
+            id: id.to_string(),
+            description: String::new(),
+            dependencies: None,
+            messages: (0..message_count)
+                .map(|i| api::Message {
+                    id: format!("{id}-msg-{i}"),
+                    task_id: id.to_string(),
+                    server_message_data: String::new(),
+                    citations: vec![],
+                    message: None,
+                    request_id: String::new(),
+                    timestamp: None,
+                })
+                .collect(),
+            summary: String::new(),
+            server_data: String::new(),
+        }
+    }
+
+    fn child_task(id: &str, parent_id: &str) -> api::Task {
+        api::Task {
+            id: id.to_string(),
+            description: String::new(),
+            dependencies: Some(api::task::Dependencies {
+                parent_task_id: parent_id.to_string(),
+            }),
+            messages: vec![],
+            summary: String::new(),
+            server_data: String::new(),
+        }
+    }
+
+    fn conversation_with_tasks(tasks: Vec<api::Task>) -> AgentConversation {
+        AgentConversation {
+            conversation: Default::default(),
+            tasks,
+        }
+    }
+
+    /// Legacy [stub + real] root shape produced by the pre-QUALITY-774
+    /// optimistic-root writer bug must be considered restorable so the
+    /// restore-side dedupe in `AIConversation::new_restored` can pick the
+    /// real root.
+    #[test]
+    fn is_restorable_accepts_legacy_stub_plus_real_root_shape() {
+        let conversation = conversation_with_tasks(vec![
+            parentless_task("optimistic-stub-uuid", 0),
+            parentless_task("server-root-id", 2),
+            child_task("child-1", "server-root-id"),
+        ]);
+        assert!(conversation.is_restorable());
+    }
+
+    /// Multi-root with multiple real roots (each non-empty) is genuinely
+    /// ambiguous and must remain rejected — the dedupe heuristic cannot
+    /// disambiguate between two real roots.
+    #[test]
+    fn is_restorable_rejects_multi_root_with_multiple_real_roots() {
+        let conversation = conversation_with_tasks(vec![
+            parentless_task("root-a", 1),
+            parentless_task("root-b", 1),
+        ]);
+        assert!(!conversation.is_restorable());
+    }
+
+    /// Multi-root where every candidate is empty has nothing to anchor
+    /// restore on and must remain rejected.
+    #[test]
+    fn is_restorable_rejects_multi_root_with_no_real_root() {
+        let conversation = conversation_with_tasks(vec![
+            parentless_task("stub-1", 0),
+            parentless_task("stub-2", 0),
+        ]);
+        assert!(!conversation.is_restorable());
+    }
+
+    /// Normal happy path: a single parentless root plus well-formed child
+    /// tasks remains restorable.
+    #[test]
+    fn is_restorable_accepts_single_root_plus_subtasks() {
+        let conversation = conversation_with_tasks(vec![
+            parentless_task("root", 1),
+            child_task("child-1", "root"),
+            child_task("child-2", "root"),
+        ]);
+        assert!(conversation.is_restorable());
+    }
+
+    /// Empty or single-task conversations are trivially restorable.
+    #[test]
+    fn is_restorable_accepts_empty_and_single_task_conversations() {
+        assert!(conversation_with_tasks(vec![]).is_restorable());
+        assert!(conversation_with_tasks(vec![parentless_task("root", 0)]).is_restorable());
+    }
 
     #[test]
     fn agent_conversation_data_roundtrips_last_event_sequence() {


### PR DESCRIPTION
## Description

Fix-forward for the bug introduced by #10794 where Agent Mode conversations can fail to restore after a quit/restart, sometimes producing the server error `Response stream finished unexpectedly with internal error: Not found: Tried to add messages to non-existent task (id=)`.

**Root cause.** PR #10794 added eager `persist_conversation_state` calls at several sites (`start_new_child_conversation`, `initialize_output_for_response_stream`, `assign_run_id_for_conversation`, `mark_conversation_as_remote_child`) that fire while the root task is still `Optimistic(Root)`. `Task::source_for_persistence` was synthesizing a stub `api::Task` for the optimistic root, which was written to `agent_tasks` keyed by the client-generated UUID. After the server upgraded the root, a second row was written keyed by the server task id; the stub row was never deleted. On restore, `AIConversation::new_restored` saw two parentless tasks and HashMap iteration order non-deterministically picked between them — when the stub won, restore left the conversation stuck with an empty root and subtask `parent_task_id` references pointing at a server root id that no longer existed in the task store.

**Fix.** Two coordinated changes:

1. **Writer side** (`Task::source_for_persistence`): returns `None` for `Optimistic(Root)`, matching the existing `Optimistic(CLIAgent(_))` behavior. No new stub rows are written. `AgentConversationData.root_task_is_optimistic` is retained on the persistence model for backward-compatible deserialization of existing local DB rows, but is no longer written and is ignored on restore.

2. **Restore side** (`AIConversation::new_restored`):
   - Two single-purpose constructors. `new_restored` is strict (returns `Err(NoRootTask)` for an empty `tasks` list) and is used by cloud-restore and fork-insert, where an empty payload is malformed input. `new_restored_synthesizing_on_empty` is a small wrapper that synthesizes a fresh in-progress `Optimistic(Root)` conversation when `tasks` is empty (mirroring `AIConversation::new()`) and is used by the local-DB restore path, where an empty `agent_tasks` row is the normal shape for child conversations persisted before their first server response.
   - Restore-side dedupe: when multiple parentless tasks exist (legacy DB case), prefer the candidate with non-empty `messages`. Silently heals pre-fix rows without a SQLite migration.

Removes `Task::new_restored_optimistic_root` and `Task::is_optimistic_root_task`; replaces the previous `PersistedConversationFields` helper by inlining the overlay logic into the single constructor. Adds a `#[cfg(test)] pub(crate)` helper for driving root upgrades in tests.

## Linked Issue

QUALITY-774 — fix-forward of #10794.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- New deterministic fail-first writer-side test `test_persist_with_optimistic_root_emits_event_with_no_task_rows` — proves the writer bug exists on `master` and disappears with the fix.
- New defense-in-depth tests in `app/src/ai/blocklist/history_model_tests.rs`:
  - `test_optimistic_root_upgrade_then_persist_emits_event_with_single_server_task_row`
  - `test_optimistic_root_restore_round_trip_yields_in_progress_optimistic_root`
  - `test_truncate_from_exchange_to_empty_persist_event_has_empty_updated_tasks`
  - `test_two_restart_cycles_keep_exactly_one_server_root_task_row`
- New restore-semantics tests in `app/src/ai/agent/conversation_tests.rs`:
  - `restored_conversation_with_empty_task_list_creates_in_progress_optimistic_root`
  - `restored_conversation_ignores_legacy_root_task_is_optimistic_flag_with_non_empty_tasks`
  - `restored_conversation_ignores_legacy_root_task_is_optimistic_flag_with_empty_tasks`
  - `new_restored_with_empty_task_list_returns_no_root_task_error`
  - `test_new_restored_prefers_parentless_task_with_messages_over_empty_stub` (50-iteration loop per Vec ordering to catch HashMap-order regressions)
- Existing `agent_conversation_data_roundtrips_optimistic_root_marker` in `crates/persistence/src/model.rs` still passes, pinning back-compat deserialization of the legacy field.
- `./script/presubmit` passes end-to-end.

**Note on legacy data:** This PR does not physically remove pre-existing orphan stub rows in dev/preview local SQLite, but the restore-side dedupe silently ignores them. Affected internal users should not need to clear local AI history.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---

_Conversation: https://staging.warp.dev/conversation/3fc61b76-c75b-4e86-bc4a-6f4534e44abb_
_Plan: https://staging.warp.dev/drive/notebook/EAwKh7EVES70otTsIdkZ9u_

<!--
CHANGELOG-NONE
-->
