### PR TITLE
Fix find match highlight offset in initial /agent queries

### DIFF
--- a/app/src/ai/blocklist/block/find.rs
+++ b/app/src/ai/blocklist/block/find.rs
@@ -3,9 +3,11 @@ use std::ops::Range;
 
 use itertools::Itertools;
 use regex::RegexBuilder;
+use warpui::SingletonEntity;
 
 use super::{AIBlock, TextLocation};
 use crate::ai::agent::{AIAgentTextSection, MessageId};
+use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 use crate::terminal::find::{FindOptions, FindableRichContentView, RichContentMatchId};
 
 /// Represents the location of a find match in an AI block.
@@ -49,8 +51,13 @@ impl FindableRichContentView for AIBlock {
         self.clear_matches(ctx);
 
         let mut new_match_ids = vec![];
+        // Match against the displayed query (including any "/agent" prefix added for the
+        // initial conversation query) so highlight ranges line up with the rendered text.
+        let initial_conversation_query = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&self.client_ids.conversation_id)
+            .and_then(|conversation| conversation.initial_user_query());
         for (i, input) in self.model.inputs_to_render(ctx).iter().enumerate() {
-            if let Some(query) = input.user_query() {
+            if let Some(query) = input.display_user_query(initial_conversation_query.as_ref()) {
                 for find_match_range in compute_find_matches(&query, options).into_iter() {
                     let id = RichContentMatchId::default();
                     new_match_ids.push(id);
@@ -131,6 +138,10 @@ impl FindableRichContentView for AIBlock {
         ctx.notify();
     }
 }
+
+#[cfg(test)]
+#[path = "find_tests.rs"]
+mod tests;
 
 /// Computes find matches (represented as character offsets) within the given `text`.
 fn compute_find_matches(text: &str, options: &FindOptions) -> Vec<Range<usize>> {

--- a/app/src/ai/blocklist/block/find_tests.rs
+++ b/app/src/ai/blocklist/block/find_tests.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::compute_find_matches;
+use crate::ai::agent::{AIAgentInput, UserQueryMode};
+use crate::terminal::find::FindOptions;
+
+fn user_query_input(query: &str, mode: UserQueryMode) -> AIAgentInput {
+    AIAgentInput::UserQuery {
+        query: query.to_string(),
+        context: Arc::new([]),
+        static_query_type: None,
+        referenced_attachments: HashMap::new(),
+        user_query_mode: mode,
+        running_command: None,
+        intended_agent: None,
+    }
+}
+
+// Regression test for https://github.com/warpdotdev/warp/issues/11697.
+// Find match highlights on the initial agent query must be computed against the displayed
+// query (prefixed with "/agent "), not the stored query, so the ranges line up with the
+// rendered text.
+#[test]
+fn find_matches_align_with_agent_prefixed_initial_query() {
+    let query = "list files".to_string();
+    let input = user_query_input(&query, UserQueryMode::Normal);
+
+    let displayed = input
+        .display_user_query(Some(&query))
+        .expect("user query should produce displayed text");
+    assert_eq!(displayed, "/agent list files");
+
+    let options = FindOptions::default().with_query(Some("list".to_string()));
+
+    // "list" starts after the "/agent " prefix (7 chars), so the match must be 7..11 — not
+    // 0..4, which is what matching against the un-prefixed stored query would produce.
+    assert_eq!(compute_find_matches(&displayed, &options), vec![7..11]);
+}
+
+// A "/plan" query is stored with its prefix already attached, so its highlights have always
+// lined up. Lock that in alongside the agent-prefix fix.
+#[test]
+fn find_matches_align_with_plan_prefixed_query() {
+    let input = user_query_input("write tests", UserQueryMode::Plan);
+
+    let displayed = input
+        .display_user_query(None)
+        .expect("user query should produce displayed text");
+    assert_eq!(displayed, "/plan write tests");
+
+    let options = FindOptions::default().with_query(Some("tests".to_string()));
+    assert_eq!(compute_find_matches(&displayed, &options), vec![12..17]);
+}


### PR DESCRIPTION
## Description

Find match highlights for the initial agent query were rendered in the wrong position. `AIBlock::run_find` computed match character ranges against `input.user_query()` (the stored query text), but the UI renders `input.display_user_query()`, which prepends `/agent ` to the initial conversation query. The cached ranges were therefore based on the shorter string and applied to the longer rendered string, shifting highlights left by the prefix length. `/plan` and `/orchestrate` queries already lined up because their prefix is part of `user_query()`.

The fix computes find matches against the displayed query (via `display_user_query`, resolving the conversation's initial query through `BlocklistAIHistoryModel` — the same pattern already used for link detection and secret redaction in `block.rs`), so the ranges align with the rendered text. This matches the root cause identified in the issue triage.

## Linked Issue

Closes #11697

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Screenshots / video included below.

## Testing

- Added regression tests in `app/src/ai/blocklist/block/find_tests.rs`:
  - `find_matches_align_with_agent_prefixed_initial_query` — asserts a `list` match in `/agent list files` resolves to `7..11` (after the `/agent ` prefix), not the buggy `0..4`.
  - `find_matches_align_with_plan_prefixed_query` — locks in the already-correct `/plan` offset to guard against regressions.
- `cargo test -p warp find_matches_align` — both pass.
- `cargo check -p warp --tests`, `cargo clippy -p warp --tests`, and `cargo fmt` all clean.
- [x] Manually verified by building the OSS app (`cargo run --bin warp-oss`) on both `master` and this branch and reproducing the same `/agent` query + find (`direc`). Before/after captured below.

### Screenshots / Videos

Same `/agent` query (`list the files in this directory`) and find term (`direc`) on both builds:
- **Before (master):** the highlight lands on "n thi", shifted left by the width of the `/agent ` prefix (7 chars).
- **After (this PR):** the highlight correctly lands on "direc" within "directory".

<img width="714" height="772" alt="warp-11697-before-after" src="https://github.com/user-attachments/assets/3865b88c-b2cf-412e-aab6-5b8b61db7143" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix find match highlight position in initial /agent queries