### PR TITLE
Fix requested command conversation association

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -17,6 +17,7 @@ use warpui::r#async::{Spawnable, Timer};
 use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
+use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentActionId, AIAgentActionResultType, AIAgentActionType, AIAgentPtyWriteMode,
     ReadShellCommandOutputResult, RequestCommandOutputResult, ShellCommandDelay, ShellCommandError,
@@ -247,6 +248,7 @@ impl ShellCommandExecutor {
                     };
                 ctx.emit(ShellCommandExecutorEvent::ExecuteCommand {
                     action_id: action_id.clone(),
+                    conversation_id: input.conversation_id,
                     command: decorated_command,
                 });
 
@@ -872,6 +874,7 @@ fn action_result_for_transfer_shell_command_control_to_user(
 pub enum ShellCommandExecutorEvent {
     ExecuteCommand {
         action_id: AIAgentActionId,
+        conversation_id: AIConversationId,
         command: String,
     },
     WriteToPty {

--- a/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command_tests.rs
@@ -3,15 +3,42 @@ use std::sync::Arc;
 use async_channel::unbounded;
 use futures::channel::oneshot;
 use parking_lot::FairMutex;
-use warpui::{App, EntityId};
+use warpui::{App, Entity, EntityId};
 
-use super::{BlockSelector, ShellCommandExecutor};
+use super::{BlockSelector, ShellCommandExecutor, ShellCommandExecutorEvent};
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::task::TaskId;
+use crate::ai::agent::{AIAgentAction, AIAgentActionId, AIAgentActionType};
 use crate::terminal::event::{BlockMetadataReceivedEvent, BlockWorkingDirectoryUpdatedEvent};
 use crate::terminal::model::block::{BlockId, BlockMetadata};
 use crate::terminal::model::session::active_session::ActiveSession;
 use crate::terminal::model::session::Sessions;
 use crate::terminal::model::terminal_model::{BlockIndex, TerminalModel};
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
+struct ShellCommandEventRecorder {
+    event: Option<ShellCommandExecutorEvent>,
+}
+
+impl Entity for ShellCommandEventRecorder {
+    type Event = ();
+}
+
+fn request_command_action(action_id: AIAgentActionId, command: &str) -> AIAgentAction {
+    AIAgentAction {
+        id: action_id,
+        task_id: TaskId::new("fake-task".to_owned()),
+        action: AIAgentActionType::RequestCommandOutput {
+            command: command.to_owned(),
+            is_read_only: None,
+            is_risky: None,
+            rationale: None,
+            uses_pager: None,
+            wait_until_completion: true,
+            citations: vec![],
+        },
+        requires_result: false,
+    }
+}
 
 /// Locks in the contract that `ShellCommandExecutor`'s requested-command finish
 /// detector reacts only to `BlockMetadataReceived` (precmd) and not to
@@ -87,5 +114,67 @@ fn block_working_directory_updated_does_not_drain_finish_senders() {
             0,
             "BlockMetadataReceived should drain the finish senders"
         );
+    });
+}
+
+#[test]
+fn execute_command_event_includes_source_conversation_id() {
+    App::test((), |mut app| async move {
+        let terminal_view_id = EntityId::new();
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let (_model_events_tx, model_events_rx) = unbounded();
+        let model_event_dispatcher =
+            app.add_model(|ctx| ModelEventDispatcher::new(model_events_rx, sessions.clone(), ctx));
+        let active_session = app.add_model(|ctx| {
+            ActiveSession::new(sessions.clone(), model_event_dispatcher.clone(), ctx)
+        });
+        let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+        let executor = app.add_model(|ctx| {
+            ShellCommandExecutor::new(
+                active_session,
+                terminal_model.clone(),
+                &model_event_dispatcher,
+                terminal_view_id,
+                ctx,
+            )
+        });
+        let recorder = app.add_model(|ctx| {
+            ctx.subscribe_to_model(
+                &executor,
+                |recorder: &mut ShellCommandEventRecorder, event, _| {
+                    recorder.event = Some(event.clone());
+                },
+            );
+            ShellCommandEventRecorder { event: None }
+        });
+
+        let action_id = AIAgentActionId::from("requested-command".to_owned());
+        let conversation_id = AIConversationId::new();
+        let action = request_command_action(action_id.clone(), "pwd");
+        executor.update(&mut app, |executor, ctx| {
+            let _ = executor.execute(
+                super::super::ExecuteActionInput {
+                    action: &action,
+                    conversation_id,
+                },
+                ctx,
+            );
+        });
+
+        let event = recorder
+            .read(&app, |recorder, _| recorder.event.clone())
+            .expect("expected requested-command execution event");
+        let ShellCommandExecutorEvent::ExecuteCommand {
+            action_id: emitted_action_id,
+            conversation_id: emitted_conversation_id,
+            command,
+        } = event
+        else {
+            panic!("expected ExecuteCommand event");
+        };
+
+        assert_eq!(emitted_action_id, action_id);
+        assert_eq!(emitted_conversation_id, conversation_id);
+        assert_eq!(command, "pwd");
     });
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6894,22 +6894,24 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         match event {
-            ShellCommandExecutorEvent::ExecuteCommand { command, action_id } => {
+            ShellCommandExecutorEvent::ExecuteCommand {
+                command,
+                action_id,
+                conversation_id,
+            } => {
                 let Some(session_id) = self.active_block_session_id() else {
                     return;
                 };
 
                 let history_model = BlocklistAIHistoryModel::as_ref(ctx);
-                let Some(conversation) = history_model
-                    .conversation_id_for_action(action_id, ctx.view_id())
-                    .and_then(|id| history_model.conversation(&id))
-                else {
+                let Some(conversation) = history_model.conversation(conversation_id) else {
                     safe_error!(
-                        safe: ("No conversation ID found for command with ID: {:?}", action_id),
+                        safe: ("No conversation found for command with ID: {:?}", action_id),
                         full: (
-                            "No conversation ID found for requested command: ID: {:?}, command: \
-                            {command}",
-                            action_id
+                            "No conversation found for requested command: ID: {:?}, \
+                            conversation_id={:?}, command: {command}",
+                            action_id,
+                            conversation_id
                         )
                     );
                     return;


### PR DESCRIPTION
## Description
Carry the source `AIConversationId` through requested shell command executor events so terminal handling no longer has to re-derive the conversation from the currently-focused terminal view. This keeps requested command approval/execution tied to the conversation that produced the action, avoiding stalls when focus or live terminal ownership changes before the command is handled.

## Linked Issue
APP-4621

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt --check`
- [x] `cargo test -p warp --lib execute_command_event_includes_source_conversation_id`
- [x] `cargo test -p warp --lib block_working_directory_updated_does_not_drain_finish_senders`
- [x] `cargo check -p warp`
- [x] `cargo clippy -p warp --lib --tests --all-features -- -D warnings`
- [ ] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` (blocked in this sandbox by missing generated channel config JSONs under `target/debug/build/.../out` referenced from `app/src/bin/channel_config.rs`)

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not applicable; this is a requested-command conversation association fix covered by a targeted regression test.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed requested command handling so agent conversations can continue when command approval is processed after focus or terminal ownership changes.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/31e744b9-2781-4b02-adc5-f7ac0b7ad2ed_
_Run: https://oz.staging.warp.dev/runs/019e6f1e-1aed-7b7b-acd4-06613c35b79b_
_This PR was generated with [Oz](https://warp.dev/oz)._
