### PR TITLE
feat: respect feedback skill organization setting

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
@@ -22,10 +22,12 @@ use crate::ai::blocklist::action_model::AIConversationId;
 use crate::ai::skills::{BundledSkillActivation, SkillManager};
 use crate::settings::AISettings;
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 
 fn initialize_app(app: &mut App) {
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(AISettings::new_with_defaults);
+    app.add_singleton_model(UserWorkspaces::default_mock);
     app.add_singleton_model(|_| DetectedRepositories::default());
     app.add_singleton_model(RepoMetadataModel::new);
     app.add_singleton_model(HomeDirectoryWatcher::new_for_test);

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -21,7 +21,8 @@ use super::SkillDescriptor;
 use crate::ai::mcp::{McpIntegration, TemplatableMCPServerManager};
 use crate::ai::skills::skill_utils::unique_skills;
 use crate::keyboard::keybinding_file_path;
-use crate::settings::{user_preferences_toml_file_path, AISettings};
+use crate::settings::user_preferences_toml_file_path;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 
 /// Activation condition for a bundled skill.
 #[derive(Debug, Clone)]
@@ -40,7 +41,9 @@ impl BundledSkillActivation {
     pub fn is_enabled(&self, ctx: &AppContext) -> bool {
         match self {
             Self::Always => true,
-            Self::FeedbackSkillSetting => *AISettings::as_ref(ctx).feedback_bundled_skill_enabled,
+            Self::FeedbackSkillSetting => {
+                UserWorkspaces::as_ref(ctx).is_feedback_bundled_skill_enabled(ctx)
+            }
             Self::RequiresMcp(integration) => {
                 TemplatableMCPServerManager::as_ref(ctx).is_mcp_server_running(*integration)
             }

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -15,6 +15,7 @@ use watcher::HomeDirectoryWatcher;
 use super::*;
 use crate::settings::AISettings;
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
+use crate::workspaces::user_workspaces::UserWorkspaces;
 
 // ============================================================================
 // Tests for get_skills_for_working_directory subdirectory scoping
@@ -79,6 +80,7 @@ fn get_skills_for_working_directory_scopes_subdirectory_skills() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         let repo_handle = app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -202,6 +204,7 @@ fn get_skills_for_working_directory_name_collision_returns_both() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         let repo_handle = app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -299,6 +302,7 @@ fn cloud_environment_skills_always_included() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         let repo_handle = app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -502,6 +506,7 @@ fn bundled_feedback_skill_is_enabled_by_default() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -532,6 +537,7 @@ fn disabling_feedback_bundled_skill_hides_only_that_bundled_skill() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -592,6 +598,7 @@ fn disabling_feedback_bundled_skill_does_not_hide_user_feedback_skill() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         let repo_handle = app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -656,6 +663,7 @@ fn disabling_feedback_bundled_skill_blocks_active_reference_lookup_only_for_bund
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -743,6 +751,7 @@ fn best_supported_provider_fast_path_returns_deduped_provider() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -769,6 +778,7 @@ fn best_supported_provider_remaps_to_supported_provider() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
@@ -800,6 +810,7 @@ fn best_supported_provider_falls_back_when_no_match() {
     App::test((), |mut app| async move {
         app.add_singleton_model(DirectoryWatcher::new);
         app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(UserWorkspaces::default_mock);
         app.add_singleton_model(|_| DetectedRepositories::default());
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -49,9 +49,9 @@ use super::workspace::{
     AiPermissionsSettings, AmbientAgentsPolicy, BillingCycleUsageData, BillingCycleUsageEntry,
     BillingCycleUsageSummary, BillingMetadata, CloudConversationStorageSettings,
     CodebaseContextSettings, CustomerType, DelinquencyStatus, EmailInvite, EnterpriseSecretRegex,
-    HostEnablementSetting, InstanceShape, InviteLinkDomainRestriction, LinkSharingSettings,
-    LlmSettings, MaxPriorCycles, SandboxedAgentSettings, SecretRedactionSettings,
-    SessionSharingPolicy, SharedNotebooksPolicy, SharedWorkflowsPolicy,
+    FeedbackSkillSettings, HostEnablementSetting, InstanceShape, InviteLinkDomainRestriction,
+    LinkSharingSettings, LlmSettings, MaxPriorCycles, SandboxedAgentSettings,
+    SecretRedactionSettings, SessionSharingPolicy, SharedNotebooksPolicy, SharedWorkflowsPolicy,
     TelemetryDataCollectionPolicy, TelemetrySettings, Tier, UgcCollectionEnablementSetting,
     UgcCollectionSettings, UgcDataCollectionPolicy, UsageBasedPricingPolicy,
     UsageVisibilityGranularity, UsageVisibilityPolicy, WarpAiPolicy, Workspace,
@@ -893,6 +893,12 @@ impl From<GqlWorkspaceSettings> for WorkspaceSettings {
             codebase_context_settings: CodebaseContextSettings {
                 setting: gql_workspace_settings
                     .codebase_context_settings
+                    .setting
+                    .into(),
+            },
+            feedback_skill_settings: FeedbackSkillSettings {
+                setting: gql_workspace_settings
+                    .feedback_skill_settings
                     .setting
                     .into(),
             },

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -1426,6 +1426,25 @@ impl UserWorkspaces {
             .unwrap_or_default()
     }
 
+    pub fn is_feedback_bundled_skill_enabled(&self, app: &AppContext) -> bool {
+        match self
+            .current_team()
+            .map(|team| {
+                team.organization_settings
+                    .feedback_skill_settings
+                    .setting
+                    .clone()
+            })
+            .unwrap_or(AdminEnablementSetting::RespectUserSetting)
+        {
+            AdminEnablementSetting::Disable => false,
+            AdminEnablementSetting::Enable => true,
+            AdminEnablementSetting::RespectUserSetting => {
+                *AISettings::as_ref(app).feedback_bundled_skill_enabled
+            }
+        }
+    }
+
     pub fn is_ai_allowed_in_remote_sessions(&self) -> bool {
         self.current_team()
             .map(|team| {

--- a/app/src/workspaces/user_workspaces_tests.rs
+++ b/app/src/workspaces/user_workspaces_tests.rs
@@ -26,8 +26,8 @@ use crate::workspaces::team_tester::TeamTesterStatus;
 use crate::workspaces::update_manager::TeamUpdateManager;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::workspaces::workspace::{
-    AdminEnablementSetting, CodebaseContextSettings, HostEnablementSetting, LlmHostSettings,
-    Workspace,
+    AdminEnablementSetting, CodebaseContextSettings, FeedbackSkillSettings, HostEnablementSetting,
+    LlmHostSettings, Workspace,
 };
 
 #[derive(Default)]
@@ -714,6 +714,123 @@ fn test_agent_attribution_respects_user_setting() {
                 setting,
                 AdminEnablementSetting::RespectUserSetting,
                 "attribution should be RespectUserSetting when the team defers to user preference"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_feedback_bundled_skill_uses_user_setting_without_workspace() {
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources { workspaces: vec![] },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx).is_feedback_bundled_skill_enabled(ctx),
+                "feedback bundled skill should use the enabled user setting when there is no workspace"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_feedback_bundled_skill_disabled_by_default_team_setting() {
+    let team = team_for_test();
+    let workspace = workspace_for_test(&team);
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        app.read(|ctx| {
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_feedback_bundled_skill_enabled(ctx),
+                "feedback bundled skill should default to disabled for team workspaces"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_feedback_bundled_skill_respects_user_setting() {
+    let mut team = team_for_test();
+    team.organization_settings.feedback_skill_settings = FeedbackSkillSettings {
+        setting: AdminEnablementSetting::RespectUserSetting,
+    };
+    let workspace = workspace_for_test(&team);
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx).is_feedback_bundled_skill_enabled(ctx),
+                "feedback bundled skill should be enabled when team respects the default enabled user setting"
+            );
+        });
+
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .feedback_bundled_skill_enabled
+                .load_value(false, true, ctx)
+                .expect("test setting update should succeed");
+        });
+
+        app.read(|ctx| {
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_feedback_bundled_skill_enabled(ctx),
+                "feedback bundled skill should be disabled when team respects the disabled user setting"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_feedback_bundled_skill_forced_on_by_team() {
+    let mut team = team_for_test();
+    team.organization_settings.feedback_skill_settings = FeedbackSkillSettings {
+        setting: AdminEnablementSetting::Enable,
+    };
+    let workspace = workspace_for_test(&team);
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .feedback_bundled_skill_enabled
+                .load_value(false, true, ctx)
+                .expect("test setting update should succeed");
+        });
+
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx).is_feedback_bundled_skill_enabled(ctx),
+                "feedback bundled skill should be enabled when forced on by the team"
             );
         });
     })

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -786,6 +786,18 @@ pub enum AdminEnablementSetting {
 pub struct CloudConversationStorageSettings {
     pub setting: AdminEnablementSetting,
 }
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FeedbackSkillSettings {
+    pub setting: AdminEnablementSetting,
+}
+
+impl Default for FeedbackSkillSettings {
+    fn default() -> Self {
+        Self {
+            setting: AdminEnablementSetting::Disable,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AiPermissionsSettings {
@@ -907,6 +919,8 @@ pub struct WorkspaceSettings {
     pub usage_based_pricing_settings: UsageBasedPricingSettings,
     pub addon_credits_settings: AddonCreditsSettings,
     pub codebase_context_settings: CodebaseContextSettings,
+    #[serde(default)]
+    pub feedback_skill_settings: FeedbackSkillSettings,
     pub sandboxed_agent_settings: Option<SandboxedAgentSettings>,
     /// The team-level agent attribution setting. When `Enable` or `Disable`, the
     /// user toggle is locked. When `RespectUserSetting` (or absent), the user can choose.

--- a/crates/graphql/src/api/workspace.rs
+++ b/crates/graphql/src/api/workspace.rs
@@ -150,6 +150,7 @@ pub struct WorkspaceSettings {
     pub usage_based_pricing_settings: UsageBasedPricingSettings,
     pub addon_credits_settings: AddonCreditsSettings,
     pub codebase_context_settings: CodebaseContextSettings,
+    pub feedback_skill_settings: FeedbackSkillSettings,
     pub sandboxed_agent_settings: Option<SandboxedAgentSettings>,
     pub ambient_agent_settings: Option<AmbientAgentSettings>,
 }
@@ -166,6 +167,10 @@ pub struct UgcCollectionSettings {
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct CloudConversationStorageSettings {
+    pub setting: AdminEnablementSetting,
+}
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct FeedbackSkillSettings {
     pub setting: AdminEnablementSetting,
 }
 

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -640,6 +640,14 @@ input CloudConversationStorageSettingsInput {
   setting: AdminEnablementSetting
 }
 
+type FeedbackSkillSettings {
+  setting: AdminEnablementSetting!
+}
+
+input FeedbackSkillSettingsInput {
+  setting: AdminEnablementSetting
+}
+
 type CloudEnvironment {
   config: CloudEnvironmentConfig!
   creator: PublicUserProfile
@@ -3936,6 +3944,7 @@ input UpdateWorkspaceSettingsInput {
   setDomainCaptureSettings: DomainCaptureSettingsInput
   setEnterpriseAnalyticsDataCollectionSettings: EnterpriseAnalyticsDataCollectionSettingsInput
   setEnterpriseBillingSettings: EnterpriseBillingSettingsInput
+  setFeedbackSkillSettings: FeedbackSkillSettingsInput
   setHarnessSettings: HarnessSettingsInput
   setLinkSharingSettings: LinkSharingSettingsInput
   setLlmSettings: LlmSettingsInput
@@ -4348,6 +4357,7 @@ type WorkspaceSettings {
   domainCaptureSettings: DomainCaptureSettings!
   enterpriseAnalyticsDataCollectionSettings: EnterpriseAnalyticsDataCollectionSettings!
   enterpriseBillingSettings: EnterpriseBillingSettings
+  feedbackSkillSettings: FeedbackSkillSettings!
   harnessSettings: HarnessSettings
   isDiscoverable: Boolean!
   isInviteLinkEnabled: Boolean!


### PR DESCRIPTION
## Summary
- Add `feedbackSkillSettings` to workspace GraphQL metadata and local workspace settings.
- Gate only Warp's bundled `feedback` skill through the workspace/org setting plus the existing user preference.
- Preserve the no-workspace fallback to the user setting and leave user/project skills named `feedback` unaffected.
- Add targeted tests for the default-disabled org behavior and bundled-skill activation/read-skill enforcement.

## Related
- Server PR: https://github.com/warpdotdev/warp-server/pull/11506

## Testing
- `cargo fmt --all --manifest-path /workspace/warp/Cargo.toml`
- `cargo fmt --all --manifest-path /workspace/warp/Cargo.toml -- --check`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp test_feedback_bundled_skill -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp bundled_feedback_skill -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp disabling_feedback_bundled_skill -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp test_read_skill_executor -- --nocapture`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/89cb8a8e-12b8-4645-957e-b9810d70dcd0_
_Run: https://oz.staging.warp.dev/runs/019e6f23-21c3-7ba2-887c-dccf04499003_
_Plans_:
- _[Org-level built-in feedback skill disablement](https://staging.warp.dev/drive/notebook/XEC6JhQw85MdIYOywOZVWc)_

_This PR was generated with [Oz](https://warp.dev/oz)._
