### PR TITLE
Show unknown creator when profile is missing

### DIFF
--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -1338,6 +1338,7 @@ impl AgentManagementView {
             task.as_ref(),
             open_action,
             copy_link_url,
+            ctx,
         );
 
         self.details_panel.update(ctx, |p, ctx| {

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -32,7 +32,7 @@ use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
     AIConversation, AIConversationId, ConversationStatus, StatusColorStyle,
 };
-use crate::ai::agent_conversations_model::entry::PrincipalType;
+use crate::ai::agent_conversations_model::entry::{AgentConversationPrincipal, PrincipalType};
 use crate::ai::agent_conversations_model::{AgentConversationEntry, AgentRunDisplayStatus};
 use crate::ai::agent_management::details_action_buttons::{
     ActionButtonsConfig, AgentDetailsButtonEvent, ConversationActionButtonsRow,
@@ -77,6 +77,7 @@ const HARNESS_CIRCLE_SIZE: f32 = 16.0;
 const HARNESS_ICON_IN_CIRCLE: f32 = 9.0;
 const LABEL_VALUE_GAP: f32 = 4.0;
 const SECTION_HEADER_GAP: f32 = 8.0;
+const UNKNOWN_CREATOR_DISPLAY_NAME: &str = "Unknown creator";
 
 /// Panel rendering mode.
 #[derive(Debug, Clone, PartialEq)]
@@ -172,10 +173,84 @@ impl PrincipalInfo {
         }
     }
 
-    /// Create a PrincipalInfo with just the first character as a fallback.
-    fn from_uid_fallback(uid: &str) -> Self {
-        let first_char = uid.chars().next().unwrap_or('?').to_uppercase().to_string();
-        Self::new(first_char, None)
+    fn unknown_creator_with_uid(uid: &str, is_service_account: bool) -> Self {
+        Self {
+            display_name: UNKNOWN_CREATOR_DISPLAY_NAME.to_string(),
+            photo_url: None,
+            uid: Some(uid.to_string()),
+            is_service_account,
+        }
+    }
+
+    fn non_empty_display_name(display_name: String) -> Option<String> {
+        (!display_name.trim().is_empty()).then_some(display_name)
+    }
+
+    fn from_user_profile(uid: &str, app: &AppContext) -> Option<Self> {
+        let profile = UserProfiles::as_ref(app).profile_for_uid(UserUid::new(uid))?;
+        let display_name = Self::non_empty_display_name(profile.displayable_identifier())?;
+        let photo_url = Some(profile.photo_url.clone()).filter(|url| !url.is_empty());
+
+        Some(Self {
+            display_name,
+            photo_url,
+            uid: Some(uid.to_string()),
+            is_service_account: false,
+        })
+    }
+
+    fn from_creator_uid(uid: &str, app: &AppContext) -> Self {
+        Self::from_user_profile(uid, app)
+            .unwrap_or_else(|| Self::unknown_creator_with_uid(uid, false))
+    }
+
+    fn from_task_creator(p: &TaskPrincipalInfo, app: &AppContext) -> Self {
+        let is_service_account =
+            PrincipalType::parse(&p.creator_type).is_some_and(|pt| pt.is_service_account());
+
+        if let Some(display_name) = p
+            .display_name
+            .clone()
+            .and_then(Self::non_empty_display_name)
+        {
+            return Self {
+                display_name,
+                photo_url: None,
+                uid: Some(p.uid.clone()),
+                is_service_account,
+            };
+        }
+
+        Self::from_user_profile(&p.uid, app)
+            .map(|mut profile| {
+                profile.is_service_account = is_service_account;
+                profile
+            })
+            .unwrap_or_else(|| Self::unknown_creator_with_uid(&p.uid, is_service_account))
+    }
+
+    fn from_entry_creator(p: &AgentConversationPrincipal, app: &AppContext) -> Option<Self> {
+        let is_service_account = p.principal_type.is_some_and(|pt| pt.is_service_account());
+
+        if let Some(display_name) = p.name.clone().and_then(Self::non_empty_display_name) {
+            return Some(Self {
+                display_name,
+                photo_url: None,
+                uid: p.uid.clone(),
+                is_service_account,
+            });
+        }
+
+        let uid = p.uid.as_ref()?;
+
+        Some(
+            Self::from_user_profile(uid, app)
+                .map(|mut profile| {
+                    profile.is_service_account = is_service_account;
+                    profile
+                })
+                .unwrap_or_else(|| Self::unknown_creator_with_uid(uid, is_service_account)),
+        )
     }
 }
 
@@ -257,17 +332,7 @@ impl ConversationDetailsData {
         let mut creator = None;
         if let Some(server_metadata) = conversation.server_metadata() {
             if let Some(creator_uid_str) = &server_metadata.metadata.creator_uid {
-                let creator_uid = UserUid::new(creator_uid_str);
-                let user_profiles = UserProfiles::handle(app).as_ref(app);
-
-                if let Some(profile) = user_profiles.profile_for_uid(creator_uid) {
-                    let display_name = profile.displayable_identifier();
-                    let photo_url = Some(profile.photo_url.clone()).filter(|url| !url.is_empty());
-                    creator = Some(PrincipalInfo::new(display_name, photo_url));
-                } else {
-                    // Fallback to first character of UID
-                    creator = Some(PrincipalInfo::from_uid_fallback(creator_uid_str));
-                }
+                creator = Some(PrincipalInfo::from_creator_uid(creator_uid_str, app));
             }
 
             // Conversation ID (from server token)
@@ -387,8 +452,7 @@ impl ConversationDetailsData {
             creator: task
                 .creator
                 .as_ref()
-                .filter(|c| c.display_name.is_some())
-                .map(PrincipalInfo::from),
+                .map(|creator| PrincipalInfo::from_task_creator(creator, app)),
             executor: task.executor.as_ref().map(PrincipalInfo::from),
             source_prompt: Some(task.prompt.clone()),
             copy_link_url,
@@ -403,13 +467,9 @@ impl ConversationDetailsData {
         task: Option<&AmbientAgentTask>,
         open_action: Option<WorkspaceAction>,
         copy_link_url: Option<String>,
+        app: &AppContext,
     ) -> Self {
-        let creator = entry
-            .display
-            .creator
-            .name
-            .clone()
-            .map(|name| PrincipalInfo::new(name, None));
+        let creator = PrincipalInfo::from_entry_creator(&entry.display.creator, app);
         let executor = entry.display.executor.as_ref().and_then(|e| {
             let display_name = e.name.clone().or_else(|| e.uid.clone())?;
             Some(PrincipalInfo {

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -1,17 +1,29 @@
 use std::collections::HashMap;
 
+use super::{ConversationDetailsData, PanelMode, UNKNOWN_CREATOR_DISPLAY_NAME};
+use crate::ai::agent::api::ServerConversationToken;
+use crate::ai::agent::conversation::{
+    AIAgentHarness, AIConversation, AIConversationId, ServerAIConversationMetadata,
+};
+use crate::ai::agent_conversations_model::entry::{
+    AgentConversationBackingData, AgentConversationCapabilities, AgentConversationDisplayData,
+    AgentConversationEntry, AgentConversationEntryId, AgentConversationIdentity,
+    AgentConversationPrincipal, AgentConversationProvenance, PrincipalType,
+};
+use crate::ai::agent_conversations_model::AgentRunDisplayStatus;
+use crate::ai::ambient_agents::task::{AgentConfigSnapshot, HarnessConfig, TaskPrincipalInfo};
+use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
+use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
+use crate::auth::UserUid;
+use crate::cloud_object::{Revision, ServerMetadata, ServerPermissions};
+use crate::server::ids::ServerId;
+use crate::workspaces::user_profiles::{UserProfileWithUID, UserProfiles};
 use chrono::{Local, Utc};
-use persistence::model::AgentConversationData;
+use persistence::model::{AgentConversationData, ConversationUsageMetadata};
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
 use warpui::{App, EntityId, SingletonEntity};
-
-use super::{ConversationDetailsData, PanelMode};
-use crate::ai::agent::conversation::{AIConversation, AIConversationId};
-use crate::ai::ambient_agents::task::{AgentConfigSnapshot, HarnessConfig, TaskPrincipalInfo};
-use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
-use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 
 fn create_test_task(task_id: &str) -> AmbientAgentTask {
     let now = Utc::now();
@@ -45,6 +57,291 @@ fn create_test_task(task_id: &str) -> AmbientAgentTask {
     }
 }
 
+fn create_server_metadata_with_creator(
+    server_token: &str,
+    creator_uid: &str,
+) -> ServerAIConversationMetadata {
+    ServerAIConversationMetadata {
+        title: "test conversation".to_string(),
+        working_directory: None,
+        harness: AIAgentHarness::Oz,
+        usage: ConversationUsageMetadata {
+            was_summarized: false,
+            context_window_usage: 0.0,
+            credits_spent: 0.0,
+            credits_spent_for_last_block: None,
+            token_usage: vec![],
+            tool_usage_metadata: Default::default(),
+        },
+        metadata: ServerMetadata {
+            uid: ServerId::default(),
+            revision: Revision::now(),
+            metadata_last_updated_ts: Utc::now().into(),
+            trashed_ts: None,
+            folder_id: None,
+            is_welcome_object: false,
+            creator_uid: Some(creator_uid.to_string()),
+            last_editor_uid: None,
+            current_editor_uid: None,
+        },
+        permissions: ServerPermissions::mock_personal(),
+        ambient_agent_task_id: None,
+        server_conversation_token: ServerConversationToken::new(server_token.to_string()),
+        artifacts: vec![],
+    }
+}
+
+fn user_profile(
+    uid: &str,
+    display_name: Option<&str>,
+    email: &str,
+    photo_url: &str,
+) -> UserProfileWithUID {
+    UserProfileWithUID {
+        firebase_uid: UserUid::new(uid),
+        display_name: display_name.map(str::to_string),
+        email: email.to_string(),
+        photo_url: photo_url.to_string(),
+    }
+}
+
+fn create_entry_with_creator_uid(creator_uid: &str) -> AgentConversationEntry {
+    let conversation_id = AIConversationId::new();
+    AgentConversationEntry {
+        id: AgentConversationEntryId::Conversation(conversation_id),
+        identity: AgentConversationIdentity {
+            local_conversation_id: Some(conversation_id),
+            ambient_agent_task_id: None,
+            server_conversation_token: None,
+            session_id: None,
+        },
+        provenance: AgentConversationProvenance::CloudSyncedConversation,
+        display: AgentConversationDisplayData {
+            title: "Entry conversation".to_string(),
+            initial_query: Some("test".to_string()),
+            created_at: Utc::now(),
+            last_updated: Utc::now(),
+            status: AgentRunDisplayStatus::ConversationSucceeded,
+            creator: AgentConversationPrincipal {
+                name: None,
+                uid: Some(creator_uid.to_string()),
+                principal_type: Some(PrincipalType::User),
+            },
+            executor: None,
+            request_usage: None,
+            run_time: None,
+            session_status: None,
+            source: None,
+            working_directory: None,
+            environment_id: None,
+            harness: None,
+            artifacts: vec![],
+        },
+        backing: AgentConversationBackingData {
+            has_loaded_conversation: false,
+            has_local_persisted_data: false,
+            has_cloud_data: true,
+            has_ambient_run: false,
+        },
+        capabilities: AgentConversationCapabilities {
+            can_open: false,
+            can_copy_link: false,
+            can_share: false,
+            can_delete: false,
+            can_fork_locally: false,
+            can_cancel: false,
+        },
+    }
+}
+
+#[test]
+fn test_from_conversation_uses_unknown_creator_when_profile_is_missing() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| UserProfiles::new(vec![]));
+
+        let conversation_id = AIConversationId::new();
+        let creator_uid = "B123456789";
+        let mut conversation = create_restored_conversation(
+            conversation_id,
+            "root-task",
+            "/tmp/unknown-creator-conversation",
+            AgentConversationData {
+                server_conversation_token: Some("server-token-unknown-creator".to_string()),
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: None,
+                agent_name: None,
+                orchestration_harness_type: None,
+                parent_conversation_id: None,
+                is_remote_child: false,
+                root_task_is_optimistic: None,
+                run_id: None,
+                autoexecute_override: None,
+                last_event_sequence: None,
+                pinned: false,
+            },
+        );
+        conversation.set_server_metadata(create_server_metadata_with_creator(
+            "server-token-unknown-creator",
+            creator_uid,
+        ));
+
+        app.update(|ctx| {
+            let data = ConversationDetailsData::from_conversation(&conversation, ctx);
+            let creator = data.creator.as_ref().expect("creator should be populated");
+
+            assert_eq!(creator.display_name, UNKNOWN_CREATOR_DISPLAY_NAME);
+            assert_eq!(creator.uid.as_deref(), Some(creator_uid));
+        });
+    });
+}
+
+#[test]
+fn test_from_conversation_uses_profile_info_when_available() {
+    App::test((), |mut app| async move {
+        let creator_uid = "profile-user-conversation";
+        app.add_singleton_model(|_| {
+            UserProfiles::new(vec![user_profile(
+                creator_uid,
+                Some("ZL"),
+                "zl@example.com",
+                "https://example.com/zl.png",
+            )])
+        });
+
+        let conversation_id = AIConversationId::new();
+        let mut conversation = create_restored_conversation(
+            conversation_id,
+            "root-task",
+            "/tmp/profile-creator-conversation",
+            AgentConversationData {
+                server_conversation_token: Some("server-token-profile-creator".to_string()),
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: None,
+                agent_name: None,
+                orchestration_harness_type: None,
+                parent_conversation_id: None,
+                is_remote_child: false,
+                root_task_is_optimistic: None,
+                run_id: None,
+                autoexecute_override: None,
+                last_event_sequence: None,
+                pinned: false,
+            },
+        );
+        conversation.set_server_metadata(create_server_metadata_with_creator(
+            "server-token-profile-creator",
+            creator_uid,
+        ));
+
+        app.update(|ctx| {
+            let data = ConversationDetailsData::from_conversation(&conversation, ctx);
+            let creator = data.creator.as_ref().expect("creator should be populated");
+
+            assert_eq!(creator.display_name, "ZL");
+            assert_eq!(
+                creator.photo_url.as_deref(),
+                Some("https://example.com/zl.png")
+            );
+            assert_eq!(creator.uid.as_deref(), Some(creator_uid));
+        });
+    });
+}
+
+#[test]
+fn test_from_task_uses_unknown_creator_when_only_uid_is_available() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        app.add_singleton_model(|_| UserProfiles::new(vec![]));
+
+        let mut task = create_test_task("550e8400-e29b-41d4-a716-000000004040");
+        let creator_uid = "B987654321";
+        task.creator = Some(TaskPrincipalInfo {
+            creator_type: "USER".to_string(),
+            uid: creator_uid.to_string(),
+            display_name: None,
+        });
+
+        app.update(|ctx| {
+            let data = ConversationDetailsData::from_task(&task, None, None, ctx);
+            let creator = data.creator.as_ref().expect("creator should be populated");
+
+            assert_eq!(creator.display_name, UNKNOWN_CREATOR_DISPLAY_NAME);
+            assert_eq!(creator.uid.as_deref(), Some(creator_uid));
+        });
+    });
+}
+
+#[test]
+fn test_from_task_uses_profile_info_when_display_name_is_missing() {
+    App::test((), |mut app| async move {
+        let creator_uid = "profile-user-task";
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        app.add_singleton_model(|_| {
+            UserProfiles::new(vec![user_profile(
+                creator_uid,
+                Some("Profile User"),
+                "profile@example.com",
+                "https://example.com/profile.png",
+            )])
+        });
+
+        let mut task = create_test_task("550e8400-e29b-41d4-a716-000000004041");
+        task.creator = Some(TaskPrincipalInfo {
+            creator_type: "USER".to_string(),
+            uid: creator_uid.to_string(),
+            display_name: None,
+        });
+
+        app.update(|ctx| {
+            let data = ConversationDetailsData::from_task(&task, None, None, ctx);
+            let creator = data.creator.as_ref().expect("creator should be populated");
+
+            assert_eq!(creator.display_name, "Profile User");
+            assert_eq!(
+                creator.photo_url.as_deref(),
+                Some("https://example.com/profile.png")
+            );
+            assert_eq!(creator.uid.as_deref(), Some(creator_uid));
+        });
+    });
+}
+
+#[test]
+fn test_from_entry_uses_profile_info_when_name_is_missing() {
+    App::test((), |mut app| async move {
+        let creator_uid = "profile-user-entry";
+        app.add_singleton_model(|_| {
+            UserProfiles::new(vec![user_profile(
+                creator_uid,
+                Some("Entry Profile"),
+                "entry@example.com",
+                "https://example.com/entry.png",
+            )])
+        });
+
+        let entry = create_entry_with_creator_uid(creator_uid);
+
+        app.update(|ctx| {
+            let data = ConversationDetailsData::from_agent_conversation_entry(
+                &entry, None, None, None, ctx,
+            );
+            let creator = data.creator.as_ref().expect("creator should be populated");
+
+            assert_eq!(creator.display_name, "Entry Profile");
+            assert_eq!(
+                creator.photo_url.as_deref(),
+                Some("https://example.com/entry.png")
+            );
+            assert_eq!(creator.uid.as_deref(), Some(creator_uid));
+        });
+    });
+}
 fn create_message_with_directory(id: &str, task_id: &str, directory: &str) -> api::Message {
     api::Message {
         id: id.to_string(),


### PR DESCRIPTION
## Description
Fixes the conversation details panel creator fallback for UID-only creators.

- Looks up creator UIDs in `UserProfiles` and uses the profile display name/photo when available.
- Falls back to `Unknown creator` instead of a UID-derived initial when no usable profile/name is available.
- Applies the behavior to restored conversations, task-backed details data, and entry-backed details data.

## Linked Issue
REMOTE-1782

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `rustfmt --edition 2021 --check /workspace/warp/app/src/ai/conversation_details_panel.rs /workspace/warp/app/src/ai/conversation_details_panel_tests.rs /workspace/warp/app/src/ai/agent_management/view.rs`
- [x] `CARGO_BUILD_JOBS=2 cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- [x] `CARGO_BUILD_JOBS=2 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp conversation_details_panel` (11 passed)
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not captured; this is covered by regression tests for the details data paths.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Show Unknown creator instead of UID-derived initials when conversation details cannot resolve creator profile data.

_Conversation: https://staging.warp.dev/conversation/3677780f-bfee-4778-ac34-874ea325a824_
_Run: https://oz.staging.warp.dev/runs/019e6f94-ff3a-7a9b-889f-292f8a44cd7e_
_This PR was generated with [Oz](https://warp.dev/oz)._
