### PR TITLE
[REMOTE-1794] Install clippy in agent dev image

### DIFF
--- a/docker/agent-dev/Dockerfile
+++ b/docker/agent-dev/Dockerfile
@@ -25,10 +25,13 @@ RUN set -eux; \
 # Install rustup. It will download the pinned version in our rust-toolchain.toml as needed.
 RUN set -eux; \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal; \
+  rustup component add clippy rustfmt; \
   chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
   rustup --version; \
   cargo --version; \
-  rustc --version
+  rustc --version; \
+  cargo clippy --version; \
+  cargo fmt --version
 
 # Install go and go command-line tools we use.
 RUN set -eux; \


### PR DESCRIPTION
## Description
Fixes REMOTE-1794 by ensuring the agent dev image installs `clippy` and `rustfmt` for the default stable Rust toolchain.

The supplied staging run used environment `SVhg783GBFQHk1OfdPfFU9` with Docker image `warpdotdev/warp-internal-dev:latest-dev`. Its transcript showed `cargo-clippy` missing for `stable-x86_64-unknown-linux-gnu`. The image Docker history showed the default toolchain was installed with `--profile minimal`, which omits `clippy`/`rustfmt` unless explicitly requested.

This updates `docker/agent-dev/Dockerfile` to:
- install `clippy` and `rustfmt` immediately after the default rustup install
- verify `cargo clippy --version` and `cargo fmt --version` during image build

## Linked Issue
REMOTE-1794

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `git diff --check origin/master...HEAD`
- Not run: Docker image build, because Docker is not available in this sandbox.
- Not run: `./script/run`, because this is a Docker image dependency change, not an app UI/runtime change.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/4ae86b95-3b08-4a88-ae74-f3b3ae87b5c4_
_Run: https://oz.staging.warp.dev/runs/019e6ff9-37ff-74f2-84c0-30dbe20abe07_
_This PR was generated with [Oz](https://warp.dev/oz)._
