### PR TITLE
Add Warp Control CLI foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7454,6 +7454,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
+name = "local_control"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "dirs 6.0.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
 name = "locale_config"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14414,6 +14428,7 @@ dependencies = [
  "libc",
  "libsqlite3-sys",
  "line-ending",
+ "local_control",
  "log",
  "log-panics",
  "lsp",
@@ -14644,7 +14659,9 @@ dependencies = [
  "color-print",
  "humantime",
  "jaq-all",
+ "local_control",
  "serde",
+ "serde_json",
  "serial_test",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ ipc = { path = "crates/ipc" }
 jsonrpc = { path = "crates/jsonrpc" }
 languages = { path = "crates/languages" }
 lsp = { path = "crates/lsp" }
+local_control = { path = "crates/local_control" }
 markdown_parser = { path = "crates/markdown_parser" }
 mcp = { path = "crates/mcp" }
 natural_language_detection = { path = "crates/natural_language_detection" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -52,6 +52,10 @@ test = false
 name = "generate_settings_schema"
 path = "src/bin/generate_settings_schema.rs"
 test = false
+[[bin]]
+name = "warpctrl"
+path = "src/bin/warpctrl.rs"
+test = false
 
 [dependencies]
 addr = "0.15.6"
@@ -237,6 +241,7 @@ voice_input = { workspace = true, optional = true }
 warpui_extras = { workspace = true, features = ["default", "user_preferences-toml"] }
 syntax_tree.workspace = true
 languages.workspace = true
+local_control.workspace = true
 warp_terminal.workspace = true
 websocket.workspace = true
 wgpu = { workspace = true, optional = true }
@@ -809,6 +814,7 @@ integration_tests = [
 ]
 traces = []
 viewing_shared_sessions = []
+warp_control_cli = []
 workflow_aliases = []
 rect_selection = []
 alacritty_settings_import = []

--- a/app/src/bin/warpctrl.rs
+++ b/app/src/bin/warpctrl.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    warp_cli::local_control::run_from_env()
+}

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -35,6 +35,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::LogExpensiveFramesInSentry,
         #[cfg(feature = "record_app_active_events")]
         FeatureFlag::RecordAppActiveEvents,
+        #[cfg(feature = "warp_control_cli")]
+        FeatureFlag::WarpControlCli,
         #[cfg(feature = "runtime_feature_flags")]
         FeatureFlag::RuntimeFeatureFlags,
         #[cfg(feature = "sequential_storage")]

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -44,6 +44,7 @@ mod gpu_state;
 mod input_classifier;
 mod interval_timer;
 mod linear;
+mod local_control;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 mod login_item;
 mod menu;
@@ -2005,6 +2006,11 @@ pub(crate) fn initialize_app(
         ];
         http_server::HttpServer::new(routers, ctx)
     });
+
+    #[cfg(not(target_family = "wasm"))]
+    if local_control::LocalControlServer::should_start(ctx) {
+        ctx.add_singleton_model(local_control::LocalControlServer::new);
+    }
 
     app_state
 }

--- a/app/src/local_control/bridge.rs
+++ b/app/src/local_control/bridge.rs
@@ -1,0 +1,100 @@
+use local_control::auth::CredentialIssuer;
+use local_control::catalog::action_metadata;
+use local_control::protocol::{
+    ControlAction, ControlError, CredentialRequest, CredentialResponse, ErrorCode, RequestEnvelope,
+    ResponseEnvelope, PROTOCOL_VERSION,
+};
+use serde_json::json;
+use warpui::ModelContext;
+
+use super::handlers::{layout, metadata};
+use super::permissions;
+
+pub struct LocalControlBridge {
+    credential_issuer: CredentialIssuer,
+}
+
+impl LocalControlBridge {
+    pub fn new(credential_issuer: CredentialIssuer) -> Self {
+        Self { credential_issuer }
+    }
+
+    pub fn issue_credential(
+        &mut self,
+        request: CredentialRequest,
+        ctx: &mut ModelContext<super::LocalControlServer>,
+    ) -> CredentialResponse {
+        self.refresh_policy(ctx);
+        match self.credential_issuer.issue(&request) {
+            Ok(credential) => CredentialResponse {
+                protocol_version: PROTOCOL_VERSION,
+                request_id: request.request_id,
+                credential: Some(credential),
+                error: None,
+            },
+            Err(error) => CredentialResponse {
+                protocol_version: PROTOCOL_VERSION,
+                request_id: request.request_id,
+                credential: None,
+                error: Some(error),
+            },
+        }
+    }
+
+    pub fn handle_request(
+        &mut self,
+        token: Option<String>,
+        request: RequestEnvelope,
+        ctx: &mut ModelContext<super::LocalControlServer>,
+    ) -> ResponseEnvelope {
+        self.refresh_policy(ctx);
+        let metadata = action_metadata(&request.action);
+        let credential = match token
+            .ok_or_else(|| {
+                ControlError::new(
+                    ErrorCode::UnauthorizedLocalClient,
+                    "missing bearer credential",
+                )
+            })
+            .and_then(|token| {
+                self.credential_issuer
+                    .verify(&token, &request.action, &metadata.permission)
+            })
+            .and_then(|credential| {
+                permissions::verify_request_policy(&request.action, &credential, ctx)?;
+                Ok(credential)
+            }) {
+            Ok(credential) => credential,
+            Err(error) => return ResponseEnvelope::error(request.request_id, error),
+        };
+        drop(credential);
+
+        match request.action {
+            ControlAction::AppPing => metadata::ping(request, ctx),
+            ControlAction::AppVersion => metadata::version(request, ctx),
+            ControlAction::TabCreate => layout::tab_create(request, ctx),
+            ControlAction::InstanceList => ResponseEnvelope::ok(
+                request.request_id,
+                None,
+                json!({ "actions": super::enabled_implemented_actions() }),
+            ),
+            ControlAction::WindowList
+            | ControlAction::TabList
+            | ControlAction::PaneList
+            | ControlAction::SessionList => ResponseEnvelope::error(
+                request.request_id,
+                ControlError::new(
+                    ErrorCode::UnsupportedAction,
+                    "action is planned but not implemented in the foundation slice",
+                ),
+            ),
+        }
+    }
+
+    fn refresh_policy(&mut self, ctx: &mut ModelContext<super::LocalControlServer>) {
+        self.credential_issuer.set_policy(
+            permissions::outside_warp_enabled(ctx),
+            permissions::outside_warp_permissions(ctx),
+        );
+    }
+}

--- a/app/src/local_control/handlers/layout.rs
+++ b/app/src/local_control/handlers/layout.rs
@@ -1,0 +1,78 @@
+use local_control::protocol::{ControlError, ErrorCode, RequestEnvelope, ResponseEnvelope};
+use serde_json::{json, Value};
+use warpui::{ModelContext, TypedActionView};
+
+use crate::workspace::{Workspace, WorkspaceAction};
+
+pub fn tab_create(
+    request: RequestEnvelope,
+    ctx: &mut ModelContext<super::super::LocalControlServer>,
+) -> ResponseEnvelope {
+    if request.params != Value::Object(Default::default()) {
+        return ResponseEnvelope::error(
+            request.request_id,
+            ControlError::new(
+                ErrorCode::InvalidParams,
+                "tab.create does not accept params in the foundation slice",
+            ),
+        );
+    }
+    if let Err(error) = super::super::resolver::validate_tab_create_target(&request.target) {
+        return ResponseEnvelope::error(request.request_id, error);
+    }
+    let window_id = match super::super::resolver::resolve_active_window(ctx) {
+        Ok(window_id) => window_id,
+        Err(error) => return ResponseEnvelope::error(request.request_id, error),
+    };
+
+    let mut previous_tab_count = None;
+    let mut current_tab_count = None;
+    let mut active_tab_index = None;
+    let mut dispatched = false;
+    let Some(workspace_handles) = ctx.views_of_type::<Workspace>(window_id) else {
+        return ResponseEnvelope::error(
+            request.request_id,
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                "active window does not contain a workspace",
+            ),
+        );
+    };
+
+    if let Some(workspace_handle) = workspace_handles.into_iter().next() {
+        workspace_handle.update(ctx, |workspace, ctx| {
+            previous_tab_count = Some(workspace.tab_count());
+            workspace.handle_action(
+                &WorkspaceAction::AddTerminalTab {
+                    hide_homepage: false,
+                },
+                ctx,
+            );
+            current_tab_count = Some(workspace.tab_count());
+            active_tab_index = Some(workspace.active_tab_index());
+            dispatched = true;
+        });
+    }
+
+    if !dispatched {
+        return ResponseEnvelope::error(
+            request.request_id,
+            ControlError::new(
+                ErrorCode::MissingTarget,
+                "active window does not contain a workspace",
+            ),
+        );
+    }
+
+    ResponseEnvelope::ok(
+        request.request_id,
+        None,
+        json!({
+            "action": "tab.create",
+            "active_window_id": format!("{:?}", window_id),
+            "previous_tab_count": previous_tab_count,
+            "current_tab_count": current_tab_count,
+            "active_tab_index": active_tab_index,
+        }),
+    )
+}

--- a/app/src/local_control/handlers/metadata.rs
+++ b/app/src/local_control/handlers/metadata.rs
@@ -1,0 +1,26 @@
+use local_control::protocol::{RequestEnvelope, ResponseEnvelope};
+use serde_json::json;
+use warp_core::channel::ChannelState;
+use warpui::ModelContext;
+
+pub fn ping(
+    request: RequestEnvelope,
+    _ctx: &mut ModelContext<super::super::LocalControlServer>,
+) -> ResponseEnvelope {
+    ResponseEnvelope::ok(request.request_id, None, json!({ "status": "ok" }))
+}
+
+pub fn version(
+    request: RequestEnvelope,
+    _ctx: &mut ModelContext<super::super::LocalControlServer>,
+) -> ResponseEnvelope {
+    ResponseEnvelope::ok(
+        request.request_id,
+        None,
+        json!({
+            "app_version": ChannelState::app_version(),
+            "channel": format!("{:?}", ChannelState::channel()),
+            "protocol_version": local_control::PROTOCOL_VERSION,
+        }),
+    )
+}

--- a/app/src/local_control/mod.rs
+++ b/app/src/local_control/mod.rs
@@ -1,0 +1,239 @@
+pub mod bridge;
+pub mod permissions;
+pub mod resolver;
+pub mod handlers {
+    pub mod layout;
+    pub mod metadata;
+}
+
+use local_control::auth::CredentialIssuer;
+use local_control::discovery::{default_registry_dir, write_record, DiscoveryRecord};
+use warp_core::features::FeatureFlag;
+use warpui::{AppContext, Entity, ModelContext, ModelSpawner, SingletonEntity};
+
+pub struct LocalControlServer {
+    pub bridge: bridge::LocalControlBridge,
+    #[cfg(not(target_family = "wasm"))]
+    instance_id: String,
+    #[cfg(not(target_family = "wasm"))]
+    endpoint: Option<String>,
+    #[cfg(not(target_family = "wasm"))]
+    _runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl LocalControlServer {
+    pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        let permissions = permissions::outside_warp_permissions(ctx);
+        let outside_warp_enabled = permissions::outside_warp_enabled(ctx);
+        let mut server = Self {
+            bridge: bridge::LocalControlBridge::new(CredentialIssuer::new(
+                outside_warp_enabled,
+                permissions,
+            )),
+            #[cfg(not(target_family = "wasm"))]
+            instance_id: uuid::Uuid::new_v4().to_string(),
+            #[cfg(not(target_family = "wasm"))]
+            endpoint: None,
+            #[cfg(not(target_family = "wasm"))]
+            _runtime: None,
+        };
+
+        #[cfg(not(target_family = "wasm"))]
+        server.start_loopback_server(ctx);
+        #[cfg(not(target_family = "wasm"))]
+        server.subscribe_to_settings(ctx);
+
+        server
+    }
+
+    pub fn should_start(ctx: &AppContext) -> bool {
+        let _ = ctx;
+        FeatureFlag::WarpControlCli.is_enabled()
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn start_loopback_server(&mut self, ctx: &mut ModelContext<Self>) {
+        match spawn_loopback_server(ctx.spawner()) {
+            Ok((runtime, endpoint)) => {
+                self.endpoint = Some(endpoint);
+                self._runtime = Some(runtime);
+                self.write_discovery_record(ctx);
+            }
+            Err(error) => {
+                log::warn!("Failed to start local-control server: {error:#}");
+                self.write_discovery_record(ctx);
+            }
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn subscribe_to_settings(&self, ctx: &mut ModelContext<Self>) {
+        ctx.subscribe_to_model(
+            &crate::settings::LocalControlSettings::handle(ctx),
+            |server, _, ctx| {
+                server.write_discovery_record(ctx);
+            },
+        );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn write_discovery_record(&self, ctx: &mut ModelContext<Self>) {
+        let Some(dir) = default_registry_dir() else {
+            return;
+        };
+        let outside_warp_control_enabled =
+            FeatureFlag::WarpControlCli.is_enabled() && permissions::outside_warp_enabled(ctx);
+        let record = DiscoveryRecord {
+            instance_id: self.instance_id.clone(),
+            pid: std::process::id(),
+            channel: format!("{:?}", warp_core::channel::ChannelState::channel()),
+            app_version: warp_core::channel::ChannelState::app_version()
+                .unwrap_or("unknown")
+                .to_owned(),
+            protocol_version: local_control::PROTOCOL_VERSION,
+            started_at_unix_ms: local_control::auth::now_unix_ms(),
+            outside_warp_control_enabled,
+            endpoint: outside_warp_control_enabled
+                .then(|| self.endpoint.clone())
+                .flatten(),
+            implemented_actions: if outside_warp_control_enabled {
+                enabled_implemented_actions()
+            } else {
+                Vec::new()
+            },
+        };
+        if let Err(error) = write_record(&dir, &record) {
+            log::warn!("Failed to write local-control discovery record: {error:#}");
+        }
+    }
+}
+
+impl Entity for LocalControlServer {
+    type Event = ();
+}
+
+impl SingletonEntity for LocalControlServer {}
+
+pub fn enabled_implemented_actions() -> Vec<String> {
+    local_control::catalog::implemented_actions()
+        .into_iter()
+        .map(|metadata| metadata.action.as_str().to_owned())
+        .collect()
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn spawn_loopback_server(
+    spawner: ModelSpawner<LocalControlServer>,
+) -> anyhow::Result<(tokio::runtime::Runtime, String)> {
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+
+    use axum::routing::post;
+    use axum::Router;
+
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))?;
+    listener.set_nonblocking(true)?;
+    let local_addr = listener.local_addr()?;
+    let endpoint = format!("http://{local_addr}");
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_io()
+        .build()?;
+    let router = Router::new()
+        .route("/v1/control/credentials", post(http::issue_credential))
+        .route("/v1/control", post(http::handle_control_request))
+        .with_state(http::ServerState { spawner });
+
+    runtime.spawn(async move {
+        let listener = match tokio::net::TcpListener::from_std(listener) {
+            Ok(listener) => listener,
+            Err(error) => {
+                log::warn!("Failed to create local-control listener: {error:#}");
+                return;
+            }
+        };
+        if let Err(error) = axum::serve(listener, router).await {
+            log::warn!("Local-control server stopped with error: {error:#}");
+        }
+    });
+
+    Ok((runtime, endpoint))
+}
+
+#[cfg(not(target_family = "wasm"))]
+mod http {
+    use axum::extract::{Json, State};
+    use axum::http::{HeaderMap, StatusCode};
+    use local_control::protocol::{
+        ControlError, CredentialRequest, CredentialResponse, ErrorCode, RequestEnvelope,
+        ResponseEnvelope, PROTOCOL_VERSION,
+    };
+    use warpui::ModelSpawner;
+
+    use super::LocalControlServer;
+
+    #[derive(Clone)]
+    pub struct ServerState {
+        pub spawner: ModelSpawner<LocalControlServer>,
+    }
+
+    pub async fn issue_credential(
+        State(state): State<ServerState>,
+        Json(request): Json<CredentialRequest>,
+    ) -> (StatusCode, Json<CredentialResponse>) {
+        let request_id = request.request_id.clone();
+        match state
+            .spawner
+            .spawn(move |server, ctx| server.bridge.issue_credential(request, ctx))
+            .await
+        {
+            Ok(response) => (StatusCode::OK, Json(response)),
+            Err(_) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(CredentialResponse {
+                    protocol_version: PROTOCOL_VERSION,
+                    request_id,
+                    credential: None,
+                    error: Some(ControlError::new(
+                        ErrorCode::TransportError,
+                        "local-control app bridge is unavailable",
+                    )),
+                }),
+            ),
+        }
+    }
+
+    pub async fn handle_control_request(
+        State(state): State<ServerState>,
+        headers: HeaderMap,
+        Json(request): Json<RequestEnvelope>,
+    ) -> (StatusCode, Json<ResponseEnvelope>) {
+        let request_id = request.request_id.clone();
+        let token = bearer_token(&headers);
+        match state
+            .spawner
+            .spawn(move |server, ctx| server.bridge.handle_request(token, request, ctx))
+            .await
+        {
+            Ok(response) => (StatusCode::OK, Json(response)),
+            Err(_) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ResponseEnvelope::error(
+                    request_id,
+                    ControlError::new(
+                        ErrorCode::TransportError,
+                        "local-control app bridge is unavailable",
+                    ),
+                )),
+            ),
+        }
+    }
+
+    fn bearer_token(headers: &HeaderMap) -> Option<String> {
+        headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .map(str::to_owned)
+    }
+}

--- a/app/src/local_control/permissions.rs
+++ b/app/src/local_control/permissions.rs
@@ -1,0 +1,58 @@
+use local_control::auth::PermissionGrant;
+use local_control::catalog::action_metadata;
+use local_control::protocol::{ControlAction, ControlError, ErrorCode, ScopedCredential};
+use settings::Setting as _;
+use warpui::{AppContext, SingletonEntity};
+
+use crate::settings::LocalControlSettings;
+
+pub fn outside_warp_enabled(ctx: &AppContext) -> bool {
+    *LocalControlSettings::as_ref(ctx).outside_warp_control_enabled
+}
+
+pub fn outside_warp_permissions(ctx: &AppContext) -> PermissionGrant {
+    let settings = LocalControlSettings::as_ref(ctx)
+        .outside_warp_permissions
+        .value()
+        .to_owned();
+    PermissionGrant {
+        metadata_read: settings.metadata_read,
+        underlying_data_read: settings.underlying_data_read,
+        app_state_mutation: settings.app_state_mutation,
+        metadata_configuration_mutation: settings.metadata_configuration_mutation,
+        underlying_data_mutation: settings.underlying_data_mutation,
+    }
+}
+
+pub fn verify_request_policy(
+    action: &ControlAction,
+    credential: &ScopedCredential,
+    ctx: &AppContext,
+) -> Result<(), ControlError> {
+    if !outside_warp_enabled(ctx) {
+        return Err(ControlError::new(
+            ErrorCode::LocalControlDisabled,
+            "outside-Warp local control is disabled",
+        ));
+    }
+    let metadata = action_metadata(action);
+    if credential.action != *action || credential.permission != metadata.permission {
+        return Err(ControlError::new(
+            ErrorCode::InsufficientPermissions,
+            "credential does not authorize the requested action",
+        ));
+    }
+    if !outside_warp_permissions(ctx).allows(&metadata.permission) {
+        return Err(ControlError::new(
+            ErrorCode::InsufficientPermissions,
+            "outside-Warp local-control permission is disabled for this action category",
+        ));
+    }
+    if metadata.requires_authenticated_user && !credential.requires_authenticated_user {
+        return Err(ControlError::new(
+            ErrorCode::AuthenticatedUserRequired,
+            "authenticated-user local-control grants are not implemented in the foundation slice",
+        ));
+    }
+    Ok(())
+}

--- a/app/src/local_control/resolver.rs
+++ b/app/src/local_control/resolver.rs
@@ -1,0 +1,15 @@
+use local_control::protocol::{ControlError, ErrorCode, TargetSelector};
+use warpui::AppContext;
+
+pub fn resolve_active_window(ctx: &AppContext) -> Result<warpui::WindowId, ControlError> {
+    ctx.windows().active_window().ok_or_else(|| {
+        ControlError::new(
+            ErrorCode::MissingTarget,
+            "tab.create requires an active Warp window",
+        )
+    })
+}
+
+pub fn validate_tab_create_target(target: &TargetSelector) -> Result<(), ControlError> {
+    local_control::selectors::validate_foundation_tab_create_target(target)
+}

--- a/app/src/settings/init.rs
+++ b/app/src/settings/init.rs
@@ -14,8 +14,8 @@ use super::{
     AISettings, AccessibilitySettings, AliasExpansionSettings, AppEditorSettings,
     BlockVisibilitySettings, ChangelogSettings, CodeSettings, DebugSettings, EmacsBindingsSettings,
     FontSettings, FontSettingsChangedEvent, GPUSettings, InputBoxType, InputModeSettings,
-    InputSettings, PaneSettings, SameLinePromptBlockSettings, ScrollSettings, SelectionSettings,
-    SshSettings, ThemeSettings, VimBannerSettings, WarpDrivePrivacySettings,
+    InputSettings, LocalControlSettings, PaneSettings, SameLinePromptBlockSettings, ScrollSettings,
+    SelectionSettings, SshSettings, ThemeSettings, VimBannerSettings, WarpDrivePrivacySettings,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::banner::BannerState;
@@ -80,6 +80,7 @@ pub fn register_all_settings(ctx: &mut AppContext) {
     CloudPreferencesSettings::register(ctx);
     WarpDrivePrivacySettings::register(ctx);
     UserAppInstallDetectionSettings::register(ctx);
+    LocalControlSettings::register(ctx);
     AppIconSettings::register(ctx);
     AppEditorSettings::register(ctx);
     InputSettings::register(ctx);

--- a/app/src/settings/local_control.rs
+++ b/app/src/settings/local_control.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+use settings::macros::define_settings_group;
+use settings::{SupportedPlatforms, SyncToCloud};
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+#[schemars(
+    description = "Private local Warp control settings.",
+    rename_all = "snake_case"
+)]
+pub struct LocalControlPermissionSettings {
+    pub metadata_read: bool,
+    pub underlying_data_read: bool,
+    pub app_state_mutation: bool,
+    pub metadata_configuration_mutation: bool,
+    pub underlying_data_mutation: bool,
+}
+
+define_settings_group!(LocalControlSettings, settings: [
+    outside_warp_control_enabled: OutsideWarpControlEnabled {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        private: true,
+        storage_key: "LocalControlOutsideWarpControlEnabled",
+    },
+    outside_warp_permissions: OutsideWarpPermissions {
+        type: LocalControlPermissionSettings,
+        default: LocalControlPermissionSettings::default(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Never,
+        private: true,
+        storage_key: "LocalControlOutsideWarpPermissions",
+    }
+]);
+
+#[cfg(test)]
+mod tests {
+    use settings::Setting as _;
+
+    use super::*;
+
+    #[test]
+    fn local_control_settings_default_fail_closed() {
+        assert!(!OutsideWarpControlEnabled::default_value());
+        let permissions = OutsideWarpPermissions::new(None);
+        assert!(!permissions.value().metadata_read);
+        assert!(!permissions.value().app_state_mutation);
+    }
+
+    #[test]
+    fn local_control_settings_are_private_and_non_synced() {
+        assert!(OutsideWarpControlEnabled::is_private());
+        assert_eq!(
+            OutsideWarpControlEnabled::sync_to_cloud(),
+            SyncToCloud::Never
+        );
+        assert!(OutsideWarpPermissions::is_private());
+        assert_eq!(OutsideWarpPermissions::sync_to_cloud(), SyncToCloud::Never);
+    }
+}

--- a/app/src/settings/mod.rs
+++ b/app/src/settings/mod.rs
@@ -20,6 +20,7 @@ mod input;
 mod input_mode;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 mod linux;
+mod local_control;
 pub mod macros;
 pub mod manager;
 pub mod native_preference;
@@ -54,6 +55,7 @@ pub use input::*;
 pub use input_mode::*;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub use linux::*;
+pub use local_control::*;
 pub use native_preference::*;
 pub use onboarding::*;
 pub use pane::*;

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -18,6 +18,7 @@ use nav::{SettingsNavItem, SettingsUmbrella};
 use pathfinder_geometry::vector::Vector2F;
 use privacy_page::{PrivacyPageView, PrivacyPageViewEvent};
 use referrals_page::{ReferralsPageEvent, ReferralsPageView};
+use scripting_page::ScriptingPageView;
 use settings_file_footer::{render_footer, SettingsFooterKind, SettingsFooterMouseStates};
 use settings_page::{
     MatchData, SettingsPage, SettingsPageEvent, SettingsPageMeta, SettingsPageViewHandle,
@@ -100,6 +101,7 @@ mod privacy;
 mod privacy_page;
 mod referrals_page;
 mod remove_custom_endpoint_confirmation_dialog;
+mod scripting_page;
 mod settings_file_footer;
 pub(crate) mod settings_page;
 mod show_blocks_view;
@@ -246,6 +248,7 @@ pub enum SettingsSection {
     Keybindings,
     Privacy,
     Referrals,
+    Scripting,
     SharedBlocks,
     Teams,
     WarpDrive,
@@ -283,6 +286,7 @@ impl Display for SettingsSection {
         match self {
             SettingsSection::BillingAndUsage => write!(f, "Billing and usage"),
             SettingsSection::Keybindings => write!(f, "Keyboard shortcuts"),
+            SettingsSection::Scripting => write!(f, "Scripting"),
             SettingsSection::SharedBlocks => write!(f, "Shared blocks"),
             SettingsSection::MCPServers => write!(f, "MCP Servers"),
             SettingsSection::WarpDrive => write!(f, "Warp Drive"),
@@ -382,6 +386,7 @@ impl FromStr for SettingsSection {
             "Keyboard shortcuts" => Ok(Self::Keybindings),
             "Privacy" => Ok(Self::Privacy),
             "Referrals" => Ok(Self::Referrals),
+            "Scripting" => Ok(Self::Scripting),
             "Shared blocks" => Ok(Self::SharedBlocks),
             "Teams" => Ok(Self::Teams),
             "Warpify" => Ok(Self::Warpify),
@@ -1018,6 +1023,7 @@ macro_rules! update_page {
             SettingsPageViewHandle::OzCloudAPIKeys(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::Privacy(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::Referrals(handle) => $ctx.update_view(handle, $update),
+            SettingsPageViewHandle::Scripting(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::AI(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::CloudEnvironments(handle) => $ctx.update_view(handle, $update),
             SettingsPageViewHandle::About(handle) => $ctx.update_view(handle, $update),
@@ -1167,6 +1173,8 @@ impl SettingsView {
             me.handle_referrals_page_event(event, ctx);
         });
 
+        let scripting_page_handle = ctx.add_typed_action_view(ScriptingPageView::new);
+
         // Warp Drive page
         let warp_drive_page_handle =
             ctx.add_typed_action_view(warp_drive_page::WarpDriveSettingsPageView::new);
@@ -1225,6 +1233,7 @@ impl SettingsView {
             SettingsPage::new(platform_page_handle),
             SettingsPage::new(warpify_page_handle),
             SettingsPage::new(referrals_page_handle),
+            SettingsPage::new(scripting_page_handle),
             SettingsPage::new(show_blocks_view_handle),
             SettingsPage::new(warp_drive_page_handle),
         ];
@@ -1265,6 +1274,7 @@ impl SettingsView {
             SettingsNavItem::Page(SettingsSection::Keybindings),
             SettingsNavItem::Page(SettingsSection::Warpify),
             SettingsNavItem::Page(SettingsSection::Referrals),
+            SettingsNavItem::Page(SettingsSection::Scripting),
             SettingsNavItem::Page(SettingsSection::SharedBlocks),
             SettingsNavItem::Page(SettingsSection::WarpDrive),
             SettingsNavItem::Page(SettingsSection::Privacy),
@@ -2017,6 +2027,7 @@ impl SettingsView {
             SettingsPageViewHandle::Privacy(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::Warpify(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::Referrals(v) => v.as_ref(app).should_render(app),
+            SettingsPageViewHandle::Scripting(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::AI(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::CloudEnvironments(v) => v.as_ref(app).should_render(app),
             SettingsPageViewHandle::MCPServers(v) => v.as_ref(app).should_render(app),

--- a/app/src/settings_view/scripting_page.rs
+++ b/app/src/settings_view/scripting_page.rs
@@ -1,0 +1,296 @@
+use settings::{Setting as _, ToggleableSetting as _};
+use warp_core::features::FeatureFlag;
+use warpui::elements::Element;
+use warpui::ui_components::components::UiComponent as _;
+use warpui::ui_components::switch::SwitchStateHandle;
+use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle};
+
+use super::settings_page::{
+    render_body_item, LocalOnlyIconState, MatchData, PageType, SettingsPageMeta,
+    SettingsPageViewHandle, SettingsWidget, ToggleState,
+};
+use super::SettingsSection;
+use crate::appearance::Appearance;
+use crate::report_if_error;
+use crate::settings::{LocalControlPermissionSettings, LocalControlSettings};
+
+#[derive(Clone, Debug)]
+pub enum ScriptingPageAction {
+    OutsideWarpControl,
+    MetadataRead,
+    UnderlyingDataRead,
+    AppStateMutation,
+    MetadataConfigurationMutation,
+    UnderlyingDataMutation,
+}
+
+pub struct ScriptingPageView {
+    page: PageType<Self>,
+}
+
+impl ScriptingPageView {
+    pub fn new(ctx: &mut ViewContext<Self>) -> Self {
+        ctx.subscribe_to_model(&LocalControlSettings::handle(ctx), |_, _, _, ctx| {
+            ctx.notify();
+        });
+
+        let page = PageType::new_uncategorized(
+            vec![
+                Box::new(OutsideWarpControlWidget::default()),
+                Box::new(PermissionWidget::new(
+                    "Read app metadata",
+                    "Allow commands like `warpctrl app ping` and `warpctrl app version` to read non-sensitive app metadata.",
+                    "local control metadata read permission app ping version",
+                    ScriptingPageAction::MetadataRead,
+                    |settings| settings.metadata_read,
+                )),
+                Box::new(PermissionWidget::new(
+                    "Read underlying data",
+                    "Reserved for future commands that read terminal, pane, or session data. Disabled by default.",
+                    "local control underlying data read permission",
+                    ScriptingPageAction::UnderlyingDataRead,
+                    |settings| settings.underlying_data_read,
+                )),
+                Box::new(PermissionWidget::new(
+                    "Mutate app state",
+                    "Allow commands like `warpctrl tab create` to change local app state.",
+                    "local control app state mutation tab create permission",
+                    ScriptingPageAction::AppStateMutation,
+                    |settings| settings.app_state_mutation,
+                )),
+                Box::new(PermissionWidget::new(
+                    "Mutate metadata configuration",
+                    "Reserved for future commands that update metadata configuration. Disabled by default.",
+                    "local control metadata configuration mutation permission",
+                    ScriptingPageAction::MetadataConfigurationMutation,
+                    |settings| settings.metadata_configuration_mutation,
+                )),
+                Box::new(PermissionWidget::new(
+                    "Mutate underlying data",
+                    "Reserved for future commands that write terminal, pane, or session data. Disabled by default.",
+                    "local control underlying data mutation permission",
+                    ScriptingPageAction::UnderlyingDataMutation,
+                    |settings| settings.underlying_data_mutation,
+                )),
+            ],
+            Some("Scripting"),
+        );
+
+        Self { page }
+    }
+
+    fn update_permissions(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+        update: impl FnOnce(&mut LocalControlPermissionSettings),
+    ) {
+        LocalControlSettings::handle(ctx).update(ctx, |settings, ctx| {
+            let mut permissions = *settings.outside_warp_permissions.value();
+            update(&mut permissions);
+            report_if_error!(settings
+                .outside_warp_permissions
+                .set_value(permissions, ctx));
+        });
+        ctx.notify();
+    }
+}
+
+impl Entity for ScriptingPageView {
+    type Event = ();
+}
+
+impl TypedActionView for ScriptingPageView {
+    type Action = ScriptingPageAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            ScriptingPageAction::OutsideWarpControl => {
+                LocalControlSettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings
+                        .outside_warp_control_enabled
+                        .toggle_and_save_value(ctx));
+                });
+                ctx.notify();
+            }
+            ScriptingPageAction::MetadataRead => {
+                self.update_permissions(ctx, |settings| {
+                    settings.metadata_read = !settings.metadata_read;
+                });
+            }
+            ScriptingPageAction::UnderlyingDataRead => {
+                self.update_permissions(ctx, |settings| {
+                    settings.underlying_data_read = !settings.underlying_data_read;
+                });
+            }
+            ScriptingPageAction::AppStateMutation => {
+                self.update_permissions(ctx, |settings| {
+                    settings.app_state_mutation = !settings.app_state_mutation;
+                });
+            }
+            ScriptingPageAction::MetadataConfigurationMutation => {
+                self.update_permissions(ctx, |settings| {
+                    settings.metadata_configuration_mutation =
+                        !settings.metadata_configuration_mutation;
+                });
+            }
+            ScriptingPageAction::UnderlyingDataMutation => {
+                self.update_permissions(ctx, |settings| {
+                    settings.underlying_data_mutation = !settings.underlying_data_mutation;
+                });
+            }
+        }
+    }
+}
+
+impl View for ScriptingPageView {
+    fn ui_name() -> &'static str {
+        "ScriptingPage"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        self.page.render(self, app)
+    }
+}
+
+impl SettingsPageMeta for ScriptingPageView {
+    fn section() -> SettingsSection {
+        SettingsSection::Scripting
+    }
+
+    fn should_render(&self, _ctx: &AppContext) -> bool {
+        FeatureFlag::WarpControlCli.is_enabled()
+    }
+
+    fn update_filter(&mut self, query: &str, ctx: &mut ViewContext<Self>) -> MatchData {
+        self.page.update_filter(query, ctx)
+    }
+
+    fn scroll_to_widget(&mut self, widget_id: &'static str) {
+        self.page.scroll_to_widget(widget_id)
+    }
+
+    fn clear_highlighted_widget(&mut self) {
+        self.page.clear_highlighted_widget();
+    }
+}
+
+impl From<ViewHandle<ScriptingPageView>> for SettingsPageViewHandle {
+    fn from(view_handle: ViewHandle<ScriptingPageView>) -> Self {
+        SettingsPageViewHandle::Scripting(view_handle)
+    }
+}
+
+#[derive(Default)]
+struct OutsideWarpControlWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for OutsideWarpControlWidget {
+    type View = ScriptingPageView;
+
+    fn search_terms(&self) -> &str {
+        "local control warpctrl scripting outside warp"
+    }
+
+    fn render(
+        &self,
+        _view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let settings = LocalControlSettings::as_ref(app);
+        render_body_item::<ScriptingPageAction>(
+            "Enable outside-Warp local control".to_owned(),
+            None,
+            LocalOnlyIconState::Hidden,
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .switch(self.switch_state.clone())
+                .check(*settings.outside_warp_control_enabled.value())
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(ScriptingPageAction::OutsideWarpControl);
+                })
+                .finish(),
+            Some(
+                "Allows external `warpctrl` processes on this machine to request short-lived scoped credentials. Disabled by default."
+                    .to_owned(),
+            ),
+        )
+    }
+}
+
+struct PermissionWidget {
+    title: &'static str,
+    description: &'static str,
+    search_terms: &'static str,
+    action: ScriptingPageAction,
+    value: fn(&LocalControlPermissionSettings) -> bool,
+    switch_state: SwitchStateHandle,
+}
+
+impl PermissionWidget {
+    fn new(
+        title: &'static str,
+        description: &'static str,
+        search_terms: &'static str,
+        action: ScriptingPageAction,
+        value: fn(&LocalControlPermissionSettings) -> bool,
+    ) -> Self {
+        Self {
+            title,
+            description,
+            search_terms,
+            action,
+            value,
+            switch_state: SwitchStateHandle::default(),
+        }
+    }
+}
+
+impl SettingsWidget for PermissionWidget {
+    type View = ScriptingPageView;
+
+    fn search_terms(&self) -> &str {
+        self.search_terms
+    }
+
+    fn render(
+        &self,
+        _view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let settings = LocalControlSettings::as_ref(app);
+        let outside_warp_enabled = *settings.outside_warp_control_enabled.value();
+        let is_checked = (self.value)(settings.outside_warp_permissions.value());
+        let toggle_state = ToggleState::from(outside_warp_enabled);
+        let action = self.action.clone();
+        let switch = appearance
+            .ui_builder()
+            .switch(self.switch_state.clone())
+            .check(is_checked);
+        let switch = if outside_warp_enabled {
+            switch
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(action.clone());
+                })
+                .finish()
+        } else {
+            switch.disable().build().finish()
+        };
+
+        render_body_item::<ScriptingPageAction>(
+            self.title.to_owned(),
+            None,
+            LocalOnlyIconState::Hidden,
+            toggle_state,
+            appearance,
+            switch,
+            Some(self.description.to_owned()),
+        )
+    }
+}

--- a/app/src/settings_view/settings_page.rs
+++ b/app/src/settings_view/settings_page.rs
@@ -38,6 +38,7 @@ use super::main_page::MainSettingsPageView;
 use super::mcp_servers_page::MCPServersSettingsPageView;
 use super::privacy_page::PrivacyPageView;
 use super::referrals_page::ReferralsPageView;
+use super::scripting_page::ScriptingPageView;
 use super::show_blocks_view::ShowBlocksView;
 use super::teams_page::TeamsPageView;
 use super::warp_drive_page::WarpDriveSettingsPageView;
@@ -111,6 +112,7 @@ pub enum SettingsPageViewHandle {
     Privacy(ViewHandle<PrivacyPageView>),
     Warpify(ViewHandle<WarpifyPageView>),
     Referrals(ViewHandle<ReferralsPageView>),
+    Scripting(ViewHandle<ScriptingPageView>),
     AI(ViewHandle<AISettingsPageView>),
     CloudEnvironments(ViewHandle<EnvironmentsPageView>),
     BillingAndUsage(ViewHandle<BillingAndUsageDispatchView>),
@@ -134,6 +136,7 @@ impl SettingsPageViewHandle {
             Privacy(view_handle) => ChildView::new(view_handle).finish(),
             Warpify(view_handle) => ChildView::new(view_handle).finish(),
             Referrals(view_handle) => ChildView::new(view_handle).finish(),
+            Scripting(view_handle) => ChildView::new(view_handle).finish(),
             AI(view_handle) => ChildView::new(view_handle).finish(),
             CloudEnvironments(view_handle) => ChildView::new(view_handle).finish(),
             BillingAndUsage(view_handle) => ChildView::new(view_handle).finish(),

--- a/crates/local_control/Cargo.toml
+++ b/crates/local_control/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "local_control"
+edition = "2024"
+description = "Shared protocol and client scaffolding for Warp local control"
+authors.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+dirs.workspace = true
+reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/local_control/src/auth.rs
+++ b/crates/local_control/src/auth.rs
@@ -1,0 +1,254 @@
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use uuid::Uuid;
+
+use crate::catalog::action_metadata;
+use crate::protocol::{
+    ControlAction, ControlError, CredentialRequest, ErrorCode, ExecutionContextProof,
+    InvocationContext, PermissionCategory, ScopedCredential,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct PermissionGrant {
+    pub metadata_read: bool,
+    pub underlying_data_read: bool,
+    pub app_state_mutation: bool,
+    pub metadata_configuration_mutation: bool,
+    pub underlying_data_mutation: bool,
+}
+
+impl PermissionGrant {
+    pub fn allows(&self, permission: &PermissionCategory) -> bool {
+        match permission {
+            PermissionCategory::MetadataRead => self.metadata_read,
+            PermissionCategory::UnderlyingDataRead => self.underlying_data_read,
+            PermissionCategory::AppStateMutation => self.app_state_mutation,
+            PermissionCategory::MetadataConfigurationMutation => {
+                self.metadata_configuration_mutation
+            }
+            PermissionCategory::UnderlyingDataMutation => self.underlying_data_mutation,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CredentialIssuer {
+    outside_warp_enabled: bool,
+    permissions: PermissionGrant,
+    credentials: HashMap<String, ScopedCredential>,
+    lifetime: Duration,
+}
+
+impl CredentialIssuer {
+    pub fn new(outside_warp_enabled: bool, permissions: PermissionGrant) -> Self {
+        Self {
+            outside_warp_enabled,
+            permissions,
+            credentials: HashMap::new(),
+            lifetime: Duration::from_secs(60),
+        }
+    }
+
+    pub fn set_policy(&mut self, outside_warp_enabled: bool, permissions: PermissionGrant) {
+        self.outside_warp_enabled = outside_warp_enabled;
+        self.permissions = permissions;
+    }
+
+    pub fn issue(&mut self, request: &CredentialRequest) -> Result<ScopedCredential, ControlError> {
+        if request.invocation_context == InvocationContext::InsideWarp {
+            return Err(ControlError::new(
+                ErrorCode::ExecutionContextNotAllowed,
+                "inside-Warp local-control credentials are reserved for future verified terminal proof support",
+            ));
+        }
+        if request.proof != ExecutionContextProof::None {
+            return Err(ControlError::new(
+                ErrorCode::ExecutionContextNotAllowed,
+                "execution context proof is not accepted for outside-Warp foundation requests",
+            ));
+        }
+        if !self.outside_warp_enabled {
+            return Err(ControlError::new(
+                ErrorCode::LocalControlDisabled,
+                "outside-Warp local control is disabled",
+            ));
+        }
+
+        let metadata = action_metadata(&request.action);
+        if !metadata
+            .allowed_invocation_contexts
+            .contains(&request.invocation_context)
+        {
+            return Err(ControlError::new(
+                ErrorCode::ExecutionContextNotAllowed,
+                "action is not allowed from the requested invocation context",
+            ));
+        }
+        if !self.permissions.allows(&metadata.permission) {
+            return Err(ControlError::new(
+                ErrorCode::InsufficientPermissions,
+                "outside-Warp local control permission is disabled for this action category",
+            ));
+        }
+        if metadata.requires_authenticated_user {
+            return Err(ControlError::new(
+                ErrorCode::AuthenticatedUserRequired,
+                "authenticated-user local-control grants are not implemented in the foundation slice",
+            ));
+        }
+
+        let credential = ScopedCredential {
+            token: Uuid::new_v4().to_string(),
+            action: request.action.clone(),
+            permission: metadata.permission,
+            invocation_context: request.invocation_context.clone(),
+            expires_at_unix_ms: now_unix_ms() + self.lifetime.as_millis() as u64,
+            requires_authenticated_user: metadata.requires_authenticated_user,
+        };
+        self.credentials
+            .insert(credential.token.clone(), credential.clone());
+        Ok(credential)
+    }
+
+    pub fn verify(
+        &self,
+        token: &str,
+        action: &ControlAction,
+        required_permission: &PermissionCategory,
+    ) -> Result<ScopedCredential, ControlError> {
+        let credential = self.credentials.get(token).ok_or_else(|| {
+            ControlError::new(
+                ErrorCode::UnauthorizedLocalClient,
+                "missing or unknown local-control credential",
+            )
+        })?;
+        if credential.expires_at_unix_ms <= now_unix_ms() {
+            return Err(ControlError::new(
+                ErrorCode::UnauthorizedLocalClient,
+                "local-control credential has expired",
+            ));
+        }
+        if &credential.action != action {
+            return Err(ControlError::new(
+                ErrorCode::InsufficientPermissions,
+                "local-control credential was issued for a different action",
+            ));
+        }
+        if &credential.permission != required_permission {
+            return Err(ControlError::new(
+                ErrorCode::InsufficientPermissions,
+                "local-control credential lacks the required permission category",
+            ));
+        }
+        Ok(credential.clone())
+    }
+
+    pub fn insert_for_tests(&mut self, credential: ScopedCredential) {
+        self.credentials
+            .insert(credential.token.clone(), credential);
+    }
+}
+
+pub fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{CredentialRequest, PROTOCOL_VERSION};
+
+    fn grant_all() -> PermissionGrant {
+        PermissionGrant {
+            metadata_read: true,
+            underlying_data_read: true,
+            app_state_mutation: true,
+            metadata_configuration_mutation: true,
+            underlying_data_mutation: true,
+        }
+    }
+
+    #[test]
+    fn rejects_inside_warp_credential_request() {
+        let mut issuer = CredentialIssuer::new(true, grant_all());
+        let request = CredentialRequest {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: "r".to_owned(),
+            action: ControlAction::AppPing,
+            invocation_context: InvocationContext::InsideWarp,
+            proof: ExecutionContextProof::VerifiedWarpTerminal {
+                proof_id: "reserved".to_owned(),
+            },
+        };
+        let error = issuer.issue(&request).unwrap_err();
+        assert_eq!(error.code, ErrorCode::ExecutionContextNotAllowed);
+    }
+
+    #[test]
+    fn disabled_outside_warp_control_rejects_credentials() {
+        let mut issuer = CredentialIssuer::new(false, grant_all());
+        let error = issuer
+            .issue(&CredentialRequest::outside_warp(ControlAction::AppPing))
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::LocalControlDisabled);
+    }
+
+    #[test]
+    fn disabled_granular_permission_rejects_credentials() {
+        let mut issuer = CredentialIssuer::new(true, PermissionGrant::default());
+        let error = issuer
+            .issue(&CredentialRequest::outside_warp(ControlAction::TabCreate))
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::InsufficientPermissions);
+    }
+
+    #[test]
+    fn verifies_valid_and_wrong_action_credentials() {
+        let mut issuer = CredentialIssuer::new(true, grant_all());
+        let credential = issuer
+            .issue(&CredentialRequest::outside_warp(ControlAction::TabCreate))
+            .unwrap();
+        assert!(
+            issuer
+                .verify(
+                    &credential.token,
+                    &ControlAction::TabCreate,
+                    &PermissionCategory::AppStateMutation,
+                )
+                .is_ok()
+        );
+        let error = issuer
+            .verify(
+                &credential.token,
+                &ControlAction::AppPing,
+                &PermissionCategory::MetadataRead,
+            )
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::InsufficientPermissions);
+    }
+
+    #[test]
+    fn rejects_expired_credentials() {
+        let mut issuer = CredentialIssuer::new(true, grant_all());
+        issuer.insert_for_tests(ScopedCredential {
+            token: "expired".to_owned(),
+            action: ControlAction::AppPing,
+            permission: PermissionCategory::MetadataRead,
+            invocation_context: InvocationContext::OutsideWarp,
+            expires_at_unix_ms: 1,
+            requires_authenticated_user: false,
+        });
+        let error = issuer
+            .verify(
+                "expired",
+                &ControlAction::AppPing,
+                &PermissionCategory::MetadataRead,
+            )
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::UnauthorizedLocalClient);
+    }
+}

--- a/crates/local_control/src/catalog.rs
+++ b/crates/local_control/src/catalog.rs
@@ -1,0 +1,98 @@
+use crate::protocol::{ActionSupportStatus, ControlAction, InvocationContext, PermissionCategory};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActionMetadata {
+    pub action: ControlAction,
+    pub support: ActionSupportStatus,
+    pub permission: PermissionCategory,
+    pub requires_authenticated_user: bool,
+    pub allowed_invocation_contexts: &'static [InvocationContext],
+    pub summary: &'static str,
+}
+
+const OUTSIDE_WARP: &[InvocationContext] = &[InvocationContext::OutsideWarp];
+
+pub fn action_metadata(action: &ControlAction) -> ActionMetadata {
+    match action {
+        ControlAction::InstanceList => ActionMetadata {
+            action: action.clone(),
+            support: ActionSupportStatus::Implemented,
+            permission: PermissionCategory::MetadataRead,
+            requires_authenticated_user: false,
+            allowed_invocation_contexts: OUTSIDE_WARP,
+            summary: "List locally discoverable Warp instances.",
+        },
+        ControlAction::AppPing => ActionMetadata {
+            action: action.clone(),
+            support: ActionSupportStatus::Implemented,
+            permission: PermissionCategory::MetadataRead,
+            requires_authenticated_user: false,
+            allowed_invocation_contexts: OUTSIDE_WARP,
+            summary: "Check whether the selected Warp instance is reachable.",
+        },
+        ControlAction::AppVersion => ActionMetadata {
+            action: action.clone(),
+            support: ActionSupportStatus::Implemented,
+            permission: PermissionCategory::MetadataRead,
+            requires_authenticated_user: false,
+            allowed_invocation_contexts: OUTSIDE_WARP,
+            summary: "Read version metadata from the selected Warp instance.",
+        },
+        ControlAction::TabCreate => ActionMetadata {
+            action: action.clone(),
+            support: ActionSupportStatus::Implemented,
+            permission: PermissionCategory::AppStateMutation,
+            requires_authenticated_user: false,
+            allowed_invocation_contexts: OUTSIDE_WARP,
+            summary: "Create a terminal tab in the active window.",
+        },
+        ControlAction::WindowList
+        | ControlAction::TabList
+        | ControlAction::PaneList
+        | ControlAction::SessionList => ActionMetadata {
+            action: action.clone(),
+            support: ActionSupportStatus::Planned,
+            permission: PermissionCategory::MetadataRead,
+            requires_authenticated_user: false,
+            allowed_invocation_contexts: OUTSIDE_WARP,
+            summary: "Planned metadata action not implemented in the foundation slice.",
+        },
+    }
+}
+
+pub fn implemented_actions() -> Vec<ActionMetadata> {
+    [
+        ControlAction::InstanceList,
+        ControlAction::AppPing,
+        ControlAction::AppVersion,
+        ControlAction::TabCreate,
+    ]
+    .into_iter()
+    .map(|action| action_metadata(&action))
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tab_create_is_logged_out_safe_app_state_mutation() {
+        let metadata = action_metadata(&ControlAction::TabCreate);
+        assert_eq!(metadata.support, ActionSupportStatus::Implemented);
+        assert_eq!(metadata.permission, PermissionCategory::AppStateMutation);
+        assert!(!metadata.requires_authenticated_user);
+        assert_eq!(metadata.allowed_invocation_contexts, OUTSIDE_WARP);
+    }
+
+    #[test]
+    fn future_actions_are_planned_not_implemented() {
+        let metadata = action_metadata(&ControlAction::WindowList);
+        assert_eq!(metadata.support, ActionSupportStatus::Planned);
+        assert!(
+            !implemented_actions()
+                .iter()
+                .any(|m| m.action == ControlAction::WindowList)
+        );
+    }
+}

--- a/crates/local_control/src/client.rs
+++ b/crates/local_control/src/client.rs
@@ -1,0 +1,57 @@
+use anyhow::{Context, Result, bail};
+use reqwest::blocking::Client as HttpClient;
+
+use crate::protocol::{
+    CredentialRequest, CredentialResponse, RequestEnvelope, ResponseEnvelope, ScopedCredential,
+};
+
+#[derive(Clone, Debug)]
+pub struct LocalControlClient {
+    endpoint: String,
+    http: HttpClient,
+}
+
+impl LocalControlClient {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into().trim_end_matches('/').to_owned(),
+            http: HttpClient::new(),
+        }
+    }
+
+    pub fn request_credential(&self, request: &CredentialRequest) -> Result<ScopedCredential> {
+        let response = self
+            .http
+            .post(format!("{}/v1/control/credentials", self.endpoint))
+            .json(request)
+            .send()
+            .context("failed to request local-control credential")?
+            .error_for_status()
+            .context("local-control credential request returned an error status")?
+            .json::<CredentialResponse>()
+            .context("failed to decode local-control credential response")?;
+        if let Some(error) = response.error {
+            bail!("{}: {}", error.code.as_str(), error.message);
+        }
+        response
+            .credential
+            .context("local-control credential response did not include a credential")
+    }
+
+    pub fn send_request(
+        &self,
+        credential: &ScopedCredential,
+        request: &RequestEnvelope,
+    ) -> Result<ResponseEnvelope> {
+        self.http
+            .post(format!("{}/v1/control", self.endpoint))
+            .bearer_auth(&credential.token)
+            .json(request)
+            .send()
+            .context("failed to send local-control request")?
+            .error_for_status()
+            .context("local-control request returned an error status")?
+            .json::<ResponseEnvelope>()
+            .context("failed to decode local-control response")
+    }
+}

--- a/crates/local_control/src/discovery.rs
+++ b/crates/local_control/src/discovery.rs
@@ -1,0 +1,141 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::PROTOCOL_VERSION;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DiscoveryRecord {
+    pub instance_id: String,
+    pub pid: u32,
+    pub channel: String,
+    pub app_version: String,
+    pub protocol_version: u16,
+    pub started_at_unix_ms: u64,
+    pub outside_warp_control_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub implemented_actions: Vec<String>,
+}
+
+impl DiscoveryRecord {
+    pub fn disabled(instance_id: impl Into<String>, pid: u32) -> Self {
+        Self {
+            instance_id: instance_id.into(),
+            pid,
+            channel: String::new(),
+            app_version: String::new(),
+            protocol_version: PROTOCOL_VERSION,
+            started_at_unix_ms: 0,
+            outside_warp_control_enabled: false,
+            endpoint: None,
+            implemented_actions: Vec::new(),
+        }
+    }
+
+    pub fn is_actionable(&self) -> bool {
+        self.outside_warp_control_enabled && self.endpoint.is_some()
+    }
+
+    pub fn is_compatible(&self) -> bool {
+        self.protocol_version == PROTOCOL_VERSION
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.pid == 0 || !self.is_compatible()
+    }
+}
+
+pub fn default_registry_dir() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|dir| dir.join("warp").join("local-control"))
+}
+
+pub fn write_record(dir: &Path, record: &DiscoveryRecord) -> io::Result<PathBuf> {
+    fs::create_dir_all(dir)?;
+    let path = dir.join(format!("{}.json", record.instance_id));
+    let bytes = serde_json::to_vec_pretty(record).map_err(io::Error::other)?;
+    fs::write(&path, bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(path)
+}
+
+pub fn read_records(dir: &Path) -> io::Result<Vec<DiscoveryRecord>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut records = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = fs::read(entry.path())?;
+        let record = serde_json::from_slice::<DiscoveryRecord>(&bytes).map_err(io::Error::other)?;
+        if record.is_stale() {
+            let _ = fs::remove_file(entry.path());
+            continue;
+        }
+        records.push(record);
+    }
+    Ok(records)
+}
+
+pub fn compatible_actionable_records(records: &[DiscoveryRecord]) -> Vec<DiscoveryRecord> {
+    records
+        .iter()
+        .filter(|record| record.is_compatible() && record.is_actionable())
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_record_has_no_actionable_endpoint() {
+        let record = DiscoveryRecord::disabled("instance", 123);
+        assert!(!record.is_actionable());
+        let json = serde_json::to_value(&record).unwrap();
+        assert!(json.get("token").is_none());
+        assert!(json.get("credential").is_none());
+        assert!(json.get("endpoint").is_none());
+    }
+
+    #[test]
+    fn read_records_prunes_incompatible_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut record = DiscoveryRecord::disabled("old", 1);
+        record.protocol_version = PROTOCOL_VERSION + 1;
+        write_record(dir.path(), &record).unwrap();
+        assert!(read_records(dir.path()).unwrap().is_empty());
+        assert!(!dir.path().join("old.json").exists());
+    }
+
+    #[test]
+    fn actionable_records_require_enabled_endpoint() {
+        let disabled = DiscoveryRecord::disabled("disabled", 1);
+        let enabled = DiscoveryRecord {
+            instance_id: "enabled".to_owned(),
+            pid: 1,
+            channel: "dev".to_owned(),
+            app_version: "1".to_owned(),
+            protocol_version: PROTOCOL_VERSION,
+            started_at_unix_ms: 1,
+            outside_warp_control_enabled: true,
+            endpoint: Some("http://127.0.0.1:1".to_owned()),
+            implemented_actions: vec!["app.ping".to_owned()],
+        };
+        assert_eq!(
+            compatible_actionable_records(&[disabled, enabled.clone()]),
+            vec![enabled]
+        );
+    }
+}

--- a/crates/local_control/src/lib.rs
+++ b/crates/local_control/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod auth;
+pub mod catalog;
+pub mod client;
+pub mod discovery;
+pub mod protocol;
+pub mod selection;
+pub mod selectors;
+
+pub use protocol::{ControlAction, ErrorCode, PROTOCOL_VERSION, PermissionCategory};

--- a/crates/local_control/src/protocol.rs
+++ b/crates/local_control/src/protocol.rs
@@ -1,0 +1,317 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+pub const PROTOCOL_VERSION: u16 = 1;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    LocalControlDisabled,
+    UnauthorizedLocalClient,
+    InsufficientPermissions,
+    AuthenticatedUserRequired,
+    AuthenticatedUserUnavailable,
+    ExecutionContextNotAllowed,
+    AmbiguousInstance,
+    AmbiguousTarget,
+    StaleTarget,
+    InvalidSelector,
+    UnsupportedAction,
+    NotAllowlisted,
+    InvalidParams,
+    TargetStateConflict,
+    MissingTarget,
+    NoInstance,
+    FeatureDisabled,
+    TransportError,
+}
+
+impl ErrorCode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::LocalControlDisabled => "local_control_disabled",
+            Self::UnauthorizedLocalClient => "unauthorized_local_client",
+            Self::InsufficientPermissions => "insufficient_permissions",
+            Self::AuthenticatedUserRequired => "authenticated_user_required",
+            Self::AuthenticatedUserUnavailable => "authenticated_user_unavailable",
+            Self::ExecutionContextNotAllowed => "execution_context_not_allowed",
+            Self::AmbiguousInstance => "ambiguous_instance",
+            Self::AmbiguousTarget => "ambiguous_target",
+            Self::StaleTarget => "stale_target",
+            Self::InvalidSelector => "invalid_selector",
+            Self::UnsupportedAction => "unsupported_action",
+            Self::NotAllowlisted => "not_allowlisted",
+            Self::InvalidParams => "invalid_params",
+            Self::TargetStateConflict => "target_state_conflict",
+            Self::MissingTarget => "missing_target",
+            Self::NoInstance => "no_instance",
+            Self::FeatureDisabled => "feature_disabled",
+            Self::TransportError => "transport_error",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionCategory {
+    MetadataRead,
+    UnderlyingDataRead,
+    AppStateMutation,
+    MetadataConfigurationMutation,
+    UnderlyingDataMutation,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvocationContext {
+    OutsideWarp,
+    InsideWarp,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ExecutionContextProof {
+    None,
+    VerifiedWarpTerminal { proof_id: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionSupportStatus {
+    Implemented,
+    Planned,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ControlAction {
+    #[serde(rename = "instance.list")]
+    InstanceList,
+    #[serde(rename = "app.ping")]
+    AppPing,
+    #[serde(rename = "app.version")]
+    AppVersion,
+    #[serde(rename = "tab.create")]
+    TabCreate,
+    #[serde(rename = "window.list")]
+    WindowList,
+    #[serde(rename = "tab.list")]
+    TabList,
+    #[serde(rename = "pane.list")]
+    PaneList,
+    #[serde(rename = "session.list")]
+    SessionList,
+}
+
+impl ControlAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::InstanceList => "instance.list",
+            Self::AppPing => "app.ping",
+            Self::AppVersion => "app.version",
+            Self::TabCreate => "tab.create",
+            Self::WindowList => "window.list",
+            Self::TabList => "tab.list",
+            Self::PaneList => "pane.list",
+            Self::SessionList => "session.list",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RequestEnvelope {
+    pub protocol_version: u16,
+    pub request_id: String,
+    pub action: ControlAction,
+    #[serde(default)]
+    pub target: TargetSelector,
+    #[serde(default)]
+    pub params: Value,
+}
+
+impl RequestEnvelope {
+    pub fn new(action: ControlAction) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: Uuid::new_v4().to_string(),
+            action,
+            target: TargetSelector::default(),
+            params: Value::Object(Default::default()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ResponseEnvelope {
+    pub ok: bool,
+    pub protocol_version: u16,
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_target: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ControlError>,
+}
+
+impl ResponseEnvelope {
+    pub fn ok(request_id: impl Into<String>, instance_id: Option<String>, result: Value) -> Self {
+        Self {
+            ok: true,
+            protocol_version: PROTOCOL_VERSION,
+            request_id: request_id.into(),
+            instance_id,
+            resolved_target: None,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(request_id: impl Into<String>, error: ControlError) -> Self {
+        Self {
+            ok: false,
+            protocol_version: PROTOCOL_VERSION,
+            request_id: request_id.into(),
+            instance_id: None,
+            resolved_target: None,
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ControlError {
+    pub code: ErrorCode,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector: Option<Value>,
+}
+
+impl ControlError {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            selector: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TargetSelector {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window: Option<WindowSelector>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tab: Option<TabSelector>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pane: Option<PaneSelector>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<SessionSelector>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block: Option<BlockSelector>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum WindowSelector {
+    Active,
+    Id(String),
+    Index(u32),
+    Title(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum TabSelector {
+    Active,
+    Id(String),
+    Index(u32),
+    Title(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum PaneSelector {
+    Active,
+    Id(String),
+    Index(u32),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum SessionSelector {
+    Active,
+    Id(String),
+    Index(u32),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum BlockSelector {
+    Id(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CredentialRequest {
+    pub protocol_version: u16,
+    pub request_id: String,
+    pub action: ControlAction,
+    pub invocation_context: InvocationContext,
+    pub proof: ExecutionContextProof,
+}
+
+impl CredentialRequest {
+    pub fn outside_warp(action: ControlAction) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: Uuid::new_v4().to_string(),
+            action,
+            invocation_context: InvocationContext::OutsideWarp,
+            proof: ExecutionContextProof::None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CredentialResponse {
+    pub protocol_version: u16,
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential: Option<ScopedCredential>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ControlError>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ScopedCredential {
+    pub token: String,
+    pub action: ControlAction,
+    pub permission: PermissionCategory,
+    pub invocation_context: InvocationContext,
+    pub expires_at_unix_ms: u64,
+    pub requires_authenticated_user: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_codes_serialize_to_stable_snake_case() {
+        let json = serde_json::to_string(&ErrorCode::ExecutionContextNotAllowed).unwrap();
+        assert_eq!(json, "\"execution_context_not_allowed\"");
+        assert_eq!(ErrorCode::InvalidParams.as_str(), "invalid_params");
+    }
+
+    #[test]
+    fn protocol_envelope_serializes_action_names_with_dots() {
+        let envelope = RequestEnvelope::new(ControlAction::TabCreate);
+        let value = serde_json::to_value(envelope).unwrap();
+        assert_eq!(value["action"], "tab.create");
+        assert_eq!(value["protocol_version"], PROTOCOL_VERSION);
+    }
+}

--- a/crates/local_control/src/selection.rs
+++ b/crates/local_control/src/selection.rs
@@ -1,0 +1,109 @@
+use crate::discovery::DiscoveryRecord;
+use crate::protocol::{ControlError, ErrorCode};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InstanceSelector {
+    Any,
+    Id(String),
+    Pid(u32),
+}
+
+pub fn select_instance(
+    records: &[DiscoveryRecord],
+    selector: &InstanceSelector,
+) -> Result<DiscoveryRecord, ControlError> {
+    let matches: Vec<DiscoveryRecord> = match selector {
+        InstanceSelector::Any => records.to_vec(),
+        InstanceSelector::Id(id) => records
+            .iter()
+            .filter(|record| &record.instance_id == id)
+            .cloned()
+            .collect(),
+        InstanceSelector::Pid(pid) => records
+            .iter()
+            .filter(|record| &record.pid == pid)
+            .cloned()
+            .collect(),
+    };
+
+    match matches.as_slice() {
+        [] => Err(ControlError::new(
+            match selector {
+                InstanceSelector::Any => ErrorCode::NoInstance,
+                InstanceSelector::Id(_) | InstanceSelector::Pid(_) => ErrorCode::StaleTarget,
+            },
+            "no compatible Warp instance matched the selector",
+        )),
+        [record] => Ok(record.clone()),
+        _ => Err(ControlError::new(
+            ErrorCode::AmbiguousInstance,
+            "multiple compatible Warp instances matched the selector",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::DiscoveryRecord;
+    use crate::protocol::PROTOCOL_VERSION;
+
+    fn record(id: &str, pid: u32) -> DiscoveryRecord {
+        DiscoveryRecord {
+            instance_id: id.to_owned(),
+            pid,
+            channel: "dev".to_owned(),
+            app_version: "1".to_owned(),
+            protocol_version: PROTOCOL_VERSION,
+            started_at_unix_ms: 1,
+            outside_warp_control_enabled: true,
+            endpoint: Some(format!("http://127.0.0.1:{pid}")),
+            implemented_actions: vec![],
+        }
+    }
+
+    #[test]
+    fn zero_one_multiple_instance_selection() {
+        assert_eq!(
+            select_instance(&[], &InstanceSelector::Any)
+                .unwrap_err()
+                .code,
+            ErrorCode::NoInstance
+        );
+        assert_eq!(
+            select_instance(&[record("a", 1)], &InstanceSelector::Any)
+                .unwrap()
+                .instance_id,
+            "a"
+        );
+        assert_eq!(
+            select_instance(&[record("a", 1), record("b", 2)], &InstanceSelector::Any)
+                .unwrap_err()
+                .code,
+            ErrorCode::AmbiguousInstance
+        );
+    }
+
+    #[test]
+    fn explicit_id_and_pid_must_resolve_exactly() {
+        let records = [record("a", 42), record("b", 43)];
+        assert_eq!(
+            select_instance(&records, &InstanceSelector::Id("a".to_owned()))
+                .unwrap()
+                .pid,
+            42
+        );
+        assert_eq!(
+            select_instance(&records, &InstanceSelector::Pid(43))
+                .unwrap()
+                .instance_id,
+            "b"
+        );
+        assert_eq!(
+            select_instance(&records, &InstanceSelector::Id("missing".to_owned()))
+                .unwrap_err()
+                .code,
+            ErrorCode::StaleTarget
+        );
+    }
+}

--- a/crates/local_control/src/selectors.rs
+++ b/crates/local_control/src/selectors.rs
@@ -1,0 +1,48 @@
+use crate::protocol::{ControlError, ErrorCode, TargetSelector, WindowSelector};
+
+pub fn validate_foundation_tab_create_target(target: &TargetSelector) -> Result<(), ControlError> {
+    if !matches!(target.window, None | Some(WindowSelector::Active)) {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            "tab.create supports only the active window selector in the foundation slice",
+        ));
+    }
+    if target.tab.is_some()
+        || target.pane.is_some()
+        || target.session.is_some()
+        || target.block.is_some()
+    {
+        return Err(ControlError::new(
+            ErrorCode::InvalidSelector,
+            "tab.create does not support lower-level target selectors in the foundation slice",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{TabSelector, TargetSelector};
+
+    #[test]
+    fn tab_create_allows_default_and_active_window_only() {
+        assert!(validate_foundation_tab_create_target(&TargetSelector::default()).is_ok());
+        assert!(
+            validate_foundation_tab_create_target(&TargetSelector {
+                window: Some(WindowSelector::Active),
+                ..Default::default()
+            })
+            .is_ok()
+        );
+        assert_eq!(
+            validate_foundation_tab_create_target(&TargetSelector {
+                tab: Some(TabSelector::Active),
+                ..Default::default()
+            })
+            .unwrap_err()
+            .code,
+            ErrorCode::InvalidSelector
+        );
+    }
+}

--- a/crates/warp_cli/Cargo.toml
+++ b/crates/warp_cli/Cargo.toml
@@ -12,7 +12,9 @@ clap = { workspace = true, features = ["derive", "env"] }
 cfg-if = { workspace = true }
 humantime.workspace = true
 jaq-all.workspace = true
+local_control.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true }
 warp_core = { path = "../warp_core" }

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -29,6 +29,7 @@ pub mod federate;
 pub mod harness_support;
 pub mod integration;
 pub mod json_filter;
+pub mod local_control;
 pub mod mcp;
 pub mod model;
 pub mod provider;

--- a/crates/warp_cli/src/local_control/mod.rs
+++ b/crates/warp_cli/src/local_control/mod.rs
@@ -1,0 +1,295 @@
+use std::io;
+
+use anyhow::{Context, Result};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::aot::{Shell, generate};
+use local_control::client::LocalControlClient;
+use local_control::discovery::{compatible_actionable_records, default_registry_dir, read_records};
+use local_control::protocol::{
+    ControlAction, ControlError, CredentialRequest, ErrorCode, RequestEnvelope, ResponseEnvelope,
+    TargetSelector, WindowSelector,
+};
+use local_control::selection::{InstanceSelector, select_instance};
+use serde_json::{Value, json};
+
+use crate::agent::OutputFormat;
+
+#[derive(Debug, Clone, Parser)]
+#[command(
+    name = "warpctrl",
+    display_name = "warpctrl",
+    about = "Control a running local Warp app instance through the allowlisted local-control protocol"
+)]
+pub struct LocalControlArgs {
+    /// Set the output format.
+    #[arg(long = "output-format", global = true, value_enum, default_value_t = OutputFormat::Pretty)]
+    pub output_format: OutputFormat,
+
+    #[command(subcommand)]
+    pub command: LocalControlCommand,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum LocalControlCommand {
+    /// Discover running Warp instances.
+    #[command(subcommand)]
+    Instance(InstanceCommand),
+    /// App metadata and health commands.
+    #[command(subcommand)]
+    App(AppCommand),
+    /// Tab commands.
+    #[command(subcommand)]
+    Tab(TabCommand),
+    /// Generate shell completions for warpctrl.
+    Completions {
+        /// Shell to generate completions for.
+        #[arg(value_enum)]
+        shell: Option<Shell>,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum InstanceCommand {
+    /// List locally discoverable Warp instances.
+    List,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AppCommand {
+    /// Ping the selected Warp instance.
+    Ping(InstanceSelectionArgs),
+    /// Return version metadata for the selected Warp instance.
+    Version(InstanceSelectionArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum TabCommand {
+    /// Create a new terminal tab in the selected Warp instance's active window.
+    Create(TabCreateArgs),
+}
+
+#[derive(Debug, Clone, Default, clap::Args)]
+pub struct InstanceSelectionArgs {
+    /// Select a Warp instance by opaque instance ID.
+    #[arg(long = "instance", conflicts_with = "pid")]
+    pub instance: Option<String>,
+    /// Select a Warp instance by process ID.
+    #[arg(long = "pid", conflicts_with = "instance")]
+    pub pid: Option<u32>,
+}
+
+impl InstanceSelectionArgs {
+    pub fn selector(&self) -> InstanceSelector {
+        if let Some(instance) = &self.instance {
+            InstanceSelector::Id(instance.clone())
+        } else if let Some(pid) = self.pid {
+            InstanceSelector::Pid(pid)
+        } else {
+            InstanceSelector::Any
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, clap::Args)]
+pub struct TabCreateArgs {
+    #[clap(flatten)]
+    pub instance: InstanceSelectionArgs,
+    /// Target the active window. Concrete window selectors are reserved for a later slice.
+    #[arg(long = "window", value_parser = ["active"], default_value = "active")]
+    pub window: String,
+}
+
+pub fn run_from_env() -> Result<()> {
+    let args = LocalControlArgs::parse();
+    let output = execute(args)?;
+    if !output.is_empty() {
+        println!("{output}");
+    }
+    Ok(())
+}
+
+pub fn execute(args: LocalControlArgs) -> Result<String> {
+    match args.command {
+        LocalControlCommand::Completions { shell } => generate_completions(shell),
+        LocalControlCommand::Instance(InstanceCommand::List) => instance_list(args.output_format),
+        LocalControlCommand::App(AppCommand::Ping(selection)) => execute_remote(
+            ControlAction::AppPing,
+            selection.selector(),
+            TargetSelector::default(),
+            args.output_format,
+        ),
+        LocalControlCommand::App(AppCommand::Version(selection)) => execute_remote(
+            ControlAction::AppVersion,
+            selection.selector(),
+            TargetSelector::default(),
+            args.output_format,
+        ),
+        LocalControlCommand::Tab(TabCommand::Create(tab_args)) => execute_remote(
+            ControlAction::TabCreate,
+            tab_args.instance.selector(),
+            TargetSelector {
+                window: Some(WindowSelector::Active),
+                ..Default::default()
+            },
+            args.output_format,
+        ),
+    }
+}
+
+fn generate_completions(shell: Option<Shell>) -> Result<String> {
+    let shell = shell
+        .or_else(Shell::from_env)
+        .context("could not determine shell from environment; provide a shell argument")?;
+    let mut command = LocalControlArgs::command();
+    generate(shell, &mut command, "warpctrl", &mut io::stdout());
+    Ok(String::new())
+}
+
+fn instance_list(output_format: OutputFormat) -> Result<String> {
+    let records = load_actionable_records()?;
+    render_output(output_format, json!({ "instances": records }))
+}
+
+fn execute_remote(
+    action: ControlAction,
+    selector: InstanceSelector,
+    target: TargetSelector,
+    output_format: OutputFormat,
+) -> Result<String> {
+    let records = load_actionable_records()?;
+    let instance = select_instance(&records, &selector).map_err(anyhow_for_control_error)?;
+    let endpoint = instance.endpoint.clone().ok_or_else(|| {
+        anyhow_for_control_error(ControlError::new(
+            ErrorCode::NoInstance,
+            "selected Warp instance does not expose an actionable endpoint",
+        ))
+    })?;
+    let client = LocalControlClient::new(endpoint);
+    let credential = client.request_credential(&CredentialRequest::outside_warp(action.clone()))?;
+    let mut request = RequestEnvelope::new(action);
+    request.target = target;
+    let response = client.send_request(&credential, &request)?;
+    render_response(output_format, response)
+}
+
+fn load_actionable_records() -> Result<Vec<local_control::discovery::DiscoveryRecord>> {
+    let Some(dir) = default_registry_dir() else {
+        return Ok(Vec::new());
+    };
+    Ok(compatible_actionable_records(&read_records(&dir)?))
+}
+
+fn render_response(output_format: OutputFormat, response: ResponseEnvelope) -> Result<String> {
+    if !response.ok
+        && let Some(error) = response.error
+    {
+        return Err(anyhow_for_control_error(error));
+    }
+    render_output(output_format, serde_json::to_value(response)?)
+}
+
+fn render_output(output_format: OutputFormat, value: Value) -> Result<String> {
+    match output_format {
+        OutputFormat::Json | OutputFormat::Ndjson => Ok(serde_json::to_string(&value)?),
+        OutputFormat::Pretty | OutputFormat::Text => Ok(render_pretty(&value)),
+    }
+}
+
+fn render_pretty(value: &Value) -> String {
+    if let Some(instances) = value.get("instances").and_then(Value::as_array) {
+        if instances.is_empty() {
+            return "No compatible Warp instances found.".to_owned();
+        }
+        return instances
+            .iter()
+            .map(|instance| {
+                format!(
+                    "{}\tpid={}\tchannel={}\tprotocol={}\tactions={}",
+                    instance["instance_id"].as_str().unwrap_or("unknown"),
+                    instance["pid"].as_u64().unwrap_or_default(),
+                    instance["channel"].as_str().unwrap_or("unknown"),
+                    instance["protocol_version"].as_u64().unwrap_or_default(),
+                    instance["implemented_actions"]
+                        .as_array()
+                        .map(|actions| actions
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .collect::<Vec<_>>()
+                            .join(","))
+                        .unwrap_or_default()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn anyhow_for_control_error(error: ControlError) -> anyhow::Error {
+    anyhow::anyhow!("{}: {}", error.code.as_str(), error.message)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn parses_first_slice_commands() {
+        assert!(matches!(
+            LocalControlArgs::try_parse_from(["warpctrl", "instance", "list"])
+                .unwrap()
+                .command,
+            LocalControlCommand::Instance(InstanceCommand::List)
+        ));
+        assert!(matches!(
+            LocalControlArgs::try_parse_from(["warpctrl", "app", "ping", "--pid", "123"])
+                .unwrap()
+                .command,
+            LocalControlCommand::App(AppCommand::Ping(_))
+        ));
+        assert!(matches!(
+            LocalControlArgs::try_parse_from([
+                "warpctrl",
+                "tab",
+                "create",
+                "--instance",
+                "abc",
+                "--window",
+                "active",
+            ])
+            .unwrap()
+            .command,
+            LocalControlCommand::Tab(TabCommand::Create(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_future_commands_not_exposed_in_foundation_parser() {
+        assert!(LocalControlArgs::try_parse_from(["warpctrl", "window", "list"]).is_err());
+        assert!(LocalControlArgs::try_parse_from(["warpctrl", "input", "run", "pwd"]).is_err());
+    }
+
+    #[test]
+    fn rejects_conflicting_instance_selectors() {
+        assert!(
+            LocalControlArgs::try_parse_from([
+                "warpctrl",
+                "app",
+                "version",
+                "--instance",
+                "a",
+                "--pid",
+                "1",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn renders_no_discovery_record_as_no_instance_output() {
+        let output = render_output(OutputFormat::Pretty, json!({ "instances": [] })).unwrap();
+        assert_eq!(output, "No compatible Warp instances found.");
+    }
+}

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -879,6 +879,9 @@ pub enum FeatureFlag {
 
     /// Gates the Grouped Tabs feature.
     GroupedTabs,
+
+    /// Gates the local Warp Control CLI foundation.
+    WarpControlCli,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -77,8 +77,8 @@ while (( "$#" )); do
       ;;
     --artifact)
       if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-        if [[ "$2" != "app" && "$2" != "cli" ]]; then
-          echo "Error: --artifact must be either 'app' or 'cli', got '$2'" >&2
+        if [[ "$2" != "app" && "$2" != "cli" && "$2" != "warpctrl" ]]; then
+          echo "Error: --artifact must be one of 'app', 'cli', or 'warpctrl', got '$2'" >&2
           exit 1
         fi
         ARTIFACT="$2"
@@ -118,13 +118,13 @@ elif [[ $RELEASE_CHANNEL = "local" || $RELEASE_CHANNEL = "dev" ]]; then
   # For dev bundles, we want to enable debug assertions to
   # catch violations that would otherwise silently pass in
   # a normal release build (e.g. in stable).
-  if [[ "$ARTIFACT" == "cli" ]]; then
+  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
     CARGO_PROFILE="release-cli-debug_assertions"
   else
     CARGO_PROFILE="release-lto-debug_assertions"
   fi
 else
-  if [[ "$ARTIFACT" == "cli" ]]; then
+  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
     CARGO_PROFILE="release-cli"
   else
     CARGO_PROFILE="release-lto"
@@ -181,6 +181,13 @@ elif [[ $RELEASE_CHANNEL = "oss" ]]; then
   FEATURES="release_bundle"
 fi
 
+if [[ "$ARTIFACT" == "warpctrl" ]]; then
+  WARP_BIN="warpctrl"
+  BINARY_NAME="warpctrl"
+  APP_NAME="warpctrl"
+  PACKAGES=()
+fi
+
 # Artifact-specific binary naming
 if [[ "$ARTIFACT" == "cli" ]]; then
   # For CLI artifacts, use oz instead of warp as the binary name.  The OSS
@@ -192,7 +199,7 @@ if [[ "$ARTIFACT" == "cli" ]]; then
 fi
 
 # Artifact-specific configuration
-if [[ "$ARTIFACT" == "cli" ]]; then
+if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   FEATURES="$FEATURES,standalone"
 elif [[ "$ARTIFACT" == "app" ]]; then
   FEATURES="$FEATURES,gui"

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -223,8 +223,8 @@ while (( "$#" )); do
       ;;
     --artifact)
       if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-        if [[ "$2" != "app" && "$2" != "cli" ]]; then
-          echo "Error: --artifact must be either 'app' or 'cli', got '$2'" >&2
+        if [[ "$2" != "app" && "$2" != "cli" && "$2" != "warpctrl" ]]; then
+          echo "Error: --artifact must be one of 'app', 'cli', or 'warpctrl', got '$2'" >&2
           exit 1
         fi
         ARTIFACT="$2"
@@ -250,13 +250,13 @@ elif [[ $RELEASE_CHANNEL = "local" || $RELEASE_CHANNEL = "dev" ]]; then
   # For dev bundles, we want to enable debug assertions to
   # catch violations that would otherwise silently pass in
   # a normal release build (e.g. in stable).
-  if [[ "$ARTIFACT" == "cli" ]]; then
+  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
     CARGO_PROFILE="release-cli-debug_assertions"
   else
     CARGO_PROFILE="release-lto-debug_assertions"
   fi
 else
-  if [[ "$ARTIFACT" == "cli" ]]; then
+  if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
     CARGO_PROFILE="release-cli"
   else
     CARGO_PROFILE="release-lto"
@@ -347,7 +347,13 @@ else
 fi
 
 # Set artifact-specific configuration.
-if [[ "$ARTIFACT" == cli ]]; then
+if [[ "$ARTIFACT" == warpctrl ]]; then
+  WARP_BIN="warpctrl"
+  WARP_APP_NAME="warpctrl"
+  BUNDLE_ID="dev.warp.warpctrl"
+fi
+
+if [[ "$ARTIFACT" == cli || "$ARTIFACT" == warpctrl ]]; then
   UNIVERSAL_BINARY=false
   OPEN_AFTER_BUNDLE=false
   FEATURES="$FEATURES,standalone"
@@ -370,7 +376,7 @@ fi
 # using the same feature flags and profile that we would be using in production.
 if [[ "$CHECK_ONLY" == "true" ]]; then
   cargo check --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --target "$DEFAULT_TARGET" --features "$FEATURES"
-  if [[ $UNIVERSAL_BINARY = true && "$ARTIFACT" != "cli" ]]; then
+  if [[ $UNIVERSAL_BINARY = true && "$ARTIFACT" == "app" ]]; then
     cargo check --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --target "$ADDITIONAL_TARGET" --features "$FEATURES"
   fi
   exit 0
@@ -561,7 +567,7 @@ EOF
   # Store the built artifact locations for GitHub Actions outputs.
   BINARY_PATH="target/$DEFAULT_TARGET/$TARGET_PROFILE_DIR/$WARP_BIN"
   DMG_PATH="$OUT_DIR/$FINAL_DMG_NAME"
-elif [[ "$ARTIFACT" == "cli" ]]; then
+elif [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   if [[ $BUILD_BINARY == true ]]; then
     # Create Info.plist before building the app, since it's embedded at build time.
     # Apple's codesigning tools will detect Info.plist files in the same directory as an executable.
@@ -666,7 +672,7 @@ if [[ $SELFSIGN = true ]]; then
   if [[ "$ARTIFACT" == app ]]; then
     echo "Self-signing $BUNDLE_DIR/$WARP_APP_NAME.app with ${SIGNING_CERT}..."
     codesign --force --deep --options runtime --sign "$SIGNING_CERT" "$BUNDLE_DIR/$WARP_APP_NAME.app" --entitlements script/Debug-Entitlements.plist
-  elif [[ "$ARTIFACT" == cli ]]; then
+  elif [[ "$ARTIFACT" == cli || "$ARTIFACT" == warpctrl ]]; then
     echo "Self-signing $OUT_DIR/$WARP_BIN with ${SIGNING_CERT}..."
     codesign --force --options runtime --sign "$SIGNING_CERT" "$OUT_DIR/$WARP_BIN" --entitlements script/Debug-Entitlements.plist
   fi
@@ -675,7 +681,7 @@ elif [[ $CODESIGN = true ]]; then
     echo "Codesigning $BUNDLE_DIR/$WARP_APP_NAME.app..."
     # Use --deep so we sign bundled frameworks as well
     codesign --deep -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$BUNDLE_DIR/$WARP_APP_NAME.app" --entitlements script/Entitlements.plist
-  elif [[ "$ARTIFACT" == cli ]]; then
+  elif [[ "$ARTIFACT" == cli || "$ARTIFACT" == warpctrl ]]; then
     echo "Codesigning $OUT_DIR/$WARP_BIN..."
     codesign -f -o runtime --timestamp -s "$APPLE_TEAM_ID" "$OUT_DIR/$WARP_BIN" --entitlements script/Entitlements.plist
 
@@ -786,7 +792,7 @@ if [[ $CODESIGN = true ]]; then
   echo "Verifying notarization ticket..."
   if [[ "$ARTIFACT" = app ]]; then
     xcrun stapler validate "$DMG_DIR/$DMG_NAME"
-  elif [[ "$ARTIFACT" = cli ]]; then
+  elif [[ "$ARTIFACT" = cli || "$ARTIFACT" = warpctrl ]]; then
     spctl -a -t open --context context:primary-signature -vv "$OUT_DIR/$WARP_BIN"
   fi
 fi

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -1,0 +1,518 @@
+# Summary
+Warp should ship an allowlisted standalone local control CLI binary, provisionally named `warpctrl`, that acts as an agent control plane for operating Warp itself. `warpctrl` lets agents and developers script the same classes of user-visible actions they can already perform inside the running app: manipulating windows, tabs, panes, sessions, terminal blocks, appearance, settings, Warp Drive views, and selected UI surfaces. The CLI should operate against one or more already-running local Warp app processes through a stable machine protocol, with deterministic target selection and clear errors when a process or target is ambiguous.
+## Problem
+Warp already has rich interactive actions, but they are primarily reachable through UI, keybindings, menus, or deeplinks. Agents can use native tools for files, code, shell commands, MCP calls, and many context reads, but they cannot reliably operate Warp's own product surfaces: arranging the user's workspace, focusing the correct pane, opening Warp Drive objects, presenting settings, or recovering from ambiguous UI state. Developers also cannot reliably compose those same actions into shell scripts, demos, automation, or agent workflows, and there is no general local protocol for addressing a specific running Warp instance, window, pane, session, terminal block, Warp Drive object, or other uniquely named Warp entity.
+## Goals / Non-goals
+Goals:
+- Provide a first-class, scriptable standalone `warpctrl` binary for controlling running Warp app processes.
+- Make Warp's own UI and app state available to agents through a typed, permissioned control plane instead of brittle screen automation or arbitrary internal dispatch.
+- Keep CLI startup lightweight by avoiding GUI-app startup or full terminal initialization for routine control commands.
+- Keep the surface allowlisted and finite instead of exposing arbitrary internal actions.
+- Make targeting explicit and deterministic across multiple Warp processes, windows, tabs, panes, terminal sessions, terminal blocks, Warp Drive objects, files, projects/workspaces, command surfaces, and other uniquely addressable Warp nouns.
+- Support both ergonomic active-target defaults and precise selectors for automation.
+- Define a complete protocol/catalog up front, while shipping the implementation incrementally.
+Non-goals:
+- Replacing the Oz CLI or mixing cloud-agent management into this CLI.
+- Exposing every internal app action, debug action, developer-only helper, or privileged state mutation.
+- Treating the CLI as a general RPC escape hatch into Warp internals.
+- Replacing native agent tools for code editing, file operations, shell execution, web/MCP calls, or attached conversation/block context when those tools already solve the task better.
+- Requiring developers or automation to spawn the Warp GUI executable in CLI mode for ordinary control commands.
+- Requiring the first implementation slice to ship every action in the catalog.
+## Primary user stories
+These stories define the most compelling product uses for `warpctrl`. The command catalog below is intentionally broader, but the product should prioritize surfaces that agents cannot already operate well through native tools.
+1. **Agent workspace orchestration.** When a user asks an agent to work on a task, the agent can inspect the current Warp state, create or reuse an appropriate window/tab layout, split panes, name and focus targets, open relevant Warp surfaces, and leave the workspace in a readable task-shaped state for the user. The agent should continue to use native tools for code edits, file reads/writes, shell execution, MCP calls, and other work that does not require operating Warp's UI or local-control permission model.
+2. **Existing-session debugging and repair.** When a user asks for help with an existing Warp session, the agent can understand Warp-specific UI and session structure before acting: which instance/window/tab/pane/session is active, whether the relevant pane still exists, whether the correct surface is focused, which panels or settings pages are open, and which selector should be used for follow-up actions. The story should focus on UI/session structure, focus, panels, settings, and deterministic targeting; native agent context tools should remain the preferred way to read attached blocks, conversations, and other content when they are available.
+3. **Warp Drive creation, navigation, and sharing.** When an agent notices reusable knowledge during normal work, it can help the user turn that knowledge into a Warp Drive object, open it for review, and guide sharing with the right scope. This includes workflows from repeated command sequences, notebooks from task writeups, prompts/rules/facts from user or project preferences, environment variable collections, MCP setup objects, folders, and spaces. Existing object navigation remains important, but creation and sharing are first-class because reusable team knowledge cannot be used until users are guided into creating it.
+4. **Deterministic demos and walkthroughs.** When a user, teammate, or go-to-market workflow needs a reliable Warp demo, an agent or script can put Warp into a known presentation state: theme, zoom, windows, tabs, panes, focused targets, panels, command palette/search, and Warp Drive surfaces. The walkthrough can then advance using structured target IDs and recover from stale or missing targets instead of relying on screen coordinates, manual setup, or brittle UI automation.
+5. **Personalization, onboarding, and preference migration.** When a user wants Warp to feel familiar, an agent can inspect user-approved settings from tools such as VS Code, iTerm, Ghostty, or shell configuration, propose Warp equivalents, apply allowlisted changes through `warpctrl`, and report unsupported mappings explicitly instead of guessing. The same flow can support team onboarding presets, presentation preferences, accessibility-related settings, themes, font and zoom, keybindings, notifications, and panels.
+Human power-user scripting is a secondary beneficiary of the same design. Scripts get reliable JSON, target selectors, structured errors, and permission categories because the API is strong enough for agents, but the primary product narrative remains agent-led operation of Warp itself.
+Persistent settings changes, Warp Drive creation or sharing, cross-app preference migration, terminal command execution, and other underlying-data mutations must be visibly reviewable or require stronger explicit permission than low-risk workspace organization. `warpctrl` should support full typed control over time, but each command must be progressively unlocked through action categories, target resolution, Agent Profile permissions, Scripting settings, and authenticated-user requirements rather than broad unchecked authority.
+## Behavior
+1. The Warp control CLI operates only on running local Warp app processes. If no compatible Warp process is available, the CLI exits non-zero with a clear “no running Warp instance found” error.
+2. The CLI exposes only explicitly allowlisted actions. Unknown action names, unsupported parameter combinations, or requests for non-allowlisted capabilities fail with structured errors; they are never forwarded to arbitrary internal dispatch.
+3. Every successful mutating request identifies:
+   - The Warp process instance that executed it.
+   - The resolved target, when the action addresses a window, tab, pane, terminal session, terminal block, file, project/workspace, Warp Drive object, surface, or other targetable noun.
+   - A success payload suitable for JSON output.
+4. Every failure identifies:
+   - A stable machine-readable error code.
+   - A human-readable explanation.
+   - Any selector that was ambiguous, missing, stale, unsupported, or invalid.
+5. The CLI supports human-readable output by default and JSON output for scripts. JSON output has stable field names and is available for discovery commands, read commands, successful mutations, and failures.
+6. The CLI supports process discovery and instance selection:
+   - `warpctrl instance list` returns all reachable local Warp app processes that support the protocol.
+   - Each process has an opaque `instance_id`, a channel/build identity, and enough display metadata for a developer to choose it.
+   - If exactly one compatible process is available, commands may target it implicitly.
+   - If multiple compatible processes are available, the CLI may select a single clearly active/frontmost instance when that state is unambiguous; otherwise it fails and asks the developer to pass an explicit instance selector.
+   - Developers can explicitly choose an instance by opaque instance ID. Channel or PID filters may be offered as convenience filters, but opaque instance ID is the canonical selector.
+7. The CLI supports introspection for target discovery:
+   - `warpctrl window list`
+   - `warpctrl tab list`
+   - `warpctrl pane list`
+   - `warpctrl session list`
+   - `warpctrl block list`
+   - `warpctrl drive list`
+   - `warpctrl app active`
+   These commands return opaque protocol-facing IDs and enough metadata for subsequent commands without requiring knowledge of internal Warp identifiers.
+8. The target selector model is hierarchical:
+   - Instance selector resolves a running Warp process.
+   - Window selector resolves within the instance.
+   - Tab selector resolves within the window.
+   - Pane selector resolves within the tab or active pane group context.
+   - Session selector resolves within the pane when the pane hosts terminal session state.
+   - Block selector resolves within the terminal session when the command is block-scoped.
+   Non-hierarchical selectors such as file paths, projects/workspaces, Warp Drive objects, and global app surfaces still resolve inside the selected instance and must not silently borrow lower-level pane/session defaults unless the action definition explicitly requires that scope.
+9. Every selector family supports an ergonomic `active` form when that concept exists:
+   - Active instance, if unambiguous.
+   - Active window in the selected instance.
+   - Active tab in the selected window.
+   - Active pane in the selected tab.
+   - Active session in the selected pane.
+   - Active or selected terminal block in the selected session when a current block is unambiguous.
+10. Every selector family supports explicit opaque IDs returned by introspection. Selector families may also support scoped indices, titles/names, or paths where those concepts are already user-visible, but IDs remain the preferred automation surface.
+   - Window selectors support `active`, opaque window IDs, window indices from `window list`, and exact window titles for interactive use.
+   - Tab selectors support `active`, opaque tab IDs, tab indices scoped to the resolved window, and exact tab titles for interactive use.
+   - Pane selectors support `active`, opaque pane IDs, and pane indices scoped to the resolved tab or pane group.
+   - Session selectors support `active`, opaque session IDs, and session indices scoped to the resolved pane when sessions are user-visible as an ordered list.
+   - Block selectors support `active`, opaque block IDs, and block indices scoped to the resolved terminal session when blocks are user-visible as an ordered list. A block command may also support read-only filters such as command text, status, time range, or “last completed” for interactive lookup, but those filters must fail on ambiguity and resolve to concrete block IDs before reading output.
+   - File selectors use paths, plus optional line/column coordinates where the command supports opening a location.
+   - Project/workspace selectors use paths, opaque project/workspace IDs when exposed by introspection, and exact names only as interactive convenience selectors.
+   - Warp Drive selectors use opaque object IDs, with optional type-scoped exact name/path lookups for interactive use. Type scopes must include the user-facing object families Warp exposes today: spaces, folders, notebooks, workflows, agent-mode workflows/prompts, environment variable collections, AI facts/rules, MCP servers, MCP server collections, and trash entries when trash operations are supported.
+11. “Active session” means the currently selected terminal session for the resolved pane/window context. If the selected target does not contain a terminal session, session-scoped actions fail rather than silently redirecting elsewhere.
+12. When a command omits lower-level selectors, it resolves them from the chosen higher-level context using active defaults. Example: a pane split command with only `--instance` uses that instance’s active window, active tab, and active pane.
+13. When an explicitly supplied target disappears between discovery and execution, the request fails with a stale-target error. The CLI must not silently choose a different tab, pane, or session.
+14. The protocol is command-oriented, not open-ended state mutation. Each action has a named command, validated parameters, and defined target scope.
+15. The complete allowlisted action catalog should be organized around stable public nouns rather than internal view/action names. The target taxonomy includes instances, windows, tabs, panes, terminal sessions, terminal blocks, input buffers, command history entries, file/path intents, projects/workspaces, Warp Drive spaces, folders, notebooks, workflows, agent-mode workflows/prompts, environment variable collections, AI facts/rules, MCP servers, MCP server collections, settings, themes, keybindings, command surfaces such as the command palette and command search, panels/surfaces such as Warp Drive, resource center, AI assistant, code review, left/right panels, and vertical tabs, plus action/capability metadata. The initial implementation may expose only a subset, but new command families should extend this noun taxonomy instead of inventing unrelated selector conventions.
+16. Discovery and read-only state actions:
+   - List instances.
+   - Get protocol/app version information for one instance.
+   - List windows, tabs, panes, and sessions.
+   - Get the currently active instance/window/tab/pane/session chain when available.
+   - Inspect enough target metadata to let a script decide what to address next.
+17. Window actions:
+   - Create a new window.
+   - Focus a target window.
+   - Close a target window.
+18. Tab actions:
+   - Create a new terminal tab.
+   - Create a new agent tab where that is already a user-visible app capability.
+   - Activate a target tab.
+   - Activate previous, next, or last tab.
+   - Move a target tab left or right.
+   - Rename or reset a tab title.
+   - Set or clear active-tab color where that is already supported in the UI.
+   - Close the active tab, a target tab, other tabs, or tabs to the right of a target tab.
+19. Pane actions:
+   - Split a target pane left, right, up, or down.
+   - Optionally choose the shell/session profile for split operations when that already maps to user-facing behavior.
+   - Focus a target pane.
+   - Navigate focus left, right, up, or down among panes.
+   - Close a target pane.
+   - Toggle maximize for a target pane.
+   - Resize pane dividers left, right, up, or down when that is supported by the app.
+20. Session and terminal-input actions:
+   - Cycle to the previous or next session where the app exposes session cycling.
+   - Insert text into the active input without executing it.
+   - Replace the active input buffer.
+   - Clear the active input buffer where that matches existing user behavior.
+   - Switch input mode between terminal and agent modes only where that mode switch is already user-visible and valid for the selected target.
+   Input staging commands must not submit terminal input or press Enter. The separate `input run` execution action may submit a command only in the later execution-underlying branch, after authenticated scripting identity, underlying-data-mutation permission, audit coverage, and explicit target resolution are implemented. Accepted-command submission and agent-prompt submission remain future protocol concepts that require separate product/security review.
+21. Appearance actions:
+   - List available themes.
+   - Set the current fixed theme.
+   - Toggle or set “follow system theme.”
+   - Set the light and dark themes used when following the system theme.
+   - Increase, decrease, or reset font size.
+   - Increase, decrease, or reset UI zoom.
+   - Set other allowlisted appearance controls only when they correspond to stable user-facing controls.
+22. Settings actions:
+   - Read allowlisted user-facing settings.
+   - Set allowlisted settings to validated values.
+   - Toggle allowlisted boolean settings.
+   - Reject attempts to mutate private, debug-only, unsafe, derived, or unsupported settings.
+   - Return a stable error when a named setting exists internally but is not part of the public local-control allowlist.
+23. The settings allowlist should initially cover settings families that are already plainly user-facing and valuable for scripting:
+   - Theme/system-theme configuration.
+   - Font/zoom-related controls.
+   - Notifications.
+   - Syntax highlighting and error-underlining toggles.
+   - Accessibility verbosity where exposed to users.
+   - Selected panel/layout toggles when the user-facing behavior is already stable.
+   Additional settings families can be added only by extending the allowlist.
+24. Panel and surface actions:
+   - Open the general settings surface.
+   - Open a specific settings page or settings search result.
+   - Open or toggle the command palette with an optional initial query where the app already supports query seeding.
+   - Open or toggle command search where that is already user-visible.
+   - Toggle or open the left panel, Warp Drive surface, right panel, resource center, AI assistant panel, code review panel, and vertical tabs panel where valid.
+25. File/path intent actions may be included when they already mirror existing user-visible deep-link behavior:
+   - Open a path in a new tab or window.
+   - Open a repository picker or repo path flow where the current app already supports it.
+   These should remain allowlisted intent actions rather than arbitrary filesystem RPCs.
+26. The following categories are explicitly excluded from the public allowlist even when internal actions exist for them:
+   - Crash, panic, heap-dump, token-copying, debug-reset, and similar developer/debug helpers.
+   - Arbitrary auth manipulation outside the explicit authenticated-scripting flows.
+   - Arbitrary cloud object mutation or broad Warp Drive CRUD outside the typed Drive actions in this spec.
+   - Arbitrary internal view dispatch by string.
+   - Arbitrary setting names outside the allowlist.
+   - Accepted-command submission and agent-prompt submission until they receive a separate product/security review.
+   Terminal command execution and typed Warp Drive object mutations are no longer excluded from the full product scope, but they belong to later authenticated underlying-data mutation branches and require stronger authenticated-user and permission gates than app-state or settings mutations. Local file content reads, writes, appends, deletes, and other filesystem-content mutations are excluded from the public `warpctrl` catalog; file/path support is limited to app-state intents such as opening a path in Warp and metadata reads of files already open in Warp.
+27. CLI command names should be noun-oriented and discoverable. During the provisional standalone-binary phase, the control CLI should expose a `warpctrl ...` command surface:
+   - `warpctrl instance list`
+   - `warpctrl app active`
+   - `warpctrl tab create`
+   - `warpctrl tab rename --window-id <window_id> --tab-id <tab_id> "Build logs"`
+   - `warpctrl tab rename --window active --tab-index 0 "Build logs"`
+   - `warpctrl window close --window-title "Scratch"`
+   - `warpctrl pane split --direction right`
+   - `warpctrl pane split --instance <id> --window active --pane active --direction right`
+   - `warpctrl input replace --session-id <session_id> "cargo check"`
+   - `warpctrl block output --pane-id <pane_id> --block-id <block_id> --plain`
+   - `warpctrl theme set "Warp Dark"`
+   - `warpctrl setting set appearance.themes.system_theme true`
+   - `warpctrl input insert "cargo check" --replace`
+   Channelized install names or aliases may vary during packaging. If the product later converges on `warp ...`, update packaging, shell completions, and operator docs together.
+28. The wire protocol mirrors the CLI model. A mutating request contains:
+   - An action name from the allowlist.
+   - A structured target selector.
+   - Validated parameters.
+   A response contains:
+   - Success/failure status.
+   - Resolved instance and target metadata.
+   - Result data or structured error data.
+29. The protocol is versioned. Clients must be able to determine whether a running Warp process supports the protocol version and action they intend to call.
+30. Multiple running Warp processes are a supported normal case, not an error state. A local stable build and local dev build, or multiple supported local app instances, can coexist; the CLI provides deterministic discovery and addressing rather than assuming one global server.
+31. Requests should be scoped to local-user control of the running app, with separate enforcement for actions that require a true logged-in Warp user. A command that fails local authentication, local authorization, execution-context checks, or authenticated-user checks reports that condition explicitly and does not degrade into a less-specific request.
+32. If a selected action is valid in general but impossible in the current UI state, the CLI reports a state-specific failure. Examples include:
+   - Splitting a pane that no longer exists.
+   - Issuing a session-scoped action against a non-terminal pane.
+   - Focusing a window that has closed.
+   - Setting a theme that is not available in that instance.
+33. The first `warpctrl` implementation slice should ship the smallest end-to-end vertical slice that proves:
+   - The current implementation supports outside-Warp local-control requests only; verified inside-Warp requests are specified for future work and rejected until the app-issued terminal proof broker exists.
+   - Process discovery and target resolution work.
+   - A standalone CLI binary can reach a running local Warp process without launching or initializing the GUI app.
+   - `warpctrl tab create` creates a new terminal tab in the selected running instance.
+   - The command returns a structured success or failure payload suitable for human-readable and JSON output.
+   The first slice should include the minimum health/introspection commands needed to discover a running instance and exercise `tab.create`.
+34. Follow-up PRs should fill out the remaining catalog in parallelizable groups once the protocol, discovery model, target resolution, error model, `tab.create` action path, and standalone `warpctrl` packaging shape have been validated by the first slice.
+35. The protocol transport should be designed so that the default target is localhost but the CLI can be extended in the future to target remote URLs (e.g., a Warp instance on another machine or a hosted control endpoint). This is not in scope for the first implementation but should not be precluded by the architecture.
+## API command surface
+The public `warpctrl` API is organized around nouns that map to stable user-facing entities. Command names are intentionally not a dump of every internal `WorkspaceAction`, `TerminalAction`, keybinding, or command-palette binding. Internal actions inform the catalog, but a command is added only when it has a stable user-facing behavior, typed parameters, deterministic target resolution, and an explicit risk classification.
+### State and data taxonomy
+The product surface must distinguish what kind of state a command touches. This distinction is part of the public API and the permission model, not just an implementation detail.
+- **Metadata reads** inspect app structure or configuration metadata without exposing user content: instances, windows, tabs, panes, sessions, capability metadata, action metadata, keybinding metadata, theme names, setting keys, current project identity, and other structural state.
+- **Underlying data reads** expose user content or data-bearing state without changing it: terminal output, block contents, command history, input buffer contents, Warp Drive object contents, AI conversation content, and any other content that could contain user data or secrets.
+- **App-state mutations** change visible local Warp UI state without directly changing user data: opening or focusing windows, creating or closing tabs, splitting panes, focusing panes, opening panels, opening command surfaces, opening files in Warp, and editing the input buffer without submitting it.
+- **Metadata/configuration mutations** change persistent configuration or metadata, but not primary user content: changing themes, font size, zoom, allowlisted settings, keybindings, tab names, pane names, and tab colors.
+- **Underlying data mutations** can change user data or cause external side effects: typed CRUD operations on Warp Drive objects, sharing Warp Drive objects to the user's team through an explicit approved command, inserting content into Warp Drive views, running allowlisted Warp Drive workflows, and running terminal commands through an explicit `input run` action. Accepted-command submission, agent-prompt submission, local file content mutation, arbitrary workflow execution, and arbitrary internal dispatch remain excluded until separately reviewed.
+A command that touches multiple categories must require the strongest applicable permission. For example, `file open` is an app-state mutation because it opens a visible Warp editor/view, while `input run` is an underlying data mutation because it executes a command in the target session.
+### Targeting flags
+All commands that address a running app target accept the same selector flags where meaningful. Generic `--window`, `--tab`, `--pane`, `--session`, and `--block` flags accept the selector grammar below; explicit typed aliases are provided so scripts can avoid string parsing ambiguity:
+- `--instance <instance_id>` selects a running Warp process from `warpctrl instance list`.
+- `--pid <pid>` is a convenience instance selector and conflicts with `--instance`.
+- `--window <active|id:<id>|index:<n>|title:<title>>` selects a window inside the instance.
+- `--window-id <id>`, `--window-index <n>`, and `--window-title <title>` are exact aliases for the corresponding `--window ...` forms.
+- `--tab <active|id:<id>|index:<n>|title:<title>>` selects a tab inside the resolved window.
+- `--tab-id <id>`, `--tab-index <n>`, and `--tab-title <title>` are exact aliases for the corresponding `--tab ...` forms.
+- `--pane <active|id:<id>|index:<n>>` selects a pane inside the resolved tab or pane-group context.
+- `--pane-id <id>` and `--pane-index <n>` are exact aliases for the corresponding `--pane ...` forms.
+- `--session <active|id:<id>|index:<n>>` selects a terminal or agent session inside the resolved pane when the command is session-scoped.
+- `--session-id <id>` and `--session-index <n>` are exact aliases for the corresponding `--session ...` forms.
+- `--block <active|id:<id>|index:<n>>` selects a terminal block inside the resolved terminal session when the command is block-scoped.
+- `--block-id <id>` and `--block-index <n>` are exact aliases for the corresponding `--block ...` forms.
+- File commands use path arguments or `--path <path>` where the path is the selected file entity; `--line <n>` and `--column <n>` refine the location when supported.
+- Drive commands use object ID arguments or `--drive-id <id>` where the ID is the selected Warp Drive entity; name/path lookup must be type-scoped when supported.
+- `--output-format <pretty|json|ndjson|text>` controls output shape and remains globally available.
+Within a selector family, specifying more than one form is invalid. For example, `--tab-id` conflicts with `--tab-index`, `--tab-title`, and `--tab`. Omitted lower-level selectors use active defaults only when that active target is unambiguous. Explicit IDs must resolve exactly or fail with `stale_target`; index/title/name/path selectors that match zero targets fail with `missing_target`, and selectors that match multiple targets fail with `ambiguous_target`.
+### Read-only command set
+The read-only branches should implement the following commands before mutating catalog expansion begins: `zach/warp-cli-readonly-metadata` owns structural metadata reads, and `zach/warp-cli-readonly-data-settings` owns underlying-data reads plus read-only settings/appearance/docs. Read-only does not mean one permission: metadata reads and underlying data reads are separate grant categories.
+Metadata and capability reads:
+- `warpctrl instance list`
+- `warpctrl instance inspect [--instance <id>|--pid <pid>]`
+- `warpctrl app ping [selectors]`
+- `warpctrl app version [selectors]`
+- `warpctrl app active [selectors]`
+- `warpctrl capability list [selectors]`
+- `warpctrl capability inspect <action> [selectors]`
+Window, tab, pane, and session reads:
+- `warpctrl window list [selectors]`
+- `warpctrl window inspect [--window <selector>] [selectors]`
+- `warpctrl tab list [--window <selector>] [selectors]`
+- `warpctrl tab inspect [--tab <selector>] [selectors]`
+- `warpctrl pane list [--tab <selector>] [selectors]`
+- `warpctrl pane inspect [--pane <selector>] [selectors]`
+- `warpctrl session list [--pane <selector>] [selectors]`
+- `warpctrl session inspect [--session <selector>] [selectors]`
+Underlying data reads, gated separately from structural metadata reads:
+- `warpctrl block list [--session <selector>|--pane <selector>] [--limit <n>] [selectors]`
+- `warpctrl block inspect --block <selector> [selectors]`
+- `warpctrl block output --block <selector> [--plain|--ansi|--json] [selectors]`
+- `warpctrl input get [--session <selector>] [selectors]`
+- `warpctrl history list [--session <selector>] [--limit <n>] [selectors]`
+Appearance, settings, and command-surface reads:
+- `warpctrl theme list [selectors]`
+- `warpctrl theme get [selectors]`
+- `warpctrl appearance get [selectors]`
+- `warpctrl setting list [--namespace <namespace>] [selectors]`
+- `warpctrl setting get <key> [selectors]`
+- `warpctrl keybinding list [selectors]`
+- `warpctrl keybinding get <binding_name> [selectors]`
+- `warpctrl action list [selectors]`
+- `warpctrl action inspect <action> [selectors]`
+Local file and project reads that expose only app/editor state, not arbitrary filesystem traversal:
+- `warpctrl file list [selectors]`
+- `warpctrl project active [selectors]`
+- `warpctrl project list [selectors]`
+Authenticated read-only Warp Drive metadata and data reads, enabled only when the selected app has a logged-in Warp user and the grant allows authenticated reads. Listing is metadata; inspecting object content is an underlying data read:
+- `warpctrl drive list --type <workflow|notebook|env-var-collection|prompt|folder|ai-fact|mcp-server|space|trash> [selectors]`
+- `warpctrl drive inspect <id> [selectors]`
+### Authenticated scripting command set
+The full product requires two authenticated scripting modes before high-risk underlying-data mutations ship:
+- **Verified Warp-terminal authenticated scripting:** `warpctrl` runs inside a Warp-managed terminal, presents the app-issued terminal proof described in `TECH.md`, and may receive authenticated-user grants only when the selected app is logged into Warp and Settings > Scripting allows authenticated actions from verified Warp terminals.
+- **External API-key authenticated scripting:** `warpctrl` runs outside Warp or in a pure automation environment and presents a Warp-issued API key or derived short-lived exchange token to the selected app's local broker. The broker verifies the key, scopes, expiry, and user subject before issuing local authenticated-user grants. This path is separate from the local-control bearer credential and is required for unattended scripts that need Drive or execution authority.
+Recommended CLI surface for API-key setup and inspection:
+- `warpctrl auth status [selectors]` reports local-control auth state, selected app login state, authenticated grant availability, and whether an external API-key identity is configured.
+- `warpctrl auth login [selectors]` focuses the selected Warp app's sign-in UI for interactive app-login flows.
+- `warpctrl auth api-key set --key-env <env_var>|--key-stdin [selectors]` stores or references an external scripting API key in platform secure storage without printing it.
+- `warpctrl auth api-key status [selectors]` reports key subject/scope metadata without revealing the key.
+- `warpctrl auth api-key revoke [selectors]` deletes the local stored reference and, where supported, revokes the server-side key.
+The API-key path must support non-interactive scripts through an environment variable or secret manager reference, but raw keys must never be written to discovery records, logs, JSON output, shell completions, or repo config.
+### Mutating command set
+The mutating branches should build on the read-only and authenticated-scripting stack. `zach/warp-cli-mutating-layout` owns app/window/tab/pane layout mutations. `zach/warp-cli-mutating-input-settings-surfaces` owns input/session/settings/surface mutations. `zach/warp-cli-mutating-drive-data` owns Warp Drive underlying-data mutations. `zach/warp-cli-mutating-execution-underlying` owns terminal command execution and other approved execution-underlying actions. Mutating commands are split by what they mutate: app-state, metadata/configuration, or underlying data. Underlying data mutations require a separate and stronger permission plus an authenticated scripting identity.
+App-state mutations for app, window, and surfaces:
+- `warpctrl app focus [selectors]`
+- `warpctrl window create [--shell <name>] [selectors]`
+- `warpctrl window focus --window <selector> [selectors]`
+- `warpctrl window close --window <selector> [selectors]`
+- `warpctrl surface settings open [--page <page>] [--query <query>] [selectors]`
+- `warpctrl surface command-palette open [--query <query>] [selectors]`
+- `warpctrl surface command-search open [--query <query>] [selectors]`
+- `warpctrl surface warp-drive open [selectors]`
+- `warpctrl surface warp-drive toggle [selectors]`
+- `warpctrl surface resource-center toggle [selectors]`
+- `warpctrl surface ai-assistant toggle [selectors]`
+- `warpctrl surface code-review toggle [selectors]`
+- `warpctrl surface left-panel toggle [selectors]`
+- `warpctrl surface right-panel toggle [selectors]`
+- `warpctrl surface vertical-tabs toggle [selectors]`
+App-state mutations for tabs:
+- `warpctrl tab create [--type terminal|agent|cloud-agent|default] [--shell <name>] [selectors]`
+- `warpctrl tab activate --tab <selector> [selectors]`
+- `warpctrl tab activate --previous [selectors]`
+- `warpctrl tab activate --next [selectors]`
+- `warpctrl tab activate --last [selectors]`
+- `warpctrl tab move --tab <selector> --direction <left|right> [selectors]`
+- `warpctrl tab close --tab <selector> [selectors]`
+- `warpctrl tab close --active [selectors]`
+- `warpctrl tab close --others --tab <selector> [selectors]`
+- `warpctrl tab close --right-of --tab <selector> [selectors]`
+Metadata mutations for tabs:
+- `warpctrl tab rename --tab <selector> <title> [selectors]`
+- `warpctrl tab reset-name --tab <selector> [selectors]`
+- `warpctrl tab color set --tab <selector> <color> [selectors]`
+- `warpctrl tab color clear --tab <selector> [selectors]`
+App-state mutations for panes:
+- `warpctrl pane split --direction <left|right|up|down> [--shell <name>] [selectors]`
+- `warpctrl pane focus --pane <selector> [selectors]`
+- `warpctrl pane navigate --direction <left|right|up|down|previous|next> [selectors]`
+- `warpctrl pane resize --direction <left|right|up|down> [--amount <cells>] [selectors]`
+- `warpctrl pane maximize [--pane <selector>] [selectors]`
+- `warpctrl pane unmaximize [selectors]`
+- `warpctrl pane close --pane <selector> [selectors]`
+Metadata mutations for panes:
+- `warpctrl pane rename --pane <selector> <title> [selectors]`
+- `warpctrl pane reset-name --pane <selector> [selectors]`
+App-state mutations for sessions and input buffers:
+- `warpctrl session activate --session <selector> [selectors]`
+- `warpctrl session previous [selectors]`
+- `warpctrl session next [selectors]`
+- `warpctrl session reopen-closed [selectors]`
+- `warpctrl input insert <text> [--session <selector>] [selectors]`
+- `warpctrl input replace <text> [--session <selector>] [selectors]`
+- `warpctrl input clear [--session <selector>] [selectors]`
+- `warpctrl input mode set <terminal|agent> [--session <selector>] [selectors]`
+These input-buffer commands only stage or edit text and must not submit the buffer. The separate `input run` command belongs only to the execution-underlying branch and requires authenticated scripting identity, underlying-data-mutation permission, explicit target resolution, and audit coverage. Accepted-command submission and agent-prompt submission remain excluded until separately reviewed.
+Metadata/configuration mutations for appearance and settings:
+- `warpctrl theme set <theme_name> [selectors]`
+- `warpctrl theme system set <true|false> [selectors]`
+- `warpctrl theme light set <theme_name> [selectors]`
+- `warpctrl theme dark set <theme_name> [selectors]`
+- `warpctrl appearance font-size increase [selectors]`
+- `warpctrl appearance font-size decrease [selectors]`
+- `warpctrl appearance font-size reset [selectors]`
+- `warpctrl appearance zoom increase [selectors]`
+- `warpctrl appearance zoom decrease [selectors]`
+- `warpctrl appearance zoom reset [selectors]`
+- `warpctrl setting set <key> <value> [selectors]`
+- `warpctrl setting toggle <key> [selectors]`
+App-state mutations for files, projects, and Warp Drive views:
+- `warpctrl file open <path> [--line <line>] [--column <column>] [--new-tab] [selectors]`
+- `warpctrl project open <path> [selectors]`
+- `warpctrl drive open <id> [selectors]`
+- `warpctrl drive notebook open <id> [selectors]`
+- `warpctrl drive env-var-collection open <id> [selectors]`
+- `warpctrl drive object share open <id> [selectors]`
+Underlying data mutations for authenticated Warp Drive objects:
+- `warpctrl drive object create --type <workflow|notebook|env-var-collection|prompt|folder> [--content <text>|--content-file <path>] [selectors]`
+- `warpctrl drive object update <id> [--content <text>|--content-file <path>] [selectors]`
+- `warpctrl drive object delete <id> [selectors]`
+- `warpctrl drive object insert <id> [--target <selector>] [selectors]`
+- `warpctrl drive object share-to-team <id> [selectors]`
+- `warpctrl drive workflow run <id> [--arg <name=value>...] [selectors]`
+Execution-underlying actions:
+- `warpctrl input run <command> [--session <selector>] [selectors]`
+These are underlying-data mutations because they can modify user data, execute code, trigger external side effects, share cloud-backed content, or run user-authored content. They require authenticated scripting identity, underlying-data-mutation permission, deterministic target resolution, audit records, and explicit tests proving lower-permission credentials cannot run them. `drive object share-to-team` is the only direct sharing mutation in the v0 product scope: it may make a personal Warp Drive object available to the user's current team using the app's standard team-sharing semantics. Arbitrary ACL editing, sharing with specific users, sharing with external guests, public-link creation, accepted-command submission, and agent-prompt submission remain excluded until separately reviewed.
+### Excluded from the public command surface
+The command surface must continue to exclude debug-only, crash-only, auth-token, heap-dump, and arbitrary internal dispatch actions even when those actions are available in command palette or keybinding registries. Examples that remain excluded are app crash/panic helpers, access-token copy helpers, heap profile dumps, debug reset actions, raw view-tree debugging, and broad internal action-by-string execution.
+## Branch stacking and delivery model
+The Warp Control CLI work should ship as a raw-git branch stack so the combined specs/foundation slice, read-only expansion, and mutating expansion remain reviewable independently:
+- `zach/warp-cli-core-foundation` is the bottom review branch and targets `master`. It owns `specs/warp-control-cli/PRODUCT.md`, `TECH.md`, `SECURITY.md`, and supporting docs alongside the first implementation slice: shared protocol, discovery/auth scaffolding, outside-Warp Settings > Scripting gates, local-control bridge/server, standalone `warpctrl` binary, packaging hooks, and the smallest safe end-to-end action. Verified inside-Warp invocation is documented for future implementation but is not supported by this branch.
+- `zach/warp-cli-readonly-metadata` stacks on `zach/warp-cli-core-foundation` and implements structural metadata reads, including instance/app health, active-chain, windows, tabs, panes, sessions, and action metadata.
+- `zach/warp-cli-readonly-data-settings` stacks on `zach/warp-cli-readonly-metadata` and fills in underlying-data reads plus read-only settings/appearance/docs, including terminal block output, input-buffer reads, history reads, and allowlisted settings metadata.
+- `zach/warp-cli-authenticated-scripting` stacks on `zach/warp-cli-readonly-data-settings` and implements authenticated-user grant plumbing for both verified Warp-terminal invocations and external API-key scripting identities. It does not broaden action support by itself; it makes later high-risk branches enforceable.
+- `zach/warp-cli-mutating-layout` stacks on `zach/warp-cli-authenticated-scripting` and implements app/window/tab/pane layout mutations.
+- `zach/warp-cli-mutating-input-settings-surfaces` stacks on `zach/warp-cli-mutating-layout` and fills in approved input/session/settings/surface mutating command families while preserving the prohibition on accepted-command submission and agent-prompt submission.
+- `zach/warp-cli-mutating-drive-data` stacks on `zach/warp-cli-mutating-input-settings-surfaces` and implements authenticated Warp Drive underlying-data mutations from the approved allowlist, including object creation/update/delete/insert and the v0 personal-to-team sharing path.
+- `zach/warp-cli-mutating-execution-underlying` stacks on `zach/warp-cli-mutating-drive-data` and implements authenticated execution-underlying actions such as `input run` and typed workflow execution where supported.
+The previous `zach/warp-cli-specs` branch is retained only as migration-source/history material. New spec changes originate on `zach/warp-cli-core-foundation` and are propagated upward through the stack with raw git so all higher implementation branches reflect the same product/security contract. Graphite is not part of this stack. If a lower branch merges first, higher branches should rebase onto the merged successor while preserving the approved spec content.
+## Built-in Warp Agent skill
+Warp should include a built-in Agent skill for `warpctrl`, analogous to the bundled `oz-platform` skill. The skill should teach Warp Agent when to use `warpctrl`, how to discover and target running instances, how to prefer read-only commands before mutating commands, how to request explicit user approval for underlying data mutations, and how to interpret structured errors. The skill should document the stable command hierarchy above, include concise recipes for common automation tasks, and avoid instructing agents to bypass the CLI by calling local-control HTTP endpoints directly.
+## CLI implementation and documentation conventions
+`warpctrl` should feel consistent with the Oz CLI from a developer's perspective and use the same CLI libraries and conventions:
+- Argument parsing, subcommand structure, help text, and shell-completion generation should use the same `clap`/`clap_complete` patterns used by the Oz CLI.
+- JSON serialization and machine-readable output should use the same `serde`/`serde_json` conventions and the same output-format vocabulary used by the Oz CLI.
+- Human-readable help, examples, errors, and generated completions should follow Oz CLI conventions unless Warp Control has a documented product reason to differ.
+CLI documentation should be generated from the command catalog instead of maintained by hand in multiple places:
+- The typed action catalog is the source of truth for command names, selector flags, parameters, output formats, state/data category, required permission, authenticated-user requirement, support status, and examples.
+- `warpctrl help`, shell completions, markdown reference docs, the built-in Warp Agent skill, and the operator README should be generated or checked from that catalog so they cannot drift silently.
+- A later branch should add native Warp completions for `warpctrl` in addition to shell completions so Warp can suggest commands, flags, selectors, and action names directly in the input editor.
+- Generated documentation must distinguish implemented commands from planned catalog entries. A command may appear in specs as planned, but public operator docs must not imply it is usable until the selected app build advertises support for it.
+- CI or presubmit checks should fail when CLI parser/help output, generated reference docs, completions, or the built-in skill are stale relative to the command catalog.
+## Action classification and permission model
+Agents, scripts, and human developers are expected to be major consumers of `warpctrl`. The action catalog must therefore classify every action by risk posture, state/data category, permission category, and authenticated-user requirement so Warp can enforce local-control permissions in the app bridge.
+Every action definition must include:
+- a stable action name and namespace;
+- a risk posture;
+- a state/data category: metadata read, underlying data read, app-state mutation, metadata/configuration mutation, or underlying data mutation;
+- whether a true logged-in Warp user is required;
+- whether the action may run from external clients, verified Warp-terminal clients, or both;
+- whether inside-Warp and outside-Warp scripting settings can enable the action;
+- the required local-control permission category;
+- any target-scope restrictions.
+By default, new actions require an authenticated Warp user. An action may be marked logged-out-safe only after deliberate review confirms it does not touch Warp Drive, AI conversation traces, synced settings, team/account data, cloud-backed user state, terminal content, or other user-sensitive data.
+### Authenticated scripting model
+Authenticated scripting is required for any command that acts on a true Warp user identity or performs underlying-data mutation. Local-control credentials prove that a process may talk to the selected app; authenticated scripting credentials prove which Warp user or automation identity is allowed to request user-backed or high-risk actions.
+Inside Warp, authenticated scripting uses the verified terminal proof flow: the selected app is already logged in, the terminal proof binds the CLI to a live Warp-managed session, and the broker may mint an authenticated-user grant for that app user when Settings > Scripting allows it.
+Outside Warp, authenticated scripting uses a Warp-issued API key or exchanged short-lived token. The API key must be scoped for scripting/local control, optionally constrained to action categories or resource families, and tied to a Warp user subject. The selected app must either be logged in as the same subject or be able to validate that the API key's subject is authorized for the requested local action without exporting cloud auth tokens to the script. External API-key grants default off in Settings > Scripting and should be separable from ordinary outside-Warp logged-out-safe control.
+### Permission categories
+Every action in the catalog belongs to exactly one of the following permission categories, from least to most sensitive:
+1. **Read-only / metadata.** Actions that return local app structure, app state, or configuration metadata without exposing terminal content, file content, Warp Drive object content, AI conversation content, or other user data.
+   - Instance discovery and health: `instance list`, `app active`, `app version`, `app ping`.
+   - Layout enumeration: `window list`, `tab list`, `pane list`, `session list`.
+   - Metadata reads: `theme list`, `setting list`, `keybinding list`, `action list`, `project active`, and Drive object listing that returns object IDs/names/types but not content.
+2. **Read-only / underlying data.** Actions that return user content or data-bearing state without changing it.
+   - Terminal reads: block output, scrollback, command history, input editor contents, session replay, or terminal-derived traces.
+   - Warp Drive object content reads, AI conversation reads, and any authenticated-user data read.
+   This category is separate from metadata because read-only content can contain secrets, source code, customer data, command output, or other sensitive data.
+3. **Mutating / app state.** Actions that change visible local Warp UI state without directly changing underlying user data.
+   - Layout and focus: `window create`, `window focus`, `tab create`, `tab activate`, `tab move`, `window close`, `tab close`, `pane split`, `pane focus`, `pane navigate`, `pane maximize`, `pane resize`, and panel/surface toggles.
+   - Input-buffer staging: `input insert`, `input replace`, and `input clear` as long as they do not submit or execute the buffer.
+   - Opening views: opening settings, command palette, command search, Warp Drive, code review, files, projects, notebooks, and env-var collections.
+4. **Mutating / metadata or configuration.** Actions that change persistent metadata or configuration but do not directly mutate primary user data.
+   - Tab and pane names, tab colors, themes, system-theme settings, font size, zoom, allowlisted app settings, and keybindings.
+   Metadata/configuration writes need a stronger permission than app-state-only changes because they persist beyond the current UI interaction, but they are still distinct from data writes.
+5. **Mutating / underlying data.** Actions that can change user data, execute code, submit prompts, or cause external side effects.
+   - Terminal execution through the explicit `input run` action and typed workflow execution where supported.
+   - Warp Drive CRUD and sharing: create, update, delete, insert, share to the user's current team, run, or otherwise mutate workflows, notebooks, prompts, env-var collections, folders, or other Drive objects.
+   - AI conversation history mutation and any action that modifies cloud-backed user content.
+   - Future agent execution: submitting an agent prompt, accepting an agent-proposed command, or otherwise causing an agent to act; these remain excluded until separately reviewed.
+   This category must be explicitly separate from app-state mutation and requires authenticated scripting identity. A client allowed to open or focus Warp UI must not automatically be allowed to execute commands, mutate Warp Drive content, or perform local file content operations.
+### Authenticated-user requirement
+An authenticated user means a true logged-in Warp user in the selected Warp app, not merely the local OS user or a `warpctrl` process authenticated to localhost.
+The allowlist must clearly indicate `requires_authenticated_user` for every action:
+- `false` only for logged-out-safe actions that operate on local app structure, local appearance metadata, or local-only settings that do not expose user-sensitive data.
+- `true` for actions that read or mutate Warp Drive, AI conversation traces, synced settings, team/account data, user identity data, or any cloud-backed Warp state.
+- `true` for actions that execute user-authored Warp Drive content, even if the execution target is a local terminal session.
+If an authenticated-user action is invoked while the selected app has no logged-in user, the CLI reports a structured authenticated-user error. It must not silently return partial logged-out data as success.
+### Warp Control authenticated scripting protocol
+`warpctrl` has two authenticated scripting modes. Interactive inside-Warp use relies on the logged-in user in the selected Warp app and verified terminal proof. External or pure scripting use relies on a Warp-issued API key that is separate from local-control credentials and is exchanged for short-lived authenticated grants.
+The CLI should expose auth/status flows for both modes:
+- `warpctrl auth status [selectors]` reports whether the selected Warp app is logged in and returns a stable, non-secret user subject/identity summary when the caller has the required local-control grant.
+- `warpctrl auth login [selectors]` does not collect credentials in the CLI or mint a separate CLI account session. It focuses or opens the selected Warp app's normal sign-in UI and waits, or exits with instructions, until the user completes sign-in in that app.
+- After app login completes, the app-side credential broker may mint an app-user grant only for the same user subject that is currently logged in to the selected app. For external API-key mode, the broker may mint an API-key-backed grant only after validating the key, scopes, subject, and local Scripting permissions.
+- Authenticated credentials are bound to the selected app instance, subject, grant mode, scopes, expiry, and optional target/resource restrictions. If the app logs out, switches users, loses auth state, or the grant's subject no longer matches a grant that requires the selected app's logged-in subject, authenticated actions fail with a structured authenticated-user error rather than using stale authority.
+- Raw Firebase, server, OAuth, cloud API tokens, and raw scripting API keys are never exported to `warpctrl` output, shell scripts, generated docs, logs, discovery records, or JSON responses.
+This authenticated scripting protocol applies only to actions whose allowlist entry requires a true logged-in Warp user, external API-key identity, or underlying-data-mutation authority. Logged-out-safe local actions continue to use local-control credentials without requiring Warp account login or API-key setup.
+### Execution context policy
+`warpctrl` should eventually distinguish verified invocations from inside Warp-managed terminal sessions from external invocations. The current foundation branch supports external invocation only and must reject verified Warp-terminal claims until the proof broker is implemented.
+- **Verified Warp-terminal invocation:** a `warpctrl` process started inside a Warp-managed terminal session and able to present an app-issued execution-context proof. The top-level setting for this context should default to on. When the selected app has a logged-in Warp user, this context can receive authenticated-user grants if the user's Scripting permissions allow that grant.
+- **External invocation:** a `warpctrl` process started outside Warp's terminal, such as from another terminal app, launch agent, IDE, or background script. The top-level setting for this context must default to off. When disabled, external invocations receive no local-control credentials, including logged-out-safe metadata credentials.
+- The app must not trust a caller-declared label. Environment variables may help discover the context, but the broker must verify a session-bound capability or equivalent proof before issuing in-Warp-only grants.
+### Settings surface
+Warp should add a new top-level Settings pane page named **Scripting**. This page should own settings for local scripting and automation surfaces, including Warp control. The current foundation branch should expose only outside-Warp Warp control settings. In the long-term model, once verified Warp-terminal invocation is implemented, Warp control should include two top-level toggles:
+- **Allow Warp control from inside Warp:** default on. Controls `warpctrl` invocations from verified Warp-managed terminal sessions.
+- **Allow Warp control from outside Warp:** default off. Controls `warpctrl` invocations from external terminals, scripts, IDEs, launch agents, and other same-user processes.
+The Scripting page should explain that inside-Warp control is scoped to commands launched from Warp-managed terminals, while outside-Warp control allows other local apps and scripts to talk to Warp's control plane. Disabling either top-level toggle should invalidate credentials for that invocation context.
+### Granular local-control permissions
+In the long-term model, the Scripting settings page should expose granular permissions beneath the inside-Warp and outside-Warp toggles. The current foundation branch exposes only the outside-Warp subset. Recommended controls:
+- Allow metadata reads.
+- Allow underlying data reads.
+- Allow app-state mutations.
+- Allow metadata/configuration mutations.
+- Allow underlying data mutations.
+- Allow authenticated-user actions from verified Warp terminals.
+- Allow authenticated-user actions from external clients, default off and separate from the in-Warp permission.
+These settings define the maximum grants the broker may issue. The app bridge still enforces the action's risk posture, state/data category, authenticated-user requirement, execution-context requirement, and target scope for every request. Enabling app-state mutation must not imply permission to mutate underlying data.
+### Agent Profile permissions
+Agent Profiles should expose a dedicated **Warp control** permission group for agents that can invoke `warpctrl`. This permission group should mirror the local-control action categories so users can choose different `warpctrl` authority for different agent workflows:
+- Metadata reads.
+- Underlying data reads.
+- App-state mutations.
+- Metadata/configuration mutations.
+- Underlying data mutations.
+Each category should support the same autonomy vocabulary used by other Agent Profile permissions: the agent may be allowed to proceed, required to ask, allowed to decide based on confidence and risk, or denied. A cautious profile can therefore allow metadata reads and ask for app-state mutations, while a demo or onboarding profile can be explicitly configured to allow workspace organization or presentation setup.
+Agent Profile permissions and global Scripting settings both apply. Settings > Scripting defines the maximum local-control authority available for an execution context, such as verified inside-Warp invocation or outside-Warp invocation. The selected Agent Profile defines what that specific agent is allowed to request within that maximum. If either layer denies an action category, authenticated-user requirement, or execution context, the request fails with a structured permission error instead of falling back to a weaker action or a raw `warpctrl` shell command.
+The profile-level permission group should preserve the native-tools-first boundary. Agents should prefer native tools for code editing, file reads/writes, shell command execution, web/MCP calls, and attached conversation or block context when those tools are available. Agents should prefer `warpctrl` when the task requires operating Warp product surfaces, preserving visible UI context for the user, using Warp Drive as a first-class app surface, or applying the app's own permissioned control plane.
+### Scoped credentials
+The local discovery record must not expose a reusable full-access credential. `warpctrl` should request scoped credentials from an app-owned broker or equivalent trusted path.
+Scoped credentials should include:
+- the selected Warp instance;
+- granted permission categories;
+- allowed action families;
+- verified execution context;
+- whether authenticated-user access is granted and for which logged-in user subject;
+- optional target scopes;
+- issuance and expiry metadata;
+- revocation/audit identity.
+The bridge, not the CLI frontend, enforces these grants. If a request exceeds its credential, the bridge returns `insufficient_permissions`, `authenticated_user_required`, `authenticated_user_unavailable`, or `execution_context_not_allowed` as appropriate.
+### Future entity extensibility: files, blocks, and Warp Drive objects
+The selector and action model should accommodate entity types beyond the current window/tab/pane/session hierarchy. Important entity families are **terminal blocks**, **file/path intents**, **projects/workspaces**, and **Warp Drive objects**. Broad Drive mutation and command execution are not in scope for the foundation branch, but they are in scope for later authenticated branches in the expanded stack. Local file content reads, writes, appends, deletes, and other filesystem-content mutations are intentionally out of scope for the public `warpctrl` catalog because native agent file tools are the preferred surface for file content operations. Agent-prompt submission remains excluded until separately reviewed.
+**Terminal blocks.** Blocks are first-class targetable terminal entities, not just data hanging off a session. Block selectors should support the same addressing primitives as terminal sessions where meaningful: active/current block, opaque block ID, and block index scoped to the resolved session. Block reads can expose command text, output, status, timing, exit code, and metadata, so block content reads are underlying-data reads while block listing that returns only IDs/status/timestamps may be metadata reads. Stale, missing, or ambiguous block selectors must fail rather than selecting a neighboring block.
+**Files.** Warp already supports file opening via deep links and the built-in editor. The `file` namespace is limited to app-state and metadata behaviors that operate Warp's visible UI:
+- `warpctrl file open <path>` — app-state mutation that opens a file in a Warp editor tab, equivalent to clicking a file link.
+- `warpctrl file open <path> --line <n>` — app-state mutation that opens at a specific line.
+- `warpctrl file list` — metadata read that lists files currently open in editor tabs across the instance.
+- `warpctrl project open <path>` — app-state mutation that opens or focuses a project/workspace in Warp where that matches existing user-visible behavior.
+File selectors use filesystem paths (absolute or relative to the working directory of the target pane/session when the command defines that behavior). Unlike window/tab/pane selectors, file selectors are not opaque IDs — they are user-visible paths. The protocol should support a `file` field in the target selector that accepts a path string, distinct from the opaque ID selectors used for windows, tabs, and panes. `warpctrl` must not expose file content reads or filesystem-content mutations; agents and scripts should use native file tools for those operations.
+**Warp Drive objects.** Warp Drive stores typed objects that users can reference, execute, edit, and share. The object taxonomy should include, at minimum, spaces, folders, notebooks, workflows, agent-mode workflows/prompts, environment variable collections, AI facts/rules, MCP servers, MCP server collections, and trash entries where trash operations are exposed. A future `drive` namespace could support:
+- `warpctrl drive list --type workflow` — authenticated metadata read that lists Warp Drive objects by type.
+- `warpctrl drive inspect <id>` — authenticated underlying data read when it returns object content.
+- `warpctrl drive workflow run <workflow-id>` — authenticated underlying data mutation that executes a typed workflow in a target session, implemented only in the execution-underlying branch with authenticated scripting identity and audit coverage.
+- `warpctrl drive object create|update|trash|restore <id>` — authenticated underlying data mutations that change cloud-backed user content.
+- `warpctrl drive object share open <id>` — app-state mutation that opens the sharing dialog for user review without changing sharing state.
+- `warpctrl drive object share-to-team <id>` — authenticated underlying data mutation that makes a personal object available to the user's current team using the app's standard team-sharing behavior. This is the only direct sharing mutation in the v0 product scope.
+- `warpctrl drive notebook open <notebook-id>` — app-state mutation that opens a view of an existing notebook without modifying it.
+Drive object selectors should support both opaque IDs (for automation stability) and human-friendly name/path lookups (for interactive use). The type field (`workflow`, `notebook`, `env_var_collection`, `prompt`, `folder`, `ai_fact`, `mcp_server`, etc.) acts as a namespace filter. Drive actions that execute content in a terminal session (e.g., running a workflow) inherit the underlying-data-mutation permission from the action classification model and are implemented only in the execution-underlying branch after authenticated scripting identity and audit coverage are in place.
+**Design constraints for these future entity families:**
+- File and Drive selectors are orthogonal to the window/tab/pane hierarchy — a file open action targets an instance (which window to open in), not a specific pane. A Drive workflow execution targets a session (which pane to run in).
+- The `TargetSelector` type in the protocol should be extensible with optional fields for these new selector families without breaking existing requests that omit them.
+- The action classification categories apply, and Drive actions require authenticated-user grants by default: listing Drive objects is metadata plus authenticated user, reading Drive object content is underlying-data-read plus authenticated user, opening an existing Drive object or its sharing dialog in the app is app-state mutation plus authenticated user, and executing, sharing, or changing a Drive object is underlying-data-mutation plus authenticated user.
+### Settings: protocol-first
+Settings reads and writes should go through the local-control protocol like other actions, not bypass it via direct file manipulation.
+- `warpctrl setting get <key>`, `warpctrl setting set <key> <value>`, and `warpctrl setting toggle <key>` send requests to the running Warp instance through the standard authenticated control endpoint.
+- The app bridge validates the key against the allowlist and the value against the expected type before applying the change.
+- This keeps authorization enforcement consistent: the same permission category, execution-context, and authenticated-user policies apply to settings mutations as to any other action, rather than creating a second unguarded path through the filesystem.
+- The app owns the write to the settings file and any side effects (e.g., theme reload, layout reflow) as a single atomic operation, avoiding races between a direct settings-file edit and the app's file watcher.
+- If a future need arises for offline settings manipulation (no running Warp process), a separate file-based path can be added later with its own validation, but it should not be the default.
+- The action classification still applies: settings reads are metadata reads, and settings writes are metadata/configuration mutations. Settings writes must not be authorized by app-state mutation permission alone.

--- a/specs/warp-control-cli/README.md
+++ b/specs/warp-control-cli/README.md
@@ -1,0 +1,96 @@
+# warpctrl operator README
+`warpctrl` is the provisional standalone CLI for controlling an already-running local Warp app instance. It is intended for scripts, demos, agent workflows, and developer automation that need to perform allowlisted Warp UI actions without launching the GUI executable in CLI mode.
+The first implementation slice is intentionally narrow:
+- discover compatible running Warp instances;
+- select one instance implicitly when unambiguous or explicitly with `--instance`;
+- request short-lived scoped credentials from the selected app before sending authenticated local-control requests;
+- create a new terminal tab with `warpctrl tab create`.
+The local-control protocol and catalog are broader than this slice, but commands outside the implemented capability set should fail with structured unsupported-action errors until their handlers land.
+## Packaging model
+`warpctrl` should be packaged as a separate CLI artifact from the Warp GUI app while reusing shared repository code:
+- `crates/local_control` owns discovery records, scoped local authentication material, client transport, protocol envelopes, action names, and error types.
+- `crates/warp_cli` owns command parsing conventions for local-control subcommands.
+- the app-side bridge owns the per-process loopback listener and dispatches supported actions onto the live Warp UI context.
+The binary should initialize only CLI parsing, instance discovery, local authentication loading, request serialization, HTTP transport, and output formatting. It should not initialize GUI state, terminal models, rendering, workspaces, or main-app startup paths.
+During the provisional naming period, release artifacts and helper names may be channelized, but operator docs and examples should use `warpctrl` unless an integration branch explicitly documents a channel-specific alias.
+This branch wires the standalone binary target and the macOS/Linux bundle-script artifact selectors:
+- `cargo build -p warp --bin warpctrl`
+- `script/macos/bundle --artifact warpctrl ...`
+- `script/linux/bundle --artifact warpctrl ...`
+Windows has the native Rust binary target, but installer/release helper exposure remains follow-up packaging work.
+## Install and invocation guidance
+### macOS
+Build locally with `cargo build -p warp --bin warpctrl`, then run `target/debug/warpctrl` or copy/symlink that binary onto `PATH`.
+For distributable standalone artifact checks, use `script/macos/bundle --artifact warpctrl` with the desired channel/signing flags. The bundle script writes a standalone `warpctrl` binary into its macOS artifact output directory instead of embedding it in the GUI app bundle.
+### Linux
+Build locally with `cargo build -p warp --bin warpctrl`, then run `target/debug/warpctrl` or copy/symlink that binary onto `PATH`.
+For distributable standalone artifact checks, use `script/linux/bundle --artifact warpctrl` with the desired channel/package selection. The Linux bundle script routes packaging through the standalone control-binary artifact path; downstream package installation should place the emitted `warpctrl` binary according to that package format.
+Run `warpctrl --version` after installation to confirm the shell is resolving the expected build.
+### Windows
+Build locally with `cargo build -p warp --bin warpctrl`, then run `target\debug\warpctrl.exe` or copy that binary onto `PATH`.
+The Windows-native binary target exists in this slice. Installer helper creation and release-artifact wiring still need a later packaging change before docs can promise an installer-provided `warpctrl` command.
+## End-to-end local test flow
+Use matching app and CLI bits from the same branch or release artifact so the protocol version and action catalog agree.
+1. Start Warp and leave at least one window open.
+2. Confirm that the local-control server registered the running process:
+   ```bash
+   warpctrl instance list
+   ```
+3. If exactly one compatible instance is listed, create a new terminal tab:
+   ```bash
+   warpctrl tab create
+   ```
+4. If multiple compatible instances are listed, copy the desired `instance_id` and target it explicitly:
+   ```bash
+   warpctrl tab create --instance <instance_id>
+   ```
+5. Verify the running app receives focus for the selected instance and a new terminal tab appears according to Warp's normal new-tab placement behavior.
+6. In a future slice that implements `tab list`, inspect state before and after the mutation:
+   ```bash
+   warpctrl tab list --instance <instance_id>
+   ```
+Expected failures:
+- no running compatible app: exits non-zero with a no-instance error;
+- multiple ambiguous instances: exits non-zero and asks for `--instance`;
+- unsupported app build or stale discovery record: exits non-zero with a protocol, stale-target, or transport error;
+- `tab.create` not yet implemented by the running app bridge: exits non-zero with an unsupported-action error.
+## Security model
+The local-control protocol is designed for same-user scripting, not cross-user or network access. The trust boundary is the local user account.
+- **Loopback-only listener.** Each Warp process binds its control server to `127.0.0.1` on an ephemeral port. The listener is not reachable from the network.
+- **Scoped credential issuance.** Discovery records never contain raw bearer tokens. A client selects an instance from discovery metadata, requests an outside-Warp credential for a specific action, and presents that short-lived scoped credential to the control endpoint. Missing, invalid, expired, wrong-action, or insufficient credentials are rejected before selector resolution or handler dispatch.
+- **Disabled discovery is non-actionable.** Outside-Warp control defaults off. While it is disabled, discovery records either are absent or contain only non-actionable disabled status; they do not expose endpoint authority or credential broker metadata.
+- **File-permission-gated discovery.** Discovery records are stored in a per-user local-control directory. On POSIX platforms, files must be created with owner-only permissions. On Windows, records must be stored under the current user's app data directory with an ACL that grants access only to the current user, Administrators, and SYSTEM.
+- **Stale-record pruning.** On each `instance list` or implicit discovery call, records whose PID is no longer alive are ignored or deleted automatically.
+- **No CORS.** The control endpoints do not set permissive CORS headers, so browser-origin JavaScript cannot read responses even if it guesses the port. Scoped credentials provide a second layer because browsers cannot obtain credentials through discovery records.
+```mermaid
+sequenceDiagram
+    participant CLI as warpctrl
+    participant FS as ~/.warp/local-control/
+    participant HTTP as Warp loopback server<br/>(127.0.0.1:ephemeral)
+    participant Bridge as App bridge
+
+    CLI->>FS: Read discovery records (user-only permissions / ACL)
+    FS-->>CLI: instance_id, endpoint metadata when enabled
+    CLI->>CLI: Prune stale PIDs, select instance
+    CLI->>HTTP: POST /v1/control/credentials<br/>action + outside-Warp context
+    HTTP-->>CLI: Short-lived scoped credential
+    CLI->>HTTP: POST /v1/control<br/>Authorization: Bearer <scoped credential>
+    HTTP->>HTTP: Verify credential scope, expiry, action, context
+    alt Invalid, expired, wrong-action, or missing credential
+        HTTP-->>CLI: 401 Unauthorized
+    else Valid token
+        HTTP->>Bridge: Dispatch action to app context
+        Bridge-->>HTTP: Structured result or error
+        HTTP-->>CLI: JSON response envelope
+    end
+```
+**Known limitations and future hardening:**
+- This foundation slice keeps raw credential authority in app-owned process memory and does not write it to discovery records. Platform secure storage for authoritative enablement and credential material remains future hardening before public shipment.
+- Scoped credentials are intentionally short-lived and action-specific, but this remains a same-user safety boundary rather than strong isolation from arbitrary compromised same-user software.
+- Windows local-control authentication is not complete until discovery-record ACL creation and validation are implemented.
+- Once higher-risk handlers land (e.g. `input.insert`, command execution), the same-user boundary becomes a code-execution trust boundary. Consider separating the token from the discovery metadata, adding per-request nonces, or switching to a Unix domain socket with `SO_PEERCRED` for kernel-verified caller identity.
+## Documentation review notes
+- Treat `warpctrl` as provisional executable naming until packaging signs off on final artifact aliases.
+- Keep examples scoped to discovery and `tab create` until additional app-side handlers are implemented.
+- Do not document catalog commands as usable just because they exist in protocol enums or parser scaffolding; operator docs should distinguish implemented commands from planned allowlist entries.
+- Windows packaging may initially follow the existing helper-wrapper pattern rather than shipping a native standalone executable. Update this README when that decision is final.

--- a/specs/warp-control-cli/SECURITY.md
+++ b/specs/warp-control-cli/SECURITY.md
@@ -1,0 +1,508 @@
+# warpctrl security architecture
+`warpctrl` is a local-control CLI for an already-running Warp app instance. Its security architecture is designed to support the control catalog: discovery, structural metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, underlying data mutations, input-buffer staging, file/path app-state intents, Warp Drive operations, and explicitly authenticated execution-underlying actions. Accepted-command submission and agent-prompt submission remain future high-risk capabilities that require separate product/security review. Local file content operations are intentionally excluded from the public `warpctrl` catalog because native agent file tools are the preferred surface for file content reads and writes.
+The correct architecture is not a single shared localhost bearer token with client-side conventions. The CLI, app bridge, and protocol must treat security as a local app-enforced capability system: discovery finds compatible instances, secure storage protects raw credential material, broker-issued credentials identify the granted scopes, the running Warp app's local-control bridge enforces action categories before dispatch, and target resolution never silently retargets a request.
+The action-category model is primarily a safety and intent mechanism, not a hard security boundary against malicious same-user software. It lets a user, script, or agent intentionally request metadata-only, data-read, app-state mutation, metadata/configuration mutation, or underlying-data mutation access so it does not accidentally mutate state, expose sensitive content, or execute commands. It should not be described as strong access control against a process that can already run arbitrary commands as the user.
+`warpctrl` has two distinct authorization dimensions: local-control authority and authenticated scripting authority. Local-control authority proves the request is allowed to control the local app. Authenticated scripting authority proves the Warp user or automation identity that is allowed to act on user-authenticated data such as Warp Drive objects, AI conversation traces, synced settings, cloud-backed user state, and execution-underlying actions. Logged-out users should retain a smaller local-only control surface, but authenticated-user and high-risk underlying-data mutation actions require either a verified Warp-terminal grant tied to the selected app's logged-in user or an external Warp-issued API-key grant.
+## Current foundation status
+The current foundation implementation supports outside-Warp local-control requests only. Verified inside-Warp invocation is specified as future work because the app-issued terminal-session proof broker, proof injection path, and session registry do not exist yet. Until those pieces land, `InvocationContext::InsideWarp` requests must be rejected with `execution_context_not_allowed`, implemented action metadata must not advertise inside-Warp support, and Settings > Scripting must not expose inside-Warp enablement or permission toggles.
+## Security goals
+- Allow trusted local users and approved automation to control a running Warp instance through a stable, scriptable interface.
+- Prevent unauthenticated localhost clients from invoking read or mutating control actions.
+- Prevent browser-origin JavaScript from becoming an ambient localhost control client.
+- Support multiple running Warp processes without a shared global mutating port or global credential.
+- Separate discovery metadata from control authority so enumerating an instance does not automatically grant full control.
+- Require explicit in-app user enablement before local control scripting from outside Warp can issue credentials or accept control requests.
+- Allow local control scripting from verified Warp-managed terminal sessions by default, subject to granular permission settings.
+- Store the authoritative enablement states in protected local storage so external apps cannot enable outside-Warp control by editing ordinary settings.
+- Keep raw credential material out of plaintext discovery records and protect it with platform secure storage where available.
+- Distinguish verified `warpctrl` invocations that originate from a Warp-managed terminal session from external same-user invocations.
+- When outside-Warp control is enabled, allow external invocations only for a smaller local-only action set by default that does not touch user-authenticated data.
+- Allow in-Warp invocations to receive authenticated-user grants when the selected Warp app has a true logged-in user and the user's local-control settings permit that grant.
+- Support least-privilege safety modes for automation and interactive use without relying on an unenforceable identity label.
+- Classify every action by state/data category and enforce the required permission category in the local app bridge, not in the CLI frontend.
+- Classify every action by whether it requires an authenticated Warp user. New actions should default to requiring an authenticated user unless they are deliberately reviewed as safe for logged-out or external use.
+- Prevent `warpctrl` from becoming an ambient full-power confused deputy that any same-user process can invoke for high-risk actions.
+- Require authenticated scripting identity, underlying-data-mutation permission, explicit target resolution, and audit records before terminal command execution or typed workflow execution can ship; accepted-command submission and agent-prompt submission remain prohibited until separately reviewed.
+- Preserve deterministic targeting so a request never silently mutates or reads the wrong window, tab, pane, session, file/path intent, or Warp Drive object.
+- Keep the action surface allowlisted and typed rather than exposing arbitrary internal app dispatch.
+- Make high-risk operations auditable and configurable without logging sensitive terminal contents or credentials.
+## Meaningful security boundaries
+The most important security boundary is preventing control from places that should have no ambient authority over the user's Warp instance:
+- arbitrary web apps running in a browser;
+- other OS users on the same machine;
+- unauthenticated clients that discover or guess the localhost control port;
+- stale discovery records from exited Warp processes;
+- malformed or unallowlisted direct protocol calls.
+The local-control design can provide meaningful protection for those cases by binding only to loopback, avoiding permissive CORS, requiring local credentials, keeping credentials out of browser-readable and world-readable locations, pruning stale records, and validating every request in the local Warp app process.
+The boundary is much weaker for a different local app running as the same OS user. Same-user local apps may already have access to user-owned files such as logs, may be able to observe the screen or UI through OS permissions such as Accessibility or Screen Recording, and can often invoke user-installed command-line tools. `warpctrl` should not imply strong isolation from such software.
+For same-user local apps, the realistic goal is narrower:
+- do not leave a raw bearer token in plaintext discovery records;
+- prevent arbitrary direct HTTP calls to the localhost control listener by requiring a credential those apps cannot simply read;
+- use platform secure storage, such as macOS Keychain, so raw credentials are accessible only to Warp-owned signed code where practical;
+- make high-risk operations go through `warpctrl` or a Warp-owned helper where user approval, configured policy, and safety grants can be applied;
+- avoid giving `warpctrl` ambient non-interactive full-control authority.
+In other words, the security model can make arbitrary direct localhost protocol calls fail, and it can make direct credential theft harder. It cannot make a same-user malicious app safe if that app can invoke `warpctrl`, automate the user's desktop, read other local state, or wait for the user to approve prompts.
+## Comparison with other local scripting models
+Other developer tools expose local automation through a few recurring patterns. The `warpctrl` design should borrow the parts that match Warp's needs while avoiding designs that assume localhost or same-user access is enough by itself.
+### VS Code
+VS Code's `code` command is primarily a launch and routing CLI: it opens files, folders, diffs, merge views, chat sessions, extension-management commands, and remote/tunnel workflows. It is not a general unauthenticated localhost API for arbitrary UI control of an already-running desktop app.
+VS Code's richer local automation runs through extension APIs and extension hosts. Extensions are installed into a trusted editor environment and run with broad access to the workspace or UI side depending on extension kind. Workspace Trust and remote extension placement help users reason about whether code should run locally, remotely, or in a browser sandbox, but they do not create a fine-grained same-user security boundary against arbitrary local software.
+Lessons for `warpctrl`:
+- a narrow, typed CLI command surface is safer to reason about than exposing arbitrary internal app commands;
+- agent and script workflows should request explicit capabilities instead of inheriting ambient full-control authority;
+- local UI control should remain distinct from remote/tunnel control because remote transports need stronger identity, approval, and network-security semantics.
+### Chrome DevTools Protocol
+Chrome DevTools Protocol is a powerful debugging and automation API. When Chrome is launched with remote debugging enabled, clients can discover targets over local HTTP endpoints and then control the browser over WebSocket. That protocol is intentionally high-power: it can inspect pages, navigate, execute JavaScript, observe network state, and interact with browser storage.
+Chrome's security history is a useful warning for `warpctrl`: a local debugging port is dangerous if it becomes reachable by unexpected clients. Recent Chrome versions restrict remote debugging against the default user data directory and recommend isolated user data directories for automation, because debugging a real browser profile can expose sensitive cookies and credentials. Chrome also distinguishes command-line remote debugging from user-confirmed debugging flows.
+Lessons for `warpctrl`:
+- loopback binding is necessary but not sufficient;
+- unauthenticated localhost endpoints should not expose powerful state or mutation;
+- browser-origin protections matter because web pages can attempt localhost requests;
+- high-power automation should prefer explicit, isolated, user-approved, or short-lived authority over a reusable full-profile control channel.
+### Ghostty and macOS AppleScript
+Ghostty exposes platform-native scripting on macOS through AppleScript. That model relies on macOS Automation/TCC prompts to decide whether one app may control another app, and Ghostty can disable AppleScript entirely with configuration. This is a good fit for macOS-native scripting, but it is platform-specific and inherits the limits of OS automation permission: once an app is allowed to automate another app, the boundary is not a per-action capability system.
+Ghostty also supports terminal-oriented features such as shell integration and command-line window creation flows. Those are useful local automation conveniences, but they are not a general cross-platform authenticated control protocol with scoped credentials.
+Lessons for `warpctrl`:
+- use platform security mechanisms where they exist, such as macOS Keychain and Automation prompts;
+- keep a user-visible kill switch or policy path for scripting/control surfaces;
+- do not rely only on platform automation permission if Warp needs cross-platform, action-scoped safety grants.
+### iTerm2 Python API
+iTerm2's Python API is a close comparison for terminal automation. The API is disabled by default. When enabled, iTerm2 listens on a Unix domain socket and requires authentication by default. Scripts launched by iTerm2 receive a random cookie in the environment, while external programs can request a cookie through AppleScript so macOS Automation permission mediates access. iTerm2 also documents an administrator-gated escape hatch to allow unauthenticated local apps.
+This model directly acknowledges that terminal contents are sensitive and that any local automation API can affect local and remote hosts connected through terminal sessions.
+Lessons for `warpctrl`:
+- default-off or policy-controlled high-power automation is reasonable for sensitive capabilities;
+- random local credentials are useful, but the path that grants or unwraps them is just as important as the token itself;
+- underlying data reads and input/command execution should be treated as higher-risk than structural metadata reads;
+- macOS Automation can be part of the approval path, but Warp still needs local app-side enforcement because direct protocol clients can bypass the official CLI.
+### tmux
+tmux is a useful lower-level comparison because its clients and server communicate through local sockets. The default socket lives in a per-user directory under `/tmp`, and that directory must not be world readable, writable, or executable. tmux control mode then exposes a text protocol where clients can issue normal tmux commands and receive asynchronous pane/session notifications. Newer tmux versions also have explicit server-access controls for sharing across users.
+tmux's model is mostly an OS-user and socket-permission model. Once a client can access the socket with write authority, it can generally control the session. Read-only modes are useful operational guardrails but are not a reason to trust untrusted users or processes with the socket.
+Lessons for `warpctrl`:
+- per-user discovery directories and sockets protect meaningfully against other OS users;
+- structured control protocols are scriptable and durable, but broad socket access quickly becomes broad control access;
+- read-only and low-risk modes are valuable “do not accidentally interfere” controls, not a complete hostile-client sandbox.
+### Overall direction for `warpctrl`
+Compared with these systems, `warpctrl` should combine:
+- tmux-style local filesystem/socket hygiene for protecting against other OS users;
+- Chrome's lesson that local debugging/control endpoints need authentication and browser-origin hardening;
+- iTerm2's use of explicit local credentials and macOS Automation-style approval for external control;
+- Ghostty's use of platform-native scripting controls where available;
+- VS Code's preference for typed public commands and separate treatment of remote control.
+The resulting architecture should not claim to solve arbitrary same-user malicious-app isolation. Its real value is preventing web-origin and other-user access, preventing unauthenticated direct localhost calls, keeping raw credentials out of plaintext discovery, giving honest scripts and agents narrow safety grants, and routing high-risk operations through local Warp app validation and user/policy approval.
+## Authoritative enablement model
+This section describes the long-term model. The current foundation branch implements only the outside-Warp half of this model and rejects inside-Warp requests until app-issued Warp-terminal proofs are implemented.
+Warp control has two top-level enablement states based on invocation context:
+- **Allow scripting from inside Warp:** controls `warpctrl` invocations from verified Warp-managed terminal sessions. This should default to on so commands run inside Warp can use local control subject to granular permissions.
+- **Allow scripting from outside Warp:** controls `warpctrl` invocations from external terminals, scripts, launch agents, IDEs, or other same-user processes. This must default to off.
+Both controls should live in a new top-level Settings pane page named **Scripting**. The Scripting page owns the user-facing controls for local scripting surfaces, including Warp control, and should explain the difference between commands run inside Warp and commands run from other apps.
+The visible UI settings are not enough by themselves. The authoritative enablement states must be stored in protected local storage that ordinary same-user apps cannot update by writing a plist, settings database row, registry key, JSON file, or synced cloud preference. This avoids turning outside-Warp control into a feature that any process can silently enable before invoking `warpctrl`.
+Current foundation implementation note: outside-Warp enablement and granular permission bits are represented in the typed `LocalControlSettings` group as private, local-only settings. Each implemented setting must use `private: true`, `SyncToCloud::Never`, an explicit private storage key, and no `toml_path`, so it is excluded from `settings.toml`, the generated settings schema, Settings Sync, Warp Drive, and user-editable or server-backed settings surfaces. This private-settings path is an interim storage boundary, not the final protected-storage requirement; before public shipment, these authoritative bits must move to platform protected storage where available.
+Enablement requirements:
+- The settings are local-only and must not sync through Settings Sync, Warp Drive, or server-backed user preferences.
+- The implemented foundation settings must remain private and absent from user-visible settings files, generated schemas, local-control settings read/write commands, and any allowlisted settings mutation catalog.
+- Only the running Warp app, through the Settings > Scripting UI, should be able to enable or disable the authoritative states.
+- `warpctrl`, shell scripts, config files, command-line flags, registry edits, defaults writes, and direct local-control protocol requests must not be able to enable either setting.
+- The in-Warp setting may default to enabled, but turning it off should prevent verified Warp-terminal invocations from receiving local-control grants.
+- The outside-Warp setting defaults to disabled and should require an intentional user gesture before enabling; the UI should explain that it allows scripts and automation from other apps to control Warp.
+- The Scripting page should expose granular local-control permission settings for implemented invocation contexts rather than a single all-powerful switch.
+- Each setting should be easy to disable from the same UI, and disabling either setting should revoke or invalidate active local-control credentials for that invocation context.
+- If enterprise or managed-device policy is added later, policy may force-disable either setting or allow an administrator-controlled default, but policy should be separate from user-editable local settings.
+Disabled-state behavior:
+- Warp should not mint scoped local-control credentials for a request whose invocation context is disabled.
+- The control listener should reject requests from disabled contexts with a structured disabled-state error before authentication, selector resolution, or handler dispatch.
+- Discovery records should avoid publishing actionable endpoint or credential-reference metadata for disabled outside-Warp control. If a minimal record is needed for UX, it should expose only non-sensitive status such as `outside_warp_control_enabled: false`.
+- `warpctrl` may detect a disabled context and print instructions to enable it in Settings > Scripting, but it must not offer a command that flips the setting.
+- Previously issued credentials must become unusable when their invocation context is disabled, even if their original expiry has not elapsed.
+These enablement gates do not create perfect same-user malicious-app isolation. A hostile process with Accessibility or Screen Recording permission might still try to automate the Warp UI. The outside-Warp gate is still important because it closes the much easier paths where external apps silently edit local preferences, call a config CLI, or write synced settings to enable a powerful control surface.
+### Granular permission settings
+Once the relevant inside-Warp or outside-Warp enablement setting allows a request context, users should control which categories of `warpctrl` authority can be granted. These permissions should appear under Settings > Scripting. Recommended independent permissions:
+- **Metadata reads:** permit external and in-Warp clients to inspect non-sensitive local app structure and configuration metadata such as instances, windows, tabs, panes, app version, theme names, setting keys, action metadata, and Drive object IDs/names/types without content.
+- **Underlying data reads:** permit reads of terminal output, scrollback, input buffers, command history, session traces, Warp Drive object contents, AI conversation content, and other content-bearing state.
+- **App-state mutations:** permit local UI/layout/focus changes such as opening windows, creating tabs, closing tabs, focusing panes, splitting panes, opening panels, opening files/projects/views, and staging text in the input buffer without executing it.
+- **Metadata/configuration mutations:** permit persistent metadata or configuration changes such as tab/pane names, tab colors, themes, font size, zoom, allowlisted settings, and keybindings.
+- **Underlying data mutations:** permit Warp Drive object CRUD and personal-to-team sharing, AI conversation mutations, and any other allowlisted action that can change user data or cause external side effects. Terminal command execution and Warp Drive workflow execution belong in this category when their later authenticated branches implement them. Accepted-command submission and agent-prompt submission remain unavailable until separately reviewed. Local file content operations are intentionally excluded from the public `warpctrl` catalog and should use native file tools instead.
+- **Authenticated-user actions from Warp terminals:** permit `warpctrl` invocations that originate from a verified Warp-managed terminal session to receive grants backed by the currently logged-in Warp user, enabling actions that read or mutate Warp Drive, AI conversation traces, synced settings, or other user-authenticated state.
+- **Authenticated-user actions from external clients:** default off. If supported, this must be a separate explicit permission from in-Warp authenticated actions because external same-user processes are a weaker context than a Warp-managed terminal session.
+Granular permissions should be independently configurable for inside-Warp and outside-Warp contexts where the distinction matters. Disabling any category should invalidate active credentials that include that category. The broker and app bridge must enforce these settings locally for every credential request and every presented credential. App-state mutation permission must not imply metadata/configuration mutation or underlying data mutation permission.
+## Trust boundaries
+`warpctrl` has several distinct trust boundaries.
+### Operating-system user boundary
+The baseline local trust boundary is the OS user account. Discovery records and local credential material must be readable only by the owning user. This protects against other local users and network peers, but it does not protect against an already-compromised same-user process.
+### Invocation boundary
+Same-user does not mean same authority. Interactive use and unattended automation may both run commands under the same user account, but they should be able to intentionally request narrower capabilities. The protocol needs scoped credentials that encode concrete grants, target scopes, and lifetimes rather than an abstract caller type that the bridge cannot reliably verify.
+These scoped credentials are guardrails for well-behaved clients. They prevent accidental overreach and make user intent explicit, but they are not a defense against malicious same-user code that can automate the CLI, inspect the user's environment, or wait for user approvals.
+### Warp-terminal execution context boundary
+`warpctrl` should be able to receive special grants when it is invoked from within a Warp-managed terminal session, but the bridge must not trust a caller-supplied string such as `caller_class=warp_terminal`. The app should issue a session-bound execution-context proof to Warp-managed terminal sessions and have the broker verify that proof before minting in-Warp-only grants.
+Acceptable designs include a short-lived per-session capability, an app-owned broker handshake tied to the terminal session, or an equivalent proof that arbitrary external processes cannot mint by setting an environment variable. Plain environment variables may be used as handles or hints, but they must not be the sole authority for in-Warp privileges because external processes can spoof them.
+Verified in-Warp context can raise the maximum eligible grant set, especially for authenticated-user actions. It does not by itself bypass the user's granular local-control settings, action categories, target scopes, or logged-in-user requirements.
+### Authenticated scripting boundary
+Actions that touch user-authenticated Warp data or perform high-risk underlying-data mutations require authenticated scripting authority. This includes Warp Drive object contents, object mutation, the v0 personal-to-team sharing path, AI conversation traces, cloud-backed user settings, team/account data, typed workflow execution, terminal command execution, and any other surface whose normal app access depends on the user's Warp account or can cause external side effects.
+There are two supported authenticated scripting modes:
+- **Verified Warp-terminal mode:** `warpctrl` presents an app-issued terminal-session proof. If the selected app is logged into Warp and Settings > Scripting permits authenticated actions from verified Warp terminals, the broker may mint an authenticated-user grant tied to the selected app's current user subject.
+- **External API-key mode:** `warpctrl` presents a Warp-issued scripting API key or a short-lived token exchanged from that key. If outside-Warp scripting and external authenticated grants are enabled, the broker verifies the key, scopes, expiry, revocation state, and user subject before minting a local authenticated-user grant.
+For app-backed authenticated actions, the app bridge should execute on behalf of the selected app's logged-in user through existing app auth state. For explicitly API-key-backed actions, the API key subject and scopes must be recorded in the local grant and the handler must not export raw Firebase, server, OAuth, or cloud API tokens to shell scripts. If the selected app logs out, switches users, or no longer matches a grant that requires app-user identity, authenticated actions fail with structured errors rather than falling back to logged-out behavior.
+Logged-out users may still use the smaller local-only action set explicitly marked as not requiring authenticated scripting authority.
+### Authenticated scripting protocol
+`warpctrl` should provide auth/status flows for both interactive app login and external API-key automation. The CLI must not collect Warp passwords and must not print or persist raw API keys outside approved secret storage.
+Requirements:
+- `warpctrl auth status [selectors]` reports whether the selected app instance is logged in, whether verified Warp-terminal authenticated grants are available, and whether an external API-key identity is configured. It may return stable, non-secret subject/scope metadata when the caller has the required grant.
+- `warpctrl auth login [selectors]` focuses or opens the selected Warp app's normal sign-in UI and waits, or exits with actionable instructions, until the user signs in through Warp itself.
+- `warpctrl auth api-key set --key-env <env_var>|--key-stdin [selectors]` stores or references a Warp-issued scripting API key in platform secure storage. Non-interactive scripts may provide the key through a secret-manager-injected environment variable.
+- `warpctrl auth api-key status [selectors]` reports non-secret subject, expiry, and scope metadata for the configured API key.
+- `warpctrl auth api-key revoke [selectors]` removes the local key reference and revokes the server-side key where supported.
+- The credential broker may mint an app-user authenticated grant only after confirming the selected app has a true logged-in Warp user and the requested authenticated-user setting is enabled for the verified invocation context.
+- The credential broker may mint an external API-key grant only after validating the key or exchanging it for a short-lived assertion, confirming that external authenticated grants are enabled, and checking that the key scope covers the requested action family and permission category.
+- Authenticated credentials are bound to the selected instance, subject, grant mode, scopes, expiry, and optional target/resource restrictions. If the app logs out, switches users, loses authenticated state, or the presented credential subject no longer matches a grant that requires app-user identity, authenticated actions fail with `authenticated_user_mismatch` or another structured authenticated-user error.
+- Raw Firebase, server, OAuth, cloud API tokens, and raw API keys must not be exported to `warpctrl` output, shell completions, generated docs, logs, discovery records, or local-control JSON responses.
+Logged-out-safe actions continue to use local-control credentials without requiring authenticated scripting identity.
+### Application identity boundary
+On platforms with secure credential storage, especially macOS, the raw local-control credential should be readable only by Warp-owned, correctly signed code. On macOS this means storing raw credential material in Keychain with access constrained by Warp's signing identity, designated requirement, Keychain access group, or equivalent platform mechanism. This narrows token extraction from “any same-user process can read a file” to “only trusted Warp-signed code can unwrap the secret.”
+This boundary protects the credential from direct theft and prevents arbitrary apps from making authenticated raw HTTP requests to the local-control listener. It also lets the authoritative enablement state be stored somewhere harder to modify than ordinary user preferences. It does not prove that the user personally intended the specific action. Any same-user process may still be able to invoke the trusted `warpctrl` binary or automate the Warp UI. That confused-deputy risk is reduced by explicit in-app enablement, scoped credential issuance, action-category policy, and local app-side bridge enforcement, but it is not eliminated as a hard same-user security boundary.
+### Action boundary
+Every action belongs to a state/data category. The bridge must map the requested action to a required permission category and compare that category to the presented credential before selector resolution or handler dispatch.
+### Target boundary
+A valid credential for one instance or target must not imply authority over another. Credentials should be bound to the issuing Warp instance and may be further scoped to target families such as terminal sessions, files, or Warp Drive objects when those surfaces are exposed.
+## Threat model
+### In scope
+- Other local OS users attempting to control a Warp instance owned by the current user.
+- Browser-origin JavaScript attempting to call localhost control endpoints.
+- Same-user automation attempting actions without the required scoped grants.
+- Same-user processes attempting to extract plaintext credentials from local state.
+- Same-user processes invoking `warpctrl` as a confused deputy for actions the process could not authorize directly.
+- External same-user processes attempting authenticated-user actions that should be limited to verified Warp-terminal invocations.
+- Logged-out requests attempting actions that require a true logged-in Warp user.
+- Stale discovery records from exited Warp processes.
+- Multiple running Warp instances where ambiguous selection could target the wrong process.
+- Malformed clients attempting unknown, unsupported, unallowlisted, or invalid action payloads.
+- Valid clients attempting actions above their granted permission category.
+- Explicit target IDs that become stale between discovery and execution.
+- Future handlers that expose terminal data, settings writes, input mutation, command execution, file intents, or Warp Drive object operations.
+### Out of scope
+- A malicious process that already has arbitrary same-user filesystem and process access, except that scoped credentials should still reduce accidental over-granting to ordinary automation.
+- Kernel, hypervisor, or administrator-level compromise.
+- Security semantics for remote URL control endpoints. Remote control requires a separate transport and identity design before it can ship.
+## Architecture overview
+The full security model has eight layers. The current foundation branch implements the outside-Warp path and keeps the inside-Warp execution-context layer as a rejected future protocol concept until proof verification exists.
+The security model has eight layers:
+1. **Protected enablement:** Use protected local storage for separate inside-Warp and outside-Warp enablement states, with inside-Warp on by default and outside-Warp off by default.
+2. **Discovery:** Find compatible live Warp instances without granting broad authority.
+3. **Secure credential storage:** Store raw secrets outside plaintext discovery records and restrict access to trusted Warp-owned code where the platform supports it.
+4. **Execution context verification:** Distinguish verified Warp-terminal invocations from external same-user invocations without trusting caller-declared labels.
+5. **Credential issuance:** Issue scope-specific credentials with explicit grants and lifetimes only when the request's invocation context is enabled and the user's granular permissions allow the requested category.
+6. **Transport authentication:** Reject disabled or unauthenticated requests before reading or mutating app state.
+7. **Safety and user-auth policy:** Enforce permission categories, target scopes, execution-context requirements, and authenticated-user requirements locally in the app bridge.
+8. **Deterministic dispatch:** Resolve targets exactly and invoke only allowlisted typed handlers.
+```mermaid
+sequenceDiagram
+    participant Invoker as User / Automation
+    participant CLI as warpctrl
+    participant Registry as Per-user discovery registry
+    participant Enablement as Protected enablement state
+    participant Context as Execution context proof
+    participant Broker as Credential broker
+    participant Store as Secure credential storage
+    participant Auth as App auth state
+    participant HTTP as Warp control listener
+    participant Bridge as App bridge + safety policy
+    participant UI as Warp app state
+
+    Invoker->>CLI: Invoke allowlisted command
+    CLI->>Registry: Read instance metadata
+    Registry-->>CLI: instance_id, endpoint, protocol version, credential reference
+    CLI->>Enablement: Check inside/outside context enablement
+    Enablement-->>CLI: Enabled or disabled
+    alt Disabled
+        CLI-->>Invoker: context disabled; enable in Settings > Scripting
+    else Enabled
+    CLI->>Broker: Request scoped credential for action
+    Broker->>Enablement: Verify protected enablement state
+    Broker->>Context: Verify external vs Warp-terminal context
+    opt Authenticated-user action
+        Broker->>Auth: Verify logged-in Warp user + setting
+        Auth-->>Broker: User subject or unavailable
+    end
+    Broker->>Store: Load or unwrap raw secret with Warp-signed access
+    Store-->>Broker: Raw secret or credential capability
+    Broker-->>CLI: Scoped credential with grants, context, user scope, expiry
+    CLI->>HTTP: Authenticated typed request
+    HTTP->>Bridge: Verify credential and protocol envelope
+    Bridge->>Bridge: Check permission category + context + authenticated-user + target scope
+    alt Denied
+        Bridge-->>CLI: structured safety-policy error
+    else Allowed
+        Bridge->>UI: Resolve target exactly and run allowlisted handler
+        UI-->>Bridge: typed result or structured target error
+        Bridge-->>CLI: response envelope
+    end
+    end
+```
+## Discovery registry
+Each participating Warp process writes a discovery record in a secure per-user local-control directory. Discovery records are metadata, not a full control-authority model.
+A discovery record should contain:
+- opaque `instance_id`;
+- PID and process start timestamp;
+- channel and build metadata;
+- protocol version and supported capability summary;
+- loopback endpoint for the instance-local control listener;
+- credential reference or bootstrap credential metadata, not necessarily the full control credential.
+Discovery rules:
+- Records must be readable only by the owning user.
+- POSIX records must use owner-only permissions such as `0600` for files and a non-world-readable directory.
+- Windows records must live under the current user's app data directory with ACLs limited to the current user, Administrators, and SYSTEM.
+- When outside-Warp control is disabled, records must not publish actionable control endpoints or credential references for external clients. A minimal disabled-status record is acceptable only if it contains no authority.
+- The CLI must prune or ignore stale records whose PID is gone or whose health/protocol check fails.
+- If multiple compatible instances are ambiguous, the CLI must require explicit `--instance` selection.
+- Discovery metadata must not expose terminal contents, environment variables, auth tokens for cloud services, raw local-control credentials, or mutating capability grants.
+## Credential model
+The full `warpctrl` catalog requires scoped credentials. A single shared full-power bearer token is not sufficient once automation, underlying data reads, app-state mutations, metadata/configuration mutations, and underlying data mutations are supported.
+### Credential properties
+A control credential should encode or reference:
+- issuing Warp instance;
+- protocol version or accepted version range;
+- granted permission categories;
+- verified execution context, such as external client or Warp-managed terminal session;
+- whether the credential may act on behalf of an authenticated Warp user;
+- authenticated Warp user subject or stable user reference when an authenticated-user grant is present;
+- optional allowed action families;
+- optional target restrictions, such as one session, one workspace, one file path, or one Warp Drive object type;
+- issued-at time;
+- expiry time or process-lifetime binding;
+- unique credential ID for revocation and auditing;
+- integrity protection so callers cannot forge or widen grants.
+### Credential issuance
+Warp should issue credentials through an app-owned local broker or equivalent trusted path. The broker decides which grants to issue based on the requested permission category, target scope, user configuration, execution context, and any explicit user approval.
+Recommended defaults:
+- Credential issuance is unavailable unless the protected enablement state allows the request's invocation context: inside Warp or outside Warp.
+- Commands should start from least privilege and request only the grant needed for the requested action.
+- External same-user invocations should default to the smaller logged-out-safe local action set unless policy or explicit approval grants more.
+- Verified Warp-terminal invocations may receive broader local-control grants when the user's granular settings allow them.
+- App-user authenticated grants are available only when the selected Warp app has a true logged-in Warp user and the requested execution context is allowed by local-control settings. External API-key authenticated grants are available only after key validation/exchange and only when external authenticated scripting is enabled.
+- Metadata reads require an explicit `read_metadata` grant.
+- Underlying data reads require an explicit `read_underlying_data` grant.
+- App-state mutations require an explicit `mutate_app_state` grant.
+- Metadata/configuration mutations require an explicit `mutate_metadata` or `mutate_configuration` grant.
+- Underlying data mutations require an explicit `mutate_underlying_data` grant and should require approval or policy for unattended automation.
+- User-authenticated data reads or mutations require an explicit `authenticated_user` grant and an allowed authenticated action family in addition to the data-category grant.
+- Integrations should receive the narrowest grant needed for the configured workflow.
+The broker must not issue broad authority merely because the request came from the signed `warpctrl` binary. It should evaluate the requested permission category, target scope, configured policy, execution context, and whether user approval is required. The CLI must not mint its own authority. It can request, load, and present credentials, but the app bridge remains the enforcement point for these safety grants.
+### Safety grants, not strong access control
+The category system should be understood as a user-intent and accident-prevention mechanism:
+- A user can ask an agent or script to operate with metadata-read grants so it can inspect structure but cannot read terminal content or mutate state.
+- A workflow can request underlying-data reads separately from structural metadata reads because terminal output, files, Drive object content, and AI conversations can contain sensitive data.
+- A script can request app-state mutation without also receiving permission to change persistent settings, execute commands, mutate Warp Drive objects, or perform local file content operations.
+- Metadata/configuration mutations can be allowed without granting underlying data mutation.
+- Underlying data mutations can require explicit approval or configured policy so surprising operations pause before they execute commands or change user data.
+This model does not make untrusted same-user software safe. A malicious local process may invoke `warpctrl`, simulate user workflows, or use other OS-level capabilities outside `warpctrl`. The category model is still valuable because it lets honest clients, agents, and scripts constrain themselves and gives Warp a structured point to prompt, deny, or audit risky actions.
+### Credential storage
+Credential storage should be platform-appropriate:
+- Local discovery may store a credential reference rather than the credential itself.
+- The authoritative local-control enablement states for inside-Warp and outside-Warp scripting should use the same class of protected local storage as raw credential material, but they should be accessible to the Warp app for the Settings > Scripting UI and not writable by `warpctrl` or arbitrary external apps.
+- Raw long-lived credentials should prefer platform-secure storage such as macOS Keychain or Windows Credential Manager when practical.
+- On macOS, raw control secrets should be stored in Keychain and restricted to trusted Warp-signed code using a designated requirement, Keychain access group, trusted-application ACL, or equivalent code-signing based mechanism. Restricting by filesystem path alone is insufficient because paths can be replaced or wrapped.
+- Keychain item access should include the Warp app, the signed `warpctrl` binary, and any signed Warp-owned local broker/helper that needs to unwrap raw secrets. It should exclude arbitrary same-user applications.
+- Short-lived credentials may be stored in owner-only local state if their lifetime and scope are narrow.
+- Credentials must never be printed in human-readable output, JSON output, logs, errors, or shell completion data.
+### Confused-deputy mitigation
+Secure storage prevents arbitrary apps from reading the token; it does not prevent arbitrary apps from asking trusted Warp code to use the token on their behalf.
+For example, if `warpctrl` can silently unwrap a full-power credential and execute any action, another same-user process can invoke `warpctrl input run ...` without reading the credential directly. That makes `warpctrl` a confused deputy.
+Mitigations:
+- Do not give `warpctrl` ambient non-interactive access to an unrestricted full-control credential.
+- Prefer action-scoped or session-scoped credentials minted just in time by the broker.
+- Require explicit user approval or preconfigured policy for underlying data mutations and other sensitive grants.
+- Distinguish user-approved credential requests from ambient unattended invocations through explicit approval prompts, configured policy, terminal/session context, or narrow credential request flows.
+- Bind issued credentials to the requested instance, permission category, optional action family, optional target scope, and short expiry.
+- Let `warpctrl` preflight and request credentials, but require the local app bridge to enforce scopes because direct protocol clients can bypass the CLI.
+- Make denials structured and non-fatal for automation so callers can request narrower or user-approved grants rather than falling back to unsafe behavior.
+These mitigations are about routing high-risk operations through intentional `warpctrl` flows rather than exposing a reusable localhost token to any process. They should not be documented as a guarantee that arbitrary same-user applications cannot cause Warp-visible actions.
+## Transport authentication
+The default transport is an instance-local loopback listener bound to `127.0.0.1` on an ephemeral per-process port.
+Transport requirements:
+- Bind only to loopback for local control.
+- Do not set permissive CORS headers.
+- Reject control requests when their inside-Warp or outside-Warp invocation context is disabled, even if the request presents an otherwise valid credential.
+- Authenticate every control request locally in the selected Warp app process before selector resolution or action dispatch.
+- Reject missing, malformed, expired, revoked, or invalid credentials with structured authentication errors.
+- Keep unauthenticated health metadata minimal and non-sensitive.
+- Preserve structured error envelopes so the CLI does not collapse security failures into generic transport errors.
+Remote URL support is a separate future transport mode. It should not reuse the local same-user credential model without additional identity, encryption, replay protection, and remote approval/policy design.
+## Logged-in user requirements
+Local-control validation always begins with local protocol state: discovery records, secure local credential references, scoped safety grants, execution-context proof, protocol version, request shape, allowlisted actions, typed parameters, and deterministic target selectors.
+Some actions additionally require authenticated scripting authority: either a true logged-in Warp user in the selected app or an external API-key-backed subject with sufficient scopes. The action allowlist must declare this explicitly with a `requires_authenticated_user` or equivalent authenticated-scripting requirement field.
+Default rule for new actions:
+- New actions require an authenticated Warp user unless the implementer deliberately classifies them as logged-out-safe.
+- The logged-out-safe set should remain meaningfully smaller and limited to local app structure, local appearance metadata, and other surfaces that do not depend on the user's cloud-backed Warp identity.
+- Actions that read or mutate Warp Drive, AI conversation traces, synced settings, team/account data, or other user-authenticated state must require an authenticated user.
+- Actions that execute user-authored cloud-backed content, such as running typed Warp Drive workflows, require both authenticated scripting authority and the appropriate high-risk action category. Agent-prompt submission remains excluded until separately reviewed.
+When an authenticated-user or authenticated-scripting action is requested:
+- app-user mode requires the selected app to have an active logged-in Warp user;
+- API-key mode requires a validated key or exchanged assertion with sufficient scopes, subject, expiry, and revocation state;
+- the presented local-control credential must include an authenticated grant for that user or API-key-backed subject;
+- the user's granular settings must allow authenticated actions for the verified execution context or external API-key mode;
+- the app bridge should execute app-user actions through the app's existing authenticated state rather than exporting raw cloud auth credentials to `warpctrl`.
+If these conditions are not met, the app returns a structured error. It must not fall back to logged-out behavior or silently omit user-authenticated data from a result that claims success.
+## Safety policy model
+Safety grants are enforced in the app bridge after transport authentication and before target resolution or handler dispatch. This provides consistent “do not accidentally do more than requested” behavior for honest clients, not a sandbox for hostile same-user code.
+The bridge must:
+1. Parse the typed request envelope.
+2. Verify protocol version compatibility.
+3. Authenticate the credential.
+4. Determine granted permission categories, execution context, target scopes, and authenticated-user grants.
+5. Map the requested action to a required permission category, action family, execution-context requirement, and authenticated-user requirement.
+6. Check optional target-family restrictions.
+7. Reject requests that exceed the credential's grants with `insufficient_permissions`.
+8. Reject authenticated-user or API-key-backed actions without the required app-user login, API-key validation, scopes, or authenticated grant with a structured authenticated-user/API-key error.
+9. Only then resolve selectors and invoke the allowlisted handler.
+The CLI frontend may provide helpful preflight errors, but those checks are advisory. Local app-side bridge enforcement is mandatory because other tools can bypass the official CLI and speak the protocol directly.
+## Action permission categories
+Every action belongs to exactly one state/data category for permission enforcement. These categories describe risk and intended safety prompts; they are not a sandbox or a complete OS-level access-control model.
+### Metadata reads
+Return app structure, app state, or configuration metadata without exposing terminal content, file content, Warp Drive object content, AI conversation content, or other user data.
+Examples:
+- `instance list`, `app active`, `app version`, `app ping`;
+- `window list`, `tab list`, `pane list`, `session list`;
+- `theme list`, `setting list`, `keybinding list`, and action/capability metadata;
+- Drive object listing that returns object IDs, names, and types but not content.
+Default unattended credentials may include this category.
+### Underlying data reads
+Return user content or data-bearing state without mutating state.
+Examples:
+- pane output, scrollback, current input buffer, command history, session replay, or transcript reads;
+- Warp Drive object content reads;
+- AI conversation content reads.
+This category is separate from metadata because content often contains secrets, source code, file paths, command output, customer data, and other sensitive information.
+### App-state mutations
+Change visible local Warp UI state without directly changing underlying user data.
+Examples:
+- creating, focusing, activating, moving, or closing windows, tabs, panes, or sessions;
+- splitting, navigating, maximizing, or resizing panes;
+- opening panels, palettes, files, projects, notebooks, and other user-facing surfaces;
+- inserting, replacing, or clearing staged input buffer text without submitting or executing it.
+### Metadata/configuration mutations
+Change persistent metadata or configuration without directly mutating primary user content.
+Examples:
+- renaming tabs or panes;
+- changing tab colors;
+- theme, font, zoom, keybinding, and allowlisted settings writes.
+This category should not authorize terminal command execution, Warp Drive CRUD, Warp Drive sharing, or local file content operations.
+### Underlying data mutations
+Can change user data, execute code, submit prompts, or cause external side effects.
+Examples:
+- terminal command execution through the explicit `input.run` action;
+- typed Warp Drive workflow execution or other approved user-authored runnable content;
+- Warp Drive object create/update/delete/insert operations;
+- Warp Drive object sharing, limited in v0 to making a personal object available to the user's current team through an explicit `share-to-team` command;
+- AI conversation history mutation or other cloud-backed content mutation.
+This category requires authenticated scripting identity plus explicit user or policy approval for unattended automation and integrations. It must remain separate from app-state mutation so a client that can open or focus Warp UI cannot automatically execute commands, submit prompts, mutate Warp Drive content, share Drive objects, or perform local file content operations. Accepted-command submission and agent-prompt submission remain unavailable until separately reviewed even if future protocol names are reserved for them.
+## Target scoping and deterministic resolution
+Targeting is part of security. The protocol must not convert ambiguous or stale selectors into best-effort mutations.
+Rules:
+- Instance selection happens before request dispatch and must be explicit when ambiguous.
+- `active` selectors may be ergonomic defaults only when the active target is unambiguous.
+- If no active target exists for a mutating request, return `missing_target` or `invalid_selector`.
+- Explicit opaque IDs must resolve exactly or return `stale_target`.
+- Index selectors must resolve to concrete IDs before execution and must not race into a different target silently.
+- Session-scoped requests against non-terminal panes return `target_state_conflict`.
+- File selectors use paths and must remain distinct from opaque UI IDs.
+- Warp Drive selectors must include object type and resolve by opaque ID for automation stability, with name/path lookup only as an interactive convenience.
+Target restrictions in credentials should be checked before invoking handlers. For example, a credential scoped to one session must not read another session's output even if the CLI can discover that session ID.
+## Allowlisted handlers
+The protocol must not expose arbitrary internal app actions by string.
+Each supported command requires:
+- a typed protocol action;
+- typed parameters;
+- validation rules;
+- a documented state/data category and permission category;
+- a documented `requires_authenticated_user` value;
+- a documented allowed execution context, including whether external clients can run it or whether it is limited to verified Warp-terminal invocations;
+- local app-side safety-grant checks;
+- deterministic target resolution;
+- a handler that reuses existing user-visible app behavior where possible;
+- typed success and error responses.
+Adding a new action should be additive and reviewable: extend the protocol enum, implement validation, map the action to a state/data category, declare whether it requires an authenticated user, declare its allowed execution contexts, add a handler, and add tests for authentication, safety-policy denial, authenticated-user denial, selector failure, and success behavior.
+## Browser and localhost protections
+Loopback is not sufficient by itself because browsers can send requests to localhost.
+Required protections:
+- No permissive CORS on control endpoints.
+- No JSONP or browser-readable fallback formats.
+- Valid scoped credentials required for all sensitive endpoints.
+- Credentials stored outside browser-readable locations.
+- Preflight and error responses must not reveal credentials or sensitive target state.
+- The protocol should avoid GET endpoints for mutating actions.
+The control plane should assume a malicious webpage can guess common localhost ports and send blind requests. It should not be able to read discovery records or obtain credentials.
+## Auditing and logging
+High-risk action support should include auditability without leaking sensitive data.
+Recommended audit fields:
+- timestamp;
+- instance ID;
+- credential ID or grant profile;
+- action name, state/data category, and permission category;
+- target type and opaque target ID when safe;
+- success or structured error code.
+Avoid logging:
+- bearer tokens or scoped credentials;
+- terminal output;
+- command text for command execution unless explicitly approved by policy in a future version that supports execution;
+- agent prompt text;
+- input buffer contents;
+- Warp Drive object contents;
+- environment variable values.
+Error-level logs should be used only for conditions that need developer attention, not normal denied requests or user-caused selector failures.
+## Security- and safety-relevant errors
+Structured errors are part of the security contract.
+Important errors include:
+- `local_control_disabled` when the relevant inside-Warp or outside-Warp scripting context is disabled in Settings > Scripting or has been disabled after credentials were issued;
+- `unauthorized_local_client` for missing, malformed, expired, revoked, or invalid credentials;
+- `insufficient_permissions` for valid credentials that lack the requested permission category or target scope;
+- `authenticated_user_required` when an action requires authenticated scripting authority but the credential lacks an authenticated-user or API-key-backed grant;
+- `api_key_required`, `api_key_invalid`, `api_key_expired`, `api_key_revoked`, and `api_key_insufficient_scope` for external API-key scripting failures, or equivalent structured variants if consolidated under existing authenticated-user errors;
+- `authenticated_user_unavailable` when the selected Warp app has no logged-in Warp user or cannot access the required authenticated user state;
+- `authenticated_user_mismatch` when an authenticated-user credential is bound to a different user subject than the user currently logged in to the selected Warp app;
+- `execution_context_not_allowed` when the action or requested grant is not allowed from the verified invocation context, such as an external client attempting an in-Warp-only authenticated-user action;
+- `ambiguous_instance` when multiple compatible instances cannot be resolved safely;
+- `invalid_selector` for malformed or unsupported selector syntax;
+- `missing_target` when an active/default target does not exist;
+- `stale_target` when an explicit target ID no longer exists;
+- `unsupported_action` for actions not implemented by the selected instance;
+- `not_allowlisted` for actions intentionally excluded from the public control surface;
+- `invalid_params` for malformed parameters;
+- `target_state_conflict` when the target exists but cannot support the requested action.
+The app must not downgrade these failures into broader default actions, and the CLI must preserve structured server errors in both human-readable and JSON output.
+## Required controls before full catalog expansion
+Before shipping each action family, verify that these controls are implemented for that family:
+- Local control scripting must be enabled for the request's invocation context before the action family can run; inside-Warp control defaults on and outside-Warp control defaults off.
+- The authoritative enablement states live under Settings > Scripting, are protected from external writes, and are local-only rather than synced.
+- The action has a documented state/data category and required permission category.
+- The action has a documented `requires_authenticated_user` value. New actions default to `true` unless explicitly reviewed as logged-out-safe.
+- The action documents allowed execution contexts and whether external clients may run it.
+- The bridge maps the action to that permission category locally in the selected Warp app process.
+- The credential model can express the required grant.
+- The credential model can express authenticated-user grants and verified execution context requirements when needed.
+- The handler checks optional target restrictions where relevant.
+- Requests with invalid credentials or insufficient safety grants fail before selector resolution or mutation.
+- Requests that require authenticated-user access fail unless the selected app has a true logged-in Warp user and the credential includes an authenticated-user grant.
+- Ambiguous, missing, and stale targets return structured errors.
+- Tests cover allowed, insufficient-permission, and denied credential paths.
+- Logs and errors do not expose credentials, terminal contents, command text, or sensitive settings.
+- Operator docs distinguish available commands from planned catalog entries.
+- Initial public action-family docs and tests prove terminal command execution, workflow execution, accepted-command submission, and agent-prompt submission are not allowlisted; input-buffer staging never submits the buffer.
+- Initial public action-family docs and tests prove local file content reads, writes, appends, deletes, and filesystem-content mutations are not allowlisted; file/path support is limited to opening visible Warp UI surfaces and listing files already open in Warp.
+## Platform requirements
+### macOS and Linux
+Discovery files must be stored in a per-user directory with owner-only permissions.
+On macOS, raw credential material and the authoritative local-control enablement states should live in Keychain, not in the discovery record or an ordinary preferences file. Keychain access should be constrained to Warp-owned signed binaries or helpers using code-signing based access control. The enablement states should be writable by the Warp app's Settings > Scripting flow and not writable by `warpctrl`. The discovery record should hold only metadata and a credential reference when the relevant inside-Warp or outside-Warp context is enabled.
+On Linux, raw credentials and the authoritative enablement states should prefer platform-secure storage where available; otherwise short-lived scoped credentials may live in owner-only local state with strict file and directory permissions. If an enablement state falls back to owner-only local state, the weaker same-user protection should be documented.
+Unix domain sockets with peer credential checks may be considered for stronger same-machine identity than bearer tokens alone.
+### Windows
+Discovery records and credential material must live under the current user's app data directory with ACLs restricted to the current user, Administrators, and SYSTEM.
+The authoritative enablement states should use Credential Manager, DPAPI-backed protected storage, or an equivalent app-controlled protected store rather than normal registry settings that arbitrary same-user processes can write.
+Windows support for authenticated local control should not be considered complete until the implementation creates, validates, and tests those ACLs and the protected enablement-state behavior for both inside-Warp and outside-Warp settings.
+## Remote control is separate
+The local architecture intentionally assumes same-machine, same-user control over a loopback listener. Future remote URLs must use a different security design that includes:
+- transport encryption;
+- remote identity and authentication;
+- replay protection;
+- explicit user or admin approval/policy;
+- network exposure review;
+- separate credential issuance from local discovery;
+- remote-safe auditing and revocation.
+Remote support should not be enabled by simply allowing `warpctrl` to point the existing local credential at an arbitrary URL.

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -1,0 +1,611 @@
+# Context
+`PRODUCT.md` defines a standalone local Warp control CLI binary, provisionally named `warpctrl`, with an allowlisted action catalog, deterministic addressing across multiple running Warp app processes, and an incremental implementation plan.
+`SECURITY.md` is the normative security architecture for this feature. Implementation work must follow it for the top-level Settings > Scripting surface, protected enablement storage, granular permissions, discovery metadata, credential storage, scoped safety grants, verified execution context, authenticated-user requirements, localhost/browser protections, permission-category enforcement, deterministic target resolution, and local app-side validation. The long-term architecture includes separate verified inside-Warp and outside-Warp invocation contexts, but the current foundation implementation supports outside-Warp requests only and must reject `InvocationContext::InsideWarp` until the verified Warp-terminal proof broker lands. If this technical plan and `SECURITY.md` disagree, update the plan before implementing rather than treating the security architecture as optional follow-up work.
+The existing app already has three relevant building blocks:
+- `crates/http_server/src/lib.rs (7-61)` runs a native-only loopback Axum server on fixed port `9277`.
+- `app/src/lib.rs (1993-2001)` registers that HTTP server in the native app and currently merges only installation-detection and profiling routers.
+- `crates/app-installation-detection/src/lib.rs (15-60)` and `app/src/profiling.rs (208-242)` show the current local HTTP routes. They are narrow endpoints, not a general control plane.
+Warp also already has the app-side behaviors the control API should reuse rather than reimplement:
+- `app/src/terminal/view/action.rs (193-196)` defines split-pane terminal actions.
+- `app/src/pane_group/mod.rs (4266-4360, 5377-5414)` shows pane creation/splitting semantics and how split events mutate pane layout.
+- `app/src/workspace/action.rs (153-156)` defines the existing tab creation actions, including default and terminal-tab variants.
+- `app/src/workspace/view.rs (21203-21244)` shows how user-visible default and terminal-tab actions are dispatched.
+- `app/src/settings/theme.rs (9-82)` defines persisted theme settings.
+- `app/src/themes/theme_chooser.rs (416-458)` shows persisted theme selection behavior.
+- `app/src/workspace/action.rs (95-776)` is the largest existing inventory of user-visible workspace actions and informs the allowlist catalog.
+- `app/src/workspace/util.rs (12-18)` defines `PaneViewLocator`, and `app/src/pane_group/pane/mod.rs (84-177)` defines serializable pane identifiers, both useful reference points for selector resolution.
+- `app/src/uri/mod.rs (822-1093, 1166-1364)` demonstrates external intents being resolved into active windows/workspaces and dispatched into running app state.
+The current Oz CLI build/distribution model is also directly relevant because the control CLI should follow the same standalone-artifact approach rather than relying on the Warp GUI executable to service ordinary shell invocations:
+- `crates/warp_cli/src/lib.rs (88-188, 316-418)` defines the existing CLI/parser conventions and channel-specific command naming support.
+- `app/src/lib.rs (631-746)` routes CLI invocations into CLI execution rather than GUI launch.
+- `script/macos/bundle (353-735)` and `script/linux/bundle (157-294)` build standalone CLI artifacts with the `standalone` feature.
+- `.github/workflows/create_release.yml (423-554, 660-858, 992-1276)` publishes macOS/Linux CLI artifacts.
+- `script/windows/windows-installer.iss (235-263)` shows the current Windows helper-wrapper pattern for CLI access.
+The most important constraint surfaced by this code is that the current fixed-port local HTTP server cannot be the entire solution for a multi-process control API. If multiple local Warp processes attempt to expose mutating routes through the same fixed port, only one can own it. The control design therefore needs explicit per-process discovery and addressing.
+## Proposed changes
+### 0. Security architecture dependency
+Before implementing any local-control listener, CLI command, credential path, or action handler, the implementation must be checked against `SECURITY.md`.
+Required security gates:
+- Long term, local control scripting has separate inside-Warp and outside-Warp enablement states. Inside-Warp control for verified Warp-managed terminal sessions can default on only after the app-issued proof broker exists; outside-Warp control for external terminals, scripts, IDEs, launch agents, and other same-user processes defaults off.
+- In the current foundation slice, only outside-Warp enablement and permissions are implemented. Inside-Warp credential requests must be rejected and inside-Warp settings must not be exposed in the UI.
+- In the long-term model, both controls live under a new top-level Settings pane page named **Scripting**.
+- The authoritative enablement states are local-only, not Settings Sync'd, and stored in protected local storage rather than ordinary user-editable settings.
+- The current foundation branch must mark all implemented outside-Warp local-control settings as `private: true` and `sync_to_cloud: SyncToCloud::Never`. They must not appear in the user-visible `settings.toml` file, generated settings schema, Settings Sync, Warp Drive, server-backed preferences, or any future `warpctrl settings` surface.
+- `warpctrl`, direct protocol requests, shell scripts, config files, registry/plist edits, defaults writes, and server-backed preferences must not be able to enable either setting.
+- Discovery records do not publish actionable endpoints or credential references for disabled outside-Warp control.
+- Credential issuance is unavailable when the request's invocation context is disabled.
+- Raw credential material is kept out of plaintext discovery records and stored in platform secure storage where available.
+- The broker distinguishes verified Warp-terminal invocations from external invocations using an app-issued execution-context proof, not a caller-declared label. Until that broker exists, `InsideWarp` is a reserved protocol concept that must not receive credentials.
+- External invocations default to a smaller logged-out-safe action set that does not touch user-authenticated data.
+- Verified Warp-terminal invocations may receive authenticated-user grants only when the selected app has a true logged-in Warp user and local-control settings allow authenticated-user actions from Warp terminals.
+- The app rejects disabled, unauthenticated, expired, revoked, insufficient-scope, unsupported, malformed, ambiguous, missing-target, and stale-target requests with structured errors.
+- Every action has a documented state/data category and the app bridge enforces the required permission category locally before selector resolution or handler dispatch.
+- Every action has a documented `requires_authenticated_user` value and allowed execution contexts. New actions default to requiring an authenticated user unless explicitly reviewed as logged-out-safe.
+- Granular local-control settings under Settings > Scripting gate the maximum grants for metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, underlying data mutations, authenticated-user actions from Warp terminals, and authenticated-user actions from external clients.
+- Permission categories are treated as user-intent and accident-prevention guardrails, not as strong same-user malicious-app isolation.
+- Remote control remains out of scope for the local same-machine credential model.
+The first implementation slice should include the protected enablement gate, credential issuance checks, and app-side permission-category enforcement even if the only mutating action initially implemented is `tab.create`. Shipping `tab.create` without the enablement and validation architecture would create the wrong foundation for the full catalog.
+### 1. Protocol crate and stable envelope
+Create a small shared protocol crate or equivalent shared module used by both the app server and standalone CLI client. It should define:
+- Protocol version metadata.
+- Discovery/health response types.
+- Execution-context proof/request types for verified Warp-terminal invocations versus external invocations.
+- Action metadata describing state/data category, required permission grant, `requires_authenticated_user`, allowed execution contexts, and target families.
+- Selector types:
+  - `InstanceSelector`
+  - `WindowSelector`
+  - `TabSelector`
+  - `PaneSelector`
+  - `SessionSelector`
+  - `BlockSelector`
+  - `FileSelector`
+  - `DriveObjectSelector`
+- Opaque protocol-facing ID newtypes for instance/window/tab/pane/session identifiers.
+- Allowlisted `ControlAction` variants and typed parameter payloads.
+- Success/error envelopes with stable machine-readable error codes.
+The protocol should treat target IDs as opaque. The app may encode existing runtime identifiers internally, but the public wire contract should not require callers to understand `EntityId`, `PaneId`, or other implementation types.
+Recommended selector variants:
+- `InstanceSelector`: `Active`, `Id(InstanceId)`, `Pid(u32)`.
+- `WindowSelector`: `Active`, `Id(WindowId)`, `Index(u32)`, `Title(String)`.
+- `TabSelector`: `Active`, `Id(TabId)`, `Index(u32)`, `Title(String)`.
+- `PaneSelector`: `Active`, `Id(PaneId)`, `Index(u32)`.
+- `SessionSelector`: `Active`, `Id(SessionId)`, `Index(u32)`.
+- `BlockSelector`: `Id(BlockId)`.
+- `FileSelector`: `Path { path, line, column }`.
+- `DriveObjectSelector`: `Id(DriveObjectId)` or `Lookup { object_type, name_or_path }`.
+Index selectors are resolved only within their parent selector context, so tab index resolution requires a resolved window and pane/session index resolution requires a resolved tab or pane. Title and name/path lookup selectors are ergonomic helpers for interactive use and must fail on ambiguity rather than choosing the first match.
+Recommended top-level request shape for `tab.create`:
+```json
+{
+  "protocol_version": 1,
+  "request_id": "client-generated-id",
+  "action": "tab.create",
+  "target": {
+    "window": "active"
+  },
+  "params": {}
+}
+```
+Recommended response shape:
+```json
+{
+  "ok": true,
+  "protocol_version": 1,
+  "request_id": "client-generated-id",
+  "instance_id": "opaque-instance-id",
+  "resolved_target": {
+    "window_id": "opaque-window-id",
+    "tab_id": "opaque-tab-id"
+  },
+  "result": {}
+}
+```
+Error payloads should include stable codes defined in `SECURITY.md`, including `local_control_disabled`, `unauthorized_local_client`, `insufficient_permissions`, `authenticated_user_required`, `authenticated_user_unavailable`, `execution_context_not_allowed`, `ambiguous_instance`, `ambiguous_target`, `stale_target`, `invalid_selector`, `unsupported_action`, `not_allowlisted`, `invalid_params`, `target_state_conflict`, `missing_target`, and `no_instance`.
+### 2. Per-process discovery instead of fixed-port-only routing
+Keep the existing fixed-port HTTP behavior intact for installation detection/profiling compatibility. Add a separate local-control listener that follows the same native Axum/Tokio pattern but supports multiple local Warp app processes.
+Recommended design:
+- Each participating Warp process creates a random opaque `instance_id` at startup.
+- Each process binds a loopback control listener on an ephemeral port or an app-managed available port.
+- Each process writes a discovery record into a secure per-user Warp state directory. The record should contain:
+  - `instance_id`
+  - PID
+  - channel/build metadata
+  - control-listener endpoint
+  - protocol version
+  - start timestamp
+  - credential metadata or secure-storage references only when the relevant inside-Warp or outside-Warp context is enabled
+- The CLI loads discovery records, removes or ignores stale records after health checks, and chooses an instance using the product selector rules.
+- `warpctrl instance list` is a CLI-first projection of this discovery registry plus health responses.
+When outside-Warp control is disabled, discovery must follow `SECURITY.md`: either publish no actionable local-control record for external clients or publish only a minimal disabled-status record with no endpoint authority or credential reference.
+This design preserves the current `9277` behavior while avoiding cross-process port contention for the new control API.
+### 3. Local authentication, enablement, and safety boundary
+Mutating localhost routes should not copy the permissive CORS posture of `/install_detection`.
+Recommended local trust model:
+- No browser-readable CORS allowance on control endpoints.
+- The relevant implemented Scripting setting must allow the request context before credentials are minted or sensitive control requests are accepted. In the current foundation branch that means outside-Warp only; future inside-Warp support must add its own verified setting gate.
+- The authoritative enablement bit must live in protected local storage and must not be writable by `warpctrl` or ordinary same-user preference/config edits.
+- Per-instance raw credential material must be kept out of plaintext discovery records and stored in platform secure storage where practical.
+- The CLI may load or request scoped credentials through an app-owned broker/helper, but it must not mint authority itself.
+- The broker verifies whether the invocation originated from a Warp-managed terminal session before issuing in-Warp-only grants.
+- The broker issues authenticated-user grants only when the selected app has a true logged-in Warp user and the relevant local-control permission is enabled.
+- The app rejects disabled-state, missing, malformed, invalid, expired, or revoked credentials before selector resolution or mutation.
+- The app maps every action to a state/data category and rejects insufficient grants before selector resolution or mutation.
+- The app maps every action to a `requires_authenticated_user` value and allowed execution contexts, rejecting mismatches before selector resolution or mutation.
+- Health metadata exposed without credentials, if needed for stale-record pruning, must not reveal mutating capabilities, credentials, or sensitive target state.
+This keeps the protocol local and scriptable without creating an ambient browser-to-localhost control surface.
+Do not ship the first slice as a plaintext discovery bearer token, even for same-user human CLI use. The first slice is the foundation for underlying data reads, app-state mutations, metadata/configuration mutations, and underlying data mutations, so it must establish the protected enablement, credential storage, scoped grant, and app-side enforcement model from `SECURITY.md`.
+### 4. Future verified Warp-terminal invocation context
+The current foundation branch does not implement verified inside-Warp invocation. `InvocationContext::InsideWarp` and `ExecutionContextProof::VerifiedWarpTerminal` may remain in the shared protocol as reserved future concepts, but the credential broker must reject them until the proof broker described here exists.
+Minimum implementable design:
+- When Warp creates or Warpifies a terminal session, the app creates a high-entropy per-session capability and records verifier state in an app-owned terminal-session registry.
+- The registry entry is bound to the selected app instance, terminal/session identifier, issuing process generation, expiry, and revocation state.
+- The shell receives only proof material needed by `warpctrl`, such as an opaque handle plus a short-lived token or challenge-response input. Plain environment variables may carry handles or hints, but a caller-set variable must not be sufficient authority.
+- `warpctrl` invoked from that terminal sends `InvocationContext::InsideWarp` and `ExecutionContextProof::VerifiedWarpTerminal` to `/v1/control/credentials` when it has proof material. Without proof material it must use `OutsideWarp`.
+- The broker verifies the proof against the app-owned registry, including app instance, session liveness, expiry, revocation, and nonce or challenge binding before minting any inside-Warp scoped credential.
+- The broker then checks Settings > Scripting and permission-category policy for the requested action. A valid proof raises the maximum eligible grant set; it does not bypass user settings, action metadata, authenticated-user requirements, target scopes, or bridge enforcement.
+- The minted credential records `invocation_context: InsideWarp`, the granted permission category, expiry, instance, and any authenticated-user subject. The app bridge revalidates the grant and current app policy on every control request.
+Hardened follow-ups can strengthen this minimum design by storing secret material in platform secure storage, exposing only opaque handles through the shell, using Unix-domain-socket or named-pipe peer-credential checks, binding proofs to broker challenges, and invalidating proofs on shell/session teardown, app logout, user switch, or Settings > Scripting changes. These hardening layers improve direct-token theft resistance, but they do not create a perfect security boundary against malicious same-user software with process, filesystem, Accessibility, or screen-observation access.
+### 5. Authenticated scripting identity and API-key grants
+The full control catalog includes Warp Drive data mutation and execution-underlying actions. Those actions require an authenticated scripting layer in addition to local-control credentials. Local-control credentials prove authority to call the local app; authenticated scripting credentials prove the Warp user or automation identity allowed to request user-backed or high-risk actions.
+#### Inside-Warp authenticated scripting
+For `warpctrl` launched inside a Warp-managed terminal, use the verified terminal proof broker from the previous section. When the proof is valid and the selected app is logged into Warp, the broker may mint an authenticated-user grant bound to the app's current user subject. The grant is available only if Settings > Scripting enables authenticated-user actions for verified Warp terminals and the requested action's permission category is enabled.
+The CLI must not receive raw Firebase, OAuth, server, or session tokens. The app bridge executes authenticated actions through the selected app's existing auth state and rejects the grant if the app logs out, switches users, or the grant subject no longer matches the app user.
+#### External API-key authenticated scripting
+For `warpctrl` launched outside Warp, by cron, or by another pure scripting environment, introduce a separate API-key path. The user creates or supplies a Warp-issued scripting API key with explicit scopes such as local-control authenticated reads, Drive mutation, or execution-underlying actions. The CLI may reference the key from a secret manager or environment variable such as `WARPCTRL_API_KEY`, or store it in platform secure storage through `warpctrl auth api-key set --key-stdin`; it must never print or write the raw key to discovery records, logs, JSON output, shell completions, or repo config.
+The local broker exchanges or validates the API key with Warp services, obtains a short-lived signed identity assertion, and mints a local authenticated-user grant only when all of the following hold:
+- outside-Warp scripting is enabled;
+- external authenticated-user grants are enabled separately from logged-out outside-Warp control;
+- the API key is valid, unexpired, unrevoked, and scoped for the requested permission category and action family;
+- the selected app is logged into the same Warp user subject, or the action is explicitly designed to use API-key-backed identity without exporting app cloud tokens;
+- the requested local-control permission category is enabled;
+- any resource or target restrictions in the key and grant are satisfied.
+The grant should record the API-key subject, scopes, credential ID, expiry, invocation context, permission category, and optional target/resource restrictions. The app bridge revalidates the grant before selector resolution and handler dispatch.
+#### Auth command surface and storage
+Add CLI and broker support for:
+- `warpctrl auth status [selectors]` to report selected app login state, configured API-key subject metadata, and available authenticated grant modes without exposing secrets.
+- `warpctrl auth login [selectors]` to focus the selected app's normal sign-in UI for interactive app login.
+- `warpctrl auth api-key set --key-env <env_var>|--key-stdin [selectors]` to store or reference an external scripting key.
+- `warpctrl auth api-key status [selectors]` to show key subject/scope metadata.
+- `warpctrl auth api-key revoke [selectors]` to delete the local reference and revoke the server-side key where supported.
+Store raw API keys only in platform secure storage where available. Environment-variable use is allowed for non-interactive automation, but commands and docs should prefer secret-manager injection over plaintext shell profiles.
+### 6. App-side request bridge onto the UI/application context
+The HTTP handler runs on a Tokio runtime thread owned by the local-control server. It cannot directly access or mutate Warp's UI models, views, or app context because all WarpUI state is single-threaded and owned by the main app event loop. The bridge solves this by sending a closure from the Tokio handler thread to the main thread, executing it in the model's context, and returning the result to the waiting HTTP handler.
+#### Thread model
+- **Tokio runtime thread (HTTP handler):** Owns the Axum router, receives HTTP requests, authenticates, deserializes the `RequestEnvelope`. Cannot touch `AppContext`, views, or models.
+- **Main app thread:** Owns all WarpUI entities (`App`, `AppContext`, views, models). All UI state reads and mutations must happen here.
+- **Bridge:** Transfers a typed closure from the Tokio thread to the main thread, executes it with `&mut ModelContext`, and sends the return value back.
+#### Implementation: `ModelSpawner`
+The bridge uses WarpUI's `ModelSpawner<T>` mechanism, which is the standard way for background threads to schedule work on a model's main-thread context:
+1. During app initialization, a `LocalControlBridge` singleton model is created. The model's `ModelContext::spawner()` method returns a `ModelSpawner<LocalControlBridge>` — a cloneable, `Send` handle that can enqueue closures from any thread.
+2. The `ModelSpawner` is stored in the Axum router's shared state (`ControlServerState`), making it available to every HTTP handler.
+3. When an HTTP request arrives, the handler calls `spawner.spawn(|bridge, ctx| { ... }).await`:
+   - `spawn` sends a boxed `FnOnce(&mut LocalControlBridge, &mut ModelContext<LocalControlBridge>) -> R` closure through an `async_channel` to the main thread's task-callback loop.
+   - The main thread dequeues the closure, constructs a fresh `ModelContext` for the bridge model, and calls the closure.
+   - Inside the closure, the bridge has full access to `ModelContext`, which derefs to `AppContext`. This means it can call `ctx.windows()`, `ctx.views_of_type::<Workspace>(window_id)`, `workspace.update(ctx, ...)`, and any other main-thread API.
+   - The closure returns a typed result (e.g., `ResponseEnvelope`), which is sent back to the Tokio thread via a `oneshot` channel.
+4. The HTTP handler awaits the oneshot result and serializes it as the HTTP response.
+#### Concrete flow for `tab.create`
+```
+HTTP handler (Tokio thread)
+  │
+  ├─ verify inside-Warp or outside-Warp context is enabled
+  ├─ verify credential, execution context, safety grant, and authenticated-user grant
+  ├─ deserialize RequestEnvelope
+  ├─ call bridge_spawner.spawn(move |bridge, ctx| {
+  │      bridge.handle_request(request, ctx)  // runs on main thread
+  │  }).await
+  │
+  └─ serialize ResponseEnvelope as JSON
+
+LocalControlBridge::handle_request (main thread)
+  │
+  ├─ verify protected context-specific enablement state is still enabled
+  ├─ map action to required permission category
+  ├─ map action to authenticated-user and execution-context requirements
+  ├─ verify presented credential grants that category, target family, execution context, and authenticated-user access
+  ├─ match request.action.kind
+  │   └─ ActionKind::TabCreate
+  │       ├─ validate_tab_create_target(&request.target)
+  │       ├─ ctx.windows().active_window()
+  │       │   └─ if none: return invalid_selector / missing_target
+  │       ├─ ctx.views_of_type::<Workspace>(window_id)
+  │       └─ workspace.update(ctx, |workspace, ctx| {
+  │             workspace.handle_action(
+  │                 &WorkspaceAction::AddTerminalTab { hide_homepage: false },
+  │                 ctx,
+  │             )
+  │           })
+  │
+  └─ return ResponseEnvelope::ok(request_id, json!({ ... }))
+```
+#### Why this pattern
+- **Thread safety.** WarpUI's entity/view system is not `Send` or `Sync`. The only safe way to interact with it from a background thread is through `ModelSpawner`, which serializes access through the main event loop.
+- **Synchronous result.** Unlike fire-and-forget patterns (e.g., URI intent dispatch in `app/src/uri/mod.rs`), the `spawn` call returns a concrete `Result<R, ModelDropped>`, so the HTTP handler can produce a structured success or error response.
+- **Reuses existing infrastructure.** `ModelSpawner` is already used throughout the codebase for background-to-main-thread communication (e.g., async file I/O results, network responses). No new concurrency primitive is needed.
+- **Action dispatch reuses existing app behavior.** The bridge calls `workspace.handle_action(&WorkspaceAction::AddTerminalTab { ... }, ctx)` — the exact same method the UI keybinding system uses. This ensures the control CLI produces identical behavior to the corresponding user action, including side effects like tab count updates, focus changes, and event emissions.
+- **Deterministic targeting.** The bridge must not silently fall back from the active window to an arbitrary ordered window for mutating actions. If the caller relies on the default active selector and no active window exists, return a structured missing-target or invalid-selector error. If future command forms allow explicit window IDs, resolve the explicit ID exactly or return `stale_target`.
+#### Adding new action handlers
+To add a new action to the bridge:
+1. Add a variant to `ActionKind` in `crates/local_control/src/protocol.rs`.
+2. Document its `SECURITY.md` state/data category, required permission grant, `requires_authenticated_user` value, and allowed execution contexts.
+3. Add a match arm in `LocalControlBridge::handle_request` in `app/src/local_control/mod.rs`.
+4. Before selector resolution or dispatch, verify local control is enabled and the presented credential grants the action category, target family, execution context, and authenticated-user access if required.
+5. Inside the match arm, use `ctx` (which is a `&mut ModelContext<LocalControlBridge>` that derefs to `&mut AppContext`) to resolve selectors and dispatch the action onto existing app types.
+6. Return a `ResponseEnvelope::ok(...)` or `ResponseEnvelope::error(...)` with the result.
+The bridge closure has access to the full `AppContext` API surface, including `ctx.windows()`, `ctx.window_ids()`, `ctx.views_of_type::<T>(window_id)`, `handle.update(ctx, ...)`, and `handle.read(ctx, ...)`. This makes it straightforward to wire new actions to existing UI behavior without introducing new concurrency concerns.
+### 7. Target resolution model
+Implement target resolution as a reusable component rather than scattering lookup logic across handlers.
+Recommended resolution order:
+1. Select instance in the CLI/discovery layer.
+2. Resolve window inside the target process.
+3. Resolve tab within the window.
+4. Resolve pane within the tab/pane-group context.
+5. Resolve session only for session-scoped commands.
+6. Resolve block/file/Drive selectors only for commands whose action metadata declares that target family.
+Selector behavior:
+- `active` resolves from current app focus/selection state.
+- Explicit opaque IDs must resolve exactly or return `stale_target`.
+- Index selectors are allowed only for user-visible indexed concepts and should resolve to a concrete opaque ID before execution.
+- Title, name, and path selectors are convenience selectors. They must be exact by default, document any future fuzzy behavior explicitly, and return `ambiguous_target` when more than one target matches.
+- A session-scoped request against a non-terminal pane returns `target_state_conflict`.
+Target resolution must happen after protected enablement, authentication, and safety-grant checks. This prevents denied requests from learning more target state than necessary and keeps enforcement centralized.
+Implementation references:
+- Window-level active selection already exists inside the app through `WindowManager`.
+- Pane scoping can build on the conceptual model of `PaneViewLocator` in `app/src/workspace/util.rs (12-18)`.
+- Existing URI intent routing in `app/src/uri/mod.rs (895-1093)` shows how to locate workspaces/windows and avoid silently acting in the wrong place.
+#### CLI selector grammar
+`crates/warp_cli/src/local_control.rs` should expose a shared selector argument group that is flattened into every command that accepts app targets. The parser must support:
+- Instance selectors: `--instance <instance_id>` and `--pid <pid>`, with clap conflicts.
+- Window selectors: `--window <active|id:<id>|index:<n>|title:<title>>`, `--window-id <id>`, `--window-index <n>`, and `--window-title <title>`, with one form allowed.
+- Tab selectors: `--tab <active|id:<id>|index:<n>|title:<title>>`, `--tab-id <id>`, `--tab-index <n>`, and `--tab-title <title>`, with one form allowed.
+- Pane selectors: `--pane <active|id:<id>|index:<n>>`, `--pane-id <id>`, and `--pane-index <n>`, with one form allowed.
+- Session selectors: `--session <active|id:<id>|index:<n>>`, `--session-id <id>`, and `--session-index <n>`, with one form allowed.
+- Block/file/Drive selectors only on commands that need them: `--block-id <id>`, path arguments or `--path <path>` plus `--line`/`--column`, and Drive object ID arguments or `--drive-id <id>`.
+The CLI converts these flags into the protocol `TargetSelector` before sending the request. It must not rely on positional entity IDs for commands like `window close 1`; target entities are selected through the shared selector flags so command arguments remain reserved for action parameters.
+### 8. Allowlisted handler families
+Use one handler module per action family. The protocol layer owns parsing/validation; handler modules own target resolution and delegation to existing app logic.
+Recommended modules/families:
+- Discovery/state:
+  - instances, version, active chain, windows/tabs/panes/sessions listings.
+- Window/tab:
+  - new, focus, close, activate, move, rename, color, close variants.
+- Pane:
+  - split, focus, navigate, close, maximize, resize.
+- Input/session:
+  - insert, replace, clear, run command, cycle session, mode switch where supported.
+- Appearance/settings:
+  - theme list/set, system-theme controls, font/zoom actions, allowlisted settings reads/writes/toggles.
+- Panels/surfaces:
+  - settings/page/search, palettes, left/right panels, Drive, resource center, code review, vertical tabs, AI assistant.
+- Files/projects:
+  - app-state-only path opening, project opening, and metadata reads for files already open in Warp. File content reads and filesystem-content mutations are intentionally excluded from the public `warpctrl` catalog.
+- Warp Drive:
+  - object listing/inspection/opening, object creation/update/delete/insert, opening the share dialog, the v0 personal-to-team share mutation, and typed workflow execution where supported.
+Do not use a generic “dispatch action by string” endpoint. Every handler should be reachable only through an explicit `ControlAction` variant.
+#### WarpCtrlBehavior review gate
+The public `ControlAction` catalog remains the source of truth for the wire protocol, CLI parser, permission metadata, generated documentation, and app bridge handlers. Internal app actions such as `WorkspaceAction`, `TerminalAction`, `PaneGroupAction`, settings actions, and future user-visible action enums must not become the public protocol directly because they can contain transient view locators, indices, debug-only variants, implementation-specific payloads, and unstable internal semantics.
+To prevent drift between user-visible Warp behavior and the `warpctrl` catalog, every user-visible app action enum should implement a `WarpCtrlBehavior` review mapping. The mapping is a code-level forcing function, not an automatic exposure mechanism. It answers whether each internal app action is:
+- `Exposed` through a specific public `ControlAction` kind.
+- `CoveredBy` an existing public `ControlAction` kind because several internal actions map to one stable CLI behavior.
+- `Excluded` with an explicit reason such as debug-only, unsafe/privileged, internal implementation detail, not user-visible, no deterministic targeting model, no stable public semantics, or prohibited in the initial public version.
+- `Deferred` with an explicit reason and tracking issue when the action might belong in `warpctrl` later but needs additional product, security, selector, or protocol design.
+`WarpCtrlBehavior` implementations must use exhaustive matches without wildcard arms. Adding a new variant to a reviewed action enum should fail compilation until the developer or agent deliberately classifies its relationship to `warpctrl`. This mirrors the existing exhaustive-action-review style used by app-state saving decisions and makes “should this exist in Warp Control?” part of the ordinary code path for adding new user-visible actions.
+Recommended shape:
+- Define a shared `WarpCtrlBehavior` trait in the local-control integration layer or another app-visible module that does not force the core `warpui::Action` blanket implementation to change.
+- Define review enums such as `WarpCtrlActionReview`, `WarpCtrlExclusionReason`, and `WarpCtrlDeferredReason`.
+- Implement `WarpCtrlBehavior` for the major user-visible action enums, starting with `WorkspaceAction` and `TerminalAction`.
+- Keep the mapping one-way from internal behavior to public catalog metadata. `WarpCtrlBehavior::Exposed(ControlActionKind::TabCreate)` means the action is represented by the public `tab.create` command; it does not mean raw `WorkspaceAction::AddTerminalTab` is serializable or dispatchable over the protocol.
+- Add tests that collect reviewed action kinds and verify every `ControlActionKind` has protocol metadata, permission metadata, CLI parser coverage, generated-doc coverage, and an app-side handler before it can be advertised as supported.
+The `warpui::Action` trait should not be extended for this purpose because it currently has a blanket implementation for any `Any + Debug + Send + Sync` type. The enforcement point is the concrete user-visible action enums and binding/action registration surfaces, where exhaustive review can be required without weakening the allowlisted protocol boundary.
+### 9. First slice: prove discovery and `tab.create`
+The first `warpctrl` implementation slice should land the minimum cross-cutting architecture plus a single representative tab mutation:
+- Shared protocol types and error envelopes.
+- `FeatureFlag::WarpControlCli` and Cargo feature `warp_control_cli`, with app-side runtime gating for settings, discovery, bridge registration, and local-control endpoints.
+- New top-level Settings > Scripting page rendered only while `FeatureFlag::WarpControlCli` is enabled. The current foundation exposes outside-Warp local-control settings only; verified inside-Warp controls are deferred until the proof broker exists.
+- Protected local-only enablement storage where outside-Warp control defaults off. Future inside-Warp enablement must use the same protected-storage class before it is exposed.
+- As an interim foundation step, the outside-Warp top-level enablement and granular permission bits live in the typed `LocalControlSettings` group as private settings with `SyncToCloud::Never`, explicit private storage keys, and no `toml_path`. This keeps them out of the user-visible settings file and generated settings schema while leaving the protected-storage migration as a required pre-ship hardening step.
+- Granular outside-Warp local-control permission storage under Settings > Scripting for metadata reads, underlying data reads, app-state mutations, metadata/configuration mutations, and underlying data mutations. Future inside-Warp permissions should be added only with verified terminal proof support.
+- Discovery registry and CLI instance selection.
+- A standalone `warpctrl` binary or artifact path that runs control commands without starting the GUI app runtime.
+- Per-process authenticated local-control server that refuses sensitive work when outside-Warp control is disabled and rejects inside-Warp credential requests until verified terminal proof support is implemented.
+- Scoped credential issuance/storage with no raw credentials in plaintext discovery records, including execution-context fields and authenticated-user grant fields.
+- App-side request bridge and selector resolver.
+- Action-category mapping and app-side safety-grant enforcement.
+- Action metadata for `tab.create` that deliberately classifies it as a logged-out-safe app-state mutation only when the user's granular local-control settings allow app-state mutation.
+- Read-only `ping/version` plus `warpctrl instance list` or equivalent minimal discovery command.
+- End-to-end `warpctrl tab create` for the selected instance, reusing the same app behavior as the user-visible new-terminal-tab action.
+Why `tab.create` first:
+- It proves a UI/layout action can be targeted and executed against live app state.
+- It exercises process discovery, local authentication, request bridging, selector defaults, app-context dispatch, and structured success/error output without introducing higher-risk terminal input execution.
+- It exercises the protected enablement and scoped-grant model before higher-risk action families depend on it.
+- It gives operators a concise end-to-end smoke test: discover a running instance, create a tab, and confirm the live app changed.
+The PR should also introduce the shell-facing CLI command grammar that the remainder of the protocol will reuse and establish a lightweight CLI startup path distinct from GUI startup.
+### 10. Follow-up slices: fill out the remaining protocol in parallel
+After the first slice validates discovery, auth, selector resolution, CLI syntax, and server-to-app execution, follow-up slices can add the remaining allowlisted catalog in parallelized action-family groups. The baseline code should make new action additions mostly additive:
+- Extend `ControlAction`.
+- Update the relevant `WarpCtrlBehavior` mappings for the internal app actions that implement, overlap with, exclude, or defer the behavior.
+- Add typed params/results.
+- Add a handler.
+- Add validation/tests.
+- Add CLI surface/tests.
+### 11. CLI parsing and output libraries
+The `warpctrl` CLI must use the same argument parsing and output libraries as the existing Oz CLI so that conventions, derive patterns, and shell-completion generation remain consistent across both binaries.
+- **clap** (with the `derive` feature) for argument parsing, subcommand trees, and help generation. Both binaries share the `warp_cli` crate, so parser types defined there are reused directly.
+- **serde** / **serde_json** for JSON request/response serialization and for `--output-format json` output.
+- **clap_complete** for shell completion generation, reusing the same infrastructure the Oz CLI uses.
+- The `OutputFormat` enum (`Pretty`, `Json`, `Ndjson`, `Text`) is shared from `warp_cli::agent::OutputFormat` so human-readable vs. machine-readable output follows the same conventions.
+- New subcommand types for `warpctrl` live in `warp_cli::local_control` and follow the same `#[derive(Parser)]` / `#[derive(Subcommand)]` / `#[derive(Args)]` patterns used by the Oz CLI's top-level `Args` and `CliCommand` types.
+Do not introduce alternative parsing libraries (e.g., `structopt`, `argh`) or alternative serialization approaches. Keeping one set of libraries across both CLIs reduces dependency weight, ensures consistent `--help` formatting, and lets contributors move between the two surfaces without learning a different stack.
+### 12. CLI packaging and release shape
+The shipped product shape should be a separate bundled `warpctrl` CLI binary that reuses shared CLI/protocol crates but does not depend on launching the GUI binary in command mode. Follow the Oz CLI release model as closely as practical:
+- macOS:
+  - Add a standalone control CLI artifact path next to the existing Oz standalone CLI artifact flow.
+  - If the app bundle also exposes a wrapper/install flow, keep channelized naming consistent with the final product name decision.
+- Linux:
+  - Extend bundle/release scripts to emit control CLI standalone artifacts and packages in the same broad pattern as the current Oz CLI tarball/deb/rpm/Arch package flow.
+- Windows:
+  - Mirror the existing installer-generated helper-wrapper pattern first if that remains the canonical Oz behavior on Windows.
+  - If the product decision is to ship a true standalone Windows control CLI binary, add a dedicated release path in follow-up work rather than silently diverging from existing Oz precedent.
+Startup and dependency expectations:
+- The CLI process should initialize only command parsing, discovery, authentication material loading, protocol serialization, HTTP transport, and output formatting needed for the requested command.
+- The CLI should not initialize GUI state, rendering, terminal session models, app workspaces, or other main-app-only subsystems.
+- Startup cost should be treated as part of the product contract because control commands are expected to compose naturally in scripts and repeated interactive shell usage.
+Naming decision:
+- Product examples use provisional `warpctrl ...` command lines for the standalone local-control binary.
+- Final artifact filenames, channelized aliases, and installer exposure should be chosen before broad rollout to avoid churn in bundle scripts, docs, shell completions, and release workflow files.
+## Implementation Plan
+### Branch stack
+Use raw git for the stack; do not use Graphite for these branches.
+The durable review stack should optimize for reviewability rather than mirroring only broad product phases. The bottom review branch now combines specs and the shared foundation so reviewers can see the product/security contract next to the protocol, settings, bridge, and CLI scaffolding that enforce it. The intended stack is:
+1. `zach/warp-cli-core-foundation` — create this branch from `master`. It owns the specs in `specs/warp-control-cli/PRODUCT.md`, `TECH.md`, `SECURITY.md`, and supporting docs, plus the shared implementation foundation: protocol crate shape, discovery/auth scaffolding, selector and error types, action metadata/catalog structure, Scripting settings surface, protected local-control settings, local-control server/bridge skeleton, standalone `warpctrl` binary skeleton, packaging hooks, module split, `WarpCtrlBehavior` scaffolding, and the minimum `tab.create` smoke path if needed to prove the end-to-end architecture.
+2. `zach/warp-cli-readonly-metadata` — create this branch from `zach/warp-cli-core-foundation`. It implements structural metadata reads: instance/app health and active-chain commands, windows, tabs, panes, sessions, capability/action metadata, opaque IDs, metadata target shapes, and metadata-read permission enforcement. It must not expose terminal output, input buffers, history, Drive object contents, or other underlying user data.
+3. `zach/warp-cli-readonly-data-settings` — create this branch from `zach/warp-cli-readonly-metadata`. It implements underlying-data reads and read-only settings/appearance/docs: block listing/inspection/output, input-buffer reads, history reads, theme/settings/keybinding/action reads, project/file app-state reads, authenticated Drive metadata/content reads where present, read-only docs, and the read-only `warpctrl` Agent skill.
+4. `zach/warp-cli-authenticated-scripting` — create this branch from `zach/warp-cli-readonly-data-settings`. It implements authenticated-user grant plumbing, the verified Warp-terminal proof broker, external API-key scripting identity, auth command surface, Settings > Scripting controls for authenticated grants, and tests proving high-risk actions cannot run without authenticated grants. It should not implement broad new action families by itself.
+5. `zach/warp-cli-mutating-layout` — create this branch from `zach/warp-cli-authenticated-scripting`. It implements layout and app-state mutations for app/window/tab/pane behavior: window create/focus/close, tab create/activate/move/close, tab metadata that belongs with layout review if appropriate, pane split/focus/navigate/resize/maximize/close, app-state mutation permission checks, and layout mutation tests.
+6. `zach/warp-cli-mutating-input-settings-surfaces` — create this branch from `zach/warp-cli-mutating-layout`. It implements session activation/cycling/reopen, input insert/replace/clear, input mode switching, theme/system-theme/font/zoom changes, allowlisted setting set/toggle, settings/palette/search/panel/surface commands, file/project/Drive open commands that are app-state-only, mutating docs, and the mutating-command Agent skill updates. It must preserve the prohibition on accepted-command submission and agent-prompt submission.
+7. `zach/warp-cli-mutating-drive-data` — create this branch from `zach/warp-cli-mutating-input-settings-surfaces`. It implements authenticated underlying-data mutations for Warp Drive objects: typed Drive object create/update/delete/insert, the v0 personal-to-team sharing path, permission enforcement, authenticated-user/API-key enforcement, and tests using disposable resources. It must not implement local file content reads, writes, appends, deletes, or other filesystem-content mutations.
+8. `zach/warp-cli-mutating-execution-underlying` — create this branch from `zach/warp-cli-mutating-drive-data`. It implements authenticated execution-underlying actions such as `input.run` and typed workflow execution where supported. It must require underlying-data-mutation permission plus authenticated scripting identity, audit records, explicit target resolution, and tests proving accepted-command submission and agent-prompt submission remain unavailable.
+The previous `zach/warp-cli-specs` branch is retained only as migration-source/history material. It is no longer a separate review PR or an authoritative branch in the active stack.
+The goal is to keep durable review branches close to roughly 2,000 lines of incremental changes where practical while avoiding a one-branch-per-command maintenance burden. Product phases still matter, but they are not the primary PR boundary. The durable branches are the review spine; short-lived shard branches can feed into them during implementation.
+Spec changes are an important part of the stacking strategy. All new spec changes must originate on `zach/warp-cli-core-foundation`, which is the authoritative source for `specs/warp-control-cli/PRODUCT.md`, `TECH.md`, `SECURITY.md`, and supporting docs. After a spec change lands there, propagate it upward through every stacked branch with raw git so the spec files stay synchronized across `zach/warp-cli-readonly-metadata`, `zach/warp-cli-readonly-data-settings`, `zach/warp-cli-authenticated-scripting`, `zach/warp-cli-mutating-layout`, `zach/warp-cli-mutating-input-settings-surfaces`, `zach/warp-cli-mutating-drive-data`, and `zach/warp-cli-mutating-execution-underlying`. Do not make independent spec edits directly on higher implementation branches except as part of resolving a propagation conflict in a way that preserves the authoritative bottom-branch content.
+Recommended raw-git setup after `zach/warp-cli-core-foundation` is ready:
+```bash
+git fetch origin
+git checkout -b zach/warp-cli-core-foundation origin/master
+git checkout -b zach/warp-cli-readonly-metadata
+git checkout -b zach/warp-cli-readonly-data-settings
+git checkout -b zach/warp-cli-authenticated-scripting
+git checkout -b zach/warp-cli-mutating-layout
+git checkout -b zach/warp-cli-mutating-input-settings-surfaces
+git checkout -b zach/warp-cli-mutating-drive-data
+git checkout -b zach/warp-cli-mutating-execution-underlying
+```
+If a lower branch changes after higher branches exist, rebase each higher branch onto its immediate lower branch with raw git and resolve conflicts by preserving both the lower branch's stable API/permission model and the higher branch's owned behavior.
+### Migrating from the earlier four-branch stack
+The earlier four-branch stack (`zach/warp-cli-specs`, `zach/warp-cli`, `zach/warp-cli-readonly`, `zach/warp-cli-read-write`) should be treated as source material for the expanded eight-PR review stack, not as the final review structure.
+Recommended migration:
+1. Create backup refs before rewriting or replacing anything:
+   - `backup/warp-cli-specs` from `zach/warp-cli-specs`.
+   - `backup/warp-cli` from `zach/warp-cli`.
+   - `backup/warp-cli-readonly` from `zach/warp-cli-readonly`.
+   - `backup/warp-cli-read-write` from `zach/warp-cli-read-write`.
+2. Create `zach/warp-cli-core-foundation` from latest `origin/master` and bring over both the specs from `zach/warp-cli-specs` and only the foundation pieces from `zach/warp-cli`. Prefer path-level checkout followed by selective editing or `git add -p`; do not preserve every old commit if that makes review boundaries worse.
+3. Create `zach/warp-cli-readonly-metadata` from `zach/warp-cli-core-foundation` and bring over only metadata-read pieces from `zach/warp-cli-readonly`.
+4. Create `zach/warp-cli-readonly-data-settings` from `zach/warp-cli-readonly-metadata` and bring over the remaining read-only underlying-data, settings, docs, and skill pieces from `zach/warp-cli-readonly`.
+5. Create `zach/warp-cli-authenticated-scripting` from `zach/warp-cli-readonly-data-settings` and bring over or implement the verified terminal proof broker, external API-key scripting identity, authenticated-user grant plumbing, auth command surface, and related Settings > Scripting controls.
+6. Create `zach/warp-cli-mutating-layout` from `zach/warp-cli-authenticated-scripting` and bring over only layout/app-state mutations from `zach/warp-cli-read-write` and its layout shards.
+7. Create `zach/warp-cli-mutating-input-settings-surfaces` from `zach/warp-cli-mutating-layout` and bring over mutating input/session/settings/surface pieces from `zach/warp-cli-read-write`.
+8. Create `zach/warp-cli-mutating-drive-data` from `zach/warp-cli-mutating-input-settings-surfaces` and bring over the approved `zach/warp-cli-read-write-drive-data` functionality. Do not bring over local file content read/write/delete functionality because it is no longer part of the public catalog.
+9. Create `zach/warp-cli-mutating-execution-underlying` from `zach/warp-cli-mutating-drive-data` and bring over `zach/warp-cli-read-write-execution-underlying` functionality while keeping accepted-command and agent-prompt submission excluded.
+10. Recompute incremental diff sizes, validate compilation/tests for each branch, push the new stack, and retire or close the old broad branches once the new review stack is accepted.
+Before redistributing feature work, prefer landing a mechanical module-split commit in `zach/warp-cli-core-foundation` so later branches do not all expand the same large files. The app-side target should be:
+- `app/src/local_control/mod.rs` for registration and top-level exports.
+- `app/src/local_control/bridge.rs` for the app request bridge.
+- `app/src/local_control/resolver.rs` for target resolution.
+- `app/src/local_control/permissions.rs` for app-side permission/auth checks.
+- `app/src/local_control/handlers/metadata.rs`.
+- `app/src/local_control/handlers/data.rs`.
+- `app/src/local_control/handlers/layout.rs`.
+- `app/src/local_control/handlers/input.rs`.
+- `app/src/local_control/handlers/settings_surfaces.rs`.
+Likewise, split CLI and protocol code if they become review bottlenecks:
+- `crates/warp_cli/src/local_control/mod.rs`.
+- `crates/warp_cli/src/local_control/selectors.rs`.
+- `crates/warp_cli/src/local_control/output.rs`.
+- `crates/warp_cli/src/local_control/commands/{metadata,data,layout,input,settings_surfaces}.rs`.
+- `crates/local_control/src/{protocol,catalog,selectors}.rs`.
+- `crates/local_control/src/actions/{metadata,data,layout,input,settings_surfaces}.rs`.
+### Feature flag and rollout gate
+The entire feature should be gated behind a Warp feature flag, proposed as `FeatureFlag::WarpControlCli` with Cargo feature `warp_control_cli`.
+Implementation should follow the existing runtime feature-flag conventions:
+- Add `warp_control_cli = []` under `[features]` in `app/Cargo.toml`, not under the default feature set until launch.
+- Add `WarpControlCli` to the `FeatureFlag` enum in `crates/warp_features/src/lib.rs`.
+- Add the `#[cfg(feature = "warp_control_cli")] FeatureFlag::WarpControlCli` entry in `app/src/features.rs` so the compile-time feature initializes the runtime flag.
+- Enable the flag for dogfood or preview by adding it to `DOGFOOD_FLAGS` or `PREVIEW_FLAGS` only when the rollout plan calls for that exposure.
+- Prefer runtime checks with `FeatureFlag::WarpControlCli.is_enabled()` over broad `#[cfg]` gates except where code cannot compile without the Cargo feature.
+When `FeatureFlag::WarpControlCli` is disabled in the Warp app:
+- the Scripting settings page should not expose Warp control settings;
+- `LocalControlSettings` should not register user-visible controls for Warp control;
+- the app should not create `LocalControlBridge` or `LocalControlServer`;
+- no local-control discovery record should be written;
+- no `/v1/control` or `/v1/control/credentials` local server endpoints should be exposed;
+- command-palette/keybinding entries related specifically to installing, configuring, or using `warpctrl` should be hidden;
+- tests should cover both enabled and disabled flag states with the repo's normal feature-flag override helpers.
+The standalone `warpctrl` binary can still exist in a build where the app feature is disabled, but it should find no compatible enabled app instance and should return a structured no-instance or feature-disabled error rather than relying on hidden server state.
+### Merge and review strategy
+Keep PR boundaries aligned with the stack:
+- PR1: `zach/warp-cli-core-foundation` into `master` for the combined specs, shared protocol, CLI, settings, bridge, and module scaffolding.
+- PR2: `zach/warp-cli-readonly-metadata` into `zach/warp-cli-core-foundation` or its merged successor for metadata reads.
+- PR3: `zach/warp-cli-readonly-data-settings` into `zach/warp-cli-readonly-metadata` or its merged successor for underlying-data reads, settings reads, docs, and skill updates.
+- PR4: `zach/warp-cli-authenticated-scripting` into `zach/warp-cli-readonly-data-settings` or its merged successor for verified terminal proofs, external API-key scripting auth, and authenticated-user grants.
+- PR5: `zach/warp-cli-mutating-layout` into `zach/warp-cli-authenticated-scripting` or its merged successor for app/window/tab/pane layout mutations.
+- PR6: `zach/warp-cli-mutating-input-settings-surfaces` into `zach/warp-cli-mutating-layout` or its merged successor for input/session/settings/surface mutations.
+- PR7: `zach/warp-cli-mutating-drive-data` into `zach/warp-cli-mutating-input-settings-surfaces` or its merged successor for authenticated Warp Drive underlying-data mutations.
+- PR8: `zach/warp-cli-mutating-execution-underlying` into `zach/warp-cli-mutating-drive-data` or its merged successor for authenticated execution-underlying actions.
+If a lower PR merges before higher branches are ready, rebase the next branch onto the merged successor of its base and continue upward through the stack. Use raw git for all rebases, conflict resolution, cherry-picks, and pushes.
+## End-to-end flow
+```mermaid
+sequenceDiagram
+    participant CLI as Warp control CLI
+    participant REG as Local discovery registry
+    participant PROC as Selected Warp process
+    participant BROKER as Credential broker
+    participant HTTP as Local control listener
+    participant BRIDGE as App request bridge
+    participant RES as Target resolver
+    participant ACT as Allowlisted action handler
+    participant UI as Live Warp app state
+
+    CLI->>REG: Read local instance records
+    CLI->>PROC: Health/protocol check for candidates
+    PROC-->>CLI: Instance metadata + compatibility
+    CLI->>CLI: Resolve instance selector
+    CLI->>BROKER: Request scoped credential for action + execution context
+    BROKER-->>CLI: Grant or structured denial
+    CLI->>HTTP: Authenticated POST tab.create request
+    HTTP->>HTTP: Verify context-specific enablement + credential + execution context
+    HTTP->>BRIDGE: Typed request + response channel
+    BRIDGE->>BRIDGE: Recheck enablement + permission + auth-user policy
+    BRIDGE->>RES: Resolve window/tab/pane/session selectors
+    RES-->>BRIDGE: Concrete target handles or typed error
+    BRIDGE->>ACT: Execute allowlisted ControlAction
+    ACT->>UI: Reuse existing tab creation behavior
+    UI-->>ACT: Mutation/read result
+    ACT-->>BRIDGE: Typed result
+    BRIDGE-->>HTTP: Response envelope
+    HTTP-->>CLI: JSON success/error response
+    CLI-->>CLI: Pretty or JSON output
+```
+## Testing and validation
+Map tests directly to `PRODUCT.md` behavior.
+- Security architecture:
+  - Protected enablement tests proving outside-Warp control defaults off, disabled outside-Warp context rejects credential issuance, sensitive discovery, and mutating requests with `local_control_disabled`, and current inside-Warp credential requests are rejected with `execution_context_not_allowed`.
+  - Tests proving discovery in disabled state exposes no actionable endpoint authority or credential reference.
+  - Credential-storage tests proving raw credentials are not written into plaintext discovery records.
+  - Execution-context tests proving external clients cannot receive grants reserved for verified Warp-terminal invocations.
+  - Permission-category enforcement tests proving insufficient grants fail with `insufficient_permissions` before selector resolution or handler dispatch, including separate denial cases for app-state mutation, metadata/configuration mutation, and underlying-data mutation.
+  - Authenticated-user tests proving user-authenticated actions fail without a logged-in app user or authenticated-user grant.
+  - External API-key tests proving missing, invalid, expired, revoked, wrong-subject, and insufficient-scope keys fail before selector resolution or handler dispatch.
+  - Settings > Scripting tests proving both top-level toggles and granular disabled categories invalidate credentials and prevent new grants.
+  - Structured-error tests for disabled, unauthenticated, expired, revoked, insufficient-scope, execution-context-denied, authenticated-user-required, authenticated-user-unavailable, unsupported, malformed, ambiguous, missing-target, stale-target, and invalid-selector requests.
+- Behavior 1-6, 29-31:
+  - Protocol version/unit tests.
+  - Discovery-registry tests with zero, one, multiple, stale, and incompatible instance records.
+  - Local-auth tests for missing, invalid, expired, revoked, and valid credentials.
+- Behavior 7-13:
+  - Selector-resolution unit tests for active, explicit ID, index, stale target, ambiguous target, and non-terminal session target.
+  - Tests that no lower-level selector silently retargets after an explicit stale selector fails.
+  - CLI selector parsing tests for every generic and explicit alias form: `--window`, `--window-id`, `--window-index`, `--window-title`, `--tab`, `--tab-id`, `--tab-index`, `--tab-title`, `--pane`, `--pane-id`, `--pane-index`, `--session`, `--session-id`, and `--session-index`.
+  - CLI conflict tests proving only one selector form per entity family is accepted and that positional target IDs are rejected where the command expects selector flags.
+- Behavior 15-28:
+  - Parser/serde tests for every first-slice `ControlAction` variant.
+  - Router tests proving unknown/unallowlisted actions are rejected.
+  - CLI parse/output tests for pretty and JSON rendering.
+- Behavior 18 and 33:
+  - App-side tests for `tab.create` using existing workspace/tab helpers or a narrow extracted helper.
+  - Manual local verification that `warpctrl tab create` creates a terminal tab in a running app.
+- Behavior 30:
+  - Multi-process integration-style coverage using two synthetic discovery records and mock health responders, plus manual testing with multiple channel builds where practical.
+- Packaging:
+  - `--artifact cli`-style bundle smoke tests or script-level checks for each supported platform path touched by the first slice.
+  - Startup-path tests or focused checks confirming `warpctrl` dispatches commands without entering GUI-app launch code.
+  - Shell completions/help output checks once final command naming is selected.
+### Computer-use CLI verification
+Before any stacked PR is considered ready for review, run an end-to-end computer-use verification pass against a cloud built validation artifact from that branch. The validation artifact is a Warp app build and standalone `warpctrl` binary built by the validation agent from the exact commit under review, with `warp_control_cli` compiled in and `FeatureFlag::WarpControlCli` enabled at runtime.
+The verifier must launch the built Warp app, enable the Scripting settings needed for the command category under test, and capture screenshots or screen recordings that prove both the terminal invocation and the user-visible result of each basic command family. Every `warpctrl` invocation executed during verification must have a durable screenshot captured immediately after the command runs, showing the exact command line and full terminal output in either pretty or JSON mode. Screenshots should be saved as durable artifacts and named by branch, invocation context, command family, command name, and whether the image shows terminal output or app UI state.
+The verifier must exercise every invocation context implemented by the branch under review. For the current foundation branch, inside-Warp verification means proving `InsideWarp` requests are rejected and no inside-Warp Settings > Scripting controls are exposed. Once verified Warp-terminal support is implemented, the verifier must also run `warpctrl` from a terminal session inside the feature-flag-enabled Warp app and prove the app-issued execution-context proof is accepted and inside-Warp settings gate command categories. The outside-Warp path must run the same `warpctrl` binary from an external terminal or automation shell outside the built Warp app and prove outside-Warp control is default-off, then works only after enabling outside-Warp scripting and the required granular permissions in Settings > Scripting.
+The verification matrix should cover every implemented command in `PRODUCT.md` at least once in JSON output mode. The verifier must capture a terminal-output screenshot for every command invocation, including successful calls, expected denials, unsupported stubs, and fail-closed policy gates. Where there is a visible UI effect, the verifier must also capture app UI screenshots after the command runs, and before the command when that is needed to prove a before/after state transition. At minimum:
+- read-only metadata commands show successful CLI output in a terminal screenshot and, for active/focus/list commands, a visible target that matches the output;
+- underlying data read commands show successful CLI output only when the underlying-data-read permission is enabled, plus terminal screenshots for disabled-permission denials;
+- app-state mutation commands show terminal-output screenshots plus before/after app UI screenshots proving the visible Warp UI changed;
+- metadata/configuration mutation commands show terminal-output screenshots plus before/after app UI screenshots proving the persisted setting or label changed;
+- underlying data mutation commands run only in a disposable test workspace/session with test Warp Drive objects, show terminal screenshots for denial without the underlying-data-mutation permission, then show terminal screenshots and any relevant app/file/Drive state evidence for success with the permission enabled;
+- authenticated-user commands show terminal screenshots for both the logged-out or missing-grant denial path and the enabled authenticated path when a test account/environment is available.
+The verifier should produce a verification manifest checked into or attached to the PR artifacts. The manifest should list each command, branch under test, invocation context, required permission category, expected result, actual result, terminal screenshot artifact path, UI screenshot artifact path when applicable, and any skipped case with a reason. Missing terminal screenshots for any executed `warpctrl` invocation block review readiness. Missing UI screenshots for visible commands also block review readiness.
+## Parallelization
+The durable review stack should remain linear, but implementation can still happen in parallel with Oz cloud agents. The pattern is contract-first fan-out: land the shared contracts and module boundaries in `zach/warp-cli-core-foundation`, then let cloud agents work on short-lived shard branches that feed the durable review branches.
+Wave 0: foundation:
+- Keep `zach/warp-cli-core-foundation` mostly sequential or use at most one or two tightly scoped agents because protocol envelope, discovery, authentication, feature-flag gating, selector resolution, module boundaries, and `tab.create` smoke behavior need one coherent architecture.
+- Acceptable foundation shards are `core-protocol-cli` for shared protocol/CLI skeleton and `core-app-foundation` for settings, bridge, resolver, permissions, and handler skeletons. These shards should merge into the single durable `zach/warp-cli-core-foundation` branch before feature fan-out begins.
+Wave 1: read-only fan-out:
+- Launch short-lived Oz cloud shard branches from `zach/warp-cli-core-foundation` once the contracts compile.
+- Suggested shards:
+  - `zach/warp-cli-shard/readonly-metadata` owns structural metadata commands and feeds `zach/warp-cli-readonly-metadata`.
+  - `zach/warp-cli-shard/readonly-data` owns block output, input-buffer reads, history reads, and other underlying-data reads, then feeds `zach/warp-cli-readonly-data-settings`.
+  - `zach/warp-cli-shard/readonly-settings-docs` owns theme/settings/keybinding/action reads, docs, and read-only skill updates, then feeds `zach/warp-cli-readonly-data-settings`.
+Wave 2: mutating fan-out:
+- Launch mutating shards only after read-only target resolution and result shapes are stable.
+- Suggested shards:
+  - `zach/warp-cli-shard/mutating-window-tab-pane` owns window/tab/pane layout mutations and feeds `zach/warp-cli-mutating-layout`.
+  - `zach/warp-cli-shard/mutating-input-session` owns session activation/cycling/reopen, input insert/replace/clear, and input mode switching, then feeds `zach/warp-cli-mutating-input-settings-surfaces`.
+  - `zach/warp-cli-shard/authenticated-scripting` owns verified terminal proofs, external API-key auth, authenticated-user grants, and auth command tests, then feeds `zach/warp-cli-authenticated-scripting`.
+  - `zach/warp-cli-shard/mutating-settings-surfaces` owns theme/font/zoom/setting mutations and settings/palette/panel/surface commands, then feeds `zach/warp-cli-mutating-input-settings-surfaces`.
+  - `zach/warp-cli-shard/mutating-drive-data` owns Drive object data mutations, including the v0 personal-to-team sharing path, then feeds `zach/warp-cli-mutating-drive-data`.
+  - `zach/warp-cli-shard/mutating-execution-underlying` owns `input.run` and typed workflow execution, then feeds `zach/warp-cli-mutating-execution-underlying`.
+Each cloud shard prompt should include:
+- The exact base branch and shard branch name.
+- Owned command families.
+- Owned files/modules.
+- Files/modules the shard must not edit without calling out the need for integration.
+- Required permission categories and authenticated-user behavior.
+- Selector resolution requirements.
+- Validation commands and expected tests.
+- A handoff requirement: report branch name, changed files, implemented commands, permission decisions, validation results, and any conflicts or follow-ups.
+Default file ownership for shards:
+- Metadata shards own metadata handler/protocol/CLI modules and metadata tests.
+- Data shards own data handler/protocol/CLI modules and underlying-data permission tests.
+- Layout shards own layout handler/protocol/CLI modules and app-state mutation tests.
+- Authenticated-scripting shards own auth broker/protocol/CLI modules, Settings > Scripting authenticated grant controls, API-key storage/exchange tests, and authenticated-user denial tests.
+- Input/session shards own input/session handler/protocol/CLI modules and tests proving staging does not submit or execute unless the branch explicitly owns `input.run`.
+- Settings/surface shards own settings/surface handler/protocol/CLI modules and metadata/configuration mutation tests.
+- Drive data shards own Drive underlying-data handler/protocol/CLI modules, authenticated-user/API-key enforcement tests, personal-to-team sharing tests, and disposable-resource tests.
+- Execution-underlying shards own `input.run` and typed workflow execution handler/protocol/CLI modules, audit tests, and denial tests proving accepted-command and agent-prompt submission remain unavailable.
+The lead integrator merges or cherry-picks accepted shard work into the durable stack with raw git, in review order. Shard branches should not become independent long-lived PRs unless the lead intentionally splits review further; their default purpose is to feed the durable stack while preserving parallel implementation and focused context windows.
+```mermaid
+flowchart LR
+    Core["zach/warp-cli-core-foundation<br/>specs + contracts + bridge"] --> ROMeta["zach/warp-cli-readonly-metadata<br/>structural reads"]
+    ROMeta --> ROData["zach/warp-cli-readonly-data-settings<br/>data/settings reads"]
+    ROData --> Auth["zach/warp-cli-authenticated-scripting<br/>terminal proof + API key auth"]
+    Auth --> MutLayout["zach/warp-cli-mutating-layout<br/>layout mutations"]
+    MutLayout --> MutInput["zach/warp-cli-mutating-input-settings-surfaces<br/>input/settings/surfaces"]
+    MutInput --> MutData["zach/warp-cli-mutating-drive-data<br/>Drive data"]
+    MutData --> MutExec["zach/warp-cli-mutating-execution-underlying<br/>execution actions"]
+    ROMetaShard["shard/readonly-metadata"] --> ROMeta
+    RODataShard["shard/readonly-data"] --> ROData
+    ROSettingsShard["shard/readonly-settings-docs"] --> ROData
+    MutLayoutShard["shard/mutating-window-tab-pane"] --> MutLayout
+    MutInputShard["shard/mutating-input-session"] --> MutInput
+    MutSettingsShard["shard/mutating-settings-surfaces"] --> MutInput
+    AuthShard["shard/authenticated-scripting"] --> Auth
+    MutDataShard["shard/mutating-drive-data"] --> MutData
+    MutExecShard["shard/mutating-execution-underlying"] --> MutExec
+```
+## Risks and mitigations
+- Fixed-port server assumptions:
+  - Mitigation: leave current `9277` endpoints undisturbed and use a per-process control listener plus discovery registry.
+- Browser-to-localhost abuse:
+  - Mitigation: no permissive CORS, protected in-app enablement, explicit local auth, scoped grants, and mutating routes gated before selector resolution.
+- External apps silently enabling outside-Warp local control:
+  - Mitigation: the outside-Warp enablement state defaults off, lives in protected local storage behind Settings > Scripting, is local-only, is not Settings Sync'd, and is not writable through `warpctrl`, config files, registry/plist preference edits, defaults writes, or server-backed settings.
+- External apps obtaining in-Warp authenticated-user grants:
+  - Mitigation: require an app-issued execution-context proof for Warp-terminal-only grants, do not trust caller-declared labels or plain environment variables as sole authority, and keep external authenticated-user grants behind a separate default-off permission.
+- Logged-out requests touching user-authenticated data:
+  - Mitigation: every action declares `requires_authenticated_user`, new actions default to true, and the bridge returns authenticated-user errors before selector resolution or dispatch.
+- Implementation drift from `SECURITY.md`:
+  - Mitigation: treat `SECURITY.md` as normative for security behavior; update this technical plan before implementation when there is disagreement, and include tests for the security architecture in the first slice.
+- Action catalog drift from real UI behavior:
+  - Mitigation: each control action reuses or factors existing UI action paths rather than duplicating behavior, and user-visible app action enums implement exhaustive `WarpCtrlBehavior` mappings so new internal actions cannot be added without an explicit expose/cover/exclude/defer decision.
+- Leaking internal unstable identifiers:
+  - Mitigation: public protocol exposes opaque IDs and selectors; internal runtime IDs stay implementation details.
+- Over-broad settings mutation:
+  - Mitigation: allowlisted setting keys only, with private/debug/derived settings rejected.
+- Command execution risk:
+  - Mitigation: keep `input.run`/typed workflow execution in the catalog but implement it only in `zach/warp-cli-mutating-execution-underlying` after authenticated scripting identity, underlying-data-mutation permission, deterministic target resolution, and audit coverage are in place.
+- Packaging churn due to provisional executable naming:
+  - Mitigation: document `warpctrl` as provisional and settle final aliases before broad release workflow rollout.
+- Heavyweight CLI startup caused by sharing the GUI binary's launch path:
+  - Mitigation: ship a separate control CLI artifact with a narrow initialization path and keep GUI-only subsystems out of ordinary CLI command execution.
+## Follow-ups
+- Decide the final artifact filename/channel alias scheme around the provisional `warpctrl ...` public command surface.
+- Decide whether Windows should follow the current Oz wrapper pattern indefinitely or gain standalone control CLI artifacts.
+- Decide whether a future subscription/watch protocol is useful for scripts that want live state changes, rather than single request/response calls only.


### PR DESCRIPTION
## Description
Adds the first foundation slice for the Warp Control CLI:

- Adds shared `local_control` protocol, catalog, auth, discovery, selection, selector, and client scaffolding.
- Adds standalone `warpctrl` command parsing for `instance list`, `app ping`, `app version`, `tab create`, and completions.
- Adds private local-control settings and a feature-gated Settings > Scripting page for outside-Warp control and granular permissions.
- Adds app-side scoped credential issuance, loopback control routing, metadata handlers, and a first `tab.create` app-state mutation path.
- Checks in local Warp Control CLI specs and updates macOS/Linux bundle scripts for the `warpctrl` artifact.

## Linked Issue
No linked issue.

## Testing
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] `cargo check -p local_control -p warp_cli`
- [x] `cargo check -p warp --features warp_control_cli --bin warpctrl`
- [x] `cargo check -p warp --bin warpctrl`
- [x] `cargo nextest run --no-fail-fast --workspace -p local_control`
- [x] `cargo nextest run --no-fail-fast -p warp_cli`
- [x] `bash -n script/macos/bundle`
- [x] `bash -n script/linux/bundle`
- [x] `git --no-pager diff --check`
- [ ] I have manually tested my changes locally with `./script/run`

Manual UI testing was not run in this session.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
