### PR TITLE
Improve Oz API key auth errors and log redaction

### DIFF
--- a/app/src/auth/auth_manager.rs
+++ b/app/src/auth/auth_manager.rs
@@ -497,6 +497,7 @@ impl AuthManager {
                         self.set_needs_reauth(true, ctx);
                     }
                     UserAuthenticationError::UserAccountDisabled(_) => {}
+                    UserAuthenticationError::ApiKeyAuthentication(_) => {}
                     UserAuthenticationError::Unexpected(_) => {}
                     UserAuthenticationError::InvalidStateParameter => {}
                     UserAuthenticationError::MissingStateParameter => {}

--- a/app/src/auth/paste_auth_token_modal.rs
+++ b/app/src/auth/paste_auth_token_modal.rs
@@ -151,6 +151,7 @@ impl PasteAuthTokenModalView {
                         LoginFailureReason::MissingStateParameter
                     }
                     UserAuthenticationError::DeniedAccessToken(_)
+                    | UserAuthenticationError::ApiKeyAuthentication(_)
                     | UserAuthenticationError::UserAccountDisabled(_)
                     | UserAuthenticationError::Unexpected(_) => {
                         LoginFailureReason::FailedUserAuthentication

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -3004,6 +3004,9 @@ impl RootView {
                 UserAuthenticationError::Unexpected(err) => {
                     log::error!("Encountered unexpected error when trying to fetch user: {err:#}");
                 }
+                UserAuthenticationError::ApiKeyAuthentication(err) => {
+                    log::error!("API key authentication failed while fetching user: {err:#}");
+                }
                 UserAuthenticationError::InvalidStateParameter => {}
                 UserAuthenticationError::MissingStateParameter => {}
             },

--- a/app/src/server/server_api/auth.rs
+++ b/app/src/server/server_api/auth.rs
@@ -311,7 +311,13 @@ impl AuthClient for ServerApi {
             .fetch_user_properties(auth_token.as_bearer_token())
             .await
             .context("Failed to fetch user response data")
-            .map_err(UserAuthenticationError::Unexpected)?;
+            .map_err(|err| {
+                if matches!(&new_credentials, Credentials::ApiKey { .. }) {
+                    UserAuthenticationError::ApiKeyAuthentication(err)
+                } else {
+                    UserAuthenticationError::Unexpected(err)
+                }
+            })?;
 
         let UserProperties {
             user,
@@ -868,6 +874,10 @@ pub enum UserAuthenticationError {
     /// be deleted per their GDPR/CCPA rights.
     #[error("Firebase returned a user error when fetching an ID token")]
     UserAccountDisabled(FirebaseError),
+    #[error(
+        "API key authentication failed. Provide a valid Warp API key. For the Oz GitHub Action, use an Agent API key created for the named agent that should run the workflow; legacy team keys may not work for new automation."
+    )]
+    ApiKeyAuthentication(#[source] anyhow::Error),
     #[error("Invalid state parameter in auth redirect")]
     InvalidStateParameter,
     #[error("Missing state parameter in auth redirect")]
@@ -891,6 +901,7 @@ impl ErrorExt for UserAuthenticationError {
                 log::info!("ignoring user account disabled error: {err:#}");
                 false
             }
+            UserAuthenticationError::ApiKeyAuthentication(err) => err.is_actionable(),
             UserAuthenticationError::Unexpected(err) => err.is_actionable(),
             UserAuthenticationError::InvalidStateParameter
             | UserAuthenticationError::MissingStateParameter => {

--- a/crates/warp_core/src/channel/config.rs
+++ b/crates/warp_core/src/channel/config.rs
@@ -1,10 +1,11 @@
 use std::borrow::Cow;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
 use crate::AppId;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct ChannelConfig {
     /// The application ID for this channel.
     pub app_id: AppId,
@@ -27,7 +28,22 @@ pub struct ChannelConfig {
     pub mcp_static_config: Option<McpStaticConfig>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+impl fmt::Debug for ChannelConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChannelConfig")
+            .field("app_id", &self.app_id)
+            .field("logfile_name", &self.logfile_name)
+            .field("server_config", &self.server_config)
+            .field("oz_config", &self.oz_config)
+            .field("telemetry_config", &self.telemetry_config)
+            .field("autoupdate_config", &self.autoupdate_config)
+            .field("crash_reporting_config", &self.crash_reporting_config)
+            .field("mcp_static_config", &self.mcp_static_config)
+            .finish()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct WarpServerConfig {
     /// The root URL for the standard server pool.
     pub server_root_url: Cow<'static, str>,
@@ -40,6 +56,19 @@ pub struct WarpServerConfig {
     pub firebase_auth_api_key: Cow<'static, str>,
 }
 
+impl fmt::Debug for WarpServerConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WarpServerConfig")
+            .field("server_root_url", &self.server_root_url)
+            .field("rtc_server_url", &self.rtc_server_url)
+            .field(
+                "session_sharing_server_url",
+                &self.session_sharing_server_url,
+            )
+            .field("firebase_auth_api_key", &"<redacted>")
+            .finish()
+    }
+}
 impl WarpServerConfig {
     pub fn production() -> Self {
         Self {
@@ -79,7 +108,7 @@ pub struct TelemetryConfig {
     pub rudderstack_config: Option<RudderStackConfig>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct RudderStackConfig {
     pub write_key: Cow<'static, str>,
     pub root_url: Cow<'static, str>,
@@ -116,12 +145,28 @@ pub struct AutoupdateConfig {
     pub show_autoupdate_menu_items: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct CrashReportingConfig {
     /// The URL/DSN for sending error logs and crash reports to Sentry.
     pub sentry_url: Cow<'static, str>,
 }
 
+impl fmt::Debug for RudderStackConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RudderStackConfig")
+            .field("write_key", &"<redacted>")
+            .field("root_url", &self.root_url)
+            .field("ugc_write_key", &"<redacted>")
+            .finish()
+    }
+}
+impl fmt::Debug for CrashReportingConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CrashReportingConfig")
+            .field("sentry_url", &"<redacted>")
+            .finish()
+    }
+}
 /// Configuration for statically-bundled MCP OAuth credentials.
 ///
 /// These are credentials for OAuth providers where dynamic client registration
@@ -133,7 +178,7 @@ pub struct McpStaticConfig {
 }
 
 /// A single OAuth provider's credentials for MCP authentication.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct McpOAuthProviderConfig {
     /// The issuer URL of the OAuth provider (e.g. `https://github.com/login/oauth`).
     pub issuer: Cow<'static, str>,
@@ -142,3 +187,17 @@ pub struct McpOAuthProviderConfig {
     /// The OAuth client secret registered for this channel.
     pub client_secret: Cow<'static, str>,
 }
+
+impl fmt::Debug for McpOAuthProviderConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("McpOAuthProviderConfig")
+            .field("issuer", &self.issuer)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;

--- a/crates/warp_core/src/channel/config_tests.rs
+++ b/crates/warp_core/src/channel/config_tests.rs
@@ -1,0 +1,46 @@
+use super::*;
+use crate::AppId;
+
+#[test]
+fn debug_redacts_sensitive_looking_channel_config_values() {
+    let config = ChannelConfig {
+        app_id: AppId::new("dev", "warp", "Warp"),
+        logfile_name: "warp.log".into(),
+        server_config: WarpServerConfig {
+            server_root_url: "https://app.warp.dev".into(),
+            rtc_server_url: "wss://rtc.app.warp.dev/graphql/v2".into(),
+            session_sharing_server_url: Some("wss://sessions.app.warp.dev".into()),
+            firebase_auth_api_key: "firebase-secret-looking-value".into(),
+        },
+        oz_config: OzConfig::production(),
+        telemetry_config: Some(TelemetryConfig {
+            telemetry_file_name: "telemetry.json".into(),
+            rudderstack_config: Some(RudderStackConfig {
+                write_key: "rudder-write-key".into(),
+                root_url: "https://rudder.example.com".into(),
+                ugc_write_key: "rudder-ugc-key".into(),
+            }),
+        }),
+        autoupdate_config: None,
+        crash_reporting_config: Some(CrashReportingConfig {
+            sentry_url: "https://sentry-secret@example.com/1".into(),
+        }),
+        mcp_static_config: Some(McpStaticConfig {
+            providers: vec![McpOAuthProviderConfig {
+                issuer: "https://github.com/login/oauth".into(),
+                client_id: "github-client-id".into(),
+                client_secret: "github-client-secret".into(),
+            }],
+        }),
+    };
+
+    let debug = format!("{config:?}");
+
+    assert!(debug.contains("<redacted>"));
+    assert!(!debug.contains("firebase-secret-looking-value"));
+    assert!(!debug.contains("rudder-write-key"));
+    assert!(!debug.contains("rudder-ugc-key"));
+    assert!(!debug.contains("sentry-secret"));
+    assert!(!debug.contains("github-client-secret"));
+    assert!(debug.contains("github-client-id"));
+}


### PR DESCRIPTION
## Summary
- Add an API-key-specific auth error for Oz CLI user-fetch failures so GitHub Action users see key-type guidance instead of an ID-token-focused generic error.
- Redact sensitive-looking channel config fields from startup debug logging, including Firebase auth API keys, RudderStack write keys, Sentry DSNs, and static MCP OAuth client secrets.
- Add a focused unit test covering channel config debug redaction.

## Validation
- `cargo test -p warp_core debug_redacts_sensitive_looking_channel_config_values`
- `cargo check`
- `cargo fmt -- --check`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

Note: `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` was also attempted, but this sandbox could not generate release-bundle channel config JSON files required by `app/src/bin/channel_config.rs`.

_Co-Authored-By: Oz <oz-agent@warp.dev>_

_Conversation: https://staging.warp.dev/conversation/9c1ddc93-8059-45ab-89f3-c5955565df45_
_Run: https://oz.staging.warp.dev/runs/019e70d6-bec0-7c02-b2b1-ad1a8a7ad296_
_Plans_:
- _[REMOTE-1798 Oz GitHub Action auth and log redaction fix](https://staging.warp.dev/drive/notebook/ZAvmo1a4rYaYAeWSJiCaNA)_

_This PR was generated with [Oz](https://warp.dev/oz)._
