### PR TITLE
[3/5] Hydrate remote project skills

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -2,9 +2,13 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use ai::skills::{
-    home_skills_path, parse_skill, ParsedSkill, SkillProvider, SKILL_PROVIDER_DEFINITIONS,
+    get_provider_for_location, home_skills_path, parse_skill, parse_skill_content_at_location,
+    ParsedSkill, SkillProvider, SkillScope, SKILL_PROVIDER_DEFINITIONS,
 };
 use async_channel::Sender;
+use remote_server::proto::{
+    file_context_proto, FileContextProto, ReadFileContextFile, ReadFileContextRequest,
+};
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repository::{Repository, SubscriberId};
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate};
@@ -20,6 +24,7 @@ use super::utils::{
     is_home_skill_directory, is_skill_file, read_local_project_skills_from_filesystem,
     read_skills_from_directories, read_skills_from_files,
 };
+use crate::remote_server::manager::RemoteServerManager;
 use crate::warp_managed_paths_watcher::{
     filter_repository_update_by_prefix, warp_managed_skill_dirs, WarpManagedPathsWatcher,
     WarpManagedPathsWatcherEvent,
@@ -30,6 +35,9 @@ pub enum SkillWatcherEvent {
     SkillsAdded { skills: Vec<ParsedSkill> },
     SkillsDeleted { paths: Vec<LocalOrRemotePath> },
 }
+
+const REMOTE_SKILL_MAX_FILE_BYTES: u32 = 1024 * 1024;
+const REMOTE_SKILL_MAX_BATCH_BYTES: u32 = 5 * 1024 * 1024;
 pub struct SkillWatcher {
     // Channel for sending repository messages from subscribers.
     repository_message_tx: Sender<SkillRepositoryMessage>,
@@ -37,8 +45,8 @@ pub struct SkillWatcher {
     /// so repo metadata changes trigger a full refresh instead of a subtree diff.
     project_skill_files_by_repo: HashMap<RepositoryIdentifier, HashSet<LocalOrRemotePath>>,
     /// Latest full project-skill refresh generation by repository. Repo metadata refreshes
-    /// parse local files asynchronously, so results from superseded tree snapshots must
-    /// not re-add deleted skills or overwrite newer parsed content.
+    /// hydrate project skills asynchronously, so results from superseded tree snapshots
+    /// must not re-add deleted skills or overwrite newer parsed content.
     project_skill_refresh_generations: HashMap<RepositoryIdentifier, u64>,
     /// Allocates refresh generations that cannot be reused if a repository is removed
     /// and subsequently re-added while an old task is still in flight.
@@ -237,27 +245,29 @@ impl SkillWatcher {
 
         let deleted_paths = previous_skill_files
             .difference(&current_skill_files)
-            .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
+            .cloned()
             .collect::<Vec<_>>();
         if !deleted_paths.is_empty() {
-            self.cleanup_symlink_watches(&deleted_paths);
+            let deleted_local_paths = deleted_paths
+                .iter()
+                .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
+                .collect::<Vec<_>>();
+            self.cleanup_symlink_watches(&deleted_local_paths);
             let _ = self
                 .watcher_event_tx
                 .try_send(SkillWatcherEvent::SkillsDeleted {
-                    paths: deleted_paths
-                        .into_iter()
-                        .map(LocalOrRemotePath::Local)
-                        .collect(),
+                    paths: deleted_paths,
                 });
         }
 
-        // Local hydration intentionally only parses local paths. Remote project
-        // skill discovery now comes from RepoMetadataModel, but hydrating/parsing
-        // remote content is coming in a subsequent PR with a remote-aware skill
-        // identity pipeline.
-        let skill_files = current_skill_files
+        let local_skill_files = current_skill_files
             .iter()
             .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
+            .collect::<Vec<_>>();
+        let remote_skill_files = current_skill_files
+            .iter()
+            .filter(|path| matches!(path, LocalOrRemotePath::Remote(_)))
+            .cloned()
             .collect::<Vec<_>>();
 
         // Project skill counts are expected to be small, so repo metadata updates
@@ -268,9 +278,18 @@ impl SkillWatcher {
         self.spawn_read_project_skills_from_files(
             repo_id.clone(),
             refresh_generation,
-            skill_files,
+            local_skill_files,
             ctx,
         );
+        if let RepositoryIdentifier::Remote(remote_repo) = repo_id {
+            self.spawn_read_remote_project_skills(
+                repo_id.clone(),
+                refresh_generation,
+                remote_repo.host_id.clone(),
+                remote_skill_files,
+                ctx,
+            );
+        }
 
         self.project_skill_files_by_repo
             .insert(repo_id.clone(), current_skill_files);
@@ -362,6 +381,39 @@ impl SkillWatcher {
             },
         );
     }
+    fn spawn_read_remote_project_skills(
+        &mut self,
+        repo_id: RepositoryIdentifier,
+        refresh_generation: u64,
+        host_id: warp_util::host_id::HostId,
+        skill_paths: Vec<LocalOrRemotePath>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if skill_paths.is_empty() {
+            return;
+        }
+        let Some(client) = RemoteServerManager::as_ref(ctx)
+            .client_for_host(&host_id)
+            .cloned()
+        else {
+            return;
+        };
+
+        ctx.spawn(
+            async move {
+                let request = remote_skill_read_request(&skill_paths);
+                let response = client.read_file_context(request).await?;
+                let skills = parse_remote_skill_file_contexts(skill_paths, response.file_contexts);
+                Ok::<Vec<ParsedSkill>, anyhow::Error>(skills)
+            },
+            move |me, skills, ctx| match skills {
+                Ok(skills) => {
+                    me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
+                }
+                Err(err) => log::warn!("Failed to read remote project skills: {err}"),
+            },
+        );
+    }
 
     fn spawn_read_project_skills_from_files(
         &mut self,
@@ -432,19 +484,17 @@ impl SkillWatcher {
         let Some(skill_files) = self.project_skill_files_by_repo.remove(repo_id) else {
             return;
         };
-        let deleted_paths = skill_files
-            .into_iter()
-            .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
-            .collect::<Vec<_>>();
+        let deleted_paths = skill_files.into_iter().collect::<Vec<_>>();
         if !deleted_paths.is_empty() {
-            self.cleanup_symlink_watches(&deleted_paths);
+            let deleted_local_paths = deleted_paths
+                .iter()
+                .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
+                .collect::<Vec<_>>();
+            self.cleanup_symlink_watches(&deleted_local_paths);
             let _ = self
                 .watcher_event_tx
                 .try_send(SkillWatcherEvent::SkillsDeleted {
-                    paths: deleted_paths
-                        .into_iter()
-                        .map(LocalOrRemotePath::Local)
-                        .collect(),
+                    paths: deleted_paths,
                 });
         }
     }
@@ -1044,6 +1094,49 @@ impl SkillWatcher {
     }
 }
 
+fn remote_skill_read_request(skill_paths: &[LocalOrRemotePath]) -> ReadFileContextRequest {
+    ReadFileContextRequest {
+        files: skill_paths
+            .iter()
+            .filter_map(|path| match path {
+                LocalOrRemotePath::Remote(remote) => Some(ReadFileContextFile {
+                    path: remote.path.as_str().to_string(),
+                    line_ranges: Vec::new(),
+                }),
+                LocalOrRemotePath::Local(_) => None,
+            })
+            .collect(),
+        max_file_bytes: Some(REMOTE_SKILL_MAX_FILE_BYTES),
+        max_batch_bytes: Some(REMOTE_SKILL_MAX_BATCH_BYTES),
+    }
+}
+
+fn parse_remote_skill_file_contexts(
+    skill_paths: Vec<LocalOrRemotePath>,
+    file_contexts: Vec<FileContextProto>,
+) -> Vec<ParsedSkill> {
+    let text_content_by_path = file_contexts
+        .into_iter()
+        .filter_map(|file_context| {
+            let file_context_proto::Content::TextContent(content) = file_context.content? else {
+                return None;
+            };
+            Some((file_context.file_name, content))
+        })
+        .collect::<HashMap<_, _>>();
+
+    skill_paths
+        .into_iter()
+        .filter_map(|path| {
+            let LocalOrRemotePath::Remote(remote) = &path else {
+                return None;
+            };
+            let content = text_content_by_path.get(remote.path.as_str())?;
+            let provider = get_provider_for_location(&path).unwrap_or(SkillProvider::Agents);
+            parse_skill_content_at_location(path, content, provider, SkillScope::Project).ok()
+        })
+        .collect()
+}
 impl Entity for SkillWatcher {
     type Event = SkillWatcherEvent;
 }

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use ai::skills::{
@@ -6,6 +7,7 @@ use ai::skills::{
     ParsedSkill, SkillProvider, SkillScope, SKILL_PROVIDER_DEFINITIONS,
 };
 use async_channel::Sender;
+use futures::future::BoxFuture;
 use remote_server::proto::{
     file_context_proto, FileContextProto, ReadFileContextFile, ReadFileContextRequest,
 };
@@ -38,6 +40,8 @@ pub enum SkillWatcherEvent {
 
 const REMOTE_SKILL_MAX_FILE_BYTES: u32 = 1024 * 1024;
 const REMOTE_SKILL_MAX_BATCH_BYTES: u32 = 5 * 1024 * 1024;
+type ProjectSkillContentsFuture =
+    BoxFuture<'static, anyhow::Result<Vec<(LocalOrRemotePath, String)>>>;
 pub struct SkillWatcher {
     // Channel for sending repository messages from subscribers.
     repository_message_tx: Sender<SkillRepositoryMessage>,
@@ -260,16 +264,6 @@ impl SkillWatcher {
                 });
         }
 
-        let local_skill_files = current_skill_files
-            .iter()
-            .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
-            .collect::<Vec<_>>();
-        let remote_skill_files = current_skill_files
-            .iter()
-            .filter(|path| matches!(path, LocalOrRemotePath::Remote(_)))
-            .cloned()
-            .collect::<Vec<_>>();
-
         // Project skill counts are expected to be small, so repo metadata updates
         // intentionally trigger a full refresh instead of attempting to diff the
         // changed subtree. This keeps local and remote project-skill behavior on
@@ -278,18 +272,9 @@ impl SkillWatcher {
         self.spawn_read_project_skills_from_files(
             repo_id.clone(),
             refresh_generation,
-            local_skill_files,
+            current_skill_files.iter().cloned().collect(),
             ctx,
         );
-        if let RepositoryIdentifier::Remote(remote_repo) = &repo_id {
-            self.spawn_read_remote_project_skills(
-                repo_id.clone(),
-                refresh_generation,
-                remote_repo.host_id.clone(),
-                remote_skill_files,
-                ctx,
-            );
-        }
 
         self.project_skill_files_by_repo
             .insert(repo_id.clone(), current_skill_files);
@@ -381,56 +366,31 @@ impl SkillWatcher {
             },
         );
     }
-    fn spawn_read_remote_project_skills(
+
+    fn spawn_read_project_skills_from_files(
         &mut self,
         repo_id: RepositoryIdentifier,
         refresh_generation: u64,
-        host_id: warp_util::host_id::HostId,
         skill_paths: Vec<LocalOrRemotePath>,
         ctx: &mut ModelContext<Self>,
     ) {
         if skill_paths.is_empty() {
             return;
         }
-        let Some(client) = RemoteServerManager::as_ref(ctx)
-            .client_for_host(&host_id)
-            .cloned()
-        else {
+        let Some(read_skill_contents) = read_project_skill_contents(skill_paths, ctx) else {
             return;
         };
 
         ctx.spawn(
             async move {
-                let request = remote_skill_read_request(&skill_paths);
-                let response = client.read_file_context(request).await?;
-                let skills = parse_remote_skill_file_contexts(skill_paths, response.file_contexts);
-                Ok::<Vec<ParsedSkill>, anyhow::Error>(skills)
+                let skill_contents = read_skill_contents.await?;
+                Ok::<Vec<ParsedSkill>, anyhow::Error>(parse_project_skill_contents(skill_contents))
             },
             move |me, skills, ctx| match skills {
                 Ok(skills) => {
                     me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
                 }
-                Err(err) => log::warn!("Failed to read remote project skills: {err}"),
-            },
-        );
-    }
-
-    fn spawn_read_project_skills_from_files(
-        &mut self,
-        repo_id: RepositoryIdentifier,
-        refresh_generation: u64,
-        skill_files: impl IntoIterator<Item = PathBuf>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let skill_files: Vec<_> = skill_files.into_iter().collect();
-        if skill_files.is_empty() {
-            return;
-        }
-
-        ctx.spawn(
-            async move { read_skills_from_files(skill_files) },
-            move |me, skills, ctx| {
-                me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
+                Err(err) => log::warn!("Failed to read project skills: {err}"),
             },
         );
     }
@@ -1094,6 +1054,29 @@ impl SkillWatcher {
     }
 }
 
+fn read_project_skill_contents(
+    skill_paths: Vec<LocalOrRemotePath>,
+    ctx: &AppContext,
+) -> Option<ProjectSkillContentsFuture> {
+    match skill_paths.first()? {
+        LocalOrRemotePath::Local(_) => Some(Box::pin(async move {
+            Ok(read_local_project_skill_contents(skill_paths))
+        })),
+        LocalOrRemotePath::Remote(remote) => {
+            let client = RemoteServerManager::as_ref(ctx)
+                .client_for_host(&remote.host_id)?
+                .clone();
+            Some(Box::pin(async move {
+                let request = remote_skill_read_request(&skill_paths);
+                let response = client.read_file_context(request).await?;
+                Ok(read_remote_project_skill_contents(
+                    skill_paths,
+                    response.file_contexts,
+                ))
+            }))
+        }
+    }
+}
 fn remote_skill_read_request(skill_paths: &[LocalOrRemotePath]) -> ReadFileContextRequest {
     ReadFileContextRequest {
         files: skill_paths
@@ -1111,10 +1094,22 @@ fn remote_skill_read_request(skill_paths: &[LocalOrRemotePath]) -> ReadFileConte
     }
 }
 
-fn parse_remote_skill_file_contexts(
+fn read_local_project_skill_contents(
+    skill_paths: Vec<LocalOrRemotePath>,
+) -> Vec<(LocalOrRemotePath, String)> {
+    skill_paths
+        .into_iter()
+        .filter_map(|path| {
+            let content = fs::read_to_string(path.to_local_path()?).ok()?;
+            Some((path, content))
+        })
+        .collect()
+}
+
+fn read_remote_project_skill_contents(
     skill_paths: Vec<LocalOrRemotePath>,
     file_contexts: Vec<FileContextProto>,
-) -> Vec<ParsedSkill> {
+) -> Vec<(LocalOrRemotePath, String)> {
     let text_content_by_path = file_contexts
         .into_iter()
         .filter_map(|file_context| {
@@ -1131,9 +1126,20 @@ fn parse_remote_skill_file_contexts(
             let LocalOrRemotePath::Remote(remote) = &path else {
                 return None;
             };
-            let content = text_content_by_path.get(remote.path.as_str())?;
+            let content = text_content_by_path.get(remote.path.as_str())?.clone();
+            Some((path, content))
+        })
+        .collect()
+}
+
+fn parse_project_skill_contents(
+    skill_contents: Vec<(LocalOrRemotePath, String)>,
+) -> Vec<ParsedSkill> {
+    skill_contents
+        .into_iter()
+        .filter_map(|(path, content)| {
             let provider = get_provider_for_path(&path).unwrap_or(SkillProvider::Agents);
-            parse_skill_content_at_location(path, content, provider, SkillScope::Project).ok()
+            parse_skill_content_at_location(path, &content, provider, SkillScope::Project).ok()
         })
         .collect()
 }

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use ai::skills::{
-    get_provider_for_location, home_skills_path, parse_skill, parse_skill_content_at_location,
+    get_provider_for_path, home_skills_path, parse_skill, parse_skill_content_at_location,
     ParsedSkill, SkillProvider, SkillScope, SKILL_PROVIDER_DEFINITIONS,
 };
 use async_channel::Sender;
@@ -1132,7 +1132,7 @@ fn parse_remote_skill_file_contexts(
                 return None;
             };
             let content = text_content_by_path.get(remote.path.as_str())?;
-            let provider = get_provider_for_location(&path).unwrap_or(SkillProvider::Agents);
+            let provider = get_provider_for_path(&path).unwrap_or(SkillProvider::Agents);
             parse_skill_content_at_location(path, content, provider, SkillScope::Project).ok()
         })
         .collect()

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -281,7 +281,7 @@ impl SkillWatcher {
             local_skill_files,
             ctx,
         );
-        if let RepositoryIdentifier::Remote(remote_repo) = repo_id {
+        if let RepositoryIdentifier::Remote(remote_repo) = &repo_id {
             self.spawn_read_remote_project_skills(
                 repo_id.clone(),
                 refresh_generation,

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -3,9 +3,13 @@ use std::fs;
 use std::path::PathBuf;
 
 use super::super::subscribers::SkillRepositoryMessage;
-use super::SkillWatcher;
+use super::{
+    parse_remote_skill_file_contexts, remote_skill_read_request, SkillWatcher,
+    REMOTE_SKILL_MAX_BATCH_BYTES, REMOTE_SKILL_MAX_FILE_BYTES,
+};
 use crate::ai::skills::skill_manager::SkillWatcherEvent;
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
+use remote_server::proto::{file_context_proto, FileContextProto};
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
 use repo_metadata::repositories::DetectedRepositories;
@@ -13,7 +17,10 @@ use repo_metadata::{
     DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate, TargetFile,
 };
 use tempfile::TempDir;
-use warp_util::{local_or_remote_path::LocalOrRemotePath, standardized_path::StandardizedPath};
+use warp_util::{
+    host_id::HostId, local_or_remote_path::LocalOrRemotePath, remote_path::RemotePath,
+    standardized_path::StandardizedPath,
+};
 use warpui::App;
 
 /// Helper function for creating a single skill file
@@ -58,6 +65,124 @@ description: {}
 fn skill_local_path(skill: &ParsedSkill) -> PathBuf {
     skill.path.to_local_path().unwrap().to_path_buf()
 }
+fn remote_skill_path(host_id: &HostId, name: &str) -> LocalOrRemotePath {
+    LocalOrRemotePath::Remote(RemotePath::new(
+        host_id.clone(),
+        StandardizedPath::try_new(format!("/repo/.agents/skills/{name}/SKILL.md").as_str())
+            .unwrap(),
+    ))
+}
+
+fn remote_skill_content(name: &str, description: &str, body: &str) -> String {
+    format!(
+        r#"---
+name: {name}
+description: {description}
+---
+{body}
+"#
+    )
+}
+
+fn remote_skill_file_context(path: &LocalOrRemotePath, content: &str) -> FileContextProto {
+    let LocalOrRemotePath::Remote(remote) = path else {
+        panic!("Expected a remote skill path");
+    };
+
+    FileContextProto {
+        file_name: remote.path.as_str().to_string(),
+        content: Some(file_context_proto::Content::TextContent(
+            content.to_string(),
+        )),
+        line_range_start: None,
+        line_range_end: None,
+        last_modified_epoch_millis: None,
+        line_count: content.lines().count() as u32,
+    }
+}
+
+#[test]
+fn parse_remote_skill_file_contexts_matches_reordered_responses_by_path() {
+    let host = HostId::new("test-host".to_string());
+    let first_path = remote_skill_path(&host, "first");
+    let second_path = remote_skill_path(&host, "second");
+    let first_content = remote_skill_content("first", "First skill", "First body");
+    let second_content = remote_skill_content("second", "Second skill", "Second body");
+
+    let skills = parse_remote_skill_file_contexts(
+        vec![first_path.clone(), second_path.clone()],
+        vec![
+            remote_skill_file_context(&second_path, &second_content),
+            remote_skill_file_context(&first_path, &first_content),
+        ],
+    );
+
+    assert_eq!(skills.len(), 2);
+    assert_eq!(skills[0].path, first_path);
+    assert_eq!(skills[0].name, "first");
+    assert_eq!(skills[0].content, first_content);
+    assert_eq!(skills[0].provider, SkillProvider::Agents);
+    assert_eq!(skills[1].path, second_path);
+    assert_eq!(skills[1].name, "second");
+    assert_eq!(skills[1].content, second_content);
+}
+
+#[test]
+fn parse_remote_skill_file_contexts_classifies_foreign_encoded_provider_path() {
+    let path = LocalOrRemotePath::Remote(RemotePath::new(
+        HostId::new("test-host".to_string()),
+        StandardizedPath::try_new(r"C:\repo\.codex\skills\windows-skill\SKILL.md").unwrap(),
+    ));
+    let content = remote_skill_content("windows-skill", "Windows skill", "Windows body");
+
+    let skills = parse_remote_skill_file_contexts(
+        vec![path.clone()],
+        vec![remote_skill_file_context(&path, &content)],
+    );
+
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].path, path);
+    assert_eq!(skills[0].provider, SkillProvider::Codex);
+}
+
+#[test]
+fn parse_remote_skill_file_contexts_keeps_paths_aligned_after_missing_reads() {
+    let host = HostId::new("test-host".to_string());
+    let missing_path = remote_skill_path(&host, "missing");
+    let present_path = remote_skill_path(&host, "present");
+    let present_content = remote_skill_content("present", "Present skill", "Present body");
+
+    let skills = parse_remote_skill_file_contexts(
+        vec![missing_path, present_path.clone()],
+        vec![remote_skill_file_context(&present_path, &present_content)],
+    );
+
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].path, present_path);
+    assert_eq!(skills[0].name, "present");
+    assert_eq!(skills[0].content, present_content);
+}
+
+#[test]
+fn remote_skill_read_request_sets_bounded_read_budget() {
+    let host = HostId::new("test-host".to_string());
+    let first_path = remote_skill_path(&host, "first");
+    let second_path = remote_skill_path(&host, "second");
+
+    let request = remote_skill_read_request(&[first_path.clone(), second_path.clone()]);
+
+    assert_eq!(request.max_file_bytes, Some(REMOTE_SKILL_MAX_FILE_BYTES));
+    assert_eq!(request.max_batch_bytes, Some(REMOTE_SKILL_MAX_BATCH_BYTES));
+    assert_eq!(request.files.len(), 2);
+    let LocalOrRemotePath::Remote(first_remote) = first_path else {
+        panic!("Expected remote path");
+    };
+    let LocalOrRemotePath::Remote(second_remote) = second_path else {
+        panic!("Expected remote path");
+    };
+    assert_eq!(request.files[0].path, first_remote.path.as_str());
+    assert_eq!(request.files[1].path, second_remote.path.as_str());
+}
 
 // ============================================================================
 // Tests for handle_repository_update
@@ -97,6 +222,46 @@ fn test_handle_repository_update_single_skill_added() {
                 skills: vec![skill]
             }
         );
+    });
+}
+
+#[test]
+fn test_removing_remote_project_repo_deletes_shared_cached_skill_paths() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let host = HostId::new("test-host".to_string());
+        let repo_id = RepositoryIdentifier::Remote(RemotePath::new(
+            host.clone(),
+            StandardizedPath::try_new("/repo").unwrap(),
+        ));
+        let first_path = remote_skill_path(&host, "first");
+        let second_path = remote_skill_path(&host, "second");
+
+        skill_watcher_handle.update(&mut app, |watcher, _| {
+            watcher.project_skill_files_by_repo.insert(
+                repo_id.clone(),
+                HashSet::from([first_path.clone(), second_path.clone()]),
+            );
+            watcher.remove_project_skills_for_repo(&repo_id);
+        });
+
+        let SkillWatcherEvent::SkillsDeleted { mut paths } = rx.recv().await.unwrap() else {
+            panic!("Expected SkillsDeleted event");
+        };
+        paths.sort_by_key(LocalOrRemotePath::display_path);
+        let mut expected = vec![first_path, second_path];
+        expected.sort_by_key(LocalOrRemotePath::display_path);
+        assert_eq!(paths, expected);
+
+        skill_watcher_handle.read(&app, |watcher, _| {
+            assert!(!watcher.project_skill_files_by_repo.contains_key(&repo_id));
+        });
     });
 }
 

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use super::super::subscribers::SkillRepositoryMessage;
 use super::{
-    parse_remote_skill_file_contexts, remote_skill_read_request, SkillWatcher,
-    REMOTE_SKILL_MAX_BATCH_BYTES, REMOTE_SKILL_MAX_FILE_BYTES,
+    parse_project_skill_contents, read_remote_project_skill_contents, remote_skill_read_request,
+    SkillWatcher, REMOTE_SKILL_MAX_BATCH_BYTES, REMOTE_SKILL_MAX_FILE_BYTES,
 };
 use crate::ai::skills::skill_manager::SkillWatcherEvent;
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
@@ -102,20 +102,21 @@ fn remote_skill_file_context(path: &LocalOrRemotePath, content: &str) -> FileCon
 }
 
 #[test]
-fn parse_remote_skill_file_contexts_matches_reordered_responses_by_path() {
+fn parse_project_skill_contents_matches_reordered_remote_responses_by_path() {
     let host = HostId::new("test-host".to_string());
     let first_path = remote_skill_path(&host, "first");
     let second_path = remote_skill_path(&host, "second");
     let first_content = remote_skill_content("first", "First skill", "First body");
     let second_content = remote_skill_content("second", "Second skill", "Second body");
 
-    let skills = parse_remote_skill_file_contexts(
+    let skill_contents = read_remote_project_skill_contents(
         vec![first_path.clone(), second_path.clone()],
         vec![
             remote_skill_file_context(&second_path, &second_content),
             remote_skill_file_context(&first_path, &first_content),
         ],
     );
+    let skills = parse_project_skill_contents(skill_contents);
 
     assert_eq!(skills.len(), 2);
     assert_eq!(skills[0].path, first_path);
@@ -128,17 +129,14 @@ fn parse_remote_skill_file_contexts_matches_reordered_responses_by_path() {
 }
 
 #[test]
-fn parse_remote_skill_file_contexts_classifies_foreign_encoded_provider_path() {
+fn parse_project_skill_contents_classifies_foreign_encoded_provider_path() {
     let path = LocalOrRemotePath::Remote(RemotePath::new(
         HostId::new("test-host".to_string()),
         StandardizedPath::try_new(r"C:\repo\.codex\skills\windows-skill\SKILL.md").unwrap(),
     ));
     let content = remote_skill_content("windows-skill", "Windows skill", "Windows body");
 
-    let skills = parse_remote_skill_file_contexts(
-        vec![path.clone()],
-        vec![remote_skill_file_context(&path, &content)],
-    );
+    let skills = parse_project_skill_contents(vec![(path.clone(), content)]);
 
     assert_eq!(skills.len(), 1);
     assert_eq!(skills[0].path, path);
@@ -146,16 +144,17 @@ fn parse_remote_skill_file_contexts_classifies_foreign_encoded_provider_path() {
 }
 
 #[test]
-fn parse_remote_skill_file_contexts_keeps_paths_aligned_after_missing_reads() {
+fn read_remote_project_skill_contents_keeps_paths_aligned_after_missing_reads() {
     let host = HostId::new("test-host".to_string());
     let missing_path = remote_skill_path(&host, "missing");
     let present_path = remote_skill_path(&host, "present");
     let present_content = remote_skill_content("present", "Present skill", "Present body");
 
-    let skills = parse_remote_skill_file_contexts(
+    let skill_contents = read_remote_project_skill_contents(
         vec![missing_path, present_path.clone()],
         vec![remote_skill_file_context(&present_path, &present_content)],
     );
+    let skills = parse_project_skill_contents(skill_contents);
 
     assert_eq!(skills.len(), 1);
     assert_eq!(skills[0].path, present_path);

--- a/app/src/ai/skills/global_skills_tests.rs
+++ b/app/src/ai/skills/global_skills_tests.rs
@@ -148,9 +148,10 @@ fn skill_path(repo_path: &Path, provider_dir: &str, skill_name: &str) -> PathBuf
 }
 
 fn parsed_skill(path: PathBuf, name: &str) -> ParsedSkill {
+    let path = LocalOrRemotePath::Local(path);
     let provider = get_provider_for_path(&path).unwrap_or(SkillProvider::Agents);
     ParsedSkill {
-        path: LocalOrRemotePath::Local(path),
+        path,
         name: name.to_string(),
         description: String::new(),
         content: String::new(),

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -591,13 +591,14 @@ fn active_skill_by_reference_distinguishes_remote_hosts_with_the_same_display_pa
 /// Helper: creates a ParsedSkill under a given provider directory.
 fn make_skill(name: &str, provider_dir: &str) -> ParsedSkill {
     let local_path = PathBuf::from(format!("/repo/{provider_dir}/skills/{name}/SKILL.md"));
+    let path = LocalOrRemotePath::Local(local_path);
     ParsedSkill {
         name: name.to_string(),
         description: format!("{name} skill"),
-        path: LocalOrRemotePath::Local(local_path.clone()),
+        path: path.clone(),
         content: format!("# {name}"),
         line_range: None,
-        provider: get_provider_for_path(&local_path).unwrap_or(SkillProvider::Warp),
+        provider: get_provider_for_path(&path).unwrap_or(SkillProvider::Warp),
         scope: SkillScope::Project,
     }
 }

--- a/crates/ai/src/skills/mod.rs
+++ b/crates/ai/src/skills/mod.rs
@@ -14,8 +14,8 @@ pub use parse_skill::{
 };
 pub use read_skills::read_skills;
 pub use skill_provider::{
-    get_provider_for_path, home_skills_path, provider_rank, SkillProvider, SkillProviderDefinition,
-    SkillScope, SKILL_PROVIDER_DEFINITIONS,
+    get_provider_for_location, get_provider_for_path, home_skills_path, provider_rank,
+    SkillProvider, SkillProviderDefinition, SkillScope, SKILL_PROVIDER_DEFINITIONS,
 };
 pub use skill_reference::SkillReference;
 pub(crate) use skill_reference::{decode_api_path_reference, encode_api_path_reference};

--- a/crates/ai/src/skills/mod.rs
+++ b/crates/ai/src/skills/mod.rs
@@ -14,8 +14,8 @@ pub use parse_skill::{
 };
 pub use read_skills::read_skills;
 pub use skill_provider::{
-    get_provider_for_location, get_provider_for_path, home_skills_path, provider_rank,
-    SkillProvider, SkillProviderDefinition, SkillScope, SKILL_PROVIDER_DEFINITIONS,
+    get_provider_for_path, home_skills_path, provider_rank, SkillProvider, SkillProviderDefinition,
+    SkillScope, SKILL_PROVIDER_DEFINITIONS,
 };
 pub use skill_reference::SkillReference;
 pub(crate) use skill_reference::{decode_api_path_reference, encode_api_path_reference};

--- a/crates/ai/src/skills/parse_skill.rs
+++ b/crates/ai/src/skills/parse_skill.rs
@@ -110,13 +110,10 @@ impl Display for ParsedSkill {
 /// # Returns
 /// * `Result<ParsedSkill>` - Parsed skill with validated name and description
 pub fn parse_skill(path: &Path) -> Result<ParsedSkill> {
-    let provider = get_provider_for_path(path).unwrap_or(SkillProvider::Agents);
     let scope = get_scope_for_path(path);
-    parse_skill_internal(
-        LocalOrRemotePath::Local(path.to_path_buf()),
-        provider,
-        scope,
-    )
+    let path = LocalOrRemotePath::Local(path.to_path_buf());
+    let provider = get_provider_for_path(&path).unwrap_or(SkillProvider::Agents);
+    parse_skill_internal(path, provider, scope)
 }
 
 /// Parse a bundled skill markdown file.

--- a/crates/ai/src/skills/skill_provider.rs
+++ b/crates/ai/src/skills/skill_provider.rs
@@ -12,6 +12,7 @@ use strum_macros::{Display, EnumString, VariantNames};
 use warp_core::ui::color::CLAUDE_ORANGE;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::Fill;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 /// Represents a skill provider/origin (Agents, Claude, Codex, or Warp).
 #[derive(
@@ -194,6 +195,27 @@ pub fn get_provider_for_path(path: &Path) -> Option<SkillProvider> {
     None
 }
 
+/// Returns the skill provider for a location without discarding remote host identity.
+///
+/// Local locations retain home-directory-aware matching. Remote project locations are
+/// classified only by their provider-directory structure, because their paths do not
+/// belong to the local filesystem.
+pub fn get_provider_for_location(path: &LocalOrRemotePath) -> Option<SkillProvider> {
+    match path {
+        LocalOrRemotePath::Local(path) => get_provider_for_path(path),
+        LocalOrRemotePath::Remote(remote) => SKILL_PROVIDER_DEFINITIONS
+            .iter()
+            .find(|definition| {
+                let provider_path = definition.skills_path.to_string_lossy();
+                remote
+                    .path
+                    .ancestors()
+                    .any(|ancestor| ancestor.ends_with(provider_path.as_ref()))
+            })
+            .map(|definition| definition.provider),
+    }
+}
+
 /// Returns the skill scope (Home or Project) for a given path.
 /// A skill is considered a "Home" skill if its path starts with the user's home directory.
 /// Otherwise, it's a "Project" skill.
@@ -212,8 +234,13 @@ pub fn get_scope_for_path(path: &Path) -> SkillScope {
 #[cfg(test)]
 mod tests {
     use super::{
-        get_provider_for_path, get_scope_for_path, home_skills_path, SkillProvider, SkillScope,
+        get_provider_for_location, get_provider_for_path, get_scope_for_path, home_skills_path,
+        SkillProvider, SkillScope,
     };
+    use warp_util::host_id::HostId;
+    use warp_util::local_or_remote_path::LocalOrRemotePath;
+    use warp_util::remote_path::RemotePath;
+    use warp_util::standardized_path::StandardizedPath;
 
     #[test]
     fn warp_home_skills_path_uses_warp_home_path() {
@@ -233,5 +260,28 @@ mod tests {
 
         assert_eq!(get_provider_for_path(&path), Some(SkillProvider::Warp));
         assert_eq!(get_scope_for_path(&path), SkillScope::Home);
+    }
+
+    #[test]
+    fn remote_provider_path_is_classified_by_structure() {
+        let path = LocalOrRemotePath::Remote(RemotePath::new(
+            HostId::new("remote-host".to_string()),
+            StandardizedPath::try_new("/repo/.claude/skills/my-skill/SKILL.md").unwrap(),
+        ));
+
+        assert_eq!(
+            get_provider_for_location(&path),
+            Some(SkillProvider::Claude)
+        );
+    }
+
+    #[test]
+    fn foreign_encoded_remote_provider_path_is_classified_by_structure() {
+        let path = LocalOrRemotePath::Remote(RemotePath::new(
+            HostId::new("remote-host".to_string()),
+            StandardizedPath::try_new(r"C:\repo\.codex\skills\my-skill\SKILL.md").unwrap(),
+        ));
+
+        assert_eq!(get_provider_for_location(&path), Some(SkillProvider::Codex));
     }
 }

--- a/crates/ai/src/skills/skill_provider.rs
+++ b/crates/ai/src/skills/skill_provider.rs
@@ -274,10 +274,7 @@ mod tests {
             StandardizedPath::try_new("/repo/.claude/skills/my-skill/SKILL.md").unwrap(),
         ));
 
-        assert_eq!(
-            get_provider_for_path(&path),
-            Some(SkillProvider::Claude)
-        );
+        assert_eq!(get_provider_for_path(&path), Some(SkillProvider::Claude));
     }
 
     #[test]

--- a/crates/ai/src/skills/skill_provider.rs
+++ b/crates/ai/src/skills/skill_provider.rs
@@ -170,45 +170,26 @@ pub fn home_skills_path(provider: SkillProvider) -> Option<PathBuf> {
 
 /// Returns the skill provider for a location, if it matches a known skill provider directory.
 ///
-/// Local locations retain home-directory-aware matching. Remote project locations are
-/// classified only by their provider-directory structure, because their paths do not
-/// belong to the local filesystem.
+/// Local locations retain home-directory-aware matching. All other locations are
+/// classified by provider-directory structure using their standardized path representation.
 pub fn get_provider_for_path(path: &LocalOrRemotePath) -> Option<SkillProvider> {
-    match path {
-        LocalOrRemotePath::Local(path) => get_provider_for_local_path(path),
-        LocalOrRemotePath::Remote(remote) => get_provider_for_remote_path(&remote.path),
-    }
+    path.to_local_path()
+        .and_then(get_home_provider_for_local_path)
+        .or_else(|| get_provider_for_standardized_path(&path.path_component()))
 }
 
-/// Returns the skill provider for a local path, if it matches a known skill provider directory.
-/// For example:
-///   get_provider_for_local_path(Path::new("/repo/.claude/skills/my-skill/SKILL.md")) returns Some(SkillProvider::Claude).
-/// Handles both SKILL.md files and files nested within a skill directory.
-fn get_provider_for_local_path(path: &Path) -> Option<SkillProvider> {
-    let path_components: Vec<_> = path.components().collect();
-
-    for def in SKILL_PROVIDER_DEFINITIONS.iter() {
-        if home_skills_path(def.provider)
-            .into_iter()
-            .any(|home_skills_path| path.starts_with(home_skills_path))
-        {
-            return Some(def.provider);
-        }
-
-        // Retrieves path components for the skill provider directory (i.e., [".claude", "skills"])
-        let skill_components: Vec<_> = def.skills_path.components().collect();
-
-        // Checks if some consecutive components of the path match the skill provider directory
-        for window in path_components.windows(skill_components.len()) {
-            if window == skill_components.as_slice() {
-                return Some(def.provider);
-            }
-        }
-    }
-    None
+fn get_home_provider_for_local_path(path: &Path) -> Option<SkillProvider> {
+    SKILL_PROVIDER_DEFINITIONS
+        .iter()
+        .find(|definition| {
+            home_skills_path(definition.provider)
+                .into_iter()
+                .any(|home_skills_path| path.starts_with(home_skills_path))
+        })
+        .map(|definition| definition.provider)
 }
 
-fn get_provider_for_remote_path(path: &StandardizedPath) -> Option<SkillProvider> {
+fn get_provider_for_standardized_path(path: &StandardizedPath) -> Option<SkillProvider> {
     SKILL_PROVIDER_DEFINITIONS
         .iter()
         .find(|definition| {
@@ -273,6 +254,20 @@ mod tests {
             HostId::new("remote-host".to_string()),
             StandardizedPath::try_new("/repo/.claude/skills/my-skill/SKILL.md").unwrap(),
         ));
+
+        assert_eq!(get_provider_for_path(&path), Some(SkillProvider::Claude));
+    }
+
+    #[test]
+    fn local_project_provider_path_is_classified_by_structure() {
+        let path = LocalOrRemotePath::Local(
+            std::env::temp_dir()
+                .join("repo")
+                .join(".claude")
+                .join("skills")
+                .join("my-skill")
+                .join("SKILL.md"),
+        );
 
         assert_eq!(get_provider_for_path(&path), Some(SkillProvider::Claude));
     }

--- a/crates/ai/src/skills/skill_provider.rs
+++ b/crates/ai/src/skills/skill_provider.rs
@@ -13,6 +13,7 @@ use warp_core::ui::color::CLAUDE_ORANGE;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::Fill;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::standardized_path::StandardizedPath;
 
 /// Represents a skill provider/origin (Agents, Claude, Codex, or Warp).
 #[derive(
@@ -167,11 +168,23 @@ pub fn home_skills_path(provider: SkillProvider) -> Option<PathBuf> {
     home_dir().map(|home_dir| home_dir.join(&definition.skills_path))
 }
 
-/// Returns the skill provider for a given path, if it matches a known skill provider directory.
+/// Returns the skill provider for a location, if it matches a known skill provider directory.
+///
+/// Local locations retain home-directory-aware matching. Remote project locations are
+/// classified only by their provider-directory structure, because their paths do not
+/// belong to the local filesystem.
+pub fn get_provider_for_path(path: &LocalOrRemotePath) -> Option<SkillProvider> {
+    match path {
+        LocalOrRemotePath::Local(path) => get_provider_for_local_path(path),
+        LocalOrRemotePath::Remote(remote) => get_provider_for_remote_path(&remote.path),
+    }
+}
+
+/// Returns the skill provider for a local path, if it matches a known skill provider directory.
 /// For example:
-///   get_provider_for_path(Path::new("/repo/.claude/skills/my-skill/SKILL.md")) returns Some(SkillProvider::Claude).
+///   get_provider_for_local_path(Path::new("/repo/.claude/skills/my-skill/SKILL.md")) returns Some(SkillProvider::Claude).
 /// Handles both SKILL.md files and files nested within a skill directory.
-pub fn get_provider_for_path(path: &Path) -> Option<SkillProvider> {
+fn get_provider_for_local_path(path: &Path) -> Option<SkillProvider> {
     let path_components: Vec<_> = path.components().collect();
 
     for def in SKILL_PROVIDER_DEFINITIONS.iter() {
@@ -195,25 +208,15 @@ pub fn get_provider_for_path(path: &Path) -> Option<SkillProvider> {
     None
 }
 
-/// Returns the skill provider for a location without discarding remote host identity.
-///
-/// Local locations retain home-directory-aware matching. Remote project locations are
-/// classified only by their provider-directory structure, because their paths do not
-/// belong to the local filesystem.
-pub fn get_provider_for_location(path: &LocalOrRemotePath) -> Option<SkillProvider> {
-    match path {
-        LocalOrRemotePath::Local(path) => get_provider_for_path(path),
-        LocalOrRemotePath::Remote(remote) => SKILL_PROVIDER_DEFINITIONS
-            .iter()
-            .find(|definition| {
-                let provider_path = definition.skills_path.to_string_lossy();
-                remote
-                    .path
-                    .ancestors()
-                    .any(|ancestor| ancestor.ends_with(provider_path.as_ref()))
-            })
-            .map(|definition| definition.provider),
-    }
+fn get_provider_for_remote_path(path: &StandardizedPath) -> Option<SkillProvider> {
+    SKILL_PROVIDER_DEFINITIONS
+        .iter()
+        .find(|definition| {
+            let provider_path = definition.skills_path.to_string_lossy();
+            path.ancestors()
+                .any(|ancestor| ancestor.ends_with(provider_path.as_ref()))
+        })
+        .map(|definition| definition.provider)
 }
 
 /// Returns the skill scope (Home or Project) for a given path.
@@ -234,8 +237,7 @@ pub fn get_scope_for_path(path: &Path) -> SkillScope {
 #[cfg(test)]
 mod tests {
     use super::{
-        get_provider_for_location, get_provider_for_path, get_scope_for_path, home_skills_path,
-        SkillProvider, SkillScope,
+        get_provider_for_path, get_scope_for_path, home_skills_path, SkillProvider, SkillScope,
     };
     use warp_util::host_id::HostId;
     use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -258,7 +260,10 @@ mod tests {
         };
         let path = warp_home_skills_dir.join("my-skill").join("SKILL.md");
 
-        assert_eq!(get_provider_for_path(&path), Some(SkillProvider::Warp));
+        assert_eq!(
+            get_provider_for_path(&LocalOrRemotePath::Local(path.clone())),
+            Some(SkillProvider::Warp)
+        );
         assert_eq!(get_scope_for_path(&path), SkillScope::Home);
     }
 
@@ -270,7 +275,7 @@ mod tests {
         ));
 
         assert_eq!(
-            get_provider_for_location(&path),
+            get_provider_for_path(&path),
             Some(SkillProvider::Claude)
         );
     }
@@ -282,6 +287,6 @@ mod tests {
             StandardizedPath::try_new(r"C:\repo\.codex\skills\my-skill\SKILL.md").unwrap(),
         ));
 
-        assert_eq!(get_provider_for_location(&path), Some(SkillProvider::Codex));
+        assert_eq!(get_provider_for_path(&path), Some(SkillProvider::Codex));
     }
 }


### PR DESCRIPTION
## Description
PR 3/5 of the remote-aware skills stack.

Hydrate project skills from remote working directories and classify provider locations structurally, without temporarily coercing remote locations into local paths for shared logic.


Plan: https://staging.warp.dev/drive/notebook/EAngN0Hb9BqY5WiPMTXFV5
Agent run: https://staging.warp.dev/conversation/88702634-8ffe-46a4-b868-1efae92630eb

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo fmt --manifest-path Cargo.toml -p warp_util -p ai -p warp`
- `cargo test -p ai skill_provider --lib`
- `cargo test -p warp parse_remote_skill_file_contexts --lib`
- Full workspace clippy was started on the cumulative stack tip but not completed before submission.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
