### PR TITLE
Improve robustness of settings file migration tests.

### DIFF
--- a/app/src/settings/init.rs
+++ b/app/src/settings/init.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use settings::{Setting as _, SettingsManager};
 use warp_core::features::FeatureFlag;
 use warp_core::semantic_selection::SemanticSelection;
@@ -330,11 +332,14 @@ pub fn init_public_user_preferences() -> (user_preferences::Model, Option<user_p
 /// 3. The migration-complete marker is absent from the native store
 ///    (handles the case where a user deletes `settings.toml` to reset).
 fn needs_settings_file_migration(ctx: &AppContext) -> bool {
+    needs_settings_file_migration_for_path(ctx, &super::user_preferences_toml_file_path())
+}
+
+fn needs_settings_file_migration_for_path(ctx: &AppContext, settings_file_path: &Path) -> bool {
     if !FeatureFlag::SettingsFile.is_enabled() {
         return false;
     }
-
-    if super::user_preferences_toml_file_path().exists() {
+    if settings_file_path.exists() {
         return false;
     }
 

--- a/app/src/settings/init_tests.rs
+++ b/app/src/settings/init_tests.rs
@@ -9,7 +9,7 @@ use warpui::SingletonEntity;
 use warpui_extras::user_preferences;
 
 use super::{
-    migrate_native_settings_to_settings_file, needs_settings_file_migration,
+    migrate_native_settings_to_settings_file, needs_settings_file_migration_for_path,
     SETTINGS_FILE_MIGRATION_COMPLETE_KEY,
 };
 use crate::terminal::session_settings::{NotificationsMode, NotificationsSettings};
@@ -221,6 +221,8 @@ fn test_migration_handles_string_setting() {
 fn test_migration_does_not_rerun_when_marker_present() {
     warpui::App::test((), |mut app| async move {
         let _guard = FeatureFlag::SettingsFile.override_enabled(true);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let settings_file_path = temp_dir.path().join("settings.toml");
 
         app.update(init_test_app);
 
@@ -235,7 +237,7 @@ fn test_migration_does_not_rerun_when_marker_present() {
         // Before migration, the guard should allow migration.
         app.read(|ctx| {
             assert!(
-                needs_settings_file_migration(ctx),
+                needs_settings_file_migration_for_path(ctx, &settings_file_path),
                 "migration should be needed before first run"
             );
         });
@@ -248,8 +250,27 @@ fn test_migration_does_not_rerun_when_marker_present() {
         // After migration, the marker should prevent re-migration.
         app.read(|ctx| {
             assert!(
-                !needs_settings_file_migration(ctx),
+                !needs_settings_file_migration_for_path(ctx, &settings_file_path),
                 "migration should not be needed after marker is written"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_migration_not_needed_when_settings_file_exists() {
+    warpui::App::test((), |mut app| async move {
+        let _guard = FeatureFlag::SettingsFile.override_enabled(true);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let settings_file_path = temp_dir.path().join("settings.toml");
+        std::fs::write(&settings_file_path, "").unwrap();
+
+        app.update(init_test_app);
+
+        app.read(|ctx| {
+            assert!(
+                !needs_settings_file_migration_for_path(ctx, &settings_file_path),
+                "migration should not be needed when settings.toml exists"
             );
         });
     });


### PR DESCRIPTION
## Description
Make the settings file migration tests hermetic by allowing the migration guard to check an injected `settings.toml` path in tests while preserving the production path behavior. This prevents local user config files, such as an existing `~/.warp-oss/settings.toml`, from changing unit test outcomes.

## Testing
- `cargo fmt`
- `cargo nextest run -p warp -E 'test(test_migration_does_not_rerun_when_marker_present) | test(test_migration_not_needed_when_settings_file_exists)'`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
