### PR TITLE
Fix internal-dev image by making sure we set the right rust default version to match the cargo version we install.

### DIFF
--- a/docker/agent-dev/Dockerfile
+++ b/docker/agent-dev/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
     ca-certificates \
     xvfb
 
-# Install rustup. It will download the pinned version in our rust-toolchain.toml as needed.
+# Install rustup. The pinned Rust toolchain is installed below from rust-toolchain.toml.
 RUN set -eux; \
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal; \
   chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
@@ -70,7 +70,10 @@ RUN set -eux; \
 
 # Ensure the correct Rust toolchain is installed
 COPY ./rust-toolchain.toml ./setup/rust-toolchain.toml
-RUN cd ./setup && rustup toolchain install
+RUN set -eux; \
+  cd ./setup; \
+  rustup toolchain install; \
+  rustup default "$(rustup show active-toolchain | cut -d' ' -f1)"
 
 # Install all dependencies needed to build, run, and test Warp
 COPY ./script ./setup/script


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
Lately our `internal-dev` image (base for the Warp Dev Environment) has been turning up some "cargo clippy not installed" errors.

This is happening because we install the default version of `rustup`, but pin the cargo version that we install to the one defined in `warp/rust-toolchain.toml`. What this means is that whenever we try to run `cargo` from outside the `warp` repo, we don't have the right `cargo` version installed for that default version of `rustup` -- right now, the default rust version is 1.95.0, while we pin `cargo` to 1.92.0. 

This PR addresses this by setting the default rust toolchain version used in this docker image to match whatever we pin in `rust-toolchain.toml`, so it's consistent across the board.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

Built an image locally before and after this change, and confirmed that `cargo clippy --version` on the former fails, while on the latter works.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
