### PR TITLE
Fix Billing & Usage member gauge to count base credits only

### DIFF
--- a/app/src/settings_view/billing_and_usage/billing_cycle_usage_rows.rs
+++ b/app/src/settings_view/billing_and_usage/billing_cycle_usage_rows.rs
@@ -76,6 +76,11 @@ pub struct MemberUsageRow {
     pub subject_uid: Option<String>,
     pub display_name: String,
     pub total_credits: i64,
+    /// Credits that draw down the base AI request limit: `BaseLimit` cost type
+    /// in the AI/Compute buckets (mirrors `get_base_limits_usage.sql`). This is
+    /// the numerator for the `used / limit` gauge, so it is not inflated by
+    /// add-on, PAYG, or cloud-only spend the way `total_credits` is.
+    pub base_credits: i64,
     pub total_cost_cents: i64,
     /// Per-user base credit limit, rendered as `used / limit`. None for service
     /// accounts, team-aggregate rows, and unlimited members.
@@ -92,6 +97,26 @@ fn member_base_limit(member: &WorkspaceMember) -> Option<i64> {
     } else {
         Some(member.usage_info.request_limit as i64)
     }
+}
+
+/// Sum of credits that count against the base AI request limit: the `BaseLimit`
+/// cost type in the AI/Compute buckets. Mirrors `get_base_limits_usage.sql` in
+/// warp-server (the quantity the per-user `request_limit` is measured against),
+/// so the `used / limit` gauge reflects base consumption only — add-on (bonus
+/// grant), PAYG, and cloud-only credits live in their own pools and must not
+/// inflate it.
+fn base_limit_credits(segments: &[BarSegment]) -> i64 {
+    segments
+        .iter()
+        .filter(|s| s.cost_type == AiCreditsUsageAndCostType::BaseLimit)
+        .filter(|s| {
+            matches!(
+                s.usage_bucket,
+                AiCreditsUsageBucket::Ai | AiCreditsUsageBucket::Compute
+            )
+        })
+        .map(|s| s.credits)
+        .sum()
 }
 
 fn viewer_identity(app: &AppContext) -> (Option<String>, String) {
@@ -140,6 +165,7 @@ impl MemberUsageRow {
             .collect_vec();
         let (segments, total_credits, total_cost_cents) =
             aggregate_segments(viewer_entries.iter().copied());
+        let base_credits = base_limit_credits(&segments);
 
         Self {
             subject_type: AiCreditsUsageAndCostSubjectType::User,
@@ -147,6 +173,7 @@ impl MemberUsageRow {
             subject_uid: viewer_uid.map(str::to_string),
             display_name: viewer_display_name,
             total_credits,
+            base_credits,
             total_cost_cents,
             base_limit: viewer_base_limit,
             segments,
@@ -173,12 +200,14 @@ impl MemberUsageRow {
         } else {
             Vec::new()
         };
+        let base_credits = base_limit_credits(&segments);
         Self {
             subject_type: AiCreditsUsageAndCostSubjectType::User,
             subject_key: SELF_OWN_KEY.to_string(),
             subject_uid: viewer_uid,
             display_name: viewer_display_name,
             total_credits: used,
+            base_credits,
             total_cost_cents: 0,
             base_limit,
             segments,
@@ -193,6 +222,7 @@ impl MemberUsageRow {
             .iter()
             .filter(|e| e.subject_type == AiCreditsUsageAndCostSubjectType::Team);
         let (segments, total_credits, total_cost_cents) = aggregate_segments(team_entries);
+        let base_credits = base_limit_credits(&segments);
 
         Self {
             subject_type: AiCreditsUsageAndCostSubjectType::Team,
@@ -200,6 +230,7 @@ impl MemberUsageRow {
             subject_uid: None,
             display_name: "Other members".to_string(),
             total_credits,
+            base_credits,
             total_cost_cents,
             base_limit: None,
             segments,
@@ -262,6 +293,7 @@ impl MemberUsageRow {
                 Some(group) => aggregate_segments(group.entries.iter()),
                 None => (Vec::new(), 0, 0),
             };
+            let base_credits = base_limit_credits(&segments);
 
             rows.push(Self {
                 subject_type: AiCreditsUsageAndCostSubjectType::User,
@@ -269,6 +301,7 @@ impl MemberUsageRow {
                 subject_uid: Some(member.uid.as_str().to_string()),
                 display_name: member.email.clone(),
                 total_credits,
+                base_credits,
                 total_cost_cents,
                 base_limit: member_base_limit(member),
                 segments,
@@ -286,12 +319,14 @@ impl MemberUsageRow {
             let subject_uid = group.entries.first().and_then(|e| e.subject_uid.clone());
             let (segments, total_credits, total_cost_cents) =
                 aggregate_segments(group.entries.iter());
+            let base_credits = base_limit_credits(&segments);
             rows.push(Self {
                 subject_type: group.subject_type,
                 subject_key: key,
                 subject_uid,
                 display_name: group.display_name,
                 total_credits,
+                base_credits,
                 total_cost_cents,
                 base_limit: None,
                 segments,
@@ -574,7 +609,7 @@ fn render_row_card(
     let credits_str = match row.base_limit {
         Some(limit) if limit > 0 => format!(
             "{}/{}",
-            format_credits(row.total_credits),
+            format_credits(row.base_credits),
             format_credits(limit)
         ),
         None => format_credits(row.total_credits),

--- a/app/src/settings_view/billing_and_usage/billing_cycle_usage_rows_tests.rs
+++ b/app/src/settings_view/billing_and_usage/billing_cycle_usage_rows_tests.rs
@@ -26,6 +26,26 @@ fn entry(
     }
 }
 
+/// Viewer-attributed entry with an explicit cost type and usage bucket, for
+/// exercising the base-vs-total split.
+fn entry_typed(
+    cost_type: AiCreditsUsageAndCostType,
+    usage_bucket: AiCreditsUsageBucket,
+    credits_used: i32,
+    cost_cents: i32,
+) -> BillingCycleUsageEntry {
+    BillingCycleUsageEntry {
+        subject_type: AiCreditsUsageAndCostSubjectType::User,
+        subject_uid: Some(VIEWER_UID.to_string()),
+        subject_display_name: None,
+        cost_type,
+        usage_bucket,
+        usage_source: AiCreditsUsageSource::Local,
+        credits_used,
+        cost_cents,
+    }
+}
+
 #[test]
 fn build_own_usage_row_drops_team_subject_entries() {
     // Team-aggregate rows belong to "everyone else" by construction; they
@@ -152,4 +172,74 @@ fn build_own_usage_row_surfaces_supplied_base_limit() {
         SourceFilter::All,
     );
     assert_eq!(row.base_limit, Some(1500));
+}
+
+#[test]
+fn base_credits_excludes_add_on_spend() {
+    // Mirrors the upgrade-mid-cycle case: base usage plus add-on (bonus grant)
+    // usage in the same cycle. The `used / limit` gauge must count base only,
+    // while the bar/tooltip total still reflects everything that was spent.
+    let entries = vec![
+        entry_typed(
+            AiCreditsUsageAndCostType::BaseLimit,
+            AiCreditsUsageBucket::Ai,
+            3376,
+            0,
+        ),
+        entry_typed(
+            AiCreditsUsageAndCostType::BonusGrant,
+            AiCreditsUsageBucket::Ai,
+            4183,
+            7366,
+        ),
+    ];
+    let row = MemberUsageRow::for_viewer(
+        &entries,
+        Some(VIEWER_UID),
+        "viewer".to_string(),
+        Some(18000),
+        SourceFilter::All,
+    );
+    // Gauge numerator: base only.
+    assert_eq!(row.base_credits, 3376);
+    // Bar + tooltip total: base + add-ons.
+    assert_eq!(row.total_credits, 7559);
+    assert_eq!(row.total_cost_cents, 7366);
+    assert_eq!(row.base_limit, Some(18000));
+}
+
+#[test]
+fn base_credits_counts_ai_and_compute_but_not_platform() {
+    // Base usage draws down the AI request limit for the AI and Compute buckets
+    // only (see get_base_limits_usage.sql); Platform base usage is accounted
+    // separately and must not inflate the gauge numerator.
+    let entries = vec![
+        entry_typed(
+            AiCreditsUsageAndCostType::BaseLimit,
+            AiCreditsUsageBucket::Ai,
+            100,
+            0,
+        ),
+        entry_typed(
+            AiCreditsUsageAndCostType::BaseLimit,
+            AiCreditsUsageBucket::Compute,
+            50,
+            0,
+        ),
+        entry_typed(
+            AiCreditsUsageAndCostType::BaseLimit,
+            AiCreditsUsageBucket::Platform,
+            25,
+            0,
+        ),
+    ];
+    let row = MemberUsageRow::for_viewer(
+        &entries,
+        Some(VIEWER_UID),
+        "viewer".to_string(),
+        Some(18000),
+        SourceFilter::All,
+    );
+    assert_eq!(row.base_credits, 150);
+    assert_eq!(row.total_credits, 175);
 }


### PR DESCRIPTION
## Description
The team **Billing & Usage → Members** gauge rendered `total_credits / base_limit`, where `total_credits` sums **every** cost type (base + add-ons/bonus grants + PAYG). Add-on credits are a separate purchased pool, so combining them with the base-only limit over-reported base utilization.

Concretely, a member who used 3,376 base credits and 4,183 add-on credits (after upgrading Build → Max mid-cycle) showed `7,559 / 18,000` — implying 7,559 of the base allotment was consumed, when only 3,376 was.

**How:** the per-member `used / limit` numerator now comes from base-limit credits only — `BASE_LIMIT` cost type in the `AI`/`Compute` buckets, mirroring the server's `get_base_limits_usage.sql` (the quantity `request_limit` is measured against). The stacked bar, the breakdown tooltip's "Total usage", and the `$` cost still reflect all spend across pools, so no information is lost.

Scope: display-only change in `billing_cycle_usage_rows.rs`. The underlying ledger and the personal `AIRequestUsageModel` meter were already base-only and are unchanged.

## Linked Issue
N/A — internal bug surfaced while investigating a customer usage discrepancy.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Added unit tests in `billing_cycle_usage_rows_tests.rs`:
- `base_credits_excludes_add_on_spend`: 3,376 base + 4,183 add-ons ⇒ gauge numerator (`base_credits`) = 3,376 while `total_credits` (bar/tooltip) = 7,559.
- `base_credits_counts_ai_and_compute_but_not_platform`: base counts AI + Compute buckets, excludes Platform.

Validation run locally:
- `cargo fmt -p warp` — clean.
- `cargo nextest run -p warp billing_cycle_usage` — 20 passed (incl. the two new tests).
- `cargo clippy -p warp --lib --tests -- -D warnings` — clean.

- [ ] I have manually tested my changes locally with `./script/run`

> Draft: still needs manual UI verification + a screenshot of the corrected Members gauge before marking ready.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the team Billing & Usage "Members" gauge counting add-on credit spend against the base credit limit (e.g. showing 7,559/18,000 when only base usage should count).

Co-Authored-By: Oz <oz-agent@warp.dev>
