### PR TITLE
Show orchestration child status in vertical tabs

### DIFF
--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -105,13 +105,11 @@ pub fn aggregated_orchestrator_status(
     ConversationStatus::Success
 }
 
-/// Returns a conversation's direct status unless it is a known orchestration
-/// parent, in which case it returns [`aggregated_orchestrator_status`].
+/// Returns a conversation's direct status, or the aggregated subtree status
+/// ([`aggregated_orchestrator_status`]) when it's a known orchestration parent.
 ///
-/// This is intended for top-level conversation chrome (tab icons, pane header
-/// icons, status rows) where the user expects the visible status badge to keep
-/// representing active child agents after the orchestrator's own turn has
-/// finished.
+/// Used by top-level chrome (tab/header icons, status rows) so the badge keeps
+/// reflecting active children after the orchestrator's own turn finishes.
 pub fn orchestration_aware_conversation_status(
     history: &BlocklistAIHistoryModel,
     conversation: &AIConversation,

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -6,7 +6,7 @@
 //! footer's credit rollup) can walk the same tree without duplicating the
 //! traversal.
 
-use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 
 /// Returns all locally-known descendants (children, grandchildren, …) of
@@ -103,6 +103,27 @@ pub fn aggregated_orchestrator_status(
         return ConversationStatus::Cancelled;
     }
     ConversationStatus::Success
+}
+
+/// Returns a conversation's direct status unless it is a known orchestration
+/// parent, in which case it returns [`aggregated_orchestrator_status`].
+///
+/// This is intended for top-level conversation chrome (tab icons, pane header
+/// icons, status rows) where the user expects the visible status badge to keep
+/// representing active child agents after the orchestrator's own turn has
+/// finished.
+pub fn orchestration_aware_conversation_status(
+    history: &BlocklistAIHistoryModel,
+    conversation: &AIConversation,
+) -> ConversationStatus {
+    if history
+        .child_conversation_ids_of(&conversation.id())
+        .is_empty()
+    {
+        conversation.status().clone()
+    } else {
+        aggregated_orchestrator_status(history, conversation.id())
+    }
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -167,8 +167,7 @@ fn descendant_conversation_ids_in_spawn_order_returns_empty_without_children() {
     });
 }
 
-/// Convenience: build an orchestrator with two children for status-aggregation
-/// tests so individual cases stay focused on the precedence logic.
+/// Builds an orchestrator with two children for the status-aggregation tests.
 fn build_orchestrator_with_two_children(
     app: &mut App,
     history_model: &ModelHandle<BlocklistAIHistoryModel>,

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -77,6 +77,77 @@ fn descendant_conversation_ids_in_spawn_order_flattens_nested_children_preorder(
 }
 
 #[test]
+fn orchestration_aware_status_uses_aggregated_status_for_known_parent() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::Success,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            let orchestrator = history_model
+                .conversation(&orchestrator_id)
+                .expect("orchestrator conversation exists");
+            assert_eq!(
+                orchestration_aware_conversation_status(history_model, orchestrator),
+                ConversationStatus::InProgress,
+            );
+        });
+    });
+}
+
+#[test]
+fn orchestration_aware_status_uses_direct_status_for_non_parent() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+        let conversation_id = history_model.update(&mut app, |history_model, ctx| {
+            let conversation_id =
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            history_model.update_conversation_status(
+                terminal_view_id,
+                conversation_id,
+                ConversationStatus::Error,
+                ctx,
+            );
+            conversation_id
+        });
+
+        history_model.read(&app, |history_model, _| {
+            let conversation = history_model
+                .conversation(&conversation_id)
+                .expect("conversation exists");
+            assert_eq!(
+                orchestration_aware_conversation_status(history_model, conversation),
+                ConversationStatus::Error,
+            );
+        });
+    });
+}
+
+#[test]
 fn descendant_conversation_ids_in_spawn_order_returns_empty_without_children() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -24,6 +24,7 @@ use crate::ai::agent::conversation::{
 };
 use crate::ai::blocklist::agent_view::agent_view_bg_fill;
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::parent_conversation_navigation_card;
+use crate::ai::blocklist::orchestration_topology::orchestration_aware_conversation_status;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::appearance::Appearance;
 use crate::drive::sharing::ShareableObject;
@@ -991,7 +992,9 @@ impl TerminalView {
 
     /// Selected conversation status for chrome, or [`ConversationStatus::InProgress`] while the
     /// active block is long-running (terminal-derived; not mirrored in history events) or while
-    /// a cloud-mode ambient agent is still in its environment-setup phase.
+    /// a cloud-mode ambient agent is still in its environment-setup phase. For orchestrator
+    /// conversations, this returns the aggregated status across known child agents so tab and
+    /// header badges continue reflecting active descendants after the orchestrator turn finishes.
     pub fn selected_conversation_status(&self, ctx: &AppContext) -> Option<ConversationStatus> {
         let long_running = self.is_long_running();
         let cloud_setup = self.is_in_cloud_agent_setup_phase(ctx);
@@ -1014,7 +1017,10 @@ impl TerminalView {
             return None;
         }
 
-        Some(conversation.status().clone())
+        Some(orchestration_aware_conversation_status(
+            BlocklistAIHistoryModel::as_ref(ctx),
+            conversation,
+        ))
     }
 
     pub fn selected_conversation_is_empty(&self, ctx: &AppContext) -> bool {

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -993,8 +993,8 @@ impl TerminalView {
     /// Selected conversation status for chrome, or [`ConversationStatus::InProgress`] while the
     /// active block is long-running (terminal-derived; not mirrored in history events) or while
     /// a cloud-mode ambient agent is still in its environment-setup phase. For orchestrator
-    /// conversations, this returns the aggregated status across known child agents so tab and
-    /// header badges continue reflecting active descendants after the orchestrator turn finishes.
+    /// conversations, returns the aggregated child status so tab/header badges keep reflecting
+    /// active descendants after its turn finishes.
     pub fn selected_conversation_status(&self, ctx: &AppContext) -> Option<ConversationStatus> {
         let long_running = self.is_long_running();
         let cloud_setup = self.is_in_cloud_agent_setup_phase(ctx);


### PR DESCRIPTION
Uses the aggregation logic we use for orchestrator pill to drive the tab badge too for vertical tabs.
Fixes https://warpdev.slack.com/archives/C0AAMT5TKC2/p1780080286343239

Before:
<img width="603" height="131" alt="image" src="https://github.com/user-attachments/assets/745ccdcf-56db-479a-9477-8402dcbcb113" />

After:

<img width="726" height="131" alt="image" src="https://github.com/user-attachments/assets/45a83d58-fe65-43a7-839b-1edbfd0347ae" />
<img width="729" height="146" alt="image" src="https://github.com/user-attachments/assets/10dbafe3-5605-4abf-9f67-1196000dfbac" />


## Description
Adds an orchestration-aware conversation status helper and routes terminal conversation chrome through it. When the selected conversation is an orchestration parent, the vertical tab avatar status badge now uses the aggregated child status from the existing PR #11367 plumbing instead of the orchestrator conversation's direct status.

This keeps the vertical tab progress/status indicator showing in-progress/blocked/error child states after the orchestrator's own turn has completed.

## Linked Issue
Closes https://linear.app/warpdotdev/issue/QUALITY-783/add-badge-to-vertical-tab-for-orchestration

## Testing
- `cargo fmt`
- `cargo test -p warp orchestration_topology --lib` (10 passed)
- `cargo clippy -p warp --lib --tests -- -D warnings`
- Attempted `cargo clippy -p warp --lib --all-targets --all-features --tests -- -D warnings`; this failed on an existing unrelated compile error in `app/src/ai/execution_profiles/profiles.rs` for missing `AIExecutionProfile::create_agent_mode_eval_profile()`.

- [x] I have manually tested my changes locally with `./script/run`

CHANGELOG-IMPROVEMENT: Vertical tab agent icons now reflect active child-agent status for orchestration sessions.

Co-Authored-By: Oz <oz-agent@warp.dev>
