### PR TITLE
store prompt attachments on queued prompt model, store on prompt queue, attach on submit

### DIFF
--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -496,13 +496,6 @@ impl BlocklistAIContextModel {
             if let Some(selected_text) = &self.pending_context_selected_text {
                 context.push(AIAgentContext::SelectedText(selected_text.clone()));
             }
-
-            // Add images from pending attachments
-            for attachment in &self.pending_attachments {
-                if let PendingAttachment::Image(image) = attachment {
-                    context.push(AIAgentContext::Image(image.clone()));
-                }
-            }
         }
 
         context
@@ -1036,6 +1029,23 @@ impl BlocklistAIContextModel {
             });
         }
         self.pending_attachments.clear();
+    }
+
+    /// Drains all pending attachments, returning them, and emits the same update event as
+    /// [`Self::clear_pending_attachments`] so the input's attachment chips disappear. Used to
+    /// move staged attachments onto a queued prompt row at enqueue time.
+    pub fn take_pending_attachments(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> Vec<PendingAttachment> {
+        if !self.pending_attachments.is_empty() {
+            ctx.emit(BlocklistAIContextEvent::UpdatedPendingContext {
+                previous_block_ids: self.pending_context_block_ids.clone(),
+                requires_block_resync: false,
+                requires_text_resync: false,
+            });
+        }
+        std::mem::take(&mut self.pending_attachments)
     }
 }
 

--- a/app/src/ai/blocklist/context_model_tests.rs
+++ b/app/src/ai/blocklist/context_model_tests.rs
@@ -17,14 +17,19 @@ use warpui::r#async::executor::Background;
 use warpui::{App, EntityId, ModelHandle};
 
 use super::{BlocklistAIContextModel, PendingAttachment, PendingFile};
+use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{AIAgentContext, ImageContext};
 use crate::ai::blocklist::agent_view::{AgentViewController, EphemeralMessageModel};
+use crate::ai::blocklist::{
+    BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel, QueuedQueryOrigin,
+};
 #[cfg(feature = "local_fs")]
 use crate::code_review::git_status_update::GitRepoStatusModel;
 use crate::terminal::color::{self, Colors};
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::test_utils::block_size;
 use crate::terminal::model::{BlockId, TerminalModel};
+use crate::test_util::settings::initialize_history_persistence_for_tests;
 use crate::util::git::{PrInfo, RepositoryInfo};
 
 impl BlocklistAIContextModel {
@@ -341,5 +346,70 @@ fn has_locking_attachment_is_true_with_mixed_image_and_file_attachments() {
         });
 
         model.read(&app, |m, _| assert!(m.has_locking_attachment()));
+    });
+}
+
+#[test]
+fn take_pending_attachments_drains_and_returns_all_staged() {
+    App::test((), |mut app| async move {
+        let model = build_test_context_model(&mut app);
+        model.update(&mut app, |m, _| {
+            m.append_pending_attachments_for_test(vec![
+                make_image_attachment("a.png"),
+                make_file_attachment("notes.txt"),
+            ]);
+        });
+
+        let taken = model.update(&mut app, |m, ctx| m.take_pending_attachments(ctx));
+        assert_eq!(taken.len(), 2);
+        assert_eq!(taken[0].file_name(), "a.png");
+        assert_eq!(taken[1].file_name(), "notes.txt");
+
+        // Draining clears the live staging so the input's attachment chips disappear.
+        model.read(&app, |m, _| assert!(m.pending_attachments().is_empty()));
+    });
+}
+
+#[test]
+fn enqueue_moves_staged_attachments_onto_the_row_and_clears_input() {
+    // Mirrors the enqueue sites in `input.rs`: `take_pending_attachments` drains the live input
+    // staging and the drained set is stored on the queued row via `new_with_attachments`, leaving
+    // no attachments behind in the input.
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let queued = app.add_singleton_model(QueuedQueryModel::new);
+        let model = build_test_context_model(&mut app);
+        let conv = AIConversationId::new();
+
+        model.update(&mut app, |m, _| {
+            m.append_pending_attachments_for_test(vec![
+                make_image_attachment("a.png"),
+                make_file_attachment("notes.txt"),
+            ]);
+        });
+
+        // Capture-and-clear, then store on the row (the exact composition used at enqueue time).
+        let taken = model.update(&mut app, |m, ctx| m.take_pending_attachments(ctx));
+        let id = queued.update(&mut app, |q, ctx| {
+            q.append(
+                conv,
+                QueuedQuery::new_with_attachments(
+                    "queued".to_owned(),
+                    QueuedQueryOrigin::AutoQueueToggle,
+                    taken,
+                ),
+                ctx,
+            )
+        });
+
+        // Live staging is cleared; the row owns the attachments.
+        model.read(&app, |m, _| assert!(m.pending_attachments().is_empty()));
+        queued.read(&app, |q, _| {
+            let attachments = q.attachments_for(conv, id);
+            assert_eq!(attachments.len(), 2);
+            assert_eq!(attachments[0].file_name(), "a.png");
+            assert_eq!(attachments[1].file_name(), "notes.txt");
+        });
     });
 }

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -677,9 +677,9 @@ impl BlocklistAIController {
         }
 
         if let Some(slash_command_request) = SlashCommandRequest::from_query(query.as_str()) {
-            // For a fired queued prompt (e.g. a queued `/compact`), route into the conversation
-            // the prompt was queued on rather than letting the slash request re-derive the target
-            // from the current UI selection. Direct submissions keep the selection-based behavior.
+            // Only fired queued rows carry `queued_query_id`. For those rows, keep slash commands
+            // (e.g. queued `/compact`) on the conversation they were queued on; direct slash
+            // submissions still re-derive their target from the current UI selection.
             let conversation_id_override = input_query
                 .queued_query_id
                 .is_some()
@@ -776,8 +776,9 @@ impl BlocklistAIController {
                 running_command,
                 ..
             } => {
-                // Resolve the attachment set for this submission: a fired queued-prompt row's
-                // stored attachments (by id), or the live input staging for a direct submission.
+                // Resolve the attachment set for this submission. The direct-send branch
+                // preserves existing behavior: live input staging is still consumed by regular
+                // submissions, but fired queued rows read from their row-owned attachment set.
                 let prompt_attachments = match queued_query_id {
                     Some(query_id) => QueuedQueryModel::as_ref(ctx)
                         .attachments_for(conversation_id, query_id)
@@ -788,6 +789,7 @@ impl BlocklistAIController {
                         .pending_attachments()
                         .to_vec(),
                 };
+
                 input_for_query(
                     query,
                     &task_id,
@@ -1353,9 +1355,7 @@ impl BlocklistAIController {
 
     /// Same as [`Self::send_slash_command_request`] but marks the emitted `SentRequest`
     /// event as a queued prompt submission so UI subscribers (e.g. the input editor)
-    /// don't clear the input buffer on the auto-send. `conversation_id` is the conversation
-    /// the prompt was queued on, used to route the send and resolve the row's attachments
-    /// rather than re-deriving from the current UI selection.
+    /// don't clear the input buffer on the auto-send.
     pub fn send_queued_slash_command_request(
         &mut self,
         slash_command: SlashCommandRequest,

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -31,13 +31,14 @@ use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonE
 use self::response_stream::{ResponseStream, ResponseStreamEvent};
 use super::action_model::{BlocklistAIActionEvent, BlocklistAIActionModel};
 use super::agent_view::{AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin};
-use super::context_model::BlocklistAIContextModel;
+use super::context_model::{BlocklistAIContextModel, PendingAttachment};
 use super::history_model::BlocklistAIHistoryModel;
 use super::input_model::InputConfig;
 use super::orchestration_event_streamer::{
     OrchestrationEventStreamer, OrchestrationEventStreamerEvent,
 };
 use super::orchestration_events::{OrchestrationEventService, OrchestrationEventServiceEvent};
+use super::queued_query::{QueuedQueryId, QueuedQueryModel};
 use super::{BlocklistAIInputModel, InputType, ResponseStreamId};
 use crate::ai::agent::api::{self, ServerConversationToken};
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
@@ -404,6 +405,9 @@ struct InputQuery {
     /// Additional referenced attachments to include in the query
     /// (e.g. file path references from shared session file uploads).
     additional_attachments: HashMap<String, AIAgentAttachment>,
+    /// When `Some`, this submission is a fired queued-prompt row; the send path resolves the
+    /// row's stored attachments by this id instead of the live input staging.
+    queued_query_id: Option<QueuedQueryId>,
 }
 
 impl InputQuery {
@@ -753,23 +757,39 @@ impl BlocklistAIController {
         }
 
         let additional_attachments = input_query.additional_attachments;
+        let queued_query_id = input_query.queued_query_id;
         let ai_input = match input_query.input_query {
             InputQueryType::UserSubmittedQueryFromInput {
                 static_query_type,
                 running_command,
                 ..
-            } => input_for_query(
-                query,
-                &task_id,
-                conversation_id,
-                static_query_type,
-                user_query_mode,
-                running_command,
-                additional_attachments,
-                self.context_model.as_ref(ctx),
-                self.active_session.as_ref(ctx),
-                ctx,
-            ),
+            } => {
+                // Resolve the attachment set for this submission: a fired queued-prompt row's
+                // stored attachments (by id), or the live input staging for a direct submission.
+                let prompt_attachments = match queued_query_id {
+                    Some(query_id) => QueuedQueryModel::as_ref(ctx)
+                        .attachments_for(conversation_id, query_id)
+                        .to_vec(),
+                    None => self
+                        .context_model
+                        .as_ref(ctx)
+                        .pending_attachments()
+                        .to_vec(),
+                };
+                input_for_query(
+                    query,
+                    &task_id,
+                    conversation_id,
+                    static_query_type,
+                    user_query_mode,
+                    running_command,
+                    additional_attachments,
+                    prompt_attachments,
+                    self.context_model.as_ref(ctx),
+                    self.active_session.as_ref(ctx),
+                    ctx,
+                )
+            }
             InputQueryType::AIInputType { ai_input } => ai_input,
         };
         inputs.push(ai_input);
@@ -908,6 +928,7 @@ impl BlocklistAIController {
             entrypoint_type,
             participant_id,
             /*is_queued_prompt*/ false,
+            /*queued_query_id*/ None,
             ctx,
         );
     }
@@ -922,6 +943,7 @@ impl BlocklistAIController {
         static_query_type: Option<StaticQueryType>,
         entrypoint_type: EntrypointType,
         participant_id: Option<ParticipantId>,
+        queued_query_id: QueuedQueryId,
         ctx: &mut ModelContext<Self>,
     ) {
         self.send_user_query_in_new_conversation_internal(
@@ -930,10 +952,12 @@ impl BlocklistAIController {
             entrypoint_type,
             participant_id,
             /*is_queued_prompt*/ true,
+            Some(queued_query_id),
             ctx,
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn send_user_query_in_new_conversation_internal(
         &mut self,
         query: String,
@@ -941,6 +965,7 @@ impl BlocklistAIController {
         entrypoint_type: EntrypointType,
         participant_id: Option<ParticipantId>,
         is_queued_prompt: bool,
+        queued_query_id: Option<QueuedQueryId>,
         ctx: &mut ModelContext<Self>,
     ) {
         let participant_id = participant_id.or_else(|| self.get_sharer_participant_id());
@@ -977,6 +1002,7 @@ impl BlocklistAIController {
                         running_command: Some(running_command),
                     },
                     additional_attachments: HashMap::new(),
+                    queued_query_id,
                 },
                 entrypoint_type,
                 participant_id,
@@ -993,6 +1019,7 @@ impl BlocklistAIController {
                         running_command: None,
                     },
                     additional_attachments: HashMap::new(),
+                    queued_query_id,
                 },
                 entrypoint_type,
                 participant_id,
@@ -1018,6 +1045,7 @@ impl BlocklistAIController {
             HashMap::new(),
             EntrypointType::AgentInitiated,
             /*is_queued_prompt*/ false,
+            /*queued_query_id*/ None,
             ctx,
         );
     }
@@ -1038,6 +1066,7 @@ impl BlocklistAIController {
             HashMap::new(),
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ false,
+            /*queued_query_id*/ None,
             ctx,
         );
     }
@@ -1051,6 +1080,7 @@ impl BlocklistAIController {
         query: String,
         conversation_id: AIConversationId,
         participant_id: Option<ParticipantId>,
+        queued_query_id: QueuedQueryId,
         ctx: &mut ModelContext<Self>,
     ) {
         self.send_user_query_in_conversation_internal(
@@ -1061,6 +1091,7 @@ impl BlocklistAIController {
             HashMap::new(),
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ true,
+            Some(queued_query_id),
             ctx,
         );
     }
@@ -1082,6 +1113,7 @@ impl BlocklistAIController {
             additional_attachments,
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ false,
+            /*queued_query_id*/ None,
             ctx,
         );
     }
@@ -1105,6 +1137,7 @@ impl BlocklistAIController {
             HashMap::new(),
             EntrypointType::UserInitiated,
             /*is_queued_prompt*/ false,
+            /*queued_query_id*/ None,
             ctx,
         );
     }
@@ -1119,6 +1152,7 @@ impl BlocklistAIController {
         additional_attachments: HashMap<String, AIAgentAttachment>,
         entrypoint_type: EntrypointType,
         is_queued_prompt: bool,
+        queued_query_id: Option<QueuedQueryId>,
         ctx: &mut ModelContext<Self>,
     ) {
         let is_viewer = self
@@ -1226,6 +1260,7 @@ impl BlocklistAIController {
                     running_command,
                 },
                 additional_attachments,
+                queued_query_id,
             },
             entrypoint_type,
             participant_id,
@@ -1250,6 +1285,7 @@ impl BlocklistAIController {
                     running_command: None,
                 },
                 additional_attachments: HashMap::new(),
+                queued_query_id: None,
             },
             EntrypointType::ZeroStateAgentModePromptSuggestion,
             participant_id,
@@ -1286,6 +1322,7 @@ impl BlocklistAIController {
                 which_task,
                 input_query: InputQueryType::AIInputType { ai_input },
                 additional_attachments: HashMap::new(),
+                queued_query_id: None,
             },
             EntrypointType::UserInitiated,
             participant_id,
@@ -1420,6 +1457,7 @@ impl BlocklistAIController {
                     },
                 },
                 additional_attachments: HashMap::new(),
+                queued_query_id: None,
             },
             EntrypointType::TriggerPassiveSuggestion {
                 trigger: trigger_type,
@@ -2384,7 +2422,10 @@ impl BlocklistAIController {
             ctx,
         );
 
-        if input_contains_user_query {
+        // Skip the context reset for a fired queued-prompt row (`is_queued_prompt`): its
+        // attachments came from the row, not the live staging, so the live `pending_attachments`
+        // belong to the user's next prompt and must be preserved.
+        if input_contains_user_query && !is_queued_prompt {
             // Get the pending document ID before clearing context
             let pending_document_id = self.context_model.as_ref(ctx).pending_document_id();
 
@@ -3086,16 +3127,27 @@ fn input_for_query(
     user_query_mode: UserQueryMode,
     running_command: Option<RunningCommand>,
     additional_attachments: HashMap<String, AIAgentAttachment>,
+    prompt_attachments: Vec<PendingAttachment>,
     context_model: &BlocklistAIContextModel,
     active_session: &ActiveSession,
     app: &AppContext,
 ) -> AIAgentInput {
+    // Split the resolved attachment set into image context (sent inline) and file references.
+    let mut image_context = Vec::new();
+    let mut file_attachments = Vec::new();
+    for attachment in prompt_attachments {
+        match attachment {
+            PendingAttachment::Image(image) => image_context.push(AIAgentContext::Image(image)),
+            PendingAttachment::File(file) => file_attachments.push(file),
+        }
+    }
+
     let context = input_context_for_request(
         true,
         context_model,
         active_session,
         Some(conversation_id),
-        vec![],
+        image_context,
         app,
     );
     let intended_agent = BlocklistAIHistoryModel::as_ref(app)
@@ -3112,6 +3164,29 @@ fn input_for_query(
         });
     let mut referenced_attachments = parse_context_attachments(&query, context_model, app);
     referenced_attachments.extend(additional_attachments);
+
+    // Add file attachments as FilePathReference, de-duplicating basenames with (1), (2), ...
+    // suffixes to avoid collisions.
+    for file in file_attachments {
+        let attachment = AIAgentAttachment::FilePathReference {
+            file_id: uuid::Uuid::new_v4().to_string(),
+            file_name: file.file_name.clone(),
+            file_path: file.file_path.to_string_lossy().to_string(),
+        };
+        let mut key = file.file_name.clone();
+        if referenced_attachments.contains_key(&key) {
+            let mut suffix = 1;
+            loop {
+                key = format!("{} ({suffix})", file.file_name);
+                if !referenced_attachments.contains_key(&key) {
+                    break;
+                }
+                suffix += 1;
+            }
+        }
+        referenced_attachments.insert(key, attachment);
+    }
+
     AIAgentInput::UserQuery {
         query,
         context,

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -31,7 +31,7 @@ use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonE
 use self::response_stream::{ResponseStream, ResponseStreamEvent};
 use super::action_model::{BlocklistAIActionEvent, BlocklistAIActionModel};
 use super::agent_view::{AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin};
-use super::context_model::{BlocklistAIContextModel, PendingAttachment};
+use super::context_model::{BlocklistAIContextModel, PendingAttachment, PendingFile};
 use super::history_model::BlocklistAIHistoryModel;
 use super::input_model::InputConfig;
 use super::orchestration_event_streamer::{
@@ -677,7 +677,19 @@ impl BlocklistAIController {
         }
 
         if let Some(slash_command_request) = SlashCommandRequest::from_query(query.as_str()) {
-            slash_command_request.send_request(self, is_queued_prompt, ctx);
+            // For a fired queued prompt (e.g. a queued `/compact`), route into the conversation
+            // the prompt was queued on rather than letting the slash request re-derive the target
+            // from the current UI selection. Direct submissions keep the selection-based behavior.
+            let conversation_id_override = input_query
+                .queued_query_id
+                .is_some()
+                .then_some(conversation_id);
+            slash_command_request.send_request(
+                self,
+                input_query.queued_query_id,
+                conversation_id_override,
+                ctx,
+            );
             return;
         }
 
@@ -1336,18 +1348,22 @@ impl BlocklistAIController {
         slash_command: SlashCommandRequest,
         ctx: &mut ModelContext<Self>,
     ) {
-        slash_command.send_request(self, /*is_queued_prompt*/ false, ctx);
+        slash_command.send_request(self, None, None, ctx);
     }
 
     /// Same as [`Self::send_slash_command_request`] but marks the emitted `SentRequest`
     /// event as a queued prompt submission so UI subscribers (e.g. the input editor)
-    /// don't clear the input buffer on the auto-send.
+    /// don't clear the input buffer on the auto-send. `conversation_id` is the conversation
+    /// the prompt was queued on, used to route the send and resolve the row's attachments
+    /// rather than re-deriving from the current UI selection.
     pub fn send_queued_slash_command_request(
         &mut self,
         slash_command: SlashCommandRequest,
+        queued_query_id: QueuedQueryId,
+        conversation_id: Option<AIConversationId>,
         ctx: &mut ModelContext<Self>,
     ) {
-        slash_command.send_request(self, /*is_queued_prompt*/ true, ctx);
+        slash_command.send_request(self, Some(queued_query_id), conversation_id, ctx);
     }
 
     /// Mark a conversation to follow up after its actions complete and attempt to send immediately
@@ -3164,9 +3180,23 @@ fn input_for_query(
         });
     let mut referenced_attachments = parse_context_attachments(&query, context_model, app);
     referenced_attachments.extend(additional_attachments);
+    add_pending_file_attachments(&mut referenced_attachments, file_attachments);
 
-    // Add file attachments as FilePathReference, de-duplicating basenames with (1), (2), ...
-    // suffixes to avoid collisions.
+    AIAgentInput::UserQuery {
+        query,
+        context,
+        static_query_type,
+        referenced_attachments,
+        user_query_mode,
+        running_command,
+        intended_agent,
+    }
+}
+
+pub(super) fn add_pending_file_attachments(
+    referenced_attachments: &mut HashMap<String, AIAgentAttachment>,
+    file_attachments: Vec<PendingFile>,
+) {
     for file in file_attachments {
         let attachment = AIAgentAttachment::FilePathReference {
             file_id: uuid::Uuid::new_v4().to_string(),
@@ -3185,16 +3215,6 @@ fn input_for_query(
             }
         }
         referenced_attachments.insert(key, attachment);
-    }
-
-    AIAgentInput::UserQuery {
-        query,
-        context,
-        static_query_type,
-        referenced_attachments,
-        user_query_mode,
-        running_command,
-        intended_agent,
     }
 }
 

--- a/app/src/ai/blocklist/controller/input_context.rs
+++ b/app/src/ai/blocklist/controller/input_context.rs
@@ -246,28 +246,8 @@ pub(super) fn parse_context_attachments(
         }
     }
 
-    // Add pending file attachments as FilePathReference.
-    // Duplicate basenames get a (1), (2), ... suffix to avoid collisions,
-    // matching the pattern in build_file_attachment_map.
-    for file in context_model.pending_files().iter() {
-        let attachment = AIAgentAttachment::FilePathReference {
-            file_id: uuid::Uuid::new_v4().to_string(),
-            file_name: file.file_name.clone(),
-            file_path: file.file_path.to_string_lossy().to_string(),
-        };
-        let mut key = file.file_name.clone();
-        if referenced_attachments.contains_key(&key) {
-            let mut suffix = 1;
-            loop {
-                key = format!("{} ({suffix})", file.file_name);
-                if !referenced_attachments.contains_key(&key) {
-                    break;
-                }
-                suffix += 1;
-            }
-        }
-        referenced_attachments.insert(key, attachment);
-    }
+    // Pending file attachments are resolved by the controller's send path (from either the live
+    // staging or a fired queued prompt's row), not sourced from the context model here.
 
     // Add pending AI document as attachment if present
     if let Some(document_id) = context_model.pending_document_id() {

--- a/app/src/ai/blocklist/controller/input_context.rs
+++ b/app/src/ai/blocklist/controller/input_context.rs
@@ -246,9 +246,6 @@ pub(super) fn parse_context_attachments(
         }
     }
 
-    // Pending file attachments are resolved by the controller's send path (from either the live
-    // staging or a fired queued prompt's row), not sourced from the context model here.
-
     // Add pending AI document as attachment if present
     if let Some(document_id) = context_model.pending_document_id() {
         if let Some(content) = AIDocumentModel::as_ref(ctx).get_document_content(&document_id, ctx)

--- a/app/src/ai/blocklist/controller/slash_command.rs
+++ b/app/src/ai/blocklist/controller/slash_command.rs
@@ -4,15 +4,19 @@ use warp_core::features::FeatureFlag;
 use warpui::{AppContext, ModelContext, SingletonEntity};
 
 use super::{
-    input_context_for_request, parse_context_attachments, BlocklistAIController,
-    BlocklistAIControllerEvent, RequestInput,
+    add_pending_file_attachments, input_context_for_request, parse_context_attachments,
+    BlocklistAIController, BlocklistAIControllerEvent, RequestInput,
 };
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentContext, AIAgentInput, CancellationReason, CloneRepositoryURL, EntrypointType,
-    RequestMetadata,
+    InvokeSkillUserQuery, RequestMetadata,
 };
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
+use crate::ai::blocklist::context_model::{
+    BlocklistAIContextModel, PendingAttachment, PendingFile,
+};
+use crate::ai::blocklist::queued_query::{QueuedQueryId, QueuedQueryModel};
 use crate::search::slash_command_menu::static_commands::commands;
 use crate::terminal::input::slash_commands::SlashCommandTrigger;
 use crate::BlocklistAIHistoryModel;
@@ -64,25 +68,61 @@ impl SlashCommandRequest {
     pub(super) fn send_request(
         self,
         controller: &mut BlocklistAIController,
-        is_queued_prompt: bool,
+        queued_query_id: Option<QueuedQueryId>,
+        conversation_id_override: Option<AIConversationId>,
         ctx: &mut ModelContext<BlocklistAIController>,
     ) {
-        let conversation_id = self.conversation_id(controller, ctx);
+        let is_queued_prompt = queued_query_id.is_some();
+        // A fired queued prompt carries the conversation it was queued on; use it directly
+        // instead of re-deriving from the current UI selection (which may point at a different
+        // conversation the user navigated to). Falls back to the selection for direct sends.
+        let conversation_id =
+            conversation_id_override.or_else(|| self.conversation_id(controller, ctx));
         // For skill invocations, include user-attached context (images, blocks, and selected
         // text) so the skill's agent sees the same attachments a non-slash-command user query
         // would. Other slash commands continue to pass `false` to preserve existing behavior.
         let is_invoke_skill = matches!(self, Self::InvokeSkill { .. });
+        let prompt_attachments = if is_invoke_skill {
+            match (queued_query_id, conversation_id) {
+                (Some(query_id), Some(conversation_id)) => QueuedQueryModel::as_ref(ctx)
+                    .attachments_for(conversation_id, query_id)
+                    .to_vec(),
+                (Some(_), None) => vec![],
+                (None, _) => controller
+                    .context_model
+                    .as_ref(ctx)
+                    .pending_attachments()
+                    .to_vec(),
+            }
+        } else {
+            vec![]
+        };
+        let mut image_context = Vec::new();
+        let mut prompt_files = Vec::new();
+        for attachment in prompt_attachments {
+            match attachment {
+                PendingAttachment::Image(image) => {
+                    image_context.push(AIAgentContext::Image(image));
+                }
+                PendingAttachment::File(file) => prompt_files.push(file),
+            }
+        }
         let context = input_context_for_request(
             is_invoke_skill,
             controller.context_model.as_ref(ctx),
             controller.active_session.as_ref(ctx),
             conversation_id,
-            vec![],
+            image_context,
             ctx,
         );
         let entrypoint = self.entrypoint();
         let is_summarize = matches!(self, Self::Summarize { .. });
-        let inputs = self.input(context, controller.context_model.as_ref(ctx), ctx);
+        let inputs = self.input(
+            context,
+            prompt_files,
+            controller.context_model.as_ref(ctx),
+            ctx,
+        );
         if inputs.is_empty() {
             return;
         }
@@ -154,12 +194,9 @@ impl SlashCommandRequest {
             ctx,
         ) {
             Ok((_, stream_id)) => {
-                // Skill invocations now consume user-attached context (images, blocks, and
-                // selected text) the same way regular user queries do. `send_request_input`
-                // only clears that context for `AIAgentInput::UserQuery`, so we mirror its
-                // reset here for `InvokeSkill` to avoid pending attachments sticking around
-                // and getting re-sent on subsequent messages.
-                if is_invoke_skill {
+                // Direct skills consume live pending context; queued skills consume row-owned
+                // context and must not clear a new draft's staged attachments.
+                if is_invoke_skill && !is_queued_prompt {
                     controller.context_model.update(ctx, |context_model, ctx| {
                         context_model.reset_context_to_default(ctx);
                     });
@@ -198,7 +235,8 @@ impl SlashCommandRequest {
     fn input(
         self,
         context: Arc<[AIAgentContext]>,
-        context_model: &crate::ai::blocklist::BlocklistAIContextModel,
+        prompt_files: Vec<PendingFile>,
+        context_model: &BlocklistAIContextModel,
         app: &AppContext,
     ) -> Vec<AIAgentInput> {
         match self {
@@ -244,17 +282,18 @@ impl SlashCommandRequest {
             }
             SlashCommandRequest::InvokeSkill { skill, user_query } => {
                 let user_query = if FeatureFlag::SkillArguments.is_enabled() {
-                    user_query
+                    let query = user_query
                         .map(|query| query.trim().to_string())
-                        .filter(|query| !query.is_empty())
-                        .map(|query| crate::ai::agent::InvokeSkillUserQuery {
-                            referenced_attachments: parse_context_attachments(
-                                &query,
-                                context_model,
-                                app,
-                            ),
+                        .unwrap_or_default();
+                    (!query.is_empty() || !prompt_files.is_empty()).then(|| {
+                        let mut referenced_attachments =
+                            parse_context_attachments(&query, context_model, app);
+                        add_pending_file_attachments(&mut referenced_attachments, prompt_files);
+                        InvokeSkillUserQuery {
+                            referenced_attachments,
                             query,
-                        })
+                        }
+                    })
                 } else {
                     None
                 };

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -1,13 +1,36 @@
+use std::collections::HashMap;
+
 use uuid::Uuid;
 use warpui::{App, SingletonEntity};
 
-use crate::ai::agent::PassiveSuggestionTrigger;
+use crate::ai::agent::task::TaskId;
+use crate::ai::agent::{
+    AIAgentAttachment, AIAgentContext, AIAgentInput, ImageContext, PassiveSuggestionTrigger,
+    UserQueryMode,
+};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::ai::blocklist::{BlocklistAIHistoryModel, PendingAttachment, PendingFile};
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
 
 fn new_ambient_agent_task_id() -> AmbientAgentTaskId {
     Uuid::new_v4().to_string().parse().unwrap()
+}
+
+fn image_attachment(file_name: &str) -> PendingAttachment {
+    PendingAttachment::Image(ImageContext {
+        data: String::new(),
+        mime_type: "image/png".to_owned(),
+        file_name: file_name.to_owned(),
+        is_figma: false,
+    })
+}
+
+fn file_attachment(file_name: &str) -> PendingAttachment {
+    PendingAttachment::File(PendingFile {
+        file_name: file_name.to_owned(),
+        file_path: file_name.into(),
+        mime_type: "text/plain".to_owned(),
+    })
 }
 
 #[test]
@@ -54,6 +77,98 @@ fn passive_suggestions_request_params_omit_ambient_agent_task_id() {
                     None
                 );
             });
+        });
+    });
+}
+
+#[test]
+fn input_for_query_converts_prompt_attachments_and_ignores_live_staging() {
+    // `input_for_query` builds its image/file context purely from the explicitly-provided
+    // attachment set (resolved by `send_query` from either the queued row or live staging),
+    // never from the context model's pending attachments.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |terminal, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    history_model.start_new_conversation(terminal.id(), false, false, false, ctx)
+                });
+
+            let controller = terminal.ai_controller();
+            let context_model = controller.as_ref(ctx).context_model.clone();
+            let active_session = controller.as_ref(ctx).active_session.clone();
+
+            // Stage *live* attachments that must NOT leak into a query built from a different,
+            // explicitly-provided attachment set.
+            context_model.update(ctx, |m, ctx| {
+                m.append_pending_attachments(
+                    vec![image_attachment("live.png"), file_attachment("live.txt")],
+                    ctx,
+                );
+            });
+
+            let task_id = TaskId::new("test-task".to_owned());
+            // Two files sharing a basename to exercise duplicate-basename suffixing.
+            let prompt_attachments = vec![
+                image_attachment("queued.png"),
+                file_attachment("notes.txt"),
+                file_attachment("notes.txt"),
+            ];
+
+            let input = super::input_for_query(
+                "build a query".to_owned(),
+                &task_id,
+                conversation_id,
+                None,
+                UserQueryMode::Normal,
+                None,
+                HashMap::new(),
+                prompt_attachments,
+                context_model.as_ref(ctx),
+                active_session.as_ref(ctx),
+                ctx,
+            );
+
+            let AIAgentInput::UserQuery {
+                context,
+                referenced_attachments,
+                ..
+            } = input
+            else {
+                panic!("expected UserQuery");
+            };
+
+            // The provided image is attached as image context; the live-staged image is not.
+            let image_names: Vec<&str> = context
+                .iter()
+                .filter_map(|c| match c {
+                    AIAgentContext::Image(img) => Some(img.file_name.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(image_names, vec!["queued.png"]);
+
+            // The provided files are attached as FilePathReference with duplicate-basename
+            // suffixing; the live-staged file is not.
+            let mut file_names: Vec<String> = referenced_attachments
+                .values()
+                .filter_map(|a| match a {
+                    AIAgentAttachment::FilePathReference { file_name, .. } => {
+                        Some(file_name.clone())
+                    }
+                    _ => None,
+                })
+                .collect();
+            file_names.sort();
+            assert_eq!(
+                file_names,
+                vec!["notes.txt".to_owned(), "notes.txt".to_owned()]
+            );
+            assert!(referenced_attachments.contains_key("notes.txt"));
+            assert!(referenced_attachments.contains_key("notes.txt (1)"));
+            assert!(!referenced_attachments.contains_key("live.txt"));
         });
     });
 }

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -16,11 +16,6 @@ impl QueuedQueryId {
     fn new() -> Self {
         Self(Uuid::new_v4())
     }
-
-    #[cfg(test)]
-    pub(crate) fn new_for_test() -> Self {
-        Self::new()
-    }
 }
 
 /// Where a queued prompt came from.
@@ -397,6 +392,27 @@ impl QueuedQueryModel {
             state.editing = None;
         }
         ctx.emit(QueuedQueryEvent::Removed {
+            conversation_id,
+            query_id,
+        });
+    }
+
+    /// Restores a fired row when submission fails after the row was removed.
+    pub(crate) fn restore_fired_row(
+        &mut self,
+        conversation_id: AIConversationId,
+        insert_index: usize,
+        query: QueuedQuery,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let state = self.queues.entry(conversation_id).or_default();
+        let query_id = query.id;
+        if state.queue.iter().any(|queued| queued.id == query_id) {
+            return;
+        }
+        let insert_index = insert_index.min(state.queue.len());
+        state.queue.insert(insert_index, query);
+        ctx.emit(QueuedQueryEvent::Appended {
             conversation_id,
             query_id,
         });

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -373,8 +373,9 @@ impl QueuedQueryModel {
         })
     }
 
-    /// Removes the row `query_id` from `conversation_id`'s queue after it has been fired or
-    /// restored to the input. Clears edit state if it pointed at the removed row.
+    /// Removes the row `query_id` from `conversation_id`'s queue after it has been fired. In the
+    /// edit-mode auto-fire path, the caller first restores the row's committed text and
+    /// attachments to the input, then calls this to drop the row and clear edit state.
     pub fn remove_fired_row(
         &mut self,
         conversation_id: AIConversationId,

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use warpui::{Entity, ModelContext, SingletonEntity};
 
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
+use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel, PendingAttachment};
 use crate::settings::{AISettings, AISettingsChangedEvent, PromptSubmissionMode};
 
 /// A globally unique identifier for a single queued prompt row.
@@ -15,6 +15,11 @@ pub struct QueuedQueryId(Uuid);
 impl QueuedQueryId {
     fn new() -> Self {
         Self(Uuid::new_v4())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Self {
+        Self::new()
     }
 }
 
@@ -42,14 +47,26 @@ pub struct QueuedQuery {
     id: QueuedQueryId,
     text: String,
     origin: QueuedQueryOrigin,
+    /// Image/file attachments captured from the input when this prompt was queued. They are
+    /// sent with the prompt when it fires and dropped automatically when the row is removed.
+    attachments: Vec<PendingAttachment>,
 }
 
 impl QueuedQuery {
     pub fn new(text: String, origin: QueuedQueryOrigin) -> Self {
+        Self::new_with_attachments(text, origin, Vec::new())
+    }
+
+    pub fn new_with_attachments(
+        text: String,
+        origin: QueuedQueryOrigin,
+        attachments: Vec<PendingAttachment>,
+    ) -> Self {
         Self {
             id: QueuedQueryId::new(),
             text,
             origin,
+            attachments,
         }
     }
 
@@ -65,6 +82,10 @@ impl QueuedQuery {
         self.origin
     }
 
+    pub fn attachments(&self) -> &[PendingAttachment] {
+        &self.attachments
+    }
+
     /// Returns true if this row is locked from user mutation, reorder, and auto-fire.
     /// Currently only the locked initial Cloud Mode row is non-mutable; lifecycle code
     /// removes it explicitly via [`QueuedQueryModel::remove_initial_cloud_mode_row`].
@@ -73,14 +94,24 @@ impl QueuedQuery {
     }
 }
 
-/// What the auto-fire drain should do with a popped row.
+/// What the auto-fire drain should do with the head row. Produced by
+/// [`QueuedQueryModel::peek_autofire`] *without* removing the row; the caller removes it via
+/// [`QueuedQueryModel::remove_fired_row`] once the prompt has been dispatched or restored.
 #[derive(Debug)]
 pub enum AutofireAction {
-    /// Submit this prompt as a normal queued user query.
-    Submit { text: String },
-    /// The popped row was in edit mode at the time of pop.
-    /// The caller places `text` (the row's last committed text) in the input box.
-    PopFromEditMode { text: String },
+    /// Submit this prompt as a normal queued user query. The row stays in the queue so the send
+    /// path can read its attachments by `query_id`; the caller removes it afterward.
+    Submit {
+        query_id: QueuedQueryId,
+        text: String,
+    },
+    /// The head row was in edit mode. The caller restores `text` (the row's last committed text)
+    /// and `attachments` to the input box, then removes the row.
+    PopFromEditMode {
+        query_id: QueuedQueryId,
+        text: String,
+        attachments: Vec<PendingAttachment>,
+    },
 }
 
 /// Per-conversation queue / edit / toggle state.
@@ -322,35 +353,68 @@ impl QueuedQueryModel {
         Some(popped)
     }
 
-    /// Auto-fire drain entry point for `conversation_id`.
-    /// Returns `None` for empty queues or when the head is locked
-    /// ([`QueuedQuery::is_locked`]); otherwise pops the first row and returns whether
-    /// the caller should submit it normally or treat it as a popped edit-mode row.
-    pub fn pop_for_autofire(
-        &mut self,
-        conversation_id: AIConversationId,
-        ctx: &mut ModelContext<Self>,
-    ) -> Option<AutofireAction> {
-        let state = self.queues.get_mut(&conversation_id)?;
+    /// Auto-fire drain entry point for `conversation_id`. Returns the action for the head row
+    /// *without* removing it (so the send path can read its attachments by id), or `None` for an
+    /// empty queue or a locked head ([`QueuedQuery::is_locked`]). The caller removes the row via
+    /// [`Self::remove_fired_row`] once it has been dispatched or restored to the input.
+    pub fn peek_autofire(&self, conversation_id: AIConversationId) -> Option<AutofireAction> {
+        let state = self.queues.get(&conversation_id)?;
         let first = state.queue.first()?;
         if first.is_locked() {
             return None;
         }
         let first_in_edit_mode = state.editing == Some(first.id);
-        let popped = state.queue.remove(0);
-        if first_in_edit_mode {
+        Some(if first_in_edit_mode {
+            AutofireAction::PopFromEditMode {
+                query_id: first.id,
+                text: first.text.clone(),
+                attachments: first.attachments.clone(),
+            }
+        } else {
+            AutofireAction::Submit {
+                query_id: first.id,
+                text: first.text.clone(),
+            }
+        })
+    }
+
+    /// Removes the row `query_id` from `conversation_id`'s queue after it has been fired or
+    /// restored to the input. Clears edit state if it pointed at the removed row.
+    pub fn remove_fired_row(
+        &mut self,
+        conversation_id: AIConversationId,
+        query_id: QueuedQueryId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(state) = self.queues.get_mut(&conversation_id) else {
+            return;
+        };
+        let Some(idx) = state.queue.iter().position(|q| q.id == query_id) else {
+            return;
+        };
+        state.queue.remove(idx);
+        if state.editing == Some(query_id) {
             state.editing = None;
         }
         ctx.emit(QueuedQueryEvent::Removed {
             conversation_id,
-            query_id: popped.id,
+            query_id,
         });
+    }
 
-        Some(if first_in_edit_mode {
-            AutofireAction::PopFromEditMode { text: popped.text }
-        } else {
-            AutofireAction::Submit { text: popped.text }
-        })
+    /// Returns the attachments captured on the queued row `query_id` within `conversation_id`'s
+    /// queue, or an empty slice if no such row exists. Used by the send path to attach a fired
+    /// queued prompt's images/files without removing the row first.
+    pub fn attachments_for(
+        &self,
+        conversation_id: AIConversationId,
+        query_id: QueuedQueryId,
+    ) -> &[PendingAttachment] {
+        self.queues
+            .get(&conversation_id)
+            .and_then(|state| state.queue.iter().find(|q| q.id == query_id))
+            .map(QueuedQuery::attachments)
+            .unwrap_or(&[])
     }
 
     /// Removes a specific row by id within `conversation_id`'s queue, if present. Returns the

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -12,7 +12,8 @@ use super::{
     QueuedQueryOrigin,
 };
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::ai::agent::ImageContext;
+use crate::ai::blocklist::{BlocklistAIHistoryModel, PendingAttachment};
 use crate::test_util::settings::initialize_history_persistence_for_tests;
 
 /// Helper to drive the singleton `QueuedQueryModel` (plus its required `BlocklistAIHistoryModel`
@@ -49,6 +50,15 @@ fn initial_cloud_mode_query(text: &str) -> QueuedQuery {
     QueuedQuery::new(text.to_owned(), QueuedQueryOrigin::InitialCloudMode)
 }
 
+fn image_attachment(file_name: &str) -> PendingAttachment {
+    PendingAttachment::Image(ImageContext {
+        data: String::new(),
+        mime_type: "image/png".to_owned(),
+        file_name: file_name.to_owned(),
+        is_figma: false,
+    })
+}
+
 fn append_user(
     model: &warpui::ModelHandle<QueuedQueryModel>,
     app: &mut App,
@@ -80,7 +90,7 @@ fn initial_cloud_mode_head_rejects_user_mutations_and_autofire() {
             model.reorder(conv, followup_id, 0, ctx);
         });
 
-        let action = model.update(&mut app, |model, ctx| model.pop_for_autofire(conv, ctx));
+        let action = model.read(&app, |model, _| model.peek_autofire(conv));
         assert!(action.is_none());
 
         model.read(&app, |model, _| {
@@ -141,9 +151,9 @@ fn remove_initial_cloud_mode_row_only_removes_the_locked_head() {
         });
         assert!(removed_again.is_none());
 
-        let action = model.update(&mut app, |model, ctx| model.pop_for_autofire(conv, ctx));
+        let action = model.read(&app, |model, _| model.peek_autofire(conv));
         match action {
-            Some(AutofireAction::Submit { text }) => assert_eq!(text, "follow up"),
+            Some(AutofireAction::Submit { text, .. }) => assert_eq!(text, "follow up"),
             other => panic!("expected Submit, got {other:?}"),
         }
 
@@ -290,41 +300,78 @@ fn pop_front_removes_head_and_emits_removed() {
 }
 
 #[test]
-fn pop_for_autofire_returns_submit_for_user_managed_head() {
+fn peek_autofire_leaves_row_until_remove_fired_row_drops_it() {
     with_model(|mut app, model, _events| {
         let conv = AIConversationId::new();
-        append_user(&model, &mut app, conv, "first");
+        let first_id = append_user(&model, &mut app, conv, "first");
         append_user(&model, &mut app, conv, "second");
 
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        // peek_autofire reports the head's Submit action WITHOUT removing the row, so the send
+        // path can still read its attachments by id.
+        let action = model.read(&app, |model, _| model.peek_autofire(conv));
         match action {
-            Some(AutofireAction::Submit { text }) => assert_eq!(text, "first"),
+            Some(AutofireAction::Submit { query_id, text }) => {
+                assert_eq!(query_id, first_id);
+                assert_eq!(text, "first");
+            }
             other => panic!("expected Submit, got {other:?}"),
         }
+        model.read(&app, |model, _| assert_eq!(model.queue(conv).len(), 2));
 
+        // remove_fired_row drops the fired head once the synchronous send completes.
+        model.update(&mut app, |model, ctx| {
+            model.remove_fired_row(conv, first_id, ctx)
+        });
         model.read(&app, |model, _| {
-            assert_eq!(model.queue(conv).len(), 1);
+            let queue = model.queue(conv);
+            assert_eq!(queue.len(), 1);
+            assert_eq!(queue[0].text(), "second");
         });
     });
 }
 
 #[test]
-fn pop_for_autofire_returns_last_committed_text_when_first_row_is_in_edit_mode() {
-    // Per spec: even when the first row is in edit mode, auto-fire's PopFromEditMode action
-    // carries the row's last-committed text, not any uncommitted live-editor buffer text.
+fn peek_autofire_returns_pop_from_edit_mode_with_committed_text_and_attachments() {
+    // Per spec: when the first row is in edit mode, peek_autofire's PopFromEditMode action
+    // carries the row's last-committed text and its stored attachments (NOT any uncommitted
+    // live-editor buffer text). peek leaves edit state intact; remove_fired_row clears it.
     with_model(|mut app, model, _events| {
         let conv = AIConversationId::new();
-        let id_a = append_user(&model, &mut app, conv, "first");
+        let id_a = model.update(&mut app, |m, ctx| {
+            m.append(
+                conv,
+                QueuedQuery::new_with_attachments(
+                    "first".to_owned(),
+                    QueuedQueryOrigin::QueueSlashCommand,
+                    vec![image_attachment("a.png")],
+                ),
+                ctx,
+            )
+        });
         append_user(&model, &mut app, conv, "second");
         model.update(&mut app, |m, ctx| m.enter_edit_mode(conv, id_a, ctx));
 
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        let action = model.read(&app, |m, _| m.peek_autofire(conv));
         match action {
-            Some(AutofireAction::PopFromEditMode { text }) => assert_eq!(text, "first"),
+            Some(AutofireAction::PopFromEditMode {
+                query_id,
+                text,
+                attachments,
+            }) => {
+                assert_eq!(query_id, id_a);
+                assert_eq!(text, "first");
+                assert_eq!(attachments.len(), 1);
+                assert_eq!(attachments[0].file_name(), "a.png");
+            }
             other => panic!("expected PopFromEditMode, got {other:?}"),
         }
-        model.read(&app, |model, _| {
-            assert_eq!(model.editing_row(conv), None);
+        // peek does not mutate: the row is still in edit mode.
+        model.read(&app, |m, _| assert_eq!(m.editing_row(conv), Some(id_a)));
+
+        model.update(&mut app, |m, ctx| m.remove_fired_row(conv, id_a, ctx));
+        model.read(&app, |m, _| {
+            assert_eq!(m.editing_row(conv), None);
+            assert_eq!(m.queue(conv).len(), 1);
         });
     });
 }

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -331,6 +331,61 @@ fn peek_autofire_leaves_row_until_remove_fired_row_drops_it() {
 }
 
 #[test]
+fn restore_fired_row_reinserts_removed_row_for_retry() {
+    with_model(|mut app, model, events| {
+        let conv = AIConversationId::new();
+        let first_id = model.update(&mut app, |model, ctx| {
+            model.append(
+                conv,
+                QueuedQuery::new_with_attachments(
+                    "first".to_owned(),
+                    QueuedQueryOrigin::QueueSlashCommand,
+                    vec![image_attachment("a.png")],
+                ),
+                ctx,
+            )
+        });
+        append_user(&model, &mut app, conv, "second");
+
+        let (retry_index, retry_query) = model.read(&app, |model, _| {
+            model
+                .queue(conv)
+                .iter()
+                .enumerate()
+                .find(|(_, query)| query.id() == first_id)
+                .map(|(index, query)| (index, query.clone()))
+                .expect("queued row should exist")
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.remove_fired_row(conv, first_id, ctx);
+        });
+        events.borrow_mut().clear();
+
+        model.update(&mut app, |model, ctx| {
+            model.restore_fired_row(conv, retry_index, retry_query, ctx);
+        });
+
+        model.read(&app, |model, _| {
+            let queue = model.queue(conv);
+            assert_eq!(queue.len(), 2);
+            assert_eq!(queue[0].id(), first_id);
+            assert_eq!(queue[0].text(), "first");
+            assert_eq!(queue[0].attachments()[0].file_name(), "a.png");
+            assert_eq!(queue[1].text(), "second");
+        });
+        let evts = events.borrow();
+        assert!(matches!(
+            evts.as_slice(),
+            [QueuedQueryEvent::Appended {
+                conversation_id,
+                query_id
+            }] if *conversation_id == conv && *query_id == first_id
+        ));
+    });
+}
+
+#[test]
 fn peek_autofire_returns_pop_from_edit_mode_with_committed_text_and_attachments() {
     // Per spec: when the first row is in edit mode, peek_autofire's PopFromEditMode action
     // carries the row's last-committed text and its stored attachments (NOT any uncommitted

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -144,7 +144,9 @@ use super::view::{
 use super::warpify::SubshellSource;
 use super::{prompt, History, HistoryEntry, SizeInfo, TerminalModel, UpArrowHistoryConfig};
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::agent::{AIAgentContext, AIAgentExchangeId, CancellationReason, EntrypointType};
+use crate::ai::agent::{
+    AIAgentContext, AIAgentExchangeId, CancellationReason, EntrypointType, ImageContext,
+};
 use crate::ai::agent_conversations_model::{
     AgentConversationNavigationSubject, AgentConversationsModel,
 };
@@ -168,15 +170,14 @@ use crate::ai::blocklist::handoff::touched_repos::{
 use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
 use crate::ai::blocklist::telemetry_banner::should_collect_ai_ugc_telemetry;
-#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
-use crate::ai::blocklist::PendingAttachment;
 use crate::ai::blocklist::{
     ai_brand_color, ai_indicator_height, render_ai_agent_mode_icon, render_ai_follow_up_icon,
     AttachmentType, BlocklistAIActionModel, BlocklistAIContextEvent, BlocklistAIContextModel,
     BlocklistAIController, BlocklistAIControllerEvent, BlocklistAIHistoryEvent,
     BlocklistAIHistoryModel, BlocklistAIInputEvent, BlocklistAIInputModel, InputConfig, InputType,
-    InputTypeAutoDetectionSource, QueuedQuery, QueuedQueryEvent, QueuedQueryModel,
-    QueuedQueryOrigin, SlashCommandRequest, BLOCK_CONTEXT_ATTACHMENT_REGEX,
+    InputTypeAutoDetectionSource, PendingAttachment, PendingFile, QueuedQuery, QueuedQueryEvent,
+    QueuedQueryId, QueuedQueryModel, QueuedQueryOrigin, SlashCommandRequest,
+    BLOCK_CONTEXT_ATTACHMENT_REGEX,
     DIFF_HUNK_ATTACHMENT_REGEX, DRIVE_OBJECT_ATTACHMENT_REGEX,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
@@ -13364,7 +13365,12 @@ impl Input {
     /// Cancels the in-flight stream first so slash/skill paths don't trip the in-flight assertion.
     /// `is_for_same_conversation: true` keeps the conversation status `InProgress` so the warping
     /// indicator stays visible.
-    pub(crate) fn submit_queued_prompt(&mut self, prompt: String, ctx: &mut ViewContext<Self>) {
+    pub(crate) fn submit_queued_prompt(
+        &mut self,
+        prompt: String,
+        query_id: QueuedQueryId,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if let Some(conversation_id) = self
             .ai_context_model
             .as_ref(ctx)
@@ -13424,12 +13430,42 @@ impl Input {
                     prompt,
                     conversation_id,
                     None,
+                    query_id,
                     ctx,
                 );
             });
         } else {
             self.ai_controller.update(ctx, move |controller, ctx| {
                 controller.send_queued_user_query_in_new_conversation(
+                    prompt,
+                    None,
+                    EntrypointType::UserInitiated,
+                    None,
+                    query_id,
+                    ctx,
+                );
+            });
+        }
+
+        ctx.emit(Event::ExecuteAIQuery);
+    }
+
+    /// Submits `prompt` immediately as a regular (non-queued) user query — the same controller
+    /// path `submit_ai_query` uses for a typed-and-entered prompt. Used by the `/queue`
+    /// not-in-progress fallback and the legacy pending-user-query submission paths, which are
+    /// immediate sends (not queued-row fires) and therefore reset their live staging.
+    pub(crate) fn submit_user_query_now(&mut self, prompt: String, ctx: &mut ViewContext<Self>) {
+        if let Some(conversation_id) = self
+            .ai_context_model
+            .as_ref(ctx)
+            .selected_conversation_id(ctx)
+        {
+            self.ai_controller.update(ctx, move |controller, ctx| {
+                controller.send_user_query_in_conversation(prompt, conversation_id, None, ctx);
+            });
+        } else {
+            self.ai_controller.update(ctx, move |controller, ctx| {
+                controller.send_user_query_in_new_conversation(
                     prompt,
                     None,
                     EntrypointType::UserInitiated,
@@ -13450,6 +13486,7 @@ impl Input {
     pub(crate) fn submit_queued_prompt_for_active_pane(
         &mut self,
         prompt: String,
+        query_id: QueuedQueryId,
         ctx: &mut ViewContext<Self>,
     ) {
         // Cloud follow-up path: the cloud run has ended an execution and the next queued
@@ -13463,24 +13500,40 @@ impl Input {
                         .is_ready_for_cloud_followup_prompt()
                 });
         if is_ready_for_cloud_followup {
+            // Cloud follow-up does not support attachments; a queued row's attachments are dropped
+            // when the row is removed after dispatch.
+            let drops_attachments = self
+                .ai_context_model
+                .as_ref(ctx)
+                .selected_conversation_id(ctx)
+                .is_some_and(|conversation_id| {
+                    !QueuedQueryModel::as_ref(ctx)
+                        .attachments_for(conversation_id, query_id)
+                        .is_empty()
+                });
+            if drops_attachments {
+                log::warn!(
+                    "Dropping attachments on a queued cloud follow-up prompt; cloud follow-up does not support attachments"
+                );
+            }
             ctx.emit(Event::SubmitCloudFollowup { prompt });
             return;
         }
 
         // Shared-session viewer path (covers an in-flight cloud run from the owner's client).
-        // Send the prompt straight to the sharer via Event::SendAgentPrompt — no buffer
-        // replace, no pending-attachment piggyback. When the user's editor is empty we
-        // also surface the standard `"<prompt> ◌"` loading affordance so the queued
-        // submission has visible feedback while the sharer ack flight is in flight; the
-        // `NetworkEvent::AgentPromptRequestInFlight` -> `unfreeze_and_clear_agent_input`
-        // hop will clear it once the sharer acknowledges receipt. If the user has typed
-        // something locally, we leave the buffer alone so their in-progress prompt is
-        // not clobbered.
+        // Send the prompt straight to the sharer via Event::SendAgentPrompt, carrying the queued
+        // row's own attachments (uploaded when supported). When the user's editor is empty we
+        // also surface the standard `"<prompt> ◌"` loading affordance so the queued submission has
+        // visible feedback while the sharer ack flight is in flight; the
+        // `NetworkEvent::AgentPromptRequestInFlight` -> `unfreeze_and_clear_agent_input` hop will
+        // clear it once the sharer acknowledges receipt. If the user has typed something locally,
+        // we leave the buffer alone so their in-progress prompt is not clobbered.
         if self.model.lock().shared_session_status().is_viewer() {
-            let server_conversation_token = self
+            let conversation_id = self
                 .ai_context_model
                 .as_ref(ctx)
-                .selected_conversation_id(ctx)
+                .selected_conversation_id(ctx);
+            let server_conversation_token = conversation_id
                 .and_then(|id| {
                     BlocklistAIHistoryModel::as_ref(ctx)
                         .conversation(&id)
@@ -13493,19 +13546,40 @@ impl Input {
                         .ok()
                         .map(ServerConversationToken::from_uuid)
                 });
+
+            // Split the firing row's stored attachments into images/files for upload.
+            let (images, files) = conversation_id
+                .map(|conversation_id| {
+                    let mut images: Vec<ImageContext> = Vec::new();
+                    let mut files: Vec<PendingFile> = Vec::new();
+                    for attachment in
+                        QueuedQueryModel::as_ref(ctx).attachments_for(conversation_id, query_id)
+                    {
+                        match attachment {
+                            PendingAttachment::Image(image) => images.push(image.clone()),
+                            PendingAttachment::File(file) => files.push(file.clone()),
+                        }
+                    }
+                    (images, files)
+                })
+                .unwrap_or_default();
+
             if self.editor.as_ref(ctx).buffer_text(ctx).is_empty() {
                 self.freeze_input_in_loading_state_with_text(&prompt, ctx);
             }
-            ctx.emit(Event::SendAgentPrompt {
+            self.upload_and_send_viewer_prompt(
                 server_conversation_token,
                 prompt,
-                attachments: vec![],
-            });
+                vec![],
+                images,
+                files,
+                ctx,
+            );
             return;
         }
 
         // Local Agent Mode path.
-        self.submit_queued_prompt(prompt, ctx);
+        self.submit_queued_prompt(prompt, query_id, ctx);
     }
 
     /// Checks whether the current input should be queued instead of executed.
@@ -13589,11 +13663,18 @@ impl Input {
         self.editor.update(ctx, |editor, ctx| {
             editor.clear_buffer(ctx);
         });
+        let attachments = self.ai_context_model.update(ctx, |context_model, ctx| {
+            context_model.take_pending_attachments(ctx)
+        });
 
         QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
             model.append(
                 conversation_id,
-                QueuedQuery::new(prompt, QueuedQueryOrigin::AutoQueueToggle),
+                QueuedQuery::new_with_attachments(
+                    prompt,
+                    QueuedQueryOrigin::AutoQueueToggle,
+                    attachments,
+                ),
                 ctx,
             );
         });
@@ -13645,13 +13726,17 @@ impl Input {
         self.editor.update(ctx, |editor, ctx| {
             editor.clear_buffer(ctx);
         });
-        self.ai_context_model.update(ctx, |context_model, ctx| {
-            context_model.clear_pending_attachments(ctx);
+        let attachments = self.ai_context_model.update(ctx, |context_model, ctx| {
+            context_model.take_pending_attachments(ctx)
         });
         QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
             model.append(
                 conversation_id,
-                QueuedQuery::new(prompt, QueuedQueryOrigin::AutoQueueToggle),
+                QueuedQuery::new_with_attachments(
+                    prompt,
+                    QueuedQueryOrigin::AutoQueueToggle,
+                    attachments,
+                ),
                 ctx,
             );
         });
@@ -13866,11 +13951,7 @@ impl Input {
                     .map(ServerConversationToken::from_uuid)
             });
 
-        let ambient_agent_task_id = self
-            .ambient_agent_view_model()
-            .and_then(|ambient_agent_model| ambient_agent_model.as_ref(ctx).task_id());
-
-        // Collect attachments from ai_context_model
+        // Collect block/selected-text references from the context model.
         let attachments: Vec<AgentAttachment> = self
             .ai_context_model
             .as_ref(ctx)
@@ -13904,7 +13985,34 @@ impl Input {
             .cloned()
             .collect();
 
-        let has_uploads = (!pending_images.is_empty() || !pending_files.is_empty())
+        self.upload_and_send_viewer_prompt(
+            server_conversation_token,
+            prompt,
+            attachments,
+            pending_images,
+            pending_files,
+            ctx,
+        );
+
+        true
+    }
+
+    /// Uploads `images`/`files` (when the cloud pane supports it) and emits `Event::SendAgentPrompt`
+    /// with the resulting attachments. Shared by the immediate viewer submission and the queued
+    /// viewer drain so both go through the identical upload-then-send path.
+    fn upload_and_send_viewer_prompt(
+        &mut self,
+        server_conversation_token: Option<ServerConversationToken>,
+        prompt: String,
+        base_attachments: Vec<AgentAttachment>,
+        images: Vec<ImageContext>,
+        files: Vec<PendingFile>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let ambient_agent_task_id = self
+            .ambient_agent_view_model()
+            .and_then(|ambient_agent_model| ambient_agent_model.as_ref(ctx).task_id());
+        let has_uploads = (!images.is_empty() || !files.is_empty())
             && FeatureFlag::CloudModeImageContext.is_enabled();
 
         if let Some(task_id) = ambient_agent_task_id.filter(|_| has_uploads) {
@@ -13913,24 +14021,22 @@ impl Input {
                 task_id,
                 server_conversation_token,
                 prompt,
-                attachments,
-                &pending_images,
-                &pending_files,
+                base_attachments,
+                &images,
+                &files,
                 ctx,
             );
         } else {
             // No files to upload, send prompt immediately
-            if !pending_images.is_empty() || !pending_files.is_empty() {
+            if !images.is_empty() || !files.is_empty() {
                 log::warn!("Cannot upload files: no task_id available");
             }
             ctx.emit(Event::SendAgentPrompt {
                 server_conversation_token,
                 prompt,
-                attachments,
+                attachments: base_attachments,
             });
         }
-
-        true
     }
 
     /// Uploads image and file attachments to GCS via presigned URLs, then emits `SendAgentPrompt`

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -13555,12 +13555,19 @@ impl Input {
             if self.editor.as_ref(ctx).buffer_text(ctx).is_empty() {
                 self.freeze_input_in_loading_state_with_text(&prompt, ctx);
             }
+            let queued_query_retry = QueuedQueryModel::as_ref(ctx)
+                .queue(conversation_id)
+                .iter()
+                .enumerate()
+                .find(|(_, query)| query.id() == query_id)
+                .map(|(index, query)| (conversation_id, index, query.clone()));
             self.upload_and_send_viewer_prompt(
                 server_conversation_token,
                 prompt,
                 vec![],
                 images,
                 files,
+                queued_query_retry,
                 ctx,
             );
             return;
@@ -13979,6 +13986,7 @@ impl Input {
             attachments,
             pending_images,
             pending_files,
+            None,
             ctx,
         );
 
@@ -13988,6 +13996,7 @@ impl Input {
     /// Uploads `images`/`files` (when the cloud pane supports it) and emits `Event::SendAgentPrompt`
     /// with the resulting attachments. Shared by the immediate viewer submission and the queued
     /// viewer drain so both go through the identical upload-then-send path.
+    #[allow(clippy::too_many_arguments)]
     fn upload_and_send_viewer_prompt(
         &mut self,
         server_conversation_token: Option<ServerConversationToken>,
@@ -13995,6 +14004,7 @@ impl Input {
         base_attachments: Vec<AgentAttachment>,
         images: Vec<ImageContext>,
         files: Vec<PendingFile>,
+        queued_query_retry: Option<(AIConversationId, usize, QueuedQuery)>,
         ctx: &mut ViewContext<Self>,
     ) {
         let ambient_agent_task_id = self
@@ -14012,6 +14022,7 @@ impl Input {
                 base_attachments,
                 &images,
                 &files,
+                queued_query_retry,
                 ctx,
             );
         } else {
@@ -14029,6 +14040,7 @@ impl Input {
 
     /// Uploads image and file attachments to GCS via presigned URLs, then emits `SendAgentPrompt`
     /// with the resulting `FileReference` attachments appended.
+    #[allow(clippy::too_many_arguments)]
     fn upload_files_then_send_prompt(
         task_id: crate::ai::ambient_agents::AmbientAgentTaskId,
         server_conversation_token: Option<
@@ -14038,6 +14050,7 @@ impl Input {
         base_attachments: Vec<AgentAttachment>,
         pending_images: &[crate::ai::agent::ImageContext],
         pending_files: &[crate::ai::blocklist::PendingFile],
+        queued_query_retry: Option<(AIConversationId, usize, QueuedQuery)>,
         ctx: &mut ViewContext<Self>,
     ) {
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
@@ -14144,28 +14157,39 @@ impl Input {
                 Some(uploaded)
             },
             move |input, maybe_uploaded, ctx| {
-                let Some(uploaded_files) = maybe_uploaded else {
-                    // Prepare request failed (e.g. attachment limit exceeded).
-                    // Keep pending attachments so the user can retry, unfreeze input,
-                    // and show an error toast.
-                    input.unfreeze_and_clear_agent_input(ctx);
-                    let window_id = ctx.window_id();
-                    ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                        toast_stack.add_ephemeral_toast(
-                            DismissibleToast::error(
-                                "Too many attachments for this conversation.".to_string(),
-                            ),
-                            window_id,
-                            ctx,
-                        );
-                    });
-                    return;
+                let is_queued_prompt = queued_query_retry.is_some();
+                let uploaded_files = match maybe_uploaded {
+                    Some(uploaded_files) => uploaded_files,
+                    None => {
+                        if let Some((conversation_id, insert_index, query)) = queued_query_retry {
+                            QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                                model.restore_fired_row(conversation_id, insert_index, query, ctx);
+                            });
+                        }
+                        // Prepare request failed (e.g. attachment limit exceeded).
+                        // Keep pending attachments so the user can retry, unfreeze input,
+                        // and show an error toast.
+                        input.unfreeze_and_clear_agent_input(ctx);
+                        let window_id = ctx.window_id();
+                        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                            toast_stack.add_ephemeral_toast(
+                                DismissibleToast::error(
+                                    "Too many attachments for this conversation.".to_string(),
+                                ),
+                                window_id,
+                                ctx,
+                            );
+                        });
+                        return;
+                    }
                 };
 
-                // Upload succeeded — clear pending attachments now.
-                input.ai_context_model.update(ctx, |context_model, ctx| {
-                    context_model.clear_pending_attachments(ctx);
-                });
+                if !is_queued_prompt {
+                    // Upload succeeded — clear pending attachments now.
+                    input.ai_context_model.update(ctx, |context_model, ctx| {
+                        context_model.clear_pending_attachments(ctx);
+                    });
+                }
 
                 let mut all_attachments = base_attachments;
                 all_attachments.extend(uploaded_files);

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3729,10 +3729,7 @@ impl Input {
                 });
                 self.focus_input_box(ctx);
             }
-            QueuedPromptsPanelEvent::RowDeleted { text } => {
-                if self.buffer_text(ctx).is_empty() {
-                    self.replace_buffer_content(text, ctx);
-                }
+            QueuedPromptsPanelEvent::RowDeleted => {
                 self.focus_input_box(ctx);
             }
             QueuedPromptsPanelEvent::EditEnded => {

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -5354,7 +5354,7 @@ impl Input {
     ///
     /// This enters AI mode, resolves the skill from SkillManager, and submits it.
     ///
-    /// When `is_queued_prompt` is true, this is the first send of a previously queued prompt:
+    /// When `queued_query_id` is `Some`, this is the first send of a previously queued prompt:
     /// the input buffer is left alone (the user may have typed new input while the agent was
     /// busy) and the emitted `SentRequest` event is tagged as a queued-prompt submission so
     /// other UI subscribers also skip their user-submission side effects.
@@ -5364,9 +5364,14 @@ impl Input {
         &mut self,
         reference: SkillReference,
         user_query: Option<String>,
-        is_queued_prompt: bool,
+        queued_query_id: Option<QueuedQueryId>,
+        // The conversation a fired queued skill was queued on, used to route the send and resolve
+        // the row's attachments instead of re-deriving from the current UI selection. `None` for
+        // direct (non-queued) skill invocations.
+        conversation_id_override: Option<AIConversationId>,
         ctx: &mut ViewContext<Self>,
     ) -> bool {
+        let is_queued_prompt = queued_query_id.is_some();
         // Resolve the skill from SkillManager
         let skill = match SkillManager::handle(ctx)
             .as_ref(ctx)
@@ -5413,8 +5418,13 @@ impl Input {
         // Send the skill invocation request
         let request = SlashCommandRequest::InvokeSkill { skill, user_query };
         self.ai_controller.update(ctx, move |controller, ctx| {
-            if is_queued_prompt {
-                controller.send_queued_slash_command_request(request, ctx);
+            if let Some(query_id) = queued_query_id {
+                controller.send_queued_slash_command_request(
+                    request,
+                    query_id,
+                    conversation_id_override,
+                    ctx,
+                );
             } else {
                 controller.send_slash_command_request(request, ctx);
             }
@@ -13368,24 +13378,19 @@ impl Input {
     pub(crate) fn submit_queued_prompt(
         &mut self,
         prompt: String,
+        conversation_id: AIConversationId,
         query_id: QueuedQueryId,
         ctx: &mut ViewContext<Self>,
     ) {
-        if let Some(conversation_id) = self
-            .ai_context_model
-            .as_ref(ctx)
-            .selected_conversation_id(ctx)
-        {
-            self.ai_controller.update(ctx, |controller, ctx| {
-                controller.cancel_conversation_progress(
-                    conversation_id,
-                    CancellationReason::FollowUpSubmitted {
-                        is_for_same_conversation: true,
-                    },
-                    ctx,
-                );
-            });
-        }
+        self.ai_controller.update(ctx, |controller, ctx| {
+            controller.cancel_conversation_progress(
+                conversation_id,
+                CancellationReason::FollowUpSubmitted {
+                    is_for_same_conversation: true,
+                },
+                ctx,
+            );
+        });
 
         let detected = self
             .slash_command_model
@@ -13405,14 +13410,13 @@ impl Input {
                     ctx,
                 )
             }
-            SlashCommandEntryState::SkillCommand(detected_skill) => {
-                self.execute_skill_command(
-                    detected_skill.reference,
-                    detected_skill.argument,
-                    /*is_queued_prompt*/ true,
-                    ctx,
-                )
-            }
+            SlashCommandEntryState::SkillCommand(detected_skill) => self.execute_skill_command(
+                detected_skill.reference,
+                detected_skill.argument,
+                Some(query_id),
+                Some(conversation_id),
+                ctx,
+            ),
             _ => false,
         };
 
@@ -13420,32 +13424,18 @@ impl Input {
             return;
         }
 
-        if let Some(conversation_id) = self
-            .ai_context_model
-            .as_ref(ctx)
-            .selected_conversation_id(ctx)
-        {
-            self.ai_controller.update(ctx, move |controller, ctx| {
-                controller.send_queued_user_query_in_conversation(
-                    prompt,
-                    conversation_id,
-                    None,
-                    query_id,
-                    ctx,
-                );
-            });
-        } else {
-            self.ai_controller.update(ctx, move |controller, ctx| {
-                controller.send_queued_user_query_in_new_conversation(
-                    prompt,
-                    None,
-                    EntrypointType::UserInitiated,
-                    None,
-                    query_id,
-                    ctx,
-                );
-            });
-        }
+        // A fired queued row always belongs to the existing conversation that finished, so we
+        // submit into that conversation directly rather than re-deriving from the current UI
+        // selection (which may point at a different conversation the user navigated to).
+        self.ai_controller.update(ctx, move |controller, ctx| {
+            controller.send_queued_user_query_in_conversation(
+                prompt,
+                conversation_id,
+                None,
+                query_id,
+                ctx,
+            );
+        });
 
         ctx.emit(Event::ExecuteAIQuery);
     }
@@ -13486,6 +13476,7 @@ impl Input {
     pub(crate) fn submit_queued_prompt_for_active_pane(
         &mut self,
         prompt: String,
+        conversation_id: AIConversationId,
         query_id: QueuedQueryId,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -13502,15 +13493,9 @@ impl Input {
         if is_ready_for_cloud_followup {
             // Cloud follow-up does not support attachments; a queued row's attachments are dropped
             // when the row is removed after dispatch.
-            let drops_attachments = self
-                .ai_context_model
-                .as_ref(ctx)
-                .selected_conversation_id(ctx)
-                .is_some_and(|conversation_id| {
-                    !QueuedQueryModel::as_ref(ctx)
-                        .attachments_for(conversation_id, query_id)
-                        .is_empty()
-                });
+            let drops_attachments = !QueuedQueryModel::as_ref(ctx)
+                .attachments_for(conversation_id, query_id)
+                .is_empty();
             if drops_attachments {
                 log::warn!(
                     "Dropping attachments on a queued cloud follow-up prompt; cloud follow-up does not support attachments"
@@ -13529,16 +13514,9 @@ impl Input {
         // clear it once the sharer acknowledges receipt. If the user has typed something locally,
         // we leave the buffer alone so their in-progress prompt is not clobbered.
         if self.model.lock().shared_session_status().is_viewer() {
-            let conversation_id = self
-                .ai_context_model
-                .as_ref(ctx)
-                .selected_conversation_id(ctx);
-            let server_conversation_token = conversation_id
-                .and_then(|id| {
-                    BlocklistAIHistoryModel::as_ref(ctx)
-                        .conversation(&id)
-                        .and_then(|conv| conv.server_conversation_token().cloned())
-                })
+            let server_conversation_token = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .and_then(|conv| conv.server_conversation_token().cloned())
                 .and_then(|token| {
                     token
                         .as_str()
@@ -13548,21 +13526,16 @@ impl Input {
                 });
 
             // Split the firing row's stored attachments into images/files for upload.
-            let (images, files) = conversation_id
-                .map(|conversation_id| {
-                    let mut images: Vec<ImageContext> = Vec::new();
-                    let mut files: Vec<PendingFile> = Vec::new();
-                    for attachment in
-                        QueuedQueryModel::as_ref(ctx).attachments_for(conversation_id, query_id)
-                    {
-                        match attachment {
-                            PendingAttachment::Image(image) => images.push(image.clone()),
-                            PendingAttachment::File(file) => files.push(file.clone()),
-                        }
-                    }
-                    (images, files)
-                })
-                .unwrap_or_default();
+            let mut images: Vec<ImageContext> = Vec::new();
+            let mut files: Vec<PendingFile> = Vec::new();
+            for attachment in
+                QueuedQueryModel::as_ref(ctx).attachments_for(conversation_id, query_id)
+            {
+                match attachment {
+                    PendingAttachment::Image(image) => images.push(image.clone()),
+                    PendingAttachment::File(file) => files.push(file.clone()),
+                }
+            }
 
             if self.editor.as_ref(ctx).buffer_text(ctx).is_empty() {
                 self.freeze_input_in_loading_state_with_text(&prompt, ctx);
@@ -13579,7 +13552,7 @@ impl Input {
         }
 
         // Local Agent Mode path.
-        self.submit_queued_prompt(prompt, query_id, ctx);
+        self.submit_queued_prompt(prompt, conversation_id, query_id, ctx);
     }
 
     /// Checks whether the current input should be queued instead of executed.

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -177,8 +177,7 @@ use crate::ai::blocklist::{
     BlocklistAIHistoryModel, BlocklistAIInputEvent, BlocklistAIInputModel, InputConfig, InputType,
     InputTypeAutoDetectionSource, PendingAttachment, PendingFile, QueuedQuery, QueuedQueryEvent,
     QueuedQueryId, QueuedQueryModel, QueuedQueryOrigin, SlashCommandRequest,
-    BLOCK_CONTEXT_ATTACHMENT_REGEX,
-    DIFF_HUNK_ATTACHMENT_REGEX, DRIVE_OBJECT_ATTACHMENT_REGEX,
+    BLOCK_CONTEXT_ATTACHMENT_REGEX, DIFF_HUNK_ATTACHMENT_REGEX, DRIVE_OBJECT_ATTACHMENT_REGEX,
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3714,11 +3714,26 @@ impl Input {
         ctx: &mut ViewContext<Self>,
     ) {
         match event {
-            QueuedPromptsPanelEvent::SendNow { text } => {
-                self.submit_queued_prompt_for_active_pane(text.clone(), ctx);
+            QueuedPromptsPanelEvent::SendNow {
+                conversation_id,
+                query_id,
+                text,
+            } => {
+                self.submit_queued_prompt_for_active_pane(
+                    text.clone(),
+                    *conversation_id,
+                    *query_id,
+                    ctx,
+                );
+                QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.remove_fired_row(*conversation_id, *query_id, ctx);
+                });
                 self.focus_input_box(ctx);
             }
-            QueuedPromptsPanelEvent::RowDeleted => {
+            QueuedPromptsPanelEvent::RowDeleted { text } => {
+                if self.buffer_text(ctx).is_empty() {
+                    self.replace_buffer_content(text, ctx);
+                }
                 self.focus_input_box(ctx);
             }
             QueuedPromptsPanelEvent::EditEnded => {

--- a/app/src/terminal/input/slash_command_model_tests.rs
+++ b/app/src/terminal/input/slash_command_model_tests.rs
@@ -2,6 +2,7 @@ use settings::Setting as _;
 use warpui::{App, SingletonEntity as _};
 
 use super::SlashCommandEntryState;
+use crate::ai::blocklist::QueuedQueryId;
 use crate::report_if_error;
 use crate::search::slash_command_menu::static_commands::commands;
 use crate::settings::AISettings;
@@ -460,7 +461,11 @@ fn test_submit_queued_prompt_routes_plain_text_to_conversation() {
         // It routes through detect_command (returning None) and falls through
         // to send_user_query_in_new_conversation.
         input.update(&mut app, |input, ctx| {
-            input.submit_queued_prompt("fix the tests".to_string(), ctx);
+            input.submit_queued_prompt(
+                "fix the tests".to_string(),
+                QueuedQueryId::new_for_test(),
+                ctx,
+            );
         });
     });
 }
@@ -492,7 +497,7 @@ fn test_submit_queued_prompt_detects_slash_command() {
             // submit_queued_prompt should detect the slash command and route through
             // execute_slash_command. This should not panic.
             input.update(&mut app, |input, ctx| {
-                input.submit_queued_prompt(command_text, ctx);
+                input.submit_queued_prompt(command_text, QueuedQueryId::new_for_test(), ctx);
             });
         }
     });

--- a/app/src/terminal/input/slash_command_model_tests.rs
+++ b/app/src/terminal/input/slash_command_model_tests.rs
@@ -2,6 +2,7 @@ use settings::Setting as _;
 use warpui::{App, SingletonEntity as _};
 
 use super::SlashCommandEntryState;
+use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::blocklist::QueuedQueryId;
 use crate::report_if_error;
 use crate::search::slash_command_menu::static_commands::commands;
@@ -463,6 +464,7 @@ fn test_submit_queued_prompt_routes_plain_text_to_conversation() {
         input.update(&mut app, |input, ctx| {
             input.submit_queued_prompt(
                 "fix the tests".to_string(),
+                AIConversationId::new(),
                 QueuedQueryId::new_for_test(),
                 ctx,
             );
@@ -497,7 +499,12 @@ fn test_submit_queued_prompt_detects_slash_command() {
             // submit_queued_prompt should detect the slash command and route through
             // execute_slash_command. This should not panic.
             input.update(&mut app, |input, ctx| {
-                input.submit_queued_prompt(command_text, QueuedQueryId::new_for_test(), ctx);
+                input.submit_queued_prompt(
+                    command_text,
+                    AIConversationId::new(),
+                    QueuedQueryId::new_for_test(),
+                    ctx,
+                );
             });
         }
     });

--- a/app/src/terminal/input/slash_command_model_tests.rs
+++ b/app/src/terminal/input/slash_command_model_tests.rs
@@ -3,7 +3,7 @@ use warpui::{App, SingletonEntity as _};
 
 use super::SlashCommandEntryState;
 use crate::ai::agent::conversation::AIConversationId;
-use crate::ai::blocklist::QueuedQueryId;
+use crate::ai::blocklist::{QueuedQuery, QueuedQueryModel, QueuedQueryOrigin};
 use crate::report_if_error;
 use crate::search::slash_command_menu::static_commands::commands;
 use crate::settings::AISettings;
@@ -462,12 +462,18 @@ fn test_submit_queued_prompt_routes_plain_text_to_conversation() {
         // It routes through detect_command (returning None) and falls through
         // to send_user_query_in_new_conversation.
         input.update(&mut app, |input, ctx| {
-            input.submit_queued_prompt(
-                "fix the tests".to_string(),
-                AIConversationId::new(),
-                QueuedQueryId::new_for_test(),
-                ctx,
-            );
+            let conversation_id = AIConversationId::new();
+            let query_id = QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                model.append(
+                    conversation_id,
+                    QueuedQuery::new(
+                        "fix the tests".to_owned(),
+                        QueuedQueryOrigin::QueueSlashCommand,
+                    ),
+                    ctx,
+                )
+            });
+            input.submit_queued_prompt("fix the tests".to_string(), conversation_id, query_id, ctx);
         });
     });
 }
@@ -499,12 +505,18 @@ fn test_submit_queued_prompt_detects_slash_command() {
             // submit_queued_prompt should detect the slash command and route through
             // execute_slash_command. This should not panic.
             input.update(&mut app, |input, ctx| {
-                input.submit_queued_prompt(
-                    command_text,
-                    AIConversationId::new(),
-                    QueuedQueryId::new_for_test(),
-                    ctx,
-                );
+                let conversation_id = AIConversationId::new();
+                let query_id = QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.append(
+                        conversation_id,
+                        QueuedQuery::new(
+                            command_text.clone(),
+                            QueuedQueryOrigin::QueueSlashCommand,
+                        ),
+                        ctx,
+                    )
+                });
+                input.submit_queued_prompt(command_text, conversation_id, query_id, ctx);
             });
         }
     });

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1103,15 +1103,24 @@ impl Input {
                     });
 
                 if should_queue {
+                    let attachments = self.ai_context_model.update(ctx, |context_model, ctx| {
+                        context_model.take_pending_attachments(ctx)
+                    });
                     QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
                         model.append(
                             conversation_id,
-                            QueuedQuery::new(prompt, QueuedQueryOrigin::QueueSlashCommand),
+                            QueuedQuery::new_with_attachments(
+                                prompt,
+                                QueuedQueryOrigin::QueueSlashCommand,
+                                attachments,
+                            ),
                             ctx,
                         );
                     });
                 } else {
-                    self.submit_queued_prompt(prompt, ctx);
+                    // Not in progress: submit immediately as a regular (non-queued) user query so
+                    // the live staging is sent and reset, rather than treated as a queued-row fire.
+                    self.submit_user_query_now(prompt, ctx);
                 }
             }
             open_repo if command.name == commands::OPEN_REPO.name => {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1238,9 +1238,7 @@ impl Input {
             SlashCommandEntryState::SkillCommand(detected_skill) => {
                 let reference = detected_skill.reference.clone();
                 let user_query = detected_skill.argument.clone();
-                self.execute_skill_command(
-                    reference, user_query, /*is_queued_prompt*/ false, ctx,
-                )
+                self.execute_skill_command(reference, user_query, None, None, ctx)
             }
             SlashCommandEntryState::None
             | SlashCommandEntryState::Composing { .. }
@@ -1339,9 +1337,7 @@ impl Input {
             SlashCommandEntryState::SkillCommand(detected_skill) => {
                 let reference = detected_skill.reference.clone();
                 let user_query = detected_skill.argument.clone();
-                self.execute_skill_command(
-                    reference, user_query, /*is_queued_prompt*/ false, ctx,
-                )
+                self.execute_skill_command(reference, user_query, None, None, ctx)
             }
             SlashCommandEntryState::None
             | SlashCommandEntryState::Composing { .. }

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -1167,10 +1167,25 @@ fn send_now_event_submits_through_active_pane_and_preserves_draft() {
             });
         });
 
+        // Seed a queued row so the host can identify it by id, fire it, and remove it afterward.
+        let conversation_id = AIConversationId::new();
+        let query_id = QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
+            model.append(
+                conversation_id,
+                QueuedQuery::new(
+                    "queued prompt".to_owned(),
+                    QueuedQueryOrigin::QueueSlashCommand,
+                ),
+                ctx,
+            )
+        });
+
         input.update(&mut app, |input, ctx| {
             input.replace_buffer_content("draft in progress", ctx);
             input.handle_queued_prompts_panel_event(
                 &QueuedPromptsPanelEvent::SendNow {
+                    conversation_id,
+                    query_id,
                     text: "queued prompt".to_owned(),
                 },
                 ctx,
@@ -1179,9 +1194,13 @@ fn send_now_event_submits_through_active_pane_and_preserves_draft() {
 
         // The queued prompt was submitted immediately...
         assert_eq!(submitted_prompts.borrow().as_slice(), ["queued prompt"]);
-        // ...and the in-progress draft the user typed was left untouched.
+        // ...the in-progress draft the user typed was left untouched...
         input.read(&app, |input, ctx| {
             assert_eq!(input.buffer_text(ctx), "draft in progress");
+        });
+        // ...and the host removed the fired row from the queue.
+        QueuedQueryModel::handle(&app).read(&app, |model, _| {
+            assert!(model.queue(conversation_id).is_empty());
         });
     });
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5250,8 +5250,15 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         if FeatureFlag::QueuedPromptsV2.is_enabled() {
+            let attachments = self.ai_context_model.update(ctx, |context_model, ctx| {
+                context_model.take_pending_attachments(ctx)
+            });
             QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
-                model.append(conversation_id, QueuedQuery::new(prompt, origin), ctx);
+                model.append(
+                    conversation_id,
+                    QueuedQuery::new_with_attachments(prompt, origin, attachments),
+                    ctx,
+                );
             });
         } else {
             self.send_user_query_after_next_conversation_finished(
@@ -5284,7 +5291,12 @@ impl TerminalView {
                 match action {
                     Some(AutofireAction::Submit { query_id, text }) => {
                         self.input.update(ctx, |input, ctx| {
-                            input.submit_queued_prompt_for_active_pane(text, query_id, ctx);
+                            input.submit_queued_prompt_for_active_pane(
+                                text,
+                                conversation_id,
+                                query_id,
+                                ctx,
+                            );
                         });
                         QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
                             model.remove_fired_row(conversation_id, query_id, ctx);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5278,21 +5278,34 @@ impl TerminalView {
                     return;
                 }
 
-                let action = QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
-                    model.pop_for_autofire(conversation_id, ctx)
-                });
+                // Peek the head row's action without removing it so the send path can read its
+                // attachments by id; the row is removed afterward via `remove_fired_row`.
+                let action = QueuedQueryModel::as_ref(ctx).peek_autofire(conversation_id);
                 match action {
-                    Some(AutofireAction::Submit { text }) => {
+                    Some(AutofireAction::Submit { query_id, text }) => {
                         self.input.update(ctx, |input, ctx| {
-                            input.submit_queued_prompt_for_active_pane(text, ctx);
+                            input.submit_queued_prompt_for_active_pane(text, query_id, ctx);
+                        });
+                        QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                            model.remove_fired_row(conversation_id, query_id, ctx);
                         });
                     }
-                    Some(AutofireAction::PopFromEditMode { text }) => {
-                        self.input.update(ctx, |input, ctx| {
-                            if input.buffer_text(ctx).is_empty() {
+                    Some(AutofireAction::PopFromEditMode {
+                        query_id,
+                        text,
+                        attachments,
+                    }) => {
+                        if self.input.as_ref(ctx).buffer_text(ctx).is_empty() {
+                            self.input.update(ctx, |input, ctx| {
                                 input.replace_buffer_content(&text, ctx);
                                 input.focus_input_box(ctx);
-                            }
+                            });
+                            self.ai_context_model.update(ctx, |context_model, ctx| {
+                                context_model.append_pending_attachments(attachments, ctx);
+                            });
+                        }
+                        QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                            model.remove_fired_row(conversation_id, query_id, ctx);
                         });
                     }
                     None => {}
@@ -5327,6 +5340,10 @@ impl TerminalView {
                 if let Some(query) = popped {
                     self.input.update(ctx, |input, ctx| {
                         input.replace_buffer_content(query.text(), ctx);
+                    });
+                    // Re-stage the restored row's attachments so a manual re-submit keeps them.
+                    self.ai_context_model.update(ctx, |context_model, ctx| {
+                        context_model.append_pending_attachments(query.attachments().to_vec(), ctx);
                     });
                 }
             }

--- a/app/src/terminal/view/pending_user_query.rs
+++ b/app/src/terminal/view/pending_user_query.rs
@@ -167,7 +167,7 @@ impl TerminalView {
         }
 
         self.input.update(ctx, |input, ctx| {
-            input.submit_queued_prompt(prompt, ctx);
+            input.submit_user_query_now(prompt, ctx);
         });
     }
 
@@ -205,7 +205,7 @@ impl TerminalView {
             match reason {
                 FinishReason::Complete => {
                     terminal_view.input.update(ctx, |input, ctx| {
-                        input.submit_queued_prompt(prompt, ctx);
+                        input.submit_user_query_now(prompt, ctx);
                     });
                 }
                 FinishReason::Error

--- a/app/src/terminal/view/queued_prompts_panel.rs
+++ b/app/src/terminal/view/queued_prompts_panel.rs
@@ -192,9 +192,8 @@ pub enum QueuedPromptsPanelEvent {
         query_id: QueuedQueryId,
         text: String,
     },
-    /// A row was deleted via the trash button. The host should place `text` into the input editor
-    /// when the editor is empty, and focus the input.
-    RowDeleted { text: String },
+    /// A row was deleted via the trash button. The host should refocus the input.
+    RowDeleted,
     /// An inline edit was committed or cancelled. The host should refocus the input.
     EditEnded,
 }
@@ -634,9 +633,7 @@ impl TypedActionView for QueuedPromptsPanelView {
                         },
                         ctx
                     );
-                    ctx.emit(QueuedPromptsPanelEvent::RowDeleted {
-                        text: removed.text().to_owned(),
-                    });
+                    ctx.emit(QueuedPromptsPanelEvent::RowDeleted);
                 }
             }
             QueuedPromptsPanelAction::StartDrag(query_id) => {

--- a/app/src/terminal/view/queued_prompts_panel.rs
+++ b/app/src/terminal/view/queued_prompts_panel.rs
@@ -185,10 +185,16 @@ pub enum QueuedPromptsPanelAction {
 /// Events emitted to the host input view.
 #[derive(Clone, Debug)]
 pub enum QueuedPromptsPanelEvent {
-    /// A row was removed via its send-now button. The host should immediately submit `text`.
-    SendNow { text: String },
-    /// A row was deleted via the trash button. The host should refocus the input.
-    RowDeleted,
+    /// A row's send-now button was clicked. The row is left in the queue so the host can read its
+    /// attachments by id; the host submits `text` immediately and then removes the fired row.
+    SendNow {
+        conversation_id: AIConversationId,
+        query_id: QueuedQueryId,
+        text: String,
+    },
+    /// A row was deleted via the trash button. The host should place `text` into the input editor
+    /// when the editor is empty, and focus the input.
+    RowDeleted { text: String },
     /// An inline edit was committed or cancelled. The host should refocus the input.
     EditEnded,
 }
@@ -595,11 +601,19 @@ impl TypedActionView for QueuedPromptsPanelView {
                     self.commit_edit(ctx);
                 }
 
-                let removed = QueuedQueryModel::handle(ctx)
-                    .update(ctx, |model, ctx| model.remove_by_id(conv_id, query_id, ctx));
-                if let Some(removed) = removed {
+                // Leave the row in the queue so the host can read its attachments by id when it
+                // fires; the host removes the fired row afterward. Locked rows (the initial
+                // cloud-mode prompt) are not send-now-able.
+                let text = QueuedQueryModel::as_ref(ctx)
+                    .queue(conv_id)
+                    .iter()
+                    .find(|row| row.id() == query_id && !row.is_locked())
+                    .map(|row| row.text().to_owned());
+                if let Some(text) = text {
                     ctx.emit(QueuedPromptsPanelEvent::SendNow {
-                        text: removed.text().to_owned(),
+                        conversation_id: conv_id,
+                        query_id,
+                        text,
                     });
                 }
             }
@@ -620,7 +634,9 @@ impl TypedActionView for QueuedPromptsPanelView {
                         },
                         ctx
                     );
-                    ctx.emit(QueuedPromptsPanelEvent::RowDeleted);
+                    ctx.emit(QueuedPromptsPanelEvent::RowDeleted {
+                        text: removed.text().to_owned(),
+                    });
                 }
             }
             QueuedPromptsPanelAction::StartDrag(query_id) => {

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -21,7 +21,7 @@ use crate::ai::agent::{ImageContext, UserQueryMode};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::{
     AutofireAction, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate,
-    PendingAttachment, QueuedQuery, QueuedQueryModel, QueuedQueryOrigin,
+    PendingAttachment, QueuedQuery, QueuedQueryId, QueuedQueryModel, QueuedQueryOrigin,
 };
 use crate::features::FeatureFlag;
 use crate::server::server_api::ai::SpawnAgentRequest;
@@ -1017,9 +1017,10 @@ fn drain_is_isolated_per_conversation() {
 }
 
 #[test]
-fn send_now_action_removes_row_and_emits_send_now_event() {
-    // Clicking "send now" on a queued row removes exactly that row and asks the host to submit its
-    // text immediately. The locked initial cloud-mode row is rejected by the model (covered by
+fn send_now_action_emits_event_and_leaves_row_for_host_to_fire() {
+    // Clicking "send now" emits a SendNow event identifying the row, but leaves the row in the
+    // queue so the host can read its attachments by id when it fires; the host removes the fired
+    // row afterward. The locked initial cloud-mode row is rejected by the model (covered by
     // `initial_cloud_mode_head_rejects_user_mutations_and_autofire`) and has its button disabled
     // in the panel, so it needs no separate panel test.
     App::test((), |mut app| async move {
@@ -1056,14 +1057,23 @@ fn send_now_action_removes_row_and_emits_send_now_event() {
             model.append(conversation_id, user_query("send me now"), ctx)
         });
 
-        let send_now_events = Rc::new(RefCell::new(Vec::<String>::new()));
+        let send_now_events = Rc::new(RefCell::new(
+            Vec::<(AIConversationId, QueuedQueryId, String)>::new(),
+        ));
         let send_now_events_for_subscription = send_now_events.clone();
         app.update(|ctx| {
             ctx.subscribe_to_view(&panel, move |_, event: &QueuedPromptsPanelEvent, _| {
-                if let QueuedPromptsPanelEvent::SendNow { text } = event {
-                    send_now_events_for_subscription
-                        .borrow_mut()
-                        .push(text.clone());
+                if let QueuedPromptsPanelEvent::SendNow {
+                    conversation_id,
+                    query_id,
+                    text,
+                } = event
+                {
+                    send_now_events_for_subscription.borrow_mut().push((
+                        *conversation_id,
+                        *query_id,
+                        text.clone(),
+                    ));
                 }
             });
         });
@@ -1072,9 +1082,13 @@ fn send_now_action_removes_row_and_emits_send_now_event() {
             panel.handle_action(&QueuedPromptsPanelAction::SendNow(query_id), ctx);
         });
 
-        assert_eq!(send_now_events.borrow().as_slice(), ["send me now"]);
+        assert_eq!(
+            send_now_events.borrow().as_slice(),
+            [(conversation_id, query_id, "send me now".to_owned())]
+        );
+        // The panel leaves the row in place; the host removes it after firing.
         QueuedQueryModel::handle(&app).read(&app, |model, _| {
-            assert!(model.queue(conversation_id).is_empty());
+            assert_eq!(model.queue(conversation_id).len(), 1);
         });
     });
 }

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -17,11 +17,11 @@ use super::queued_prompts_panel::{
 };
 use super::TerminalView;
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
-use crate::ai::agent::UserQueryMode;
+use crate::ai::agent::{ImageContext, UserQueryMode};
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::{
     AutofireAction, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate,
-    QueuedQuery, QueuedQueryModel, QueuedQueryOrigin,
+    PendingAttachment, QueuedQuery, QueuedQueryModel, QueuedQueryOrigin,
 };
 use crate::features::FeatureFlag;
 use crate::server::server_api::ai::SpawnAgentRequest;
@@ -33,6 +33,43 @@ use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_te
 
 fn user_query(text: &str) -> QueuedQuery {
     QueuedQuery::new(text.to_owned(), QueuedQueryOrigin::QueueSlashCommand)
+}
+
+fn image_attachment(file_name: &str) -> PendingAttachment {
+    PendingAttachment::Image(ImageContext {
+        data: String::new(),
+        mime_type: "image/png".to_owned(),
+        file_name: file_name.to_owned(),
+        is_figma: false,
+    })
+}
+
+fn query_with_attachments(text: &str, attachments: Vec<PendingAttachment>) -> QueuedQuery {
+    QueuedQuery::new_with_attachments(
+        text.to_owned(),
+        QueuedQueryOrigin::QueueSlashCommand,
+        attachments,
+    )
+}
+
+/// Mirrors `TerminalView::drain_queued_prompts`' Complete path at the model level: peek the head
+/// row's action, then remove the fired row (both `AutofireAction` variants carry the row id).
+fn drain_one(
+    model: &warpui::ModelHandle<QueuedQueryModel>,
+    app: &mut App,
+    conv: AIConversationId,
+) -> Option<AutofireAction> {
+    model.update(app, |m, ctx| {
+        let action = m.peek_autofire(conv);
+        if let Some(
+            AutofireAction::Submit { query_id, .. }
+            | AutofireAction::PopFromEditMode { query_id, .. },
+        ) = &action
+        {
+            m.remove_fired_row(conv, *query_id, ctx);
+        }
+        action
+    })
 }
 
 fn add_window_with_cloud_mode_terminal(app: &mut App) -> ViewHandle<TerminalView> {
@@ -147,9 +184,9 @@ fn complete_drain_pops_head_and_returns_submit_action() {
             m.append(conv, user_query("second"), ctx);
         });
 
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        let action = drain_one(&model, &mut app, conv);
         match action {
-            Some(AutofireAction::Submit { text }) => assert_eq!(text, "first"),
+            Some(AutofireAction::Submit { text, .. }) => assert_eq!(text, "first"),
             other => panic!("expected Submit, got {other:?}"),
         }
         model.read(&app, |m, _| {
@@ -690,9 +727,9 @@ fn complete_drain_with_first_row_in_edit_mode_returns_pop_from_edit_mode() {
             m.enter_edit_mode(conv, id_a, ctx);
         });
 
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        let action = drain_one(&model, &mut app, conv);
         match action {
-            Some(AutofireAction::PopFromEditMode { text }) => assert_eq!(text, "first"),
+            Some(AutofireAction::PopFromEditMode { text, .. }) => assert_eq!(text, "first"),
             other => panic!("expected PopFromEditMode, got {other:?}"),
         }
         // Edit mode is cleared after pop.
@@ -719,7 +756,7 @@ fn complete_drain_with_non_empty_input_preserves_edited_head_row() {
         if !(simulated_input_is_non_empty
             && model.read(&app, |m, _| m.first_row_is_in_edit_mode(conv)))
         {
-            model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+            drain_one(&model, &mut app, conv);
         }
 
         model.read(&app, |m, _| {
@@ -734,7 +771,7 @@ fn complete_drain_with_non_empty_input_preserves_edited_head_row() {
 #[test]
 fn complete_drain_with_empty_queue_returns_none() {
     with_singleton(|mut app, model, conv| {
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        let action = drain_one(&model, &mut app, conv);
         assert!(action.is_none());
     });
 }
@@ -937,21 +974,21 @@ fn complete_drain_after_error_drain_continues_with_next_row() {
         );
 
         // Complete: pop "second".
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        let action = drain_one(&model, &mut app, conv);
         match action {
-            Some(AutofireAction::Submit { text }) => assert_eq!(text, "second"),
+            Some(AutofireAction::Submit { text, .. }) => assert_eq!(text, "second"),
             other => panic!("expected Submit(\"second\"), got {other:?}"),
         }
 
         // Complete again: pop "third".
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        let action = drain_one(&model, &mut app, conv);
         match action {
-            Some(AutofireAction::Submit { text }) => assert_eq!(text, "third"),
+            Some(AutofireAction::Submit { text, .. }) => assert_eq!(text, "third"),
             other => panic!("expected Submit(\"third\"), got {other:?}"),
         }
 
         // Queue is now empty; the next drain returns None.
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv, ctx));
+        let action = drain_one(&model, &mut app, conv);
         assert!(action.is_none());
     });
 }
@@ -966,9 +1003,9 @@ fn drain_is_isolated_per_conversation() {
             m.append(conv_b, user_query("b-first"), ctx);
         });
 
-        let action = model.update(&mut app, |m, ctx| m.pop_for_autofire(conv_a, ctx));
+        let action = drain_one(&model, &mut app, conv_a);
         match action {
-            Some(AutofireAction::Submit { text }) => assert_eq!(text, "a-first"),
+            Some(AutofireAction::Submit { text, .. }) => assert_eq!(text, "a-first"),
             other => panic!("expected Submit(\"a-first\"), got {other:?}"),
         }
         model.read(&app, |m, _| {
@@ -1110,6 +1147,54 @@ fn send_now_disabled_for_all_rows_while_initial_cloud_mode_row_is_present() {
             assert_eq!(
                 panel.send_now_button_disabled_for_test(followup_id, ctx),
                 Some(false)
+            );
+        });
+    });
+}
+
+#[test]
+fn multi_cycle_queue_keeps_each_rows_attachments_independent() {
+    // attach -> queue -> attach -> queue: each row owns its own attachments, and draining one
+    // never disturbs the other's.
+    with_singleton(|mut app, model, conv| {
+        let first_id = model.update(&mut app, |m, ctx| {
+            m.append(
+                conv,
+                query_with_attachments("first", vec![image_attachment("first.png")]),
+                ctx,
+            )
+        });
+        let second_id = model.update(&mut app, |m, ctx| {
+            m.append(
+                conv,
+                query_with_attachments("second", vec![image_attachment("second.png")]),
+                ctx,
+            )
+        });
+
+        model.read(&app, |m, _| {
+            assert_eq!(
+                m.attachments_for(conv, first_id)[0].file_name(),
+                "first.png"
+            );
+            assert_eq!(
+                m.attachments_for(conv, second_id)[0].file_name(),
+                "second.png"
+            );
+        });
+
+        // Drain the first row; the second row's attachments are untouched.
+        let action = drain_one(&model, &mut app, conv);
+        match action {
+            Some(AutofireAction::Submit { text, .. }) => assert_eq!(text, "first"),
+            other => panic!("expected Submit, got {other:?}"),
+        }
+        model.read(&app, |m, _| {
+            assert!(m.attachments_for(conv, first_id).is_empty());
+            assert_eq!(m.attachments_for(conv, second_id).len(), 1);
+            assert_eq!(
+                m.attachments_for(conv, second_id)[0].file_name(),
+                "second.png"
             );
         });
     });

--- a/specs/APP-4617/PRODUCT.md
+++ b/specs/APP-4617/PRODUCT.md
@@ -1,0 +1,26 @@
+# Product Spec: Attachments on Queued Prompts
+
+Linear: [APP-4617](https://linear.app/warpdotdev/issue/APP-4617)
+Figma: none provided
+
+## Summary
+Queued agent prompts retain the image and file attachments staged in the input at the time they were queued. The attachments move off the input onto the queued row, are sent with that prompt when it fires, and are restored to the input if the row is brought back for editing.
+
+## Problem
+With queued prompts, staged attachments lived only in the live input. Queuing a prompt either left them in the input (where they would be re-sent with the user's next prompt) or cleared them (losing them entirely). A queued prompt could never carry its own attachments, and a fired queued prompt could steal attachments meant for the next message.
+
+## Behavior
+1. When a prompt is queued while one or more attachments (images, files) are staged in the input, those attachments are captured onto the queued row and removed from the live input. The input returns to empty — no text and no attachment chips — ready for the next prompt.
+2. Each queued row owns its own attachment set. Queuing prompt A with attachment X and then prompt B with attachment Y produces two rows that each carry only their own attachments; firing or removing one row never alters the other's attachments.
+3. When a queued row fires (the conversation it was queued on finishes), the prompt is sent with that row's stored attachments: images are sent inline as image context, and files are sent as file references. Files that share a basename are disambiguated with `(1)`, `(2)`, … suffixes.
+4. A fired queued row is always submitted into the conversation it was queued on, even if the user has since navigated to a different conversation. Its attachments resolve from the row, never from whatever is currently staged in the input.
+5. Attachments staged for the user's next prompt are never consumed by a firing queued row. If the user stages new attachments after queuing, those stay in the input and are sent with the user's next prompt, independent of any row that fires in the meantime.
+6. Restoring a queued row to the input re-stages its attachments (the chips reappear):
+   - If the head row was in edit mode when auto-fire reached it and the input is empty, the row's last-committed text and its attachments are placed back into the input. Uncommitted live-editor text is not used.
+   - When the user manually restores a row to the input for editing, its attachments are re-staged so a manual re-submit keeps them.
+7. Removing a queued row — whether deleted by the user or removed after it fires — drops its attachments. They are not left behind in the input or any other row.
+8. Queued slash commands and queued skill invocations carry attachments the same way: a queued skill invocation with staged images/files sends them with the skill when it fires. A direct (non-queued) skill invocation continues to consume the live input staging as before.
+9. The `/queue` command, when the agent is not currently in progress, submits immediately as a regular prompt — consuming and clearing the live staging — rather than being treated as a queued-row fire.
+10. **Known limitation — cloud follow-up:** when a queued row fires into a cloud follow-up prompt, which does not support attachments, the prompt text is still sent but the row's attachments are dropped (a warning is logged). No attachment chips or files reach the cloud run.
+11. **Shared-session viewer:** when a queued row fires in a shared-session viewer, its stored images/files are uploaded and sent with the prompt (when the cloud pane supports image context), via the same upload-then-send path as an immediate viewer submission.
+12. Empty-queue and locked-row behavior is unchanged: draining an empty queue does nothing, and the locked initial Cloud Mode row never auto-fires. Each conversation keeps an independent queue, so attachments on one conversation's rows never appear on another's.

--- a/specs/APP-4617/TECH.md
+++ b/specs/APP-4617/TECH.md
@@ -1,0 +1,81 @@
+# Tech Spec: Attachments on Queued Prompts
+
+See `specs/APP-4617/PRODUCT.md` for user-visible behavior.
+
+## Context
+Queued prompts (V2) store per-conversation rows in `QueuedQueryModel` (`app/src/ai/blocklist/queued_query.rs`). Before this change a `QueuedQuery` held only `text` + `origin`; staged attachments lived solely in the live input staging on `BlocklistAIContextModel.pending_attachments`. Two things coupled attachments to the live input rather than the queued row:
+
+- At enqueue time the input attachments were left in place or cleared, so a row never carried them.
+- The send path always sourced pending attachments from the context model: `input_for_query` built image context from `vec![]` and `input_context_for_request` (`app/src/ai/blocklist/controller/input_context.rs`) appended `context_model.pending_files()` as `FilePathReference`s. A fired queued row therefore picked up whatever was currently staged, and a direct send after queuing re-sent the previous attachments.
+
+Relevant code (current branch):
+- `app/src/ai/blocklist/queued_query.rs` — `QueuedQuery` (text/origin), `AutofireAction`, `pop_for_autofire` (removed the head row and returned its action)
+- `app/src/ai/blocklist/context_model.rs` — `pending_attachments` staging, `clear_pending_attachments`
+- `app/src/ai/blocklist/controller.rs:3132` — `input_for_query`; send path in `send_query` (~758)
+- `app/src/ai/blocklist/controller/input_context.rs (230-)` — pending-file → `FilePathReference` conversion
+- `app/src/ai/blocklist/controller/slash_command.rs:68` — `SlashCommandRequest::send_request`
+- `app/src/terminal/input.rs:13179` `submit_queued_prompt`, `:13277` `submit_queued_prompt_for_active_pane`, `:5242` `execute_skill_command`, viewer send (~13767)
+- `app/src/terminal/input/slash_commands/mod.rs (1069-)` — `/queue` handling
+- `app/src/terminal/view.rs:5199` enqueue, `:5227` `drain_queued_prompts`
+- `app/src/terminal/view/pending_user_query.rs` — legacy pending-query submission
+
+## Proposed changes
+### 1. Rows own their attachments (`queued_query.rs`)
+`QueuedQuery` gains `attachments: Vec<PendingAttachment>`, a `new_with_attachments(text, origin, attachments)` constructor (`:59`; `new` delegates to it), and an `attachments()` accessor (`:100`). `attachments_for(conversation_id, query_id)` (`:374`) returns a row's attachments by id without removing it; it returns `&[]` when the row is absent.
+
+### 2. Capture-and-clear at every enqueue site
+Each enqueue site drains the live input via a new `BlocklistAIContextModel::take_pending_attachments(ctx)` (`context_model.rs:987`) and stores the drained set on the row with `new_with_attachments`. `take_pending_attachments` emits the same `UpdatedPendingContext` event as `clear_pending_attachments` so the input's attachment chips disappear. Sites: `terminal/view.rs:5199`, the two auto-queue-toggle paths in `terminal/input.rs` (~13433, ~13490), and the `/queue` in-progress branch in `slash_commands/mod.rs`.
+
+### 3. Auto-fire becomes peek + remove (`queued_query.rs`, `view.rs`)
+`pop_for_autofire` (which mutated the queue) is replaced by:
+- `peek_autofire(conversation_id) -> Option<AutofireAction>` (`:326`) — read-only; returns the head row's action while leaving the row in the queue so the send path can resolve its attachments by id.
+- `remove_fired_row(conversation_id, query_id, ctx)` (`:349`) — removes the row after dispatch/restore and clears edit state if it pointed at that row.
+
+Both `AutofireAction` variants now carry `query_id`; `PopFromEditMode` additionally carries `attachments`. `drain_queued_prompts` (`view.rs:5227`) peeks, dispatches or restores, then calls `remove_fired_row`. This peek-then-remove ordering is required: the row must stay addressable during the synchronous send so attachments can be read by id.
+
+### 4. Send path resolves attachments by source (`controller.rs`, `input_context.rs`)
+`InputQuery` gains `queued_query_id: Option<QueuedQueryId>`. In `send_query`, the attachment set for a `UserSubmittedQueryFromInput` is resolved once:
+- `Some(id)` → `QueuedQueryModel::attachments_for(conversation_id, id)` (the fired row)
+- `None` → `context_model.pending_attachments()` (live staging)
+
+`input_for_query` (`:3132`) now takes `prompt_attachments: Vec<PendingAttachment>`, splits them into image context (sent inline) and file references, and no longer relies on `input_context_for_request` for pending files. The pending-file → `FilePathReference` conversion (with duplicate-basename suffixing) moves out of `input_context.rs` into a shared `add_pending_file_attachments` (`controller.rs:3190`); `input_context.rs` no longer sources pending files.
+
+### 5. Conversation routing for fired rows (`controller.rs`, `slash_command.rs`, `input.rs`)
+A fired row routes into the conversation it was queued on rather than re-deriving from the current UI selection. `send_queued_slash_command_request` and `send_queued_user_query_in_conversation` thread `queued_query_id` plus a `conversation_id` override; `SlashCommandRequest::send_request` (`slash_command.rs:68`) replaces its `is_queued_prompt: bool` with `queued_query_id: Option<QueuedQueryId>` + `conversation_id_override: Option<AIConversationId>` and derives `is_queued_prompt` from the id. Queued skill invocations resolve `prompt_attachments` from the row (or `vec![]` if the conversation is unknown) and feed them through `add_pending_file_attachments` into `InvokeSkillUserQuery`.
+
+### 6. Preserve next-prompt staging (`controller.rs`, `slash_command.rs`)
+The context reset after a send is skipped when `is_queued_prompt` is true (the fired row's attachments came from the row, so the live `pending_attachments` belong to the user's next prompt). The same guard applies to queued skill invocations so they don't clear a new draft's staged attachments; direct skills still reset.
+
+### 7. Split immediate vs. queued submission (`input.rs`, `pending_user_query.rs`, `slash_commands/mod.rs`)
+- `submit_queued_prompt` (`input.rs:13179`) now takes `conversation_id` + `query_id` and submits the fired row into that conversation.
+- New `submit_user_query_now` (`input.rs:13248`) is the immediate (non-queued) path that resets live staging; used by the `/queue` not-in-progress fallback and the legacy pending-user-query paths in `pending_user_query.rs`.
+- `submit_queued_prompt_for_active_pane` (`input.rs:13277`) takes `conversation_id` + `query_id` and branches: cloud follow-up (drop attachments, log a warning), shared-session viewer (upload via the shared path below), local agent (`submit_queued_prompt`).
+- `execute_skill_command` (`input.rs:5242`) replaces `is_queued_prompt: bool` with `queued_query_id` + `conversation_id_override`.
+
+### 8. Shared viewer upload path (`input.rs`)
+A new `upload_and_send_viewer_prompt` is extracted from the immediate viewer-submit path and shared with the queued viewer drain, so both go through the identical upload-then-send (`Event::SendAgentPrompt`) flow. The queued viewer drain reads the firing row's images/files from `attachments_for` and passes them in.
+
+### 9. Re-stage on restore (`view.rs`)
+`drain_queued_prompts`' `PopFromEditMode` branch and the manual edit/restore path call `context_model.append_pending_attachments(row attachments)` after restoring the row's text, so the chips reappear and a manual re-submit keeps them.
+
+## Testing and validation
+Unit tests added alongside the changed modules; each maps to PRODUCT.md invariants:
+- `context_model_tests.rs` — `take_pending_attachments` drains and returns all staged attachments and clears the input (inv. 1); enqueue moves staged attachments onto the row and leaves the input empty (inv. 1, 7).
+- `queued_query_tests.rs` — `peek_autofire` leaves the row until `remove_fired_row` drops it (inv. 3); `PopFromEditMode` carries committed text + attachments and peek is non-mutating (inv. 6).
+- `controller_tests.rs` — `input_for_query` builds image/file context purely from the provided attachment set, ignoring live staging, including duplicate-basename suffixing (inv. 3, 5).
+- `queued_prompts_tests.rs` — multi-cycle queue keeps each row's attachments independent and draining one leaves the other intact (inv. 2); shared `drain_one` helper mirrors peek + `remove_fired_row`.
+
+Manual verification:
+- Stage an image + file, queue while the agent is busy → chips clear from input; on fire the prompt arrives with the image inline and the file referenced (inv. 1, 3).
+- Queue two prompts with different attachments → each fires with only its own (inv. 2).
+- Stage attachments after queuing → they ride the next manual prompt, not the fired row (inv. 5).
+- Edit-mode auto-fire pop and manual restore → attachments re-appear in the input (inv. 6).
+- Cloud follow-up fire → text sent, attachments dropped, warning logged (inv. 10).
+- Shared-session viewer fire → attachments uploaded and sent (inv. 11).
+
+## Risks and mitigations
+- **Double-fire / leaked rows:** peek no longer removes the row, so `remove_fired_row` must run after every dispatch and every restore. `drain_queued_prompts` removes in both `Submit` and `PopFromEditMode` arms immediately after the synchronous dispatch.
+- **Attachment lifetime:** attachments are cloned when resolved by id during send and dropped when the row is removed; there is no shared ownership between the row and the live input, which is what keeps inv. 2 and inv. 5 independent.
+
+## Parallelization
+Not beneficial. The change is a single tightly-coupled thread through the queued-prompt enqueue, drain, and send paths (`queued_query.rs` → `view.rs`/`input.rs` → `controller.rs`/`slash_command.rs`); the signature changes ripple across these files and must land together. Best done sequentially in one PR.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Before this PR, if you queued a prompt with an image attached, the image would stay attached in the input and not get associated with the prompt/cleared until send time. This isn't great, and is especially untenable if we want to allow users to queue multiple prompts, each with their own attachments. 

This PR fixes it so that the queued prompt singleton stores prompt attachments along with the prompt text such that, when the prompt is queued, we can clear the attachments from the input and, when the prompt is sent, we can send the attachments with the prompt.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/814a8562374a456ead64f409321f1a0b

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode