### PR TITLE
Fix broken feature requests search link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       label: "Pre-submit Checks"
       options:
-        - label: "I have [searched Warp feature requests](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+label%3AFEATURE) and there are no duplicates"
+        - label: "I have [searched Warp feature requests](https://github.com/warpdotdev/warp/issues?q=is%3Aissue+label%3Aenhancement) and there are no duplicates"
           required: true
         - label: "I have [searched Warp docs](https://docs.warp.dev) and my feature is not there"
           required: true


### PR DESCRIPTION
## Description
The "searched Warp feature requests" link in the Feature Request issue template filtered by `label:FEATURE`, which is not a real label. GitHub rejects it with "Invalid value FEATURE for label", so the link landed on an empty/erroring search instead of existing feature requests.

Feature requests are labeled `enhancement` (see `labels: ["enhancement"]` in the same template), so this points the link at `label:enhancement`.

**What:** Update the pre-submit check link in `.github/ISSUE_TEMPLATE/02_feature_request.yml`.
**Why:** The previous link was broken and didn't surface duplicate feature requests for users.
**How:** Replaced `label%3AFEATURE` with `label%3Aenhancement` in the search URL.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Documentation/config-only change. Verified the corrected query resolves to the actual feature request list rather than GitHub's "Invalid value" error.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
