### PR TITLE
Fix Accept gate when "New API key" is selected in orchestration secret picker

### DIFF
--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -152,6 +152,13 @@ impl OrchestrationEditState {
             AuthSecretSelection::Inherit | AuthSecretSelection::Unset => None,
         }
     }
+
+    /// User picked "New API key…". Reset to `Unset` so the picker keeps the
+    /// "New API key…" label and Accept stays blocked until a key is created
+    /// or chosen.
+    pub fn select_create_new_auth_secret(&mut self) {
+        self.auth_secret_selection = AuthSecretSelection::Unset;
+    }
 }
 
 impl OrchestrationEditState {
@@ -1250,18 +1257,14 @@ pub fn apply_auth_secret_change<A: OrchestrationControlAction, V: View>(
     persist_auth_secret_selection(&state.harness_type, &state.auth_secret_selection, ctx);
 }
 
-/// No-op on `state` — the prior selection is preserved so cancelling the
-/// modal restores the user to a working configuration. Successful creation
-/// updates the selection via the `AuthSecretCreated` subscription's call
-/// to [`apply_created_auth_secret_if_matches`].
-///
-/// Kept as a named function so both card views call through the same
-/// path; a future revision can hook snapshot-and-restore behavior here
-/// without touching call sites.
+/// Resets the selection to `Unset` while the create-key modal is open so
+/// Accept matches what the picker shows. Does not persist, so a cancel can
+/// still re-resolve the prior choice. Shared by both card views.
 pub fn apply_create_new_auth_secret_requested<V: View>(
-    _state: &mut OrchestrationEditState,
+    state: &mut OrchestrationEditState,
     _ctx: &mut ViewContext<V>,
 ) {
+    state.select_create_new_auth_secret();
 }
 
 /// Adopts a freshly-created secret as the active selection when its

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -100,15 +100,18 @@ pub trait OrchestrationControlAction: DropdownItemAction + Clone {
 // ── Shared edit state ───────────────────────────────────────────────
 
 /// The user's current selection in the auth secret picker. Only `Named(_)`
-/// is persisted across sessions; `Inherit` and `Unset` are per-session.
+/// is persisted across sessions; the other variants are per-session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthSecretSelection {
-    /// No choice yet. Picker shows "+ New API key…" and Accept is blocked.
+    /// No choice yet; re-seeded from persisted settings. Blocks Accept.
     Unset,
     /// User explicitly chose to inherit credentials from the worker env.
     Inherit,
     /// User picked a managed secret by name.
     Named(String),
+    /// Creating a key (modal open). Blocks Accept and, unlike `Unset`, is
+    /// not re-seeded from persisted settings.
+    CreatingNew,
 }
 
 impl AuthSecretSelection {
@@ -149,15 +152,16 @@ impl OrchestrationEditState {
         }
         match &self.auth_secret_selection {
             AuthSecretSelection::Named(name) => Some(name.as_str()),
-            AuthSecretSelection::Inherit | AuthSecretSelection::Unset => None,
+            AuthSecretSelection::Inherit
+            | AuthSecretSelection::Unset
+            | AuthSecretSelection::CreatingNew => None,
         }
     }
 
-    /// User picked "New API key…". Reset to `Unset` so the picker keeps the
-    /// "New API key…" label and Accept stays blocked until a key is created
-    /// or chosen.
+    /// User picked "New API key…"; mark `CreatingNew` to block Accept until a
+    /// key is created or another option is chosen.
     pub fn select_create_new_auth_secret(&mut self) {
-        self.auth_secret_selection = AuthSecretSelection::Unset;
+        self.auth_secret_selection = AuthSecretSelection::CreatingNew;
     }
 }
 
@@ -1115,7 +1119,10 @@ pub fn auth_secret_selection_required(state: &OrchestrationEditState, _ctx: &App
     if !should_show_auth_secret_picker(state) {
         return false;
     }
-    if !matches!(state.auth_secret_selection, AuthSecretSelection::Unset) {
+    if !matches!(
+        state.auth_secret_selection,
+        AuthSecretSelection::Unset | AuthSecretSelection::CreatingNew
+    ) {
         return false;
     }
     let Some(harness) = Harness::parse_orchestration_harness(&state.harness_type) else {
@@ -1223,6 +1230,7 @@ pub fn populate_auth_secret_picker_for_harness<A: OrchestrationControlAction, V:
         let final_selection = match &selection {
             AuthSecretSelection::Named(name) => name.clone(),
             AuthSecretSelection::Inherit => AUTH_SECRET_INHERIT_LABEL.to_string(),
+            AuthSecretSelection::CreatingNew => AUTH_SECRET_CREATE_NEW_LABEL.to_string(),
             AuthSecretSelection::Unset if supports_create_new => {
                 AUTH_SECRET_CREATE_NEW_LABEL.to_string()
             }
@@ -1257,9 +1265,8 @@ pub fn apply_auth_secret_change<A: OrchestrationControlAction, V: View>(
     persist_auth_secret_selection(&state.harness_type, &state.auth_secret_selection, ctx);
 }
 
-/// Resets the selection to `Unset` while the create-key modal is open so
-/// Accept matches what the picker shows. Does not persist, so a cancel can
-/// still re-resolve the prior choice. Shared by both card views.
+/// Marks `CreatingNew` (not re-seeded from settings, so a background refresh
+/// can't restore a stale selection mid-create). Used by both card views.
 pub fn apply_create_new_auth_secret_requested<V: View>(
     state: &mut OrchestrationEditState,
     _ctx: &mut ViewContext<V>,
@@ -1292,7 +1299,8 @@ pub fn apply_created_auth_secret_if_matches<V: View>(
 /// Persists the user's auth-secret choice for the active harness.
 /// `Named` writes to `last_selected_auth_secret` and clears any prior
 /// `Inherit` flag. `Inherit` clears the named entry and sets the inherit
-/// flag. `Unset` clears both (no recorded choice). No-op for Oz / unknown.
+/// flag. `Unset`/`CreatingNew` clear both (no recorded choice). No-op for
+/// Oz / unknown.
 fn persist_auth_secret_selection<V: View>(
     harness_type: &str,
     selection: &AuthSecretSelection,
@@ -1317,7 +1325,7 @@ fn persist_auth_secret_selection<V: View>(
                 named_map.remove(&key);
                 inherit_map.insert(key, true);
             }
-            AuthSecretSelection::Unset => {
+            AuthSecretSelection::Unset | AuthSecretSelection::CreatingNew => {
                 named_map.remove(&key);
                 inherit_map.remove(&key);
             }
@@ -1613,6 +1621,7 @@ pub fn sync_picker_selections<A: OrchestrationControlAction, V: View>(
             let label = match &selection {
                 AuthSecretSelection::Named(name) => name.clone(),
                 AuthSecretSelection::Inherit => AUTH_SECRET_INHERIT_LABEL.to_string(),
+                AuthSecretSelection::CreatingNew => AUTH_SECRET_CREATE_NEW_LABEL.to_string(),
                 AuthSecretSelection::Unset if supports_create_new => {
                     AUTH_SECRET_CREATE_NEW_LABEL.to_string()
                 }

--- a/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
@@ -2,7 +2,22 @@ use ai::agent::action::RunAgentsExecutionMode;
 use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationExecutionMode};
 use warp_core::features::FeatureFlag;
 
-use super::{should_show_harness_picker, OrchestrationEditState};
+use super::{
+    should_show_auth_secret_picker, should_show_harness_picker, AuthSecretSelection,
+    OrchestrationEditState,
+};
+
+fn remote_claude_state() -> OrchestrationEditState {
+    OrchestrationEditState::from_run_agents_fields(
+        "sonnet",
+        "claude",
+        &RunAgentsExecutionMode::Remote {
+            environment_id: "env-1".to_string(),
+            worker_host: "warp".to_string(),
+            computer_use_enabled: false,
+        },
+    )
+}
 
 fn local_config(harness_type: &str, model_id: &str) -> OrchestrationConfig {
     OrchestrationConfig {
@@ -155,5 +170,36 @@ fn resolve_from_config_sanitizes_disabled_local_harness() {
     assert!(matches!(
         state.execution_mode,
         RunAgentsExecutionMode::Local
+    ));
+}
+
+#[test]
+fn select_create_new_auth_secret_resets_named_to_unset() {
+    let mut state = remote_claude_state();
+    state.auth_secret_selection = AuthSecretSelection::Named("my-key".to_string());
+    assert_eq!(state.auth_secret_name(), Some("my-key"));
+
+    state.select_create_new_auth_secret();
+
+    // `Unset` + a visible picker is what blocks Accept and shows the
+    // "New API key…" label.
+    assert!(matches!(
+        state.auth_secret_selection,
+        AuthSecretSelection::Unset
+    ));
+    assert_eq!(state.auth_secret_name(), None);
+    assert!(should_show_auth_secret_picker(&state));
+}
+
+#[test]
+fn select_create_new_auth_secret_resets_inherit_to_unset() {
+    let mut state = remote_claude_state();
+    state.auth_secret_selection = AuthSecretSelection::Inherit;
+
+    state.select_create_new_auth_secret();
+
+    assert!(matches!(
+        state.auth_secret_selection,
+        AuthSecretSelection::Unset
     ));
 }

--- a/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
@@ -174,25 +174,24 @@ fn resolve_from_config_sanitizes_disabled_local_harness() {
 }
 
 #[test]
-fn select_create_new_auth_secret_resets_named_to_unset() {
+fn select_create_new_auth_secret_marks_creating_new_from_named() {
     let mut state = remote_claude_state();
     state.auth_secret_selection = AuthSecretSelection::Named("my-key".to_string());
     assert_eq!(state.auth_secret_name(), Some("my-key"));
 
     state.select_create_new_auth_secret();
 
-    // `Unset` + a visible picker is what blocks Accept and shows the
-    // "New API key…" label.
+    // `CreatingNew` (distinct from `Unset`) blocks Accept and isn't re-seeded.
     assert!(matches!(
         state.auth_secret_selection,
-        AuthSecretSelection::Unset
+        AuthSecretSelection::CreatingNew
     ));
     assert_eq!(state.auth_secret_name(), None);
     assert!(should_show_auth_secret_picker(&state));
 }
 
 #[test]
-fn select_create_new_auth_secret_resets_inherit_to_unset() {
+fn select_create_new_auth_secret_marks_creating_new_from_inherit() {
     let mut state = remote_claude_state();
     state.auth_secret_selection = AuthSecretSelection::Inherit;
 
@@ -200,6 +199,6 @@ fn select_create_new_auth_secret_resets_inherit_to_unset() {
 
     assert!(matches!(
         state.auth_secret_selection,
-        AuthSecretSelection::Unset
+        AuthSecretSelection::CreatingNew
     ));
 }


### PR DESCRIPTION
Before - Accept isn't disabled (steps to get here are to open the New API key modal and then cancel it):
<img width="1386" height="464" alt="image" src="https://github.com/user-attachments/assets/cb4fe07a-ed1a-4d5f-982b-880b269185fa" />

After - Accept is disabled:
<img width="1714" height="514" alt="image" src="https://github.com/user-attachments/assets/60962fca-fc02-42b6-8129-d354943a1809" />

Fixes https://linear.app/warpdotdev/issue/QUALITY-753/accept-button-should-be-disabled-if-set-to-new-api-key-in-dropdown


## Description
Fixes a bug in the non-Oz orchestration auth-secret picker (the `run_agents` confirmation card and the plan-card config block). When a user opened the **API key** dropdown and selected **"New API key…"**, the dropdown's displayed label switched to "New API key…", but the underlying `auth_secret_selection` kept its prior value (`Named(_)` or `Inherit`). As a result the **Accept** button stayed enabled and, on accept, would silently use the old key instead of the (not-yet-created) new one.

**Fix:** picking "New API key…" now resets the selection to `Unset`, which both renders the "New API key…" label and blocks Accept until a key is actually created (adopted via the existing `AuthSecretCreated` flow) or an existing one is chosen. The change lives in the shared `apply_create_new_auth_secret_requested` helper, so both card views are fixed. The reset is in-memory only and does not clear the persisted per-harness choice.

## Testing
Added unit tests in `orchestration_controls_tests.rs` covering the reset from both `Named` and `Inherit` to `Unset`, and verifying no secret is emitted on the wire (`auth_secret_name() == None`) while the picker remains visible (the conditions that drive the Accept gate). Ran `cargo nextest run -p warp orchestration_controls` (11 passed), plus `cargo fmt` and `cargo clippy -p warp --all-targets --tests -- -D warnings` (clean).

- [x] I have manually tested my changes locally with `./script/run`

CHANGELOG-BUG-FIX: Fixed the Accept button staying enabled in the multi-agent run card when "New API key" was selected in the harness API key picker without a key being created.
