### PR TITLE
Fix dropped terminal response sequences when PTY writes block

### DIFF
--- a/app/src/terminal/local_tty/event_loop.rs
+++ b/app/src/terminal/local_tty/event_loop.rs
@@ -246,11 +246,17 @@ where
             };
 
             // Process the bytes read into the buffer.
+            let mut terminal_response_sequences = Vec::new();
             state.parser.parse_bytes(
                 terminal.deref_mut(),
                 &buf[..bytes_in_buffer],
-                &mut self.pty.writer(),
+                &mut terminal_response_sequences,
             );
+            if !terminal_response_sequences.is_empty() {
+                state
+                    .write_list
+                    .push_back(Cow::Owned(terminal_response_sequences));
+            }
 
             bytes_processed += bytes_in_buffer;
             bytes_in_buffer = 0;
@@ -370,9 +376,16 @@ where
 
                     // If there were no events but `poll` returned, that means we hit the timeout.
                     if events.is_empty() {
-                        state
-                            .parser
-                            .finish_sync_output(&mut *self.terminal.lock(), &mut self.pty.writer());
+                        let mut terminal_response_sequences = Vec::new();
+                        state.parser.finish_sync_output(
+                            &mut *self.terminal.lock(),
+                            &mut terminal_response_sequences,
+                        );
+                        if !terminal_response_sequences.is_empty() {
+                            state
+                                .write_list
+                                .push_back(Cow::Owned(terminal_response_sequences));
+                        }
                         continue;
                     }
 

--- a/app/src/terminal/local_tty/event_loop.rs
+++ b/app/src/terminal/local_tty/event_loop.rs
@@ -386,6 +386,12 @@ where
                                 .write_list
                                 .push_back(Cow::Owned(terminal_response_sequences));
                         }
+                        if state.needs_write() && can_write {
+                            if let Err(err) = self.pty_write(&mut state, &mut can_write) {
+                                error!("Error writing to PTY in event loop: {err}");
+                                break 'event_loop;
+                            }
+                        }
                         continue;
                     }
 

--- a/app/src/terminal/local_tty/event_loop.rs
+++ b/app/src/terminal/local_tty/event_loop.rs
@@ -386,13 +386,6 @@ where
                                 .write_list
                                 .push_back(Cow::Owned(terminal_response_sequences));
                         }
-                        if state.needs_write() && can_write {
-                            if let Err(err) = self.pty_write(&mut state, &mut can_write) {
-                                error!("Error writing to PTY in event loop: {err}");
-                                break 'event_loop;
-                            }
-                        }
-                        continue;
                     }
 
                     for event in events.iter() {


### PR DESCRIPTION
## Description

Fixes a Windows PTY issue where terminal response sequences generated during ANSI parsing could be dropped if the PTY writer returned `WouldBlock`.

ANSI includes some "queries" that applications can send to the terminal, e.g. device attributes, device status/cursor position, synchronized-output mode state, XTVERSION, terminal size, dynamic colors, Kitty keyboard flags. The terminal is supposed to send an ANSI escape code response back to the application.

Currently, the parser already handles those codes and we do implement many of these responses. The problem is that on Windows the PTY is non-blocking and will error with `WouldBlock` if it isn't ready to be written to. We already handle this with user-written bytes such that we queue the writes. However, bytes generated for these terminal response sequences are not going through this queue machinery. They attempt to write directly to `EventLoop::pty::writer` which simply ignores errors (including `WouldBlock`) and drops the bytes. In that case, the bytes never get written.

The problem with Microsoft's `edit.exe` is that it hangs indefinitely waiting for DA/DSR responses (lol). So, dropping the response would mean hanging it forever.

## Linked Issue

Fixes https://github.com/warpdotdev/warp/issues/8796 and possibly a related issue with the `micro` editor.

It also fixes an issue I'm seeing in NeoVim 0.12, [see here](https://github.com/neovim/neovim/discussions/38648). See the warning message at the bottom:


<img width="1831" height="1147" alt="Screenshot 2026-05-29 140617" src="https://github.com/user-attachments/assets/cd135690-f1ac-4a7d-9cc4-827fd8be3512" />

## Testing

Running this locally, I am able to run `edit.exe` and NeoVim without the error in the screenshot.


CHANGELOG-BUG-FIX: [Windows] Prevent terminal response sequences from getting dropped. This fixes `edit.exe` hanging indefinitely and slower startup times in NeoVim 0.12.
