### PR TITLE
Fix restored conversation cd quoting on Windows

### DIFF
--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -44,8 +44,10 @@ use crate::terminal::model::block::SerializedBlock;
 use crate::terminal::model::blocks::RichContentItem;
 use crate::terminal::model::rich_content::RichContentType;
 use crate::terminal::model::session::active_session::ActiveSession;
+use crate::terminal::model::session::command_executor::shell_escape_single_quotes;
 use crate::terminal::model::terminal_model::BlockIndex;
 use crate::terminal::model_events::ModelEventDispatcher;
+use crate::terminal::shell::ShellType;
 use crate::terminal::view::{
     AIBlockMetadata, Event, RichContent, RichContentInsertionPosition, RichContentMetadata,
     TerminalView,
@@ -62,6 +64,14 @@ pub(crate) enum RestorationDirState {
     MissingOriginalDir,
     /// The terminal needs to cd into the conversation's directory.
     NeedsCd { path: String },
+}
+
+fn cd_command_for_restore_path(path: &str, shell_type: ShellType) -> String {
+    let escaped_path = shell_escape_single_quotes(path, shell_type);
+    match shell_type {
+        ShellType::PowerShell => format!("Set-Location -LiteralPath '{escaped_path}'"),
+        ShellType::Bash | ShellType::Zsh | ShellType::Fish => format!("cd -- '{escaped_path}'"),
+    }
 }
 
 /// Specifies how AI conversations should be restored when creating a TerminalView.
@@ -293,8 +303,12 @@ impl TerminalView {
         match restore_context_state {
             RestorationDirState::NeedsCd { path } => {
                 let path_for_hint = path.clone();
+                let shell_type = self
+                    .active_session_shell_type(ctx)
+                    .unwrap_or(ShellType::Bash);
+                let cd_command = cd_command_for_restore_path(&path, shell_type);
                 let did_execute_cd = self.input.update(ctx, |input, ctx| {
-                    input.try_execute_command(&format!("cd \"{path}\""), ctx)
+                    input.try_execute_command(&cd_command, ctx)
                 });
                 if did_execute_cd {
                     self.on_next_block_completed(move |me, ctx| {

--- a/app/src/terminal/view/load_ai_conversation_tests.rs
+++ b/app/src/terminal/view/load_ai_conversation_tests.rs
@@ -1,7 +1,7 @@
+use super::{cd_command_for_restore_path, find_block_indices_for_exchange_timestamps};
+use crate::terminal::shell::ShellType;
 use chrono::{Local, TimeZone};
 use warp_terminal::model::BlockIndex;
-
-use super::find_block_indices_for_exchange_timestamps;
 
 /// Helper: create a `DateTime<Local>` from a unix timestamp in seconds.
 fn ts(secs: i64) -> chrono::DateTime<Local> {
@@ -10,6 +10,33 @@ fn ts(secs: i64) -> chrono::DateTime<Local> {
 
 fn bi(idx: usize) -> BlockIndex {
     BlockIndex::from(idx)
+}
+
+#[test]
+fn restore_cd_command_uses_literal_powershell_path() {
+    let command = cd_command_for_restore_path(
+        r"C:\Users\me\$(exit)\project's folder",
+        ShellType::PowerShell,
+    );
+
+    assert_eq!(
+        command,
+        r"Set-Location -LiteralPath 'C:\Users\me\$(exit)\project''s folder'"
+    );
+}
+
+#[test]
+fn restore_cd_command_escapes_posix_single_quotes() {
+    let command = cd_command_for_restore_path("/Users/me/project's folder", ShellType::Bash);
+
+    assert_eq!(command, r#"cd -- '/Users/me/project'"'"'s folder'"#);
+}
+
+#[test]
+fn restore_cd_command_escapes_fish_single_quotes() {
+    let command = cd_command_for_restore_path("/Users/me/project's folder", ShellType::Fish);
+
+    assert_eq!(command, r"cd -- '/Users/me/project\'s folder'");
 }
 
 // ── All blocks in increasing timestamp order ──────────────────────────


### PR DESCRIPTION
## Summary
- Fix active-pane conversation restore to build a shell-aware literal `cd` command instead of `cd "..."`.
- Use `Set-Location -LiteralPath` for PowerShell so Windows paths containing `$()` or quotes cannot be evaluated while restoring.
- Add unit coverage for PowerShell, POSIX, and Fish path quoting.

## Test Plan
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib terminal::view::load_ai_conversation::tests::restore_cd_command -- --nocapture`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib terminal::view::load_ai_conversation::tests -- --nocapture`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml -p warp --check`

Linear: APP-4636

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/9a94a58e-2c98-430d-8c38-6e6a1af03f81_
_Run: https://oz.staging.warp.dev/runs/019e75fa-f83f-72a0-ac38-7eb6be3b3f0c_

_This PR was generated with [Oz](https://warp.dev/oz)._
