### PR TITLE
[APP-4635] Fix outdated imported code review comments

### DIFF
--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use ai::agent::action::InsertReviewComment;
+use ai::agent::action::{
+    CommentSide, InsertReviewComment, InsertedCommentLine, InsertedCommentLocation,
+};
 use chrono::Local;
 use lsp::LspManagerModel;
 use repo_metadata::repositories::DetectedRepositories;
@@ -361,6 +363,73 @@ fn test_relocate_comments_empty_input() {
                 "Empty input should return empty output"
             );
             assert_eq!(fallbacks, 0, "Empty input should have no fallbacks");
+        });
+    });
+}
+
+#[test]
+fn test_imported_context_line_comment_not_marked_outdated() {
+    App::test((), |mut app| async move {
+        let _flag_override = FeatureFlag::PRCommentsSlashCommand.override_enabled(true);
+
+        let ctx = TestContext::new(&mut app, "test.txt", "line 1\nline 2\nline 3");
+        let pending_comment = PendingImportedReviewComment::try_from(InsertReviewComment {
+            comment_id: "context-line-comment".to_string(),
+            author: "reviewer".to_string(),
+            last_modified_timestamp: "2024-01-01T00:00:00Z".to_string(),
+            comment_body: "Comment on unchanged context".to_string(),
+            parent_comment_id: None,
+            comment_location: Some(InsertedCommentLocation {
+                relative_file_path: "test.txt".to_string(),
+                line: Some(InsertedCommentLine {
+                    comment_line_range: 2..2,
+                    diff_hunk_line_range: 1..3,
+                    diff_hunk_text: "@@ -1,3 +1,3 @@\n line 1\n line 2\n line 3".to_string(),
+                    side: Some(CommentSide::Right),
+                }),
+            }),
+            html_url: None,
+        })
+        .expect("valid pending imported context comment");
+
+        let mut attached =
+            attach_pending_imported_comments(vec![pending_comment], &ctx.repo_location);
+        assert_eq!(attached.len(), 1);
+
+        let original_id = attached[0].id;
+        match &attached[0].target {
+            AttachedReviewCommentTarget::Line { content, .. } => {
+                assert_eq!(content.content, "line 2");
+                assert_eq!(content.original_text(), "line 2");
+            }
+            _ => panic!("expected line comment target"),
+        }
+
+        ctx.code_review_view.update(&mut app, |_view, view_ctx| {
+            let RelocateCommentsResult {
+                comments: relocated,
+                fallback_count: fallbacks,
+            } = CodeReviewView::relocate_comments(
+                std::mem::take(&mut attached),
+                &ctx.state,
+                &ctx.repo_location,
+                view_ctx,
+            );
+
+            assert_eq!(relocated.len(), 1);
+            assert_eq!(relocated[0].id, original_id);
+            assert!(
+                !relocated[0].outdated,
+                "Imported context-line comments should match the editor text without the diff context marker"
+            );
+            assert_eq!(fallbacks, 0);
+
+            match &relocated[0].target {
+                AttachedReviewCommentTarget::Line { line, .. } => {
+                    assert_eq!(line.line_number(), Some(LineCount::from(1)));
+                }
+                _ => panic!("expected line comment target"),
+            }
         });
     });
 }

--- a/app/src/code_review/comments/comment.rs
+++ b/app/src/code_review/comments/comment.rs
@@ -50,10 +50,13 @@ impl LineDiffContent {
     /// (which removes all leading occurrences) so that content characters are preserved.
     pub(crate) fn original_text(&self) -> String {
         let s = self.content.trim_end_matches('\n');
-        s.strip_prefix('+')
-            .or_else(|| s.strip_prefix('-'))
-            .unwrap_or(s)
-            .to_string()
+        if self.lines_added > LineCount::from(0) {
+            s.strip_prefix('+').unwrap_or(s).to_string()
+        } else if self.lines_removed > LineCount::from(0) {
+            s.strip_prefix('-').unwrap_or(s).to_string()
+        } else {
+            s.to_string()
+        }
     }
 
     pub(crate) fn from_content(diff_line: &str) -> Self {

--- a/app/src/code_review/comments/comment_tests.rs
+++ b/app/src/code_review/comments/comment_tests.rs
@@ -35,6 +35,23 @@ fn original_text_strips_only_one_leading_minus() {
     let content = LineDiffContent::from_content("--text");
     assert_eq!(content.original_text(), "-text");
 }
+#[test]
+fn original_text_preserves_leading_dash_for_unmodified_line() {
+    let content = LineDiffContent {
+        content: "- context list item".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(content.original_text(), "- context list item");
+}
+
+#[test]
+fn original_text_preserves_leading_plus_for_unmodified_line() {
+    let content = LineDiffContent {
+        content: "+ context value".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(content.original_text(), "+ context value");
+}
 
 #[test]
 fn original_text_preserves_space_prefixed_content() {

--- a/app/src/code_review/comments/diff_hunk_parser.rs
+++ b/app/src/code_review/comments/diff_hunk_parser.rs
@@ -68,8 +68,18 @@ fn build_line_result(
     let lines_added = usize::from(matches!(line_type, DiffLineType::Add));
     let lines_removed = usize::from(matches!(line_type, DiffLineType::Delete));
 
+    let content = match line_type {
+        DiffLineType::Context => line.strip_prefix(' ').unwrap_or(line).to_string(),
+        DiffLineType::Add | DiffLineType::Delete => line.to_string(),
+        DiffLineType::HunkHeader => {
+            return Err(DiffHunkParseError::UnexpectedHunkHeader {
+                line_index: line_index_in_hunk,
+            });
+        }
+    };
+
     let line_diff_content = LineDiffContent {
-        content: line.to_string(),
+        content,
         lines_added: LineCount::from(lines_added),
         lines_removed: LineCount::from(lines_removed),
     };

--- a/app/src/code_review/comments/diff_hunk_parser_tests.rs
+++ b/app/src/code_review/comments/diff_hunk_parser_tests.rs
@@ -130,7 +130,8 @@ fn test_parse_context_line_starting_with_dash() {
     let result = parse_diff_hunk(diff_hunk, 1, Some(CommentSide::Right));
     assert!(result.is_ok());
     let (_, content) = result.unwrap();
-    assert_eq!(content.content, " - list item");
+    assert_eq!(content.content, "- list item");
+    assert_eq!(content.original_text(), "- list item");
 }
 
 /// Context line with content that starts with `@`.
@@ -141,5 +142,18 @@ fn test_parse_context_line_starting_with_at_sign() {
     let result = parse_diff_hunk(diff_hunk, 1, Some(CommentSide::Right));
     assert!(result.is_ok());
     let (_, content) = result.unwrap();
-    assert_eq!(content.content, " @decorator");
+    assert_eq!(content.content, "@decorator");
+    assert_eq!(content.original_text(), "@decorator");
+}
+
+/// Context line whose actual content is indented.
+#[test]
+fn test_parse_indented_context_line_preserves_content_indent() {
+    let diff_hunk = "@@ -1,2 +1,2 @@\n     indented\n next";
+
+    let result = parse_diff_hunk(diff_hunk, 1, Some(CommentSide::Right));
+    assert!(result.is_ok());
+    let (_, content) = result.unwrap();
+    assert_eq!(content.content, "    indented");
+    assert_eq!(content.original_text(), "    indented");
 }


### PR DESCRIPTION
## Description
Fixes APP-4635 by correcting imported GitHub review comment parsing for unchanged context lines.

The staging MAA request for the report included recent review comments attached to context lines in unified diff hunks. Those lines were stored with the leading unified-diff context marker (` `) as if it were part of the source line, so relocation compared `" line"` against the editor's actual `"line"` and fell back to marking the comment outdated.

This PR normalizes context lines during diff hunk parsing, keeps add/delete prefix stripping tied to the line metadata, and adds regression coverage for imported context-line comments and unchanged lines that begin with `+` or `-`.

## Linked Issue
- APP-4635
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp code_review::comments::diff_hunk_parser --lib`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp code_review::comments::comment --lib`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp test_imported_context_line_comment_not_marked_outdated --lib`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed imported GitHub code review comments on unchanged context lines being marked as outdated.

_Conversation: https://staging.warp.dev/conversation/eb9e0087-8bf4-43bf-8ae9-4bdd6067f130_
_Run: https://oz.staging.warp.dev/runs/019e75fa-9642-7945-a197-6d1cd977aa10_

_This PR was generated with [Oz](https://warp.dev/oz)._
