### PR TITLE
bump completions version to include dotnet spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14644,7 +14644,7 @@ dependencies = [
 [[package]]
 name = "warp-command-signatures"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/command-signatures.git?rev=b3061096d193bf4915eabb0d03b4e6b403c6ea45#b3061096d193bf4915eabb0d03b4e6b403c6ea45"
+source = "git+https://github.com/warpdotdev/command-signatures.git?rev=a1000677e302b8fdcefb08365f3f7a81bbba23b3#a1000677e302b8fdcefb08365f3f7a81bbba23b3"
 dependencies = [
  "cfg-if",
  "itertools 0.10.5",
@@ -14662,7 +14662,7 @@ dependencies = [
 [[package]]
 name = "warp-completion-metadata"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/command-signatures.git?rev=b3061096d193bf4915eabb0d03b4e6b403c6ea45#b3061096d193bf4915eabb0d03b4e6b403c6ea45"
+source = "git+https://github.com/warpdotdev/command-signatures.git?rev=a1000677e302b8fdcefb08365f3f7a81bbba23b3#a1000677e302b8fdcefb08365f3f7a81bbba23b3"
 dependencies = [
  "html-escape",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,7 +356,7 @@ dirs = "6.0.0"
 rayon = "1.10.0"
 sha2 = "0.10"
 shellexpand = "3.1.1"
-warp-command-signatures = { git = "https://github.com/warpdotdev/command-signatures.git", rev = "b3061096d193bf4915eabb0d03b4e6b403c6ea45", default-features = false }
+warp-command-signatures = { git = "https://github.com/warpdotdev/command-signatures.git", rev = "a1000677e302b8fdcefb08365f3f7a81bbba23b3", default-features = false }
 winit = { git = "https://github.com/warpdotdev/winit.git", rev = "a4e0ecb5f9626ccac9445a73dc28354b52423abc" }
 x11rb = "0.13.0"
 mockito = "1.7.0"


### PR DESCRIPTION
## Description

Includes this: warpdotdev/command-signatures#276

<img width="1920" height="1200" alt="Screenshot 2026-05-29 173026" src="https://github.com/user-attachments/assets/aff7d4a3-1f20-49ac-bd93-3c48c37c1416" />

Closes #11920