### PR TITLE
Separate project-context discovery from display-only repository browsing

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use ai::skills::{parse_skill, ParsedSkill, SkillProvider, SkillReference, SkillScope};
+use remote_server::manager::RemoteServerManager;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
 use repo_metadata::RepoMetadataModel;
@@ -30,6 +31,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(RepoMetadataModel::new);
     app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
     app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+    app.add_singleton_model(RemoteServerManager::new);
     app.add_singleton_model(SkillManager::new);
 }
 

--- a/app/src/ai/blocklist/block/view_impl/output_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/output_tests.rs
@@ -1,5 +1,6 @@
 use ai::agent::action::UploadArtifactRequest;
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
+use remote_server::manager::RemoteServerManager;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel};
 use warp_util::host_id::HostId;
@@ -106,6 +107,7 @@ fn parsed_skill_for_common_locations_resolves_cached_remote_skill() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let manager = app.add_singleton_model(SkillManager::new);
         manager.update(&mut app, |manager, _| {
             manager.add_skill_for_testing(skill.clone());
@@ -143,6 +145,7 @@ fn parsed_skill_for_common_locations_does_not_mix_remote_hosts() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let manager = app.add_singleton_model(SkillManager::new);
         manager.update(&mut app, |manager, _| {
             manager.add_skill_for_testing(skill);

--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use ai::project_context::model::ProjectContextModel;
 use parking_lot::FairMutex;
 use warp_core::features::FeatureFlag;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{
     AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity, WeakModelHandle,
 };
@@ -394,6 +395,25 @@ impl BlocklistAIContextModel {
     /// If `is_user_query` is true, includes blocks, selected text, and images as context.
     /// If false, excludes these user-specific contexts but includes everything else.
     pub fn pending_context(&self, app: &AppContext, is_user_query: bool) -> Vec<AIAgentContext> {
+        let current_working_directory_location = self.current_pwd().and_then(|path| {
+            PathBuf::from_str(&path)
+                .ok()
+                .and_then(|path| path.canonicalize().ok())
+                .map(LocalOrRemotePath::Local)
+        });
+        self.pending_context_for_location(
+            app,
+            is_user_query,
+            current_working_directory_location.as_ref(),
+        )
+    }
+
+    pub fn pending_context_for_location(
+        &self,
+        app: &AppContext,
+        is_user_query: bool,
+        current_working_directory_location: Option<&LocalOrRemotePath>,
+    ) -> Vec<AIAgentContext> {
         let pwd = self.current_pwd();
         let is_pwd_indexed = if cfg!(feature = "agent_mode_evals") {
             // In evals, we want to disable file outline based search. Full
@@ -406,15 +426,9 @@ impl BlocklistAIContextModel {
                 })
         };
 
-        let project_rules = if let Some(pwd) = pwd.clone().and_then(|path| {
-            PathBuf::from_str(&path)
-                .ok()
-                .and_then(|s| s.canonicalize().ok())
-        }) {
-            ProjectContextModel::as_ref(app).find_applicable_rules(&pwd)
-        } else {
-            None
-        };
+        let project_rules = current_working_directory_location.and_then(|pwd| {
+            ProjectContextModel::as_ref(app).find_applicable_rules_at_location(pwd)
+        });
 
         let mut context = Vec::new();
 
@@ -451,14 +465,14 @@ impl BlocklistAIContextModel {
         // Always include project rules if available
         if let Some(rules) = project_rules {
             context.push(AIAgentContext::ProjectRules {
-                root_path: rules.root_path.to_string_lossy().into(),
+                root_path: rules.root_path.display_path(),
                 active_rules: rules
                     .active_rules
                     .into_iter()
                     .map(|rule| {
                         let line_count = rule.content.lines().count();
                         FileContext {
-                            file_name: rule.path.to_string_lossy().into(),
+                            file_name: rule.path.display_path(),
                             content: AnyFileContent::StringContent(rule.content.clone()),
                             line_range: None,
                             last_modified: None,

--- a/app/src/ai/blocklist/controller/input_context.rs
+++ b/app/src/ai/blocklist/controller/input_context.rs
@@ -52,7 +52,12 @@ pub(super) fn input_context_for_request(
     additional_context: Vec<AIAgentContext>,
     app: &AppContext,
 ) -> Arc<[AIAgentContext]> {
-    let mut context = context_model.pending_context(app, is_user_query);
+    let current_working_directory_location = active_session.current_working_directory_location(app);
+    let mut context = context_model.pending_context_for_location(
+        app,
+        is_user_query,
+        current_working_directory_location.as_ref(),
+    );
 
     context.push(AIAgentContext::CurrentTime {
         current_time: Local::now(),

--- a/app/src/ai/facts/view/mod.rs
+++ b/app/src/ai/facts/view/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use warp_core::ui::appearance::Appearance;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{
     Align, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container,
     CrossAxisAlignment, Expanded, Flex, MainAxisAlignment, MainAxisSize, ParentElement,
@@ -55,7 +56,7 @@ impl std::fmt::Display for AIFactPage {
 pub enum AIFactViewEvent {
     Pane(PaneEvent),
     OpenSettings,
-    OpenFile(PathBuf),
+    OpenFile(LocalOrRemotePath),
     InitializeProject(PathBuf),
 }
 

--- a/app/src/ai/facts/view/rule.rs
+++ b/app/src/ai/facts/view/rule.rs
@@ -6,6 +6,7 @@ use markdown_parser::weight::CustomWeight;
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
 use warp_core::ui::appearance::{Appearance, AppearanceEvent};
 use warp_core::ui::theme::color::internal_colors;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{
     Align, Border, ChildView, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
     Expanded, Flex, FormattedTextElement, HighlightedHyperlink, Hoverable, MainAxisAlignment,
@@ -68,7 +69,7 @@ pub enum RuleViewEvent {
     AddRule,
     Edit(SyncId),
     OpenSettings,
-    OpenFile(PathBuf),
+    OpenFile(LocalOrRemotePath),
     InitializeProject(PathBuf),
 }
 
@@ -79,7 +80,7 @@ pub enum RuleViewAction {
     Edit(SyncId),
     OpenSettings,
     SelectScope(RuleScope),
-    OpenFile(PathBuf),
+    OpenFile(LocalOrRemotePath),
 }
 
 #[derive(Default, Debug, Clone)]
@@ -101,7 +102,7 @@ struct CloudRuleRow {
 /// plus an "Open file" button.
 #[derive(Debug, Clone)]
 struct FileBackedRow {
-    file_path: PathBuf,
+    file_path: LocalOrRemotePath,
     mouse_state: MouseStateHandle,
 }
 
@@ -126,9 +127,9 @@ impl RuleRow {
             }
             RuleRow::FileBacked(row) => row
                 .file_path
-                .to_str()
-                .map(|s| s.to_lowercase().contains(search_term))
-                .unwrap_or(false),
+                .display_path()
+                .to_lowercase()
+                .contains(search_term),
         }
     }
 
@@ -137,7 +138,9 @@ impl RuleRow {
             (RuleRow::Global(a), RuleRow::Global(b)) => {
                 b.fact.metadata().revision.cmp(&a.fact.metadata().revision)
             }
-            (RuleRow::FileBacked(a), RuleRow::FileBacked(b)) => a.file_path.cmp(&b.file_path),
+            (RuleRow::FileBacked(a), RuleRow::FileBacked(b)) => {
+                a.file_path.display_path().cmp(&b.file_path.display_path())
+            }
             _ => std::cmp::Ordering::Equal,
         }
     }
@@ -219,7 +222,7 @@ impl RuleView {
             .as_ref(ctx)
             .global_rule_paths()
             .map(|p| FileBackedRow {
-                file_path: p,
+                file_path: LocalOrRemotePath::Local(p),
                 mouse_state: Default::default(),
             })
             .collect();
@@ -245,7 +248,7 @@ impl RuleView {
                         .as_ref(ctx)
                         .global_rule_paths()
                         .map(|p| FileBackedRow {
-                            file_path: p,
+                            file_path: LocalOrRemotePath::Local(p),
                             mouse_state: Default::default(),
                         })
                         .collect();
@@ -705,7 +708,7 @@ impl RuleView {
         project_row: FileBackedRow,
         appearance: &Appearance,
     ) -> Option<Box<dyn Element>> {
-        let row_name = project_row.file_path.to_str().map(|s| s.to_string())?;
+        let row_name = project_row.file_path.display_path();
         let mut row = Flex::row()
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)

--- a/app/src/ai/metadata_project_rules.rs
+++ b/app/src/ai/metadata_project_rules.rs
@@ -1,0 +1,204 @@
+use std::collections::HashMap;
+
+use ai::project_context::model::{ProjectContextModel, ProjectRule};
+use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
+use remote_server::proto::{ProjectContextFileKind, ProjectContextFilesSnapshot};
+use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+pub(crate) struct MetadataProjectRulesModel {
+    refresh_generations: HashMap<RepositoryIdentifier, u64>,
+    next_refresh_generation: u64,
+}
+
+impl MetadataProjectRulesModel {
+    pub(crate) fn new(ctx: &mut ModelContext<Self>) -> Self {
+        let repo_metadata = RepoMetadataModel::handle(ctx);
+        ctx.subscribe_to_model(&repo_metadata, |me, event, ctx| {
+            me.handle_repo_metadata_event(event, ctx);
+        });
+        ctx.subscribe_to_model(
+            &RemoteServerManager::handle(ctx),
+            |me, event, ctx| match event {
+                RemoteServerManagerEvent::ProjectContextFilesSnapshot { host_id, snapshot } => {
+                    me.handle_remote_project_context_snapshot(host_id, snapshot, ctx);
+                }
+                RemoteServerManagerEvent::HostDisconnected { host_id } => {
+                    me.remove_remote_project_rules_for_host(host_id, ctx);
+                }
+                _ => {}
+            },
+        );
+
+        let mut model = Self {
+            refresh_generations: HashMap::new(),
+            next_refresh_generation: 0,
+        };
+        for repo_id in RepoMetadataModel::as_ref(ctx).local_repository_ids(ctx) {
+            model.refresh_local_project_rules(&repo_id, ctx);
+        }
+        model
+    }
+
+    fn handle_repo_metadata_event(
+        &mut self,
+        event: &repo_metadata::wrapper_model::RepoMetadataEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        use repo_metadata::wrapper_model::RepoMetadataEvent;
+
+        match event {
+            RepoMetadataEvent::RepositoryUpdated {
+                id: repo_id @ RepositoryIdentifier::Local(_),
+            }
+            | RepoMetadataEvent::FileTreeEntryUpdated {
+                id: repo_id @ RepositoryIdentifier::Local(_),
+            }
+            | RepoMetadataEvent::UpdatingRepositoryFailed {
+                id: repo_id @ RepositoryIdentifier::Local(_),
+            } => self.refresh_local_project_rules(repo_id, ctx),
+            RepoMetadataEvent::RepositoryRemoved {
+                id: repo_id @ RepositoryIdentifier::Local(_),
+            } => self.clear_project_rules_for_removed_repository(repo_id, ctx),
+            RepoMetadataEvent::RepositoryUpdated {
+                id: RepositoryIdentifier::Remote(_),
+            }
+            | RepoMetadataEvent::RepositoryRemoved {
+                id: RepositoryIdentifier::Remote(_),
+            }
+            | RepoMetadataEvent::FileTreeUpdated { .. }
+            | RepoMetadataEvent::FileTreeEntryUpdated {
+                id: RepositoryIdentifier::Remote(_),
+            }
+            | RepoMetadataEvent::UpdatingRepositoryFailed {
+                id: RepositoryIdentifier::Remote(_),
+            }
+            | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
+        }
+    }
+
+    fn refresh_local_project_rules(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let refresh_generation = self.advance_refresh_generation(repo_id);
+        let repo_id = repo_id.clone();
+        let Some(local_root) = repo_id.local_path_buf() else {
+            return;
+        };
+        let local_root_for_scan = local_root.clone();
+
+        ctx.spawn(
+            async move {
+                ProjectContextModel::read_project_rules_from_metadata_root(&local_root_for_scan)
+                    .await
+            },
+            move |me, rules, ctx| {
+                if me.refresh_generations.get(&repo_id) != Some(&refresh_generation) {
+                    return;
+                }
+                match rules {
+                    Ok(rules) => {
+                        ProjectContextModel::handle(ctx).update(ctx, |project_context, ctx| {
+                            project_context
+                                .replace_local_project_rules_from_metadata(local_root, rules, ctx);
+                        })
+                    }
+                    Err(error) => {
+                        log::warn!("Failed to refresh local project rules: {error:#}");
+                    }
+                }
+            },
+        );
+    }
+
+    fn handle_remote_project_context_snapshot(
+        &mut self,
+        host_id: &HostId,
+        snapshot: &ProjectContextFilesSnapshot,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if snapshot.kind != ProjectContextFileKind::ProjectRules as i32 {
+            return;
+        }
+        let Ok(repo_path) = StandardizedPath::try_new(&snapshot.repo_path) else {
+            log::warn!(
+                "Ignoring remote project-rule snapshot with invalid repository path: {}",
+                snapshot.repo_path
+            );
+            return;
+        };
+        let remote_root = RemotePath::new(host_id.clone(), repo_path);
+        let repo_id = RepositoryIdentifier::Remote(remote_root.clone());
+        let refresh_generation = self.advance_refresh_generation(&repo_id);
+        let rules = snapshot
+            .files
+            .iter()
+            .filter_map(|file| {
+                let path = StandardizedPath::try_new(&file.path).ok()?;
+                Some(ProjectRule {
+                    path: LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), path)),
+                    content: file.content.clone(),
+                })
+            })
+            .collect();
+        if self.refresh_generations.get(&repo_id) != Some(&refresh_generation) {
+            return;
+        }
+        ProjectContextModel::handle(ctx).update(ctx, |model, ctx| {
+            model.replace_remote_project_rules_from_metadata(remote_root, rules, ctx);
+        });
+    }
+
+    fn remove_remote_project_rules_for_host(
+        &mut self,
+        host_id: &HostId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.refresh_generations.retain(|repo_id, _| {
+            !matches!(
+                repo_id,
+                RepositoryIdentifier::Remote(path) if path.host_id == *host_id
+            )
+        });
+        ProjectContextModel::handle(ctx).update(ctx, |model, ctx| {
+            model.clear_remote_project_rules_for_host(host_id, ctx);
+        });
+    }
+
+    fn clear_project_rules_for_removed_repository(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.refresh_generations.remove(repo_id);
+        let Some(local_root) = repo_id.local_path_buf() else {
+            return;
+        };
+        ProjectContextModel::handle(ctx).update(ctx, |model, ctx| {
+            model.clear_local_project_rules_for_removed_metadata_root(local_root, ctx);
+        });
+    }
+
+    fn advance_refresh_generation(&mut self, repo_id: &RepositoryIdentifier) -> u64 {
+        self.next_refresh_generation += 1;
+        self.refresh_generations
+            .insert(repo_id.clone(), self.next_refresh_generation);
+        self.next_refresh_generation
+    }
+}
+
+impl Entity for MetadataProjectRulesModel {
+    type Event = ();
+}
+
+impl SingletonEntity for MetadataProjectRulesModel {}
+
+#[cfg(test)]
+#[path = "metadata_project_rules_tests.rs"]
+mod tests;

--- a/app/src/ai/metadata_project_rules.rs
+++ b/app/src/ai/metadata_project_rules.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use ai::project_context::model::{ProjectContextModel, ProjectRule};
 use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
 use remote_server::proto::{ProjectContextFileKind, ProjectContextFilesSnapshot};
+use repo_metadata::local_model::IndexedRepoState;
 use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -39,7 +40,7 @@ impl MetadataProjectRulesModel {
             next_refresh_generation: 0,
         };
         for repo_id in RepoMetadataModel::as_ref(ctx).local_repository_ids(ctx) {
-            model.refresh_local_project_rules(&repo_id, ctx);
+            model.refresh_or_fallback_project_rules_for_repo(&repo_id, ctx);
         }
         model
     }
@@ -57,10 +58,10 @@ impl MetadataProjectRulesModel {
             }
             | RepoMetadataEvent::FileTreeEntryUpdated {
                 id: repo_id @ RepositoryIdentifier::Local(_),
-            }
-            | RepoMetadataEvent::UpdatingRepositoryFailed {
-                id: repo_id @ RepositoryIdentifier::Local(_),
             } => self.refresh_local_project_rules(repo_id, ctx),
+            RepoMetadataEvent::UpdatingRepositoryFailed {
+                id: repo_id @ RepositoryIdentifier::Local(_),
+            } => self.refresh_local_project_rules_from_filesystem_fallback(repo_id, ctx),
             RepoMetadataEvent::RepositoryRemoved {
                 id: repo_id @ RepositoryIdentifier::Local(_),
             } => self.clear_project_rules_for_removed_repository(repo_id, ctx),
@@ -74,10 +75,25 @@ impl MetadataProjectRulesModel {
             | RepoMetadataEvent::FileTreeEntryUpdated {
                 id: RepositoryIdentifier::Remote(_),
             }
+            | RepoMetadataEvent::LazyDisplayTreeUpdated { .. }
+            | RepoMetadataEvent::LazyDisplayTreeRemoved { .. }
             | RepoMetadataEvent::UpdatingRepositoryFailed {
                 id: RepositoryIdentifier::Remote(_),
             }
             | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
+        }
+    }
+    fn refresh_or_fallback_project_rules_for_repo(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match RepoMetadataModel::as_ref(ctx).repository_state(repo_id, ctx) {
+            Some(IndexedRepoState::Indexed(_)) => self.refresh_local_project_rules(repo_id, ctx),
+            Some(IndexedRepoState::Failed(_)) => {
+                self.refresh_local_project_rules_from_filesystem_fallback(repo_id, ctx);
+            }
+            Some(IndexedRepoState::Pending(_)) | None => {}
         }
     }
 
@@ -171,6 +187,22 @@ impl MetadataProjectRulesModel {
         });
     }
 
+    fn refresh_local_project_rules_from_filesystem_fallback(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.advance_refresh_generation(repo_id);
+        let Some(local_root) = repo_id.local_path_buf() else {
+            return;
+        };
+        ProjectContextModel::handle(ctx).update(ctx, |model, ctx| {
+            model.use_local_filesystem_rule_fallback_for_root(&local_root);
+            if let Err(error) = model.index_and_store_rules(local_root, ctx) {
+                log::warn!("Failed to index project rules from local fallback: {error}");
+            }
+        });
+    }
     fn clear_project_rules_for_removed_repository(
         &mut self,
         repo_id: &RepositoryIdentifier,

--- a/app/src/ai/metadata_project_rules_tests.rs
+++ b/app/src/ai/metadata_project_rules_tests.rs
@@ -5,7 +5,8 @@ use ai::project_context::model::{ProjectContextModel, ProjectContextModelEvent};
 use remote_server::proto::{
     ProjectContextFile, ProjectContextFileKind, ProjectContextFilesSnapshot,
 };
-use repo_metadata::RepositoryIdentifier;
+use repo_metadata::repositories::DetectedRepositories;
+use repo_metadata::{DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier};
 use tempfile::TempDir;
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -100,6 +101,121 @@ fn local_metadata_refresh_uses_dedicated_rule_scan() {
                 .collect();
             assert!(contents.contains(&"root rule"));
             assert!(contents.contains(&"nested rule"));
+        });
+    });
+}
+
+#[test]
+fn failed_local_repository_uses_filesystem_rule_fallback() {
+    let (indexed_tx, indexed_rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let repo_metadata = app.add_singleton_model(RepoMetadataModel::new);
+        let _listener = app.add_model(|ctx| RulesIndexedListener::new(indexed_tx, ctx));
+        let rules_model = app.add_model(|_| metadata_rules_model());
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        fs::write(repo.join("WARP.md"), "failed fallback rule").unwrap();
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+        repo_metadata.update(&mut app, |model, ctx| {
+            model.insert_test_failed_state(StandardizedPath::try_from_local(&repo).unwrap(), ctx);
+        });
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.refresh_or_fallback_project_rules_for_repo(&repo_id, ctx);
+        });
+        indexed_rx.recv().await.unwrap();
+
+        project_context.read(&app, |model, _| {
+            let result = model
+                .find_applicable_project_rules(&repo.join("main.rs"))
+                .expect("failed-metadata local project rule fallback should apply");
+            assert_eq!(result.active_rules.len(), 1);
+            assert_eq!(result.active_rules[0].content, "failed fallback rule");
+        });
+    });
+}
+
+#[test]
+fn failed_local_fallback_rescan_persists_deleted_rule_paths() {
+    let (indexed_tx, indexed_rx) = async_channel::unbounded();
+    let (deleted_tx, deleted_rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let repo_metadata = app.add_singleton_model(RepoMetadataModel::new);
+        let _indexed_listener = app.add_model(|ctx| RulesIndexedListener::new(indexed_tx, ctx));
+        let _deleted_listener = app.add_model(|ctx| RulesDeltaListener::new(deleted_tx, ctx));
+        let rules_model = app.add_model(|_| metadata_rules_model());
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let rule_path = repo.join("WARP.md");
+        fs::write(&rule_path, "fallback rule").unwrap();
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+        repo_metadata.update(&mut app, |model, ctx| {
+            model.insert_test_failed_state(StandardizedPath::try_from_local(&repo).unwrap(), ctx);
+        });
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.refresh_or_fallback_project_rules_for_repo(&repo_id, ctx);
+        });
+        indexed_rx.recv().await.unwrap();
+        assert!(deleted_rx.recv().await.unwrap().is_empty());
+
+        fs::remove_file(&rule_path).unwrap();
+        rules_model.update(&mut app, |model, ctx| {
+            model.refresh_or_fallback_project_rules_for_repo(&repo_id, ctx);
+        });
+        indexed_rx.recv().await.unwrap();
+        assert_eq!(deleted_rx.recv().await.unwrap(), vec![rule_path]);
+        project_context.read(&app, |model, _| {
+            assert!(model
+                .find_applicable_project_rules(&repo.join("main.rs"))
+                .is_none());
+        });
+    });
+}
+
+#[test]
+fn failed_local_repository_discovers_nested_rules_with_filesystem_fallback() {
+    let (indexed_tx, indexed_rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let repo_metadata = app.add_singleton_model(RepoMetadataModel::new);
+        let _listener = app.add_model(|ctx| RulesIndexedListener::new(indexed_tx, ctx));
+        let rules_model = app.add_model(|_| metadata_rules_model());
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let nested_dir = repo.join("src");
+        fs::create_dir_all(&nested_dir).unwrap();
+        fs::write(nested_dir.join("WARP.md"), "fallback rule").unwrap();
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+        repo_metadata.update(&mut app, |model, ctx| {
+            model.insert_test_failed_state(StandardizedPath::try_from_local(&repo).unwrap(), ctx);
+        });
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.refresh_or_fallback_project_rules_for_repo(&repo_id, ctx);
+        });
+        indexed_rx.recv().await.unwrap();
+
+        project_context.read(&app, |model, _| {
+            let result = model
+                .find_applicable_project_rules(&nested_dir.join("main.rs"))
+                .expect("filesystem-fallback local project rule should apply");
+            assert_eq!(result.active_rules.len(), 1);
+            assert_eq!(result.active_rules[0].content, "fallback rule");
         });
     });
 }

--- a/app/src/ai/metadata_project_rules_tests.rs
+++ b/app/src/ai/metadata_project_rules_tests.rs
@@ -1,0 +1,262 @@
+use std::collections::HashMap;
+use std::fs;
+
+use ai::project_context::model::{ProjectContextModel, ProjectContextModelEvent};
+use remote_server::proto::{
+    ProjectContextFile, ProjectContextFileKind, ProjectContextFilesSnapshot,
+};
+use repo_metadata::RepositoryIdentifier;
+use tempfile::TempDir;
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
+use warpui::{App, Entity, ModelContext, SingletonEntity};
+
+use super::MetadataProjectRulesModel;
+
+struct RulesIndexedListener;
+
+impl RulesIndexedListener {
+    fn new(indexed_tx: async_channel::Sender<()>, ctx: &mut ModelContext<Self>) -> Self {
+        ctx.subscribe_to_model(&ProjectContextModel::handle(ctx), move |_, event, _| {
+            if matches!(event, ProjectContextModelEvent::PathIndexed) {
+                let _ = indexed_tx.try_send(());
+            }
+        });
+        Self
+    }
+}
+
+impl Entity for RulesIndexedListener {
+    type Event = ();
+}
+
+struct RulesDeltaListener;
+
+impl RulesDeltaListener {
+    fn new(
+        deleted_tx: async_channel::Sender<Vec<std::path::PathBuf>>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        ctx.subscribe_to_model(&ProjectContextModel::handle(ctx), move |_, event, _| {
+            if let ProjectContextModelEvent::KnownRulesChanged(delta) = event {
+                let _ = deleted_tx.try_send(delta.deleted_rules.clone());
+            }
+        });
+        Self
+    }
+}
+
+impl Entity for RulesDeltaListener {
+    type Event = ();
+}
+
+fn metadata_rules_model() -> MetadataProjectRulesModel {
+    MetadataProjectRulesModel {
+        refresh_generations: HashMap::new(),
+        next_refresh_generation: 0,
+    }
+}
+
+fn remote_rule_path(host_id: &HostId, path: &str) -> LocalOrRemotePath {
+    LocalOrRemotePath::Remote(RemotePath::new(
+        host_id.clone(),
+        StandardizedPath::try_new(path).unwrap(),
+    ))
+}
+
+#[test]
+fn local_metadata_refresh_uses_dedicated_rule_scan() {
+    let (indexed_tx, indexed_rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let _listener = app.add_model(|ctx| RulesIndexedListener::new(indexed_tx, ctx));
+        let rules_model = app.add_model(|_| metadata_rules_model());
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let nested_dir = repo.join("src");
+        fs::create_dir_all(&nested_dir).unwrap();
+        fs::write(repo.join("WARP.md"), "root rule").unwrap();
+        fs::write(nested_dir.join("WARP.md"), "nested rule").unwrap();
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.refresh_local_project_rules(&repo_id, ctx);
+        });
+        indexed_rx.recv().await.unwrap();
+
+        project_context.read(&app, |model, _| {
+            let result = model
+                .find_applicable_project_rules(&nested_dir.join("main.rs"))
+                .expect("dedicated metadata-triggered scan should discover rules");
+            assert_eq!(result.active_rules.len(), 2);
+            let contents: Vec<&str> = result
+                .active_rules
+                .iter()
+                .map(|rule| rule.content.as_str())
+                .collect();
+            assert!(contents.contains(&"root rule"));
+            assert!(contents.contains(&"nested rule"));
+        });
+    });
+}
+
+#[test]
+fn removed_local_metadata_repository_clears_rules_and_persists_deletion() {
+    let (indexed_tx, indexed_rx) = async_channel::unbounded();
+    let (deleted_tx, deleted_rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let _indexed_listener = app.add_model(|ctx| RulesIndexedListener::new(indexed_tx, ctx));
+        let _deleted_listener = app.add_model(|ctx| RulesDeltaListener::new(deleted_tx, ctx));
+        let rules_model = app.add_model(|_| metadata_rules_model());
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let rule_path = repo.join("WARP.md");
+        fs::write(&rule_path, "metadata rule").unwrap();
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.refresh_local_project_rules(&repo_id, ctx);
+        });
+        indexed_rx.recv().await.unwrap();
+        assert!(deleted_rx.recv().await.unwrap().is_empty());
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.clear_project_rules_for_removed_repository(&repo_id, ctx);
+        });
+        indexed_rx.recv().await.unwrap();
+        assert_eq!(deleted_rx.recv().await.unwrap(), vec![rule_path]);
+
+        project_context.read(&app, |model, _| {
+            assert!(model
+                .find_applicable_project_rules(&repo.join("src/main.rs"))
+                .is_none());
+        });
+    });
+}
+
+#[test]
+fn remote_project_rule_snapshot_replaces_removed_files() {
+    App::test((), |mut app| async move {
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let rules_model = app.add_model(|_| metadata_rules_model());
+        let host = HostId::new("test-host".to_string());
+        let nested_path = remote_rule_path(&host, "/repo/nested/WARP.md");
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.handle_remote_project_context_snapshot(
+                &host,
+                &ProjectContextFilesSnapshot {
+                    repo_path: "/repo".to_string(),
+                    kind: ProjectContextFileKind::ProjectRules.into(),
+                    files: vec![ProjectContextFile {
+                        path: "/repo/nested/WARP.md".to_string(),
+                        content: "remote rules".to_string(),
+                    }],
+                },
+                ctx,
+            );
+        });
+        project_context.read(&app, |model, _| {
+            let result = model
+                .find_applicable_project_rules_at_location(&remote_rule_path(
+                    &host,
+                    "/repo/nested/main.rs",
+                ))
+                .expect("typed remote snapshot should hydrate project rules");
+            assert_eq!(result.active_rules[0].path, nested_path);
+            assert_eq!(result.active_rules[0].content, "remote rules");
+        });
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.handle_remote_project_context_snapshot(
+                &host,
+                &ProjectContextFilesSnapshot {
+                    repo_path: "/repo".to_string(),
+                    kind: ProjectContextFileKind::ProjectRules.into(),
+                    files: vec![],
+                },
+                ctx,
+            );
+        });
+        project_context.read(&app, |model, _| {
+            assert!(model
+                .find_applicable_project_rules_at_location(&remote_rule_path(
+                    &host,
+                    "/repo/nested/main.rs",
+                ))
+                .is_none());
+        });
+    });
+}
+
+#[test]
+fn non_rule_project_context_snapshot_is_ignored() {
+    App::test((), |mut app| async move {
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let rules_model = app.add_model(|_| metadata_rules_model());
+        let host = HostId::new("test-host".to_string());
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.handle_remote_project_context_snapshot(
+                &host,
+                &ProjectContextFilesSnapshot {
+                    repo_path: "/repo".to_string(),
+                    kind: ProjectContextFileKind::ProjectSkills.into(),
+                    files: vec![ProjectContextFile {
+                        path: "/repo/WARP.md".to_string(),
+                        content: "not a rules snapshot".to_string(),
+                    }],
+                },
+                ctx,
+            );
+        });
+        project_context.read(&app, |model, _| {
+            assert!(model
+                .find_applicable_project_rules_at_location(&remote_rule_path(
+                    &host,
+                    "/repo/main.rs",
+                ))
+                .is_none());
+        });
+    });
+}
+
+#[test]
+fn host_disconnect_clears_remote_project_rules() {
+    App::test((), |mut app| async move {
+        let project_context = app.add_singleton_model(|_| ProjectContextModel::default());
+        let rules_model = app.add_model(|_| metadata_rules_model());
+        let host = HostId::new("test-host".to_string());
+
+        rules_model.update(&mut app, |model, ctx| {
+            model.handle_remote_project_context_snapshot(
+                &host,
+                &ProjectContextFilesSnapshot {
+                    repo_path: "/repo".to_string(),
+                    kind: ProjectContextFileKind::ProjectRules.into(),
+                    files: vec![ProjectContextFile {
+                        path: "/repo/WARP.md".to_string(),
+                        content: "remote rules".to_string(),
+                    }],
+                },
+                ctx,
+            );
+            model.remove_remote_project_rules_for_host(&host, ctx);
+        });
+        project_context.read(&app, |model, _| {
+            assert!(model
+                .find_applicable_project_rules_at_location(&remote_rule_path(
+                    &host,
+                    "/repo/main.rs",
+                ))
+                .is_none());
+        });
+    });
+}

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -31,6 +31,7 @@ pub mod harness_availability;
 pub(crate) mod harness_display;
 pub(crate) mod llms;
 pub(crate) mod local_harness_setup;
+pub(crate) mod metadata_project_rules;
 pub mod onboarding;
 pub(crate) mod persisted_workspace;
 pub(crate) mod predict;

--- a/app/src/ai/persisted_workspace.rs
+++ b/app/src/ai/persisted_workspace.rs
@@ -314,7 +314,7 @@ impl PersistedWorkspace {
                 let DetectedRepositoriesEvent::DetectedGitRepo { repository, .. } = event;
                 let repo_path = repository.as_ref(ctx).root_dir().to_local_path_lossy();
 
-                me.index_repo(repo_path, ctx);
+                me.index_repo(repo_path, false, ctx);
             });
         }
 
@@ -668,10 +668,17 @@ impl PersistedWorkspace {
     }
 
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
-    fn index_repo(&self, directory_path: PathBuf, ctx: &mut ModelContext<Self>) {
-        ProjectContextModel::handle(ctx).update(ctx, |model, ctx| {
-            let _ = model.index_and_store_rules(directory_path.clone(), ctx);
-        });
+    fn index_repo(
+        &self,
+        directory_path: PathBuf,
+        index_project_rules: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if index_project_rules {
+            ProjectContextModel::handle(ctx).update(ctx, |model, ctx| {
+                let _ = model.index_and_store_rules(directory_path.clone(), ctx);
+            });
+        }
         if FeatureFlag::FullSourceCodeEmbedding.is_enabled()
             && UserWorkspaces::as_ref(ctx).is_codebase_context_enabled(ctx)
             && *CodeSettings::as_ref(ctx).auto_indexing_enabled
@@ -711,7 +718,9 @@ impl PersistedWorkspace {
         }
 
         self.persist_metadata_for_index(&path);
-        self.index_repo(path.clone(), ctx);
+        // Explicitly added folders may not be metadata-backed repositories, so retain direct
+        // project-rule scanning for this manual-workspace path.
+        self.index_repo(path.clone(), true, ctx);
         ctx.emit(PersistedWorkspaceEvent::WorkspaceAdded { path });
     }
 

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -7,14 +7,14 @@ use ai::skills::{
     ParsedSkill, SkillProvider, SkillScope, SKILL_PROVIDER_DEFINITIONS,
 };
 use async_channel::Sender;
-use futures::future::BoxFuture;
-use remote_server::proto::{
-    file_context_proto, FileContextProto, ReadFileContextFile, ReadFileContextRequest,
-};
+use remote_server::proto::{ProjectContextFileKind, ProjectContextFilesSnapshot};
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repository::{Repository, SubscriberId};
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate};
+use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 use watcher::{BulkFilesystemWatcherEvent, HomeDirectoryWatcher, HomeDirectoryWatcherEvent};
 
@@ -26,7 +26,7 @@ use super::utils::{
     is_home_skill_directory, is_skill_file, read_local_project_skills_from_filesystem,
     read_skills_from_directories, read_skills_from_files,
 };
-use crate::remote_server::manager::RemoteServerManager;
+use crate::remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
 use crate::warp_managed_paths_watcher::{
     filter_repository_update_by_prefix, warp_managed_skill_dirs, WarpManagedPathsWatcher,
     WarpManagedPathsWatcherEvent,
@@ -38,10 +38,6 @@ pub enum SkillWatcherEvent {
     SkillsDeleted { paths: Vec<LocalOrRemotePath> },
 }
 
-const REMOTE_SKILL_MAX_FILE_BYTES: u32 = 1024 * 1024;
-const REMOTE_SKILL_MAX_BATCH_BYTES: u32 = 5 * 1024 * 1024;
-type ProjectSkillContentsFuture =
-    BoxFuture<'static, anyhow::Result<Vec<(LocalOrRemotePath, String)>>>;
 pub struct SkillWatcher {
     // Channel for sending repository messages from subscribers.
     repository_message_tx: Sender<SkillRepositoryMessage>,
@@ -56,7 +52,8 @@ pub struct SkillWatcher {
     /// and subsequently re-added while an old task is still in flight.
     next_project_skill_refresh_generation: u64,
     /// Failed local repos still need the project file watcher path because
-    /// repo metadata indexing can fail for oversized repos. This replaces the
+    /// no authoritative metadata events remain available after indexing fails.
+    /// This replaces the
     /// previous `watched_repos` set so we only subscribe when fallback is active
     /// and can also clean up the subscriber on repo removal.
     failed_local_project_watchers: HashMap<PathBuf, (ModelHandle<Repository>, SubscriberId)>,
@@ -103,6 +100,13 @@ impl SkillWatcher {
         read_skills_from_files(skill_files)
     }
 
+    /// Reads project skills directly from a repository root whose authoritative
+    /// metadata index is unavailable. The remote daemon uses the same fallback
+    /// discovery policy before publishing authoritative project-skill snapshots.
+    pub(crate) fn read_failed_local_project_skills(repo_path: &Path) -> Vec<ParsedSkill> {
+        read_local_project_skills_from_filesystem(repo_path)
+    }
+
     pub fn new(ctx: &mut ModelContext<Self>, watcher_event_tx: Sender<SkillWatcherEvent>) -> Self {
         Self::new_internal(ctx, watcher_event_tx, dirs::home_dir())
     }
@@ -124,6 +128,7 @@ impl SkillWatcher {
     ) -> Self {
         // Create channel for receiving repository messages (scans and updates)
         let (repository_message_tx, repository_message_rx) = async_channel::unbounded();
+        let subscribe_to_runtime_sources = home_dir.is_some();
 
         // Subscribe to repository messages for both projects and home directory
         // When a message is received, handle_message is used to dispatch the message to the appropriate handler
@@ -135,7 +140,7 @@ impl SkillWatcher {
             |_, _| {}, // No cleanup needed when stream ends
         );
 
-        if home_dir.is_some() {
+        if subscribe_to_runtime_sources {
             ctx.subscribe_to_model(
                 &HomeDirectoryWatcher::handle(ctx),
                 |me, event, ctx| match event {
@@ -185,20 +190,19 @@ impl SkillWatcher {
             }
         }
 
-        // RepositoryMetadataEvent::RepositoryUpdated fires after the file tree is
-        // built, so we can query it for skill files. Project skill updates use
-        // RepoMetadataModel for both local and remote repos when available, while
-        // local repos fall back to a direct project watcher only if metadata
-        // indexing fails.
+        // Authoritative local RepositoryUpdated/FileTreeEntryUpdated events drive
+        // metadata-backed skill refresh. If local repository indexing fails, a
+        // filesystem watcher provides discovery instead. Remote project skills
+        // are refreshed through server-backed discovery rather than display trees.
         ctx.subscribe_to_model(&RepoMetadataModel::handle(ctx), |me, event, ctx| {
             use repo_metadata::wrapper_model::RepoMetadataEvent;
             match event {
-                RepoMetadataEvent::RepositoryUpdated { id } => {
-                    me.refresh_project_skills_for_repo(id, ctx);
+                RepoMetadataEvent::RepositoryUpdated {
+                    id: id @ RepositoryIdentifier::Local(_),
                 }
-                RepoMetadataEvent::FileTreeEntryUpdated { id } => {
-                    me.refresh_project_skills_for_repo(id, ctx);
-                }
+                | RepoMetadataEvent::FileTreeEntryUpdated {
+                    id: id @ RepositoryIdentifier::Local(_),
+                } => me.refresh_project_skills_for_repo(id, ctx),
                 RepoMetadataEvent::RepositoryRemoved { id } => {
                     me.remove_project_skills_for_repo(id);
                     me.stop_failed_local_project_watcher(id, ctx);
@@ -206,10 +210,32 @@ impl SkillWatcher {
                 RepoMetadataEvent::UpdatingRepositoryFailed { id } => {
                     me.fallback_to_local_project_watcher(id, ctx);
                 }
-                RepoMetadataEvent::FileTreeUpdated { .. }
+                RepoMetadataEvent::RepositoryUpdated {
+                    id: RepositoryIdentifier::Remote(_),
+                }
+                | RepoMetadataEvent::FileTreeEntryUpdated {
+                    id: RepositoryIdentifier::Remote(_),
+                }
+                | RepoMetadataEvent::FileTreeUpdated { .. }
+                | RepoMetadataEvent::LazyDisplayTreeUpdated { .. }
+                | RepoMetadataEvent::LazyDisplayTreeRemoved { .. }
                 | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
             }
         });
+        if subscribe_to_runtime_sources {
+            ctx.subscribe_to_model(
+                &RemoteServerManager::handle(ctx),
+                |me, event, ctx| match event {
+                    RemoteServerManagerEvent::ProjectContextFilesSnapshot { host_id, snapshot } => {
+                        me.handle_remote_project_context_snapshot(host_id, snapshot, ctx);
+                    }
+                    RemoteServerManagerEvent::HostDisconnected { host_id } => {
+                        me.remove_remote_project_skills_for_host(host_id);
+                    }
+                    _ => {}
+                },
+            );
+        }
 
         Self {
             repository_message_tx,
@@ -221,6 +247,93 @@ impl SkillWatcher {
             home_provider_watchers,
             symlink_canonical_to_originals: HashMap::new(),
             symlink_target_watchers: HashMap::new(),
+        }
+    }
+
+    fn emit_filesystem_project_skills_if_current(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        refresh_generation: u64,
+        skills: Vec<ParsedSkill>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.project_skill_refresh_generations.get(repo_id) != Some(&refresh_generation) {
+            return;
+        }
+
+        let current_skill_files: HashSet<_> =
+            skills.iter().map(|skill| skill.path.clone()).collect();
+        let previous_skill_files = self
+            .project_skill_files_by_repo
+            .insert(repo_id.clone(), current_skill_files.clone())
+            .unwrap_or_default();
+        let deleted_paths = previous_skill_files
+            .difference(&current_skill_files)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !deleted_paths.is_empty() {
+            let deleted_local_paths = deleted_paths
+                .iter()
+                .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
+                .collect::<Vec<_>>();
+            self.cleanup_symlink_watches(&deleted_local_paths);
+            let _ = self
+                .watcher_event_tx
+                .try_send(SkillWatcherEvent::SkillsDeleted {
+                    paths: deleted_paths,
+                });
+        }
+
+        self.emit_project_skills_if_current(repo_id, refresh_generation, skills, ctx);
+    }
+    fn handle_remote_project_context_snapshot(
+        &mut self,
+        host_id: &HostId,
+        snapshot: &ProjectContextFilesSnapshot,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if snapshot.kind != ProjectContextFileKind::ProjectSkills as i32 {
+            return;
+        }
+        let Ok(repo_path) = StandardizedPath::try_new(&snapshot.repo_path) else {
+            log::warn!(
+                "Ignoring remote project-skill snapshot with invalid repository path: {}",
+                snapshot.repo_path
+            );
+            return;
+        };
+        let repo_id = RepositoryIdentifier::Remote(RemotePath::new(host_id.clone(), repo_path));
+        let refresh_generation = self.advance_project_skill_refresh_generation(&repo_id);
+        let skills = parse_project_skill_contents(
+            snapshot
+                .files
+                .iter()
+                .filter_map(|file| {
+                    let path = StandardizedPath::try_new(&file.path).ok()?;
+                    Some((
+                        LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), path)),
+                        file.content.clone(),
+                    ))
+                })
+                .collect(),
+        );
+        self.emit_filesystem_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
+    }
+
+    fn remove_remote_project_skills_for_host(&mut self, host_id: &HostId) {
+        let repo_ids = self
+            .project_skill_files_by_repo
+            .keys()
+            .filter(|repo_id| {
+                matches!(
+                    repo_id,
+                    RepositoryIdentifier::Remote(path) if path.host_id == *host_id
+                )
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for repo_id in repo_ids {
+            self.remove_project_skills_for_repo(&repo_id);
         }
     }
 
@@ -264,11 +377,10 @@ impl SkillWatcher {
                 });
         }
 
-        // Project skill counts are expected to be small, so repo metadata updates
+        // Project skill counts are expected to be small, so authoritative local metadata updates
         // intentionally trigger a full refresh instead of attempting to diff the
-        // changed subtree. This keeps local and remote project-skill behavior on
-        // the same RepoMetadataModel path and avoids a separate FileWatcher update
-        // path for local repos.
+        // changed subtree and avoids a separate FileWatcher update path for successful
+        // local repository indexing.
         self.spawn_read_project_skills_from_files(
             repo_id.clone(),
             refresh_generation,
@@ -299,13 +411,14 @@ impl SkillWatcher {
             return;
         };
 
-        self.scan_local_project_skills_from_filesystem(&local_path, ctx);
-        self.watch_failed_local_project_repo(local_path, ctx);
+        self.scan_local_project_skills_from_filesystem(repo_id, ctx);
+        self.watch_failed_local_project_repo(repo_id, local_path, ctx);
     }
 
     /// Register a failed local project root to watch for skill file changes.
     fn watch_failed_local_project_repo(
         &mut self,
+        repo_id: &RepositoryIdentifier,
         repo_path: PathBuf,
         ctx: &mut ModelContext<Self>,
     ) {
@@ -324,6 +437,7 @@ impl SkillWatcher {
         };
 
         let subscriber = Box::new(ProjectSkillSubscriber {
+            repo_id: repo_id.clone(),
             message_tx: self.repository_message_tx.clone(),
         });
         let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
@@ -350,19 +464,26 @@ impl SkillWatcher {
 
     fn scan_local_project_skills_from_filesystem(
         &mut self,
-        repo_path: &Path,
+        repo_id: &RepositoryIdentifier,
         ctx: &mut ModelContext<Self>,
     ) {
-        let repo_path = repo_path.to_path_buf();
+        let RepositoryIdentifier::Local(repo_path) = repo_id else {
+            return;
+        };
+        let Some(repo_path) = repo_path.to_local_path() else {
+            return;
+        };
+        let refresh_generation = self.advance_project_skill_refresh_generation(repo_id);
+        let repo_id = repo_id.clone();
         ctx.spawn(
             async move { read_local_project_skills_from_filesystem(&repo_path) },
             move |me, skills, ctx| {
-                if !skills.is_empty() {
-                    me.register_symlink_watches(&skills, ctx);
-                    let _ = me
-                        .watcher_event_tx
-                        .try_send(SkillWatcherEvent::SkillsAdded { skills });
-                }
+                me.emit_filesystem_project_skills_if_current(
+                    &repo_id,
+                    refresh_generation,
+                    skills,
+                    ctx,
+                );
             },
         );
     }
@@ -377,20 +498,13 @@ impl SkillWatcher {
         if skill_paths.is_empty() {
             return;
         }
-        let Some(read_skill_contents) = read_project_skill_contents(skill_paths, ctx) else {
-            return;
-        };
 
         ctx.spawn(
             async move {
-                let skill_contents = read_skill_contents.await?;
-                Ok::<Vec<ParsedSkill>, anyhow::Error>(parse_project_skill_contents(skill_contents))
+                parse_project_skill_contents(read_local_project_skill_contents(skill_paths))
             },
-            move |me, skills, ctx| match skills {
-                Ok(skills) => {
-                    me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
-                }
-                Err(err) => log::warn!("Failed to read project skills: {err}"),
+            move |me, skills, ctx| {
+                me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
             },
         );
     }
@@ -493,8 +607,8 @@ impl SkillWatcher {
                     .watcher_event_tx
                     .try_send(SkillWatcherEvent::SkillsAdded { skills });
             }
-            SkillRepositoryMessage::ProjectRepositoryUpdate { update } => {
-                self.handle_failed_local_project_update(&update, ctx);
+            SkillRepositoryMessage::ProjectRepositoryUpdate { repo_id } => {
+                self.scan_local_project_skills_from_filesystem(&repo_id, ctx);
             }
             SkillRepositoryMessage::HomeRepositoryUpdate { update } => {
                 self.handle_repository_update(&update, ctx);
@@ -505,86 +619,6 @@ impl SkillWatcher {
         }
     }
 
-    fn handle_failed_local_project_update(
-        &mut self,
-        update: &RepositoryUpdate,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let mut deleted_paths = Vec::new();
-
-        // Process deleted files
-        for target_file in &update.deleted {
-            deleted_paths.push(target_file.path.clone());
-        }
-
-        // Process moved files
-        for (to_target, from_target) in &update.moved {
-            deleted_paths.push(from_target.path.clone());
-            self.handle_failed_local_project_added_or_modified_path(&to_target.path, ctx);
-        }
-
-        // Process added or modified files
-        for target_file in update.added_or_modified() {
-            self.handle_failed_local_project_added_or_modified_path(&target_file.path, ctx);
-        }
-
-        // Process deleted paths in a batch
-        if !deleted_paths.is_empty() {
-            self.cleanup_symlink_watches(&deleted_paths);
-            let _ = self
-                .watcher_event_tx
-                .try_send(SkillWatcherEvent::SkillsDeleted {
-                    paths: deleted_paths
-                        .into_iter()
-                        .map(LocalOrRemotePath::Local)
-                        .collect(),
-                });
-        }
-    }
-
-    fn handle_failed_local_project_added_or_modified_path(
-        &mut self,
-        path: &Path,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        if is_skill_file(path) {
-            let skill_file_path = path.to_path_buf();
-            ctx.spawn(
-                async move { parse_skill(&skill_file_path) },
-                move |me, skill, ctx| {
-                    if let Ok(skill) = skill {
-                        me.register_symlink_watches(std::slice::from_ref(&skill), ctx);
-                        let _ = me
-                            .watcher_event_tx
-                            .try_send(SkillWatcherEvent::SkillsAdded {
-                                skills: vec![skill],
-                            });
-                    }
-                },
-            );
-        } else if path.is_symlink() && path.is_dir() && path.join("SKILL.md").exists() {
-            let skill_file_path = path.join("SKILL.md");
-            ctx.spawn(
-                async move { parse_skill(&skill_file_path) },
-                move |me, skill, ctx| {
-                    if let Ok(skill) = skill {
-                        me.register_symlink_watches(std::slice::from_ref(&skill), ctx);
-                        let _ = me
-                            .watcher_event_tx
-                            .try_send(SkillWatcherEvent::SkillsAdded {
-                                skills: vec![skill],
-                            });
-                    }
-                },
-            );
-        } else if path.is_dir() {
-            // The original local watcher deferred added directories until RepoMetadataModel
-            // incorporated them. This handler runs only after metadata indexing has failed, so
-            // scan added directories directly from disk instead of waiting for an update that
-            // may never arrive.
-            self.scan_local_project_skills_from_filesystem(path, ctx);
-        }
-    }
     fn handle_repository_update(
         &mut self,
         update: &RepositoryUpdate,
@@ -1054,46 +1088,6 @@ impl SkillWatcher {
     }
 }
 
-fn read_project_skill_contents(
-    skill_paths: Vec<LocalOrRemotePath>,
-    ctx: &AppContext,
-) -> Option<ProjectSkillContentsFuture> {
-    match skill_paths.first()? {
-        LocalOrRemotePath::Local(_) => Some(Box::pin(async move {
-            Ok(read_local_project_skill_contents(skill_paths))
-        })),
-        LocalOrRemotePath::Remote(remote) => {
-            let client = RemoteServerManager::as_ref(ctx)
-                .client_for_host(&remote.host_id)?
-                .clone();
-            Some(Box::pin(async move {
-                let request = remote_skill_read_request(&skill_paths);
-                let response = client.read_file_context(request).await?;
-                Ok(read_remote_project_skill_contents(
-                    skill_paths,
-                    response.file_contexts,
-                ))
-            }))
-        }
-    }
-}
-fn remote_skill_read_request(skill_paths: &[LocalOrRemotePath]) -> ReadFileContextRequest {
-    ReadFileContextRequest {
-        files: skill_paths
-            .iter()
-            .filter_map(|path| match path {
-                LocalOrRemotePath::Remote(remote) => Some(ReadFileContextFile {
-                    path: remote.path.as_str().to_string(),
-                    line_ranges: Vec::new(),
-                }),
-                LocalOrRemotePath::Local(_) => None,
-            })
-            .collect(),
-        max_file_bytes: Some(REMOTE_SKILL_MAX_FILE_BYTES),
-        max_batch_bytes: Some(REMOTE_SKILL_MAX_BATCH_BYTES),
-    }
-}
-
 fn read_local_project_skill_contents(
     skill_paths: Vec<LocalOrRemotePath>,
 ) -> Vec<(LocalOrRemotePath, String)> {
@@ -1101,32 +1095,6 @@ fn read_local_project_skill_contents(
         .into_iter()
         .filter_map(|path| {
             let content = fs::read_to_string(path.to_local_path()?).ok()?;
-            Some((path, content))
-        })
-        .collect()
-}
-
-fn read_remote_project_skill_contents(
-    skill_paths: Vec<LocalOrRemotePath>,
-    file_contexts: Vec<FileContextProto>,
-) -> Vec<(LocalOrRemotePath, String)> {
-    let text_content_by_path = file_contexts
-        .into_iter()
-        .filter_map(|file_context| {
-            let file_context_proto::Content::TextContent(content) = file_context.content? else {
-                return None;
-            };
-            Some((file_context.file_name, content))
-        })
-        .collect::<HashMap<_, _>>();
-
-    skill_paths
-        .into_iter()
-        .filter_map(|path| {
-            let LocalOrRemotePath::Remote(remote) = &path else {
-                return None;
-            };
-            let content = text_content_by_path.get(remote.path.as_str())?.clone();
             Some((path, content))
         })
         .collect()

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
-use remote_server::proto::{file_context_proto, FileContextProto};
+use remote_server::proto::{
+    ProjectContextFile, ProjectContextFileKind, ProjectContextFilesSnapshot,
+};
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
 use repo_metadata::repositories::DetectedRepositories;
@@ -18,10 +20,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
 use super::super::subscribers::SkillRepositoryMessage;
-use super::{
-    parse_project_skill_contents, read_remote_project_skill_contents, remote_skill_read_request,
-    SkillWatcher, REMOTE_SKILL_MAX_BATCH_BYTES, REMOTE_SKILL_MAX_FILE_BYTES,
-};
+use super::{parse_project_skill_contents, SkillWatcher};
 use crate::ai::skills::skill_manager::SkillWatcherEvent;
 
 /// Helper function for creating a single skill file
@@ -85,48 +84,14 @@ description: {description}
     )
 }
 
-fn remote_skill_file_context(path: &LocalOrRemotePath, content: &str) -> FileContextProto {
+fn remote_project_skill_file(path: &LocalOrRemotePath, content: &str) -> ProjectContextFile {
     let LocalOrRemotePath::Remote(remote) = path else {
         panic!("Expected a remote skill path");
     };
-
-    FileContextProto {
-        file_name: remote.path.as_str().to_string(),
-        content: Some(file_context_proto::Content::TextContent(
-            content.to_string(),
-        )),
-        line_range_start: None,
-        line_range_end: None,
-        last_modified_epoch_millis: None,
-        line_count: content.lines().count() as u32,
+    ProjectContextFile {
+        path: remote.path.as_str().to_string(),
+        content: content.to_string(),
     }
-}
-
-#[test]
-fn parse_project_skill_contents_matches_reordered_remote_responses_by_path() {
-    let host = HostId::new("test-host".to_string());
-    let first_path = remote_skill_path(&host, "first");
-    let second_path = remote_skill_path(&host, "second");
-    let first_content = remote_skill_content("first", "First skill", "First body");
-    let second_content = remote_skill_content("second", "Second skill", "Second body");
-
-    let skill_contents = read_remote_project_skill_contents(
-        vec![first_path.clone(), second_path.clone()],
-        vec![
-            remote_skill_file_context(&second_path, &second_content),
-            remote_skill_file_context(&first_path, &first_content),
-        ],
-    );
-    let skills = parse_project_skill_contents(skill_contents);
-
-    assert_eq!(skills.len(), 2);
-    assert_eq!(skills[0].path, first_path);
-    assert_eq!(skills[0].name, "first");
-    assert_eq!(skills[0].content, first_content);
-    assert_eq!(skills[0].provider, SkillProvider::Agents);
-    assert_eq!(skills[1].path, second_path);
-    assert_eq!(skills[1].name, "second");
-    assert_eq!(skills[1].content, second_content);
 }
 
 #[test]
@@ -145,43 +110,91 @@ fn parse_project_skill_contents_classifies_foreign_encoded_provider_path() {
 }
 
 #[test]
-fn read_remote_project_skill_contents_keeps_paths_aligned_after_missing_reads() {
-    let host = HostId::new("test-host".to_string());
-    let missing_path = remote_skill_path(&host, "missing");
-    let present_path = remote_skill_path(&host, "present");
-    let present_content = remote_skill_content("present", "Present skill", "Present body");
+fn typed_remote_snapshot_replaces_removed_project_skills() {
+    let (tx, rx) = async_channel::unbounded();
 
-    let skill_contents = read_remote_project_skill_contents(
-        vec![missing_path, present_path.clone()],
-        vec![remote_skill_file_context(&present_path, &present_content)],
-    );
-    let skills = parse_project_skill_contents(skill_contents);
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+        let host = HostId::new("test-host".to_string());
+        let first_path = remote_skill_path(&host, "first");
+        let second_path = remote_skill_path(&host, "second");
+        let first_content = remote_skill_content("first", "First skill", "First body");
+        let second_content = remote_skill_content("second", "Second skill", "Second body");
+        let initial = ProjectContextFilesSnapshot {
+            repo_path: "/repo".to_string(),
+            kind: ProjectContextFileKind::ProjectSkills as i32,
+            files: vec![
+                remote_project_skill_file(&first_path, &first_content),
+                remote_project_skill_file(&second_path, &second_content),
+            ],
+        };
+        skill_watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher.handle_remote_project_context_snapshot(&host, &initial, ctx);
+        });
+        let SkillWatcherEvent::SkillsAdded { skills } = rx.recv().await.unwrap() else {
+            panic!("Expected initial SkillsAdded event");
+        };
+        assert_eq!(skills.len(), 2);
 
-    assert_eq!(skills.len(), 1);
-    assert_eq!(skills[0].path, present_path);
-    assert_eq!(skills[0].name, "present");
-    assert_eq!(skills[0].content, present_content);
+        let replacement = ProjectContextFilesSnapshot {
+            repo_path: "/repo".to_string(),
+            kind: ProjectContextFileKind::ProjectSkills as i32,
+            files: vec![remote_project_skill_file(&second_path, &second_content)],
+        };
+        skill_watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher.handle_remote_project_context_snapshot(&host, &replacement, ctx);
+        });
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsDeleted {
+                paths: vec![first_path]
+            }
+        );
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsAdded {
+                skills: parse_project_skill_contents(vec![(second_path, second_content)])
+            }
+        );
+    });
 }
 
 #[test]
-fn remote_skill_read_request_sets_bounded_read_budget() {
-    let host = HostId::new("test-host".to_string());
-    let first_path = remote_skill_path(&host, "first");
-    let second_path = remote_skill_path(&host, "second");
+fn remote_host_disconnect_clears_project_skills() {
+    let (tx, rx) = async_channel::unbounded();
 
-    let request = remote_skill_read_request(&[first_path.clone(), second_path.clone()]);
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+        let host = HostId::new("test-host".to_string());
+        let path = remote_skill_path(&host, "remote");
+        let content = remote_skill_content("remote", "Remote skill", "Remote body");
+        let snapshot = ProjectContextFilesSnapshot {
+            repo_path: "/repo".to_string(),
+            kind: ProjectContextFileKind::ProjectSkills as i32,
+            files: vec![remote_project_skill_file(&path, &content)],
+        };
+        skill_watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher.handle_remote_project_context_snapshot(&host, &snapshot, ctx);
+        });
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsAdded { .. }
+        ));
 
-    assert_eq!(request.max_file_bytes, Some(REMOTE_SKILL_MAX_FILE_BYTES));
-    assert_eq!(request.max_batch_bytes, Some(REMOTE_SKILL_MAX_BATCH_BYTES));
-    assert_eq!(request.files.len(), 2);
-    let LocalOrRemotePath::Remote(first_remote) = first_path else {
-        panic!("Expected remote path");
-    };
-    let LocalOrRemotePath::Remote(second_remote) = second_path else {
-        panic!("Expected remote path");
-    };
-    assert_eq!(request.files[0].path, first_remote.path.as_str());
-    assert_eq!(request.files[1].path, second_remote.path.as_str());
+        skill_watcher_handle.update(&mut app, |watcher, _| {
+            watcher.remove_remote_project_skills_for_host(&host);
+        });
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsDeleted { paths: vec![path] }
+        );
+    });
 }
 
 // ============================================================================
@@ -220,6 +233,71 @@ fn test_handle_repository_update_single_skill_added() {
             event,
             SkillWatcherEvent::SkillsAdded {
                 skills: vec![skill]
+            }
+        );
+    });
+}
+
+#[test]
+fn test_failed_local_project_metadata_routes_through_filesystem_fallback() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let nested_dir = repo.join("packages/frontend");
+        let nested_skill =
+            create_skill_file_in_directory(&nested_dir, "fallback", "Fallback", "Content");
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.fallback_to_local_project_watcher(&repo_id, ctx);
+        });
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsAdded {
+                skills: vec![nested_skill]
+            }
+        );
+    });
+}
+
+#[test]
+fn test_removing_local_fallback_repo_deletes_filesystem_discovered_skills() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let skill = create_skill_file_in_directory(&repo, "fallback", "Fallback", "Content");
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.fallback_to_local_project_watcher(&repo_id, ctx);
+        });
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsAdded { .. }
+        ));
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, _| {
+            skill_watcher.remove_project_skills_for_repo(&repo_id);
+        });
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsDeleted {
+                paths: vec![skill.path]
             }
         );
     });
@@ -436,9 +514,19 @@ fn test_local_project_fallback_scans_filesystem_when_repo_metadata_fails() {
             panic!("Expected SkillsAdded event");
         };
         skills.sort_by_key(|skill| skill.path.display_path());
-        let mut expected = vec![root_skill, subdir_skill];
+        let mut expected = vec![root_skill.clone(), subdir_skill.clone()];
         expected.sort_by_key(|skill| skill.path.display_path());
         assert_eq!(skills, expected);
+
+        skill_watcher_handle.read(&app, |skill_watcher, _| {
+            assert_eq!(
+                skill_watcher.project_skill_files_by_repo.get(&repo_id),
+                Some(&HashSet::from([
+                    root_skill.path.clone(),
+                    subdir_skill.path.clone()
+                ]))
+            );
+        });
     });
 }
 
@@ -498,20 +586,14 @@ fn test_local_project_fallback_update_reuses_repository_update_handler() {
         let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
 
         let temp_dir = TempDir::new().unwrap();
-        let skill = create_skill_file(&temp_dir, "fallback-update", "Fallback update", "Content");
-        let update = RepositoryUpdate {
-            added: HashSet::new(),
-            modified: HashSet::from([TargetFile::new(skill_local_path(&skill), false)]),
-            deleted: HashSet::new(),
-            moved: HashMap::new(),
-            commit_updated: false,
-            index_lock_detected: false,
-            remote_ref_updated: false,
-        };
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let skill =
+            create_skill_file_in_directory(&repo, "fallback-update", "Fallback update", "Content");
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.handle_message(
-                SkillRepositoryMessage::ProjectRepositoryUpdate { update },
+                SkillRepositoryMessage::ProjectRepositoryUpdate { repo_id },
                 ctx,
             );
         });
@@ -536,22 +618,15 @@ fn test_local_project_fallback_directory_addition_scans_filesystem() {
         let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
 
         let temp_dir = TempDir::new().unwrap();
-        let new_dir = temp_dir.path().join("packages/frontend");
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+        let new_dir = repo.join("packages/frontend");
         let skill =
             create_skill_file_in_directory(&new_dir, "fallback-dir", "Fallback dir", "Content");
-        let update = RepositoryUpdate {
-            added: HashSet::from([TargetFile::new(new_dir, false)]),
-            modified: HashSet::new(),
-            deleted: HashSet::new(),
-            moved: HashMap::new(),
-            commit_updated: false,
-            index_lock_detected: false,
-            remote_ref_updated: false,
-        };
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.handle_message(
-                SkillRepositoryMessage::ProjectRepositoryUpdate { update },
+                SkillRepositoryMessage::ProjectRepositoryUpdate { repo_id },
                 ctx,
             );
         });

--- a/app/src/ai/skills/file_watchers/subscribers.rs
+++ b/app/src/ai/skills/file_watchers/subscribers.rs
@@ -4,7 +4,7 @@ use ai::skills::{read_skills, ParsedSkill, SKILL_PROVIDER_DEFINITIONS};
 use async_channel::Sender;
 use futures::Future;
 use repo_metadata::repository::RepositorySubscriber;
-use repo_metadata::{Repository, RepositoryUpdate};
+use repo_metadata::{Repository, RepositoryIdentifier, RepositoryUpdate};
 use warpui::ModelContext;
 
 /// Messages sent from [`RepositorySubscriber`]s to [`SkillManager`].
@@ -12,7 +12,7 @@ pub enum SkillRepositoryMessage {
     /// Initial scan of a home skills directory (e.g., `~/.agents`).
     HomeInitialScan { skills: Vec<ParsedSkill> },
     /// Incremental file system updates from a local project fallback watcher.
-    ProjectRepositoryUpdate { update: RepositoryUpdate },
+    ProjectRepositoryUpdate { repo_id: RepositoryIdentifier },
     /// Incremental file system updates from a home provider directory.
     HomeRepositoryUpdate { update: RepositoryUpdate },
     /// File changes detected in a resolved symlink target directory.
@@ -21,6 +21,7 @@ pub enum SkillRepositoryMessage {
 
 /// A repository subscriber for project directories that forwards file change events to [`SkillManager`].
 pub struct ProjectSkillSubscriber {
+    pub repo_id: RepositoryIdentifier,
     pub message_tx: Sender<SkillRepositoryMessage>,
 }
 
@@ -38,15 +39,15 @@ impl RepositorySubscriber for ProjectSkillSubscriber {
     fn on_files_updated(
         &mut self,
         _repository: &Repository,
-        update: &RepositoryUpdate,
+        _update: &RepositoryUpdate,
         _ctx: &mut ModelContext<Repository>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
         let tx = self.message_tx.clone();
-        let update = update.clone();
+        let repo_id = self.repo_id.clone();
 
         Box::pin(async move {
             let _ = tx
-                .send(SkillRepositoryMessage::ProjectRepositoryUpdate { update })
+                .send(SkillRepositoryMessage::ProjectRepositoryUpdate { repo_id })
                 .await;
         })
     }

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use ai::skills::{
@@ -65,16 +66,18 @@ pub fn find_skill_files_in_tree(
 
 /// Reads local project skills by discovering provider directories on the filesystem.
 ///
-/// This is a local-only fallback for repositories whose repo metadata indexing fails. Successful
-/// local and remote repos should use [`find_skill_files_in_tree`] so the normal metadata-backed
-/// path remains shared.
+/// This is a local-only fallback for repositories whose authoritative repo metadata indexing
+/// fails. Successfully indexed local repositories use [`find_skill_files_in_tree`].
 pub(super) fn read_local_project_skills_from_filesystem(scan_root: &Path) -> Vec<ParsedSkill> {
+    let Ok(scan_root) = dunce::canonicalize(scan_root) else {
+        return Vec::new();
+    };
     let direct_skill_file = scan_root.join("SKILL.md");
     if is_skill_file(&direct_skill_file) {
         return read_skills_from_files([direct_skill_file]);
     }
 
-    read_skills_from_directories(find_local_provider_directories_on_filesystem(scan_root))
+    read_skills_from_directories(find_local_provider_directories_on_filesystem(&scan_root))
 }
 
 fn find_local_provider_directories_on_filesystem(scan_root: &Path) -> Vec<PathBuf> {
@@ -90,7 +93,10 @@ fn find_local_provider_directories_on_filesystem(scan_root: &Path) -> Vec<PathBu
             }
             continue;
         }
-        if entry.file_type().is_dir() && is_project_provider_path(entry.path()) {
+        if entry.file_type().is_dir()
+            && is_project_provider_path(entry.path())
+            && is_trusted_project_provider_directory(scan_root, entry.path())
+        {
             provider_dirs.push(entry.into_path());
             entries.skip_current_dir();
         }
@@ -101,6 +107,18 @@ fn find_local_provider_directories_on_filesystem(scan_root: &Path) -> Vec<PathBu
 
 fn is_ignored_fallback_scan_entry(entry: &DirEntry) -> bool {
     entry.file_name().to_str() == Some(".git")
+}
+
+fn is_trusted_project_provider_directory(scan_root: &Path, provider_path: &Path) -> bool {
+    if !provider_path.starts_with(scan_root)
+        || fs::symlink_metadata(provider_path)
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+    {
+        return false;
+    }
+
+    dunce::canonicalize(provider_path)
+        .is_ok_and(|canonical_provider| canonical_provider.starts_with(scan_root))
 }
 
 /// Finds symlinked skill directories under loaded local provider directories in a repository.

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
 use repo_metadata::file_tree_update::{
@@ -7,6 +9,7 @@ use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{
     DirectoryWatcher, RepoMetadataModel, RepoMetadataUpdate, RepositoryIdentifier,
 };
+use tempfile::TempDir;
 use virtual_fs::{Stub, VirtualFS};
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -16,7 +19,8 @@ use warpui::App;
 
 use super::{
     extract_skill_parent_directory, find_skill_files_in_tree, is_home_provider_path,
-    is_home_skill_directory, is_skill_file, read_skills_from_files,
+    is_home_skill_directory, is_skill_file, read_local_project_skills_from_filesystem,
+    read_skills_from_files,
 };
 
 // ============================================================================
@@ -425,6 +429,44 @@ fn is_home_provider_path_false_for_partial_path() {
 
     // Just home
     assert!(!is_home_provider_path(&home_dir));
+}
+
+#[test]
+fn local_project_fallback_discovers_provider_paths_ignored_by_git() {
+    let repo = TempDir::new().unwrap();
+    let repo_path = dunce::canonicalize(repo.path()).unwrap();
+    let skill_path = repo_path.join(".agents/skills/ignored/SKILL.md");
+    fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+    fs::write(repo_path.join(".gitignore"), ".agents/\n").unwrap();
+    fs::write(
+        &skill_path,
+        "---\nname: ignored\ndescription: ignored provider\n---\ncontent\n",
+    )
+    .unwrap();
+
+    let skills = read_local_project_skills_from_filesystem(&repo_path);
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].path, LocalOrRemotePath::Local(skill_path));
+}
+
+#[cfg(unix)]
+#[test]
+fn local_project_fallback_rejects_symlinked_provider_roots() {
+    let repo = TempDir::new().unwrap();
+    let external = TempDir::new().unwrap();
+    let external_skills = external.path().join("skills");
+    let escaped_skill = external_skills.join("escaped/SKILL.md");
+    fs::create_dir_all(escaped_skill.parent().unwrap()).unwrap();
+    fs::write(
+        &escaped_skill,
+        "---\nname: escaped\ndescription: escaped provider\n---\ncontent\n",
+    )
+    .unwrap();
+    let provider_parent = repo.path().join(".agents");
+    fs::create_dir_all(&provider_parent).unwrap();
+    std::os::unix::fs::symlink(&external_skills, provider_parent.join("skills")).unwrap();
+
+    assert!(read_local_project_skills_from_filesystem(repo.path()).is_empty());
 }
 
 // ============================================================================

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 
 use ai::skills::{get_provider_for_path, ParsedSkill, SkillProvider, SkillReference, SkillScope};
+use remote_server::manager::RemoteServerManager;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel};
 use tempfile::TempDir;
@@ -86,6 +87,7 @@ fn get_skills_for_working_directory_scopes_subdirectory_skills() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let skill_manager_handle = app.add_singleton_model(SkillManager::new);
 
         // Register the repo root so get_root_for_path returns Some.
@@ -219,6 +221,7 @@ fn get_skills_for_working_directory_name_collision_returns_both() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let skill_manager_handle = app.add_singleton_model(SkillManager::new);
 
         // Register the repo root so get_root_for_path returns Some.
@@ -323,6 +326,7 @@ fn cloud_environment_skills_always_included() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let skill_manager_handle = app.add_singleton_model(SkillManager::new);
 
         let canonical_repo_a =
@@ -532,6 +536,7 @@ fn active_skill_by_reference_resolves_exact_remote_identity() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let handle = app.add_singleton_model(SkillManager::new);
 
         handle.update(&mut app, |manager, _| {
@@ -564,6 +569,7 @@ fn active_skill_by_reference_distinguishes_remote_hosts_with_the_same_display_pa
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let handle = app.add_singleton_model(SkillManager::new);
 
         handle.update(&mut app, |manager, _| {
@@ -619,6 +625,7 @@ fn best_supported_provider_fast_path_returns_deduped_provider() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let handle = app.add_singleton_model(SkillManager::new);
 
         let claude_skill = make_skill("deploy", ".claude");
@@ -645,6 +652,7 @@ fn best_supported_provider_remaps_to_supported_provider() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let handle = app.add_singleton_model(SkillManager::new);
 
         let agents_skill = make_skill("deploy", ".agents");
@@ -676,6 +684,7 @@ fn best_supported_provider_falls_back_when_no_match() {
         app.add_singleton_model(RepoMetadataModel::new);
         app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
         app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        app.add_singleton_model(RemoteServerManager::new);
         let handle = app.add_singleton_model(SkillManager::new);
 
         let agents_skill = make_skill("deploy", ".agents");

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -556,6 +556,17 @@ impl FileTreeView {
                     }
                 }
             }
+            RepoMetadataEvent::LazyDisplayTreeUpdated { path } => {
+                if let Some(state) = RepoMetadataModel::as_ref(ctx).get_lazy_display_tree(path, ctx)
+                {
+                    if let Some(root_dir) = self.root_directories.get_mut(path) {
+                        root_dir.entry = state.entry.clone();
+                        self.rebuild_flattened_items_for_root(path);
+                        self.apply_pending_focus_target();
+                        ctx.notify();
+                    }
+                }
+            }
             RepoMetadataEvent::UpdatingRepositoryFailed {
                 id: RepositoryIdentifier::Local(std_path),
             } => {
@@ -617,6 +628,7 @@ impl FileTreeView {
             }
             RepoMetadataEvent::FileTreeUpdated { .. }
             | RepoMetadataEvent::RepositoryRemoved { .. }
+            | RepoMetadataEvent::LazyDisplayTreeRemoved { .. }
             | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
             | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
         }
@@ -1404,6 +1416,9 @@ impl FileTreeView {
         if RepoMetadataModel::as_ref(ctx)
             .get_repository(&backing_id, ctx)
             .is_none()
+            && RepoMetadataModel::as_ref(ctx)
+                .get_lazy_display_tree(&backing_root, ctx)
+                .is_none()
         {
             return;
         }
@@ -1426,7 +1441,10 @@ impl FileTreeView {
             log::warn!("Failed to load directory {dir_path}: {error}");
         }
 
-        if let Some(state) = RepoMetadataModel::as_ref(ctx).get_repository(&backing_id, ctx) {
+        let state = RepoMetadataModel::as_ref(ctx)
+            .get_repository(&backing_id, ctx)
+            .or_else(|| RepoMetadataModel::as_ref(ctx).get_lazy_display_tree(&backing_root, ctx));
+        if let Some(state) = state {
             if let Some(root_dir) = self.root_directories.get_mut(root_path) {
                 root_dir.entry = state.entry.clone();
             }
@@ -1571,20 +1589,20 @@ impl FileTreeView {
             }
         }
 
-        let id = repo_metadata::RepositoryIdentifier::local(path.clone());
-        let repo_state = RepoMetadataModel::as_ref(ctx).repository_state(&id, ctx);
         if let Some(root_dir) = self.root_directories.get_mut(path) {
-            match repo_state {
-                Some(IndexedRepoState::Indexed(state)) => {
-                    root_dir.entry = state.entry.clone();
-                }
-                Some(IndexedRepoState::Pending(_)) => {
-                    // Repo is being (re-)indexed. Keep whatever entry we already
-                    // have so the tree doesn't flash back to a loading state
-                    // during the Pending → Indexed transition.
-                }
-                Some(IndexedRepoState::Failed(_)) | None => {
-                    root_dir.entry = Self::create_empty_entry(path);
+            if let Some(state) = RepoMetadataModel::as_ref(ctx).get_lazy_display_tree(path, ctx) {
+                root_dir.entry = state.entry.clone();
+            } else {
+                let id = repo_metadata::RepositoryIdentifier::local(path.clone());
+                match RepoMetadataModel::as_ref(ctx).repository_state(&id, ctx) {
+                    Some(IndexedRepoState::Pending(_)) => {
+                        // Keep the current UI tree during an authoritative re-index.
+                    }
+                    Some(IndexedRepoState::Indexed(_))
+                    | Some(IndexedRepoState::Failed(_))
+                    | None => {
+                        root_dir.entry = Self::create_empty_entry(path);
+                    }
                 }
             }
         }

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -4086,7 +4086,7 @@ impl CodeReviewView {
                 ProjectContextModel::as_ref(app).find_applicable_project_rules(repo_path)
             {
                 if let Some(first_rule) = rules.active_rules.first() {
-                    if let Some(file_name) = first_rule.path.file_name().and_then(|n| n.to_str()) {
+                    if let Some(file_name) = first_rule.path.file_name() {
                         zero_state_column.add_child(
                             Container::new(
                                 Text::new(

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -144,6 +144,7 @@ use ai::ambient_agents::scheduled::ScheduledAgentManager;
 use ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use ai::execution_profiles::editor::ExecutionProfileEditorManager;
 use ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use ai::metadata_project_rules::MetadataProjectRulesModel;
 use ai::persisted_workspace::PersistedWorkspace;
 use auth::auth_manager::AuthManager;
 use auth::auth_state::{AuthState, AuthStateProvider};
@@ -1995,6 +1996,7 @@ pub(crate) fn initialize_app(
     ctx.add_singleton_model(|ctx| {
         ProjectContextModel::new_from_persisted(persisted_project_rules, ctx)
     });
+    ctx.add_singleton_model(MetadataProjectRulesModel::new);
 
     // Index global rules (e.g. ~/.agents/AGENTS.md) on a background task so
     // they are available to subsequent agent queries.

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -179,6 +179,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(voice_input::VoiceInput::new);
     #[cfg(feature = "local_fs")]
     app.add_singleton_model(RepoMetadataModel::new);
+    app.add_singleton_model(remote_server::manager::RemoteServerManager::new);
     app.add_singleton_model(SkillManager::new);
     app.add_singleton_model(FileSearchModel::new);
     app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
@@ -202,7 +203,6 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(|_| History::new(vec![]));
     app.add_singleton_model(|_| GitHubAuthNotifier::new());
     app.add_singleton_model(AgentConversationsModel::new);
-    app.add_singleton_model(remote_server::manager::RemoteServerManager::new);
 }
 
 struct MockOptions {

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -454,6 +454,7 @@ impl RemoteCodebaseIndexModel {
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+            | RemoteServerManagerEvent::ProjectContextFilesSnapshot { .. }
             | RemoteServerManagerEvent::BufferUpdated { .. }
             | RemoteServerManagerEvent::BufferConflictDetected { .. }
             | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -10,6 +10,7 @@ use ::ai::index::full_source_code_embedding::manager::{
 use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
+use ::ai::project_context::model::{ProjectContextModel, ProjectRule};
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
@@ -47,11 +48,12 @@ use super::proto::{
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
     GetFragmentMetadataFromHashSuccess, IndexCodebase, Initialize, InitializeResponse,
     MissingFragmentMetadata, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
-    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
-    ResolveConflictSuccess, ResyncCodebase, RunCommandError, RunCommandErrorCode,
-    RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
-    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, UploadHandoffSnapshot,
-    WriteFile, WriteFileResponse, WriteFileSuccess,
+    OpenBufferResponse, ProjectContextFile, ProjectContextFileKind, ProjectContextFilesSnapshot,
+    ReadFileContextResponse, ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess,
+    ResyncCodebase, RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse,
+    RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage,
+    SessionBootstrapped, TextEdit, UploadHandoffSnapshot, WriteFile, WriteFileResponse,
+    WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
@@ -349,14 +351,30 @@ impl ServerModel {
                             sent_roots.insert(path.clone());
                         }
                     }
+                    me.push_authoritative_project_rule_snapshot(path.clone(), ctx);
                 }
-                RepoMetadataEvent::RepositoryRemoved { .. }
-                | RepoMetadataEvent::FileTreeUpdated { .. }
-                | RepoMetadataEvent::FileTreeEntryUpdated { .. }
-                | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
+                RepoMetadataEvent::RepositoryRemoved {
+                    id: RepositoryIdentifier::Local(path),
+                } => me.push_project_rule_snapshot(path, Vec::new()),
+                RepoMetadataEvent::UpdatingRepositoryFailed {
+                    id: RepositoryIdentifier::Local(path),
+                } => me.push_authoritative_project_rule_snapshot(path.clone(), ctx),
+                RepoMetadataEvent::FileTreeUpdated { .. }
+                | RepoMetadataEvent::FileTreeEntryUpdated {
+                    id: RepositoryIdentifier::Remote(_),
+                }
+                | RepoMetadataEvent::RepositoryRemoved {
+                    id: RepositoryIdentifier::Remote(_),
+                }
+                | RepoMetadataEvent::UpdatingRepositoryFailed {
+                    id: RepositoryIdentifier::Remote(_),
+                }
                 | RepoMetadataEvent::RepositoryUpdated {
                     id: RepositoryIdentifier::Remote(_),
                 } => {}
+                RepoMetadataEvent::FileTreeEntryUpdated {
+                    id: RepositoryIdentifier::Local(path),
+                } => me.push_authoritative_project_rule_snapshot(path.clone(), ctx),
             });
         }
         let index_manager = CodebaseIndexManager::handle(ctx);
@@ -823,6 +841,46 @@ impl ServerModel {
             None,
             server_message::Message::CodebaseIndexStatusUpdated(CodebaseIndexStatusUpdated {
                 status: Some(status),
+            }),
+        );
+    }
+
+    fn push_authoritative_project_rule_snapshot(
+        &mut self,
+        repo_path: StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(local_path) = repo_path.to_local_path() else {
+            return;
+        };
+        ctx.spawn(
+            async move { ProjectContextModel::read_project_rules_from_metadata_root(&local_path).await },
+            move |me, rules, _ctx| match rules {
+                Ok(rules) => me.push_project_rule_snapshot(&repo_path, rules),
+                Err(error) => {
+                    log::warn!("Failed to build daemon project-rule snapshot: {error:#}");
+                }
+            },
+        );
+    }
+
+    fn push_project_rule_snapshot(&self, repo_path: &StandardizedPath, rules: Vec<ProjectRule>) {
+        let files = rules
+            .into_iter()
+            .filter_map(|rule| {
+                Some(ProjectContextFile {
+                    path: rule.path.to_local_path()?.to_string_lossy().to_string(),
+                    content: rule.content,
+                })
+            })
+            .collect();
+        self.send_server_message(
+            None,
+            None,
+            server_message::Message::ProjectContextFilesSnapshot(ProjectContextFilesSnapshot {
+                repo_path: repo_path.to_string(),
+                kind: ProjectContextFileKind::ProjectRules.into(),
+                files,
             }),
         );
     }
@@ -1747,12 +1805,15 @@ impl ServerModel {
                             None,
                             server_message::Message::RepoMetadataSnapshot(
                                 super::proto::RepoMetadataSnapshot {
-                                    repo_path: indexed_path,
+                                    repo_path: indexed_path.clone(),
                                     entries,
                                     sync_complete: true,
                                 },
                             ),
                         );
+                        if is_git {
+                            me.push_authoritative_project_rule_snapshot(root_path.clone(), ctx);
+                        }
                         if is_git {
                             if let Some(sent_roots) = me
                                 .snapshot_sent_roots_by_connection

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 
 use ::ai::index::full_source_code_embedding::manager::{
@@ -11,9 +12,13 @@ use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
 use ::ai::project_context::model::{ProjectContextModel, ProjectRule};
+use ::ai::skills::ParsedSkill;
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
-use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
+use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
+use repo_metadata::{
+    RepoMetadataEvent, RepoMetadataModel, Repository, RepositoryIdentifier, RepositoryUpdate,
+};
 use warp_core::channel::ChannelState;
 use warp_core::{safe_error, SessionId};
 use warp_files::{FileModel, FileModelEvent};
@@ -56,6 +61,7 @@ use super::proto::{
     WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
+use crate::ai::skills::SkillWatcher;
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
 use crate::code_review::diff_state::{DiffMode, FileStatusInfo};
 use crate::terminal::shell::ShellType;
@@ -132,6 +138,33 @@ struct PendingFileOp {
     request_id: RequestId,
     conn_id: ConnectionId,
     kind: FileOpKind,
+}
+struct FailedProjectSkillSubscriber {
+    repo_path: StandardizedPath,
+    message_tx: async_channel::Sender<StandardizedPath>,
+}
+
+impl RepositorySubscriber for FailedProjectSkillSubscriber {
+    fn on_scan(
+        &mut self,
+        _repository: &Repository,
+        _ctx: &mut ModelContext<Repository>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+        Box::pin(async {})
+    }
+
+    fn on_files_updated(
+        &mut self,
+        _repository: &Repository,
+        _update: &RepositoryUpdate,
+        _ctx: &mut ModelContext<Repository>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+        let repo_path = self.repo_path.clone();
+        let message_tx = self.message_tx.clone();
+        Box::pin(async move {
+            let _ = message_tx.send(repo_path).await;
+        })
+    }
 }
 
 /// Manages pending file operations and ensures that the corresponding
@@ -232,6 +265,11 @@ pub struct ServerModel {
     buffers: ServerBufferTracker,
     /// Manages per-(repo, mode) diff state models and per-connection subscriptions.
     diff_states: ModelHandle<RemoteDiffStateManager>,
+    /// Repository subscriptions for project-skill filesystem fallback when
+    /// authoritative metadata indexing has failed.
+    failed_project_skill_watchers:
+        HashMap<StandardizedPath, (ModelHandle<Repository>, SubscriberId)>,
+    project_skill_refresh_tx: async_channel::Sender<StandardizedPath>,
 }
 
 impl Entity for ServerModel {
@@ -243,6 +281,7 @@ impl SingletonEntity for ServerModel {}
 impl ServerModel {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         let host_id = uuid::Uuid::new_v4().to_string();
+        let (project_skill_refresh_tx, project_skill_refresh_rx) = async_channel::unbounded();
         log::info!(
             "Daemon started: PID={}, host_id={}",
             std::process::id(),
@@ -259,7 +298,17 @@ impl ServerModel {
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
             buffers: ServerBufferTracker::new(),
             diff_states: ctx.add_model(|_| RemoteDiffStateManager::new()),
+            failed_project_skill_watchers: HashMap::new(),
+            project_skill_refresh_tx,
         };
+        ctx.spawn_stream_local(
+            project_skill_refresh_rx,
+            |me, repo_path, ctx| {
+                me.push_failed_project_skill_snapshot(&repo_path, ctx);
+                me.push_failed_project_rule_snapshot(&repo_path);
+            },
+            |_, _| {},
+        );
         // Subscribe to FileModel and RepoMetadataModel events
         // file operation results and repo metadata pushes are forwarded to all
         // connected proxy sessions.
@@ -351,30 +400,72 @@ impl ServerModel {
                             sent_roots.insert(path.clone());
                         }
                     }
+                    me.stop_failed_project_skill_watcher(path, ctx);
+                    me.push_authoritative_project_skill_snapshot(path, ctx);
+                    me.push_authoritative_project_rule_snapshot(path.clone(), ctx);
+                }
+                RepoMetadataEvent::LazyDisplayTreeUpdated { path } => {
+                    let repo_model = RepoMetadataModel::handle(ctx);
+                    if let Some(state) = repo_model.as_ref(ctx).get_lazy_display_tree(path, ctx) {
+                        let entries = super::repo_metadata_proto::file_tree_entry_to_snapshot_proto(
+                            &state.entry,
+                        );
+                        me.send_server_message(
+                            None,
+                            None,
+                            server_message::Message::RepoMetadataSnapshot(
+                                super::proto::RepoMetadataSnapshot {
+                                    repo_path: path.to_string(),
+                                    entries,
+                                    sync_complete: true,
+                                },
+                            ),
+                        );
+                    }
+                }
+                RepoMetadataEvent::UpdatingRepositoryFailed {
+                    id: RepositoryIdentifier::Local(path),
+                } => {
+                    let failed_path = path.clone();
+                    let repo_model = RepoMetadataModel::handle(ctx);
+                    repo_model.update(ctx, |repo_model, ctx| {
+                        if let Err(error) = repo_model.index_lazy_loaded_path(&failed_path, ctx) {
+                            log::warn!(
+                                "Failed to build display tree after repository indexing failed for {failed_path}: {error}"
+                            );
+                        }
+                    });
+                    me.push_failed_project_skill_snapshot(path, ctx);
+                    me.push_failed_project_rule_snapshot(path);
+                    me.watch_failed_project_skills(path, ctx);
+                }
+                RepoMetadataEvent::FileTreeEntryUpdated {
+                    id: RepositoryIdentifier::Local(path),
+                } => {
+                    me.push_authoritative_project_skill_snapshot(path, ctx);
                     me.push_authoritative_project_rule_snapshot(path.clone(), ctx);
                 }
                 RepoMetadataEvent::RepositoryRemoved {
                     id: RepositoryIdentifier::Local(path),
-                } => me.push_project_rule_snapshot(path, Vec::new()),
-                RepoMetadataEvent::UpdatingRepositoryFailed {
-                    id: RepositoryIdentifier::Local(path),
-                } => me.push_authoritative_project_rule_snapshot(path.clone(), ctx),
-                RepoMetadataEvent::FileTreeUpdated { .. }
+                } => {
+                    me.stop_failed_project_skill_watcher(path, ctx);
+                    me.push_project_skill_snapshot(path, Vec::new());
+                    me.push_project_rule_snapshot(path, Vec::new());
+                }
+                RepoMetadataEvent::RepositoryRemoved {
+                    id: RepositoryIdentifier::Remote(_),
+                }
+                | RepoMetadataEvent::FileTreeUpdated { .. }
                 | RepoMetadataEvent::FileTreeEntryUpdated {
                     id: RepositoryIdentifier::Remote(_),
                 }
-                | RepoMetadataEvent::RepositoryRemoved {
-                    id: RepositoryIdentifier::Remote(_),
-                }
+                | RepoMetadataEvent::LazyDisplayTreeRemoved { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed {
                     id: RepositoryIdentifier::Remote(_),
                 }
                 | RepoMetadataEvent::RepositoryUpdated {
                     id: RepositoryIdentifier::Remote(_),
                 } => {}
-                RepoMetadataEvent::FileTreeEntryUpdated {
-                    id: RepositoryIdentifier::Local(path),
-                } => me.push_authoritative_project_rule_snapshot(path.clone(), ctx),
             });
         }
         let index_manager = CodebaseIndexManager::handle(ctx);
@@ -845,25 +936,6 @@ impl ServerModel {
         );
     }
 
-    fn push_authoritative_project_rule_snapshot(
-        &mut self,
-        repo_path: StandardizedPath,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let Some(local_path) = repo_path.to_local_path() else {
-            return;
-        };
-        ctx.spawn(
-            async move { ProjectContextModel::read_project_rules_from_metadata_root(&local_path).await },
-            move |me, rules, _ctx| match rules {
-                Ok(rules) => me.push_project_rule_snapshot(&repo_path, rules),
-                Err(error) => {
-                    log::warn!("Failed to build daemon project-rule snapshot: {error:#}");
-                }
-            },
-        );
-    }
-
     fn push_project_rule_snapshot(&self, repo_path: &StandardizedPath, rules: Vec<ProjectRule>) {
         let files = rules
             .into_iter()
@@ -1258,6 +1330,143 @@ impl ServerModel {
         }
 
         Ok(())
+    }
+
+    fn push_authoritative_project_skill_snapshot(
+        &self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(local_path) = repo_path.to_local_path() else {
+            return;
+        };
+        self.push_project_skill_snapshot(
+            repo_path,
+            SkillWatcher::read_local_skills_for_repos(std::slice::from_ref(&local_path), ctx),
+        );
+    }
+
+    fn push_failed_project_skill_snapshot(
+        &self,
+        repo_path: &StandardizedPath,
+        _ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(local_path) = repo_path.to_local_path() else {
+            return;
+        };
+        self.push_project_skill_snapshot(
+            repo_path,
+            SkillWatcher::read_failed_local_project_skills(&local_path),
+        );
+    }
+
+    fn push_authoritative_project_rule_snapshot(
+        &mut self,
+        repo_path: StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(local_path) = repo_path.to_local_path() else {
+            return;
+        };
+        ctx.spawn(
+            async move { ProjectContextModel::read_project_rules_from_metadata_root(&local_path).await },
+            move |me, rules, _ctx| match rules {
+                Ok(rules) => me.push_project_rule_snapshot(&repo_path, rules),
+                Err(error) => {
+                    log::warn!("Failed to build daemon project-rule snapshot: {error:#}");
+                }
+            },
+        );
+    }
+
+    fn push_failed_project_rule_snapshot(&self, repo_path: &StandardizedPath) {
+        let Some(local_path) = repo_path.to_local_path() else {
+            return;
+        };
+        self.push_project_rule_snapshot(
+            repo_path,
+            ProjectContextModel::read_project_rule_snapshot_from_filesystem_fallback(&local_path),
+        );
+    }
+
+    fn push_project_skill_snapshot(&self, repo_path: &StandardizedPath, skills: Vec<ParsedSkill>) {
+        let files = skills
+            .into_iter()
+            .filter_map(|skill| {
+                Some(ProjectContextFile {
+                    path: skill.path.to_local_path()?.to_string_lossy().to_string(),
+                    content: skill.content,
+                })
+            })
+            .collect();
+        self.send_server_message(
+            None,
+            None,
+            server_message::Message::ProjectContextFilesSnapshot(ProjectContextFilesSnapshot {
+                repo_path: repo_path.to_string(),
+                kind: ProjectContextFileKind::ProjectSkills.into(),
+                files,
+            }),
+        );
+    }
+
+    fn watch_failed_project_skills(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.failed_project_skill_watchers.contains_key(repo_path) {
+            return;
+        }
+        let Some(local_path) = repo_path.to_local_path() else {
+            return;
+        };
+        let Some(repo_handle) =
+            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(&local_path, ctx)
+        else {
+            log::warn!(
+                "Cannot watch failed remote project-skill repository {repo_path}; repository is not registered"
+            );
+            return;
+        };
+        let repo_path_for_subscriber = repo_path.clone();
+        let message_tx = self.project_skill_refresh_tx.clone();
+        let start = repo_handle.update(ctx, |repository, ctx| {
+            repository.start_watching(
+                Box::new(FailedProjectSkillSubscriber {
+                    repo_path: repo_path_for_subscriber,
+                    message_tx,
+                }),
+                ctx,
+            )
+        });
+        let subscriber_id = start.subscriber_id;
+        self.failed_project_skill_watchers
+            .insert(repo_path.clone(), (repo_handle, subscriber_id));
+        let repo_path = repo_path.clone();
+        ctx.spawn(start.registration_future, move |me, result, ctx| {
+            if let Err(error) = result {
+                log::warn!(
+                    "Failed to watch remote project-skill fallback repository {repo_path}: {error}"
+                );
+                me.stop_failed_project_skill_watcher(&repo_path, ctx);
+            }
+        });
+    }
+
+    fn stop_failed_project_skill_watcher(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some((repo_handle, subscriber_id)) =
+            self.failed_project_skill_watchers.remove(repo_path)
+        else {
+            return;
+        };
+        repo_handle.update(ctx, |repository, ctx| {
+            repository.stop_watching(subscriber_id, ctx);
+        });
     }
 
     /// Routes a server message to its destination.
@@ -1789,7 +1998,12 @@ impl ServerModel {
 
                     let id = RepositoryIdentifier::local(root_path.clone());
                     let repo_model = RepoMetadataModel::handle(ctx);
-                    if let Some(state) = repo_model.as_ref(ctx).get_repository(&id, ctx) {
+                    let state = repo_model.as_ref(ctx).get_repository(&id, ctx).or_else(|| {
+                        repo_model
+                            .as_ref(ctx)
+                            .get_lazy_display_tree(&root_path, ctx)
+                    });
+                    if let Some(state) = state {
                         let entries = super::repo_metadata_proto::file_tree_entry_to_snapshot_proto(
                             &state.entry,
                         );
@@ -1890,9 +2104,15 @@ impl ServerModel {
 
         // Read back the loaded children and serialize them.
         let id = RepositoryIdentifier::local(repo_path.clone());
-        let entries = RepoMetadataModel::handle(ctx)
+        let repo_model = RepoMetadataModel::handle(ctx);
+        let entries = repo_model
             .as_ref(ctx)
             .get_repository(&id, ctx)
+            .or_else(|| {
+                repo_model
+                    .as_ref(ctx)
+                    .get_lazy_display_tree(&repo_path, ctx)
+            })
             .map(|state| {
                 super::repo_metadata_proto::file_tree_children_to_proto_entries(
                     &state.entry,

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ai::project_context::model::ProjectRule;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
 use super::super::diff_state_tracker::RemoteDiffStateManager;
-use super::super::proto::{Authenticate, Initialize};
+use super::super::proto::{server_message, Authenticate, Initialize, ProjectContextFileKind};
 use super::super::server_buffer_tracker::ServerBufferTracker;
 use super::{PendingFileOps, ServerModel};
 use crate::auth::auth_state::AuthState;
@@ -44,6 +46,49 @@ fn fresh_model_starts_without_auth_token() {
         assert_eq!(model.auth_token().as_deref(), None);
         assert_eq!(model.auth_state.user_id(), None);
         assert_eq!(model.auth_state.user_email(), None);
+    });
+}
+
+#[test]
+fn project_rule_snapshot_serializes_typed_context_files() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        let (message_tx, message_rx) = async_channel::unbounded();
+        model
+            .connection_senders
+            .insert(uuid::Uuid::new_v4(), message_tx);
+
+        let repo_path = StandardizedPath::try_new("/repo").unwrap();
+        model.push_project_rule_snapshot(
+            &repo_path,
+            vec![ProjectRule {
+                path: LocalOrRemotePath::Local("/repo/WARP.md".into()),
+                content: "server rule".to_string(),
+            }],
+        );
+
+        let message = message_rx.recv().await.unwrap();
+        match message.message.unwrap() {
+            server_message::Message::ProjectContextFilesSnapshot(snapshot) => {
+                assert_eq!(snapshot.repo_path, "/repo");
+                assert_eq!(snapshot.kind, ProjectContextFileKind::ProjectRules as i32);
+                assert_eq!(snapshot.files[0].path, "/repo/WARP.md");
+                assert_eq!(snapshot.files[0].content, "server rule");
+            }
+            other => panic!("expected a project-context snapshot, got {other:?}"),
+        }
+
+        model.push_project_rule_snapshot(&repo_path, Vec::new());
+
+        let message = message_rx.recv().await.unwrap();
+        match message.message.unwrap() {
+            server_message::Message::ProjectContextFilesSnapshot(snapshot) => {
+                assert_eq!(snapshot.repo_path, "/repo");
+                assert_eq!(snapshot.kind, ProjectContextFileKind::ProjectRules as i32);
+                assert!(snapshot.files.is_empty());
+            }
+            other => panic!("expected an empty project-context snapshot, got {other:?}"),
+        }
     });
 }
 

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -15,6 +15,7 @@ use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
 
 fn test_model(app: &mut App) -> ServerModel {
+    let (project_skill_refresh_tx, _) = async_channel::unbounded();
     ServerModel {
         connection_senders: HashMap::new(),
         snapshot_sent_roots_by_connection: HashMap::new(),
@@ -26,6 +27,8 @@ fn test_model(app: &mut App) -> ServerModel {
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
         buffers: ServerBufferTracker::new(),
         diff_states: app.add_model(|_| RemoteDiffStateManager::new()),
+        failed_project_skill_watchers: HashMap::new(),
+        project_skill_refresh_tx,
     }
 }
 

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -58,6 +58,8 @@ impl FileSearchModel {
                 }
                 RepoMetadataEvent::FileTreeEntryUpdated { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
+                | RepoMetadataEvent::LazyDisplayTreeUpdated { .. }
+                | RepoMetadataEvent::LazyDisplayTreeRemoved { .. }
                 | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
             },
         );

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -173,6 +173,7 @@ impl Sessions {
                 | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                 | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
                 | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+                | RemoteServerManagerEvent::ProjectContextFilesSnapshot { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
                 | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4643,6 +4643,7 @@ impl TerminalView {
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+                    | RemoteServerManagerEvent::ProjectContextFilesSnapshot { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
                     | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -142,6 +142,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+            | RemoteServerManagerEvent::ProjectContextFilesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
             | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -1,4 +1,5 @@
 use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
+use remote_server::manager::RemoteServerManager;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
 #[cfg(feature = "local_fs")]
@@ -132,6 +133,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(RepoOutlines::new_for_test);
     app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
     app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+    app.add_singleton_model(RemoteServerManager::new);
     app.add_singleton_model(SkillManager::new);
     app.add_singleton_model(|ctx| {
         CodebaseIndexManager::new_for_test(ServerApiProvider::as_ref(ctx).get(), ctx)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5740,28 +5740,42 @@ impl Workspace {
                 self.show_settings_with_section(Some(SettingsSection::WarpAgent), ctx);
             }
             #[allow(unused_variables)]
-            AIFactViewEvent::OpenFile(path) => {
+            AIFactViewEvent::OpenFile(location) => {
                 #[cfg(feature = "local_fs")]
                 {
-                    let settings = EditorSettings::as_ref(ctx);
-                    let target = resolve_file_target_with_editor_choice(
-                        path,
-                        *settings.open_file_editor,
-                        *settings.prefer_markdown_viewer,
-                        *settings.open_file_layout,
-                        None,
-                    );
-                    self.open_file_with_target(
-                        path.clone(),
-                        target,
-                        None,
-                        CodeSource::Link {
-                            path: path.clone(),
-                            range_start: None,
-                            range_end: None,
-                        },
-                        ctx,
-                    );
+                    match location {
+                        LocalOrRemotePath::Local(path) => {
+                            let settings = EditorSettings::as_ref(ctx);
+                            let target = resolve_file_target_with_editor_choice(
+                                path,
+                                *settings.open_file_editor,
+                                *settings.prefer_markdown_viewer,
+                                *settings.open_file_layout,
+                                None,
+                            );
+                            self.open_file_with_target(
+                                path.clone(),
+                                target,
+                                None,
+                                CodeSource::ProjectRules {
+                                    location: location.clone(),
+                                },
+                                ctx,
+                            );
+                        }
+                        LocalOrRemotePath::Remote(_) => {
+                            self.open_code(
+                                CodeSource::ProjectRules {
+                                    location: location.clone(),
+                                },
+                                EditorLayout::SplitPane,
+                                None,
+                                false,
+                                &[],
+                                ctx,
+                            );
+                        }
+                    }
                 }
             }
             AIFactViewEvent::InitializeProject(path) => {

--- a/crates/ai/src/project_context/global_rules.rs
+++ b/crates/ai/src/project_context/global_rules.rs
@@ -7,6 +7,7 @@ use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use warp_core::safe_warn;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::{ModelContext, ModelHandle, SingletonEntity};
 use watcher::{HomeDirectoryWatcher, HomeDirectoryWatcherEvent};
@@ -85,7 +86,8 @@ impl GlobalRules {
         self.rules
             .values()
             .next()
-            .and_then(|rule| rule.path.parent().map(|p| p.to_path_buf()))
+            .and_then(|rule| rule.path.parent())
+            .and_then(|parent| parent.to_local_path().map(Path::to_path_buf))
     }
 
     /// Index all configured global rule sources (see [`GlobalRuleSource`]).
@@ -159,7 +161,7 @@ impl GlobalRules {
                     me.global_rules.rules.insert(
                         file_path.clone(),
                         ProjectRule {
-                            path: file_path.clone(),
+                            path: LocalOrRemotePath::Local(file_path.clone()),
                             content,
                         },
                     );

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -762,11 +762,15 @@ impl ProjectContextModel {
     /// Uses repo_metadata::entry::build_tree for efficient directory traversal
     #[cfg(feature = "local_fs")]
     async fn scan_directory_for_rules(dir_path: &Path) -> Result<ProjectRules> {
+        Self::scan_directory_for_rules_sync(dir_path)
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn scan_directory_for_rules_sync(dir_path: &Path) -> Result<ProjectRules> {
         use repo_metadata::entry::IgnoredPathStrategy;
 
         let mut rule_files = ProjectRules::default();
-
-        if !async_fs::metadata(dir_path).await?.is_dir() {
+        if !std::fs::metadata(dir_path)?.is_dir() {
             return Ok(rule_files);
         }
 
@@ -801,7 +805,7 @@ impl ProjectContextModel {
                 if matches_rules_pattern(file_name_str) {
                     // Read the content of the rule file
                     let local_path = file_metadata.path.to_local_path_lossy();
-                    let content = match async_fs::read_to_string(&local_path).await {
+                    let content = match std::fs::read_to_string(&local_path) {
                         Ok(content) => content,
                         Err(e) => {
                             log::warn!("Failed to read rule file {}: {e}", file_metadata.path,);
@@ -830,6 +834,21 @@ impl ProjectContextModel {
             .flat_map(|rule| [rule.warp_md, rule.agents_md])
             .flatten()
             .collect())
+    }
+    /// Reads the full fallback rule set using the same policy as local failed-index discovery.
+    #[cfg(feature = "local_fs")]
+    pub fn read_project_rule_snapshot_from_filesystem_fallback(
+        dir_path: &Path,
+    ) -> Vec<ProjectRule> {
+        let Ok(rules) = Self::scan_directory_for_rules_sync(dir_path) else {
+            return Vec::new();
+        };
+        rules
+            .rules
+            .into_iter()
+            .flat_map(|rules| [rules.warp_md, rules.agents_md])
+            .flatten()
+            .collect()
     }
 
     #[cfg(feature = "local_fs")]
@@ -954,16 +973,25 @@ impl ProjectContextModel {
             ctx,
         );
     }
+
     pub fn clear_remote_project_rules_for_host(
         &mut self,
         host_id: &HostId,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.path_to_rules.retain(|root, _| match root {
-            LocalOrRemotePath::Remote(path) => path.host_id != *host_id,
-            LocalOrRemotePath::Local(_) => true,
-        });
-        ctx.emit(ProjectContextModelEvent::PathIndexed);
+        let remote_roots = self
+            .path_to_rules
+            .keys()
+            .filter_map(|root_path| match root_path {
+                LocalOrRemotePath::Remote(remote_root) if remote_root.host_id == *host_id => {
+                    Some(remote_root.clone())
+                }
+                LocalOrRemotePath::Local(_) | LocalOrRemotePath::Remote(_) => None,
+            })
+            .collect::<Vec<_>>();
+        for remote_root in remote_roots {
+            self.clear_remote_project_rules_for_removed_metadata_root(remote_root, ctx);
+        }
     }
 
     fn group_project_rules(rules: Vec<ProjectRule>) -> ProjectRules {

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -6,6 +6,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 #[cfg(feature = "local_fs")]
 use repo_metadata::repositories::RepoDetectionSource;
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
 use warpui::{Entity, ModelContext, SingletonEntity};
 
 use super::GlobalRules;
@@ -15,8 +18,9 @@ cfg_if::cfg_if! {
         use async_channel::Sender;
         use ignore::gitignore::Gitignore;
         use repo_metadata::entry::{Entry, FileMetadata};
-        use repo_metadata::repository::RepositorySubscriber;
+        use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
         use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate};
+        use warpui::ModelHandle;
 
         const RULES_FILE_PATTERN: [&str; 2] = ["WARP.md", "AGENTS.md"];
         const MAX_SCAN_DEPTH: usize = 3;
@@ -24,15 +28,15 @@ cfg_if::cfg_if! {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ProjectRule {
-    pub path: PathBuf,
+    pub path: LocalOrRemotePath,
     pub content: String,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 struct RuleAtPath {
-    parent_path: PathBuf,
+    parent_path: LocalOrRemotePath,
     warp_md: Option<ProjectRule>,
     agents_md: Option<ProjectRule>,
 }
@@ -43,9 +47,9 @@ impl RuleAtPath {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ProjectRulesResult {
-    pub root_path: PathBuf,
+    pub root_path: LocalOrRemotePath,
     pub active_rules: Vec<ProjectRule>,
     pub additional_rule_paths: Vec<String>,
 }
@@ -81,7 +85,7 @@ struct ProjectRules {
 
 impl ProjectRules {
     /// Finds the set of rules that are active in the given path and the set that are available to be applied.
-    fn find_active_or_applicable_rules(&self, path: &Path) -> FindRulesResult {
+    fn find_active_or_applicable_rules(&self, path: &LocalOrRemotePath) -> FindRulesResult {
         let mut active_rules = Vec::new();
         let mut available_rule_paths = Vec::new();
 
@@ -92,7 +96,7 @@ impl ProjectRules {
                 if path.starts_with(&rule.parent_path) {
                     active_rules.push(respected_rule.clone());
                 } else {
-                    available_rule_paths.push(respected_rule.path.to_string_lossy().to_string());
+                    available_rule_paths.push(respected_rule.path.display_path());
                 }
             }
         }
@@ -105,9 +109,9 @@ impl ProjectRules {
 
     /// Remove a rule from the set of project rules. This returns the removed rule.
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
-    fn remove_rule(&mut self, path: &Path) -> Option<ProjectRule> {
+    fn remove_rule(&mut self, path: &LocalOrRemotePath) -> Option<ProjectRule> {
         let parent = path.parent()?;
-        let file_name = path.file_name().and_then(|name| name.to_str())?;
+        let file_name = path.file_name()?;
 
         let rule = self
             .rules
@@ -126,11 +130,11 @@ impl ProjectRules {
     /// Upsert a rule to the set of project rules. This will create a new RuleAtPath entry if none exists and update the existing one
     /// otherwise.
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
-    fn upsert_rule(&mut self, path: &Path, content: String) {
+    fn upsert_rule(&mut self, path: &LocalOrRemotePath, content: String) {
         let Some(parent) = path.parent() else {
             return;
         };
-        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        let Some(file_name) = path.file_name() else {
             return;
         };
 
@@ -140,7 +144,7 @@ impl ProjectRules {
             .find(|rule| rule.parent_path == parent);
 
         let rule_file = Some(ProjectRule {
-            path: path.to_path_buf(),
+            path: path.clone(),
             content,
         });
 
@@ -154,8 +158,9 @@ impl ProjectRules {
             }
             None => {
                 let mut rule = RuleAtPath {
-                    parent_path: parent.to_path_buf(),
-                    ..Default::default()
+                    parent_path: parent,
+                    warp_md: None,
+                    agents_md: None,
                 };
                 if file_name.to_lowercase() == "warp.md" {
                     rule.warp_md = rule_file;
@@ -174,16 +179,27 @@ impl ProjectRules {
 #[derive(Debug, Default)]
 pub struct ProjectContextModel {
     /// Mapping from directory path to list of rule files found in that directory
-    path_to_rules: HashMap<PathBuf, ProjectRules>,
+    path_to_rules: HashMap<LocalOrRemotePath, ProjectRules>,
     /// Queued repository updates for paths that have an in-flight processing task.
     /// The presence of a key indicates an active async task for that path;
     /// the Vec holds updates that arrived while that task was running.
     #[cfg(feature = "local_fs")]
     pending_updates: HashMap<PathBuf, Vec<RepositoryUpdate>>,
+    /// Most recent full filesystem scan generation for each local root, so a slower older
+    /// fallback scan cannot replace newer rule state.
+    #[cfg(feature = "local_fs")]
+    local_scan_generations: HashMap<PathBuf, u64>,
+    #[cfg(feature = "local_fs")]
+    next_local_scan_generation: u64,
     /// Repo roots that already have a watcher registered, so we never
     /// subscribe more than once per root.
     #[cfg(feature = "local_fs")]
-    watched_roots: HashSet<PathBuf>,
+    watched_roots: HashMap<PathBuf, (ModelHandle<Repository>, SubscriberId)>,
+    /// Local roots whose rule state is owned by metadata and therefore must not be modified by
+    /// fallback filesystem scans or watchers. A removed metadata root remains here with empty
+    /// rule state until an explicit fallback refresh selects filesystem ownership again.
+    #[cfg(feature = "local_fs")]
+    local_roots_with_metadata_owned_rule_state: HashSet<PathBuf>,
     /// File-based global rules and their local watcher state. Kept separate
     /// from `path_to_rules`, which is project-scoped.
     pub(super) global_rules: GlobalRules,
@@ -251,8 +267,10 @@ impl ProjectContextModel {
         ctx.spawn(
             async move { Self::read_persisted_rules(persisted_rules).await },
             |me, mut res, ctx| {
-                for root in res.keys() {
-                    me.try_initialize_and_register_watcher(root, ctx);
+                for root in res.keys().filter_map(LocalOrRemotePath::to_local_path) {
+                    if !me.local_roots_with_metadata_owned_rule_state.contains(root) {
+                        me.try_initialize_and_register_watcher(root, ctx);
+                    }
                 }
 
                 // If we have any rules detected before fully loading the persisted rules, we want to
@@ -277,36 +295,51 @@ impl ProjectContextModel {
         #[cfg(feature = "local_fs")]
         {
             let root_clone = root_path.clone();
+            self.next_local_scan_generation += 1;
+            let scan_generation = self.next_local_scan_generation;
+            self.local_scan_generations
+                .insert(root_clone.clone(), scan_generation);
 
             ctx.spawn(
                 async move { Self::scan_directory_for_rules(&root_path).await },
                 move |me, res: Result<ProjectRules>, ctx| match res {
                     Ok(rule_files) => {
+                        if me
+                            .local_roots_with_metadata_owned_rule_state
+                            .contains(&root_clone)
+                            || me.local_scan_generations.get(&root_clone) != Some(&scan_generation)
+                        {
+                            return;
+                        }
                         me.register_watcher_for_path(&root_clone, ctx);
 
                         // Persist the discovered rules.
+                        let previous_paths = me
+                            .path_to_rules
+                            .get(&LocalOrRemotePath::Local(root_clone.clone()))
+                            .map(Self::local_rule_paths)
+                            .unwrap_or_default();
+                        let current_paths = Self::local_rule_paths(&rule_files);
                         let delta = RulesDelta {
-                            discovered_rules: rule_files
-                                .rules
-                                .iter()
-                                .filter_map(|rule| {
-                                    rule.warp_md.as_ref().map(|rule| ProjectRulePath {
-                                        project_root: root_clone.clone(),
-                                        path: rule.path.clone(),
-                                    })
+                            discovered_rules: current_paths
+                                .difference(&previous_paths)
+                                .cloned()
+                                .map(|path| ProjectRulePath {
+                                    project_root: root_clone.clone(),
+                                    path,
                                 })
-                                .chain(rule_files.rules.iter().filter_map(|rule| {
-                                    rule.agents_md.as_ref().map(|rule| ProjectRulePath {
-                                        project_root: root_clone.clone(),
-                                        path: rule.path.clone(),
-                                    })
-                                }))
                                 .collect(),
-                            deleted_rules: Default::default(),
+                            deleted_rules: previous_paths
+                                .difference(&current_paths)
+                                .cloned()
+                                .collect(),
                         };
-                        ctx.emit(ProjectContextModelEvent::KnownRulesChanged(delta));
+                        if !delta.discovered_rules.is_empty() || !delta.deleted_rules.is_empty() {
+                            ctx.emit(ProjectContextModelEvent::KnownRulesChanged(delta));
+                        }
 
-                        me.path_to_rules.insert(root_clone, rule_files);
+                        me.path_to_rules
+                            .insert(LocalOrRemotePath::Local(root_clone), rule_files);
                         ctx.emit(ProjectContextModelEvent::PathIndexed);
                     }
                     Err(e) => log::warn!(
@@ -355,7 +388,11 @@ impl ProjectContextModel {
 
     #[cfg(feature = "local_fs")]
     fn register_watcher_for_path(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
-        if self.watched_roots.contains(path) {
+        if self.watched_roots.contains_key(path)
+            || self
+                .local_roots_with_metadata_owned_rule_state
+                .contains(path)
+        {
             return;
         }
 
@@ -364,8 +401,6 @@ impl ProjectContextModel {
         else {
             return;
         };
-
-        self.watched_roots.insert(path.to_path_buf());
 
         let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
         let start = repository_model.update(ctx, |repo, ctx| {
@@ -378,17 +413,23 @@ impl ProjectContextModel {
         });
 
         let subscriber_id = start.subscriber_id;
-        let repository_model_for_cleanup = repository_model.downgrade();
+        self.watched_roots.insert(
+            path.to_path_buf(),
+            (repository_model.clone(), subscriber_id),
+        );
         let path_clone = path.to_path_buf();
         let path_for_log = path_clone.clone();
-        ctx.spawn(start.registration_future, move |_, res, ctx| {
+        let path_for_cleanup = path_clone.clone();
+        ctx.spawn(start.registration_future, move |me, res, ctx| {
             if let Err(err) = res {
                 log::warn!(
                     "Failed to start watching repository for rule updates at {}: {err}",
                     path_for_log.display()
                 );
 
-                if let Some(repository_model) = repository_model_for_cleanup.upgrade(ctx) {
+                if let Some((repository_model, subscriber_id)) =
+                    me.watched_roots.remove(&path_for_cleanup)
+                {
                     repository_model.update(ctx, |repo, ctx| {
                         repo.stop_watching(subscriber_id, ctx);
                     });
@@ -410,7 +451,8 @@ impl ProjectContextModel {
                     return;
                 }
 
-                let Some(rules) = me.path_to_rules.get(&path_clone).cloned() else {
+                let path_location = LocalOrRemotePath::Local(path_clone.clone());
+                let Some(rules) = me.path_to_rules.get(&path_location).cloned() else {
                     return;
                 };
 
@@ -430,6 +472,18 @@ impl ProjectContextModel {
         );
     }
 
+    #[cfg(feature = "local_fs")]
+    fn stop_watcher_for_path(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
+        let Some((repository_model, subscriber_id)) = self.watched_roots.remove(path) else {
+            return;
+        };
+
+        repository_model.update(ctx, |repo, ctx| {
+            repo.stop_watching(subscriber_id, ctx);
+        });
+        self.pending_updates.remove(path);
+    }
+
     /// Called when an async update task completes: emits events, stores the new rules,
     /// and drains any updates that queued up while the task was in flight.
     #[cfg(feature = "local_fs")]
@@ -440,10 +494,27 @@ impl ProjectContextModel {
         rule_delta: RulesDelta,
         ctx: &mut ModelContext<Self>,
     ) {
+        if self
+            .local_roots_with_metadata_owned_rule_state
+            .contains(path)
+        {
+            self.pending_updates.remove(path);
+            return;
+        }
         ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
-        self.path_to_rules.insert(path.to_path_buf(), rules);
+        self.path_to_rules
+            .insert(LocalOrRemotePath::Local(path.to_path_buf()), rules);
         self.drain_pending_updates(path, ctx);
         ctx.emit(ProjectContextModelEvent::PathIndexed);
+    }
+
+    /// Selects direct filesystem scanning and watching for a local root whose repository
+    /// metadata cannot safely provide complete project-rule discovery.
+    #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
+    pub fn use_local_filesystem_rule_fallback_for_root(&mut self, root_path: &Path) {
+        #[cfg(feature = "local_fs")]
+        self.local_roots_with_metadata_owned_rule_state
+            .remove(root_path);
     }
 
     /// Processes any queued updates for a path after the previous async task completes.
@@ -461,7 +532,8 @@ impl ProjectContextModel {
         }
 
         let updates = std::mem::take(queued);
-        let Some(rules) = self.path_to_rules.get(&path_buf).cloned() else {
+        let path_location = LocalOrRemotePath::Local(path_buf.clone());
+        let Some(rules) = self.path_to_rules.get(&path_location).cloned() else {
             self.pending_updates.remove(&path_buf);
             return;
         };
@@ -503,7 +575,16 @@ impl ProjectContextModel {
     /// Use this for callers that need a project-initialization signal rather
     /// than the full rule context sent to agents.
     pub fn find_applicable_project_rules(&self, path: &Path) -> Option<ProjectRulesResult> {
-        let mut current_path = path.to_owned();
+        self.find_applicable_project_rules_at_location(&LocalOrRemotePath::Local(
+            path.to_path_buf(),
+        ))
+    }
+
+    pub fn find_applicable_project_rules_at_location(
+        &self,
+        path: &LocalOrRemotePath,
+    ) -> Option<ProjectRulesResult> {
+        let mut current_path = path.clone();
 
         // Walk upwards from `path` toward the filesystem root, stopping at the
         // first directory we have indexed project rules for. `path_to_rules`
@@ -523,9 +604,8 @@ impl ProjectContextModel {
                 });
             }
 
-            if !current_path.pop() {
-                return None;
-            }
+            let parent = current_path.parent()?;
+            current_path = parent;
         }
     }
 
@@ -542,7 +622,14 @@ impl ProjectContextModel {
     /// a project-only signal should use
     /// [`Self::find_applicable_project_rules`] instead.
     pub fn find_applicable_rules(&self, path: &Path) -> Option<ProjectRulesResult> {
-        let project_result = self.find_applicable_project_rules(path);
+        self.find_applicable_rules_at_location(&LocalOrRemotePath::Local(path.to_path_buf()))
+    }
+
+    pub fn find_applicable_rules_at_location(
+        &self,
+        path: &LocalOrRemotePath,
+    ) -> Option<ProjectRulesResult> {
+        let project_result = self.find_applicable_project_rules_at_location(path);
 
         // Layered precedence: global rules are always included alongside
         // project rules. `global_rules` is a `BTreeMap`, so iteration is
@@ -563,8 +650,9 @@ impl ProjectContextModel {
 
         // Use the indexed project root when available; otherwise fall back to
         // the parent of the first global rule (or empty).
-        let root_path = project_root
-            .unwrap_or_else(|| self.global_rules.first_rule_parent().unwrap_or_default());
+        let root_path = project_root.unwrap_or_else(|| {
+            LocalOrRemotePath::Local(self.global_rules.first_rule_parent().unwrap_or_default())
+        });
 
         Some(ProjectRulesResult {
             root_path,
@@ -590,7 +678,7 @@ impl ProjectContextModel {
             {
                 if matches_rules_pattern(file_name_str) {
                     // Remove the rule from existing rules
-                    existing_rules.remove_rule(&target_file.path);
+                    existing_rules.remove_rule(&LocalOrRemotePath::Local(target_file.path.clone()));
                     rules_delta.deleted_rules.push(target_file.path.clone());
 
                     log::debug!("Removed rule file: {}", target_file.path.display());
@@ -607,11 +695,16 @@ impl ProjectContextModel {
             if let Some(file_name_str) = to_target.path.file_name().and_then(|name| name.to_str()) {
                 if matches_rules_pattern(file_name_str) {
                     // Find and update the rule with the old path
-                    if let Some(rule) = existing_rules.remove_rule(&from_target.path) {
+                    if let Some(rule) = existing_rules
+                        .remove_rule(&LocalOrRemotePath::Local(from_target.path.clone()))
+                    {
                         // Emit deletion event for old path
                         rules_delta.deleted_rules.push(from_target.path.clone());
 
-                        existing_rules.upsert_rule(&to_target.path, rule.content);
+                        existing_rules.upsert_rule(
+                            &LocalOrRemotePath::Local(to_target.path.clone()),
+                            rule.content,
+                        );
 
                         // Emit upsert event for new path
                         rules_delta.discovered_rules.push(ProjectRulePath {
@@ -641,7 +734,10 @@ impl ProjectContextModel {
                     // Read the content of the rule file
                     match async_fs::read_to_string(&target_file.path).await {
                         Ok(content) => {
-                            existing_rules.upsert_rule(&target_file.path, content);
+                            existing_rules.upsert_rule(
+                                &LocalOrRemotePath::Local(target_file.path.clone()),
+                                content,
+                            );
                             rules_delta.discovered_rules.push(ProjectRulePath {
                                 path: target_file.path.clone(),
                                 project_root: project_root.clone(),
@@ -713,7 +809,7 @@ impl ProjectContextModel {
                         }
                     };
 
-                    rule_files.upsert_rule(&local_path, content);
+                    rule_files.upsert_rule(&LocalOrRemotePath::Local(local_path), content);
                 }
             }
         }
@@ -721,17 +817,34 @@ impl ProjectContextModel {
         Ok(rule_files)
     }
 
+    /// Reads project-rule contents for a metadata-tracked repository without
+    /// consulting the generic repository file-tree/display surface.
+    #[cfg(feature = "local_fs")]
+    pub async fn read_project_rules_from_metadata_root(
+        dir_path: &Path,
+    ) -> Result<Vec<ProjectRule>> {
+        let project_rules = Self::scan_directory_for_rules(dir_path).await?;
+        Ok(project_rules
+            .rules
+            .into_iter()
+            .flat_map(|rule| [rule.warp_md, rule.agents_md])
+            .flatten()
+            .collect())
+    }
+
     #[cfg(feature = "local_fs")]
     async fn read_persisted_rules(
         rule_paths: Vec<ProjectRulePath>,
-    ) -> HashMap<PathBuf, ProjectRules> {
-        let mut rules: HashMap<PathBuf, ProjectRules> = HashMap::new();
+    ) -> HashMap<LocalOrRemotePath, ProjectRules> {
+        let mut rules: HashMap<LocalOrRemotePath, ProjectRules> = HashMap::new();
 
         for rule in rule_paths {
             match async_fs::read_to_string(&rule.path).await {
                 Ok(content) => {
-                    let existing_rules = rules.entry(rule.project_root).or_default();
-                    existing_rules.upsert_rule(&rule.path, content);
+                    let existing_rules = rules
+                        .entry(LocalOrRemotePath::Local(rule.project_root))
+                        .or_default();
+                    existing_rules.upsert_rule(&LocalOrRemotePath::Local(rule.path), content);
                 }
                 Err(e) => {
                     log::debug!(
@@ -747,7 +860,7 @@ impl ProjectContextModel {
         rules
     }
 
-    pub fn indexed_rules(&self) -> impl Iterator<Item = PathBuf> + '_ {
+    pub fn indexed_rules(&self) -> impl Iterator<Item = LocalOrRemotePath> + '_ {
         self.path_to_rules.values().flat_map(|rules| {
             rules.rules.iter().filter_map(|rules| {
                 rules
@@ -766,14 +879,152 @@ impl ProjectContextModel {
     /// Returns the rule file paths associated with a specific workspace root path.
     pub fn rules_for_workspace(&self, workspace_path: &Path) -> Vec<PathBuf> {
         self.path_to_rules
-            .get(workspace_path)
+            .get(&LocalOrRemotePath::Local(workspace_path.to_path_buf()))
             .into_iter()
             .flat_map(|rules| {
                 rules.rules.iter().filter_map(|rule| {
-                    rule.respected_rule()
-                        .map(|project_rule| project_rule.path.clone())
+                    rule.respected_rule().and_then(|project_rule| {
+                        project_rule.path.to_local_path().map(Path::to_path_buf)
+                    })
                 })
             })
+            .collect()
+    }
+
+    pub fn replace_local_project_rules_from_metadata(
+        &mut self,
+        local_root: PathBuf,
+        rules: Vec<ProjectRule>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let root_path = LocalOrRemotePath::Local(local_root.clone());
+        let project_rules = Self::group_project_rules(rules);
+
+        #[cfg(feature = "local_fs")]
+        self.transition_local_project_rules_to_metadata_ownership(
+            &local_root,
+            &root_path,
+            &project_rules,
+            ctx,
+        );
+
+        self.replace_indexed_project_rules(root_path, project_rules, ctx);
+    }
+
+    pub fn replace_remote_project_rules_from_metadata(
+        &mut self,
+        remote_root: RemotePath,
+        rules: Vec<ProjectRule>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.replace_indexed_project_rules(
+            LocalOrRemotePath::Remote(remote_root),
+            Self::group_project_rules(rules),
+            ctx,
+        );
+    }
+
+    pub fn clear_local_project_rules_for_removed_metadata_root(
+        &mut self,
+        local_root: PathBuf,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let root_path = LocalOrRemotePath::Local(local_root.clone());
+        let project_rules = ProjectRules::default();
+
+        #[cfg(feature = "local_fs")]
+        self.transition_local_project_rules_to_metadata_ownership(
+            &local_root,
+            &root_path,
+            &project_rules,
+            ctx,
+        );
+
+        self.replace_indexed_project_rules(root_path, project_rules, ctx);
+    }
+
+    pub fn clear_remote_project_rules_for_removed_metadata_root(
+        &mut self,
+        remote_root: RemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.replace_indexed_project_rules(
+            LocalOrRemotePath::Remote(remote_root),
+            ProjectRules::default(),
+            ctx,
+        );
+    }
+    pub fn clear_remote_project_rules_for_host(
+        &mut self,
+        host_id: &HostId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.path_to_rules.retain(|root, _| match root {
+            LocalOrRemotePath::Remote(path) => path.host_id != *host_id,
+            LocalOrRemotePath::Local(_) => true,
+        });
+        ctx.emit(ProjectContextModelEvent::PathIndexed);
+    }
+
+    fn group_project_rules(rules: Vec<ProjectRule>) -> ProjectRules {
+        let mut project_rules = ProjectRules::default();
+        for rule in rules {
+            project_rules.upsert_rule(&rule.path, rule.content);
+        }
+        project_rules
+    }
+
+    fn replace_indexed_project_rules(
+        &mut self,
+        root_path: LocalOrRemotePath,
+        project_rules: ProjectRules,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.path_to_rules.insert(root_path, project_rules);
+        ctx.emit(ProjectContextModelEvent::PathIndexed);
+    }
+    #[cfg(feature = "local_fs")]
+    fn transition_local_project_rules_to_metadata_ownership(
+        &mut self,
+        local_root: &Path,
+        root_path: &LocalOrRemotePath,
+        project_rules: &ProjectRules,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.local_roots_with_metadata_owned_rule_state
+            .insert(local_root.to_path_buf());
+        self.local_scan_generations.remove(local_root);
+        let previous_paths = self
+            .path_to_rules
+            .get(root_path)
+            .map(Self::local_rule_paths)
+            .unwrap_or_default();
+        let current_paths = Self::local_rule_paths(project_rules);
+        let delta = RulesDelta {
+            discovered_rules: current_paths
+                .difference(&previous_paths)
+                .cloned()
+                .map(|path| ProjectRulePath {
+                    path,
+                    project_root: local_root.to_path_buf(),
+                })
+                .collect(),
+            deleted_rules: previous_paths.difference(&current_paths).cloned().collect(),
+        };
+        self.stop_watcher_for_path(local_root, ctx);
+        if !delta.discovered_rules.is_empty() || !delta.deleted_rules.is_empty() {
+            ctx.emit(ProjectContextModelEvent::KnownRulesChanged(delta));
+        }
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn local_rule_paths(rules: &ProjectRules) -> HashSet<PathBuf> {
+        rules
+            .rules
+            .iter()
+            .flat_map(|rule| [rule.warp_md.as_ref(), rule.agents_md.as_ref()])
+            .flatten()
+            .filter_map(|rule| rule.path.to_local_path().map(Path::to_path_buf))
             .collect()
     }
 }

--- a/crates/ai/src/project_context/model_tests.rs
+++ b/crates/ai/src/project_context/model_tests.rs
@@ -1,11 +1,41 @@
 use std::path::PathBuf;
 
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
+
+fn local_path(path: &str) -> LocalOrRemotePath {
+    LocalOrRemotePath::Local(PathBuf::from(path))
+}
+
+fn insert_remote_project_rule(
+    model: &mut ProjectContextModel,
+    host_id: &str,
+    project_root: &str,
+    rule_path: &str,
+    content: &str,
+) {
+    let rules = model
+        .path_to_rules
+        .entry(remote_path(host_id, project_root))
+        .or_default();
+    rules.upsert_rule(&remote_path(host_id, rule_path), content.to_string());
+}
+
+fn remote_path(host_id: &str, path: &str) -> LocalOrRemotePath {
+    LocalOrRemotePath::Remote(RemotePath::new(
+        HostId::new(host_id.to_string()),
+        StandardizedPath::try_new(path).unwrap(),
+    ))
+}
+
 use super::*;
 
 #[test]
 fn test_find_applicable_rules_empty_rules() {
     let rules = ProjectRules { rules: vec![] };
-    let path = PathBuf::from("/a/b/c/file.rs");
+    let path = local_path("/a/b/c/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert!(result.is_empty());
@@ -15,10 +45,10 @@ fn test_find_applicable_rules_empty_rules() {
 fn test_find_applicable_rules_no_matching_rules() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/x/y/WARP.md"), "content1".to_string());
-    rules.upsert_rule(Path::new("/z/AGENTS.md"), "content2".to_string());
+    rules.upsert_rule(&local_path("/x/y/WARP.md"), "content1".to_string());
+    rules.upsert_rule(&local_path("/z/AGENTS.md"), "content2".to_string());
 
-    let path = PathBuf::from("/a/b/c/file.rs");
+    let path = local_path("/a/b/c/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert!(result.is_empty());
@@ -28,52 +58,52 @@ fn test_find_applicable_rules_no_matching_rules() {
 fn test_find_applicable_rules_single_matching_rule() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/a/WARP.md"), "content1".to_string());
-    rules.upsert_rule(Path::new("/x/AGENTS.md"), "content2".to_string());
+    rules.upsert_rule(&local_path("/a/WARP.md"), "content1".to_string());
+    rules.upsert_rule(&local_path("/x/AGENTS.md"), "content2".to_string());
 
-    let path = PathBuf::from("/a/b/c/file.rs");
+    let path = local_path("/a/b/c/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].path, PathBuf::from("/a/WARP.md"));
+    assert_eq!(result[0].path, local_path("/a/WARP.md"));
 }
 
 #[test]
 fn test_find_applicable_rules_includes_all_ancestor_rules() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/a/WARP.md"), "root_warp".to_string());
-    rules.upsert_rule(Path::new("/a/b/WARP.md"), "nested_warp".to_string());
-    rules.upsert_rule(Path::new("/a/b/c/WARP.md"), "deep_warp".to_string());
+    rules.upsert_rule(&local_path("/a/WARP.md"), "root_warp".to_string());
+    rules.upsert_rule(&local_path("/a/b/WARP.md"), "nested_warp".to_string());
+    rules.upsert_rule(&local_path("/a/b/c/WARP.md"), "deep_warp".to_string());
 
-    let path = PathBuf::from("/a/b/c/d/file.rs");
+    let path = local_path("/a/b/c/d/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 3);
 
     // All should be WARP.md files (same priority), order is not specified by depth
     // Just verify all expected rules are present
-    let paths: Vec<PathBuf> = result.iter().map(|r| r.path.clone()).collect();
-    assert!(paths.contains(&PathBuf::from("/a/WARP.md")));
-    assert!(paths.contains(&PathBuf::from("/a/b/WARP.md")));
-    assert!(paths.contains(&PathBuf::from("/a/b/c/WARP.md")));
+    let paths: Vec<LocalOrRemotePath> = result.iter().map(|r| r.path.clone()).collect();
+    assert!(paths.contains(&local_path("/a/WARP.md")));
+    assert!(paths.contains(&local_path("/a/b/WARP.md")));
+    assert!(paths.contains(&local_path("/a/b/c/WARP.md")));
 }
 
 #[test]
 fn test_find_applicable_rules_multiple_patterns() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/a/b/AGENTS.md"), "agents_content".to_string());
-    rules.upsert_rule(Path::new("/a/WARP.md"), "warp_content".to_string());
+    rules.upsert_rule(&local_path("/a/b/AGENTS.md"), "agents_content".to_string());
+    rules.upsert_rule(&local_path("/a/WARP.md"), "warp_content".to_string());
 
-    let path = PathBuf::from("/a/b/file.rs");
+    let path = local_path("/a/b/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 2);
 
-    assert_eq!(result[0].path, PathBuf::from("/a/b/AGENTS.md"));
+    assert_eq!(result[0].path, local_path("/a/b/AGENTS.md"));
     assert_eq!(result[0].content, "agents_content");
-    assert_eq!(result[1].path, PathBuf::from("/a/WARP.md"));
+    assert_eq!(result[1].path, local_path("/a/WARP.md"));
     assert_eq!(result[1].content, "warp_content");
 }
 
@@ -81,13 +111,13 @@ fn test_find_applicable_rules_multiple_patterns() {
 fn test_find_applicable_rules_exact_path_match() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/a/b/WARP.md"), "exact_match".to_string());
+    rules.upsert_rule(&local_path("/a/b/WARP.md"), "exact_match".to_string());
 
-    let path = PathBuf::from("/a/b/file.rs");
+    let path = local_path("/a/b/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].path, PathBuf::from("/a/b/WARP.md"));
+    assert_eq!(result[0].path, local_path("/a/b/WARP.md"));
     assert_eq!(result[0].content, "exact_match");
 }
 
@@ -95,14 +125,14 @@ fn test_find_applicable_rules_exact_path_match() {
 fn test_find_applicable_rules_ignores_deeper_paths() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/a/WARP.md"), "applicable".to_string());
-    rules.upsert_rule(Path::new("/a/b/c/d/e/WARP.md"), "too_deep".to_string()); // Path doesn't contain /a/b
+    rules.upsert_rule(&local_path("/a/WARP.md"), "applicable".to_string());
+    rules.upsert_rule(&local_path("/a/b/c/d/e/WARP.md"), "too_deep".to_string()); // Path doesn't contain /a/b
 
-    let path = PathBuf::from("/a/b/file.rs");
+    let path = local_path("/a/b/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].path, PathBuf::from("/a/WARP.md"));
+    assert_eq!(result[0].path, local_path("/a/WARP.md"));
     assert_eq!(result[0].content, "applicable");
 }
 
@@ -110,13 +140,13 @@ fn test_find_applicable_rules_ignores_deeper_paths() {
 fn test_find_applicable_rules_handles_root_path() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/WARP.md"), "root_rule".to_string());
+    rules.upsert_rule(&local_path("/WARP.md"), "root_rule".to_string());
 
-    let path = PathBuf::from("/a/b/file.rs");
+    let path = local_path("/a/b/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].path, PathBuf::from("/WARP.md"));
+    assert_eq!(result[0].path, local_path("/WARP.md"));
     assert_eq!(result[0].content, "root_rule");
 }
 
@@ -130,21 +160,21 @@ fn test_find_applicable_rules_complex_scenario() {
     // - /a/b/AGENTS.md
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/a/WARP.md"), "a_warp".to_string());
-    rules.upsert_rule(Path::new("/a/AGENTS.md"), "a_agents".to_string());
-    rules.upsert_rule(Path::new("/a/b/WARP.md"), "ab_warp".to_string());
-    rules.upsert_rule(Path::new("/a/b/AGENTS.md"), "ab_agents".to_string());
-    rules.upsert_rule(Path::new("/x/WARP.md"), "irrelevant".to_string()); // Should be ignored
+    rules.upsert_rule(&local_path("/a/WARP.md"), "a_warp".to_string());
+    rules.upsert_rule(&local_path("/a/AGENTS.md"), "a_agents".to_string());
+    rules.upsert_rule(&local_path("/a/b/WARP.md"), "ab_warp".to_string());
+    rules.upsert_rule(&local_path("/a/b/AGENTS.md"), "ab_agents".to_string());
+    rules.upsert_rule(&local_path("/x/WARP.md"), "irrelevant".to_string()); // Should be ignored
 
-    let path = PathBuf::from("/a/b/c/file.rs");
+    let path = local_path("/a/b/c/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 2);
 
     // Expect only WARP.md files to be included as they have higher priority.
-    assert_eq!(result[0].path, PathBuf::from("/a/WARP.md"));
+    assert_eq!(result[0].path, local_path("/a/WARP.md"));
     assert_eq!(result[0].content, "a_warp");
-    assert_eq!(result[1].path, PathBuf::from("/a/b/WARP.md"));
+    assert_eq!(result[1].path, local_path("/a/b/WARP.md"));
     assert_eq!(result[1].content, "ab_warp");
 }
 
@@ -152,14 +182,14 @@ fn test_find_applicable_rules_complex_scenario() {
 fn test_find_applicable_rules_handles_unknown_file_patterns() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("/a/WARP.md"), "known_pattern".to_string());
-    rules.upsert_rule(Path::new("/a/UNKNOWN.md"), "unknown_pattern".to_string());
-    let path = PathBuf::from("/a/file.rs");
+    rules.upsert_rule(&local_path("/a/WARP.md"), "known_pattern".to_string());
+    rules.upsert_rule(&local_path("/a/UNKNOWN.md"), "unknown_pattern".to_string());
+    let path = local_path("/a/file.rs");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 1);
 
-    assert_eq!(result[0].path, PathBuf::from("/a/WARP.md"));
+    assert_eq!(result[0].path, local_path("/a/WARP.md"));
     assert_eq!(result[0].content, "known_pattern");
 }
 
@@ -167,22 +197,22 @@ fn test_find_applicable_rules_handles_unknown_file_patterns() {
 fn test_find_applicable_rules_with_relative_paths() {
     let mut rules = ProjectRules::default();
 
-    rules.upsert_rule(Path::new("src/WARP.md"), "src_warp".to_string());
+    rules.upsert_rule(&local_path("src/WARP.md"), "src_warp".to_string());
     rules.upsert_rule(
-        Path::new("src/components/WARP.md"),
+        &local_path("src/components/WARP.md"),
         "components_warp".to_string(),
     );
 
-    let path = PathBuf::from("src/components/Button.tsx");
+    let path = local_path("src/components/Button.tsx");
 
     let result = rules.find_active_or_applicable_rules(&path).active_rules;
     assert_eq!(result.len(), 2);
 
     // Both are WARP.md files (same priority), order within same priority is not guaranteed
     // Just verify both rules are present
-    let paths: Vec<PathBuf> = result.iter().map(|r| r.path.clone()).collect();
-    assert!(paths.contains(&PathBuf::from("src/WARP.md")));
-    assert!(paths.contains(&PathBuf::from("src/components/WARP.md")));
+    let paths: Vec<LocalOrRemotePath> = result.iter().map(|r| r.path.clone()).collect();
+    assert!(paths.contains(&local_path("src/WARP.md")));
+    assert!(paths.contains(&local_path("src/components/WARP.md")));
 }
 
 fn make_rule_path(path: &str) -> ProjectRulePath {
@@ -303,7 +333,7 @@ fn insert_global_rule(model: &mut ProjectContextModel, path: &Path, content: &st
     model.global_rules.rules.insert(
         path.to_path_buf(),
         ProjectRule {
-            path: path.to_path_buf(),
+            path: LocalOrRemotePath::Local(path.to_path_buf()),
             content: content.to_string(),
         },
     );
@@ -317,9 +347,35 @@ fn insert_project_rule(
 ) {
     let rules = model
         .path_to_rules
-        .entry(project_root.to_path_buf())
+        .entry(LocalOrRemotePath::Local(project_root.to_path_buf()))
         .or_default();
-    rules.upsert_rule(rule_path, content.to_string());
+    rules.upsert_rule(
+        &LocalOrRemotePath::Local(rule_path.to_path_buf()),
+        content.to_string(),
+    );
+}
+
+#[test]
+fn test_remote_project_rules_require_matching_host() {
+    let mut model = ProjectContextModel::default();
+    insert_remote_project_rule(
+        &mut model,
+        "host-a",
+        "/repo",
+        "/repo/WARP.md",
+        "remote_project_rule",
+    );
+
+    let same_host = model
+        .find_applicable_project_rules_at_location(&remote_path("host-a", "/repo/src/main.rs"))
+        .expect("same-host remote rule should apply");
+    assert_eq!(same_host.root_path, remote_path("host-a", "/repo"));
+    assert_eq!(same_host.active_rules.len(), 1);
+    assert_eq!(same_host.active_rules[0].content, "remote_project_rule");
+
+    let other_host = model
+        .find_applicable_project_rules_at_location(&remote_path("host-b", "/repo/src/main.rs"));
+    assert!(other_host.is_none());
 }
 
 #[test]
@@ -338,7 +394,7 @@ fn test_global_rule_alone_no_project_rules() {
     assert_eq!(result.active_rules.len(), 1);
     assert_eq!(
         result.active_rules[0].path,
-        PathBuf::from("/home/u/.agents/AGENTS.md")
+        local_path("/home/u/.agents/AGENTS.md")
     );
     assert_eq!(result.active_rules[0].content, "global_content");
     assert!(result.additional_rule_paths.is_empty());
@@ -363,7 +419,7 @@ fn test_global_rule_layered_with_project_warp() {
     assert_eq!(result.active_rules.len(), 2);
     assert_eq!(result.active_rules[0].content, "global");
     assert_eq!(result.active_rules[1].content, "project_warp");
-    assert_eq!(result.root_path, PathBuf::from("/repo"));
+    assert_eq!(result.root_path, local_path("/repo"));
 }
 
 #[test]
@@ -412,7 +468,7 @@ fn test_global_rule_root_path_falls_back_to_parent() {
         .expect("global rule should produce a result");
 
     // No project root indexed; root_path falls back to parent of the global rule.
-    assert_eq!(result.root_path, PathBuf::from("/home/u/.agents"));
+    assert_eq!(result.root_path, local_path("/home/u/.agents"));
 }
 
 #[test]

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -73,6 +73,7 @@ message ServerMessage {
     GetFragmentMetadataFromHashResponse get_fragment_metadata_from_hash_response = 24;
     GetBranchesResponse get_branches_response = 25;
     UploadHandoffSnapshotResponse upload_handoff_snapshot_response = 26;
+    ProjectContextFilesSnapshot project_context_files_snapshot = 27;
   }
 }
 
@@ -217,6 +218,24 @@ message FileNodeMetadata {
   string path = 1;
   optional string extension = 2;
   bool ignored = 3;
+}
+
+enum ProjectContextFileKind {
+  PROJECT_CONTEXT_FILE_KIND_UNSPECIFIED = 0;
+  PROJECT_SKILLS = 1;
+  PROJECT_RULES = 2;
+}
+
+message ProjectContextFile {
+  string path = 1;
+  string content = 2;
+}
+
+// Server → client: authoritative replacement snapshot of feature-owned project context files.
+message ProjectContextFilesSnapshot {
+  string repo_path = 1;
+  ProjectContextFileKind kind = 2;
+  repeated ProjectContextFile files = 3;
 }
 
 // Mirrors FileTreeEntryUpdate in Rust. Describes a subtree patch rooted

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -21,10 +21,10 @@ use crate::proto::{
     FileStatusInfo, FragmentMetadataLookupErrorCode, GetBranches, GetDiffState,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashSuccess,
     IndexCodebase, Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
-    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextRequest,
-    ReadFileContextResponse, ResyncCodebase, RunCommandRequest, RunCommandResponse, SaveBuffer,
-    ServerMessage, SessionBootstrapped, TextEdit, UnsubscribeDiffState, UploadHandoffSnapshot,
-    UploadHandoffSnapshotResponse, WriteFile,
+    NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ProjectContextFilesSnapshot,
+    ReadFileContextRequest, ReadFileContextResponse, ResyncCodebase, RunCommandRequest,
+    RunCommandResponse, SaveBuffer, ServerMessage, SessionBootstrapped, TextEdit,
+    UnsubscribeDiffState, UploadHandoffSnapshot, UploadHandoffSnapshotResponse, WriteFile,
 };
 use crate::repo_metadata_proto::{proto_snapshot_to_update, proto_to_repo_metadata_update};
 
@@ -92,6 +92,10 @@ pub enum ClientEvent {
     /// An incremental repo metadata update was pushed by the server.
     RepoMetadataUpdated {
         update: repo_metadata::RepoMetadataUpdate,
+    },
+    /// An authoritative project-context replacement snapshot was pushed by the server.
+    ProjectContextFilesSnapshotReceived {
+        snapshot: ProjectContextFilesSnapshot,
     },
     /// A full remote codebase-index status snapshot was pushed by the server.
     CodebaseIndexStatusesSnapshotReceived {
@@ -842,6 +846,9 @@ impl RemoteServerClient {
             server_message::Message::RepoMetadataUpdate(push) => {
                 let update = proto_to_repo_metadata_update(&push)?;
                 Some(ClientEvent::RepoMetadataUpdated { update })
+            }
+            server_message::Message::ProjectContextFilesSnapshot(snapshot) => {
+                Some(ClientEvent::ProjectContextFilesSnapshotReceived { snapshot })
             }
             server_message::Message::CodebaseIndexStatusesSnapshot(snapshot) => {
                 let statuses = proto_to_codebase_index_statuses_snapshot(&snapshot);

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -10,7 +10,8 @@ use crate::proto::{
     CodebaseIndexStatusesSnapshot, ErrorCode, FileOperationError, FragmentMetadata,
     FragmentMetadataLookupError, FragmentMetadataLookupErrorCode,
     GetFragmentMetadataFromHashResponse, GetFragmentMetadataFromHashSuccess, InitializeResponse,
-    MissingFragmentMetadata, RunCommandResponse, RunCommandSuccess, ServerMessage,
+    MissingFragmentMetadata, ProjectContextFile, ProjectContextFileKind,
+    ProjectContextFilesSnapshot, RunCommandResponse, RunCommandSuccess, ServerMessage,
 };
 use crate::protocol;
 
@@ -107,6 +108,48 @@ async fn codebase_index_push_messages_become_client_events() {
     }
 }
 
+#[tokio::test]
+async fn project_context_snapshot_push_message_becomes_client_event() {
+    let (client_stream, server_stream) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    drop(server_read);
+
+    let executor = executor::Background::default();
+    let (_client, event_rx, _failure_rx) =
+        RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
+    let mut writer = server_write.compat_write();
+
+    protocol::write_server_message(
+        &mut writer,
+        &ServerMessage {
+            request_id: String::new(),
+            message: Some(server_message::Message::ProjectContextFilesSnapshot(
+                ProjectContextFilesSnapshot {
+                    repo_path: "/repo".to_string(),
+                    kind: ProjectContextFileKind::ProjectRules.into(),
+                    files: vec![ProjectContextFile {
+                        path: "/repo/WARP.md".to_string(),
+                        content: "remote rule".to_string(),
+                    }],
+                },
+            )),
+        },
+    )
+    .await
+    .unwrap();
+    writer.flush().await.unwrap();
+
+    match event_rx.recv().await.unwrap() {
+        ClientEvent::ProjectContextFilesSnapshotReceived { snapshot } => {
+            assert_eq!(snapshot.repo_path, "/repo");
+            assert_eq!(snapshot.kind, ProjectContextFileKind::ProjectRules as i32);
+            assert_eq!(snapshot.files[0].path, "/repo/WARP.md");
+            assert_eq!(snapshot.files[0].content, "remote rule");
+        }
+        other => panic!("Expected ProjectContextFilesSnapshotReceived, got {other:?}"),
+    }
+}
 /// Sets up a duplex stream, spawns `mock_server_with` with the given responder,
 /// and returns a connected `RemoteServerClient`, its event receiver, and the
 /// background executor (which must be kept alive for the test duration).

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -27,7 +27,7 @@ use crate::codebase_index_proto::RemoteCodebaseIndexStatus;
 use crate::proto::{
     diff_state, get_diff_state_response, CodebaseIndexLimits, DiffMode, DiffState,
     DiffStateErrorValue, DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot,
-    FileStatusInfo, GetDiffStateResponse, TextEdit,
+    FileStatusInfo, GetDiffStateResponse, ProjectContextFilesSnapshot, TextEdit,
 };
 use crate::repo_metadata_proto::proto_load_repo_metadata_directory_response_to_update;
 #[cfg(not(target_family = "wasm"))]
@@ -254,6 +254,7 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::Disconnected => "disconnected",
         ClientEvent::RepoMetadataSnapshotReceived { .. } => "repo_metadata_snapshot",
         ClientEvent::RepoMetadataUpdated { .. } => "repo_metadata_updated",
+        ClientEvent::ProjectContextFilesSnapshotReceived { .. } => "project_context_files_snapshot",
         ClientEvent::CodebaseIndexStatusesSnapshotReceived { .. } => {
             "codebase_index_statuses_snapshot"
         }
@@ -463,6 +464,11 @@ pub enum RemoteServerManagerEvent {
         host_id: HostId,
         update: RepoMetadataUpdate,
     },
+    /// Authoritative server-discovered project-context file contents.
+    ProjectContextFilesSnapshot {
+        host_id: HostId,
+        snapshot: ProjectContextFilesSnapshot,
+    },
     /// A full remote codebase-index status snapshot was pushed or requested.
     CodebaseIndexStatusesSnapshot {
         host_id: HostId,
@@ -607,6 +613,7 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+            | RemoteServerManagerEvent::ProjectContextFilesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
                 session_id: None, ..
@@ -2099,6 +2106,12 @@ impl RemoteServerManager {
             }
             ClientEvent::RepoMetadataUpdated { update } => {
                 ctx.emit(RemoteServerManagerEvent::RepoMetadataUpdated { host_id, update });
+            }
+            ClientEvent::ProjectContextFilesSnapshotReceived { snapshot } => {
+                ctx.emit(RemoteServerManagerEvent::ProjectContextFilesSnapshot {
+                    host_id,
+                    snapshot,
+                });
             }
             ClientEvent::CodebaseIndexStatusesSnapshotReceived { statuses } => {
                 let statuses = statuses

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -22,7 +22,7 @@ pub enum RepoContent<'a> {
 
 use warp_util::standardized_path::StandardizedPath;
 
-use crate::entry::{BuildTreeError, BuildTreeOptions, Entry, FileId, IgnoredPathStrategy};
+use crate::entry::{BuildTreeOptions, Entry, FileId, IgnoredPathStrategy};
 use crate::repository::Repository;
 use crate::telemetry::RepoMetadataTelemetryEvent;
 use crate::{gitignores_for_directory, matches_gitignores, RepoMetadataError};
@@ -76,6 +76,14 @@ pub enum RepositoryMetadataEvent {
     FileTreeEntryUpdated {
         path: StandardizedPath,
     },
+    /// A display-only lazily loaded tree was added or updated.
+    LazyDisplayTreeUpdated {
+        path: StandardizedPath,
+    },
+    /// A display-only lazily loaded tree was removed.
+    LazyDisplayTreeRemoved {
+        path: StandardizedPath,
+    },
     UpdatingRepositoryFailed {
         path: StandardizedPath,
     },
@@ -124,6 +132,11 @@ impl IndexedRepoState {
     }
 }
 
+#[derive(Debug)]
+struct LazyDisplayTreeState {
+    tree: FileTreeState,
+    refcount: usize,
+}
 /// Singleton model for managing local repository metadata.
 ///
 /// This model tracks repositories on the local filesystem, using file watchers
@@ -134,8 +147,12 @@ impl IndexedRepoState {
 pub struct LocalRepoMetadataModel {
     /// Mapping from repository path to its indexed state.
     repositories: HashMap<StandardizedPath, IndexedRepoState>,
-    /// Refcounts for lazily-loaded standalone paths tracked in the model.
-    lazy_loaded_paths: HashMap<StandardizedPath, usize>,
+    /// Display-only lazily-loaded trees keyed by the displayed root.
+    ///
+    /// These trees intentionally remain separate from `repositories`: a partial
+    /// tree suitable for browsing must not be exposed as successful repository
+    /// metadata to project-context discovery consumers.
+    lazy_display_trees: HashMap<StandardizedPath, LazyDisplayTreeState>,
     /// File system watcher for monitoring changes.
     #[cfg(feature = "local_fs")]
     watcher: Option<ModelHandle<BulkFilesystemWatcher>>,
@@ -227,7 +244,7 @@ impl LocalRepoMetadataModel {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         let mut model = Self {
             repositories: HashMap::new(),
-            lazy_loaded_paths: HashMap::new(),
+            lazy_display_trees: HashMap::new(),
             #[cfg(feature = "local_fs")]
             watcher: None,
             emit_incremental_updates: false,
@@ -294,23 +311,27 @@ impl LocalRepoMetadataModel {
         event: &BulkFilesystemWatcherEvent,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Create a map to collect changes per repository
-        let mut repo_updates: HashMap<StandardizedPath, RepoUpdate> = HashMap::new();
+        // Create a map to collect changes per authoritative or display-only tree.
+        let mut tree_updates: HashMap<StandardizedPath, (RepoUpdate, bool)> = HashMap::new();
 
         // Process added or updated files
         for path in event.added_or_updated_iter() {
-            if let Some(repo_path) = self.find_repository_for_path(path) {
-                let repo_update = repo_updates.entry(repo_path).or_default();
+            if let Some((tree_path, lazy_display)) = self.find_watched_tree_for_path(path) {
+                let (repo_update, _) = tree_updates
+                    .entry(tree_path)
+                    .or_insert_with(|| (RepoUpdate::default(), lazy_display));
                 repo_update.added.push(path.to_path_buf());
             }
         }
 
         // Process deleted files
         for path in &event.deleted {
-            if let Some(repo_path) =
-                self.find_repository_for_path_string(path.to_string_lossy().as_ref())
+            if let Some((tree_path, lazy_display)) =
+                self.find_watched_tree_for_path_string(path.to_string_lossy().as_ref())
             {
-                let repo_update = repo_updates.entry(repo_path).or_default();
+                let (repo_update, _) = tree_updates
+                    .entry(tree_path)
+                    .or_insert_with(|| (RepoUpdate::default(), lazy_display));
                 repo_update.deleted.push(path.to_path_buf());
             } else {
                 log::warn!("Deleted file not found in any repo: {path:?} not found in any repo");
@@ -319,8 +340,10 @@ impl LocalRepoMetadataModel {
 
         // Process moved files
         for (to_path, from_path) in &event.moved {
-            if let Some(repo_path) = self.find_repository_for_path(to_path) {
-                let repo_update = repo_updates.entry(repo_path).or_default();
+            if let Some((tree_path, lazy_display)) = self.find_watched_tree_for_path(to_path) {
+                let (repo_update, _) = tree_updates
+                    .entry(tree_path)
+                    .or_insert_with(|| (RepoUpdate::default(), lazy_display));
                 repo_update
                     .moved
                     .insert(to_path.to_path_buf(), from_path.to_path_buf());
@@ -329,40 +352,74 @@ impl LocalRepoMetadataModel {
 
         // Collect all paths that have been updated and emit an event.
         ctx.emit(RepositoryMetadataEvent::FileTreeUpdated {
-            paths: repo_updates.keys().cloned().collect(),
+            paths: tree_updates
+                .iter()
+                .filter_map(|(path, (_, lazy_display))| (!lazy_display).then_some(path.clone()))
+                .collect(),
         });
         // Apply updates to each affected repository asynchronously.
         // Phase 1 (background thread): compute lightweight mutations via filesystem I/O.
         // Phase 2 (main thread callback): apply mutations directly to the tree — no clone needed.
-        for (repo_path, repo_scoped_update) in repo_updates {
-            if let Some(IndexedRepoState::Indexed(state)) = self.repositories.get_mut(&repo_path) {
-                let repo_path_clone = repo_path.clone();
+        for (tree_path, (tree_scoped_update, lazy_display)) in tree_updates {
+            let state = if lazy_display {
+                self.lazy_display_trees
+                    .get(&tree_path)
+                    .map(|state| &state.tree)
+            } else {
+                self.repositories
+                    .get(&tree_path)
+                    .and_then(|state| match state {
+                        IndexedRepoState::Indexed(state) => Some(state),
+                        IndexedRepoState::Pending(_) | IndexedRepoState::Failed(_) => None,
+                    })
+            };
+            if let Some(state) = state {
+                let tree_path_clone = tree_path.clone();
                 let gitignores_clone = state.gitignores.clone();
                 let ignored_path_interests = self.ignored_path_interests.clone();
-                let lazy_load = self.lazy_loaded_paths.contains_key(&repo_path);
                 ctx.spawn(
                     async move {
                         let mutations = Self::compute_file_tree_mutations(
-                            &repo_scoped_update,
+                            &tree_scoped_update,
                             &gitignores_clone,
                             &ignored_path_interests,
                         )
                         .await;
-                        (mutations, repo_path_clone, lazy_load)
+                        (mutations, tree_path_clone, lazy_display)
                     },
-                    |model, (mutations, repo_path, lazy_load), ctx| {
-                        if let Some(IndexedRepoState::Indexed(state)) =
-                            model.repositories.get_mut(&repo_path)
-                        {
+                    |model, (mutations, tree_path, lazy_display), ctx| {
+                        let state = if lazy_display {
+                            model
+                                .lazy_display_trees
+                                .get_mut(&tree_path)
+                                .map(|state| &mut state.tree)
+                        } else {
+                            model
+                                .repositories
+                                .get_mut(&tree_path)
+                                .and_then(|state| match state {
+                                    IndexedRepoState::Indexed(state) => Some(state),
+                                    IndexedRepoState::Pending(_) | IndexedRepoState::Failed(_) => {
+                                        None
+                                    }
+                                })
+                        };
+                        if let Some(state) = state {
                             let update = Self::apply_file_tree_mutations(
                                 &mut state.entry,
                                 mutations,
-                                lazy_load,
+                                lazy_display,
                                 model.emit_incremental_updates,
                             );
-                            ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
-                                path: repo_path,
-                            });
+                            if lazy_display {
+                                ctx.emit(RepositoryMetadataEvent::LazyDisplayTreeUpdated {
+                                    path: tree_path,
+                                });
+                            } else {
+                                ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
+                                    path: tree_path,
+                                });
+                            }
 
                             if let Some(update) = update {
                                 ctx.emit(RepositoryMetadataEvent::IncrementalUpdateReady {
@@ -386,6 +443,34 @@ impl LocalRepoMetadataModel {
             })
             .max_by_key(|(repo_path, _)| repo_path.as_str().len())
             .map(|(repo_path, _)| repo_path.clone())
+    }
+    #[cfg(feature = "local_fs")]
+    fn find_watched_tree_for_path_string(
+        &self,
+        path_str: &str,
+    ) -> Option<(StandardizedPath, bool)> {
+        self.repositories
+            .iter()
+            .filter_map(|(repo_path, state)| {
+                (path_str.starts_with(repo_path.as_str())
+                    && matches!(state, IndexedRepoState::Indexed(_)))
+                .then_some((repo_path, false))
+            })
+            .chain(
+                self.lazy_display_trees
+                    .keys()
+                    .filter(|path| path_str.starts_with(path.as_str()))
+                    .map(|path| (path, true)),
+            )
+            .max_by_key(|(path, _)| path.as_str().len())
+            .map(|(path, lazy_display)| (path.clone(), lazy_display))
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn find_watched_tree_for_path(&self, path: &Path) -> Option<(StandardizedPath, bool)> {
+        StandardizedPath::from_local_canonicalized(path)
+            .ok()
+            .and_then(|std_path| self.find_watched_tree_for_path_string(std_path.as_str()))
     }
 
     #[cfg(feature = "local_fs")]
@@ -501,7 +586,12 @@ impl LocalRepoMetadataModel {
 
     /// Returns whether the given path is tracked as a lazily-loaded standalone path.
     pub fn is_lazy_loaded_path(&self, path: &StandardizedPath) -> bool {
-        self.lazy_loaded_paths.contains_key(path)
+        self.lazy_display_trees.contains_key(path)
+    }
+
+    /// Returns the display-only lazily-loaded tree for `path`, if one exists.
+    pub fn get_lazy_display_tree(&self, path: &StandardizedPath) -> Option<&FileTreeState> {
+        self.lazy_display_trees.get(path).map(|state| &state.tree)
     }
 
     /// Lazily indexes a standalone path with only the first level of children.
@@ -515,8 +605,8 @@ impl LocalRepoMetadataModel {
     ) -> Result<(), RepoMetadataError> {
         // Already tracked as a lazy-loaded path — increase the refcount and keep the
         // existing watcher/model entry alive.
-        if let Some(refcount) = self.lazy_loaded_paths.get_mut(path) {
-            *refcount += 1;
+        if let Some(state) = self.lazy_display_trees.get_mut(path) {
+            state.refcount += 1;
             return Ok(());
         }
 
@@ -555,8 +645,23 @@ impl LocalRepoMetadataModel {
         .map_err(RepoMetadataError::BuildTree)?;
 
         let state = FileTreeState::new_lazy_loaded(root_entry);
-        self.add_repository_internal(path.clone(), state, ctx)?;
-        self.lazy_loaded_paths.insert(path.clone(), 1);
+        if let Some(ref watcher) = self.watcher {
+            watcher.update(ctx, |watcher, _ctx| {
+                std::mem::drop(watcher.register_path(
+                    &local_path,
+                    repo_watch_filter(),
+                    RecursiveMode::Recursive,
+                ));
+            });
+        }
+        self.lazy_display_trees.insert(
+            path.clone(),
+            LazyDisplayTreeState {
+                tree: state,
+                refcount: 1,
+            },
+        );
+        ctx.emit(RepositoryMetadataEvent::LazyDisplayTreeUpdated { path: path.clone() });
         Ok(())
     }
 
@@ -567,16 +672,22 @@ impl LocalRepoMetadataModel {
         path: &StandardizedPath,
         ctx: &mut ModelContext<Self>,
     ) {
-        let Some(refcount) = self.lazy_loaded_paths.get_mut(path) else {
+        let Some(state) = self.lazy_display_trees.get_mut(path) else {
             return;
         };
-        if *refcount > 1 {
-            *refcount -= 1;
+        if state.refcount > 1 {
+            state.refcount -= 1;
             return;
         }
-        self.lazy_loaded_paths.remove(path);
-        // remove_repository unregisters the watcher and emits RepositoryRemoved.
-        let _ = self.remove_repository(path, ctx);
+        self.lazy_display_trees.remove(path);
+        if let Some(ref watcher) = self.watcher {
+            if let Some(local_path) = path.to_local_path() {
+                watcher.update(ctx, |watcher, _ctx| {
+                    std::mem::drop(watcher.unregister_path(&local_path));
+                });
+            }
+        }
+        ctx.emit(RepositoryMetadataEvent::LazyDisplayTreeRemoved { path: path.clone() });
     }
 
     /// Loads a specific directory inside an already-tracked tree.
@@ -588,7 +699,13 @@ impl LocalRepoMetadataModel {
         dir_path: &StandardizedPath,
         ctx: &mut ModelContext<Self>,
     ) -> Result<(), RepoMetadataError> {
-        let Some(IndexedRepoState::Indexed(state)) = self.repositories.get_mut(repo_root) else {
+        let lazy_display = self.lazy_display_trees.contains_key(repo_root);
+        let state = if let Some(state) = self.lazy_display_trees.get_mut(repo_root) {
+            &mut state.tree
+        } else if let Some(IndexedRepoState::Indexed(state)) = self.repositories.get_mut(repo_root)
+        {
+            state
+        } else {
             return Err(RepoMetadataError::RepoNotFound(repo_root.to_string()));
         };
 
@@ -598,9 +715,15 @@ impl LocalRepoMetadataModel {
             .load_at_path(dir_path, &mut gitignores)
             .map_err(RepoMetadataError::BuildTree)?;
 
-        ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
-            path: repo_root.clone(),
-        });
+        if lazy_display {
+            ctx.emit(RepositoryMetadataEvent::LazyDisplayTreeUpdated {
+                path: repo_root.clone(),
+            });
+        } else {
+            ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
+                path: repo_root.clone(),
+            });
+        }
         Ok(())
     }
 
@@ -891,18 +1014,10 @@ impl LocalRepoMetadataModel {
         let repo_path_str = std_path.to_string();
 
         // Check if the repository is already indexed or currently being indexed.
-        // Allow re-indexing if the existing entry was a lazily-loaded path placeholder.
         match self.repositories.get(&std_path) {
-            Some(IndexedRepoState::Indexed(_))
-                if !self.lazy_loaded_paths.contains_key(&std_path) =>
-            {
+            Some(IndexedRepoState::Indexed(_)) => {
                 log::debug!("Repository already indexed: {std_path}");
                 return Ok(());
-            }
-            Some(IndexedRepoState::Indexed(_)) => {
-                // Was a lazy-loaded path – allow upgrading to a real repo.
-                log::info!("Upgrading lazy-loaded path to git repo: {repo_path_str}");
-                self.lazy_loaded_paths.remove(&std_path);
             }
             Some(IndexedRepoState::Pending(_)) => {
                 log::debug!("Repository already being indexed: {repo_path_str}");
@@ -941,14 +1056,10 @@ impl LocalRepoMetadataModel {
             async move {
                 let mut files: Vec<crate::entry::FileMetadata> = Vec::new();
                 let mut gitignores_for_build = gitignores_for_build;
-                // Snapshot the initial gitignores so we can retry from a clean
-                // state if the full-depth build is partially populated before
-                // it hits the file limit.
-                let initial_gitignores = gitignores_for_build.clone();
 
                 let mut file_limit = MAX_FILES_PER_REPO;
 
-                let mut build_result = Entry::build_tree_with_ignored_path_interests(
+                let build_result = Entry::build_tree_with_ignored_path_interests(
                     &repo_path_for_build,
                     &mut files,
                     &mut gitignores_for_build,
@@ -961,34 +1072,6 @@ impl LocalRepoMetadataModel {
                     },
                 );
 
-                // Repos with more than MAX_FILES_PER_REPO tracked files can't
-                // be indexed at full depth. Fall back to a single-level scan
-                // (with the file quota disabled — direct-child files at
-                // depth=1 still consume the quota, so reusing it would
-                // re-trigger ExceededMaxFileLimit on repos with >MAX_FILES_PER_REPO
-                // files directly under the root) so the user can still browse
-                // the tree; subdirectories are loaded on expand via
-                // LAZY_LOAD_FILE_LIMIT.
-                let mut indexed_with_limit = false;
-                if matches!(build_result, Err(BuildTreeError::ExceededMaxFileLimit)) {
-                    files.clear();
-                    gitignores_for_build = initial_gitignores;
-                    build_result = Entry::build_tree_with_ignored_path_interests(
-                        &repo_path_for_build,
-                        &mut files,
-                        &mut gitignores_for_build,
-                        None,
-                        BuildTreeOptions {
-                            max_depth: 1, // Only first level.
-                            current_depth: 0,
-                            ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
-                            ignored_path_interests: &ignored_path_interests,
-                        },
-                    );
-                    if build_result.is_ok() {
-                        indexed_with_limit = true;
-                    }
-                }
 
                 (
                     build_result,
@@ -997,7 +1080,6 @@ impl LocalRepoMetadataModel {
                     repo_path_str_for_log,
                     std_path_for_completion,
                     repository_handle_for_completion,
-                    indexed_with_limit,
                 )
             },
             move |model: &mut LocalRepoMetadataModel,
@@ -1008,26 +1090,22 @@ impl LocalRepoMetadataModel {
                       repo_path_str,
                       std_repo_path,
                       repository_handle,
-                      indexed_with_limit,
-                  ): (Result<Entry, _>, Vec<crate::entry::FileMetadata>, _, String, StandardizedPath, ModelHandle<Repository>, bool),
+                  ): (Result<Entry, _>, Vec<crate::entry::FileMetadata>, _, String, StandardizedPath, ModelHandle<Repository>),
                   ctx| {
                 match build_result {
                     Ok(root_entry) => {
                         let state =
                             FileTreeState::new(root_entry, gitignores_for_build, Some(repository_handle));
 
-                        if let Err(e) =
-                            model.add_repository_internal(std_repo_path.clone(), state, ctx)
+                        if let Err(e) = model.add_repository_internal(
+                            std_repo_path.clone(),
+                            state,
+                            ctx,
+                        )
                         {
                             log::warn!("Failed to add repository {repo_path_str}: {e:?}");
                             // On failure, mark the repository as failed so waiters are notified.
                             model.mark_repository_failed(std_repo_path, e, ctx);
-                        } else if indexed_with_limit {
-                            safe_warn!(
-                                safe: ("Repository exceeded max file limit; indexed in degraded mode"),
-                                full: ("Repository {repo_path_str} exceeded max file limit ({MAX_FILES_PER_REPO}); indexed only first level — subdirectories load on expand")
-                            );
-                            send_telemetry_from_ctx!(RepoMetadataTelemetryEvent::BuildTreeFailed { error: format!("{:#}", BuildTreeError::ExceededMaxFileLimit) }, ctx);
                         } else {
                             log::info!(
                                 "Successfully indexed repository: {} with {} files",
@@ -1171,6 +1249,14 @@ impl LocalRepoMetadataModel {
     /// Insert a repository state directly for testing purposes.
     pub fn insert_test_state(&mut self, repo_path: StandardizedPath, state: FileTreeState) {
         self.replace_repository_state(repo_path, IndexedRepoState::Indexed(state));
+    }
+
+    /// Insert a failed local repository state directly for testing fallback consumers.
+    pub fn insert_test_failed_state(&mut self, repo_path: StandardizedPath) {
+        self.replace_repository_state(
+            repo_path,
+            IndexedRepoState::Failed(RepoMetadataError::InvalidPath("test failure".to_string())),
+        );
     }
 }
 

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -486,6 +486,10 @@ impl LocalRepoMetadataModel {
     pub fn repository_state(&self, repo_path: &StandardizedPath) -> Option<&IndexedRepoState> {
         self.repositories.get(repo_path)
     }
+    /// Returns all tracked local repository paths, including pending and failed repositories.
+    pub fn repository_paths(&self) -> impl Iterator<Item = &StandardizedPath> {
+        self.repositories.keys()
+    }
 
     /// Checks if a repository is being tracked and indexed.
     pub fn has_repository(&self, repo_path: &StandardizedPath) -> bool {

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -32,7 +32,7 @@ mod tests {
         fn new_for_test() -> Self {
             Self {
                 repositories: HashMap::new(),
-                lazy_loaded_paths: Default::default(),
+                lazy_display_trees: Default::default(),
                 #[cfg(feature = "local_fs")]
                 watcher: Default::default(),
                 emit_incremental_updates: false,
@@ -331,7 +331,12 @@ mod tests {
                     assert!(model.is_lazy_loaded_path(
                         &StandardizedPath::from_local_canonicalized(&shared_dir).unwrap()
                     ));
-                    assert!(model.has_repository(
+                    assert!(model
+                        .get_lazy_display_tree(
+                            &StandardizedPath::from_local_canonicalized(&shared_dir).unwrap()
+                        )
+                        .is_some());
+                    assert!(!model.has_repository(
                         &StandardizedPath::from_local_canonicalized(&shared_dir).unwrap()
                     ));
                 });
@@ -345,7 +350,8 @@ mod tests {
 
                 model_handle.read(&app, |model, _ctx| {
                     assert!(model.is_lazy_loaded_path(&shared_dir_std));
-                    assert!(model.has_repository(&shared_dir_std));
+                    assert!(model.get_lazy_display_tree(&shared_dir_std).is_some());
+                    assert!(!model.has_repository(&shared_dir_std));
                 });
 
                 model_handle.update(&mut app, |model, ctx| {
@@ -356,9 +362,11 @@ mod tests {
                     assert!(!model.is_lazy_loaded_path(
                         &StandardizedPath::from_local_canonicalized(&shared_dir).unwrap()
                     ));
-                    assert!(!model.has_repository(
-                        &StandardizedPath::from_local_canonicalized(&shared_dir).unwrap()
-                    ));
+                    assert!(model
+                        .get_lazy_display_tree(
+                            &StandardizedPath::from_local_canonicalized(&shared_dir).unwrap()
+                        )
+                        .is_none());
                 });
             });
         });
@@ -366,7 +374,7 @@ mod tests {
 
     #[cfg(feature = "local_fs")]
     #[test]
-    fn test_index_directory_upgrades_lazy_loaded_path_to_repo() {
+    fn test_index_directory_preserves_separate_lazy_display_tree_until_unregistered() {
         VirtualFS::test("lazy_loaded_path_upgrade", |dirs, mut vfs| {
             vfs.mkdir("repo/.git/objects")
                 .mkdir("repo/src/nested")
@@ -407,10 +415,10 @@ mod tests {
                     assert!(model.is_lazy_loaded_path(
                         &StandardizedPath::from_local_canonicalized(&repo_root).unwrap()
                     ));
-                    let Some(IndexedRepoState::Indexed(state)) = model.repository_state(
+                    let Some(state) = model.get_lazy_display_tree(
                         &StandardizedPath::from_local_canonicalized(&repo_root).unwrap(),
                     ) else {
-                        panic!("expected indexed lazy-loaded path");
+                        panic!("expected lazy display tree");
                     };
                     assert!(state
                         .entry
@@ -447,7 +455,7 @@ mod tests {
                     .expect("repo upgrade completion sender dropped");
 
                 model_handle.read(&app, |model, _ctx| {
-                    assert!(!model.is_lazy_loaded_path(
+                    assert!(model.is_lazy_loaded_path(
                         &StandardizedPath::from_local_canonicalized(&repo_root).unwrap()
                     ));
                     let Some(IndexedRepoState::Indexed(state)) = model.repository_state(
@@ -458,6 +466,32 @@ mod tests {
                     assert!(state
                         .entry
                         .contains(&StandardizedPath::try_from_local(&source_file).unwrap()));
+                    let lazy_display = model
+                        .get_lazy_display_tree(
+                            &StandardizedPath::from_local_canonicalized(&repo_root).unwrap(),
+                        )
+                        .expect("display tree stays registered until its UI owner removes it");
+                    assert!(!lazy_display
+                        .entry
+                        .contains(&StandardizedPath::try_from_local(&source_file).unwrap()));
+                });
+
+                model_handle.update(&mut app, |model, ctx| {
+                    model.remove_lazy_loaded_path(
+                        &StandardizedPath::from_local_canonicalized(&repo_root).unwrap(),
+                        ctx,
+                    );
+                });
+                model_handle.read(&app, |model, _ctx| {
+                    assert!(!model.is_lazy_loaded_path(
+                        &StandardizedPath::from_local_canonicalized(&repo_root).unwrap()
+                    ));
+                    assert!(matches!(
+                        model.repository_state(
+                            &StandardizedPath::from_local_canonicalized(&repo_root).unwrap()
+                        ),
+                        Some(IndexedRepoState::Indexed(_))
+                    ));
                 });
             });
         });

--- a/crates/repo_metadata/src/wrapper_model.rs
+++ b/crates/repo_metadata/src/wrapper_model.rs
@@ -388,6 +388,15 @@ impl RepoMetadataModel {
     ) -> impl Iterator<Item = &'a RemoteRepositoryIdentifier> {
         self.remote.as_ref(ctx).remote_repository_ids()
     }
+    /// Returns all tracked local repository identifiers, including pending and failed entries.
+    pub fn local_repository_ids(&self, ctx: &AppContext) -> Vec<RepositoryIdentifier> {
+        self.local
+            .as_ref(ctx)
+            .repository_paths()
+            .cloned()
+            .map(RepositoryIdentifier::local)
+            .collect()
+    }
 
     /// Returns whether the given local path is tracked as a lazily-loaded standalone path.
     pub fn is_lazy_loaded_path(&self, path: &StandardizedPath, ctx: &AppContext) -> bool {

--- a/crates/repo_metadata/src/wrapper_model.rs
+++ b/crates/repo_metadata/src/wrapper_model.rs
@@ -35,6 +35,10 @@ pub enum RepoMetadataEvent {
     FileTreeUpdated { ids: Vec<RepositoryIdentifier> },
     /// A file tree entry was updated.
     FileTreeEntryUpdated { id: RepositoryIdentifier },
+    /// A display-only lazy local file tree was added or updated.
+    LazyDisplayTreeUpdated { path: StandardizedPath },
+    /// A display-only lazy local file tree was removed.
+    LazyDisplayTreeRemoved { path: StandardizedPath },
     /// Updating a repository failed.
     UpdatingRepositoryFailed { id: RepositoryIdentifier },
     /// An incremental file tree update is ready to be sent to the remote
@@ -66,6 +70,16 @@ impl RepoMetadataModel {
         ctx.subscribe_to_model(&remote, Self::forward_remote_event);
 
         Self { local, remote }
+    }
+
+    /// Returns the display-only lazy local tree for a displayed path, if available.
+    #[cfg(feature = "local_fs")]
+    pub fn get_lazy_display_tree<'a>(
+        &self,
+        path: &StandardizedPath,
+        ctx: &'a AppContext,
+    ) -> Option<&'a FileTreeState> {
+        self.local.as_ref(ctx).get_lazy_display_tree(path)
     }
 
     /// Creates a new `RepoMetadataModel` with incremental update emission
@@ -114,6 +128,12 @@ impl RepoMetadataModel {
                 RepoMetadataEvent::FileTreeEntryUpdated {
                     id: RepositoryIdentifier::local(path.clone()),
                 }
+            }
+            RepositoryMetadataEvent::LazyDisplayTreeUpdated { path } => {
+                RepoMetadataEvent::LazyDisplayTreeUpdated { path: path.clone() }
+            }
+            RepositoryMetadataEvent::LazyDisplayTreeRemoved { path } => {
+                RepoMetadataEvent::LazyDisplayTreeRemoved { path: path.clone() }
             }
             RepositoryMetadataEvent::UpdatingRepositoryFailed { path } => {
                 RepoMetadataEvent::UpdatingRepositoryFailed {
@@ -421,6 +441,17 @@ impl RepoMetadataModel {
     ) {
         self.local.update(ctx, |local, _ctx| {
             local.insert_test_state(repo_path, state);
+        });
+    }
+
+    /// Inserts a failed local repository state for testing fallback behavior.
+    pub fn insert_test_failed_state(
+        &self,
+        repo_path: StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.local.update(ctx, |local, _ctx| {
+            local.insert_test_failed_state(repo_path);
         });
     }
 }


### PR DESCRIPTION
## Description
- Stack this follow-up above #11460, which now owns normal direct project-rule discovery and the typed remote project-rule snapshot transport.
- Keep repository-wide metadata authoritative: indexing failures remain failures rather than shallow successful trees, while lazy display trees provide separate local and remote browsing recovery.
- Route local project skills and project rules through authoritative metadata when indexing succeeds and filesystem fallback only after authoritative indexing fails; extend project-rule publication with failed-index fallback without reintroducing normal tree-backed discovery.
- Publish and consume typed remote project-skill replacement snapshots, while preventing display-only remote file-tree snapshots from becoming a project-context source.
- Align production-style `SkillManager` test fixtures with its `RemoteServerManager` runtime-source subscription dependency exposed by the restack.

## Linked Issue
No linked issue was provided for this stacked draft follow-up.

## Testing
- `./script/format`
- `cargo test -p warp --lib ai::agent_sdk::driver::tests::split_loading_env_loads_all_global_loads_subset -- --nocapture`
- `cargo test -p warp --lib ai::skills -- --nocapture`
- `cargo test -p warp --lib metadata_project_rules`
- `cargo test -p ai --features local_fs project_context`
- `cargo test -p warp --lib remote_server::server_model::tests`
- `cargo test -p warp --lib skill_watcher`
- `./script/presubmit`

- [ ] I have manually tested my changes locally with `./script/run` (not run; focused model, watcher, daemon, fixture-regression, and full presubmit validation were run for this branch).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent Artifacts
- Conversation: https://staging.warp.dev/conversation/dd300173-8538-4d9f-85d1-beeffa00b8bb
- Reorder plan: https://staging.warp.dev/drive/notebook/jATYCff51aSDIIXFKWciVr
- Design plan: https://staging.warp.dev/drive/notebook/N8ECz4kVfIJjgSZZDzdKON

Co-Authored-By: Oz <oz-agent@warp.dev>