### PR TITLE
prevent flickering windows on Windows by adding DETACHED_PROCESS

### DIFF
--- a/crates/command/src/async.rs
+++ b/crates/command/src/async.rs
@@ -100,11 +100,13 @@ impl Command {
         #[cfg(all(windows, not(feature = "test-util")))]
         {
             use async_process::windows::CommandExt;
+            use windows::Win32::System::Threading;
             // We need to set the `CREATE_BREAKAWAY_FROM_JOB` flag to avoid assigning
             // the process to the same Job Object as the Warp process, otherwise the
             // process will be killed when the Warp process is killed.
-            let flags = windows::Win32::System::Threading::CREATE_NO_WINDOW.0
-                | windows::Win32::System::Threading::CREATE_BREAKAWAY_FROM_JOB.0;
+            let flags = Threading::CREATE_NO_WINDOW.0
+                | Threading::DETACHED_PROCESS.0
+                | Threading::CREATE_BREAKAWAY_FROM_JOB.0;
             inner.creation_flags(flags);
         }
         Self {


### PR DESCRIPTION
## Description

With Warp on Windows running, sometimes random console windows flicker into view. Very annoying. This PR fixes that.

https://github.com/user-attachments/assets/16949122-5b09-4d93-bd50-4b07710abbd4

Apparently `CREATE_NO_WINDOW` only prevents the direct child from creating a visible window. It doesn't prevent the child from inheriting the console host. Grandchildren might still create a visible window since it doesn't pass the same creation flags (unlike console host, the flags are NOT inherited). `DETACHED_PROCESS` is necessary because it starts the background shell without any console attached in the first place, so PowerShell and its console-subsystem children have no foreground console host to flash.


## Linked Issue

Fixes #11224

## Testing

I don't see flickering windows anymore.

