### PR TITLE
Add Shift+Click to extend terminal text selection (iTerm2-style)

### DIFF
--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -273,13 +273,35 @@ impl AltScreenElement {
             SelectionType::from_click_count(click_count)
         };
 
-        if should_intercept_mouse(&self.model.lock(), mouse_state.modifiers().shift, app) {
-            ctx.dispatch_typed_action(TerminalAction::AltSelect(SelectAction::Begin {
-                point,
-                side,
-                selection_type,
-                position: local_position,
-            }));
+        let (should_intercept, has_selection) = {
+            let model = self.model.lock();
+            (
+                should_intercept_mouse(&model, mouse_state.modifiers().shift, app),
+                model.alt_screen().selection().is_some(),
+            )
+        };
+
+        if should_intercept {
+            let should_extend_selection = mouse_state.modifiers().shift
+                && selection_type == SelectionType::Simple
+                && self.highlighted_url.is_none()
+                && self.hovered_secret.is_none()
+                && has_selection;
+
+            if should_extend_selection {
+                ctx.dispatch_typed_action(TerminalAction::AltSelect(SelectAction::Extend {
+                    point,
+                    side,
+                    position: local_position,
+                }));
+            } else {
+                ctx.dispatch_typed_action(TerminalAction::AltSelect(SelectAction::Begin {
+                    point,
+                    side,
+                    selection_type,
+                    position: local_position,
+                }));
+            }
         } else {
             ctx.dispatch_typed_action(TerminalAction::MaybeClearAltSelect);
             ctx.dispatch_typed_action(TerminalAction::AltMouseAction(mouse_state.set_point(point)));

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -605,6 +605,7 @@ pub struct BlockListElement {
     scroll_position: ScrollPosition,
     is_terminal_focused: bool,
     is_terminal_selecting: bool,
+    is_extending_block_text_selection: bool,
     /// This map contains the IDs of sessions that were subshells as keys. Their corresponding
     /// values are the command that spawned the subshell, which is needed to paint the "flag"
     subshell_sessions: HashMap<SessionId, SubshellSource>,
@@ -910,6 +911,8 @@ impl BlockListElement {
             scroll_position: terminal_view_render_context.scroll_position,
             is_terminal_focused: terminal_view_render_context.is_terminal_focused,
             is_terminal_selecting: terminal_view_render_context.is_terminal_selecting,
+            is_extending_block_text_selection: terminal_view_render_context
+                .is_extending_block_text_selection,
             subshell_sessions: terminal_view_render_context.spawning_command_for_subshell_sessions,
             subshell_flags: HashMap::new(),
             size: None,
@@ -1596,41 +1599,65 @@ impl BlockListElement {
                                 }
                             }
 
-                            // If the find bar is open, allow selecting the active block again so users can
-                            // scope find to that block.
-                            let find_bar_open = self.find_model.as_ref(app).is_find_bar_open();
-                            // If there's only a non-simple selection, clear the clicked block to avoid a
-                            // text selection and a block selection being rendered at the same time.
-                            // Note we should only dispatch block selection actions when the mouse is not
-                            // clicking on highlighted links or a rich block or if this mouse_down is unselecting
-                            // text.
-                            if selection_type == SelectionType::Simple
+                            // iTerm-style shift+left-click extends the existing text selection
+                            // by moving the nearest boundary instead of starting a fresh one.
+                            // Only kicks in when there's actually a selection to extend and the
+                            // click isn't on a link or a revealed secret.
+                            let extend_text_selection = modifiers.shift
+                                && selection_type == SelectionType::Simple
                                 && self.highlighted_url.is_none()
                                 && self.hovered_secret.is_none()
-                                && model.block_list().selection().is_none()
-                                // Clicking on an active long running block should focus that block instead,
-                                // except when the find bar is open, in which case we allow selecting it.
-                                && (!on_long_running_block || find_bar_open)
-                            {
-                                ctx.dispatch_typed_action(TerminalAction::BlockSelect {
-                                    action: BlockSelectAction::MouseDown(Some(block_index)),
-                                    should_redetermine_focus,
-                                });
-                            } else {
+                                && model.block_list().selection().is_some();
+
+                            if extend_text_selection {
                                 ctx.dispatch_typed_action(TerminalAction::BlockSelect {
                                     action: BlockSelectAction::ClearAllBlocks,
                                     should_redetermine_focus,
                                 });
-                            }
+                                ctx.dispatch_typed_action(TerminalAction::BlockTextSelect(
+                                    BlockTextSelectAction::Extend {
+                                        point,
+                                        side,
+                                        position,
+                                    },
+                                ));
+                            } else {
+                                // If the find bar is open, allow selecting the active block again so users can
+                                // scope find to that block.
+                                let find_bar_open = self.find_model.as_ref(app).is_find_bar_open();
+                                // If there's only a non-simple selection, clear the clicked block to avoid a
+                                // text selection and a block selection being rendered at the same time.
+                                // Note we should only dispatch block selection actions when the mouse is not
+                                // clicking on highlighted links or a rich block or if this mouse_down is unselecting
+                                // text.
+                                if selection_type == SelectionType::Simple
+                                    && self.highlighted_url.is_none()
+                                    && self.hovered_secret.is_none()
+                                    && model.block_list().selection().is_none()
+                                    // Clicking on an active long running block should focus that block instead,
+                                    // except when the find bar is open, in which case we allow selecting it.
+                                    && (!on_long_running_block || find_bar_open)
+                                {
+                                    ctx.dispatch_typed_action(TerminalAction::BlockSelect {
+                                        action: BlockSelectAction::MouseDown(Some(block_index)),
+                                        should_redetermine_focus,
+                                    });
+                                } else {
+                                    ctx.dispatch_typed_action(TerminalAction::BlockSelect {
+                                        action: BlockSelectAction::ClearAllBlocks,
+                                        should_redetermine_focus,
+                                    });
+                                }
 
-                            ctx.dispatch_typed_action(TerminalAction::BlockTextSelect(
-                                BlockTextSelectAction::Begin {
-                                    point,
-                                    side,
-                                    selection_type,
-                                    position,
-                                },
-                            ));
+                                ctx.dispatch_typed_action(TerminalAction::BlockTextSelect(
+                                    BlockTextSelectAction::Begin {
+                                        point,
+                                        side,
+                                        selection_type,
+                                        position,
+                                    },
+                                ));
+                            }
                         }
                         // While rich content blocks can't be selected like command blocks,
                         // text selections can still originate in them (i.e. with AI blocks)
@@ -1969,7 +1996,9 @@ impl BlockListElement {
             let side = self
                 .size_info
                 .get_mouse_side(position - vec2f(bounds.origin().x(), snackbar_bottom));
-            if !is_selecting_blocks
+            // Shift+Click Extend starts as a text-selection gesture. Keep allowing drag updates
+            // even though the Shift modifier would otherwise classify the drag as block selection.
+            if (!is_selecting_blocks || self.is_extending_block_text_selection)
                 && let Some(point) = self.coord_to_point(
                     SnackbarPoint::underneath_snackbar(position),
                     ClampingMode::ClampToGrid,

--- a/app/src/terminal/model/alt_screen.rs
+++ b/app/src/terminal/model/alt_screen.rs
@@ -236,6 +236,21 @@ impl AltScreen {
         self.set_selection(selection);
     }
 
+    pub fn extend_selection(&mut self, point: Point, side: Side) {
+        let mut selection = match self.selection.take() {
+            None => return,
+            Some(selection) => selection,
+        };
+
+        selection.extend_to_nearest_boundary(point, side);
+        if selection.is_tail_before_head() {
+            selection.set_smart_select_side(Direction::Right);
+        } else {
+            selection.set_smart_select_side(Direction::Left);
+        }
+        self.set_selection(selection);
+    }
+
     fn set_selection(&mut self, value: Selection) {
         self.selection = Some(value);
         self.event_proxy

--- a/app/src/terminal/model/alt_screen_tests.rs
+++ b/app/src/terminal/model/alt_screen_tests.rs
@@ -145,6 +145,15 @@ fn test_alt_screen_extend_selection_shrinks_inside_selection() {
 }
 
 #[test]
+fn test_alt_screen_extend_selection_without_existing_selection_noops() {
+    let mut screen = new_alt_screen(default_size());
+
+    screen.extend_selection(Point::new(3, 1), Side::Right);
+
+    assert!(screen.selection().is_none());
+}
+
+#[test]
 fn test_accumulate_lines_to_scroll() {
     let mut screen = new_alt_screen(default_size());
 

--- a/app/src/terminal/model/alt_screen_tests.rs
+++ b/app/src/terminal/model/alt_screen_tests.rs
@@ -87,6 +87,64 @@ fn test_alt_screen_single_cell_selection() {
 }
 
 #[test]
+fn test_alt_screen_extend_selection_to_nearest_boundary() {
+    let mut screen = new_alt_screen(default_size());
+    let semantic_selection = SemanticSelection::mock(false, "");
+
+    screen.start_selection(Point::new(2, 1), SelectionType::Simple, Side::Left);
+    screen.update_selection(Point::new(7, 1), Side::Right);
+
+    screen.extend_selection(Point::new(9, 1), Side::Right);
+    assert_eq!(
+        screen.selection_range(&semantic_selection),
+        Some(ExpandedSelectionRange::Regular {
+            start: Point::new(2, 1),
+            end: Point::new(9, 1),
+            reversed: false,
+        })
+    );
+
+    screen.extend_selection(Point::new(1, 1), Side::Left);
+    assert_eq!(
+        screen.selection_range(&semantic_selection),
+        Some(ExpandedSelectionRange::Regular {
+            start: Point::new(1, 1),
+            end: Point::new(9, 1),
+            reversed: false,
+        })
+    );
+}
+
+#[test]
+fn test_alt_screen_extend_selection_shrinks_inside_selection() {
+    let mut screen = new_alt_screen(default_size());
+    let semantic_selection = SemanticSelection::mock(false, "");
+
+    screen.start_selection(Point::new(2, 1), SelectionType::Simple, Side::Left);
+    screen.update_selection(Point::new(8, 1), Side::Right);
+
+    screen.extend_selection(Point::new(3, 1), Side::Left);
+    assert_eq!(
+        screen.selection_range(&semantic_selection),
+        Some(ExpandedSelectionRange::Regular {
+            start: Point::new(3, 1),
+            end: Point::new(8, 1),
+            reversed: false,
+        })
+    );
+
+    screen.extend_selection(Point::new(7, 1), Side::Right);
+    assert_eq!(
+        screen.selection_range(&semantic_selection),
+        Some(ExpandedSelectionRange::Regular {
+            start: Point::new(3, 1),
+            end: Point::new(7, 1),
+            reversed: false,
+        })
+    );
+}
+
+#[test]
 fn test_accumulate_lines_to_scroll() {
     let mut screen = new_alt_screen(default_size());
 

--- a/app/src/terminal/model/alt_screen_tests.rs
+++ b/app/src/terminal/model/alt_screen_tests.rs
@@ -110,7 +110,7 @@ fn test_alt_screen_extend_selection_to_nearest_boundary() {
         Some(ExpandedSelectionRange::Regular {
             start: Point::new(1, 1),
             end: Point::new(9, 1),
-            reversed: false,
+            reversed: true,
         })
     );
 }
@@ -129,7 +129,7 @@ fn test_alt_screen_extend_selection_shrinks_inside_selection() {
         Some(ExpandedSelectionRange::Regular {
             start: Point::new(3, 1),
             end: Point::new(8, 1),
-            reversed: false,
+            reversed: true,
         })
     );
 
@@ -140,6 +140,27 @@ fn test_alt_screen_extend_selection_shrinks_inside_selection() {
             start: Point::new(3, 1),
             end: Point::new(7, 1),
             reversed: false,
+        })
+    );
+}
+
+#[test]
+fn test_alt_screen_nearest_boundary_extend_then_update_keeps_extended_boundary() {
+    let mut screen = new_alt_screen(default_size());
+    let semantic_selection = SemanticSelection::mock(false, "");
+
+    screen.start_selection(Point::new(4, 1), SelectionType::Simple, Side::Left);
+    screen.update_selection(Point::new(9, 1), Side::Right);
+
+    screen.extend_selection(Point::new(2, 1), Side::Left);
+    screen.update_selection(Point::new(1, 1), Side::Left);
+
+    assert_eq!(
+        screen.selection_range(&semantic_selection),
+        Some(ExpandedSelectionRange::Regular {
+            start: Point::new(1, 1),
+            end: Point::new(9, 1),
+            reversed: true,
         })
     );
 }

--- a/app/src/terminal/model/blocks/selection.rs
+++ b/app/src/terminal/model/blocks/selection.rs
@@ -22,8 +22,8 @@ use crate::terminal::event::Event as TerminalEvent;
 use crate::terminal::model::block::BlockSection;
 use crate::terminal::model::index::{Direction, Point, Side};
 use crate::terminal::model::selection::{
-    should_extend_selection_start, ExpandedSelectionRange, Selection, SelectionDirection,
-    SelectionPoint,
+    ExpandedSelectionRange, Selection, SelectionDirection, SelectionPoint,
+    should_extend_selection_start,
 };
 use crate::terminal::model::terminal_model::{BlockIndex, WithinBlock};
 use crate::terminal::warpify::success_block::WarpifySuccessBlock;

--- a/app/src/terminal/model/blocks/selection.rs
+++ b/app/src/terminal/model/blocks/selection.rs
@@ -118,6 +118,8 @@ impl BlockListSelection {
     }
 
     /// Extend the selection by moving whichever boundary is closest to `point`.
+    /// The moved boundary is stored as the tail so a following drag can
+    /// continue fine-tuning the same side.
     pub fn extend_to_nearest_boundary(&mut self, point: BlockListPoint, side: Side) {
         let target = BlockAnchor::new(point, side);
         let head_is_selection_start = !Self::points_need_swap(self.head.point, self.tail.point);
@@ -133,10 +135,13 @@ impl BlockListSelection {
             Self::selection_point(selection_end.point),
         );
 
-        match (should_update_selection_start, head_is_selection_start) {
-            (true, true) | (false, false) => self.head = target,
-            (true, false) | (false, true) => self.tail = target,
-        }
+        let fixed_boundary = if should_update_selection_start {
+            selection_end
+        } else {
+            selection_start
+        };
+        self.head = fixed_boundary;
+        self.tail = target;
     }
 
     /// Given a block list position (offset from the top-left corner of the

--- a/app/src/terminal/model/blocks/selection.rs
+++ b/app/src/terminal/model/blocks/selection.rs
@@ -21,7 +21,10 @@ use crate::terminal::GridType;
 use crate::terminal::event::Event as TerminalEvent;
 use crate::terminal::model::block::BlockSection;
 use crate::terminal::model::index::{Direction, Point, Side};
-use crate::terminal::model::selection::{ExpandedSelectionRange, Selection, SelectionDirection};
+use crate::terminal::model::selection::{
+    should_extend_selection_start, ExpandedSelectionRange, Selection, SelectionDirection,
+    SelectionPoint,
+};
 use crate::terminal::model::terminal_model::{BlockIndex, WithinBlock};
 use crate::terminal::warpify::success_block::WarpifySuccessBlock;
 
@@ -104,6 +107,35 @@ impl BlockListSelection {
             head
         } else {
             tail
+        }
+    }
+
+    fn selection_point(point: BlockListPoint) -> SelectionPoint {
+        SelectionPoint {
+            row: point.row,
+            col: point.column,
+        }
+    }
+
+    /// Extend the selection by moving whichever boundary is closest to `point`.
+    pub fn extend_to_nearest_boundary(&mut self, point: BlockListPoint, side: Side) {
+        let target = BlockAnchor::new(point, side);
+        let head_is_selection_start = !Self::points_need_swap(self.head.point, self.tail.point);
+        let (selection_start, selection_end) = if head_is_selection_start {
+            (self.head, self.tail)
+        } else {
+            (self.tail, self.head)
+        };
+
+        let should_update_selection_start = should_extend_selection_start(
+            Self::selection_point(point),
+            Self::selection_point(selection_start.point),
+            Self::selection_point(selection_end.point),
+        );
+
+        match (should_update_selection_start, head_is_selection_start) {
+            (true, true) | (false, false) => self.head = target,
+            (true, false) | (false, true) => self.tail = target,
         }
     }
 
@@ -439,6 +471,18 @@ impl BlockList {
         let block_anchor = BlockAnchor::new(point, side);
 
         selection.tail = block_anchor;
+
+        self.set_selection(selection);
+    }
+
+    /// Used to extend an existing selection to a new BlockListPoint, moving whichever boundary
+    /// is closest to the point. Must have an existing selection to update.
+    pub fn extend_selection_to_nearest_boundary(&mut self, point: BlockListPoint, side: Side) {
+        let Some(mut selection) = self.selection.take() else {
+            return;
+        };
+
+        selection.extend_to_nearest_boundary(point, side);
 
         self.set_selection(selection);
     }

--- a/app/src/terminal/model/blocks/selection_tests.rs
+++ b/app/src/terminal/model/blocks/selection_tests.rs
@@ -102,6 +102,60 @@ pub fn test_selection_range_cleared_when_block_finishes() {
 }
 
 #[test]
+pub fn test_extend_selection_to_nearest_boundary() {
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+
+    block_list.start_selection(
+        BlockListPoint::new(10.0, 2),
+        SelectionType::Simple,
+        Side::Left,
+    );
+    block_list.update_selection(BlockListPoint::new(20.0, 2), Side::Right);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(25.0, 4), Side::Right);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 10.0);
+    assert_eq!(selection.head.point.column, 2);
+    assert_lines_approx_eq!(selection.tail.point.row, 25.0);
+    assert_eq!(selection.tail.point.column, 4);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(5.0, 1), Side::Left);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 5.0);
+    assert_eq!(selection.head.point.column, 1);
+    assert_lines_approx_eq!(selection.tail.point.row, 25.0);
+    assert_eq!(selection.tail.point.column, 4);
+}
+
+#[test]
+pub fn test_extend_selection_to_nearest_boundary_shrinks_inside_selection() {
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+
+    block_list.start_selection(
+        BlockListPoint::new(10.0, 2),
+        SelectionType::Simple,
+        Side::Left,
+    );
+    block_list.update_selection(BlockListPoint::new(20.0, 2), Side::Right);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(12.0, 4), Side::Left);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 12.0);
+    assert_eq!(selection.head.point.column, 4);
+    assert_lines_approx_eq!(selection.tail.point.row, 20.0);
+    assert_eq!(selection.tail.point.column, 2);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(18.0, 4), Side::Right);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 12.0);
+    assert_eq!(selection.head.point.column, 4);
+    assert_lines_approx_eq!(selection.tail.point.row, 18.0);
+    assert_eq!(selection.tail.point.column, 4);
+}
+
+#[test]
 pub fn test_selection_ranges_single_command_grid() {
     let mut blocks = new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
     let size = *blocks.size();

--- a/app/src/terminal/model/blocks/selection_tests.rs
+++ b/app/src/terminal/model/blocks/selection_tests.rs
@@ -122,10 +122,10 @@ pub fn test_extend_selection_to_nearest_boundary() {
 
     block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(5.0, 1), Side::Left);
     let selection = block_list.selection().expect("selection should exist");
-    assert_lines_approx_eq!(selection.head.point.row, 5.0);
-    assert_eq!(selection.head.point.column, 1);
-    assert_lines_approx_eq!(selection.tail.point.row, 25.0);
-    assert_eq!(selection.tail.point.column, 4);
+    assert_lines_approx_eq!(selection.head.point.row, 25.0);
+    assert_eq!(selection.head.point.column, 4);
+    assert_lines_approx_eq!(selection.tail.point.row, 5.0);
+    assert_eq!(selection.tail.point.column, 1);
 }
 
 #[test]
@@ -142,10 +142,10 @@ pub fn test_extend_selection_to_nearest_boundary_shrinks_inside_selection() {
 
     block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(12.0, 4), Side::Left);
     let selection = block_list.selection().expect("selection should exist");
-    assert_lines_approx_eq!(selection.head.point.row, 12.0);
-    assert_eq!(selection.head.point.column, 4);
-    assert_lines_approx_eq!(selection.tail.point.row, 20.0);
-    assert_eq!(selection.tail.point.column, 2);
+    assert_lines_approx_eq!(selection.head.point.row, 20.0);
+    assert_eq!(selection.head.point.column, 2);
+    assert_lines_approx_eq!(selection.tail.point.row, 12.0);
+    assert_eq!(selection.tail.point.column, 4);
 
     block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(18.0, 4), Side::Right);
     let selection = block_list.selection().expect("selection should exist");
@@ -170,9 +170,9 @@ pub fn test_extend_selection_to_nearest_boundary_shrinks_same_row_by_column() {
     block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(10.0, 4), Side::Left);
     let selection = block_list.selection().expect("selection should exist");
     assert_lines_approx_eq!(selection.head.point.row, 10.0);
-    assert_eq!(selection.head.point.column, 4);
+    assert_eq!(selection.head.point.column, 20);
     assert_lines_approx_eq!(selection.tail.point.row, 10.0);
-    assert_eq!(selection.tail.point.column, 20);
+    assert_eq!(selection.tail.point.column, 4);
 
     block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(10.0, 18), Side::Right);
     let selection = block_list.selection().expect("selection should exist");
@@ -203,9 +203,9 @@ pub fn test_extend_selection_to_nearest_boundary_handles_reversed_selection() {
 
     block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(25.0, 4), Side::Right);
     let selection = block_list.selection().expect("selection should exist");
-    assert_lines_approx_eq!(selection.head.point.row, 25.0);
+    assert_lines_approx_eq!(selection.head.point.row, 5.0);
     assert_eq!(selection.head.point.column, 4);
-    assert_lines_approx_eq!(selection.tail.point.row, 5.0);
+    assert_lines_approx_eq!(selection.tail.point.row, 25.0);
     assert_eq!(selection.tail.point.column, 4);
 }
 

--- a/app/src/terminal/model/blocks/selection_tests.rs
+++ b/app/src/terminal/model/blocks/selection_tests.rs
@@ -156,6 +156,70 @@ pub fn test_extend_selection_to_nearest_boundary_shrinks_inside_selection() {
 }
 
 #[test]
+pub fn test_extend_selection_to_nearest_boundary_shrinks_same_row_by_column() {
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+
+    block_list.start_selection(
+        BlockListPoint::new(10.0, 2),
+        SelectionType::Simple,
+        Side::Left,
+    );
+    block_list.update_selection(BlockListPoint::new(10.0, 20), Side::Right);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(10.0, 4), Side::Left);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 10.0);
+    assert_eq!(selection.head.point.column, 4);
+    assert_lines_approx_eq!(selection.tail.point.row, 10.0);
+    assert_eq!(selection.tail.point.column, 20);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(10.0, 18), Side::Right);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 10.0);
+    assert_eq!(selection.head.point.column, 4);
+    assert_lines_approx_eq!(selection.tail.point.row, 10.0);
+    assert_eq!(selection.tail.point.column, 18);
+}
+
+#[test]
+pub fn test_extend_selection_to_nearest_boundary_handles_reversed_selection() {
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+
+    block_list.start_selection(
+        BlockListPoint::new(20.0, 2),
+        SelectionType::Simple,
+        Side::Right,
+    );
+    block_list.update_selection(BlockListPoint::new(10.0, 2), Side::Left);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(5.0, 4), Side::Left);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 20.0);
+    assert_eq!(selection.head.point.column, 2);
+    assert_lines_approx_eq!(selection.tail.point.row, 5.0);
+    assert_eq!(selection.tail.point.column, 4);
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(25.0, 4), Side::Right);
+    let selection = block_list.selection().expect("selection should exist");
+    assert_lines_approx_eq!(selection.head.point.row, 25.0);
+    assert_eq!(selection.head.point.column, 4);
+    assert_lines_approx_eq!(selection.tail.point.row, 5.0);
+    assert_eq!(selection.tail.point.column, 4);
+}
+
+#[test]
+pub fn test_extend_selection_to_nearest_boundary_without_existing_selection_noops() {
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+
+    block_list.extend_selection_to_nearest_boundary(BlockListPoint::new(10.0, 4), Side::Right);
+
+    assert!(block_list.selection().is_none());
+}
+
+#[test]
 pub fn test_selection_ranges_single_command_grid() {
     let mut blocks = new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
     let size = *blocks.size();

--- a/app/src/terminal/model/selection.rs
+++ b/app/src/terminal/model/selection.rs
@@ -14,7 +14,7 @@ use vec1::Vec1;
 use warp_core::semantic_selection::SemanticSelection;
 use warp_terminal::model::grid::cell;
 use warpui::text::SelectionType;
-use warpui::units::Lines;
+use warpui::units::{IntoLines as _, Lines};
 
 use super::index::{Direction, VisibleRow};
 use crate::terminal::Vector2F;
@@ -236,6 +236,51 @@ impl Ord for SelectionPoint {
     }
 }
 
+impl SelectionPoint {
+    pub fn from_grid_point(point: Point) -> Self {
+        Self {
+            row: point.row.into_lines(),
+            col: point.col,
+        }
+    }
+}
+
+fn point_distance_to_selection_boundary(
+    point: SelectionPoint,
+    boundary: SelectionPoint,
+) -> (f64, usize) {
+    (
+        (point.row - boundary.row).as_f64().abs(),
+        point.col.abs_diff(boundary.col),
+    )
+}
+
+/// Returns true when extending a selection to `point` should move the start
+/// boundary rather than the end boundary. `start` must be before `end`.
+pub fn should_extend_selection_start(
+    point: SelectionPoint,
+    start: SelectionPoint,
+    end: SelectionPoint,
+) -> bool {
+    if point <= start {
+        return true;
+    }
+
+    if point >= end {
+        return false;
+    }
+
+    let (start_row_distance, start_col_distance) =
+        point_distance_to_selection_boundary(point, start);
+    let (end_row_distance, end_col_distance) = point_distance_to_selection_boundary(point, end);
+
+    if (start_row_distance - end_row_distance).abs() > f64::EPSILON {
+        return start_row_distance < end_row_distance;
+    }
+
+    start_col_distance <= end_col_distance
+}
+
 #[derive(Debug, Clone)]
 pub enum SelectAction<T> {
     Begin {
@@ -248,6 +293,14 @@ pub enum SelectAction<T> {
         point: T,
         side: Side,
         delta: Lines,
+        position: Vector2F,
+    },
+    /// Extends an existing selection to `point`, moving whichever boundary is
+    /// nearest to the clicked point. Used for iTerm-style shift+left-click
+    /// selection extension.
+    Extend {
+        point: T,
+        side: Side,
         position: Vector2F,
     },
     End,
@@ -323,6 +376,32 @@ impl Selection {
     /// Update the end of the selection.
     pub fn update(&mut self, point: Point, side: Side) {
         self.region.end = Anchor::new(point, side);
+    }
+
+    /// Extend the selection by moving whichever boundary is closest to `point`.
+    pub fn extend_to_nearest_boundary(&mut self, point: Point, side: Side) {
+        let target = Anchor::new(point, side);
+        let region_start_is_selection_start =
+            !Self::points_need_swap(self.region.start.point, self.region.end.point);
+        let (selection_start, selection_end) = if region_start_is_selection_start {
+            (self.region.start, self.region.end)
+        } else {
+            (self.region.end, self.region.start)
+        };
+
+        let should_update_selection_start = should_extend_selection_start(
+            SelectionPoint::from_grid_point(point),
+            SelectionPoint::from_grid_point(selection_start.point),
+            SelectionPoint::from_grid_point(selection_end.point),
+        );
+
+        match (
+            should_update_selection_start,
+            region_start_is_selection_start,
+        ) {
+            (true, true) | (false, false) => self.region.start = target,
+            (true, false) | (false, true) => self.region.end = target,
+        }
     }
 
     pub fn is_tail_before_head(&self) -> bool {

--- a/app/src/terminal/model/selection.rs
+++ b/app/src/terminal/model/selection.rs
@@ -379,6 +379,8 @@ impl Selection {
     }
 
     /// Extend the selection by moving whichever boundary is closest to `point`.
+    /// The moved boundary is stored as the update endpoint so a following drag
+    /// can continue fine-tuning the same side.
     pub fn extend_to_nearest_boundary(&mut self, point: Point, side: Side) {
         let target = Anchor::new(point, side);
         let region_start_is_selection_start =
@@ -395,13 +397,13 @@ impl Selection {
             SelectionPoint::from_grid_point(selection_end.point),
         );
 
-        match (
-            should_update_selection_start,
-            region_start_is_selection_start,
-        ) {
-            (true, true) | (false, false) => self.region.start = target,
-            (true, false) | (false, true) => self.region.end = target,
-        }
+        let fixed_boundary = if should_update_selection_start {
+            selection_end
+        } else {
+            selection_start
+        };
+        self.region.start = fixed_boundary;
+        self.region.end = target;
     }
 
     pub fn is_tail_before_head(&self) -> bool {

--- a/app/src/terminal/model/selection_tests.rs
+++ b/app/src/terminal/model/selection_tests.rs
@@ -128,6 +128,84 @@ fn simple_is_empty() {
 }
 
 #[test]
+fn extend_to_nearest_boundary_moves_outer_boundary() {
+    let mut selection = Selection::new(SelectionType::Simple, Point::new(10, 2), Side::Left);
+    selection.update(Point::new(20, 2), Side::Right);
+
+    selection.extend_to_nearest_boundary(Point::new(25, 4), Side::Right);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(10, 2), Side::Left)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(25, 4), Side::Right)
+    );
+
+    selection.extend_to_nearest_boundary(Point::new(5, 1), Side::Left);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(5, 1), Side::Left)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(25, 4), Side::Right)
+    );
+}
+
+#[test]
+fn extend_to_nearest_boundary_shrinks_inside_selection() {
+    let mut selection = Selection::new(SelectionType::Simple, Point::new(10, 2), Side::Left);
+    selection.update(Point::new(20, 2), Side::Right);
+
+    selection.extend_to_nearest_boundary(Point::new(12, 4), Side::Left);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(12, 4), Side::Left)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(20, 2), Side::Right)
+    );
+
+    selection.extend_to_nearest_boundary(Point::new(18, 4), Side::Right);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(12, 4), Side::Left)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(18, 4), Side::Right)
+    );
+}
+
+#[test]
+fn extend_to_nearest_boundary_handles_reversed_selection() {
+    let mut selection = Selection::new(SelectionType::Simple, Point::new(20, 2), Side::Right);
+    selection.update(Point::new(10, 2), Side::Left);
+
+    selection.extend_to_nearest_boundary(Point::new(5, 4), Side::Left);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(20, 2), Side::Right)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(5, 4), Side::Left)
+    );
+
+    selection.extend_to_nearest_boundary(Point::new(25, 4), Side::Right);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(25, 4), Side::Right)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(5, 4), Side::Left)
+    );
+}
+
+#[test]
 fn simple_max_min_column() {
     // If the selection starts on the Right side of a cell, it should skip that cell
     let mut selection = Selection::new(SelectionType::Simple, Point::new(0, 0), Side::Right);

--- a/app/src/terminal/model/selection_tests.rs
+++ b/app/src/terminal/model/selection_tests.rs
@@ -180,6 +180,32 @@ fn extend_to_nearest_boundary_shrinks_inside_selection() {
 }
 
 #[test]
+fn extend_to_nearest_boundary_shrinks_same_row_by_column() {
+    let mut selection = Selection::new(SelectionType::Simple, Point::new(10, 2), Side::Left);
+    selection.update(Point::new(10, 20), Side::Right);
+
+    selection.extend_to_nearest_boundary(Point::new(10, 4), Side::Left);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(10, 4), Side::Left)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(10, 20), Side::Right)
+    );
+
+    selection.extend_to_nearest_boundary(Point::new(10, 18), Side::Right);
+    assert_eq!(
+        selection.region.start,
+        Anchor::new(Point::new(10, 4), Side::Left)
+    );
+    assert_eq!(
+        selection.region.end,
+        Anchor::new(Point::new(10, 18), Side::Right)
+    );
+}
+
+#[test]
 fn extend_to_nearest_boundary_handles_reversed_selection() {
     let mut selection = Selection::new(SelectionType::Simple, Point::new(20, 2), Side::Right);
     selection.update(Point::new(10, 2), Side::Left);

--- a/app/src/terminal/model/selection_tests.rs
+++ b/app/src/terminal/model/selection_tests.rs
@@ -145,11 +145,11 @@ fn extend_to_nearest_boundary_moves_outer_boundary() {
     selection.extend_to_nearest_boundary(Point::new(5, 1), Side::Left);
     assert_eq!(
         selection.region.start,
-        Anchor::new(Point::new(5, 1), Side::Left)
+        Anchor::new(Point::new(25, 4), Side::Right)
     );
     assert_eq!(
         selection.region.end,
-        Anchor::new(Point::new(25, 4), Side::Right)
+        Anchor::new(Point::new(5, 1), Side::Left)
     );
 }
 
@@ -161,11 +161,11 @@ fn extend_to_nearest_boundary_shrinks_inside_selection() {
     selection.extend_to_nearest_boundary(Point::new(12, 4), Side::Left);
     assert_eq!(
         selection.region.start,
-        Anchor::new(Point::new(12, 4), Side::Left)
+        Anchor::new(Point::new(20, 2), Side::Right)
     );
     assert_eq!(
         selection.region.end,
-        Anchor::new(Point::new(20, 2), Side::Right)
+        Anchor::new(Point::new(12, 4), Side::Left)
     );
 
     selection.extend_to_nearest_boundary(Point::new(18, 4), Side::Right);
@@ -187,11 +187,11 @@ fn extend_to_nearest_boundary_shrinks_same_row_by_column() {
     selection.extend_to_nearest_boundary(Point::new(10, 4), Side::Left);
     assert_eq!(
         selection.region.start,
-        Anchor::new(Point::new(10, 4), Side::Left)
+        Anchor::new(Point::new(10, 20), Side::Right)
     );
     assert_eq!(
         selection.region.end,
-        Anchor::new(Point::new(10, 20), Side::Right)
+        Anchor::new(Point::new(10, 4), Side::Left)
     );
 
     selection.extend_to_nearest_boundary(Point::new(10, 18), Side::Right);
@@ -223,11 +223,11 @@ fn extend_to_nearest_boundary_handles_reversed_selection() {
     selection.extend_to_nearest_boundary(Point::new(25, 4), Side::Right);
     assert_eq!(
         selection.region.start,
-        Anchor::new(Point::new(25, 4), Side::Right)
+        Anchor::new(Point::new(5, 4), Side::Left)
     );
     assert_eq!(
         selection.region.end,
-        Anchor::new(Point::new(5, 4), Side::Left)
+        Anchor::new(Point::new(25, 4), Side::Right)
     );
 }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2285,6 +2285,7 @@ pub struct TerminalViewRenderContext {
     pub link_tool_tip: Option<GridHighlightedLink>,
     pub is_terminal_focused: bool,
     pub is_terminal_selecting: bool,
+    pub is_extending_block_text_selection: bool,
     pub is_context_menu_open: bool,
     pub is_waterfall_gap_mode: bool,
     pub pane_state: SplitPaneState,
@@ -2479,6 +2480,8 @@ pub struct TerminalView {
 
     /// Whether there is an active text selection.
     is_selecting: bool,
+    /// Whether the active block-list text selection gesture began from Shift+Click Extend.
+    is_extending_block_text_selection: bool,
 
     context_menu: ViewHandle<Menu<TerminalAction>>,
 
@@ -4254,6 +4257,7 @@ impl TerminalView {
             alt_screen_scroll_top: Lines::zero(),
             horizontal_clipped_scroll_state: Default::default(),
             is_selecting: false,
+            is_extending_block_text_selection: false,
             context_menu_state: None,
             context_menu,
             hovered_secret: None,
@@ -6623,6 +6627,7 @@ impl TerminalView {
                         // selection visuals don't persist after switching selection focus to the
                         // CLI subagent view.
                         me.is_selecting = false;
+                        me.is_extending_block_text_selection = false;
                         me.block_text_selection_start_position = None;
                         me.clear_selected_text_except(Some(view.id()), ctx);
                         ctx.notify();
@@ -17789,6 +17794,9 @@ impl TerminalView {
             SelectAction::Update {
                 point, side, delta, ..
             } => self.update_alt_selection(*point, *side, delta, ctx),
+            SelectAction::Extend { point, side, .. } => {
+                self.extend_alt_selection(*point, *side, ctx)
+            }
             SelectAction::End => {
                 self.end_alt_selection(ctx);
             }
@@ -17813,6 +17821,7 @@ impl TerminalView {
             .alt_screen_mut()
             .start_selection(point, selection_type, side);
         self.is_selecting = true;
+        self.is_extending_block_text_selection = false;
 
         ctx.notify();
     }
@@ -17831,9 +17840,26 @@ impl TerminalView {
         ctx.notify();
     }
 
+    fn extend_alt_selection(&mut self, point: Point, side: Side, ctx: &mut ViewContext<Self>) {
+        if self.model.lock().alt_screen().selection().is_none() {
+            // Extend is only dispatched for an existing selection; direct action invocations
+            // without one are ignored.
+            return;
+        }
+
+        self.model
+            .lock()
+            .alt_screen_mut()
+            .extend_selection(point, side);
+        self.is_selecting = true;
+        self.is_extending_block_text_selection = false;
+        ctx.notify();
+    }
+
     fn end_alt_selection(&mut self, ctx: &mut ViewContext<Self>) {
         if self.is_selecting {
             self.is_selecting = false;
+            self.is_extending_block_text_selection = false;
             self.maybe_copy_selection_to_clipboard(ctx);
             ctx.notify();
         } else {
@@ -17844,6 +17870,7 @@ impl TerminalView {
     fn end_text_selection(&mut self, ctx: &mut ViewContext<Self>) {
         if self.is_selecting {
             self.is_selecting = false;
+            self.is_extending_block_text_selection = false;
             self.block_text_selection_start_position = None;
 
             let selected_text = {
@@ -18151,6 +18178,11 @@ impl TerminalView {
                 delta,
                 position,
             } => self.update_block_text_selection(*point, *side, *delta, *position, ctx),
+            BlockTextSelectAction::Extend {
+                point,
+                side,
+                position,
+            } => self.extend_block_text_selection(*point, *side, *position, ctx),
             BlockTextSelectAction::End => {
                 self.end_text_selection(ctx);
             }
@@ -18560,6 +18592,7 @@ impl TerminalView {
             .block_list_mut()
             .start_selection(point, selection_type, side);
         self.is_selecting = true;
+        self.is_extending_block_text_selection = false;
 
         if self.rich_content_views.is_empty() {
             ctx.notify();
@@ -18649,6 +18682,43 @@ impl TerminalView {
 
         // Clear the selected block index on mouse drag.
         self.clear_selected_blocks(ctx);
+        self.model
+            .lock()
+            .block_list_mut()
+            .extend_selection_to_nearest_boundary(point, side);
+
+        ctx.notify();
+    }
+
+    /// Extends the existing block-text selection to `point`, keeping the
+    /// original anchor (head) fixed and moving only the tail. This backs
+    /// iTerm-style shift+left-click selection extension. If there is no existing
+    /// selection to extend, falls back to starting a new simple selection at
+    /// `point` so the gesture always does something sensible.
+    fn extend_block_text_selection(
+        &mut self,
+        point: BlockListPoint,
+        side: Side,
+        _position: Vector2F,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let has_selection = self.model.lock().block_list().selection().is_some();
+        if !has_selection {
+            // Extend is only dispatched when a selection already exists. Ignore direct
+            // invocations that arrive without a selection instead of creating a surprising one.
+            return;
+        }
+
+        // This is an explicit selection gesture, not a drag, so there's no
+        // text-vs-block drag ambiguity to debounce.
+        self.block_text_selection_start_position = None;
+        self.is_selecting = true;
+        self.is_extending_block_text_selection = true;
+
+        // Text and block selections are mutually exclusive context sources;
+        // extending a text selection clears any block selection.
+        self.clear_selected_blocks(ctx);
+
         self.model
             .lock()
             .block_list_mut()
@@ -19942,6 +20012,7 @@ impl TerminalView {
         // rich content view component (i.e. `CodeEditorView`), setting `is_selecting` to false
         // will prevent the selection from "spilling" into neighbouring blocks.
         self.is_selecting = false;
+        self.is_extending_block_text_selection = false;
 
         // TODO(Simon): This doesn't work as intended for nested inline SelectableAreas.
         // This includes inline action headers, requested commands, and env var collection blocks.
@@ -23218,6 +23289,7 @@ impl TerminalView {
                 .expect("terminal should upgrade")
                 .is_focused(app),
             is_terminal_selecting: self.is_selecting(),
+            is_extending_block_text_selection: self.is_extending_block_text_selection,
             is_context_menu_open: self.is_context_menu_open(),
             is_waterfall_gap_mode: self.is_waterfall_gap_mode(model, app),
             pane_state,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -18685,16 +18685,14 @@ impl TerminalView {
         self.model
             .lock()
             .block_list_mut()
-            .extend_selection_to_nearest_boundary(point, side);
+            .update_selection(point, side);
 
         ctx.notify();
     }
 
-    /// Extends the existing block-text selection to `point`, keeping the
-    /// original anchor (head) fixed and moving only the tail. This backs
-    /// iTerm-style shift+left-click selection extension. If there is no existing
-    /// selection to extend, falls back to starting a new simple selection at
-    /// `point` so the gesture always does something sensible.
+    /// Extends the existing block-text selection to `point` by moving whichever
+    /// boundary is nearest to the point. The moved boundary becomes the active
+    /// drag endpoint so Shift+Click+drag can keep fine-tuning the same side.
     fn extend_block_text_selection(
         &mut self,
         point: BlockListPoint,
@@ -18722,7 +18720,7 @@ impl TerminalView {
         self.model
             .lock()
             .block_list_mut()
-            .update_selection(point, side);
+            .extend_selection_to_nearest_boundary(point, side);
 
         ctx.notify();
     }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -2677,6 +2677,105 @@ fn read_from_clipboard(ctx: &mut ViewContext<TerminalView>) -> String {
     TerminalView::read_from_clipboard(Some(ShellFamily::Posix), ctx)
 }
 
+fn add_multiline_command_block(view: &mut TerminalView) -> Lines {
+    let command = (0..30)
+        .map(|line| format!("line_{line:02}\n"))
+        .collect::<String>();
+    let mut model = view.model.lock();
+    let blocks = model.block_list_mut();
+    let block_index = insert_block(blocks, &command, "");
+    blocks
+        .block_at(block_index)
+        .expect("block should exist")
+        .command_grid_offset()
+}
+
+#[test]
+fn test_block_text_selection_nearest_boundary_update_keeps_drag_endpoint() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            let command_grid_offset = add_multiline_command_block(view);
+            let start = BlockListPoint::new(command_grid_offset, 2);
+            let first_drag = BlockListPoint::new(command_grid_offset + 20.0, 2);
+            let second_drag = BlockListPoint::new(command_grid_offset + 4.0, 4);
+
+            view.begin_block_text_selection(
+                start,
+                Side::Left,
+                SelectionType::Simple,
+                Vector2F::zero(),
+                ctx,
+            );
+            view.update_block_text_selection(
+                first_drag,
+                Side::Right,
+                Lines::zero(),
+                Vector2F::new(100.0, 100.0),
+                ctx,
+            );
+            view.update_block_text_selection(
+                second_drag,
+                Side::Right,
+                Lines::zero(),
+                Vector2F::new(110.0, 110.0),
+                ctx,
+            );
+
+            let semantic_selection = SemanticSelection::mock(false, "");
+            let model = view.model.lock();
+            let selection_range = model
+                .block_list()
+                .renderable_selection(&semantic_selection, false)
+                .expect("selection range should exist");
+            assert_eq!(selection_range.first().start, start);
+            assert_eq!(selection_range.first().end, second_drag);
+        });
+    })
+}
+
+#[test]
+fn test_block_text_selection_nearest_boundary_extend_moves_boundary() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            let command_grid_offset = add_multiline_command_block(view);
+            let start = BlockListPoint::new(command_grid_offset, 2);
+            let first_drag = BlockListPoint::new(command_grid_offset + 20.0, 2);
+            let shift_click = BlockListPoint::new(command_grid_offset + 4.0, 4);
+
+            view.begin_block_text_selection(
+                start,
+                Side::Left,
+                SelectionType::Simple,
+                Vector2F::zero(),
+                ctx,
+            );
+            view.update_block_text_selection(
+                first_drag,
+                Side::Right,
+                Lines::zero(),
+                Vector2F::new(100.0, 100.0),
+                ctx,
+            );
+            view.extend_block_text_selection(shift_click, Side::Left, Vector2F::zero(), ctx);
+
+            let semantic_selection = SemanticSelection::mock(false, "");
+            let model = view.model.lock();
+            let selection_range = model
+                .block_list()
+                .renderable_selection(&semantic_selection, false)
+                .expect("selection range should exist");
+            assert_eq!(selection_range.first().start, shift_click);
+            assert_eq!(selection_range.first().end, first_drag);
+        });
+    })
+}
+
 #[test]
 fn test_insert() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Summary

Adds iTerm2-style **Shift+Click to extend a terminal text selection**. With a selection already present, **Shift + left-click** moves the nearest selection boundary to the clicked point:

- clicking before the selection extends the start/head side
- clicking after the selection extends the end/tail side
- clicking inside the selection shrinks whichever side is closer

A plain click still starts a new selection, and Shift+Click+drag can continue fine-tuning the extended text selection. This makes selecting long / multi-screen output much easier: pick a start, scroll, then Shift+Click the other side instead of drag-and-auto-scrolling the whole way.

Closes #3426

(Supersedes the duplicate reports #11932, #9963, and #4715 -- same iTerm2-style Shift+Click extend behavior.)

## How it works

The shared selection model now exposes nearest-boundary extension logic, so block-list and alt-screen selections use the same behavior.

- **Selection model** (`selection.rs`): adds reusable nearest-boundary logic for moving start vs end when extending. The moved boundary remains the active update endpoint so Shift+Click+drag keeps fine-tuning the same side.
- **Block list** (`block_list_element.rs`, `view.rs`): Shift+Click dispatches `Extend` when a simple text selection already exists and the click is not on a link / revealed secret. Plain drag still updates the drag endpoint, while Shift+Click+drag continues dispatching text-selection updates instead of being misclassified as block selection.
- **Alt screen** (`alt_screen_element.rs`, `alt_screen.rs`): Shift+Click extension is wired for full-screen apps as well.

## Scope / follow-ups

- AI rich-content block internal selections are intentionally left out of scope for this PR because they are implemented differently.

## Testing

Verified after rebasing onto latest `upstream/master` (`c20645b9`) with this PR applied:

- `cargo fmt`
- `cargo test -p warp nearest_boundary --lib` -- 13 passed
- `cargo test -p warp test_alt_screen_extend_selection_without_existing_selection_noops --lib` -- 1 passed
- `cargo check -p warp`

The `nearest_boundary` coverage includes model tests plus view-level regressions for keeping plain drag updates on the drag endpoint and keeping Shift+Click+drag on the boundary selected by Extend.

Earlier macOS GUI evidence for the cross-screen block-list workflow is here: https://gist.github.com/cola-runner/37a80d8cf984abe661964e1b9d3fa9a9

Generated with [Claude Code](https://claude.com/claude-code)
