### PR TITLE
fix: update tar to resolve GHSA-3pv8-6f4r-ffg2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12938,9 +12938,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## Summary
- Updates the locked Rust crate `tar` from `0.4.45` to `0.4.46` in `Cargo.lock`.
- Resolves GitHub Dependabot alert 13 for `GHSA-3pv8-6f4r-ffg2`.

## Vulnerability details
- Advisory: https://github.com/advisories/GHSA-3pv8-6f4r-ffg2
- Dependabot alert: https://github.com/warpdotdev/warp/security/dependabot/13
- Package: `tar`
- Ecosystem: Rust / Cargo
- Manifest: `Cargo.lock`
- Vulnerable range: `<= 0.4.45`
- Patched version: `0.4.46`
- Relationship: direct dependency via `crates/node_runtime/Cargo.toml` (`tar = "0.4"`)

## Verification
- `cargo audit --file /workspace/warp/Cargo.lock --json | jq -r '.vulnerabilities.list[] | [.advisory.id, .advisory.title, .package.name, .package.version] | @tsv'` confirms `GHSA-3pv8-6f4r-ffg2` / `tar` is no longer reported. The remaining audit findings are unrelated existing advisories for `warp` and `websocket`.
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p node_runtime`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p node_runtime`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/7218cec5-3859-49f8-aeb2-ec7b9a052faa_
_Run: https://oz.staging.warp.dev/runs/019e799d-310a-772b-ba07-bafe4116a50c_
_This PR was generated with [Oz](https://warp.dev/oz)._
