### PR TITLE
Make StandardizedPath::strip_prefix component-aware

### DIFF
--- a/crates/warp_util/src/local_or_remote_path_tests.rs
+++ b/crates/warp_util/src/local_or_remote_path_tests.rs
@@ -178,3 +178,26 @@ fn local_or_remote_path_strip_repo_prefix_requires_same_host() {
         "local-vs-remote strip should be rejected"
     );
 }
+
+#[test]
+fn local_or_remote_path_strip_repo_prefix_rejects_sibling_dirs() {
+    // A remote file under a *sibling* directory whose name merely shares a
+    // string prefix with the repo (`/repository` vs `/repo`) is not inside
+    // the repo and must not be stripped. This must match the `Local` arm,
+    // which already rejects it via component-aware `Path::strip_prefix`.
+    let host = HostId::new("host".to_string());
+    let repo = LocalOrRemotePath::Remote(RemotePath::new(
+        host.clone(),
+        StandardizedPath::try_new("/repo").unwrap(),
+    ));
+    let sibling = LocalOrRemotePath::Remote(RemotePath::new(
+        host,
+        StandardizedPath::try_new("/repository/src/foo.rs").unwrap(),
+    ));
+
+    assert_eq!(
+        repo.strip_repo_prefix(&sibling),
+        None,
+        "sibling dir sharing a string prefix is not inside the repo"
+    );
+}

--- a/crates/warp_util/src/standardized_path.rs
+++ b/crates/warp_util/src/standardized_path.rs
@@ -151,16 +151,27 @@ impl StandardizedPath {
     }
 
     /// Strip a prefix from this path, returning the relative remainder.
+    ///
+    /// Matching is done at the component level (consistent with
+    /// [`starts_with`](Self::starts_with)), so `base = /repo` does **not**
+    /// match `self = /repository/foo.rs`; that returns `None` rather than a
+    /// bogus mid-component remainder.
     pub fn strip_prefix(&self, base: &StandardizedPath) -> Option<&str> {
-        let self_str = self.as_str();
-        let base_str = base.as_str();
-        self_str.strip_prefix(base_str).map(|remainder| {
-            // Remove leading separator if present.
+        // Gate on the component-aware `starts_with` so we never strip a base
+        // that is only a *string* prefix (e.g. `/repo` vs `/repository`). For
+        // two normalized paths, a component prefix is also a byte prefix, so
+        // slicing at `base` length lands exactly on a component boundary.
+        if !self.starts_with(base) {
+            return None;
+        }
+        let remainder = &self.as_str()[base.as_str().len()..];
+        Some(
+            // Remove the separator left between `base` and the remainder.
             remainder
                 .strip_prefix('/')
                 .or_else(|| remainder.strip_prefix('\\'))
-                .unwrap_or(remainder)
-        })
+                .unwrap_or(remainder),
+        )
     }
 
     /// Join a relative segment onto this path.

--- a/crates/warp_util/src/standardized_path_tests.rs
+++ b/crates/warp_util/src/standardized_path_tests.rs
@@ -103,6 +103,30 @@ fn strip_prefix() {
 }
 
 #[test]
+fn strip_prefix_equal_path() {
+    let p = StandardizedPath::try_new("/home/user/project").unwrap();
+    let base = StandardizedPath::try_new("/home/user/project").unwrap();
+    assert_eq!(p.strip_prefix(&base), Some(""));
+}
+
+#[test]
+fn strip_prefix_matches_only_whole_components() {
+    // `/repository` is a string-prefix sibling of `/repo`, but it is NOT a
+    // path-component descendant of it. `strip_prefix` must behave like
+    // `starts_with` and refuse to strip, returning `None` rather than a
+    // bogus mid-component remainder like `Some("sitory/foo.rs")`.
+    let base = StandardizedPath::try_new("/repo").unwrap();
+    let sibling = StandardizedPath::try_new("/repository/foo.rs").unwrap();
+    assert!(!sibling.starts_with(&base));
+    assert_eq!(sibling.strip_prefix(&base), None);
+
+    let nested_base = StandardizedPath::try_new("/home/user").unwrap();
+    let nested_sibling = StandardizedPath::try_new("/home/username/x").unwrap();
+    assert!(!nested_sibling.starts_with(&nested_base));
+    assert_eq!(nested_sibling.strip_prefix(&nested_base), None);
+}
+
+#[test]
 fn join() {
     let p = StandardizedPath::try_new("/home/user").unwrap();
     let joined = p.join("project/src");


### PR DESCRIPTION
StandardizedPath::strip_prefix` stripped a raw string prefix instead of matching whole path components. As a result a base like `/repo` was treated as a prefix of the sibling path `/repository/foo.rs`, returning a bogus mid-component remainder `Some("sitory/foo.rs")` instead of `None`.

This contradicted the sibling `starts_with`/`ends_with` methods (both component-aware) and silently broke `LocalOrRemotePath::strip_repo_prefix` for remote paths: its `Local` arm uses the component-aware `Path::strip_prefix` and correctly rejects siblings, while its `Remote` arm went through this method and mis-attributed files in a sibling directory to the repo.

Gate the strip on the component-aware `starts_with` before slicing. For two normalized paths a component prefix is also a byte prefix, so the cut lands on a component boundary. Add regression tests at both the `StandardizedPath` and `strip_repo_prefix` levels.

solve #11937
