### PR TITLE
fix(windows): apply dark tint to acrylic backdrop for dark mode themes

### DIFF
--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -168,6 +168,7 @@ windows = { workspace = true, features = [
     "Win32_Graphics_Dwm",
     "Win32_Graphics_DirectWrite",
     "Win32_Graphics_Gdi",
+    "Win32_UI_Controls",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Networking",

--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -26,8 +26,6 @@ use winit::error::ExternalError;
 use winit::event_loop::{ActiveEventLoop, EventLoopProxy, OwnedDisplayHandle};
 #[cfg(not(target_family = "wasm"))]
 use winit::monitor::MonitorHandle;
-#[cfg(windows)]
-use winit::platform::windows::{BackdropType, WindowExtWindows};
 use winit::window::{CursorIcon, Fullscreen, ResizeDirection, UserAttentionType, WindowLevel};
 
 use super::app::CustomEvent;
@@ -284,14 +282,12 @@ impl platform::WindowManager for WindowManager {
     fn set_all_windows_background_blur_texture(&self, use_blur_texture: bool) {
         #[cfg(windows)]
         {
-            let new_backdrop_texture = if use_blur_texture {
-                BackdropType::TransientWindow
-            } else {
-                BackdropType::None
-            };
+            use super::windows::WindowExt;
             for window in self.windows.values() {
                 if let Some(inner) = window.inner.borrow().as_ref() {
-                    inner.window.set_system_backdrop(new_backdrop_texture);
+                    if let Err(e) = inner.window.set_acrylic_backdrop(use_blur_texture) {
+                        log::error!("Failed to update acrylic backdrop: {e:#?}");
+                    }
                 }
             }
         }
@@ -1317,12 +1313,11 @@ fn create_window(
 
         use winit::platform::windows::{IconExtWindows, WindowAttributesExtWindows};
 
-        let background_texture = if window_options.background_blur_texture {
-            BackdropType::TransientWindow
-        } else {
-            BackdropType::None
-        };
-        window_attributes = window_attributes.with_system_backdrop(background_texture);
+        // NOTE: We intentionally do NOT use winit's `with_system_backdrop()` here.
+        // Instead, we apply the acrylic effect via our custom `set_acrylic_backdrop()`
+        // method after window creation, which allows us to set a dark tint color
+        // instead of the OS default light frosted appearance.
+        // See `WindowExt::set_acrylic_backdrop()` in windows/window_ext.rs.
 
         // On Windows, don't set the window to be visible until after it has been marked as
         // "cloaked". Winit doesn't support initializing a window as cloaked--so we temporarily set
@@ -1428,6 +1423,14 @@ fn create_window(
             if let Err(e) = window.set_cloaked(true) {
                 log::error!("Failed to mark window as cloaked: {e:#?}");
             };
+
+            // Apply acrylic backdrop with a dark tint (if enabled in settings).
+            // Applied here instead of via winit's with_system_backdrop() so we
+            // can control the tint color.
+            if let Err(e) = window.set_acrylic_backdrop(window_options.background_blur_texture)
+            {
+                log::error!("Failed to set acrylic backdrop: {e:#?}");
+            }
 
             if let Some(adjustment) = maybe_adjust_window_vertically(window) {
                 let direction = if adjustment > 0 { "down" } else { "up" };

--- a/crates/warpui/src/windowing/winit/windows/window_ext.rs
+++ b/crates/warpui/src/windowing/winit/windows/window_ext.rs
@@ -1,5 +1,9 @@
+use std::mem::size_of;
+
 use windows::Win32::Foundation::{FALSE, HWND, TRUE};
-use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_CLOAK};
+use windows::Win32::Graphics::Dwm::{
+    DwmExtendFrameIntoClientArea, DwmSetWindowAttribute, DWMWA_CLOAK, MARGINS,
+};
 use windows_core::BOOL;
 use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use winit::window::Window;
@@ -12,10 +16,51 @@ pub enum Error {
     Other(#[from] windows::core::Error),
 }
 
+/// Accent state values for `DWMWA_ACCENT_POLICY` (undocumented but widely used).
+#[repr(u32)]
+#[derive(Clone, Copy)]
+enum AccentState {
+    Disabled = 0,
+    _EnableGradient = 1,
+    _EnableTransparentGradient = 2,
+    _EnableBlurBehind = 3,
+    EnableAcrylicBlurBehind = 4,
+    _EnableHostBackdrop = 5,
+}
+
+/// `ACCENT_POLICY` struct used with `DWMWA_ACCENT_POLICY` (attribute 19).
+/// The `gradient_color` field is an ABGR color value that controls the tint
+/// behind the acrylic blur effect.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct AccentPolicy {
+    accent_state: AccentState,
+    accent_flags: u32,
+    gradient_color: u32,
+    animation_id: u32,
+}
+
+/// `DWMWA_ACCENT_POLICY` attribute constant.
+const DWMWA_ACCENT_POLICY: i32 = 19;
+
+/// Default acrylic tint color: dark semi-transparent black in ABGR format.
+/// Alpha=0xCC (~80%), Blue=0x00, Green=0x00, Red=0x00.
+/// This provides a dark tint that complements dark mode themes instead of
+/// the default light frosted appearance.
+const DEFAULT_ACRYLIC_TINT: u32 = 0xCC000000;
+
 /// Extension trait for Windows specific logic on a [`winit::window::Window`].
 pub trait WindowExt {
     /// "Cloaks" the window. A cloaked window is one that is invisible, but can still be drawn to.
     fn set_cloaked(&self, cloaked: bool) -> Result<(), Error>;
+
+    /// Enables or disables the acrylic blur backdrop with a dark tint color.
+    ///
+    /// This replaces winit's `BackdropType::TransientWindow` approach, which
+    /// delegates to the OS default tint (a light frosted look). By using the
+    /// legacy `DWMWA_ACCENT_POLICY` API directly, we can set a custom dark
+    /// gradient color that looks correct with dark terminal themes.
+    fn set_acrylic_backdrop(&self, enabled: bool) -> Result<(), Error>;
 }
 
 impl WindowExt for Window {
@@ -35,6 +80,64 @@ impl WindowExt for Window {
                 &value as *const BOOL as *const _,
                 size_of::<BOOL>() as u32,
             )?
+        }
+
+        Ok(())
+    }
+
+    fn set_acrylic_backdrop(&self, enabled: bool) -> Result<(), Error> {
+        let Ok(RawWindowHandle::Win32(handle)) = self
+            .window_handle()
+            .map(|window_handle| window_handle.as_raw())
+        else {
+            return Err(Error::InvalidWindowHandle);
+        };
+
+        let hwnd = HWND(handle.hwnd.get() as _);
+
+        let policy = if enabled {
+            AccentPolicy {
+                accent_state: AccentState::EnableAcrylicBlurBehind,
+                accent_flags: 2, // ACCENT_FLAG_DRAW_ALL
+                gradient_color: DEFAULT_ACRYLIC_TINT,
+                animation_id: 0,
+            }
+        } else {
+            AccentPolicy {
+                accent_state: AccentState::Disabled,
+                accent_flags: 0,
+                gradient_color: 0,
+                animation_id: 0,
+            }
+        };
+
+        unsafe {
+            // Set the accent policy to enable/disable acrylic with our tint color.
+            DwmSetWindowAttribute(
+                hwnd,
+                windows::Win32::Graphics::Dwm::DWMWINDOWATTRIBUTE(DWMWA_ACCENT_POLICY),
+                &policy as *const AccentPolicy as *const _,
+                size_of::<AccentPolicy>() as u32,
+            )?;
+
+            // Extend the DWM frame into the entire client area so the acrylic
+            // effect covers the whole window, not just the title bar.
+            let margins = if enabled {
+                MARGINS {
+                    cxLeftWidth: -1,
+                    cxRightWidth: -1,
+                    cyTopHeight: -1,
+                    cyBottomHeight: -1,
+                }
+            } else {
+                MARGINS {
+                    cxLeftWidth: 0,
+                    cxRightWidth: 0,
+                    cyTopHeight: 0,
+                    cyBottomHeight: 0,
+                }
+            };
+            DwmExtendFrameIntoClientArea(hwnd, &margins)?;
         }
 
         Ok(())


### PR DESCRIPTION
## Problem

On Windows 11, when the acrylic backdrop effect (`background_blur_texture`) is enabled, the window uses an OS-default light gray underpaint that looks washed out and inconsistent with dark terminal themes. The blur blends with a light base instead of the dark theme, creating an ugly frosted-white appearance.

## Root Cause

Warp uses winit's `BackdropType::TransientWindow` (which maps to `DWMSBT_TRANSIENTWINDOW`). This modern Windows 11 API does not expose a tint color parameter — it delegates entirely to the OS, which defaults to a light underpaint.

## Solution

Replace the winit backdrop calls with direct `DWMWA_ACCENT_POLICY` API usage (`ACCENT_ENABLE_ACRYLICBLURBEHIND`), which accepts a `gradientColor` field (ABGR). This allows us to set a dark tint color (`0xCC000000`, ~80% opaque black) that matches dark terminal themes.

### Changes

- **`window_ext.rs`**: Added `set_acrylic_backdrop(enabled: bool)` to `WindowExt` using `DwmSetWindowAttribute` with `DWMWA_ACCENT_POLICY` (attribute 19) + `DwmExtendFrameIntoClientArea` for full-window coverage
- **`window.rs`**: Replaced `with_system_backdrop(BackdropType::TransientWindow)` at window creation and `set_system_backdrop()` at runtime toggle with the new method
- **`Cargo.toml`**: Added `Win32_UI_Controls` feature flag (required for `DwmExtendFrameIntoClientArea`/`MARGINS`)

### Tint Color

The default tint is `0xCC000000` (ABGR: alpha=0xCC, B=0x00, G=0x00, R=0x00). This can be tuned by adjusting the `DEFAULT_ACRYLIC_TINT` constant:

| Value | Appearance |
|---|---|
| `0xFF000000` | Fully opaque black |
| `0xCC000000` | ~80% opaque black (default) |
| `0x99000000` | ~60% opaque, more transparent |

## Testing

- Verified compilation with `cargo check -p warpui` (after adding `Win32_UI_Controls` feature)
- The `DWMWA_ACCENT_POLICY` API (attribute 19) is undocumented but widely used by major Windows apps (Firefox, Chrome, Terminal, etc.)