### PR TITLE
Add vertical tabs item padding control

### DIFF
--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -300,6 +300,8 @@ pub enum WorkspaceAction {
     SetVerticalTabsDisplayGranularity(VerticalTabsDisplayGranularity),
     SetVerticalTabsTabItemMode(VerticalTabsTabItemMode),
     SetVerticalTabsViewMode(VerticalTabsViewMode),
+    PreviewVerticalTabsItemPadding(u8),
+    SetVerticalTabsItemPadding(u8),
     SetVerticalTabsPrimaryInfo(VerticalTabsPrimaryInfo),
     SetVerticalTabsCompactSubtitle(VerticalTabsCompactSubtitle),
     ToggleVerticalTabsShowPrLink,
@@ -901,6 +903,8 @@ impl WorkspaceAction {
             | SetVerticalTabsDisplayGranularity(_)
             | SetVerticalTabsTabItemMode(_)
             | SetVerticalTabsViewMode(_)
+            | PreviewVerticalTabsItemPadding(_)
+            | SetVerticalTabsItemPadding(_)
             | SetVerticalTabsPrimaryInfo(_)
             | SetVerticalTabsCompactSubtitle(_)
             | ToggleVerticalTabsShowPrLink

--- a/app/src/workspace/action_tests.rs
+++ b/app/src/workspace/action_tests.rs
@@ -1,10 +1,11 @@
+use settings::Setting as _;
 use warpui::EntityId;
 
 use super::WorkspaceAction;
 use crate::pane_group::TerminalPaneId;
 use crate::workspace::tab_settings::{
-    VerticalTabsDisplayGranularity, VerticalTabsPrimaryInfo, VerticalTabsTabItemMode,
-    VerticalTabsViewMode,
+    VerticalTabsDisplayGranularity, VerticalTabsItemPadding, VerticalTabsPrimaryInfo,
+    VerticalTabsTabItemMode, VerticalTabsViewMode,
 };
 use crate::workspace::PaneViewLocator;
 
@@ -14,6 +15,19 @@ fn vertical_tabs_view_mode_change_does_not_save_workspace_state() {
         !WorkspaceAction::SetVerticalTabsViewMode(VerticalTabsViewMode::Compact)
             .should_save_app_state_on_action()
     );
+}
+
+#[test]
+fn vertical_tabs_item_padding_defaults_to_existing_row_padding() {
+    assert_eq!(VerticalTabsItemPadding::default_value(), 8);
+    assert_eq!(VerticalTabsItemPadding::MIN, 2);
+    assert_eq!(VerticalTabsItemPadding::MAX, 16);
+}
+
+#[test]
+fn vertical_tabs_item_padding_changes_do_not_save_workspace_state() {
+    assert!(!WorkspaceAction::PreviewVerticalTabsItemPadding(2).should_save_app_state_on_action());
+    assert!(!WorkspaceAction::SetVerticalTabsItemPadding(16).should_save_app_state_on_action());
 }
 
 #[test]

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -508,6 +508,15 @@ define_settings_group!(TabSettings, settings: [
     vertical_tabs_display_granularity: VerticalTabsDisplayGranularity,
     vertical_tabs_tab_item_mode: VerticalTabsTabItemMode,
     vertical_tabs_view_mode: VerticalTabsViewMode,
+    vertical_tabs_item_padding: VerticalTabsItemPadding {
+        type: u8,
+        default: 8,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "appearance.vertical_tabs.item_padding",
+        description: "The padding, in pixels, applied around each vertical tabs item.",
+    },
     vertical_tabs_primary_info: VerticalTabsPrimaryInfo,
     vertical_tabs_compact_subtitle: VerticalTabsCompactSubtitle,
     vertical_tabs_show_pr_link: VerticalTabsShowPrLink {
@@ -543,6 +552,15 @@ define_settings_group!(TabSettings, settings: [
     close_button_position: TabCloseButtonPosition,
     directory_tab_colors: DirectoryTabColors,
 ]);
+
+impl VerticalTabsItemPadding {
+    pub const MIN: u8 = 2;
+    pub const MAX: u8 = 16;
+
+    fn validate(&self, new_value: u8) -> u8 {
+        new_value.clamp(Self::MIN, Self::MAX)
+    }
+}
 
 #[cfg(test)]
 #[path = "tab_settings_tests.rs"]

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3521,6 +3521,7 @@ impl Workspace {
             }
             TabSettingsChangedEvent::VerticalTabsViewMode { .. }
             | TabSettingsChangedEvent::VerticalTabsTabItemMode { .. }
+            | TabSettingsChangedEvent::VerticalTabsItemPadding { .. }
             | TabSettingsChangedEvent::VerticalTabsPrimaryInfo { .. }
             | TabSettingsChangedEvent::VerticalTabsCompactSubtitle { .. }
             | TabSettingsChangedEvent::UseLatestUserPromptAsConversationTitleInTabNames {
@@ -22061,6 +22062,31 @@ impl TypedActionView for Workspace {
                 send_telemetry_from_ctx!(
                     VerticalTabsTelemetryEvent::DisplayOptionChanged(
                         VerticalTabsDisplayOption::ViewMode(mode),
+                    ),
+                    ctx
+                );
+                ctx.notify();
+            }
+            PreviewVerticalTabsItemPadding(item_padding) => {
+                let item_padding = *item_padding;
+                TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                    let _ = settings
+                        .vertical_tabs_item_padding
+                        .set_value(item_padding, ctx);
+                });
+                ctx.notify();
+            }
+            SetVerticalTabsItemPadding(item_padding) => {
+                let item_padding = *item_padding;
+                let stored_item_padding = TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                    let _ = settings
+                        .vertical_tabs_item_padding
+                        .set_value(item_padding, ctx);
+                    *settings.vertical_tabs_item_padding.value()
+                });
+                send_telemetry_from_ctx!(
+                    VerticalTabsTelemetryEvent::DisplayOptionChanged(
+                        VerticalTabsDisplayOption::ItemPadding(stored_item_padding),
                     ),
                     ctx
                 );

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -31,7 +31,8 @@ use warpui::fonts::{Properties, Weight};
 use warpui::platform::Cursor;
 use warpui::prelude::Align;
 use warpui::text_layout::ClipConfig;
-use warpui::ui_components::components::{UiComponent, UiComponentStyles};
+use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
+use warpui::ui_components::slider::SliderStateHandle;
 use warpui::ui_components::text_input::TextInput;
 use warpui::{AppContext, EntityId, SingletonEntity, ViewHandle, WindowId};
 
@@ -73,7 +74,8 @@ use crate::workspace::hoa_onboarding::HoaOnboardingStep;
 use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::{
     TabSettings, VerticalTabsCompactSubtitle, VerticalTabsDisplayGranularity,
-    VerticalTabsPrimaryInfo, VerticalTabsTabItemMode, VerticalTabsViewMode,
+    VerticalTabsItemPadding, VerticalTabsPrimaryInfo, VerticalTabsTabItemMode,
+    VerticalTabsViewMode,
 };
 use crate::workspace::view::vertical_tabs::telemetry::{
     VerticalTabsChipEntrypoint, VerticalTabsTelemetryEvent,
@@ -99,6 +101,7 @@ const TAB_GROUP_HEADER_ACTION_ICON_SIZE: f32 = 14.;
 const GROUP_ACTION_BUTTON_PADDING: f32 = 2.;
 const GROUP_ACTION_BUTTON_GAP: f32 = 2.;
 const ROW_CORNER_RADIUS: f32 = 4.;
+const ITEM_PADDING_SLIDER_WIDTH: f32 = 128.;
 const TAB_GROUP_MEMBER_INDENT: f32 = 12.;
 const TAB_GROUP_ICON_SIZE: f32 = 16.;
 const TAB_GROUP_CONTENT_INSET: f32 = 4.;
@@ -123,6 +126,21 @@ const VERTICAL_TABS_ICON_SIZE: f32 = 24.;
 /// Icon size for the per-line conversation status pill in Summary mode. Pairs with
 /// `STATUS_ELEMENT_PADDING` (2px) for an overall ~14px element next to a 12pt title.
 const VERTICAL_TABS_SUMMARY_STATUS_ICON_SIZE: f32 = 10.;
+
+fn vertical_tabs_item_padding_value(app: &AppContext) -> u8 {
+    *TabSettings::as_ref(app).vertical_tabs_item_padding.value()
+}
+
+fn vertical_tabs_item_padding_from_slider_value(value: f32) -> u8 {
+    value.round().clamp(
+        f32::from(VerticalTabsItemPadding::MIN),
+        f32::from(VerticalTabsItemPadding::MAX),
+    ) as u8
+}
+
+fn vertical_tabs_row_padding(app: &AppContext) -> Padding {
+    Padding::uniform(f32::from(vertical_tabs_item_padding_value(app)))
+}
 
 fn vtab_pane_row_position_id(pane_group_id: EntityId, pane_id: PaneId) -> String {
     format!("vertical_tabs:pane_row:{pane_group_id:?}:{pane_id}")
@@ -590,6 +608,8 @@ pub(super) struct VerticalTabsPanelState {
     summary_option_mouse_state: MouseStateHandle,
     compact_segment_mouse_state: MouseStateHandle,
     expanded_segment_mouse_state: MouseStateHandle,
+    item_padding_slider_state: SliderStateHandle,
+    item_padding_reset_mouse_state: MouseStateHandle,
     command_option_mouse_state: MouseStateHandle,
     directory_option_mouse_state: MouseStateHandle,
     branch_option_mouse_state: MouseStateHandle,
@@ -627,6 +647,8 @@ impl Default for VerticalTabsPanelState {
             summary_option_mouse_state: Default::default(),
             compact_segment_mouse_state: Default::default(),
             expanded_segment_mouse_state: Default::default(),
+            item_padding_slider_state: Default::default(),
+            item_padding_reset_mouse_state: Default::default(),
             command_option_mouse_state: Default::default(),
             directory_option_mouse_state: Default::default(),
             branch_option_mouse_state: Default::default(),
@@ -2953,7 +2975,7 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
         .with_child(Shrinkable::new(1., text_content).finish())
         .finish();
 
-    render_pane_row_element(props, Padding::uniform(8.), true, content, theme)
+    render_pane_row_element(props, vertical_tabs_row_padding(app), true, content, theme)
 }
 
 enum TypedPane<'a> {
@@ -4203,7 +4225,7 @@ fn render_summary_tab_item(
         .with_child(Shrinkable::new(1., text_col.finish()).finish())
         .finish();
 
-    render_pane_row_element(props, Padding::uniform(8.), true, content, theme)
+    render_pane_row_element(props, vertical_tabs_row_padding(app), true, content, theme)
 }
 
 fn render_summary_primary_label_line(
@@ -5042,6 +5064,7 @@ pub(super) fn render_settings_popup(
         .value();
     let current_tab_item_mode = *TabSettings::as_ref(app).vertical_tabs_tab_item_mode.value();
     let current_mode = *TabSettings::as_ref(app).vertical_tabs_view_mode.value();
+    let current_item_padding = vertical_tabs_item_padding_value(app);
     let current_primary_info = *TabSettings::as_ref(app).vertical_tabs_primary_info.value();
     let current_subtitle = resolve_compact_subtitle(
         current_primary_info,
@@ -5280,6 +5303,16 @@ pub(super) fn render_settings_popup(
         theme,
     );
 
+    let item_padding_header = render_item_padding_header(
+        state,
+        SETTINGS_POPUP_MENU_ITEM_FONT_SIZE,
+        sub_text,
+        appearance,
+        theme,
+    );
+    let item_padding_slider_row =
+        render_item_padding_slider(state, current_item_padding, appearance, theme);
+
     // Assemble popup — top-level display granularity first, then density and pane-row sections.
     let mut popup_col = Flex::column()
         .with_main_axis_size(MainAxisSize::Min)
@@ -5299,6 +5332,8 @@ pub(super) fn render_settings_popup(
         popup_col.add_child(make_divider(theme));
         popup_col.add_child(density_header);
         popup_col.add_child(segmented_control_row);
+        popup_col.add_child(item_padding_header);
+        popup_col.add_child(item_padding_slider_row);
         popup_col.add_child(make_divider(theme));
         popup_col.add_child(pane_title_header);
         popup_col.add_child(command_option);
@@ -5386,6 +5421,10 @@ pub(super) fn render_settings_popup(
                 theme,
             ));
         }
+    } else {
+        popup_col.add_child(make_divider(theme));
+        popup_col.add_child(item_padding_header);
+        popup_col.add_child(item_padding_slider_row);
     }
     popup_col.add_child(make_divider(theme));
 
@@ -5414,6 +5453,152 @@ pub(super) fn render_settings_popup(
         .finish(),
     )
     .on_left_mouse_down(|_, _, _| DispatchEventResult::StopPropagation)
+    .finish()
+}
+
+fn render_item_padding_slider(
+    state: &VerticalTabsPanelState,
+    current_item_padding: u8,
+    appearance: &Appearance,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    const FONT_SIZE: f32 = 12.;
+    const GAP: f32 = 8.;
+
+    let slider = appearance
+        .ui_builder()
+        .slider(state.item_padding_slider_state.clone())
+        .with_range(
+            f32::from(VerticalTabsItemPadding::MIN)..f32::from(VerticalTabsItemPadding::MAX),
+        )
+        .with_default_value(f32::from(current_item_padding))
+        .with_step(1.)
+        .with_style(UiComponentStyles {
+            width: Some(ITEM_PADDING_SLIDER_WIDTH),
+            margin: Some(Coords::default().top(2.).bottom(2.)),
+            ..Default::default()
+        })
+        .on_drag(|ctx, _, value| {
+            ctx.dispatch_typed_action(WorkspaceAction::PreviewVerticalTabsItemPadding(
+                vertical_tabs_item_padding_from_slider_value(value),
+            ));
+        })
+        .on_change(|ctx, _, value| {
+            ctx.dispatch_typed_action(WorkspaceAction::SetVerticalTabsItemPadding(
+                vertical_tabs_item_padding_from_slider_value(value),
+            ));
+        })
+        .build()
+        .finish();
+
+    let value_label = Text::new_inline(
+        format!("{current_item_padding}px"),
+        appearance.ui_font_family(),
+        FONT_SIZE,
+    )
+    .with_color(theme.sub_text_color(theme.background()).into())
+    .finish();
+
+    Container::new(
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(GAP)
+            .with_child(slider)
+            .with_child(value_label)
+            .finish(),
+    )
+    .with_horizontal_padding(16.)
+    .with_padding_bottom(4.)
+    .finish()
+}
+
+fn render_item_padding_header(
+    state: &VerticalTabsPanelState,
+    font_size: f32,
+    text_color: WarpThemeFill,
+    appearance: &Appearance,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    let title = Text::new_inline(
+        "Item padding".to_string(),
+        appearance.ui_font_family(),
+        font_size,
+    )
+    .with_color(text_color.into())
+    .finish();
+
+    Container::new(
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(title)
+            .with_child(render_item_padding_reset_button(
+                state.item_padding_reset_mouse_state.clone(),
+                appearance,
+                theme,
+            ))
+            .finish(),
+    )
+    .with_horizontal_padding(16.)
+    .with_margin_bottom(4.)
+    .finish()
+}
+
+fn render_item_padding_reset_button(
+    mouse_state: MouseStateHandle,
+    appearance: &Appearance,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    const BUTTON_PADDING: f32 = 3.;
+    const BUTTON_CORNER_RADIUS: f32 = 4.;
+    const ICON_SIZE: f32 = 12.;
+
+    let icon_color = theme.sub_text_color(theme.background());
+    let ui_builder = appearance.ui_builder().clone();
+
+    Hoverable::new(mouse_state, move |hover_state| {
+        let icon = ConstrainedBox::new(UiIcon::Refresh.to_warpui_icon(icon_color).finish())
+            .with_width(ICON_SIZE)
+            .with_height(ICON_SIZE)
+            .finish();
+
+        let mut button = Container::new(icon)
+            .with_uniform_padding(BUTTON_PADDING)
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(BUTTON_CORNER_RADIUS)));
+        if hover_state.is_hovered() {
+            button = button.with_background(internal_colors::fg_overlay_1(theme));
+        }
+
+        let button = button.finish();
+        if hover_state.is_hovered() {
+            let tooltip = ui_builder
+                .tool_tip("Reset to default".to_string())
+                .build()
+                .finish();
+            let mut stack = Stack::new().with_child(button);
+            stack.add_positioned_overlay_child(
+                tooltip,
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., -4.),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::TopMiddle,
+                    ChildAnchor::BottomMiddle,
+                ),
+            );
+            stack.finish()
+        } else {
+            button
+        }
+    })
+    .on_click(|ctx, _, _| {
+        ctx.dispatch_typed_action(WorkspaceAction::SetVerticalTabsItemPadding(
+            VerticalTabsItemPadding::default_value(),
+        ));
+    })
+    .with_cursor(Cursor::PointingHand)
     .finish()
 }
 
@@ -6694,7 +6879,7 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
         .with_child(Shrinkable::new(1., text_col.finish()).finish())
         .finish();
 
-    render_pane_row_element(props, Padding::uniform(8.), true, content, theme)
+    render_pane_row_element(props, vertical_tabs_row_padding(app), true, content, theme)
 }
 
 impl Workspace {

--- a/app/src/workspace/view/vertical_tabs/telemetry.rs
+++ b/app/src/workspace/view/vertical_tabs/telemetry.rs
@@ -15,6 +15,7 @@ pub enum VerticalTabsDisplayOption {
     DisplayGranularity(VerticalTabsDisplayGranularity),
     TabItemMode(VerticalTabsTabItemMode),
     ViewMode(VerticalTabsViewMode),
+    ItemPadding(u8),
     PrimaryInfo(VerticalTabsPrimaryInfo),
     CompactSubtitle(VerticalTabsCompactSubtitle),
     ShowPrLink(bool),
@@ -28,6 +29,7 @@ impl VerticalTabsDisplayOption {
             Self::DisplayGranularity(_) => "display_granularity",
             Self::TabItemMode(_) => "tab_item_mode",
             Self::ViewMode(_) => "view_mode",
+            Self::ItemPadding(_) => "item_padding",
             Self::PrimaryInfo(_) => "primary_info",
             Self::CompactSubtitle(_) => "compact_subtitle",
             Self::ShowPrLink(_) => "show_pr_link",
@@ -44,6 +46,7 @@ impl VerticalTabsDisplayOption {
             Self::TabItemMode(VerticalTabsTabItemMode::Summary) => json!("summary"),
             Self::ViewMode(VerticalTabsViewMode::Compact) => json!("compact"),
             Self::ViewMode(VerticalTabsViewMode::Expanded) => json!("expanded"),
+            Self::ItemPadding(value) => json!(value),
             Self::PrimaryInfo(VerticalTabsPrimaryInfo::Command) => json!("command"),
             Self::PrimaryInfo(VerticalTabsPrimaryInfo::WorkingDirectory) => {
                 json!("working_directory")

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -15,7 +15,8 @@ use super::{
     sort_summary_primary_labels_status_first, summary_overflow_count,
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
     terminal_pull_request_badge_label, terminal_search_text_fragments,
-    terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
+    terminal_title_fallback_font, uses_outer_group_container,
+    vertical_tabs_item_padding_from_slider_value, visible_pane_ids_for_detail_target,
     vtab_diff_stats_text, AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons,
     TerminalAgentText, TerminalPrimaryLineData, TerminalPrimaryLineFont, VerticalTabsDetailTarget,
     VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
@@ -634,6 +635,14 @@ fn tabs_granularity_does_not_use_outer_group_container() {
     assert!(!uses_outer_group_container(
         VerticalTabsDisplayGranularity::Tabs
     ));
+}
+
+#[test]
+fn vertical_tabs_item_padding_slider_values_are_rounded_and_clamped() {
+    assert_eq!(vertical_tabs_item_padding_from_slider_value(0.), 2);
+    assert_eq!(vertical_tabs_item_padding_from_slider_value(2.4), 2);
+    assert_eq!(vertical_tabs_item_padding_from_slider_value(8.6), 9);
+    assert_eq!(vertical_tabs_item_padding_from_slider_value(20.), 16);
 }
 
 #[test]


### PR DESCRIPTION
## Description
Adds a synced `appearance.vertical_tabs.item_padding` setting and a vertical-tabs settings popup slider for adjusting the inner padding of vertical tab and pane rows. The control sits under Density, shows the current pixel value, and includes a reset button that restores the 8px default.

This helps users with many panes or agent sessions make the vertical sidebar more compact without changing horizontal tabs.

## Linked Issue
Closes #11941

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
  Note: I created #11941, but this account does not have permission to add repo labels.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- [x] `cargo fmt --check --package warp`
- [x] `cargo clippy -p warp --lib -- -D warnings`
- [x] `cargo test -p warp vertical_tabs_item_padding --lib`
- [x] `cargo check -p warp --lib`
- [x] `git diff --check origin/master...HEAD`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<img width="1392" height="912" alt="image" src="https://github.com/user-attachments/assets/35cf0615-e8c7-42c4-af28-7d4408b1c814" />
<img width="1392" height="912" alt="image" src="https://github.com/user-attachments/assets/f46fa3c0-268a-4547-afba-40d8deee8bb9" />
<img width="1392" height="912" alt="image" src="https://github.com/user-attachments/assets/8803a12f-b2eb-4978-9717-5dc8e17a08dd" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a vertical tabs item padding control to make dense sidebars easier to scan.

Co-Authored-By: Warp <agent@warp.dev>