### PR TITLE
Report focus events for normal-screen terminal apps

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7590,9 +7590,7 @@ impl TerminalView {
         let focus_reporting_enabled = *AltScreenReporting::as_ref(ctx)
             .focus_reporting_enabled
             .value();
-        focus_reporting_enabled
-            && model.is_alt_screen_active()
-            && model.alt_screen().is_mode_set(TermMode::FOCUS_IN_OUT)
+        focus_reporting_enabled && model.is_term_mode_set(TermMode::FOCUS_IN_OUT)
     }
 
     fn maybe_report_focus_in(&mut self, ctx: &mut ViewContext<Self>) {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -101,6 +101,46 @@ fn has_pending_user_query_block(view: &TerminalView) -> bool {
         rich_content.view_id() == view_id && rich_content.is_pending_user_query()
     })
 }
+
+#[test]
+fn focus_reporting_writes_focus_events_in_normal_screen() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let mut model = view.model.lock();
+            model.simulate_long_running_block("python3 /tmp/warp_focus_test.py", "");
+            assert!(!model.is_alt_screen_active());
+            ansi::Handler::set_mode(&mut *model, ansi::Mode::ReportFocusInOut);
+            assert!(model.is_term_mode_set(TermMode::FOCUS_IN_OUT));
+            drop(model);
+            assert!(view.should_report_focus(ctx));
+
+            view.maybe_report_focus_out(ctx);
+            view.maybe_report_focus_in(ctx);
+        });
+
+        assert_eq!(
+            *pty_writes.borrow(),
+            vec![
+                escape_sequences::EscCodes::FOCUS_OUT.to_vec(),
+                escape_sequences::EscCodes::FOCUS_IN.to_vec(),
+            ]
+        );
+    })
+}
+
 fn input_operations_for_buffer_content(app: &mut App, content: &str) -> Vec<CrdtOperation> {
     let terminal = add_window_with_terminal(app, None);
     terminal.update(app, |view, ctx| {


### PR DESCRIPTION
## Description

Fixes normal-screen DECSET 1004 focus reporting. Warp already parsed `ESC[?1004h` and emitted focus events for alt-screen apps, but the focus-reporting gate required `model.is_alt_screen_active()`. Normal-screen foreground apps that enable focus reporting, such as a long-running CLI TUI/probe, never received `ESC[O` on blur or `ESC[I` on focus.

This changes the gate to use the active terminal mode via `model.is_term_mode_set(TermMode::FOCUS_IN_OUT)`, so focus events are emitted for whichever screen/mode currently owns the foreground process.

## Linked Issue

Fixes #11945

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
  - #11945 is now labeled `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Manual:
- Ran a normal-screen DECSET 1004 probe in a local Warp build and confirmed switching away/back prints `FOCUS_OUT` then `FOCUS_IN`.

Automated:
- `cargo test -p warp focus_reporting_writes_focus_events_in_normal_screen`
- `cargo check -p warp --lib`
- `cargo fmt --package warp --check`
- `git diff --check`
- `cargo clippy -p warp --lib -- -D warnings`

### Screenshots / Videos

https://github.com/BobbyWang0120/warp/releases/download/focus-reporting-demo-assets/warp-focus-reporting-demo.mp4

Demo: a normal-screen DECSET 1004 probe receives `FOCUS_OUT` after Warp loses focus and `FOCUS_IN` after Warp regains focus.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed focus reporting for normal-screen terminal apps that opt into DECSET 1004.
-->

Co-Authored-By: Warp <agent@warp.dev>
