### PR TITLE
Make wildcard `?`/literal glob matching character-aware

### DIFF
--- a/crates/fuzzy_match/src/fuzzy_tests.rs
+++ b/crates/fuzzy_match/src/fuzzy_tests.rs
@@ -156,6 +156,32 @@ fn test_ui_star_partial_patterns() {
     assert!(result3.is_some());
 }
 
+#[test]
+fn test_question_mark_matches_one_character_not_one_byte() {
+    // `?` must match exactly one *character*, not one byte. "é" is a single
+    // (two-byte) character, so the two-`?` pattern "??" requires two
+    // characters and must not match. A byte-oriented matcher would let each
+    // `?` consume one byte of "é" and wrongly report a match.
+    assert!(match_wildcard_pattern("é", "??").is_none());
+    assert!(match_wildcard_pattern("a", "??").is_none());
+
+    // A single `?` should match the single multi-byte character.
+    assert!(match_wildcard_pattern("é", "?").is_some());
+
+    // `?` inside a longer multi-byte pattern matches one character per `?`.
+    assert!(match_wildcard_pattern("héllo", "h?llo").is_some());
+    assert!(match_wildcard_pattern("héllo", "h??llo").is_none());
+}
+
+#[test]
+fn test_literal_multibyte_match_requires_full_character() {
+    // Literal multi-byte characters must compare per character, so a pattern
+    // that is one character longer than the text cannot match even though the
+    // text has more *bytes* than the pattern has characters.
+    assert!(match_wildcard_pattern("ä", "a").is_none());
+    assert!(match_wildcard_pattern("ä", "ä").is_some());
+}
+
 use crate::{
     match_indices, match_indices_case_insensitive, match_indices_case_insensitive_ignore_spaces,
 };

--- a/crates/fuzzy_match/src/lib.rs
+++ b/crates/fuzzy_match/src/lib.rs
@@ -364,8 +364,15 @@ fn find_partial_suffix_match(text: &str, partial_suffix: &str) -> Option<Vec<usi
 ///
 /// This function requires the pattern to match the entire text, unlike
 /// [`find_substring_glob_match`] which finds patterns anywhere in the text.
+///
+/// Matching is performed over Unicode scalar values (`char`s), so `?` matches
+/// exactly one character and a literal matches one character — not one byte.
+/// Operating over bytes would let `?` match a single byte of a multi-byte
+/// character (e.g. wrongly matching the one-character `"é"` against `"??"`).
 fn is_glob_match(text: &str, pattern: &str) -> bool {
-    is_glob_match_recursive(text.as_bytes(), pattern.as_bytes(), 0, 0)
+    let text_chars: Vec<char> = text.chars().collect();
+    let pattern_chars: Vec<char> = pattern.chars().collect();
+    is_glob_match_chars(&text_chars, &pattern_chars)
 }
 
 /// Finds a glob pattern as a substring anywhere in the text.
@@ -568,52 +575,6 @@ fn is_glob_match_chars_recursive(
             // Regular character - must match exactly (case insensitive)
             if text[text_idx].eq_ignore_ascii_case(&c) {
                 is_glob_match_chars_recursive(text, pattern, text_idx + 1, pattern_idx + 1)
-            } else {
-                false
-            }
-        }
-    }
-}
-
-fn is_glob_match_recursive(
-    text: &[u8],
-    pattern: &[u8],
-    text_idx: usize,
-    pattern_idx: usize,
-) -> bool {
-    // If we've consumed the entire pattern
-    if pattern_idx >= pattern.len() {
-        return text_idx >= text.len();
-    }
-
-    // If we've consumed the entire text but pattern remains
-    if text_idx >= text.len() {
-        // Only match if the remaining pattern is all '*'
-        return pattern[pattern_idx..].iter().all(|&c| c == b'*');
-    }
-
-    match pattern[pattern_idx] {
-        b'*' => {
-            // Try matching zero characters (skip the *)
-            if is_glob_match_recursive(text, pattern, text_idx, pattern_idx + 1) {
-                return true;
-            }
-            // Try matching one or more characters
-            for i in text_idx..text.len() {
-                if is_glob_match_recursive(text, pattern, i + 1, pattern_idx + 1) {
-                    return true;
-                }
-            }
-            false
-        }
-        b'?' => {
-            // ? matches exactly one character
-            is_glob_match_recursive(text, pattern, text_idx + 1, pattern_idx + 1)
-        }
-        c => {
-            // Regular character - must match exactly (case insensitive)
-            if text[text_idx].eq_ignore_ascii_case(&c) {
-                is_glob_match_recursive(text, pattern, text_idx + 1, pattern_idx + 1)
             } else {
                 false
             }


### PR DESCRIPTION
`is_glob_match` ran its recursion over raw bytes (`is_glob_match_recursive` operating on `&[u8]`). As a result the `?` wildcard advanced by a single *byte* and a literal compared a single byte, instead of a whole Unicode character. This contradicts the documented contract ("`?` matches exactly one character") and the sibling `is_glob_match_chars`, which already walks `char`s correctly.

The byte view let a single multi-byte character satisfy multiple pattern positions. For example `match_wildcard_pattern("é", "??")` returned a match even though `"é"` is one character and `"??"` requires two — the two `?`s each consumed one byte of the two-byte `é`. The all-ASCII equivalent `match_wildcard_pattern("a", "??")` correctly returned `None`, so the bug only surfaced for non-ASCII text reaching the exact-glob fallback (e.g. file search over paths with accented or CJK characters).

Route `is_glob_match` through the existing character-based matcher (`is_glob_match_chars`) and delete the redundant byte-based recursion. This fixes the contract violation and removes duplicated logic. Add regression tests covering `?` and literal matching against multi-byte characters.

fixes #11969