### PR TITLE
Add report_error log frequency mode

### DIFF
--- a/crates/warp_core/src/errors.rs
+++ b/crates/warp_core/src/errors.rs
@@ -35,30 +35,48 @@ pub enum ReportErrorLogMode {
 /// upon.)
 #[macro_export]
 macro_rules! report_error {
-    ($err:expr) => {{
-        $crate::report_error!($err, $crate::errors::ReportErrorLogMode::EveryTime);
+    (@log $err:expr) => {{
+        #[allow(unused_imports)]
+        use $crate::errors::{AnyhowErrorExt as _, ErrorExt as _, LOG_TARGET};
+        let err = $err;
+        let log_level = if err.is_actionable() {
+            err.report_error();
+            log::Level::Error
+        } else {
+            log::Level::Warn
+        };
+        log::log!(target: LOG_TARGET, log_level, "{:#}", err);
     }};
-    ($err:expr, $log_mode:expr) => {{
+    (@once_per_run $err:expr) => {{
         static HAS_LOGGED_REPORT_ERROR: ::std::sync::atomic::AtomicBool =
             ::std::sync::atomic::AtomicBool::new(false);
-
-        let should_log = match $log_mode {
-            $crate::errors::ReportErrorLogMode::EveryTime => true,
-            $crate::errors::ReportErrorLogMode::OncePerRun => !HAS_LOGGED_REPORT_ERROR
-                .swap(true, ::std::sync::atomic::Ordering::Relaxed),
-        };
-
-        if should_log {
-            #[allow(unused_imports)]
-            use $crate::errors::{AnyhowErrorExt as _, ErrorExt as _, LOG_TARGET};
-            let err = $err;
-            let log_level = if err.is_actionable() {
-                err.report_error();
-                log::Level::Error
-            } else {
-                log::Level::Warn
-            };
-            log::log!(target: LOG_TARGET, log_level, "{:#}", err);
+        if !HAS_LOGGED_REPORT_ERROR.swap(true, ::std::sync::atomic::Ordering::Relaxed) {
+            $crate::report_error!(@log $err);
+        }
+    }};
+    ($err:expr) => {{
+        $crate::report_error!(@log $err);
+    }};
+    ($err:expr, $crate::errors::ReportErrorLogMode::EveryTime) => {{
+        $crate::report_error!(@log $err);
+    }};
+    ($err:expr, ReportErrorLogMode::EveryTime) => {{
+        $crate::report_error!(@log $err);
+    }};
+    ($err:expr, $crate::errors::ReportErrorLogMode::OncePerRun) => {{
+        $crate::report_error!(@once_per_run $err);
+    }};
+    ($err:expr, ReportErrorLogMode::OncePerRun) => {{
+        $crate::report_error!(@once_per_run $err);
+    }};
+    ($err:expr, $log_mode:expr) => {{
+        match $log_mode {
+            $crate::errors::ReportErrorLogMode::EveryTime => {
+                $crate::report_error!(@log $err);
+            }
+            $crate::errors::ReportErrorLogMode::OncePerRun => {
+                $crate::report_error!(@once_per_run $err);
+            }
         }
     }};
 }

--- a/crates/warp_core/src/errors.rs
+++ b/crates/warp_core/src/errors.rs
@@ -16,6 +16,17 @@ pub use self::anyhow::AnyhowErrorExt;
 /// The `target` that is set by log entries from this module.
 pub const LOG_TARGET: &str = "errors::report_error";
 
+/// Controls how often a [`report_error!`] invocation logs errors.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReportErrorLogMode {
+    /// Log every time the error is reported.
+    #[default]
+    EveryTime,
+    /// Log only the first time this macro invocation is reached during the
+    /// current app run.
+    OncePerRun,
+}
+
 /// Reports an error encountered during execution.
 ///
 /// This checks whether or not the error is actionable, and logs an error or
@@ -25,16 +36,30 @@ pub const LOG_TARGET: &str = "errors::report_error";
 #[macro_export]
 macro_rules! report_error {
     ($err:expr) => {{
-        #[allow(unused_imports)]
-        use $crate::errors::{AnyhowErrorExt as _, ErrorExt as _, LOG_TARGET};
-        let err = $err;
-        let log_level = if err.is_actionable() {
-            err.report_error();
-            log::Level::Error
-        } else {
-            log::Level::Warn
+        $crate::report_error!($err, $crate::errors::ReportErrorLogMode::EveryTime);
+    }};
+    ($err:expr, $log_mode:expr) => {{
+        static HAS_LOGGED_REPORT_ERROR: ::std::sync::atomic::AtomicBool =
+            ::std::sync::atomic::AtomicBool::new(false);
+
+        let should_log = match $log_mode {
+            $crate::errors::ReportErrorLogMode::EveryTime => true,
+            $crate::errors::ReportErrorLogMode::OncePerRun => !HAS_LOGGED_REPORT_ERROR
+                .swap(true, ::std::sync::atomic::Ordering::Relaxed),
         };
-        log::log!(target: LOG_TARGET, log_level, "{:#}", err);
+
+        if should_log {
+            #[allow(unused_imports)]
+            use $crate::errors::{AnyhowErrorExt as _, ErrorExt as _, LOG_TARGET};
+            let err = $err;
+            let log_level = if err.is_actionable() {
+                err.report_error();
+                log::Level::Error
+            } else {
+                log::Level::Warn
+            };
+            log::log!(target: LOG_TARGET, log_level, "{:#}", err);
+        }
     }};
 }
 pub use report_error;
@@ -50,6 +75,11 @@ macro_rules! report_if_error {
     ($result:expr) => {{
         if let Err(error) = &$result {
             $crate::report_error!(error);
+        }
+    }};
+    ($result:expr, $log_mode:expr) => {{
+        if let Err(error) = &$result {
+            $crate::report_error!(error, $log_mode);
         }
     }};
 }
@@ -76,3 +106,7 @@ pub trait ErrorExt: RegisteredError + std::error::Error {
         sentry::capture_error(self);
     }
 }
+
+#[cfg(test)]
+#[path = "errors_tests.rs"]
+mod tests;

--- a/crates/warp_core/src/errors_tests.rs
+++ b/crates/warp_core/src/errors_tests.rs
@@ -1,0 +1,85 @@
+use std::sync::{Mutex, OnceLock};
+
+use log::{Level, Log, Metadata, Record};
+
+use crate::errors::{ReportErrorLogMode, LOG_TARGET};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LogEntry {
+    target: String,
+    level: Level,
+    message: String,
+}
+
+struct TestLogger;
+
+static LOGGER: TestLogger = TestLogger;
+static LOGS: OnceLock<Mutex<Vec<LogEntry>>> = OnceLock::new();
+
+impl Log for TestLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        logs().lock().unwrap().push(LogEntry {
+            target: record.target().to_owned(),
+            level: record.level(),
+            message: record.args().to_string(),
+        });
+    }
+
+    fn flush(&self) {}
+}
+
+fn logs() -> &'static Mutex<Vec<LogEntry>> {
+    LOGS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn init_logger() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Trace);
+    logs().lock().unwrap().clear();
+}
+
+fn logged_report_count(message: &str) -> usize {
+    logs()
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|entry| {
+            entry.target == LOG_TARGET && entry.level == Level::Error && entry.message == message
+        })
+        .count()
+}
+
+fn report_once_per_run_error() {
+    crate::report_error!(
+        anyhow::anyhow!("once per run"),
+        ReportErrorLogMode::OncePerRun
+    );
+}
+
+#[test]
+fn report_error_log_mode_controls_log_frequency() {
+    init_logger();
+
+    for _ in 0..2 {
+        crate::report_error!(anyhow::anyhow!("default"));
+    }
+    assert_eq!(logged_report_count("default"), 2);
+
+    logs().lock().unwrap().clear();
+    for _ in 0..2 {
+        crate::report_error!(
+            anyhow::anyhow!("explicit every time"),
+            ReportErrorLogMode::EveryTime
+        );
+    }
+    assert_eq!(logged_report_count("explicit every time"), 2);
+
+    logs().lock().unwrap().clear();
+    report_once_per_run_error();
+    report_once_per_run_error();
+    assert_eq!(logged_report_count("once per run"), 1);
+}

--- a/crates/warp_core/src/errors_tests.rs
+++ b/crates/warp_core/src/errors_tests.rs
@@ -60,6 +60,24 @@ fn report_once_per_run_error() {
     );
 }
 
+fn report_first_callsite_once_per_run_error() {
+    crate::report_error!(
+        anyhow::anyhow!("separate once per run"),
+        ReportErrorLogMode::OncePerRun
+    );
+}
+
+fn report_second_callsite_once_per_run_error() {
+    crate::report_error!(
+        anyhow::anyhow!("separate once per run"),
+        ReportErrorLogMode::OncePerRun
+    );
+}
+
+fn report_if_error_once_per_run(result: Result<(), anyhow::Error>) {
+    crate::report_if_error!(result, ReportErrorLogMode::OncePerRun);
+}
+
 #[test]
 fn report_error_log_mode_controls_log_frequency() {
     init_logger();
@@ -82,4 +100,17 @@ fn report_error_log_mode_controls_log_frequency() {
     report_once_per_run_error();
     report_once_per_run_error();
     assert_eq!(logged_report_count("once per run"), 1);
+
+    logs().lock().unwrap().clear();
+    for _ in 0..2 {
+        report_first_callsite_once_per_run_error();
+        report_second_callsite_once_per_run_error();
+    }
+    assert_eq!(logged_report_count("separate once per run"), 2);
+
+    logs().lock().unwrap().clear();
+    for _ in 0..2 {
+        report_if_error_once_per_run(Err(anyhow::anyhow!("result once per run")));
+    }
+    assert_eq!(logged_report_count("result once per run"), 1);
 }


### PR DESCRIPTION
## Description
Adds a `ReportErrorLogMode` enum for `report_error!` so call sites can choose between the existing default `EveryTime` behavior and a new `OncePerRun` mode.

The `OncePerRun` mode uses a per-macro-invocation `static AtomicBool`, so each call site logs the first time it is reached during the app run and suppresses later hits. The default one-argument `report_error!(err)` form remains backwards-compatible and logs every time.

Also threads the same option through `report_if_error!(result, log_mode)` for callers that use the result helper.

## Linked Issue
N/A — Slack request.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Added `warp_core::errors::tests::report_error_log_mode_controls_log_frequency`, which installs a test logger and verifies:
- default `report_error!(err)` logs twice for two hits
- `ReportErrorLogMode::EveryTime` logs twice for two hits
- `ReportErrorLogMode::OncePerRun` logs once for two hits of the same macro callsite

Validation run:
- [x] `./script/format`
- [x] `./script/format --check && cargo clippy -p warp_core --all-targets --tests -- -D warnings`
- [x] `cargo nextest run -p warp_core -E 'test(report_error_log_mode_controls_log_frequency)'` — 1 passed
- [x] `cargo nextest run -p warp_core` — 44 passed
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

I also tried `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`; it failed before reaching this change because release-bundle app binaries expected generated channel config files such as `stable_config.json`, `dev_config.json`, `local_config.json`, and `preview_config.json` under `OUT_DIR`.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — no UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/b3b97505-1e9f-427c-b87d-7f8757773bd3_
_Run: https://oz.staging.warp.dev/runs/019e7f0b-9f95-72e6-bb15-5b5b3ad074db_

_This PR was generated with [Oz](https://warp.dev/oz)._
