### PR TITLE
Avoid duplicate project skill tree scans

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -22,9 +22,9 @@ use super::subscribers::{
     HomeSkillSubscriber, ProjectSkillSubscriber, SkillRepositoryMessage, SymlinkSkillSubscriber,
 };
 use super::utils::{
-    find_skill_files_in_tree, find_symlinked_skill_files_in_tree, is_home_provider_path,
-    is_home_skill_directory, is_skill_file, read_local_project_skills_from_filesystem,
-    read_skills_from_directories, read_skills_from_files,
+    find_project_skill_files_in_tree, is_home_provider_path, is_home_skill_directory,
+    is_skill_file, read_local_project_skills_from_filesystem, read_skills_from_directories,
+    read_skills_from_files,
 };
 use crate::remote_server::manager::RemoteServerManager;
 use crate::warp_managed_paths_watcher::{
@@ -89,15 +89,7 @@ impl SkillWatcher {
         let skill_files: Vec<PathBuf> = repo_paths
             .iter()
             .filter_map(|repo_path| RepositoryIdentifier::try_local(repo_path))
-            .flat_map(|repo_id| {
-                let mut skill_files = find_skill_files_in_tree(&repo_id, repo_metadata, ctx);
-                skill_files.extend(
-                    find_symlinked_skill_files_in_tree(&repo_id, repo_metadata, ctx)
-                        .into_iter()
-                        .map(LocalOrRemotePath::Local),
-                );
-                skill_files
-            })
+            .flat_map(|repo_id| find_project_skill_files_in_tree(&repo_id, repo_metadata, ctx))
             .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
             .collect();
         read_skills_from_files(skill_files)
@@ -232,13 +224,9 @@ impl SkillWatcher {
         let refresh_generation = self.advance_project_skill_refresh_generation(repo_id);
         let current_skill_files: HashSet<LocalOrRemotePath> = {
             let repo_metadata = RepoMetadataModel::as_ref(ctx);
-            let mut skill_files = find_skill_files_in_tree(repo_id, repo_metadata, ctx);
-            skill_files.extend(
-                find_symlinked_skill_files_in_tree(repo_id, repo_metadata, ctx)
-                    .into_iter()
-                    .map(LocalOrRemotePath::Local),
-            );
-            skill_files.into_iter().collect()
+            find_project_skill_files_in_tree(repo_id, repo_metadata, ctx)
+                .into_iter()
+                .collect()
         };
 
         let previous_skill_files = self

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -326,7 +326,7 @@ fn test_removing_project_repo_invalidates_pending_refresh_result() {
 
 #[test]
 #[cfg(unix)]
-fn test_refresh_project_skills_for_repo_loads_symlinked_project_skill_directory() {
+fn test_refresh_project_skills_for_repo_loads_indexed_and_symlinked_skill_directories() {
     let (tx, rx) = async_channel::unbounded();
 
     App::test((), |mut app| async move {
@@ -337,6 +337,12 @@ fn test_refresh_project_skills_for_repo_loads_symlinked_project_skill_directory(
 
         let repo_dir = TempDir::new().unwrap();
         let target_dir = TempDir::new().unwrap();
+        let indexed_skill = create_skill_file(
+            &repo_dir,
+            "indexed-skill",
+            "Indexed skill",
+            "Indexed content",
+        );
         let target_skill = create_skill_file(
             &target_dir,
             "linked-skill",
@@ -359,19 +365,19 @@ fn test_refresh_project_skills_for_repo_loads_symlinked_project_skill_directory(
         let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
         let repo_key = StandardizedPath::try_from_local(&repo).unwrap();
         repo_metadata_handle.update(&mut app, |model, ctx| {
-            model.insert_test_state(repo_key, project_provider_state(&repo), ctx);
+            model.insert_test_state(repo_key, project_state(&repo, Some(&indexed_skill)), ctx);
         });
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);
         });
-
-        assert_eq!(
-            rx.recv().await.unwrap(),
-            SkillWatcherEvent::SkillsAdded {
-                skills: vec![expected_skill]
-            }
-        );
+        let SkillWatcherEvent::SkillsAdded { mut skills } = rx.recv().await.unwrap() else {
+            panic!("Expected SkillsAdded event");
+        };
+        skills.sort_by_key(|skill| skill.path.display_path());
+        let mut expected = vec![indexed_skill, expected_skill];
+        expected.sort_by_key(|skill| skill.path.display_path());
+        assert_eq!(skills, expected);
     });
 }
 
@@ -796,29 +802,6 @@ fn project_state(repo: &std::path::Path, skill: Option<&ParsedSkill>) -> FileTre
     let root = Entry::Directory(DirectoryEntry {
         path: StandardizedPath::try_from_local(repo).unwrap(),
         children,
-        ignored: false,
-        loaded: true,
-    });
-    FileTreeState::new(root, Vec::new(), None)
-}
-
-#[cfg(unix)]
-fn project_provider_state(repo: &std::path::Path) -> FileTreeState {
-    let skills_dir = Entry::Directory(DirectoryEntry {
-        path: StandardizedPath::try_from_local(&repo.join(".agents/skills")).unwrap(),
-        children: Vec::new(),
-        ignored: false,
-        loaded: true,
-    });
-    let agents_dir = Entry::Directory(DirectoryEntry {
-        path: StandardizedPath::try_from_local(&repo.join(".agents")).unwrap(),
-        children: vec![skills_dir],
-        ignored: false,
-        loaded: true,
-    });
-    let root = Entry::Directory(DirectoryEntry {
-        path: StandardizedPath::try_from_local(repo).unwrap(),
-        children: vec![agents_dir],
         ignored: false,
         loaded: true,
     });

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -27,47 +27,65 @@ fn local_or_remote_path_for_repo_path(
     }
 }
 
-/// Finds concrete `SKILL.md` files in a repository tree.
+/// Finds project skill files and local symlinked skill files with one metadata traversal.
 ///
-/// Remote sessions cannot walk the filesystem from the client, so callers use
-/// repo metadata to locate files and then fetch contents through the daemon.
-pub fn find_skill_files_in_tree(
+/// Local provider directories are included in the metadata query so filesystem hydration can
+/// supplement indexed files with directory symlinks. Remote repositories only return indexed
+/// skill files because their filesystems are unavailable to the client.
+pub(super) fn find_project_skill_files_in_tree(
     repo_id: &RepositoryIdentifier,
     repo_metadata: &RepoMetadataModel,
     ctx: &AppContext,
 ) -> Vec<LocalOrRemotePath> {
+    let include_local_provider_directories = matches!(repo_id, RepositoryIdentifier::Local(_));
     let repo_id_for_filter = repo_id.clone();
     let args = GetContentsArgs {
-        include_folders: false,
+        include_folders: include_local_provider_directories,
         ..GetContentsArgs::default()
     }
     .include_ignored()
-    .with_filter(move |content| {
-        let RepoContent::File(file) = content else {
-            return false;
-        };
-        let path = local_or_remote_path_for_repo_path(&repo_id_for_filter, &file.path);
-        extract_skill_parent_directory(&path).is_ok()
+    .with_filter(move |content| match content {
+        RepoContent::File(file) => {
+            let path = local_or_remote_path_for_repo_path(&repo_id_for_filter, &file.path);
+            extract_skill_parent_directory(&path).is_ok()
+        }
+        RepoContent::Directory(directory) => {
+            include_local_provider_directories
+                && is_project_provider_path(&directory.path.to_local_path_lossy())
+        }
     });
 
-    repo_metadata
+    let mut skill_files = Vec::new();
+    let mut local_provider_directories = Vec::new();
+    for content in repo_metadata
         .get_repo_contents(repo_id, args, ctx)
         .unwrap_or_default()
-        .into_iter()
-        .filter_map(|content| {
-            let RepoContent::File(file) = content else {
-                return None;
-            };
-            Some(local_or_remote_path_for_repo_path(repo_id, &file.path))
-        })
-        .collect()
+    {
+        match content {
+            RepoContent::File(file) => {
+                skill_files.push(local_or_remote_path_for_repo_path(repo_id, &file.path));
+            }
+            RepoContent::Directory(directory) => {
+                if let Some(path) = directory.path.to_local_path() {
+                    local_provider_directories.push(path);
+                }
+            }
+        }
+    }
+
+    skill_files.extend(
+        find_symlinked_skill_files_in_local_provider_directories(local_provider_directories)
+            .into_iter()
+            .map(LocalOrRemotePath::Local),
+    );
+    skill_files
 }
 
 /// Reads local project skills by discovering provider directories on the filesystem.
 ///
 /// This is a local-only fallback for repositories whose repo metadata indexing fails. Successful
-/// local and remote repos should use [`find_skill_files_in_tree`] so the normal metadata-backed
-/// path remains shared.
+/// local and remote project refreshes should use [`find_project_skill_files_in_tree`] so the
+/// normal metadata-backed path remains shared.
 pub(super) fn read_local_project_skills_from_filesystem(scan_root: &Path) -> Vec<ParsedSkill> {
     let direct_skill_file = scan_root.join("SKILL.md");
     if is_skill_file(&direct_skill_file) {
@@ -108,16 +126,9 @@ fn is_ignored_fallback_scan_entry(entry: &DirEntry) -> bool {
 /// Repo metadata intentionally skips directory symlinks to avoid duplicate trees/cycles. Project
 /// skill refreshes are still triggered by repo metadata, but local hydration supplements the tree
 /// with `SKILL.md` files from symlinked skill directories so existing symlink handling is preserved.
-pub(super) fn find_symlinked_skill_files_in_tree(
-    repo_id: &RepositoryIdentifier,
-    repo_metadata: &RepoMetadataModel,
-    ctx: &AppContext,
+fn find_symlinked_skill_files_in_local_provider_directories(
+    provider_dirs: Vec<PathBuf>,
 ) -> Vec<PathBuf> {
-    if !matches!(repo_id, RepositoryIdentifier::Local(_)) {
-        return Vec::new();
-    }
-
-    let provider_dirs = find_local_provider_directories_in_tree(repo_id, repo_metadata, ctx);
     provider_dirs
         .into_iter()
         .flat_map(|provider_dir| {
@@ -135,34 +146,6 @@ pub(super) fn find_symlinked_skill_files_in_tree(
                     }
                     None
                 })
-        })
-        .collect()
-}
-
-fn find_local_provider_directories_in_tree(
-    repo_id: &RepositoryIdentifier,
-    repo_metadata: &RepoMetadataModel,
-    ctx: &AppContext,
-) -> Vec<PathBuf> {
-    let args = GetContentsArgs {
-        include_folders: true,
-        ..GetContentsArgs::default()
-    }
-    .include_ignored()
-    .with_filter(|content| {
-        let RepoContent::Directory(directory) = content else {
-            return false;
-        };
-        is_project_provider_path(&directory.path.to_local_path_lossy())
-    });
-
-    repo_metadata
-        .get_repo_contents(repo_id, args, ctx)
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|content| match content {
-            RepoContent::Directory(directory) => directory.path.to_local_path(),
-            RepoContent::File(_) => None,
         })
         .collect()
 }

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -15,7 +15,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
 use super::{
-    extract_skill_parent_directory, find_skill_files_in_tree, is_home_provider_path,
+    extract_skill_parent_directory, find_project_skill_files_in_tree, is_home_provider_path,
     is_home_skill_directory, is_skill_file, read_skills_from_files,
 };
 
@@ -543,7 +543,7 @@ fn find_skill_files_in_tree_finds_root_skills() {
 
             model_handle.read(&app, |model, ctx| {
                 let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
-                let skill_files = find_skill_files_in_tree(&repo_id, model, ctx);
+                let skill_files = find_project_skill_files_in_tree(&repo_id, model, ctx);
                 assert_eq!(skill_files.len(), 2);
                 assert!(skill_files.contains(&LocalOrRemotePath::Local(
                     repo.join(".agents/skills/root-skill-1/SKILL.md")
@@ -696,7 +696,7 @@ fn find_skill_files_in_tree_finds_subdirectory_skills() {
 
             model_handle.read(&app, |model, ctx| {
                 let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
-                let skill_files = find_skill_files_in_tree(&repo_id, model, ctx);
+                let skill_files = find_project_skill_files_in_tree(&repo_id, model, ctx);
                 assert_eq!(skill_files.len(), 2);
                 assert!(skill_files.contains(&LocalOrRemotePath::Local(
                     repo.join(".agents/skills/root-skill/SKILL.md")
@@ -767,7 +767,7 @@ fn find_skill_files_in_tree_returns_remote_skill_paths_for_remote_repos() {
         });
 
         model_handle.read(&app, |model, ctx| {
-            let skill_files = find_skill_files_in_tree(&repo_id, model, ctx);
+            let skill_files = find_project_skill_files_in_tree(&repo_id, model, ctx);
             assert_eq!(
                 skill_files,
                 vec![LocalOrRemotePath::Remote(RemotePath::new(
@@ -839,7 +839,7 @@ fn find_skill_files_in_tree_includes_ignored_skill_files() {
             model_handle.read(&app, |model, ctx| {
                 let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
                 assert_eq!(
-                    find_skill_files_in_tree(&repo_id, model, ctx),
+                    find_project_skill_files_in_tree(&repo_id, model, ctx),
                     vec![LocalOrRemotePath::Local(
                         repo.join(".agents/skills/ignored-skill/SKILL.md")
                     )]
@@ -891,7 +891,7 @@ fn find_skill_files_in_tree_empty_repo() {
 
             model_handle.read(&app, |model, ctx| {
                 let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
-                let skill_files = find_skill_files_in_tree(&repo_id, model, ctx);
+                let skill_files = find_project_skill_files_in_tree(&repo_id, model, ctx);
                 assert!(skill_files.is_empty());
             });
         });


### PR DESCRIPTION
## Description
Avoid duplicate full repo metadata traversals during project skill refreshes.

Project skill refresh previously queried repo contents once to find indexed `SKILL.md` files and again to find local provider directories for symlink hydration. On large repos, that duplicated file-tree lookups on the main-thread refresh path. This PR replaces the separate discovery paths with a single metadata-backed helper that returns indexed skill files and, for local repos, uses provider directories from the same traversal to hydrate symlinked skill directories.

Remote project-skill behavior and the local filesystem fallback for failed metadata indexing are unchanged.

> [!NOTE]
> note from dstern: i hit some lag in WarpDev, grabbed a process sample, and had Agent Mode analyze the sample and propose a fix.  i haven't done a ton of due diligence here, though the analysis and fix seem directionally correct.

## Linked Issue
None.

## Testing
- [x] `./script/format`
- [x] `cargo check --manifest-path /Users/david/src/warp-skill-refresh-one-pass/Cargo.toml -p warp --lib`
- [x] `cargo nextest run --manifest-path /Users/david/src/warp-skill-refresh-one-pass/Cargo.toml -p warp -E 'test(find_skill_files_in_tree) | test(test_refresh_project_skills_for_repo_loads_indexed_and_symlinked_skill_directories)'`
- [x] `cargo nextest run --manifest-path /Users/david/src/warp-skill-refresh-one-pass/Cargo.toml -p warp -E 'test(test_local_project_fallback)'`
- [ ] I have manually tested my changes locally with `./script/run`

Manual app testing was not run; this is a metadata-discovery performance refactor validated with targeted unit tests.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
