### PR TITLE
Fix terminal markdown links with trailing sentence periods

### DIFF
--- a/app/src/terminal/view/link_detection.rs
+++ b/app/src/terminal/view/link_detection.rs
@@ -37,6 +37,15 @@ const PREFIXES_TO_REMOVE: [&str; 2] = ["a/", "b/"];
 #[cfg(feature = "local_fs")]
 const SUFFIXES_TO_REMOVE: [&str; 1] = ["@"];
 
+/// Natural-language terminal output often ends a sentence with a path followed by a period.
+/// Try this suffix before the raw token so Windows path normalization cannot validate `foo.md.`
+/// as `foo.md` while leaving the visible link range on the sentence period.
+#[cfg(all(feature = "local_fs", windows))]
+const PREFERRED_SUFFIXES_TO_REMOVE: [&str; 1] = ["."];
+
+#[cfg(all(feature = "local_fs", not(windows)))]
+const PREFERRED_SUFFIXES_TO_REMOVE: [&str; 0] = [];
+
 /// Highlighted link within a terminal model grid.
 #[derive(Debug, Clone)]
 pub enum GridHighlightedLink {
@@ -500,6 +509,28 @@ impl super::TerminalView {
         let mut link = None;
         'path_loop: for within_model_possible_path in possible_paths {
             let possible_path = within_model_possible_path.get_inner();
+            for suffix in PREFERRED_SUFFIXES_TO_REMOVE {
+                if let Some((new_possible_cleaned_path, new_range)) =
+                    Self::strip_suffix_from_possible_path(possible_path, max_columns, suffix)
+                {
+                    let absolute_path = absolute_path_if_valid(
+                        &new_possible_cleaned_path,
+                        ShellPathType::ShellNative(working_directory.to_string()),
+                        shell_launch_data.as_ref(),
+                    );
+
+                    if let Some(absolute_path) = absolute_path {
+                        link = Some(Self::create_valid_link(
+                            absolute_path,
+                            new_possible_cleaned_path.line_and_column_num,
+                            new_range,
+                            &within_model_possible_path,
+                        ));
+                        break 'path_loop;
+                    }
+                }
+            }
+
             // We want to check if the clean path result is a valid path and get the canonical
             // absolute path back.
             let absolute_path = absolute_path_if_valid(
@@ -551,11 +582,9 @@ impl super::TerminalView {
             }
 
             for suffix in SUFFIXES_TO_REMOVE {
-                if let Some(new_possible_path) = possible_path.path.path.strip_suffix(suffix) {
-                    let new_possible_cleaned_path = CleanPathResult {
-                        path: new_possible_path.into(),
-                        line_and_column_num: possible_path.path.line_and_column_num,
-                    };
+                if let Some((new_possible_cleaned_path, new_range)) =
+                    Self::strip_suffix_from_possible_path(possible_path, max_columns, suffix)
+                {
                     let absolute_path = absolute_path_if_valid(
                         &new_possible_cleaned_path,
                         ShellPathType::ShellNative(working_directory.to_string()),
@@ -564,15 +593,10 @@ impl super::TerminalView {
 
                     // check if new_possible_path is valid
                     if let Some(absolute_path) = absolute_path {
-                        let new_end_point = possible_path
-                            .range
-                            .end()
-                            .wrapping_sub(max_columns, suffix.len());
-
                         link = Some(Self::create_valid_link(
                             absolute_path,
                             new_possible_cleaned_path.line_and_column_num,
-                            *possible_path.range.start()..=new_end_point,
+                            new_range,
                             &within_model_possible_path,
                         ));
 
@@ -584,6 +608,27 @@ impl super::TerminalView {
         }
 
         link.map(GridHighlightedLink::File)
+    }
+
+    fn strip_suffix_from_possible_path(
+        possible_path: &grid_handler::PossiblePath,
+        max_columns: usize,
+        suffix: &str,
+    ) -> Option<(CleanPathResult, std::ops::RangeInclusive<Point>)> {
+        let new_possible_path = possible_path.path.path.strip_suffix(suffix)?;
+        let new_possible_cleaned_path = CleanPathResult {
+            path: new_possible_path.into(),
+            line_and_column_num: possible_path.path.line_and_column_num,
+        };
+        let new_end_point = possible_path
+            .range
+            .end()
+            .wrapping_sub(max_columns, suffix.chars().count());
+
+        Some((
+            new_possible_cleaned_path,
+            *possible_path.range.start()..=new_end_point,
+        ))
     }
 
     fn create_valid_link(
@@ -627,3 +672,7 @@ impl super::TerminalView {
         }
     }
 }
+
+#[cfg(all(test, feature = "local_fs"))]
+#[path = "link_detection_tests.rs"]
+mod tests;

--- a/app/src/terminal/view/link_detection_tests.rs
+++ b/app/src/terminal/view/link_detection_tests.rs
@@ -1,0 +1,19 @@
+use super::*;
+
+#[test]
+fn strip_suffix_from_possible_path_removes_sentence_period_from_range() {
+    let possible_path = grid_handler::PossiblePath {
+        path: CleanPathResult {
+            path: "C:/Users/chris/warp-md-test.md.".to_string(),
+            line_and_column_num: None,
+        },
+        range: Point::new(0, 11)..=Point::new(0, 42),
+    };
+
+    let (clean_path, range) =
+        super::super::TerminalView::strip_suffix_from_possible_path(&possible_path, 80, ".")
+            .expect("trailing period should produce a stripped candidate");
+
+    assert_eq!(clean_path.path, "C:/Users/chris/warp-md-test.md");
+    assert_eq!(range, Point::new(0, 11)..=Point::new(0, 41));
+}


### PR DESCRIPTION
## Description

Fixes terminal file-link detection for markdown paths followed by sentence punctuation.

On Windows, a terminal token such as \`C:/Users/chris/warp-md-test.md.\` can resolve successfully because the filesystem normalizes the trailing period away. Before this change, Warp kept the period in the highlighted link range and in the path used for file-type classification, so the markdown viewer did not engage and the file opened as raw text.

This change:
- Extracts a `strip_suffix_from_possible_path` helper (refactors the existing `SUFFIXES_TO_REMOVE` path to reuse it)
- Adds `PREFERRED_SUFFIXES_TO_REMOVE` — tried **before** the raw token — currently `["."]` on Windows only, empty array on all other platforms
- Keeps the visible underline/highlight aligned with the actual file path
- Preserves markdown classification for `.md` files

**Re: POSIX regression concern from reviewer** — `PREFERRED_SUFFIXES_TO_REMOVE` is gated `#[cfg(all(feature = "local_fs", windows))]` so it is an empty array on Linux/macOS. POSIX paths ending in `.` are unaffected; only Windows (which normalizes trailing periods) gets the stripped-first behavior.

## Linked Issue

Fixes #11477

- [x] The linked issue is labeled `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- [x] Added a focused unit test covering trailing-period stripping and link-range adjustment (`link_detection_tests.rs`).
- [ ] I have manually tested my changes locally with `./script/run`

The Rust/app toolchain is not available in this environment. A screenshot/recording of the fix end-to-end would require running Warp on a Windows machine with a `.md` file path printed followed by a period. The unit test validates the core logic: `strip_suffix_from_possible_path` strips the period from both the path string and the highlight range endpoint.

### Unit test

```
strip_suffix_from_possible_path_removes_sentence_period_from_range
  input path:  "C:/Users/chris/warp-md-test.md."  range: (0,11)..=(0,42)
  output path: "C:/Users/chris/warp-md-test.md"   range: (0,11)..=(0,41)
```

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed terminal file links so markdown paths followed by a sentence period open as markdown instead of raw text.