### PR TITLE
Make channel config logging at startup more human-readable

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1415,9 +1415,9 @@ pub(crate) fn initialize_app(
     remote_server::wire_auth_token_rotation(ctx);
 
     log::info!(
-        "Starting warp with channel state {} and version {:?}",
+        "Starting warp version {:?} with channel state:\n{}",
+        ChannelState::app_version(),
         ChannelState::debug_str(),
-        ChannelState::app_version()
     );
 
     // Teach our app that sometimes option means meta.

--- a/crates/warp_core/src/channel/state.rs
+++ b/crates/warp_core/src/channel/state.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
+use std::fmt;
 
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
@@ -164,7 +165,7 @@ impl ChannelState {
     }
 
     pub fn debug_str() -> String {
-        format!("{:?}", *CHANNEL_STATE.lock())
+        CHANNEL_STATE.lock().to_string()
     }
 
     pub fn logfile_name() -> Cow<'static, str> {
@@ -391,6 +392,59 @@ impl ChannelState {
             Channel::Local => "warplocal",
             Channel::Oss => "warposs",
         }
+    }
+}
+
+impl fmt::Display for ChannelState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Channel: {}", self.channel)?;
+        if !self.additional_features.is_empty() {
+            writeln!(
+                f,
+                "Channel-specific features: {:?}",
+                self.additional_features
+            )?;
+        }
+        writeln!(f, "App ID: {}", self.config.app_id)?;
+
+        writeln!(f, "Server config:")?;
+        writeln!(f, "    API: {}", self.config.server_config.server_root_url)?;
+        writeln!(f, "    RTC: {}", self.config.server_config.rtc_server_url)?;
+        if let Some(session_sharing_url) = self
+            .config
+            .server_config
+            .session_sharing_server_url
+            .as_ref()
+        {
+            writeln!(f, "    Session sharing: {session_sharing_url}")?;
+        }
+        writeln!(f, "    Oz: {}", self.config.oz_config.oz_root_url)?;
+
+        if self.config.telemetry_config.is_some() || self.config.crash_reporting_config.is_some() {
+            writeln!(f, "Telemetry and crash reporting:")?;
+            if let Some(rudderstack_config) = self
+                .config
+                .telemetry_config
+                .as_ref()
+                .and_then(|c| c.rudderstack_config.as_ref())
+            {
+                writeln!(f, "    RudderStack URL: {}", rudderstack_config.root_url)?;
+            }
+            if let Some(crash_reporting_config) = self.config.crash_reporting_config.as_ref() {
+                writeln!(f, "    Sentry URL: {}", crash_reporting_config.sentry_url)?;
+            }
+        }
+
+        if let Some(static_mcp_config) = self.config.mcp_static_config.as_ref() {
+            if !static_mcp_config.providers.is_empty() {
+                writeln!(f, "Static MCP server providers:")?;
+                for server in static_mcp_config.providers.iter() {
+                    writeln!(f, "    - {} @ {}", server.client_id, server.issuer)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description

At startup, we log the current channel config. Historically, this has caused confusion for a couple reasons:
* It includes the Firebase API key, which isn't actually an API key (it's essentially a client ID) - we get frequent reports of this as a leaked secret
* The debug representation of this struct is a big blob that's not super readable

Instead, we can implement `fmt::Display` to print a friendlier representation - for example:
* We can format the app ID
* We can concisely list all upstream servers
* We can list static MCP provider URLs on their own lines

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<img width="796" height="540" alt="Screenshot 2026-06-01 at 2 04 29 PM" src="https://github.com/user-attachments/assets/18033c45-0d8c-4bd2-8825-2c465deb265f" />


## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

