### PR TITLE
Coerce nested integers in MCP tool arguments

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool.rs
@@ -173,31 +173,125 @@ impl Entity for CallMCPToolExecutor {
 /// MCP tool args round-trip through `google.protobuf.Struct` on the wire, whose
 /// `NumberValue` stores everything as `f64`. Without this fix, serde_json emits
 /// whole-number floats as `"5.0"`, which strict MCP servers reject for integer fields.
+///
+/// Walks the schema recursively, so nested objects, array items, and `oneOf` /
+/// `anyOf` / `allOf` composition are all covered. Nullable integer fields
+/// (`"type": ["integer", "null"]`) are recognized. `$ref` resolution is not
+/// implemented; schemas that rely on it will fall through unchanged.
+///
+/// Composition handling is intentionally permissive: when multiple branches of
+/// `oneOf` / `anyOf` declare integer-compatible types, the value is coerced
+/// without disambiguating which branch actually matches. Strict `oneOf`
+/// validation would require full schema evaluation; for the wire-format bug
+/// this guards against (`5.0` → `5`), the permissive form is sufficient and
+/// never widens behavior beyond what schema-aware servers will already accept.
 pub(crate) fn coerce_integer_args(
     args: &mut serde_json::Map<String, serde_json::Value>,
     input_schema: &serde_json::Map<String, serde_json::Value>,
 ) {
-    let Some(properties) = input_schema.get("properties").and_then(|p| p.as_object()) else {
-        return;
-    };
+    coerce_object_against_schema(args, input_schema);
+}
 
-    for (key, prop_def) in properties {
-        let is_integer = prop_def.get("type").and_then(|t| t.as_str()) == Some("integer");
-        if !is_integer {
-            continue;
+fn coerce_object_against_schema(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    schema: &serde_json::Map<String, serde_json::Value>,
+) {
+    for &key in COMPOSITION_KEYS {
+        if let Some(serde_json::Value::Array(branches)) = schema.get(key) {
+            for branch in branches {
+                if let Some(branch_schema) = branch.as_object() {
+                    coerce_object_against_schema(obj, branch_schema);
+                }
+            }
         }
-        let Some(serde_json::Value::Number(n)) = args.get_mut(key) else {
-            continue;
-        };
-        let Some(f) = n.as_f64() else { continue };
-        if f.fract() != 0.0 {
-            continue;
-        }
-        if let Ok(i) = i64::try_from(f as i128) {
-            *n = serde_json::Number::from(i);
+    }
+
+    if let Some(serde_json::Value::Object(properties)) = schema.get("properties") {
+        for (prop_key, prop_schema) in properties {
+            if let Some(child) = obj.get_mut(prop_key) {
+                coerce_value_against_schema(child, prop_schema);
+            }
         }
     }
 }
+
+fn coerce_value_against_schema(value: &mut serde_json::Value, schema: &serde_json::Value) {
+    let Some(schema_obj) = schema.as_object() else {
+        return;
+    };
+
+    if let serde_json::Value::Number(n) = value {
+        if schema_declares_integer(schema_obj) {
+            try_coerce_number_to_integer(n);
+        }
+    }
+
+    // Composition: best-effort — if any branch declares integer, the coercion
+    // above will fire. This is intentionally permissive; strict `oneOf`
+    // disambiguation would require full schema evaluation.
+    for &key in COMPOSITION_KEYS {
+        if let Some(serde_json::Value::Array(branches)) = schema_obj.get(key) {
+            for branch in branches {
+                coerce_value_against_schema(value, branch);
+            }
+        }
+    }
+
+    match value {
+        serde_json::Value::Object(map) => {
+            coerce_object_against_schema(map, schema_obj);
+        }
+        serde_json::Value::Array(arr) => match schema_obj.get("items") {
+            Some(items_schema @ serde_json::Value::Object(_)) => {
+                for item in arr.iter_mut() {
+                    coerce_value_against_schema(item, items_schema);
+                }
+            }
+            Some(serde_json::Value::Array(items_schemas)) => {
+                // Tuple form: each subschema applies positionally. Array
+                // elements past the tuple length are left alone — JSON Schema
+                // would route them through `additionalItems`, which we don't
+                // implement here.
+                for (item, item_schema) in arr.iter_mut().zip(items_schemas) {
+                    coerce_value_against_schema(item, item_schema);
+                }
+            }
+            Some(
+                serde_json::Value::Null
+                | serde_json::Value::Bool(_)
+                | serde_json::Value::Number(_)
+                | serde_json::Value::String(_),
+            )
+            | None => {}
+        },
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => {}
+    }
+}
+
+fn schema_declares_integer(schema: &serde_json::Map<String, serde_json::Value>) -> bool {
+    match schema.get("type") {
+        Some(serde_json::Value::String(s)) => s == "integer",
+        Some(serde_json::Value::Array(types)) => {
+            types.iter().any(|t| t.as_str() == Some("integer"))
+        }
+        _ => false,
+    }
+}
+
+fn try_coerce_number_to_integer(n: &mut serde_json::Number) {
+    let Some(f) = n.as_f64() else { return };
+    if f.fract() != 0.0 {
+        return;
+    }
+    if let Ok(i) = i64::try_from(f as i128) {
+        *n = serde_json::Number::from(i);
+    }
+}
+
+const COMPOSITION_KEYS: &[&str] = &["oneOf", "anyOf", "allOf"];
 
 #[cfg(test)]
 #[path = "call_mcp_tool_tests.rs"]

--- a/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/call_mcp_tool_tests.rs
@@ -47,3 +47,265 @@ fn no_coercion_when_not_typed_as_integer() {
         assert_eq!(serde_json::to_string(&args["x"]).unwrap(), "1.0");
     }
 }
+
+#[test]
+fn nested_object_integer_is_coerced() {
+    let mut args = obj(json!({ "outer": { "inner": 5.0 } }));
+    let schema = obj(json!({
+        "properties": {
+            "outer": {
+                "type": "object",
+                "properties": { "inner": { "type": "integer" } }
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["outer"]["inner"].as_i64(), Some(5));
+    assert_eq!(serde_json::to_string(&args["outer"]["inner"]).unwrap(), "5");
+}
+
+#[test]
+fn array_items_integer_is_coerced() {
+    let mut args = obj(json!({ "values": [1.0, 2.0, 3.0] }));
+    let schema = obj(json!({
+        "properties": {
+            "values": {
+                "type": "array",
+                "items": { "type": "integer" }
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(serde_json::to_string(&args["values"]).unwrap(), "[1,2,3]");
+}
+
+#[test]
+fn tuple_array_items_integer_is_coerced_positionally() {
+    // `items` as an array (tuple validation) applies each subschema by index.
+    let mut args = obj(json!({ "pair": [1.0, 2.5] }));
+    let schema = obj(json!({
+        "properties": {
+            "pair": {
+                "type": "array",
+                "items": [
+                    { "type": "integer" },
+                    { "type": "number" }
+                ]
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["pair"][0].as_i64(), Some(1));
+    assert_eq!(args["pair"][1].as_f64(), Some(2.5));
+}
+
+#[test]
+fn oneof_integer_branch_is_coerced() {
+    // Mirrors the failing case from issue #10596: a filter object whose `value`
+    // can be either an array of strings or an integer timestamp.
+    let mut args = obj(json!({
+        "filter": { "field": "timestamp", "value": 1_730_419_200_000.0 }
+    }));
+    let schema = obj(json!({
+        "properties": {
+            "filter": {
+                "oneOf": [
+                    { "properties": { "value": { "type": "array", "items": { "type": "string" } } } },
+                    { "properties": { "value": { "type": "integer" } } }
+                ]
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["filter"]["value"].as_i64(), Some(1_730_419_200_000));
+}
+
+#[test]
+fn anyof_integer_branch_is_coerced() {
+    let mut args = obj(json!({ "x": 7.0 }));
+    let schema = obj(json!({
+        "properties": {
+            "x": {
+                "anyOf": [
+                    { "type": "string" },
+                    { "type": "integer" }
+                ]
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["x"].as_i64(), Some(7));
+}
+
+#[test]
+fn allof_integer_is_coerced() {
+    let mut args = obj(json!({ "x": 9.0 }));
+    let schema = obj(json!({
+        "properties": {
+            "x": {
+                "allOf": [
+                    { "type": "integer" },
+                    { "minimum": 0 }
+                ]
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["x"].as_i64(), Some(9));
+}
+
+#[test]
+fn nullable_integer_type_array_is_coerced() {
+    // OpenAPI / JSON Schema allow `"type": ["integer", "null"]` for a nullable
+    // integer; the integer-typed value should still be coerced.
+    let mut args = obj(json!({ "maybe": 42.0 }));
+    let schema = obj(json!({
+        "properties": {
+            "maybe": { "type": ["integer", "null"] }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["maybe"].as_i64(), Some(42));
+}
+
+#[test]
+fn fractional_floats_in_nested_shapes_are_preserved() {
+    // Regression: even when the schema declares integer, a value with a
+    // fractional part must not be silently truncated. Leave the float intact
+    // so the server's schema validation can reject it explicitly.
+    let mut args = obj(json!({
+        "outer": { "inner": 5.25 },
+        "values": [1.5, 2.5],
+    }));
+    let schema = obj(json!({
+        "properties": {
+            "outer": {
+                "properties": { "inner": { "type": "integer" } }
+            },
+            "values": {
+                "type": "array",
+                "items": { "type": "integer" }
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["outer"]["inner"].as_f64(), Some(5.25));
+    assert_eq!(args["values"][0].as_f64(), Some(1.5));
+    assert_eq!(args["values"][1].as_f64(), Some(2.5));
+}
+
+#[test]
+fn nested_non_integer_fields_are_left_alone() {
+    let mut args = obj(json!({
+        "outer": { "ratio": 0.5, "label": "x" }
+    }));
+    let schema = obj(json!({
+        "properties": {
+            "outer": {
+                "properties": {
+                    "ratio": { "type": "number" },
+                    "label": { "type": "string" }
+                }
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["outer"]["ratio"].as_f64(), Some(0.5));
+    assert_eq!(args["outer"]["label"].as_str(), Some("x"));
+}
+
+#[test]
+fn top_level_composition_is_walked() {
+    // Some OpenAPI-derived MCP schemas put `oneOf` / `anyOf` at the root rather
+    // than inside a property — make sure the entry point walks composition at
+    // the top level too, not just inside properties.
+    let mut args = obj(json!({ "x": 5.0 }));
+    let schema = obj(json!({
+        "oneOf": [
+            { "properties": { "x": { "type": "integer" } } },
+            { "properties": { "y": { "type": "string" } } }
+        ]
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    assert_eq!(args["x"].as_i64(), Some(5));
+}
+
+#[test]
+fn audit_management_log_request_matches_reporter_payload() {
+    // End-to-end repro from issue #10596 using the reporter's exact schema and
+    // payload. Verifies every integer field serializes without a `.0` suffix.
+    let mut args = obj(json!({
+        "request_data": {
+            "search_from": 0.0,
+            "search_to": 100.0,
+            "filters": [
+                { "field": "timestamp", "operator": "gte", "value": 1_730_419_200_000.0 }
+            ]
+        }
+    }));
+    let schema = obj(json!({
+        "type": "object",
+        "properties": {
+            "request_data": {
+                "type": "object",
+                "properties": {
+                    "search_from": { "type": "integer" },
+                    "search_to":   { "type": "integer" },
+                    "filters": {
+                        "type": "array",
+                        "items": {
+                            "oneOf": [
+                                { "properties": { "value": { "type": "array", "items": { "type": "string" } } } },
+                                { "properties": { "value": { "type": "integer" } } }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }));
+
+    coerce_integer_args(&mut args, &schema);
+
+    // The core of the bug: no whole-number float suffixes should remain in the
+    // serialized payload, regardless of object key ordering.
+    let serialized = serde_json::to_string(&args).unwrap();
+    assert!(
+        !serialized.contains(".0"),
+        "expected no \".0\" suffixes after coercion, got: {serialized}"
+    );
+
+    // Round-trip through `Value` to compare structurally (key order in the raw
+    // string is implementation-defined; content equality is what matters).
+    let actual: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+    let expected = json!({
+        "request_data": {
+            "search_from": 0,
+            "search_to": 100,
+            "filters": [
+                { "field": "timestamp", "operator": "gte", "value": 1_730_419_200_000_i64 }
+            ]
+        }
+    });
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
## Description

`coerce_integer_args` only walked depth-1 properties typed exactly
`{"type": "integer"}`. Nested objects, array items, `oneOf` / `anyOf` /
`allOf` composition, and nullable `["integer", "null"]` were bypassed,
so the agent kept sending `5.0` / `1730419200000.0` for integer fields
nested inside those shapes. Strict MCP servers reject them.

The helper now walks the schema recursively alongside the JSON value
and covers all the shapes above. `oneOf` is permissive (any
integer-typed branch triggers coercion) since strict disambiguation
isn't needed for a wire-format guard.

## Linked Issue

Fixes #10596

- [x] The linked issue is labeled `ready-to-implement`.

## Testing

11 new unit tests in `call_mcp_tool_tests.rs` covering each new shape
(nested object, array items single/tuple, `oneOf` / `anyOf` / `allOf`,
nullable `["integer", "null"]`, top-level composition) plus regressions
(fractional floats untouched, non-integer fields untouched) plus an
end-to-end test using the reporter's exact schema and payload. Existing
depth-1 tests still pass.

**Manual proof:** registered a local MCP server (~70-line Python) whose
`inputSchema` puts an integer inside `array → items → oneOf →
properties.value` (the deeply nested shape #10596 calls out), asked
the agent to invoke it, captured the wire JSON:

```
arguments: {"filters":[{"field":"timestamp","operator":"gte","value":1730419200000}],"search_from":0,"search_to":100}
```

All three integer fields — including `filters[0].value`, which depth-1
coercion could never reach — arrive as integers, not `.0` floats.

- [x] I have manually tested my changes locally with `./script/run`.

## Agent Mode
- [ ] Warp Agent Mode — built with Claude Code.

CHANGELOG-BUG-FIX: Fix MCP tool calls sending floats (e.g. `5.0`) instead of integers (`5`) for integer fields nested inside objects, arrays, `oneOf` / `anyOf` / `allOf` composition, or nullable `["integer", "null"]` types.
