### PR TITLE
QUALITY-780: client pill bar + aggregation (Wave 2)

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -122,18 +122,19 @@ pub(super) const DONE_STATUS_KEY: u8 = 3;
 
 /// Sort priority within a pill section. Lower sorts leftmost. Cancelled
 /// and Success share one "done" bucket; recency decides their order.
-/// `WaitingForEvents` shares the `InProgress` bucket so yielded runs
-/// stay in the active half of the bar (per QUALITY-780 client TECH §7);
-/// `client-pill-bar` will refine the precedence + sort-key ordering.
+/// `WaitingForEvents` shares the `InProgress` bucket (same sort key) so
+/// yielded pills sort alongside actively-streaming ones in the active
+/// half of the bar, left of the done section (per QUALITY-780 client
+/// TECH §7).
 fn pill_status_sort_key(status: Option<&ConversationStatus>) -> u8 {
     match status {
         Some(ConversationStatus::Blocked { .. }) => 0,
         Some(ConversationStatus::Error) => 1,
-        // TODO(client-pill-bar): give `WaitingForEvents` its own slot if
-        // design wants it visually distinct from `InProgress` within
-        // the active section. For now we co-bucket so yielded pills
-        // sort to the same place as actively-streaming ones.
-        Some(ConversationStatus::InProgress) | Some(ConversationStatus::WaitingForEvents) => 2,
+        Some(ConversationStatus::InProgress) => 2,
+        // `WaitingForEvents` is quiescent but not terminal — keep it in
+        // the active bucket alongside `InProgress` so the pill stays
+        // visible to the user as a run that may resume on its own.
+        Some(ConversationStatus::WaitingForEvents) => 2,
         Some(ConversationStatus::Cancelled) | Some(ConversationStatus::Success) => DONE_STATUS_KEY,
         None => 2,
     }

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -56,6 +56,18 @@ fn pill_status_sort_key_treats_none_as_in_progress() {
 }
 
 #[test]
+fn pill_status_sort_key_places_waiting_for_events_in_active_bucket() {
+    // Per QUALITY-780 client TECH §7, `WaitingForEvents` shares the
+    // `InProgress` bucket so yielded pills stay in the active section of
+    // the bar, strictly to the left of the done bucket. Covers PRODUCT.md
+    // (24).
+    let waiting_key = pill_status_sort_key(Some(&ConversationStatus::WaitingForEvents));
+    let in_progress_key = pill_status_sort_key(Some(&ConversationStatus::InProgress));
+    assert_eq!(waiting_key, in_progress_key);
+    assert!(waiting_key < DONE_STATUS_KEY);
+}
+
+#[test]
 fn pill_done_recency_key_puts_most_recent_first_and_unknown_last() {
     let older = pill_done_recency_key(Some(1_000));
     let newer = pill_done_recency_key(Some(2_000));

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -56,9 +56,13 @@ pub fn collect_descendant_conversation_ids_in_spawn_order(
 ///   2. `Blocked` — at least one node is waiting on user input. The
 ///      `blocked_action` from the first blocked node encountered is preserved
 ///      so callers can display it.
-///   3. `Error` — at least one node finished with an error.
-///   4. `Cancelled` — at least one node was cancelled.
-///   5. `Success` — everything finished successfully.
+///   3. `WaitingForEvents` — at least one node yielded via `wait_for_events`
+///      and is listening for inbound input. The run is quiescent but not
+///      terminal — the driver stays alive until something resumes it. See
+///      `specs/QUALITY-780/TECH.md` §7.
+///   4. `Error` — at least one node finished with an error.
+///   5. `Cancelled` — at least one node was cancelled.
+///   6. `Success` — everything finished successfully.
 ///
 /// Returns `Success` if the orchestrator is not loaded and has no descendants.
 pub fn aggregated_orchestrator_status(
@@ -74,19 +78,13 @@ pub fn aggregated_orchestrator_status(
 
     let mut first_blocked: Option<ConversationStatus> = None;
     let mut any_in_progress = false;
+    let mut any_waiting = false;
     let mut any_error = false;
     let mut any_cancelled = false;
-    // TODO(client-pill-bar): track an `any_waiting` accumulator and
-    // promote `WaitingForEvents` ahead of `Error`/`Cancelled` per
-    // QUALITY-780 client TECH §7 precedence
-    // (`InProgress > Blocked > WaitingForEvents > Error > Cancelled > Success`).
-    // For now we co-bucket `WaitingForEvents` with `InProgress` so the
-    // aggregator still reflects an active orchestration tree.
     for status in statuses {
         match status {
-            ConversationStatus::InProgress | ConversationStatus::WaitingForEvents => {
-                any_in_progress = true
-            }
+            ConversationStatus::InProgress => any_in_progress = true,
+            ConversationStatus::WaitingForEvents => any_waiting = true,
             ConversationStatus::Blocked { .. } => {
                 if first_blocked.is_none() {
                     first_blocked = Some(status);
@@ -103,6 +101,9 @@ pub fn aggregated_orchestrator_status(
     }
     if let Some(blocked) = first_blocked {
         return blocked;
+    }
+    if any_waiting {
+        return ConversationStatus::WaitingForEvents;
     }
     if any_error {
         return ConversationStatus::Error;

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -373,3 +373,180 @@ fn aggregated_status_respects_orchestrator_own_in_progress_state() {
         });
     });
 }
+
+// --- QUALITY-780 §7: `WaitingForEvents` aggregation precedence ---
+//
+// Precedence is `InProgress > Blocked > WaitingForEvents > Error > Cancelled
+// > Success`. The cases below pin each boundary so a future refactor can't
+// silently demote `WaitingForEvents` past `Error`/`Cancelled` (or promote it
+// past `Blocked`/`InProgress`). Covers PRODUCT.md (22).
+
+#[test]
+fn aggregated_status_is_waiting_when_orchestrator_yields_and_children_succeeded() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Orchestrator yielded via `wait_for_events`; all children finished
+        // cleanly. The tree is quiescent but not terminal — the aggregator
+        // must report WaitingForEvents so the pill bar reflects that the
+        // run is listening for inbound input.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::Success,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::WaitingForEvents,
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_in_progress_over_waiting_for_events() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Orchestrator is waiting, but one child is still actively streaming.
+        // `InProgress` outranks `WaitingForEvents` so the user sees the
+        // active state.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::InProgress,
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_blocked_over_waiting_for_events() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Orchestrator is waiting for events, but a child is blocked on user
+        // input. Blocked outranks WaitingForEvents because the user needs to
+        // unblock the tree before it can make progress.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::Blocked {
+                    blocked_action: "approve_command".to_string(),
+                },
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::Blocked {
+                    blocked_action: "approve_command".to_string(),
+                },
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_waiting_for_events_over_error() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Orchestrator is waiting; one child errored. `WaitingForEvents`
+        // outranks `Error` because the run is not terminal — it may still
+        // resume on its own and the user shouldn't see a terminal
+        // "Error" pill while the driver is still alive.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::Error,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::WaitingForEvents,
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Description

QUALITY-780 Wave 2: implement the client-side §7 of the pill bar + aggregation spec on top of the Wave 1 `WaitingForEvents` foundation.

`aggregated_orchestrator_status` now uses the full precedence:

`InProgress > Blocked > WaitingForEvents > Error > Cancelled > Success`

Wave 1 left `WaitingForEvents` co-bucketed with `InProgress` via `any_in_progress` (with a `TODO(client-pill-bar)`). This PR introduces a dedicated `any_waiting` accumulator and returns `WaitingForEvents` when set and no higher-precedence status was observed. The doc-comment precedence list is updated to match.

`pill_status_sort_key` now gives `WaitingForEvents` an explicit slot with the same sort key as `InProgress` (`2`), so yielded pills stay in the active half of the bar and strictly to the left of the `DONE_STATUS_KEY (3)` done bucket. The comment is updated to spell this out instead of pointing at a follow-up. `render_avatar_with_status_overlay` and the hover card already auto-route the new variant through `ConversationStatus::status_icon_and_color`, so no changes are needed at those sites.

Stacks on `matthew/QUALITY-780-client-core` (#11998); the orchestrator will integrate all four Wave 2 branches into client-core in Wave 3.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

`orchestration_topology_tests.rs` (covers PRODUCT.md (22)):
- orchestrator `WaitingForEvents` + all children `Success` → `WaitingForEvents`
- orchestrator `WaitingForEvents` + one child `InProgress` → `InProgress`
- orchestrator `WaitingForEvents` + one child `Blocked` → `Blocked`
- orchestrator `WaitingForEvents` + one child `Error` → `WaitingForEvents`

`orchestration_pill_bar_tests.rs` (covers PRODUCT.md (24)):
- `pill_status_sort_key(WaitingForEvents)` equals `pill_status_sort_key(InProgress)` and is `< DONE_STATUS_KEY`.

Validation run on this branch:
- `cargo fmt`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo nextest run -p warp -E '...'` (21 tests, 21 passed — including the 5 new tests)
- `./script/presubmit` (all checks green)

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/1504c798-b4b7-48ff-8a54-6d8331416eb7_
_Run: https://oz.staging.warp.dev/runs/019e83b1-72c1-7583-b163-f8829128d435_

_This PR was generated with [Oz](https://warp.dev/oz)._
