### PR TITLE
Prefer stateful mouse reporting command palette entry

### DIFF
--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -586,13 +586,6 @@ pub fn init(app: &mut AppContext) {
         .with_group(bindings::BindingGroup::Navigation.as_str())
         .with_custom_action(CustomAction::ActivateNextPane),
         EditableBinding::new(
-            "workspace:toggle_mouse_reporting",
-            "Toggle Mouse Reporting",
-            WorkspaceAction::ToggleMouseReporting,
-        )
-        .with_group(bindings::BindingGroup::Settings.as_str())
-        .with_context_predicate(id!("Workspace")),
-        EditableBinding::new(
             "workspace:create_team_notebook",
             BindingDescription::new("Create a new team notebook")
                 .with_custom_description(bindings::MAC_MENUS_CONTEXT, "New Team Notebook"),


### PR DESCRIPTION
## Description
Removes the older generic command-palette/editable binding for mouse reporting that appeared as “Toggle Mouse Reporting”. PR #11512 already added the clearer state-aware `Enable/Disable mouse reporting` command-palette entry, so this keeps that entry and removes the duplicate generic toggle.

This follows the Slack thread suggestion to prefer the explicit enable/disable wording in the command palette.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Slack thread: feedback-app duplicate command palette items report.

## Testing
- `cargo fmt --manifest-path /workspace/warp/app/Cargo.toml`
- `cargo check --manifest-path /workspace/warp/app/Cargo.toml -p warp`
- `git diff --check`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A; this removes a duplicate command-palette registration and was validated with formatting and compile checks.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed duplicate command palette entries for mouse reporting.

_Conversation: https://staging.warp.dev/conversation/ff982ffa-de02-4dbc-b3c5-cd3d86d79711_
_Run: https://oz.staging.warp.dev/runs/019e8418-5e87-7744-ae59-7130cb62c528_
_This PR was generated with [Oz](https://warp.dev/oz)._
