### PR TITLE
APP-4640: Prevent Fast Forward toggle from approving commands

### DIFF
--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -846,6 +846,23 @@ impl BlocklistAIContextModel {
         &self,
         ctx: &AppContext,
     ) -> AIConversationAutoexecuteMode {
+        // When AgentView is enabled, the autoexecution toggle applies to the active agent view
+        // conversation -- even when starting a new conversation, the agent view always has a
+        // conversation ID. Read the same target here so callers can tell whether a toggle will
+        // enable or disable Fast Forward.
+        if FeatureFlag::AgentView.is_enabled() {
+            if let Some(conversation_id) = self
+                .agent_view_controller
+                .as_ref(ctx)
+                .agent_view_state()
+                .active_conversation_id()
+            {
+                return BlocklistAIHistoryModel::as_ref(ctx)
+                    .conversation(&conversation_id)
+                    .map(|conversation| conversation.autoexecute_override())
+                    .unwrap_or_default();
+            }
+        }
         match &self.pending_query_state {
             PendingQueryState::New {
                 autoexecute_override,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6488,6 +6488,16 @@ impl TerminalView {
         }
     }
 
+    fn is_autoexecute_mode_enabled(&self, ctx: &AppContext) -> bool {
+        self.ai_context_model
+            .as_ref(ctx)
+            .pending_query_autoexecute_override(ctx)
+            .is_autoexecute_any_action()
+    }
+
+    fn should_accept_pending_action_before_autoexecute_toggle(&self, ctx: &AppContext) -> bool {
+        !self.is_autoexecute_mode_enabled(ctx)
+    }
     /// Returns true if the window is wide enough to auto-open side panels.
     pub fn can_auto_open_panel(&self) -> bool {
         self.size_info.pane_width_px().as_f32() > MINIMUM_WIDTH_TO_AUTO_OPEN_PANE
@@ -26401,11 +26411,17 @@ impl TypedActionView for TerminalView {
                     return;
                 }
 
-                // If there's a pending (blocked) requested code diff, accept it first.
-                if let Some(ai_block) = self.last_ai_block() {
-                    ai_block.update(ctx, |ai_block, ctx| {
-                        ai_block.accept_pending_action(ctx);
-                    });
+                // When Fast Forward is currently off, Cmd/Ctrl+Shift+I doubles as the
+                // "Auto-approve" affordance on pending action speed-bumps: approve the
+                // current action and enable Fast Forward for the rest of the task. When
+                // Fast Forward is currently on, the same shortcut should only turn it off;
+                // approving a blocked command while disabling Fast Forward is surprising.
+                if self.should_accept_pending_action_before_autoexecute_toggle(ctx) {
+                    if let Some(ai_block) = self.last_ai_block() {
+                        ai_block.update(ctx, |ai_block, ctx| {
+                            ai_block.accept_pending_action(ctx);
+                        });
+                    }
                 }
 
                 self.ai_context_model.update(ctx, |context_model, ctx| {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -6514,6 +6514,51 @@ fn ctrl_c_does_not_accept_prompt_suggestion_banner() {
     })
 }
 
+#[test]
+fn toggle_autoexecute_mode_accepts_pending_actions_only_when_enabling() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = view.agent_view_controller().update(ctx, |controller, ctx| {
+                controller
+                    .try_enter_agent_view(
+                        None,
+                        AgentViewEntryOrigin::Input {
+                            was_prompt_autodetected: false,
+                        },
+                        ctx,
+                    )
+                    .expect("Should be able to enter agent view")
+            });
+
+            assert!(
+                view.should_accept_pending_action_before_autoexecute_toggle(ctx),
+                "when Fast Forward is off, the toggle should still auto-accept the pending action"
+            );
+
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                history_model.toggle_autoexecute_override(&conversation_id, view.view_id, ctx);
+            });
+
+            assert!(
+                !view.should_accept_pending_action_before_autoexecute_toggle(ctx),
+                "when Fast Forward is already on, the toggle should only disable it"
+            );
+
+            view.handle_action(&TerminalAction::ToggleAutoexecuteMode, ctx);
+
+            assert!(
+                view.should_accept_pending_action_before_autoexecute_toggle(ctx),
+                "after disabling Fast Forward, the next toggle may auto-accept while enabling again"
+            );
+        });
+    })
+}
+
 /// Regression test for GH703: a Linear deeplink prompt must never be auto-submitted
 /// to the LLM. Because `LinearDeepLink` returns `AutoTriggerBehavior::Never`, the
 /// prompt must land in the input buffer as a draft and the "press enter again to


### PR DESCRIPTION
## Summary
- Prevent Cmd/Ctrl+Shift+I from approving pending agent actions when Fast Forward is already enabled.
- Align Agent View autoexecute state reads with the active conversation that the toggle mutates.
- Add regression coverage for enabling vs. disabling Fast Forward behavior.

## Validation
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp toggle_autoexecute_mode_accepts_pending_actions_only_when_enabling`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/6c35b124-1045-44f2-9215-7a5a84c1dd46_
_Run: https://oz.staging.warp.dev/runs/019e8424-7e5a-7b5d-a266-afd6e42e2d8b_
_This PR was generated with [Oz](https://warp.dev/oz)._
