### PR TITLE
Classify agent session share auth failures

### DIFF
--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -25,9 +25,15 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
             ),
         ),
         AgentDriverError::ShareSessionFailed { error: share_err } => {
+            let bin = warp_cli::binary_name().unwrap_or_else(|| "warp".to_string());
             let message = match share_err {
                 ShareSessionError::Internal(_) => {
                     "Failed to share agent session due to an internal error. Please try running your task again.".to_string()
+                }
+                ShareSessionError::Failed(reason) if share_err.is_authentication_required() => {
+                    format!(
+                        "Failed to share agent session because Warp authentication is missing or expired. Log in via '{bin} login', provide an API key via '--api-key', or set the WARP_API_KEY environment variable."
+                    )
                 }
                 ShareSessionError::Failed(reason) => {
                     // The reason string comes from the session-sharing layer and is aimed at
@@ -58,6 +64,9 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                     message,
                     match share_err {
                         ShareSessionError::Disabled => PlatformErrorCode::FeatureNotAvailable,
+                        _ if share_err.is_authentication_required() => {
+                            PlatformErrorCode::AuthenticationRequired
+                        }
                         _ => PlatformErrorCode::InternalError,
                     },
                 ),

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -1,7 +1,9 @@
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::classify_driver_error;
-use crate::ai::agent_sdk::driver::terminal::ShareSessionError;
+use crate::ai::agent_sdk::driver::terminal::{
+    ShareSessionError, LOGIN_REQUIRED_SHARE_SESSION_REASON,
+};
 use crate::ai::agent_sdk::driver::AgentDriverError;
 
 fn assert_state_and_code(
@@ -161,6 +163,20 @@ fn share_session_failed_includes_reason() {
     });
     assert_eq!(state, AgentTaskState::Error);
     assert!(update.message.contains("server rejected"));
+}
+
+#[test]
+fn share_session_login_required_gets_auth_required() {
+    let (state, update) = classify_driver_error(&AgentDriverError::ShareSessionFailed {
+        error: ShareSessionError::Failed(LOGIN_REQUIRED_SHARE_SESSION_REASON.into()),
+    });
+    assert_eq!(state, AgentTaskState::Error);
+    assert_eq!(
+        update.error_code,
+        Some(PlatformErrorCode::AuthenticationRequired)
+    );
+    assert!(update.message.contains("Warp authentication"));
+    assert!(update.message.contains("WARP_API_KEY"));
 }
 
 // --- Conversation-level outcomes ---

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -58,8 +58,16 @@ pub(crate) enum ShareSessionError {
     Interrupted,
 }
 
+pub(super) const LOGIN_REQUIRED_SHARE_SESSION_REASON: &str =
+    "You must be logged in to share sessions.";
 const TERMINAL_SESSION_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(60);
 const TERMINAL_SESSION_SHARE_DELAY: Duration = Duration::from_secs(10);
+
+impl ShareSessionError {
+    pub(super) fn is_authentication_required(&self) -> bool {
+        matches!(self, Self::Failed(reason) if reason == LOGIN_REQUIRED_SHARE_SESSION_REASON)
+    }
+}
 
 /// Options for creating the terminal view before constructing a [`TerminalDriver`].
 pub(crate) struct TerminalDriverOptions {


### PR DESCRIPTION
## Summary
- Classifies the session-sharing server's login-required rejection for agent sessions as `AuthenticationRequired` instead of `InternalError`.
- Replaces the wrapped interactive "You must be logged in" copy with actionable CLI/API-key guidance for cloud/CLI agent runs.
- Adds a regression test for the agent session-sharing auth failure classification.

## Validation
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`
- `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml -p warp -E 'test(share_session_login_required_gets_auth_required)'`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/d3169026-399e-4602-b346-1c62fc034e73_
_Run: https://oz.staging.warp.dev/runs/019e8425-9c26-7449-8cbf-f49faad3176c_

_This PR was generated with [Oz](https://warp.dev/oz)._
