### PR TITLE
QUALITY-780: client sync + notifications (Wave 2)

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -367,13 +367,16 @@ impl AgentRunDisplayStatus {
             ConversationStatus::Blocked { blocked_action } => Self::ConversationBlocked {
                 blocked_action: blocked_action.clone(),
             },
-            // QUALITY-780 placeholder: treat a yielded conversation as
-            // still in progress for the conversation-list display. This
-            // mirrors the `LocalAgentTaskSyncModel::map_conversation_status`
-            // mapping (§5 in the client TECH spec) so the agent-run list
-            // view doesn't flip yielded runs to a terminal status.
-            // `client-sync-notif` may refine this if a distinct display
-            // variant is needed.
+            // QUALITY-780 §6 + §5: treat a yielded conversation as still in
+            // progress for the agent-run list display. The list view
+            // groups by terminal-vs-active and a yielded run is active, so
+            // mapping to `ConversationInProgress` keeps it in the working
+            // bucket. This mirrors `LocalAgentTaskSyncModel::map_conversation_status`,
+            // which reports `AgentTaskState::InProgress` to the server for
+            // the same reason. A distinct display variant for waiting is
+            // intentionally not introduced here — visually distinguishing
+            // waiting from streaming belongs to the orchestration pill bar
+            // (client TECH §7), not to this list-row status enum.
             ConversationStatus::WaitingForEvents => Self::ConversationInProgress,
         }
     }

--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -385,15 +385,13 @@ impl AgentNotificationsModel {
                     ctx,
                 );
             }
-            // QUALITY-780 placeholder owned by `client-sync-notif`. A yielded
-            // conversation is still active (it just isn't streaming this
-            // instant), so we intentionally do not emit a `Complete` or
-            // `Request` toast here — that would tell the user the run is
-            // done when it actually isn't. `client-sync-notif` will replace
-            // this with the final notification-suppression behavior from
-            // §6 of the client TECH spec.
+            // QUALITY-780 §6: a yielded conversation is still active (it
+            // just isn't streaming right now), so we do not emit a new
+            // toast. Mirror the `InProgress` arm above and clear any stale
+            // notification for this origin so the mailbox doesn't show a
+            // misleading "Task completed" entry while we wait for events.
             ConversationStatus::WaitingForEvents => {
-                // TODO(client-sync-notif)
+                self.remove_notification_by_source(origin, ctx);
             }
         }
     }
@@ -481,13 +479,25 @@ pub enum AgentManagementEvent {
 impl ConversationStatus {
     /// Returns true if the updating the conversation with this status should trigger some
     /// notification to the user.
+    ///
+    /// This is an exhaustive `match` rather than a `matches!` macro so that adding a new
+    /// `ConversationStatus` variant in the future forces a deliberate decision about whether
+    /// it should fire a notification (per QUALITY-780 §6).
     pub fn should_trigger_notification(&self) -> bool {
-        matches!(
-            self,
+        match self {
             ConversationStatus::Success
-                | ConversationStatus::Blocked { .. }
-                | ConversationStatus::Error
-        )
+            | ConversationStatus::Blocked { .. }
+            | ConversationStatus::Error => true,
+            // A run that is still streaming hasn't reached a notable state yet.
+            ConversationStatus::InProgress
+            // A run yielded via `wait_for_events` is quiescent but not terminal —
+            // it's still active and should not produce a "Task completed"-style toast.
+            // PRODUCT.md (16), (18).
+            | ConversationStatus::WaitingForEvents
+            // User-initiated cancellations should not fire a notification
+            // (the user already knows they cancelled).
+            | ConversationStatus::Cancelled => false,
+        }
     }
 }
 

--- a/app/src/ai/agent_management/agent_management_model_tests.rs
+++ b/app/src/ai/agent_management/agent_management_model_tests.rs
@@ -4,7 +4,7 @@ use warpui::{App, EntityId, ModelHandle, SingletonEntity};
 
 use super::AgentNotificationsModel;
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::agent_management::notifications::{
     NotificationCategory, NotificationFilter, NotificationOrigin, NotificationSourceAgent,
 };
@@ -253,6 +253,201 @@ fn separate_conversations_have_independent_pending_artifacts() {
             let b = model.flush_pending_artifacts(conv_b);
             assert_eq!(b.len(), 1);
             assert!(matches!(&b[0], Artifact::Plan { title: Some(t), .. } if t == "Plan B"));
+        });
+    });
+}
+
+// --- QUALITY-780 §6: should_trigger_notification exhaustive behavior ---
+//
+// These are pure-function tests on the `ConversationStatus` predicate; they
+// do not require any app setup. They lock in the contract documented in
+// PRODUCT.md (16), (19), (20):
+// - Terminal-error and blocked states always surface to the user.
+// - In-progress, waiting-for-events, and user-cancelled states do not.
+// - The orchestrator's own terminal status is decided locally; descendant
+//   state is *not* consulted (no parameter to consult) — the predicate
+//   takes only `&self` (PRODUCT.md (20)).
+
+#[test]
+fn should_trigger_notification_returns_true_for_success() {
+    assert!(ConversationStatus::Success.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_true_for_blocked() {
+    assert!(ConversationStatus::Blocked {
+        blocked_action: "approve diff".to_owned(),
+    }
+    .should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_true_for_error() {
+    assert!(ConversationStatus::Error.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_false_for_in_progress() {
+    assert!(!ConversationStatus::InProgress.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_false_for_waiting_for_events() {
+    assert!(!ConversationStatus::WaitingForEvents.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_false_for_cancelled() {
+    assert!(!ConversationStatus::Cancelled.should_trigger_notification());
+}
+
+// --- QUALITY-780 §6: mailbox suppression for non-terminal status updates ---
+//
+// These tests drive `handle_history_event` end-to-end via a real
+// `UpdatedConversationStatus::Changed` event emitted by
+// `AIConversation::update_status`, which is the only path that mutates
+// the private status field on a conversation. They verify the observable
+// behavior of the new mailbox code path for the two non-terminal
+// transitions introduced by QUALITY-780: `* → WaitingForEvents` and the
+// `WaitingForEvents → InProgress` resume.
+//
+// In `App::test` there is no real `AgentViewController`, so
+// `ActiveAgentViewsModel::is_conversation_open` always returns false; the
+// gate at the top of `handle_history_event_for_mailbox` consequently
+// clears any stale notification regardless of status. That is the same
+// outcome as the new `WaitingForEvents` arm and as the existing
+// `InProgress` arm, so the test still captures the user-visible contract:
+// no stale or new "Task completed" toast survives a non-terminal
+// transition.
+
+/// Disables `show_agent_notifications` so subsequent `add_notification`
+/// calls skip the `send_telemetry_from_ctx!` branch — the test app does
+/// not register a `TelemetryContextProvider` singleton and the macro
+/// would otherwise panic.
+fn disable_telemetry_path(app: &mut App) {
+    AISettings::handle(app).update(app, |settings, ctx| {
+        report_if_error!(settings.show_agent_notifications.set_value(false, ctx));
+    });
+}
+
+/// Pre-populates a `Complete` notification for `conversation_id` so that a
+/// subsequent non-terminal status update has something to clear.
+fn seed_stale_notification(
+    notifications: &ModelHandle<AgentNotificationsModel>,
+    app: &mut App,
+    conversation_id: AIConversationId,
+    terminal_view_id: EntityId,
+) {
+    notifications.update(app, |model, ctx| {
+        model.add_notification(
+            "Agent task".to_owned(),
+            "Task completed.".to_owned(),
+            NotificationCategory::Complete,
+            NotificationSourceAgent::Oz { is_ambient: false },
+            NotificationOrigin::Conversation(conversation_id),
+            terminal_view_id,
+            vec![],
+            None,
+            ctx,
+        );
+    });
+}
+
+#[test]
+fn waiting_for_events_clears_stale_notification_and_adds_none() {
+    App::test((), |mut app| async move {
+        let _guard = FeatureFlag::HOANotifications.override_enabled(true);
+        let (history, notifications) = setup_app(&mut app);
+        disable_telemetry_path(&mut app);
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = EntityId::new();
+        history.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        seed_stale_notification(&notifications, &mut app, conversation_id, terminal_view_id);
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                1,
+                "precondition: one stale notification queued"
+            );
+        });
+
+        history.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.update_status(ConversationStatus::WaitingForEvents, terminal_view_id, ctx);
+        });
+
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                0,
+                "WaitingForEvents must clear stale notifications and add no new toast"
+            );
+        });
+    });
+}
+
+#[test]
+fn in_progress_resume_clears_stale_notification_and_adds_none() {
+    App::test((), |mut app| async move {
+        let _guard = FeatureFlag::HOANotifications.override_enabled(true);
+        let (history, notifications) = setup_app(&mut app);
+        disable_telemetry_path(&mut app);
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = EntityId::new();
+        history.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        // First move the conversation into WaitingForEvents, then back into
+        // InProgress. The second transition is the resume signal that
+        // PRODUCT.md (18) requires not to fire a notification.
+        history.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.update_status(ConversationStatus::WaitingForEvents, terminal_view_id, ctx);
+        });
+
+        seed_stale_notification(&notifications, &mut app, conversation_id, terminal_view_id);
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                1,
+                "precondition: one stale notification queued before the resume transition"
+            );
+        });
+
+        history.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation still exists");
+            conv.update_status(ConversationStatus::InProgress, terminal_view_id, ctx);
+        });
+
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                0,
+                "WaitingForEvents → InProgress resume must not fire a notification \
+                 (covers PRODUCT.md (18))"
+            );
         });
     });
 }

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -318,9 +318,9 @@ fn map_conversation_status(
         ConversationStatus::InProgress => (AgentTaskState::InProgress, None),
         // QUALITY-780 §5: when the conversation has yielded via
         // `wait_for_events`, the client actively reports `IN_PROGRESS` for
-        // the task. This is the final shape from §5 of the client TECH
-        // spec; `client-sync-notif` may add or refine the status message,
-        // but the `AgentTaskState` and the `None` status message are stable.
+        // the task so the server's `shouldPreserveInProgressOnClientSuccess`
+        // backstop is not relied on. No status message is attached: the
+        // yield is an internal state, not a user-visible status.
         ConversationStatus::WaitingForEvents => (AgentTaskState::InProgress, None),
         ConversationStatus::Success => (AgentTaskState::Succeeded, None),
         ConversationStatus::Error => {

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -7,8 +7,11 @@ use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 use warpui::App;
 
 use super::super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
-use super::{classify_renderable_error, map_cli_session_status, LocalAgentTaskSyncModel};
-use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+use super::{
+    classify_renderable_error, map_cli_session_status, map_conversation_status,
+    LocalAgentTaskSyncModel,
+};
+use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::agent::RenderableAIError;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::server::server_api::ai::{AIClient, MockAIClient, TaskStatusUpdate};
@@ -120,6 +123,64 @@ fn other_error_is_error_with_internal() {
         Some(PlatformErrorCode::InternalError),
         Some("something broke"),
     );
+}
+
+// --- map_conversation_status ---
+
+/// QUALITY-780 §5: a yielded conversation must report `IN_PROGRESS` to the
+/// task service so the task row stays active across the yield, rather than
+/// relying on the server's `shouldPreserveInProgressOnClientSuccess`
+/// backstop. No status message is attached because the yield is an
+/// internal state, not a user-facing status.
+///
+/// `AIConversation::update_status` is the only path that mutates the
+/// private status field, so the test routes the conversation through the
+/// history model to flip it into `WaitingForEvents` before calling the
+/// pure `map_conversation_status` helper.
+#[test]
+fn map_conversation_status_waiting_for_events_reports_in_progress_with_no_message() {
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+        history_model.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.update_status(ConversationStatus::WaitingForEvents, terminal_view_id, ctx);
+        });
+
+        history_model.read(&app, |model, _| {
+            let conv = model.conversation(&conversation_id).unwrap();
+            assert_eq!(conv.status(), &ConversationStatus::WaitingForEvents);
+            let (state, update) = map_conversation_status(conv);
+            assert_eq!(state, AgentTaskState::InProgress);
+            assert!(
+                update.is_none(),
+                "WaitingForEvents must not attach a status message"
+            );
+        });
+    });
+}
+
+#[test]
+fn map_conversation_status_in_progress_reports_in_progress_with_no_message() {
+    let conversation = AIConversation::new(false, false);
+    assert_eq!(
+        conversation.status(),
+        &ConversationStatus::InProgress,
+        "freshly constructed conversation should start in InProgress"
+    );
+
+    let (state, update) = map_conversation_status(&conversation);
+
+    assert_eq!(state, AgentTaskState::InProgress);
+    assert!(update.is_none());
 }
 
 // --- map_cli_session_status ---


### PR DESCRIPTION
## Description
Implements client TECH §5 (task sync) and §6 (mailbox notifications) for QUALITY-780 by replacing the `WaitingForEvents` placeholders left by Wave 1's client-core branch.

This is the Wave 2 `client-sync-notif` slice that stacks on top of [client-core (#11998)](https://github.com/warpdotdev/warp/pull/11998). PR targets `matthew/QUALITY-780-client-core`, not `master`.

**`local_agent_task_sync_model::map_conversation_status` (§5)**
- The `WaitingForEvents` arm reports `(AgentTaskState::InProgress, None)` so the server task row stays active across the yield. The implementation itself was already in place from client-core; this PR removes the `client-sync-notif` placeholder language from the surrounding comment and locks the contract.

**`agent_management_model` (§6)**
- `handle_history_event_for_mailbox`: the `WaitingForEvents` arm now mirrors the existing `InProgress` arm — clear stale notifications via `remove_notification_by_source`, emit no new toast.
- `should_trigger_notification` is rewritten from a `matches!` macro into an exhaustive `match` so a future `ConversationStatus` variant forces a deliberate decision instead of defaulting to `false`. Behavior is preserved: `Success | Blocked | Error` → true; `InProgress | WaitingForEvents | Cancelled` → false.

**`agent_conversations_model::AgentRunDisplayStatus::from_conversation_status`**
- Confirmed the placeholder mapping `WaitingForEvents => ConversationInProgress` matches the task-sync side and removed the `client-sync-notif` TODO marker. Visual differentiation of waiting vs streaming belongs to the orchestration pill bar (client TECH §7), not this status enum.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing
Added the following targeted tests (all passing):
- `local_agent_task_sync_model_tests::map_conversation_status_waiting_for_events_reports_in_progress_with_no_message` — routes a conversation through the history model to set `WaitingForEvents` and asserts the mapping.
- `local_agent_task_sync_model_tests::map_conversation_status_in_progress_reports_in_progress_with_no_message`.
- `agent_management_model_tests::should_trigger_notification_returns_*` — six pure-function tests, one per `ConversationStatus` variant.
- `agent_management_model_tests::waiting_for_events_clears_stale_notification_and_adds_none` — end-to-end via `update_status`.
- `agent_management_model_tests::in_progress_resume_clears_stale_notification_and_adds_none` — covers PRODUCT.md (18).

Test coverage caveat: in `App::test` there is no real `AgentViewController`, so `ActiveAgentViewsModel::is_conversation_open` returns false; the gate at the top of `handle_history_event_for_mailbox` clears notifications before reaching the per-status arms. The new `WaitingForEvents` arm calls the same `remove_notification_by_source`, so the user-visible contract — "no stale or new toast survives a non-terminal transition" — is exercised. Stronger integration tests of the arm itself require setting up a real controller and are deferred to the Wave 3 integration step. PRODUCT.md (20) — orchestrator terminal status fires regardless of descendant state — is covered by the `should_trigger_notification_returns_true_for_*` tests plus structural review (the function takes only `&self` and cannot consult descendants).

Validation run locally:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo nextest run -p warp` for the affected modules (101 tests, all pass)

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/b8599c39-054e-4d87-a251-ca9c863c255b_
_Run: https://oz.staging.warp.dev/runs/019e83b1-72f2-7bb5-9d44-b1e40026b3cb_

_This PR was generated with [Oz](https://warp.dev/oz)._
