### PR TITLE
QUALITY-780: client detection + ordering rule (Wave 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -3035,7 +3035,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4352,7 +4352,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4657,7 +4657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6918,7 +6918,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7112,7 +7112,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10078,8 +10078,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "petgraph",
@@ -10098,7 +10098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10111,7 +10111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10356,7 +10356,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11245,7 +11245,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11258,7 +11258,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11326,7 +11326,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12974,7 +12974,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15011,7 +15011,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=792d5878fd2ab93cc1681d88c2d74ab670c0a4ef#792d5878fd2ab93cc1681d88c2d74ab670c0a4ef"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=d622e1cec8de5c50b55c2d4f3050ce48dae464c4#d622e1cec8de5c50b55c2d4f3050ce48dae464c4"
 dependencies = [
  "prost 0.14.3",
  "prost-reflect",
@@ -15983,7 +15983,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "792d5878fd2ab93cc1681d88c2d74ab670c0a4ef" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "d622e1cec8de5c50b55c2d4f3050ce48dae464c4" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1650,16 +1650,14 @@ pub(crate) fn convert_tool_call_result_to_input(
             log::warn!("No result present for tool call ID: {tool_call_id}");
             None
         }
-        // QUALITY-780 placeholder owned by `client-detection`. The
-        // `WaitForEvents` tool-call result is consumed by
-        // `apply_client_actions` (per client TECH §8.3) and does not
-        // surface as a restorable exchange input. Return `None` so the
-        // restore path skips it. `client-detection` will replace this if
-        // the variant needs to be rendered in restored transcripts.
-        Some(ToolCallResultType::WaitForEvents(_)) => {
-            // TODO(client-detection)
-            None
-        }
+        // QUALITY-780 §8.3: the `WaitForEvents` tool-call result is
+        // consumed by the wait-state transition in
+        // `BlocklistAIHistoryModel::apply_client_actions` and does not
+        // surface as a restorable exchange input. The agent's next turn
+        // sees the empty result through the normal message stream rather
+        // than via a synthesised `AIAgentInput::ActionResult`, so the
+        // restore path can safely skip it.
+        Some(ToolCallResultType::WaitForEvents(_)) => None,
     }
 }
 
@@ -1792,13 +1790,16 @@ fn create_cancelled_result_for_tool_call(
         }
         // These tools are deprecated.
         ToolType::SuggestCreatePlan(_) | ToolType::SuggestPlan(_) => return None,
-        // QUALITY-780 placeholder owned by `client-detection`. A cancelled
-        // `WaitForEvents` tool call doesn't surface as a restorable action
-        // result — the resume signal arrives as a separate tool-call
-        // result (`Cancel` or `WaitForEvents`) per client TECH §8.3.
-        // `client-detection` will replace this with the final behavior.
+        // QUALITY-780 §8.3: a cancelled `WaitForEvents` tool call does
+        // not surface as a restorable `AIAgentInput::ActionResult`. The
+        // resume signal is the *next* `ToolCallResult` (a generic
+        // `Cancel` for inbound supersede or a `WaitForEvents` for the
+        // watchdog timeout) referencing the same `tool_call_id`; the
+        // wait-state transition lives entirely on
+        // `BlocklistAIHistoryModel`, not on the exchange input stream.
+        // Returning `None` here keeps the restored transcript symmetric
+        // with the server-handled `Server` variant just above.
         ToolType::WaitForEvents(_) => {
-            // TODO(client-detection)
             return None;
         }
     };

--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -706,6 +706,14 @@ impl TryFrom<AIAgentActionResult> for api::request::input::user_inputs::user_inp
             AIAgentActionResultType::RunAgents(orchestrate_result) => {
                 Some(orchestrate_result.try_into()?)
             }
+            // QUALITY-780: the watchdog-timeout result is produced by the
+            // client's local `wait_for_events` watchdog (driver wave). The
+            // outbound `Request.Input.ToolCallResult.WaitForEvents` proto
+            // variant carries no payload; the agent's next turn sees the
+            // empty result and decides how to proceed.
+            AIAgentActionResultType::WaitForEvents(wait_for_events_result) => {
+                Some(wait_for_events_result.try_into()?)
+            }
         };
         Ok(
             api::request::input::user_inputs::user_input::Input::ToolCallResult(

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -321,6 +321,18 @@ pub struct AIConversation {
     /// Whether the user has pinned this child agent in the orchestration
     /// pill bar. Persisted via `AgentConversationData.pinned`.
     pinned: bool,
+
+    /// The `tool_call_id` of the unresolved `WaitForEvents` tool call that
+    /// triggered the current waiting state. Only meaningful when `status`
+    /// is `WaitingForEvents`; cleared back to `None` when the wait is
+    /// resolved by a matching `Cancel` or `WaitForEventsResult` (see
+    /// `specs/QUALITY-780/TECH.md` §8). **Not persisted**: on restart a
+    /// `WaitingForEvents` conversation hydrates with this field `None`,
+    /// and `apply_client_actions` reconstructs the unresolved id by
+    /// scanning the restored transcript when the matching resume signal
+    /// arrives. See the comment on
+    /// `AgentConversationData.waiting_for_events` for the rationale.
+    waiting_for_events_tool_call_id: Option<String>,
 }
 
 pub(crate) fn artifact_from_fork_proto(
@@ -375,6 +387,7 @@ impl AIConversation {
             last_event_sequence: None,
             orchestration_configs: HashMap::new(),
             pinned: false,
+            waiting_for_events_tool_call_id: None,
         }
     }
 
@@ -415,6 +428,13 @@ impl AIConversation {
             .as_ref()
             .map(|data| data.waiting_for_events)
             .unwrap_or(false);
+        // QUALITY-780 §8: the unresolved `tool_call_id` is **not** persisted.
+        // On restart it starts as `None`; the watchdog (§4) skips scheduling
+        // and `apply_client_actions` reconstructs the pending id by scanning
+        // the transcript when a matching `Cancel` / `WaitForEventsResult`
+        // arrives. This matches how other unresolved tool calls are treated
+        // on restart and avoids an extra durable field.
+        let waiting_for_events_tool_call_id: Option<String> = None;
 
         let (task_store, todo_lists, status) = if tasks.is_empty() {
             // Bypass `derive_status_from_root_task`: it would return `Success`
@@ -634,6 +654,7 @@ impl AIConversation {
             last_event_sequence,
             orchestration_configs: HashMap::new(),
             pinned,
+            waiting_for_events_tool_call_id,
         })
     }
 
@@ -859,6 +880,25 @@ impl AIConversation {
     }
     pub fn status_error_message(&self) -> Option<&str> {
         self.status_error_message.as_deref()
+    }
+
+    /// Returns the `tool_call_id` of the unresolved `WaitForEvents` tool
+    /// call that produced the current waiting state, if any. Only set when
+    /// `status` is `ConversationStatus::WaitingForEvents`. See
+    /// `specs/QUALITY-780/TECH.md` §8.
+    pub fn waiting_for_events_tool_call_id(&self) -> Option<&str> {
+        self.waiting_for_events_tool_call_id.as_deref()
+    }
+
+    /// Sets (or clears) the unresolved `WaitForEvents` tool-call id
+    /// associated with the current waiting state. Used together with
+    /// `update_status(ConversationStatus::WaitingForEvents | InProgress)`
+    /// by the detection helpers in `BlocklistAIHistoryModel` to keep the
+    /// in-memory state and the visible status in sync. Not persisted; see
+    /// the field doc on `waiting_for_events_tool_call_id` for the
+    /// runtime-only semantics. See `specs/QUALITY-780/TECH.md` §8.
+    pub(crate) fn set_waiting_for_events_tool_call_id(&mut self, id: Option<String>) {
+        self.waiting_for_events_tool_call_id = id;
     }
 
     pub fn update_status(
@@ -3202,6 +3242,11 @@ impl AIConversation {
                 last_event_sequence: self.last_event_sequence,
                 pinned: self.pinned,
                 waiting_for_events: matches!(self.status, ConversationStatus::WaitingForEvents),
+                // QUALITY-780 §8: the in-memory
+                // `waiting_for_events_tool_call_id` is intentionally **not**
+                // persisted; see the field comment on `AgentConversationData`
+                // and the restore code in
+                // `new_restored_synthesizing_on_empty`.
             },
         };
         ctx.spawn(

--- a/app/src/ai/agent/redaction.rs
+++ b/app/src/ai/agent/redaction.rs
@@ -264,6 +264,9 @@ pub(crate) fn redact_inputs(inputs: &mut [AIAgentInput]) {
                     // Orchestrate results contain agent IDs / canonical error
                     // strings only; no user-provided text to redact.
                     AIAgentActionResultType::RunAgents(_) => {}
+                    // QUALITY-780: the watchdog-timeout result carries no
+                    // payload, so there is nothing to redact.
+                    AIAgentActionResultType::WaitForEvents(_) => {}
                 }
             }
             AIAgentInput::FetchReviewComments { repo_path, context } => {

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -302,6 +302,9 @@ pub mod text {
                 AIAgentActionResultType::AskUserQuestion(_) => Ok(()),
                 // RunAgents is a desktop-client-only action; not used in the SDK.
                 AIAgentActionResultType::RunAgents(_) => Ok(()),
+                // QUALITY-780: the watchdog-timeout result has no
+                // user-visible payload; no SDK output to emit.
+                AIAgentActionResultType::WaitForEvents(_) => Ok(()),
             },
         }
     }

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -508,14 +508,34 @@ impl BlocklistAIController {
                         // variant.
                         ConversationStatus::Cancelled
                     };
-                    history_model.update(ctx, |history_model, ctx| {
-                        history_model.update_conversation_status(
-                            me.terminal_view_id,
-                            *conversation_id,
-                            updated_conversation_status,
-                            ctx,
-                        );
-                    });
+                    // QUALITY-780 §8.2 ordering rule: if the conversation
+                    // already transitioned to `WaitingForEvents` earlier in
+                    // this response stream (via the detection point in
+                    // `apply_client_actions`), the post-stream
+                    // "all actions succeeded → Success" transition must
+                    // not clobber it. The response stream itself still
+                    // gets marked completed successfully (response-stream
+                    // success is independent of conversation status —
+                    // `mark_response_stream_completed_successfully` is
+                    // invoked from the `Finished` event handler above);
+                    // we just skip the conversation-level
+                    // `update_conversation_status` call here.
+                    let conversation_is_waiting_for_events = history_model
+                        .as_ref(ctx)
+                        .conversation(conversation_id)
+                        .is_some_and(|conversation| conversation.status().is_waiting_for_events());
+                    if !(conversation_is_waiting_for_events
+                        && matches!(updated_conversation_status, ConversationStatus::Success))
+                    {
+                        history_model.update(ctx, |history_model, ctx| {
+                            history_model.update_conversation_status(
+                                me.terminal_view_id,
+                                *conversation_id,
+                                updated_conversation_status,
+                                ctx,
+                            );
+                        });
+                    }
                 }
                 return;
             }
@@ -2509,6 +2529,40 @@ impl BlocklistAIController {
     ) {
         self.action_model.update(ctx, |action_model, _| {
             action_model.clear_finished_action_results(conversation_id);
+        });
+    }
+
+    /// QUALITY-780 §4: emit a `WaitForEvents` tool-call-result for the
+    /// supplied unresolved `tool_call_id`. Called by the driver wave's
+    /// local watchdog when its idle timer fires before an inbound resume
+    /// input arrives.
+    ///
+    /// This helper performs the local state transition
+    /// (`WaitingForEvents` → `InProgress`) immediately by clearing the
+    /// stored unresolved id via
+    /// `BlocklistAIHistoryModel::clear_conversation_waiting_for_events_if_matches`,
+    /// so the driver / task-sync / notifications / pill-bar all observe
+    /// the resume right away. The wire form of the result
+    /// (`Request.Input.ToolCallResult.WaitForEvents`) is emitted on the
+    /// next outbound request from the driver wave; the agent's next
+    /// turn sees the empty timeout result and decides how to proceed.
+    ///
+    /// See `specs/QUALITY-780/TECH.md` §4.
+    pub fn submit_wait_for_events_timeout(
+        &mut self,
+        conversation_id: AIConversationId,
+        tool_call_id: String,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
+        let terminal_view_id = self.terminal_view_id;
+        history_model.update(ctx, |history_model, ctx| {
+            history_model.clear_conversation_waiting_for_events_if_matches(
+                conversation_id,
+                &tool_call_id,
+                terminal_view_id,
+                ctx,
+            );
         });
     }
 

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
-use warp_multi_agent_api::client_action::{Action, StartNewConversation};
+use warp_multi_agent_api as api;
+use warp_multi_agent_api::client_action::{Action, AddMessagesToTask, StartNewConversation};
 use warp_multi_agent_api::response_event::stream_finished::{
     ConversationUsageMetadata, TokenUsage,
 };
@@ -1547,6 +1548,38 @@ impl BlocklistAIHistoryModel {
                     )?;
                     current_conversation_id = new_conversation_id;
                 }
+                Some(Action::AddMessagesToTask(action)) => {
+                    // QUALITY-780 §8.1: detect the new public `WaitForEvents`
+                    // tool call (enter the waiting state) and §8.3: detect the
+                    // matching resume signals (`WaitForEventsResult` for the
+                    // watchdog-timeout path; generic `Cancel` for the
+                    // inbound-supersede path). Both leave the conversation in
+                    // `InProgress`. Detection runs **before** the call is
+                    // dispatched to `conversation.apply_client_action`, so the
+                    // status change is in place before any downstream subscriber
+                    // (driver, task-sync, pill-bar, notifications) observes the
+                    // message batch — see §8.2 for the ordering rule that
+                    // protects this transition from being clobbered by the
+                    // subsequent `Success` transition on the response stream.
+                    self.detect_wait_for_events_transitions(
+                        current_conversation_id,
+                        terminal_view_id,
+                        &action,
+                        ctx,
+                    );
+                    let conversation = self
+                        .conversations_by_id
+                        .get_mut(&current_conversation_id)
+                        .ok_or(UpdateHistoryError::ConversationNotFound(
+                        current_conversation_id,
+                    ))?;
+                    conversation.apply_client_action(
+                        response_stream_id,
+                        terminal_view_id,
+                        Action::AddMessagesToTask(action),
+                        ctx,
+                    )?;
+                }
                 Some(action) => {
                     let conversation = self
                         .conversations_by_id
@@ -1567,6 +1600,183 @@ impl BlocklistAIHistoryModel {
             }
         }
         Ok(())
+    }
+
+    /// QUALITY-780 §8.1 / §8.3: scans the messages in an
+    /// `AddMessagesToTask` action for `WaitForEvents` tool calls (enter the
+    /// waiting state) or matching resume signals (`WaitForEventsResult` or a
+    /// generic `Cancel` referencing the unresolved tool-call id), and updates
+    /// the conversation accordingly.
+    fn detect_wait_for_events_transitions(
+        &mut self,
+        conversation_id: AIConversationId,
+        terminal_view_id: EntityId,
+        action: &AddMessagesToTask,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        for message in &action.messages {
+            match message.message.as_ref() {
+                Some(api::message::Message::ToolCall(tool_call)) => {
+                    if matches!(
+                        tool_call.tool.as_ref(),
+                        Some(api::message::tool_call::Tool::WaitForEvents(_))
+                    ) {
+                        self.mark_conversation_waiting_for_events(
+                            conversation_id,
+                            tool_call.tool_call_id.clone(),
+                            terminal_view_id,
+                            ctx,
+                        );
+                    }
+                }
+                Some(api::message::Message::ToolCallResult(result)) => {
+                    match result.result.as_ref() {
+                        // The client watchdog (§4) emitted a synthetic
+                        // `WaitForEventsResult` that the server has echoed
+                        // back — the agent's next turn will observe the
+                        // empty timeout result.
+                        Some(api::message::tool_call_result::Result::WaitForEvents(_)) => {
+                            self.clear_conversation_waiting_for_events_if_matches(
+                                conversation_id,
+                                &result.tool_call_id,
+                                terminal_view_id,
+                                ctx,
+                            );
+                        }
+                        // An inbound user message / inter-agent message /
+                        // lifecycle event superseded the pending
+                        // `WaitForEvents` call; the server emitted a generic
+                        // `Cancel` tool-call result referencing that id.
+                        // Only clear when the stored id matches — unrelated
+                        // tool cancellations must not collapse the waiting
+                        // state.
+                        Some(api::message::tool_call_result::Result::Cancel(_)) => {
+                            self.clear_conversation_waiting_for_events_if_matches(
+                                conversation_id,
+                                &result.tool_call_id,
+                                terminal_view_id,
+                                ctx,
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// QUALITY-780 §8.1: atomically transition the conversation to
+    /// `WaitingForEvents`, record the unresolved `tool_call_id`, persist the
+    /// new durable state, and emit an `UpdatedConversationStatus` event so
+    /// the driver / task-sync / notifications / pill-bar all re-evaluate.
+    ///
+    /// No-op if the conversation cannot be found or is already in
+    /// `WaitingForEvents` for the same `tool_call_id` (idempotent against
+    /// duplicate detection passes).
+    pub fn mark_conversation_waiting_for_events(
+        &mut self,
+        conversation_id: AIConversationId,
+        tool_call_id: String,
+        terminal_view_id: EntityId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) else {
+            log::warn!(
+                "mark_conversation_waiting_for_events: conversation {conversation_id:?} not found"
+            );
+            return;
+        };
+
+        // Idempotency: avoid emitting a duplicate status-update event if the
+        // conversation is already in the waiting state with the same id.
+        if matches!(conversation.status(), ConversationStatus::WaitingForEvents)
+            && conversation.waiting_for_events_tool_call_id() == Some(tool_call_id.as_str())
+        {
+            return;
+        }
+
+        conversation.set_waiting_for_events_tool_call_id(Some(tool_call_id));
+        // `update_status` mutates the in-memory status and emits
+        // `UpdatedConversationStatus`. Persist afterwards so the durable
+        // record reflects `waiting_for_events = true` plus the stored
+        // tool-call id.
+        conversation.update_status(ConversationStatus::WaitingForEvents, terminal_view_id, ctx);
+        conversation.write_updated_conversation_state(ctx);
+    }
+
+    /// QUALITY-780 §8.3: clear the waiting state and resume the conversation
+    /// in `InProgress`, but only when the supplied `tool_call_id` matches the
+    /// unresolved `WaitForEvents` tool call that put the conversation in the
+    /// waiting state. Unrelated cancellations (e.g. an unrelated `Cancel`
+    /// result for a different tool call) must not collapse the waiting
+    /// state.
+    ///
+    /// Matching logic:
+    /// - If the conversation has an in-memory `tool_call_id` (the runtime
+    ///   path), match against that.
+    /// - Otherwise (post-restart: see the field doc on
+    ///   `AIConversation::waiting_for_events_tool_call_id`), scan the
+    ///   restored transcript for the most recent `Tool::WaitForEvents` call
+    ///   without a matching `ToolCallResult` and check the supplied id
+    ///   against it.
+    ///
+    /// No-op if the conversation cannot be found, is not currently
+    /// `WaitingForEvents`, or no matching unresolved `WaitForEvents` call is
+    /// found.
+    pub fn clear_conversation_waiting_for_events_if_matches(
+        &mut self,
+        conversation_id: AIConversationId,
+        tool_call_id: &str,
+        terminal_view_id: EntityId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) else {
+            return;
+        };
+        if !matches!(conversation.status(), ConversationStatus::WaitingForEvents) {
+            return;
+        }
+        let matches = match conversation.waiting_for_events_tool_call_id() {
+            // Runtime path: match against the in-memory unresolved id.
+            Some(stored) => stored == tool_call_id,
+            // Post-restart path: the in-memory id is `None` because we do
+            // not persist it (see `AgentConversationData.waiting_for_events`
+            // doc). Recover the unresolved id by scanning the restored
+            // transcript for the most recent `Tool::WaitForEvents` call that
+            // has no matching `ToolCallResult`. If the incoming result's
+            // `tool_call_id` matches, treat it as a resume signal.
+            None => find_unresolved_wait_for_events_tool_call_id(conversation)
+                .is_some_and(|id| id == tool_call_id),
+        };
+        if !matches {
+            return;
+        }
+        conversation.set_waiting_for_events_tool_call_id(None);
+        conversation.update_status(ConversationStatus::InProgress, terminal_view_id, ctx);
+        conversation.write_updated_conversation_state(ctx);
+    }
+
+    /// QUALITY-780 §8.3: unconditional variant of
+    /// `clear_conversation_waiting_for_events_if_matches` for callers that
+    /// already know the wait is being cleared regardless of id (e.g. an
+    /// explicit "abort wait" path on cancel). Not currently wired from the
+    /// detection point; provided for the helper-symmetry the spec calls for.
+    pub fn clear_conversation_waiting_for_events(
+        &mut self,
+        conversation_id: AIConversationId,
+        terminal_view_id: EntityId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) else {
+            return;
+        };
+        if !matches!(conversation.status(), ConversationStatus::WaitingForEvents) {
+            return;
+        }
+        conversation.set_waiting_for_events_tool_call_id(None);
+        conversation.update_status(ConversationStatus::InProgress, terminal_view_id, ctx);
+        conversation.write_updated_conversation_state(ctx);
     }
 
     pub fn update_conversation_cost_and_usage_for_request(
@@ -2385,6 +2595,42 @@ impl BlocklistAIHistoryModel {
 /// conversation.
 fn agent_id_key(conversation: &AIConversation) -> Option<String> {
     conversation.orchestration_agent_id()
+}
+
+/// QUALITY-780 §8: scan the conversation's linearized transcript for the
+/// most recent `Tool::WaitForEvents` tool-call message that has no
+/// corresponding `ToolCallResult`, and return its `tool_call_id`.
+///
+/// Used by [`BlocklistAIHistoryModel::clear_conversation_waiting_for_events_if_matches`]
+/// as a post-restart fallback when the in-memory unresolved
+/// `tool_call_id` is `None` (it is not persisted; see the field doc on
+/// `AIConversation::waiting_for_events_tool_call_id`). Returns `None` if
+/// the transcript has no unresolved `WaitForEvents` call.
+fn find_unresolved_wait_for_events_tool_call_id(conversation: &AIConversation) -> Option<String> {
+    // Walk forward to record which tool_call_ids already have results, then
+    // pick the latest `WaitForEvents` call whose id is not in that set.
+    let messages: Vec<&api::Message> = conversation.all_linearized_messages();
+    let mut resolved_ids: HashSet<&str> = HashSet::new();
+    for message in &messages {
+        if let Some(api::message::Message::ToolCallResult(result)) = message.message.as_ref() {
+            resolved_ids.insert(result.tool_call_id.as_str());
+        }
+    }
+    messages.iter().rev().find_map(|message| {
+        let api::message::Message::ToolCall(tool_call) = message.message.as_ref()? else {
+            return None;
+        };
+        if !matches!(
+            tool_call.tool.as_ref(),
+            Some(api::message::tool_call::Tool::WaitForEvents(_))
+        ) {
+            return None;
+        }
+        if resolved_ids.contains(tool_call.tool_call_id.as_str()) {
+            return None;
+        }
+        Some(tool_call.tool_call_id.clone())
+    })
 }
 
 fn agent_id_key_from_persisted_data(conversation_data: &AgentConversationData) -> Option<&str> {

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -2996,6 +2996,271 @@ fn test_fork_conversation_preserves_task_ids_when_requested() {
     });
 }
 
+// QUALITY-780 §8.1 + §8.3: helpers that drive the `WaitingForEvents`
+// transitions in `BlocklistAIHistoryModel`. The tests below exercise the
+// public API of those helpers directly; the wire-format detection that
+// invokes them (via `apply_client_actions`) is covered upstream where
+// the proto message construction lives.
+
+/// Test helper for QUALITY-780 helper tests. Sets up the minimum app
+/// state needed for `BlocklistAIHistoryModel::mark_conversation_waiting_for_events`
+/// and its sibling clear helpers to run cleanly: settings are required
+/// because `start_new_conversation` reads default autoexecute mode, and
+/// a mock `GlobalResourceHandlesProvider` is required because
+/// `write_updated_conversation_state` sends through it.
+fn setup_app_for_quality_780_tests(app: &mut App) {
+    initialize_settings_for_tests(app);
+    let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(8);
+    let mut global_resource_handles = GlobalResourceHandles::mock(app);
+    global_resource_handles.model_event_sender = Some(sender);
+    app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+}
+
+/// QUALITY-780 §8.1: `mark_conversation_waiting_for_events` transitions
+/// the conversation status and stores the unresolved tool-call id so the
+/// later resume signal can be matched against it.
+#[test]
+fn test_mark_conversation_waiting_for_events_sets_status_and_id() {
+    use crate::ai::agent::conversation::ConversationStatus;
+
+    App::test((), |mut app| async move {
+        setup_app_for_quality_780_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        history_model.update(&mut app, |model, ctx| {
+            model.mark_conversation_waiting_for_events(
+                conversation_id,
+                "wait-tool-call-id-1".to_string(),
+                terminal_view_id,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |model, _| {
+            let conversation = model
+                .conversation(&conversation_id)
+                .expect("conversation should exist after start_new_conversation");
+            assert!(
+                matches!(conversation.status(), ConversationStatus::WaitingForEvents),
+                "status should be WaitingForEvents after mark helper, got {:?}",
+                conversation.status(),
+            );
+            assert_eq!(
+                conversation.waiting_for_events_tool_call_id(),
+                Some("wait-tool-call-id-1"),
+            );
+        });
+    });
+}
+
+/// QUALITY-780 §8.3: `clear_conversation_waiting_for_events_if_matches`
+/// transitions back to `InProgress` and clears the stored id when the
+/// supplied id matches the unresolved call.
+#[test]
+fn test_clear_conversation_waiting_for_events_if_matches_clears_on_match() {
+    use crate::ai::agent::conversation::ConversationStatus;
+
+    App::test((), |mut app| async move {
+        setup_app_for_quality_780_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        history_model.update(&mut app, |model, ctx| {
+            model.mark_conversation_waiting_for_events(
+                conversation_id,
+                "wait-tool-call-id-1".to_string(),
+                terminal_view_id,
+                ctx,
+            );
+            model.clear_conversation_waiting_for_events_if_matches(
+                conversation_id,
+                "wait-tool-call-id-1",
+                terminal_view_id,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |model, _| {
+            let conversation = model
+                .conversation(&conversation_id)
+                .expect("conversation should exist after start_new_conversation");
+            assert!(
+                matches!(conversation.status(), ConversationStatus::InProgress),
+                "status should be InProgress after matching clear, got {:?}",
+                conversation.status(),
+            );
+            assert_eq!(
+                conversation.waiting_for_events_tool_call_id(),
+                None,
+                "stored unresolved id should be cleared",
+            );
+        });
+    });
+}
+
+/// QUALITY-780 §8.3: a non-matching `tool_call_id` is a no-op. Unrelated
+/// `Cancel` results (e.g. for a different tool call) must not collapse
+/// the waiting state.
+#[test]
+fn test_clear_conversation_waiting_for_events_if_matches_noop_on_mismatch() {
+    use crate::ai::agent::conversation::ConversationStatus;
+
+    App::test((), |mut app| async move {
+        setup_app_for_quality_780_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        history_model.update(&mut app, |model, ctx| {
+            model.mark_conversation_waiting_for_events(
+                conversation_id,
+                "wait-tool-call-id-1".to_string(),
+                terminal_view_id,
+                ctx,
+            );
+            model.clear_conversation_waiting_for_events_if_matches(
+                conversation_id,
+                "some-other-tool-call-id",
+                terminal_view_id,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |model, _| {
+            let conversation = model
+                .conversation(&conversation_id)
+                .expect("conversation should exist after start_new_conversation");
+            assert!(
+                matches!(conversation.status(), ConversationStatus::WaitingForEvents),
+                "status should still be WaitingForEvents after mismatched clear, got {:?}",
+                conversation.status(),
+            );
+            assert_eq!(
+                conversation.waiting_for_events_tool_call_id(),
+                Some("wait-tool-call-id-1"),
+                "stored unresolved id should be preserved on mismatch",
+            );
+        });
+    });
+}
+
+/// QUALITY-780 §8: the unconditional
+/// `clear_conversation_waiting_for_events` helper clears the waiting
+/// state without checking the id. Provided for callers that already
+/// know the wait is being aborted (e.g. user cancel).
+#[test]
+fn test_clear_conversation_waiting_for_events_unconditional() {
+    use crate::ai::agent::conversation::ConversationStatus;
+
+    App::test((), |mut app| async move {
+        setup_app_for_quality_780_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        let conversation_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        history_model.update(&mut app, |model, ctx| {
+            model.mark_conversation_waiting_for_events(
+                conversation_id,
+                "wait-tool-call-id-1".to_string(),
+                terminal_view_id,
+                ctx,
+            );
+            model.clear_conversation_waiting_for_events(conversation_id, terminal_view_id, ctx);
+        });
+
+        history_model.read(&app, |model, _| {
+            let conversation = model
+                .conversation(&conversation_id)
+                .expect("conversation should exist after start_new_conversation");
+            assert!(
+                matches!(conversation.status(), ConversationStatus::InProgress),
+                "unconditional clear should always transition to InProgress",
+            );
+            assert_eq!(
+                conversation.waiting_for_events_tool_call_id(),
+                None,
+                "unconditional clear should always clear the stored id",
+            );
+        });
+    });
+}
+
+/// QUALITY-780 PRODUCT.md (31): a newly started conversation in a
+/// terminal view that previously held a `WaitingForEvents` conversation
+/// does not inherit `waiting_for_events = true`. Each fresh
+/// `start_new_conversation` begins in the default in-progress-ready
+/// state with no stored unresolved id.
+#[test]
+fn test_new_conversation_does_not_inherit_waiting_for_events() {
+    use crate::ai::agent::conversation::ConversationStatus;
+
+    App::test((), |mut app| async move {
+        setup_app_for_quality_780_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        // First conversation enters the waiting state.
+        let first_id = history_model.update(&mut app, |model, ctx| {
+            let id = model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            model.mark_conversation_waiting_for_events(
+                id,
+                "wait-tool-call-id-first".to_string(),
+                terminal_view_id,
+                ctx,
+            );
+            id
+        });
+        history_model.read(&app, |model, _| {
+            let first = model.conversation(&first_id).expect("first should exist");
+            assert!(matches!(
+                first.status(),
+                ConversationStatus::WaitingForEvents
+            ));
+            assert_eq!(
+                first.waiting_for_events_tool_call_id(),
+                Some("wait-tool-call-id-first"),
+            );
+        });
+
+        // Starting a new conversation in the same terminal view must not
+        // copy the waiting state forward.
+        let second_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        assert_ne!(
+            first_id, second_id,
+            "a fresh conversation should have a distinct id",
+        );
+        history_model.read(&app, |model, _| {
+            let second = model.conversation(&second_id).expect("second should exist");
+            assert!(
+                !matches!(second.status(), ConversationStatus::WaitingForEvents),
+                "a newly started conversation must not start in WaitingForEvents",
+            );
+            assert_eq!(
+                second.waiting_for_events_tool_call_id(),
+                None,
+                "a newly started conversation must not inherit the unresolved id",
+            );
+        });
+    });
+}
+
 #[test]
 fn test_fork_conversation_title_override_replaces_prefix() {
     use crate::ai::agent::conversation::AIConversation;

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -1452,6 +1452,22 @@ impl TryFrom<InsertReviewCommentsResult> for api::request::input::tool_call_resu
     }
 }
 
+impl TryFrom<WaitForEventsResult> for api::request::input::tool_call_result::Result {
+    type Error = ConvertToAPITypeError;
+
+    /// QUALITY-780: emit the wire form of the watchdog-timeout result so
+    /// the server receives the empty `WaitForEventsResult` and echoes it
+    /// back through the normal stream. The agent's next turn observes
+    /// the empty result and decides how to proceed.
+    fn try_from(_result: WaitForEventsResult) -> Result<Self, Self::Error> {
+        Ok(
+            api::request::input::tool_call_result::Result::WaitForEvents(
+                api::WaitForEventsResult {},
+            ),
+        )
+    }
+}
+
 #[cfg(test)]
 #[path = "convert_tests.rs"]
 mod tests;

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -100,6 +100,14 @@ pub enum AIAgentActionResultType {
     /// The result of an orchestrate tool call: launched (with per-agent
     /// outcomes), launch denied (Stage 2), failure, or cancelled.
     RunAgents(RunAgentsResult),
+
+    /// QUALITY-780: result emitted by the client when its local
+    /// `wait_for_events` watchdog fires before an inbound resume input
+    /// arrives. The payload is intentionally empty — the variant
+    /// identity alone tells the agent "your wait timed out" so it can
+    /// decide how to proceed on the next turn. See
+    /// `specs/QUALITY-780/TECH.md` §4 / §8.
+    WaitForEvents(WaitForEventsResult),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -167,6 +175,7 @@ impl Display for AIAgentActionResultType {
             AIAgentActionResultType::TransferShellCommandControlToUser(result) => result.fmt(f),
             AIAgentActionResultType::AskUserQuestion(result) => result.fmt(f),
             AIAgentActionResultType::RunAgents(result) => result.fmt(f),
+            AIAgentActionResultType::WaitForEvents(result) => result.fmt(f),
             AIAgentActionResultType::OpenCodeReview | AIAgentActionResultType::InitProject => {
                 Ok(())
             }
@@ -768,6 +777,9 @@ impl AIAgentActionResultType {
             AIAgentActionResultType::RunAgents(_) => {
                 "The result of an orchestrate batch of child agents"
             }
+            AIAgentActionResultType::WaitForEvents(_) => {
+                "The local watchdog timed out while waiting for inbound events"
+            }
         }
     }
 
@@ -806,6 +818,11 @@ impl AIAgentActionResultType {
             ) => true,
             Self::AskUserQuestion(AskUserQuestionResult::Success { .. }) => true,
             Self::RunAgents(RunAgentsResult::Launched { .. }) => true,
+            // QUALITY-780: the watchdog-timeout result is a successful
+            // tool-call completion from the conversation's perspective —
+            // there is no error to surface and the agent will decide how
+            // to proceed on its next turn.
+            Self::WaitForEvents(_) => true,
             _ => false,
         }
     }
@@ -1452,5 +1469,21 @@ impl Display for AskUserQuestionResult {
                 )
             }
         }
+    }
+}
+
+/// QUALITY-780: result emitted by the client's `wait_for_events` watchdog
+/// when it fires before an inbound resume input arrives. The proto wire
+/// form (`Message::ToolCallResult.WaitForEvents`) carries no payload — the
+/// variant identity is the entire signal. The agent's next turn observes
+/// this empty result and decides how to proceed (commonly `finish_task`,
+/// but the agent may also re-yield or ask the user). See
+/// `specs/QUALITY-780/TECH.md` §4 / §8.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WaitForEventsResult;
+
+impl Display for WaitForEventsResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Wait for events timed out")
     }
 }

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1075,7 +1075,10 @@ pub struct AgentConversationData {
     /// `wait_for_events` (status was `WaitingForEvents`). On restore this
     /// flag wins over the status derived from the last exchange so the
     /// driver, task sync, notifications, and pill bar all re-enter the
-    /// waiting state. See `warp/specs/QUALITY-780/TECH.md` §3.
+    /// waiting state. The unresolved `tool_call_id` is intentionally
+    /// **not** persisted — it is rebuilt at runtime by scanning the
+    /// transcript when an inbound `Cancel` / `WaitForEventsResult`
+    /// arrives post-restart. See `warp/specs/QUALITY-780/TECH.md` §3 / §8.
     #[serde(default, skip_serializing_if = "is_false")]
     pub waiting_for_events: bool,
 }


### PR DESCRIPTION
## Description

Wave 2 of the QUALITY-780 client-side rollout. Implements §8 (tool-call detection + ordering rule) and §4 (watchdog-emission helper) of `specs/QUALITY-780/TECH.md`, branched off `matthew/QUALITY-780-client-core`.

### What

- **§8.1 detection**: `BlocklistAIHistoryModel.apply_client_actions` pattern-matches the new public `Message::ToolCall::WaitForEvents` proto variant in inbound `AddMessagesToTask` actions and transitions the owning conversation to `WaitingForEvents` via the new `mark_conversation_waiting_for_events` helper. The in-memory unresolved `tool_call_id` is stored on `AIConversation` so the later resume signal can be matched against it. The id is intentionally **not** persisted; on restart it hydrates to `None` and the post-restart fallback (`find_unresolved_wait_for_events_tool_call_id`) scans the transcript for the most recent unresolved `WaitForEvents` call.

- **§8.3 resume detection**: the same hook also matches `Message::ToolCallResult.WaitForEvents` (server echo of the watchdog-timeout result) and `Message::ToolCallResult.Cancel` (generic supersede-by-inbound-input marker), routing both through `clear_conversation_waiting_for_events_if_matches` so only the unresolved `tool_call_id` collapses the waiting state. Unrelated cancellations are a no-op.

- **§8.2 ordering rule**: the `BlocklistAIController` action subscriber that fires the post-stream `Success` transition now skips `update_conversation_status(Success)` when the conversation is already in `WaitingForEvents`, so the detection transition isn't clobbered by the response-stream completion path. The response stream itself is still marked completed successfully via `mark_response_stream_completed_successfully`.

- **§4 emission helper** (orchestrator scope-expansion): adds a public `submit_wait_for_events_timeout(conversation_id, tool_call_id, ctx)` on `BlocklistAIController` for the driver wave's local watchdog to call when its idle timer fires. The helper performs the `WaitingForEvents → InProgress` transition immediately via `clear_conversation_waiting_for_events_if_matches`; the wire form (`Request.Input.ToolCallResult.WaitForEvents`) is emitted on the next outbound request via the new `TryFrom<WaitForEventsResult>` proto conversion.

- Adds `AIAgentActionResultType::WaitForEvents(WaitForEventsResult)` with Display / description / is_successful / redaction / SDK-output arms. Wires Wave 0 proto SHA bump `d622e1cec8de5c50b55c2d4f3050ce48dae464c4` (which adds the input-form `Request.Input.ToolCallResult.WaitForEvents` variant + top-level `WaitForEventsResult`).

- Cleans up `TODO(client-detection)` markers in `app/src/ai/agent/api/convert_conversation.rs`: both `convert_tool_call_result_to_input` and `create_cancelled_result_for_tool_call` return `None` for `WaitForEvents` because the wait-state transition lives in `apply_client_actions`, not on the exchange input stream — restored transcripts stay symmetric with the `Server` variant.

### Why

Per `specs/QUALITY-780/TECH.md` §8, this is the client-side detection layer for the new public `wait_for_events` proto variant. Without it, an Oz cloud agent that yields via `wait_for_events` looks identical to a successful completion to the existing `BlocklistAIController` Success transition, so the driver tears the worker down seconds after yielding and fires a misleading "Task completed" toast. §8.2's ordering guard is what stops the `Success` transition from clobbering the new `WaitingForEvents` state; without it the bug recurs even with the new proto variant.

The wait state is intentionally in-memory only (with a post-restart transcript-scan fallback) because the orchestrator decided that durable storage of the unresolved `tool_call_id` adds restore-time complexity for no behavioral gain.

## Testing

- [x] `history_model_tests` covers the new helpers:
  - `mark_conversation_waiting_for_events` sets status and stores the id.
  - `clear_conversation_waiting_for_events_if_matches` clears on match, no-ops on mismatch (the unrelated-`Cancel` case).
  - Unconditional `clear_conversation_waiting_for_events`.
  - PRODUCT.md (31): a newly started conversation does not inherit the waiting state.
- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`, and `cargo nextest run` (for the new tests) all pass locally. Full `./script/presubmit` to be run on the integrated `matthew/QUALITY-780-client-core` branch.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/25ba29f0-f50f-44be-8365-64c8cf305e75_
_Run: https://oz.staging.warp.dev/runs/019e83b1-7265-73d6-92ad-d01ef000795f_

_This PR was generated with [Oz](https://warp.dev/oz)._
