### PR TITLE
Fix ask-question speedbump dropdown overflow and reduce spacing

### DIFF
--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -43,9 +43,10 @@ use warp_core::ui::color::contrast::{
 use warp_core::ui::color::Rgb;
 use warp_core::ui::theme::{Fill, WarpTheme};
 use warpui::elements::{
-    Align, Border, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty, Expanded,
-    Flex, FormattedTextElement, Highlight, HighlightedRange, Hoverable, MainAxisAlignment,
-    MainAxisSize, MouseStateHandle, ParentElement, Radius, SavePosition, SelectableArea, Text,
+    Align, Border, Clipped, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty,
+    Expanded, Flex, FormattedTextElement, Highlight, HighlightedRange, Hoverable,
+    MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Radius, SavePosition,
+    SelectableArea, Text,
 };
 use warpui::fonts::Properties;
 use warpui::platform::Cursor;
@@ -735,56 +736,59 @@ where
 {
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
-    Flex::row()
-        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_main_axis_size(MainAxisSize::Max)
-        .with_child(
-            Container::new(
-                Text::new(
-                    description,
-                    appearance.ui_font_family(),
-                    appearance.monospace_font_size() - 1.,
+    Clipped::new(
+        Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_child(
+                Container::new(
+                    Text::new(
+                        description,
+                        appearance.ui_font_family(),
+                        appearance.monospace_font_size() - 1.,
+                    )
+                    .with_color(blended_colors::text_sub(theme, theme.surface_1()))
+                    .with_selectable(false)
+                    .finish(),
                 )
-                .with_color(blended_colors::text_sub(theme, theme.surface_1()))
-                .with_selectable(false)
-                .finish(),
-            )
-            .with_margin_right(8.)
-            .finish(),
-        )
-        .with_child(
-            Container::new(warpui::elements::ChildView::new(dropdown).finish())
                 .with_margin_right(8.)
                 .finish(),
-        )
-        .with_child(
-            Expanded::new(
-                1.,
-                Align::new(
-                    appearance
-                        .ui_builder()
-                        .link(
-                            "Manage AI Autonomy permissions".into(),
-                            None,
-                            Some(Box::new(move |ctx| {
-                                ctx.dispatch_typed_action(
-                                    WorkspaceAction::ShowSettingsPageWithSearch {
-                                        search_query: "Autonomy".to_string(),
-                                        section: Some(SettingsSection::AI),
-                                    },
-                                );
-                            })),
-                            settings_link_handle,
-                        )
-                        .build()
-                        .finish(),
+            )
+            .with_child(
+                Container::new(warpui::elements::ChildView::new(dropdown).finish())
+                    .with_margin_right(8.)
+                    .finish(),
+            )
+            .with_child(
+                Expanded::new(
+                    1.,
+                    Align::new(
+                        appearance
+                            .ui_builder()
+                            .link(
+                                "Manage AI Autonomy permissions".into(),
+                                None,
+                                Some(Box::new(move |ctx| {
+                                    ctx.dispatch_typed_action(
+                                        WorkspaceAction::ShowSettingsPageWithSearch {
+                                            search_query: "Autonomy".to_string(),
+                                            section: Some(SettingsSection::AI),
+                                        },
+                                    );
+                                })),
+                                settings_link_handle,
+                            )
+                            .build()
+                            .finish(),
+                    )
+                    .right()
+                    .finish(),
                 )
-                .right()
                 .finish(),
             )
             .finish(),
-        )
-        .finish()
+    )
+    .finish()
 }
 
 /// TODO: All AIBlock footer-related rendering logic should probably be put into its own View.

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -754,7 +754,7 @@ where
         )
         .with_child(
             Container::new(warpui::elements::ChildView::new(dropdown).finish())
-                .with_margin_right(16.)
+                .with_margin_right(8.)
                 .finish(),
         )
         .with_child(

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -752,7 +752,11 @@ where
             .with_margin_right(8.)
             .finish(),
         )
-        .with_child(warpui::elements::ChildView::new(dropdown).finish())
+        .with_child(
+            Container::new(warpui::elements::ChildView::new(dropdown).finish())
+                .with_margin_right(16.)
+                .finish(),
+        )
         .with_child(
             Expanded::new(
                 1.,

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -860,6 +860,7 @@ impl AskUserQuestionView {
             );
             dropdown.set_vertical_margin(0., ctx);
             dropdown.set_top_bar_height(24., ctx);
+            dropdown.set_main_axis_size(MainAxisSize::Min, ctx);
             let permissions = [
                 AskUserQuestionPermission::Never,
                 AskUserQuestionPermission::AskExceptInAutoApprove,


### PR DESCRIPTION
## Description

Fix two issues with the Ask-User-Question speedbump footer:

1. **Dropdown overflow on narrow screens** — The dropdown's `MainAxisSize` defaulted to `Max`, expanding the top bar to 190px regardless of content. On small screens this pushed the row well past its container. Setting `MainAxisSize::Min` makes the dropdown size to its selected label.

2. **Excessive spacing** — The right margin on the dropdown container was 16px; reduced to 8px to match the label's left margin and tighten the footer layout.

Loom: https://www.loom.com/share/01984070648d4617bd2d0f586e1defd5

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Verified compilation passes (`cargo check`, `cargo clippy`, `./script/format`).

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fix ask-question speedbump dropdown overflowing its container on narrow screens
-->

_Conversation: https://staging.warp.dev/conversation/00232837-6fde-4e0c-a0df-91ea41385cee_
_Run: https://oz.staging.warp.dev/runs/019e854d-0432-74e2-9ebb-03c850219dd1_

_This PR was generated with [Oz](https://warp.dev/oz)._
