### PR TITLE
Promote orchestration viewer streamer

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -668,6 +668,7 @@ default = [
     "orchestration_v2",
     "orchestration_pill_bar",
     "orchestration_viewer_pill_bar",
+    "orchestration_viewer_streamer",
     "run_agents_tool",
     "pending_user_query_indicator",
     "cloud_mode_input_v2",
@@ -966,6 +967,7 @@ incremental_auto_reload = []
 orchestration_v2 = []
 orchestration_pill_bar = []
 orchestration_viewer_pill_bar = []
+orchestration_viewer_streamer = []
 run_agents_tool = []
 pending_user_query_indicator = []
 queue_slash_command = []

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -423,6 +423,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::OrchestrationPillBar,
         #[cfg(feature = "orchestration_viewer_pill_bar")]
         FeatureFlag::OrchestrationViewerPillBar,
+        #[cfg(feature = "orchestration_viewer_streamer")]
+        FeatureFlag::OrchestrationViewerStreamer,
         #[cfg(feature = "run_agents_tool")]
         FeatureFlag::RunAgentsTool,
         #[cfg(feature = "pending_user_query_indicator")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -955,7 +955,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::RemoteCodebaseIndexing,
     FeatureFlag::GroupedTabs,
     FeatureFlag::AsyncFind,
-    FeatureFlag::OrchestrationViewerStreamer,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Promotes orchestration_viewer_streamer from Dogfood-only to enabled in default Warp client builds by:
- adding the Cargo feature to the default feature set
- bridging the Cargo feature to FeatureFlag::OrchestrationViewerStreamer at runtime
- removing the flag from DOGFOOD_FLAGS now that it is enabled by default

## Testing
- ./script/format
- cargo clippy --workspace --all-targets --all-features --tests -- -D warnings

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/cc96ebef-b124-42c7-a914-80978c5738a3_
_Run: https://oz.staging.warp.dev/runs/019e84be-4a3f-7a85-9423-55e19eafdd43_
_This PR was generated with [Oz](https://warp.dev/oz)._
