### PR TITLE
Adjust pill bar scrollbar to prevent overlap with agent chips

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -89,9 +89,12 @@ const STATIC_PILL_LABEL_MAX_WIDTH: f32 = 110.;
 const STATIC_PILL_HORIZONTAL_PADDING_RIGHT: f32 = 10.;
 /// Width of the overlaid horizontal scrollbar; thin hairline by design.
 const PILL_BAR_SCROLLBAR_WIDTH: f32 = 4.;
-/// Bottom gutter inside the scrollable so the overlaid scrollbar paints below
-/// the pills, not across them. Slightly wider than the scrollbar for a 2px gap.
-const PILL_BAR_SCROLLBAR_GUTTER: f32 = 6.;
+/// Desired gap between the pills and the scrollbar thumb.
+const PILL_BAR_SCROLLBAR_GAP: f32 = 1.;
+/// Bottom gutter for the overlaid scrollbar. Its track sits 2px below the thumb
+/// (NewScrollable's `RIGHT_PADDING`), so gap = gutter - width - 2.
+const PILL_BAR_SCROLLBAR_GUTTER: f32 =
+    PILL_BAR_SCROLLBAR_GAP + PILL_BAR_SCROLLBAR_WIDTH + 2.;
 
 /// Stable palette used to color child agent avatars deterministically by name.
 fn pill_palette(theme: &WarpTheme) -> [ColorU; 6] {

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -87,6 +87,11 @@ const PILL_ICON_SIZE: f32 = 12.;
 const PILL_OVERFLOW_BUTTON_RIGHT_OFFSET: f32 = 4.;
 const STATIC_PILL_LABEL_MAX_WIDTH: f32 = 110.;
 const STATIC_PILL_HORIZONTAL_PADDING_RIGHT: f32 = 10.;
+/// Width of the overlaid horizontal scrollbar; thin hairline by design.
+const PILL_BAR_SCROLLBAR_WIDTH: f32 = 4.;
+/// Bottom gutter inside the scrollable so the overlaid scrollbar paints below
+/// the pills, not across them. Slightly wider than the scrollbar for a 2px gap.
+const PILL_BAR_SCROLLBAR_GUTTER: f32 = 6.;
 
 /// Stable palette used to color child agent avatars deterministically by name.
 fn pill_palette(theme: &WarpTheme) -> [ColorU; 6] {
@@ -1197,28 +1202,34 @@ impl View for OrchestrationPillBar {
         let scrollable = NewScrollable::horizontal(
             SingleAxisConfig::Clipped {
                 handle: horizontal_scroll_state,
-                child: row.finish(),
+                // Gutter goes inside the scrollable; outer padding can't clear
+                // the scrollbar since it sits outside the scrollbar's track.
+                child: Container::new(row.finish())
+                    .with_padding_bottom(PILL_BAR_SCROLLBAR_GUTTER)
+                    .finish(),
             },
             theme.nonactive_ui_detail().into(),
             theme.active_ui_detail().into(),
             ElementFill::None,
         )
-        // 4px overlaid scrollbar so the bar height stays constant
-        // whether or not the row overflows.
-        .with_horizontal_scrollbar(ScrollableAppearance::new(ScrollbarWidth::Custom(4.), true))
+        // Overlaid so the bar height stays constant whether or not it overflows.
+        .with_horizontal_scrollbar(ScrollableAppearance::new(
+            ScrollbarWidth::Custom(PILL_BAR_SCROLLBAR_WIDTH),
+            true,
+        ))
         // Let a standard vertical mouse wheel pan the bar horizontally;
         // trackpad horizontal swipes already work through the default path.
         .with_remap_cross_axis_wheel_to_main_axis(true)
         .with_propagate_mousewheel_if_not_handled(true)
         .finish();
 
-        // Padding lives outside the scrollable so it doesn't scroll away
-        // with the content.
+        // L/R padding outside so it doesn't scroll with the content; bottom is
+        // small since the scrollbar gutter is handled inside the scrollable.
         let bar = Container::new(scrollable)
             .with_padding_left(12.)
             .with_padding_right(12.)
             .with_padding_top(4.)
-            .with_padding_bottom(4.)
+            .with_padding_bottom(2.)
             .finish();
 
         // When the 3-dot menu is open, overlay it directly beneath the

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -93,8 +93,7 @@ const PILL_BAR_SCROLLBAR_WIDTH: f32 = 4.;
 const PILL_BAR_SCROLLBAR_GAP: f32 = 1.;
 /// Bottom gutter for the overlaid scrollbar. Its track sits 2px below the thumb
 /// (NewScrollable's `RIGHT_PADDING`), so gap = gutter - width - 2.
-const PILL_BAR_SCROLLBAR_GUTTER: f32 =
-    PILL_BAR_SCROLLBAR_GAP + PILL_BAR_SCROLLBAR_WIDTH + 2.;
+const PILL_BAR_SCROLLBAR_GUTTER: f32 = PILL_BAR_SCROLLBAR_GAP + PILL_BAR_SCROLLBAR_WIDTH + 2.;
 
 /// Stable palette used to color child agent avatars deterministically by name.
 fn pill_palette(theme: &WarpTheme) -> [ColorU; 6] {


### PR DESCRIPTION
Add margin to avoid overlap for scrollbar with orchestration pill bar - from Slack feedback.

Before:
<img width="341" height="108" alt="image" src="https://github.com/user-attachments/assets/12f0c056-3c46-4677-a797-de3184603eb9" />


After:
<img width="497" height="120" alt="image" src="https://github.com/user-attachments/assets/c95496bf-e2d9-4c21-aba2-2e2d2a732279" />


## Description
The orchestration pill bar's overlaid horizontal scrollbar paints along the **bottom edge of the scrollable's content**, so it sliced across the bottom of the agent chips/pills. Outer container padding can't fix this because it lives *outside* the scrollbar's track.

**Fix:** reserve a small bottom gutter *inside* the scrollable (below the pill row) so the scrollbar lands just below the pills instead of across them, and trim the outer bottom padding so the bar stays compact (net +4px height). Also pulled the magic `4.` scrollbar width into a named const so the gutter↔scrollbar relationship is documented.

All in `app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs`. The breadcrumb scrollable is intentionally left alone (its existing comment notes the scrollbar-over-labels trade-off was already accepted).

## Linked Issue
https://linear.app/warpdotdev/issue/QUALITY-743/adjust-scrollbar-to-prevent-overlap-with-agent-chips
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Compiles cleanly (`cargo fmt` + `cargo check -p warp --lib`). Visual-only change to vertical spacing of the orchestration pill bar.
- [x] I have manually tested my changes locally with `./script/run`

CHANGELOG-BUG-FIX: Fixed the orchestration pill bar's scrollbar overlapping the agent chips.

Co-Authored-By: Oz <oz-agent@warp.dev>