### PR TITLE
enable cross-window tab dragging in preview

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -959,7 +959,10 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
-pub const PREVIEW_FLAGS: &[FeatureFlag] = &[FeatureFlag::DragTabsToWindows];
+pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
+    #[cfg(target_os = "macos")]
+    FeatureFlag::DragTabsToWindows,
+];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).
 /// NOTE: if you are promoting a feature from Preview to launch, you'll likely

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -959,9 +959,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
-pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
-    FeatureFlag::DragTabsToWindows,
-];
+pub const PREVIEW_FLAGS: &[FeatureFlag] = &[FeatureFlag::DragTabsToWindows];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).
 /// NOTE: if you are promoting a feature from Preview to launch, you'll likely

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -951,7 +951,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::LocalDockerSandbox,
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
-    FeatureFlag::DragTabsToWindows,
     FeatureFlag::RemoteCodebaseIndexing,
     FeatureFlag::GroupedTabs,
     FeatureFlag::AsyncFind,
@@ -960,7 +959,9 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
-pub const PREVIEW_FLAGS: &[FeatureFlag] = &[];
+pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
+    FeatureFlag::DragTabsToWindows,
+];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).
 /// NOTE: if you are promoting a feature from Preview to launch, you'll likely


### PR DESCRIPTION
This PR enables tab dragging in preview. There are two main issues:
1. Dragging a tab out and in repeatedly in the same mousedown doesn't work: https://github.com/warpdotdev/warp/pull/12044
2. @acarl005 reported a random crash on Windows. I tried using a VM to reproduce but have been unsuccessful.

#1 is not trivial to fix, and I'm deliberately scoping out of Preview. I'll take another pass before considering this feature for Stable.

I'm hoping to leverage Preview users to hone in on #2, but will continue to attempt to reproduce until the Preview release on Thursday.