### PR TITLE
Create standing results to track project skills and project rules

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -13,9 +13,7 @@ use remote_server::proto::{
 };
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repository::{Repository, SubscriberId};
-use repo_metadata::{
-    DirectoryWatcher, MetadataUpdateType, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate,
-};
+use repo_metadata::{DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 use watcher::{BulkFilesystemWatcherEvent, HomeDirectoryWatcher, HomeDirectoryWatcherEvent};
@@ -24,9 +22,9 @@ use super::subscribers::{
     HomeSkillSubscriber, ProjectSkillSubscriber, SkillRepositoryMessage, SymlinkSkillSubscriber,
 };
 use super::utils::{
-    find_project_skill_files_in_tree, is_home_provider_path, is_home_skill_directory,
-    is_skill_file, read_local_project_skills_from_filesystem, read_skills_from_directories,
-    read_skills_from_files, update_might_affect_project_skills,
+    find_local_project_skill_files_on_filesystem, find_project_skill_files_in_tree,
+    is_home_provider_path, is_home_skill_directory, is_skill_file, read_skills_from_directories,
+    read_skills_from_files,
 };
 use crate::remote_server::manager::RemoteServerManager;
 use crate::warp_managed_paths_watcher::{
@@ -195,24 +193,6 @@ impl SkillWatcher {
                         me.refresh_project_skills_for_repo(id, ctx);
                     }
                 }
-                RepoMetadataEvent::FileTreeEntryUpdated {
-                    id,
-                    update_type: MetadataUpdateType::IncrementalUpdate(update),
-                } => {
-                    if update_might_affect_project_skills(
-                        id,
-                        update,
-                        me.project_skill_files_by_repo.get(id),
-                    ) {
-                        me.refresh_project_skills_for_repo(id, ctx);
-                    }
-                }
-                RepoMetadataEvent::FileTreeEntryUpdated {
-                    id,
-                    update_type: MetadataUpdateType::FullReplace,
-                } => {
-                    me.refresh_project_skills_for_repo(id, ctx);
-                }
                 RepoMetadataEvent::RepositoryRemoved { id } => {
                     me.remove_project_skills_for_repo(id);
                     me.stop_failed_local_project_watcher(id, ctx);
@@ -221,6 +201,7 @@ impl SkillWatcher {
                     me.fallback_to_local_project_watcher(id, ctx);
                 }
                 RepoMetadataEvent::FileTreeUpdated { .. }
+                | RepoMetadataEvent::FileTreeEntryUpdated { .. }
                 | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
             }
         });
@@ -363,14 +344,9 @@ impl SkillWatcher {
     ) {
         let repo_path = repo_path.to_path_buf();
         ctx.spawn(
-            async move { read_local_project_skills_from_filesystem(&repo_path) },
-            move |me, skills, ctx| {
-                if !skills.is_empty() {
-                    me.register_symlink_watches(&skills, ctx);
-                    let _ = me
-                        .watcher_event_tx
-                        .try_send(SkillWatcherEvent::SkillsAdded { skills });
-                }
+            async move { find_local_project_skill_files_on_filesystem(&repo_path) },
+            move |me, skill_paths, ctx| {
+                me.spawn_read_fallback_project_skills_from_files(skill_paths, ctx);
             },
         );
     }
@@ -390,10 +366,7 @@ impl SkillWatcher {
         };
 
         ctx.spawn(
-            async move {
-                let skill_contents = read_skill_contents.await?;
-                Ok::<Vec<ParsedSkill>, anyhow::Error>(parse_project_skill_contents(skill_contents))
-            },
+            async move { read_and_parse_project_skills(read_skill_contents).await },
             move |me, skills, ctx| match skills {
                 Ok(skills) => {
                     me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
@@ -413,13 +386,37 @@ impl SkillWatcher {
         if self.project_skill_refresh_generations.get(repo_id) != Some(&refresh_generation) {
             return;
         }
+        self.emit_project_skills(skills, ctx);
+    }
 
+    fn emit_project_skills(&mut self, skills: Vec<ParsedSkill>, ctx: &mut ModelContext<Self>) {
         if !skills.is_empty() {
             self.register_symlink_watches(&skills, ctx);
             let _ = self
                 .watcher_event_tx
                 .try_send(SkillWatcherEvent::SkillsAdded { skills });
         }
+    }
+
+    fn spawn_read_fallback_project_skills_from_files(
+        &mut self,
+        skill_paths: Vec<LocalOrRemotePath>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if skill_paths.is_empty() {
+            return;
+        }
+        let Some(read_skill_contents) = read_project_skill_contents(skill_paths, ctx) else {
+            return;
+        };
+
+        ctx.spawn(
+            async move { read_and_parse_project_skills(read_skill_contents).await },
+            |me, skills, ctx| match skills {
+                Ok(skills) => me.emit_project_skills(skills, ctx),
+                Err(err) => log::warn!("Failed to read fallback project skills: {err}"),
+            },
+        );
     }
 
     fn stop_failed_local_project_watcher(
@@ -555,35 +552,17 @@ impl SkillWatcher {
         path: &Path,
         ctx: &mut ModelContext<Self>,
     ) {
-        if is_skill_file(path) {
-            let skill_file_path = path.to_path_buf();
-            ctx.spawn(
-                async move { parse_skill(&skill_file_path) },
-                move |me, skill, ctx| {
-                    if let Ok(skill) = skill {
-                        me.register_symlink_watches(std::slice::from_ref(&skill), ctx);
-                        let _ = me
-                            .watcher_event_tx
-                            .try_send(SkillWatcherEvent::SkillsAdded {
-                                skills: vec![skill],
-                            });
-                    }
-                },
-            );
+        let skill_file_path = if is_skill_file(path) {
+            Some(path.to_path_buf())
         } else if path.is_symlink() && path.is_dir() && path.join("SKILL.md").exists() {
-            let skill_file_path = path.join("SKILL.md");
-            ctx.spawn(
-                async move { parse_skill(&skill_file_path) },
-                move |me, skill, ctx| {
-                    if let Ok(skill) = skill {
-                        me.register_symlink_watches(std::slice::from_ref(&skill), ctx);
-                        let _ = me
-                            .watcher_event_tx
-                            .try_send(SkillWatcherEvent::SkillsAdded {
-                                skills: vec![skill],
-                            });
-                    }
-                },
+            Some(path.join("SKILL.md"))
+        } else {
+            None
+        };
+        if let Some(skill_file_path) = skill_file_path {
+            self.spawn_read_fallback_project_skills_from_files(
+                vec![LocalOrRemotePath::Local(skill_file_path)],
+                ctx,
             );
         } else if path.is_dir() {
             // The original local watcher deferred added directories until RepoMetadataModel
@@ -1082,6 +1061,12 @@ fn read_project_skill_contents(
             }))
         }
     }
+}
+
+async fn read_and_parse_project_skills(
+    read_skill_contents: ProjectSkillContentsFuture,
+) -> anyhow::Result<Vec<ParsedSkill>> {
+    Ok(parse_project_skill_contents(read_skill_contents.await?))
 }
 fn remote_skill_read_request(skill_paths: &[LocalOrRemotePath]) -> ReadFileContextRequest {
     ReadFileContextRequest {

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -190,6 +190,11 @@ impl SkillWatcher {
                 RepoMetadataEvent::RepositoryUpdated { id } => {
                     me.refresh_project_skills_for_repo(id, ctx);
                 }
+                RepoMetadataEvent::StandingQueryResultsUpdated { id, delta } => {
+                    if delta.project_skills_changed() {
+                        me.refresh_project_skills_for_repo(id, ctx);
+                    }
+                }
                 RepoMetadataEvent::FileTreeEntryUpdated {
                     id,
                     update_type: MetadataUpdateType::IncrementalUpdate(update),

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -8,7 +8,8 @@ use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{
-    DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate, TargetFile,
+    DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate,
+    StandingQueryContent, StandingQueryResults, StandingQueryResultsDelta, TargetFile,
 };
 use tempfile::TempDir;
 use warp_util::host_id::HostId;
@@ -365,7 +366,16 @@ fn test_refresh_project_skills_for_repo_loads_indexed_and_symlinked_skill_direct
         let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
         let repo_key = StandardizedPath::try_from_local(&repo).unwrap();
         repo_metadata_handle.update(&mut app, |model, ctx| {
-            model.insert_test_state(repo_key, project_state(&repo, Some(&indexed_skill)), ctx);
+            model.insert_test_state(
+                repo_key.clone(),
+                project_state(&repo, Some(&indexed_skill)),
+                ctx,
+            );
+            model.insert_test_standing_results(
+                repo_key,
+                project_standing_results(&repo, Some(&indexed_skill)),
+                ctx,
+            );
         });
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
@@ -398,7 +408,12 @@ fn test_refresh_project_skills_for_repo_uses_repo_metadata_without_fallback_watc
         let repo_key = StandardizedPath::try_from_local(&repo).unwrap();
 
         repo_metadata_handle.update(&mut app, |model, ctx| {
-            model.insert_test_state(repo_key, project_state(&repo, Some(&skill)), ctx);
+            model.insert_test_state(repo_key.clone(), project_state(&repo, Some(&skill)), ctx);
+            model.insert_test_standing_results(
+                repo_key,
+                project_standing_results(&repo, Some(&skill)),
+                ctx,
+            );
         });
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);
@@ -808,6 +823,28 @@ fn project_state(repo: &std::path::Path, skill: Option<&ParsedSkill>) -> FileTre
     FileTreeState::new(root, Vec::new(), None)
 }
 
+fn project_standing_results(
+    repo: &std::path::Path,
+    skill: Option<&ParsedSkill>,
+) -> StandingQueryResults {
+    let mut delta = StandingQueryResultsDelta {
+        upserted_project_skills: vec![StandingQueryContent::directory(
+            StandardizedPath::try_from_local(&repo.join(".agents/skills")).unwrap(),
+        )],
+        ..StandingQueryResultsDelta::default()
+    };
+    if let Some(skill) = skill {
+        delta
+            .upserted_project_skills
+            .push(StandingQueryContent::file(
+                StandardizedPath::try_from_local(&skill_local_path(skill)).unwrap(),
+            ));
+    }
+    let mut results = StandingQueryResults::default();
+    results.apply_delta(&delta);
+    results
+}
+
 #[test]
 fn test_refresh_project_skills_for_repo_removes_missing_project_skill_paths() {
     let (tx, rx) = async_channel::unbounded();
@@ -826,6 +863,11 @@ fn test_refresh_project_skills_for_repo_removes_missing_project_skill_paths() {
 
         repo_metadata_handle.update(&mut app, |model, ctx| {
             model.insert_test_state(repo_key.clone(), project_state(&repo, Some(&skill)), ctx);
+            model.insert_test_standing_results(
+                repo_key.clone(),
+                project_standing_results(&repo, Some(&skill)),
+                ctx,
+            );
         });
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);
@@ -839,7 +881,12 @@ fn test_refresh_project_skills_for_repo_removes_missing_project_skill_paths() {
         );
 
         repo_metadata_handle.update(&mut app, |model, ctx| {
-            model.insert_test_state(repo_key, project_state(&repo, None), ctx);
+            model.insert_test_state(repo_key.clone(), project_state(&repo, None), ctx);
+            model.insert_test_standing_results(
+                repo_key,
+                project_standing_results(&repo, None),
+                ctx,
+            );
         });
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use ai::skills::{
@@ -6,8 +5,7 @@ use ai::skills::{
     ParsedSkill, SkillProvider, SKILL_PROVIDER_DEFINITIONS,
 };
 use anyhow::Error;
-use repo_metadata::file_tree_update::RepoNodeMetadata;
-use repo_metadata::{RepoMetadataModel, RepoMetadataUpdate, RepositoryIdentifier};
+use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
 use walkdir::{DirEntry, WalkDir};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
@@ -28,44 +26,6 @@ fn local_or_remote_path_for_repo_path(
     }
 }
 
-/// Returns whether an incremental metadata update can alter project skills for a repository.
-///
-/// Local provider-directory changes are included because symlinked skill directories are
-/// hydrated from the local filesystem rather than represented directly in repo metadata.
-pub(super) fn update_might_affect_project_skills(
-    repo_id: &RepositoryIdentifier,
-    update: &RepoMetadataUpdate,
-    known_skill_files: Option<&HashSet<LocalOrRemotePath>>,
-) -> bool {
-    if update.remove_entries.iter().any(|removed_path| {
-        let removed_path = local_or_remote_path_for_repo_path(repo_id, removed_path);
-        known_skill_files
-            .into_iter()
-            .flatten()
-            .any(|known_skill_file| known_skill_file.starts_with(&removed_path))
-    }) {
-        return true;
-    }
-
-    let is_local_repo = matches!(repo_id, RepositoryIdentifier::Local(_));
-    update.update_entries.iter().any(|entry_update| {
-        if is_local_repo
-            && is_project_provider_path(&entry_update.parent_path_to_replace.to_local_path_lossy())
-        {
-            return true;
-        }
-
-        entry_update.subtree_metadata.iter().any(|node| match node {
-            RepoNodeMetadata::File(file) => {
-                let path = local_or_remote_path_for_repo_path(repo_id, &file.path);
-                extract_skill_parent_directory(&path).is_ok()
-            }
-            RepoNodeMetadata::Directory(directory) => {
-                is_local_repo && is_project_provider_path(&directory.path.to_local_path_lossy())
-            }
-        })
-    })
-}
 /// Finds project skill files and local symlinked skill files from stored standing results.
 ///
 /// Local provider directories are included in the metadata query so filesystem hydration can
@@ -102,18 +62,34 @@ pub(super) fn find_project_skill_files_in_tree(
     skill_files
 }
 
-/// Reads local project skills by discovering provider directories on the filesystem.
+/// Finds local project skill files by discovering provider directories on the filesystem.
 ///
 /// This is a local-only fallback for repositories whose repo metadata indexing fails. Successful
 /// local and remote project refreshes should use [`find_project_skill_files_in_tree`] so the
 /// normal metadata-backed path remains shared.
-pub(super) fn read_local_project_skills_from_filesystem(scan_root: &Path) -> Vec<ParsedSkill> {
+pub(super) fn find_local_project_skill_files_on_filesystem(
+    scan_root: &Path,
+) -> Vec<LocalOrRemotePath> {
     let direct_skill_file = scan_root.join("SKILL.md");
     if is_skill_file(&direct_skill_file) {
-        return read_skills_from_files([direct_skill_file]);
+        return vec![LocalOrRemotePath::Local(direct_skill_file)];
     }
 
-    read_skills_from_directories(find_local_provider_directories_on_filesystem(scan_root))
+    find_local_provider_directories_on_filesystem(scan_root)
+        .into_iter()
+        .flat_map(|provider_dir| std::fs::read_dir(provider_dir).into_iter().flatten())
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let skill_dir = entry.path();
+            if !skill_dir.is_dir() {
+                return None;
+            }
+            let skill_file = skill_dir.join("SKILL.md");
+            skill_file
+                .exists()
+                .then_some(LocalOrRemotePath::Local(skill_file))
+        })
+        .collect()
 }
 
 fn find_local_provider_directories_on_filesystem(scan_root: &Path) -> Vec<PathBuf> {

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -7,8 +7,7 @@ use ai::skills::{
 };
 use anyhow::Error;
 use repo_metadata::file_tree_update::RepoNodeMetadata;
-use repo_metadata::local_model::GetContentsArgs;
-use repo_metadata::{RepoContent, RepoMetadataModel, RepoMetadataUpdate, RepositoryIdentifier};
+use repo_metadata::{RepoMetadataModel, RepoMetadataUpdate, RepositoryIdentifier};
 use walkdir::{DirEntry, WalkDir};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
@@ -67,7 +66,7 @@ pub(super) fn update_might_affect_project_skills(
         })
     })
 }
-/// Finds project skill files and local symlinked skill files with one metadata traversal.
+/// Finds project skill files and local symlinked skill files from stored standing results.
 ///
 /// Local provider directories are included in the metadata query so filesystem hydration can
 /// supplement indexed files with directory symlinks. Remote repositories only return indexed
@@ -77,39 +76,21 @@ pub(super) fn find_project_skill_files_in_tree(
     repo_metadata: &RepoMetadataModel,
     ctx: &AppContext,
 ) -> Vec<LocalOrRemotePath> {
-    let include_local_provider_directories = matches!(repo_id, RepositoryIdentifier::Local(_));
-    let repo_id_for_filter = repo_id.clone();
-    let args = GetContentsArgs {
-        include_folders: include_local_provider_directories,
-        ..GetContentsArgs::default()
-    }
-    .include_ignored()
-    .with_filter(move |content| match content {
-        RepoContent::File(file) => {
-            let path = local_or_remote_path_for_repo_path(&repo_id_for_filter, &file.path);
-            extract_skill_parent_directory(&path).is_ok()
-        }
-        RepoContent::Directory(directory) => {
-            include_local_provider_directories
-                && is_project_provider_path(&directory.path.to_local_path_lossy())
-        }
-    });
-
     let mut skill_files = Vec::new();
     let mut local_provider_directories = Vec::new();
     for content in repo_metadata
-        .get_repo_contents(repo_id, args, ctx)
-        .unwrap_or_else(|_| Vec::new())
+        .standing_query_results(repo_id, ctx)
+        .into_iter()
+        .flat_map(|results| results.project_skills())
     {
-        match content {
-            RepoContent::File(file) => {
-                skill_files.push(local_or_remote_path_for_repo_path(repo_id, &file.path));
-            }
-            RepoContent::Directory(directory) => {
-                if let Some(path) = directory.path.to_local_path() {
+        if content.is_directory {
+            if matches!(repo_id, RepositoryIdentifier::Local(_)) {
+                if let Some(path) = content.path.to_local_path() {
                     local_provider_directories.push(path);
                 }
             }
+        } else {
+            skill_files.push(local_or_remote_path_for_repo_path(repo_id, &content.path));
         }
     }
 

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -8,6 +8,7 @@ use repo_metadata::file_tree_update::{
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{
     DirectoryWatcher, RepoMetadataModel, RepoMetadataUpdate, RepositoryIdentifier,
+    StandingQueryContent, StandingQueryResults, StandingQueryResultsDelta,
 };
 use virtual_fs::{Stub, VirtualFS};
 use warp_util::host_id::HostId;
@@ -21,6 +22,15 @@ use super::{
     is_home_skill_directory, is_skill_file, read_skills_from_files,
     update_might_affect_project_skills,
 };
+fn project_standing_results(
+    skill_paths: impl IntoIterator<Item = StandardizedPath>,
+) -> StandingQueryResults {
+    let mut results = StandingQueryResults::default();
+    for skill_path in skill_paths {
+        results.insert_project_skill(StandingQueryContent::file(skill_path));
+    }
+    results
+}
 
 // ============================================================================
 // Tests for is_skill_file
@@ -541,7 +551,21 @@ fn find_skill_files_in_tree_finds_root_skills() {
                 let key =
                     warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&repo)
                         .unwrap();
-                model.insert_test_state(key, state, ctx);
+                model.insert_test_state(key.clone(), state, ctx);
+                model.insert_test_standing_results(
+                    key,
+                    project_standing_results([
+                        StandardizedPath::try_from_local(
+                            &repo.join(".agents/skills/root-skill-1/SKILL.md"),
+                        )
+                        .unwrap(),
+                        StandardizedPath::try_from_local(
+                            &repo.join(".claude/skills/root-skill-2/SKILL.md"),
+                        )
+                        .unwrap(),
+                    ]),
+                    ctx,
+                );
             });
 
             model_handle.read(&app, |model, ctx| {
@@ -584,6 +608,7 @@ fn update_relevance_ignores_unrelated_local_file_updates() {
                 ignored: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
 
     assert!(!update_might_affect_project_skills(&repo_id, &update, None));
@@ -605,6 +630,7 @@ fn update_relevance_detects_local_skill_and_provider_directory_updates() {
                 ignored: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
     let provider_update = RepoMetadataUpdate {
         repo_path,
@@ -617,6 +643,7 @@ fn update_relevance_detects_local_skill_and_provider_directory_updates() {
                 loaded: true,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
 
     assert!(update_might_affect_project_skills(
@@ -645,6 +672,7 @@ fn update_relevance_detects_removal_of_known_skill_ancestor() {
         repo_path,
         remove_entries: vec![StandardizedPath::try_new("/repo/.agents/skills/review").unwrap()],
         update_entries: Vec::new(),
+        standing_results_delta: Default::default(),
     };
 
     assert!(update_might_affect_project_skills(
@@ -670,6 +698,7 @@ fn update_relevance_filters_remote_updates_by_skill_file_paths() {
                 ignored: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
     let skill_update = RepoMetadataUpdate {
         repo_path,
@@ -683,6 +712,7 @@ fn update_relevance_filters_remote_updates_by_skill_file_paths() {
                 ignored: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
 
     assert!(!update_might_affect_project_skills(
@@ -822,7 +852,21 @@ fn find_skill_files_in_tree_finds_subdirectory_skills() {
                 let key =
                     warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&repo)
                         .unwrap();
-                model.insert_test_state(key, state, ctx);
+                model.insert_test_state(key.clone(), state, ctx);
+                model.insert_test_standing_results(
+                    key,
+                    project_standing_results([
+                        StandardizedPath::try_from_local(
+                            &repo.join(".agents/skills/root-skill/SKILL.md"),
+                        )
+                        .unwrap(),
+                        StandardizedPath::try_from_local(
+                            &repo.join("packages/frontend/.agents/skills/frontend-skill/SKILL.md"),
+                        )
+                        .unwrap(),
+                    ]),
+                    ctx,
+                );
             });
 
             model_handle.read(&app, |model, ctx| {
@@ -891,6 +935,10 @@ fn find_skill_files_in_tree_returns_remote_skill_paths_for_remote_repos() {
                     }),
                 ],
             }],
+            standing_results_delta: StandingQueryResultsDelta {
+                upserted_project_skills: vec![StandingQueryContent::file(skill_path.clone())],
+                ..Default::default()
+            },
         };
 
         model_handle.update(&mut app, |model, ctx| {
@@ -964,7 +1012,15 @@ fn find_skill_files_in_tree_includes_ignored_skill_files() {
             let model_handle = app.add_singleton_model(RepoMetadataModel::new);
             model_handle.update(&mut app, |model, ctx| {
                 let key = StandardizedPath::from_local_canonicalized(&repo).unwrap();
-                model.insert_test_state(key, state, ctx);
+                model.insert_test_state(key.clone(), state, ctx);
+                model.insert_test_standing_results(
+                    key,
+                    project_standing_results([StandardizedPath::try_from_local(
+                        &repo.join(".agents/skills/ignored-skill/SKILL.md"),
+                    )
+                    .unwrap()]),
+                    ctx,
+                );
             });
 
             model_handle.read(&app, |model, ctx| {

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
 use repo_metadata::file_tree_update::{
@@ -20,7 +18,6 @@ use warpui::App;
 use super::{
     extract_skill_parent_directory, find_project_skill_files_in_tree, is_home_provider_path,
     is_home_skill_directory, is_skill_file, read_skills_from_files,
-    update_might_affect_project_skills,
 };
 fn project_standing_results(
     skill_paths: impl IntoIterator<Item = StandardizedPath>,
@@ -591,140 +588,6 @@ fn find_skill_files_in_tree_finds_root_skills() {
             });
         });
     });
-}
-
-#[test]
-fn update_relevance_ignores_unrelated_local_file_updates() {
-    let repo_path = StandardizedPath::try_new("/repo").unwrap();
-    let repo_id = RepositoryIdentifier::local(repo_path.clone());
-    let update = RepoMetadataUpdate {
-        repo_path: repo_path.clone(),
-        remove_entries: Vec::new(),
-        update_entries: vec![FileTreeEntryUpdate {
-            parent_path_to_replace: StandardizedPath::try_new("/repo/src").unwrap(),
-            subtree_metadata: vec![RepoNodeMetadata::File(FileNodeMetadata {
-                path: StandardizedPath::try_new("/repo/src/main.rs").unwrap(),
-                extension: Some("rs".to_string()),
-                ignored: false,
-            })],
-        }],
-        standing_results_delta: Default::default(),
-    };
-
-    assert!(!update_might_affect_project_skills(&repo_id, &update, None));
-}
-
-#[test]
-fn update_relevance_detects_local_skill_and_provider_directory_updates() {
-    let repo_path = StandardizedPath::try_new("/repo").unwrap();
-    let repo_id = RepositoryIdentifier::local(repo_path.clone());
-    let skill_update = RepoMetadataUpdate {
-        repo_path: repo_path.clone(),
-        remove_entries: Vec::new(),
-        update_entries: vec![FileTreeEntryUpdate {
-            parent_path_to_replace: StandardizedPath::try_new("/repo/.agents/skills/review")
-                .unwrap(),
-            subtree_metadata: vec![RepoNodeMetadata::File(FileNodeMetadata {
-                path: StandardizedPath::try_new("/repo/.agents/skills/review/SKILL.md").unwrap(),
-                extension: Some("md".to_string()),
-                ignored: false,
-            })],
-        }],
-        standing_results_delta: Default::default(),
-    };
-    let provider_update = RepoMetadataUpdate {
-        repo_path,
-        remove_entries: Vec::new(),
-        update_entries: vec![FileTreeEntryUpdate {
-            parent_path_to_replace: StandardizedPath::try_new("/repo").unwrap(),
-            subtree_metadata: vec![RepoNodeMetadata::Directory(DirectoryNodeMetadata {
-                path: StandardizedPath::try_new("/repo/.agents/skills").unwrap(),
-                ignored: false,
-                loaded: true,
-            })],
-        }],
-        standing_results_delta: Default::default(),
-    };
-
-    assert!(update_might_affect_project_skills(
-        &repo_id,
-        &skill_update,
-        None
-    ));
-    assert!(update_might_affect_project_skills(
-        &repo_id,
-        &provider_update,
-        None
-    ));
-}
-
-#[test]
-fn update_relevance_detects_removal_of_known_skill_ancestor() {
-    let repo_path = StandardizedPath::try_new("/repo").unwrap();
-    let repo_id = RepositoryIdentifier::local(repo_path.clone());
-    let known_skill = LocalOrRemotePath::Local(
-        StandardizedPath::try_new("/repo/.agents/skills/review/SKILL.md")
-            .unwrap()
-            .to_local_path_lossy(),
-    );
-    let known_skill_files = HashSet::from([known_skill]);
-    let update = RepoMetadataUpdate {
-        repo_path,
-        remove_entries: vec![StandardizedPath::try_new("/repo/.agents/skills/review").unwrap()],
-        update_entries: Vec::new(),
-        standing_results_delta: Default::default(),
-    };
-
-    assert!(update_might_affect_project_skills(
-        &repo_id,
-        &update,
-        Some(&known_skill_files)
-    ));
-}
-
-#[test]
-fn update_relevance_filters_remote_updates_by_skill_file_paths() {
-    let host_id = HostId::new("test-host".to_string());
-    let repo_path = StandardizedPath::try_new("/repo").unwrap();
-    let repo_id = RepositoryIdentifier::Remote(RemotePath::new(host_id, repo_path.clone()));
-    let unrelated_update = RepoMetadataUpdate {
-        repo_path: repo_path.clone(),
-        remove_entries: Vec::new(),
-        update_entries: vec![FileTreeEntryUpdate {
-            parent_path_to_replace: StandardizedPath::try_new("/repo/src").unwrap(),
-            subtree_metadata: vec![RepoNodeMetadata::File(FileNodeMetadata {
-                path: StandardizedPath::try_new("/repo/src/main.rs").unwrap(),
-                extension: Some("rs".to_string()),
-                ignored: false,
-            })],
-        }],
-        standing_results_delta: Default::default(),
-    };
-    let skill_update = RepoMetadataUpdate {
-        repo_path,
-        remove_entries: Vec::new(),
-        update_entries: vec![FileTreeEntryUpdate {
-            parent_path_to_replace: StandardizedPath::try_new("/repo/.claude/skills/review")
-                .unwrap(),
-            subtree_metadata: vec![RepoNodeMetadata::File(FileNodeMetadata {
-                path: StandardizedPath::try_new("/repo/.claude/skills/review/SKILL.md").unwrap(),
-                extension: Some("md".to_string()),
-                ignored: false,
-            })],
-        }],
-        standing_results_delta: Default::default(),
-    };
-
-    assert!(!update_might_affect_project_skills(
-        &repo_id,
-        &unrelated_update,
-        None
-    ));
-    assert!(update_might_affect_project_skills(
-        &repo_id,
-        &skill_update,
-        None
-    ));
 }
 
 #[test]

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -617,6 +617,7 @@ impl FileTreeView {
             }
             RepoMetadataEvent::FileTreeUpdated { .. }
             | RepoMetadataEvent::RepositoryRemoved { .. }
+            | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
             | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
             | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
         }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1539,6 +1539,12 @@ pub(crate) fn initialize_app(
                     .map(|provider| provider.skills_path.clone()),
                 ctx,
             );
+            model.set_project_skill_provider_paths(
+                ::ai::skills::SKILL_PROVIDER_DEFINITIONS
+                    .iter()
+                    .map(|provider| provider.skills_path.clone()),
+                ctx,
+            );
 
             // Subscribe to RemoteServerManager push events so that remote repo
             // metadata snapshots and incremental updates populate the remote

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -336,6 +336,10 @@ impl ServerModel {
                         let entries = super::repo_metadata_proto::file_tree_entry_to_snapshot_proto(
                             &state.entry,
                         );
+                        let standing_results = repo_model
+                            .as_ref(ctx)
+                            .standing_query_results(&id, ctx)
+                            .map(|results| (&results.as_snapshot_delta()).into());
                         me.send_server_message(
                             None,
                             None,
@@ -344,6 +348,7 @@ impl ServerModel {
                                     repo_path: path.to_string(),
                                     entries,
                                     sync_complete: true,
+                                    standing_results,
                                 },
                             ),
                         );
@@ -357,6 +362,7 @@ impl ServerModel {
                 RepoMetadataEvent::RepositoryRemoved { .. }
                 | RepoMetadataEvent::FileTreeUpdated { .. }
                 | RepoMetadataEvent::FileTreeEntryUpdated { .. }
+                | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                 | RepoMetadataEvent::RepositoryUpdated {
                     id: RepositoryIdentifier::Remote(_),
@@ -1869,6 +1875,10 @@ impl ServerModel {
                         let entries = super::repo_metadata_proto::file_tree_entry_to_snapshot_proto(
                             &state.entry,
                         );
+                        let standing_results = repo_model
+                            .as_ref(ctx)
+                            .standing_query_results(&id, ctx)
+                            .map(|results| (&results.as_snapshot_delta()).into());
                         // Git snapshots target the requesting connection;
                         // non-git snapshots broadcast to all.
                         let target = if is_git {
@@ -1884,6 +1894,7 @@ impl ServerModel {
                                     repo_path: indexed_path,
                                     entries,
                                     sync_complete: true,
+                                    standing_results,
                                 },
                             ),
                         );

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -57,6 +57,7 @@ impl FileSearchModel {
                     }
                 }
                 RepoMetadataEvent::FileTreeEntryUpdated { .. }
+                | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                 | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
             },

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -1,4 +1,6 @@
 use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
+#[cfg(feature = "local_fs")]
+use ai::skills::SKILL_PROVIDER_DEFINITIONS;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
 #[cfg(feature = "local_fs")]
@@ -131,7 +133,22 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());
     #[cfg(feature = "local_fs")]
-    app.add_singleton_model(RepoMetadataModel::new);
+    app.add_singleton_model(|ctx| {
+        let model = RepoMetadataModel::new(ctx);
+        model.register_ignored_path_interests(
+            SKILL_PROVIDER_DEFINITIONS
+                .iter()
+                .map(|provider| provider.skills_path.clone()),
+            ctx,
+        );
+        model.set_project_skill_provider_paths(
+            SKILL_PROVIDER_DEFINITIONS
+                .iter()
+                .map(|provider| provider.skills_path.clone()),
+            ctx,
+        );
+        model
+    });
     app.add_singleton_model(FileSearchModel::new);
     app.add_singleton_model(|_| GitStatusUpdateModel::new());
     app.add_singleton_model(RepoOutlines::new_for_test);

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+#[cfg(feature = "local_fs")]
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -66,6 +68,26 @@ impl ProjectRules {
                 .chain(rule.agents_md.iter())
                 .map(|rule| &rule.path)
         })
+    }
+    #[cfg(feature = "local_fs")]
+    fn retain_rule_paths(&mut self, retained_paths: &HashSet<PathBuf>) {
+        self.rules.retain_mut(|rule| {
+            if rule
+                .warp_md
+                .as_ref()
+                .is_some_and(|rule| !retained_paths.contains(&rule.path))
+            {
+                rule.warp_md = None;
+            }
+            if rule
+                .agents_md
+                .as_ref()
+                .is_some_and(|rule| !retained_paths.contains(&rule.path))
+            {
+                rule.agents_md = None;
+            }
+            rule.warp_md.is_some() || rule.agents_md.is_some()
+        });
     }
     /// Finds the set of rules that are active in the given path and the set that are available to be applied.
     fn find_active_or_applicable_rules(&self, path: &Path) -> FindRulesResult {
@@ -302,6 +324,11 @@ impl ProjectContextModel {
             .filter(|content| !content.is_directory)
             .filter_map(|content| content.path.to_local_path())
             .collect::<Vec<_>>();
+        let existing_rules = self
+            .path_to_rules
+            .get(&project_root)
+            .cloned()
+            .unwrap_or_default();
 
         self.next_rule_refresh_generation += 1;
         let refresh_generation = self.next_rule_refresh_generation;
@@ -309,19 +336,7 @@ impl ProjectContextModel {
             .insert(project_root.clone(), refresh_generation);
         let project_root_for_read = project_root.clone();
         ctx.spawn(
-            async move {
-                let mut rules = ProjectRules::default();
-                for rule_path in rule_paths {
-                    match async_fs::read_to_string(&rule_path).await {
-                        Ok(content) => rules.upsert_rule(&rule_path, content),
-                        Err(error) => log::debug!(
-                            "Failed to read project rule file {}: {error}",
-                            rule_path.display()
-                        ),
-                    }
-                }
-                rules
-            },
+            async move { Self::read_standing_project_rules(rule_paths, existing_rules).await },
             move |me, rules, ctx| {
                 if me.rule_refresh_generations.get(&project_root_for_read)
                     != Some(&refresh_generation)
@@ -352,6 +367,26 @@ impl ProjectContextModel {
                 ctx.emit(ProjectContextModelEvent::PathIndexed);
             },
         );
+    }
+
+    #[cfg(feature = "local_fs")]
+    async fn read_standing_project_rules(
+        rule_paths: Vec<PathBuf>,
+        mut existing_rules: ProjectRules,
+    ) -> ProjectRules {
+        let retained_paths = rule_paths.iter().cloned().collect::<HashSet<_>>();
+        existing_rules.retain_rule_paths(&retained_paths);
+
+        for rule_path in rule_paths {
+            match async_fs::read_to_string(&rule_path).await {
+                Ok(content) => existing_rules.upsert_rule(&rule_path, content),
+                Err(error) => log::debug!(
+                    "Failed to read project rule file {}: {error}",
+                    rule_path.display()
+                ),
+            }
+        }
+        existing_rules
     }
 
     #[cfg(feature = "local_fs")]

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -1,26 +1,15 @@
 use std::collections::HashMap;
-#[cfg(feature = "local_fs")]
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-#[cfg(feature = "local_fs")]
-use repo_metadata::repositories::RepoDetectionSource;
 use warpui_core::{Entity, ModelContext, SingletonEntity};
 
 use super::GlobalRules;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
-        use async_channel::Sender;
-        use ignore::gitignore::Gitignore;
-        use repo_metadata::entry::{BudgetExceededBehavior, Entry, FileMetadata};
-        use repo_metadata::repository::RepositorySubscriber;
-        use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate};
-
-        const RULES_FILE_PATTERN: [&str; 2] = ["WARP.md", "AGENTS.md"];
-        const MAX_SCAN_DEPTH: usize = 3;
-        const MAX_FILES_TO_SCAN: usize = 5000;
+        use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
+        use warp_util::standardized_path::StandardizedPath;
     }
 }
 
@@ -64,22 +53,20 @@ struct FindRulesResult {
     available_rule_paths: Vec<String>,
 }
 
-#[cfg(feature = "local_fs")]
-fn matches_rules_pattern(file_name_str: &str) -> bool {
-    for pattern in RULES_FILE_PATTERN {
-        if file_name_str.to_lowercase() == pattern.to_lowercase() {
-            return true;
-        }
-    }
-    false
-}
-
 #[derive(Debug, Default, Clone)]
 struct ProjectRules {
     rules: Vec<RuleAtPath>,
 }
 
 impl ProjectRules {
+    fn all_rule_paths(&self) -> impl Iterator<Item = &PathBuf> {
+        self.rules.iter().flat_map(|rule| {
+            rule.warp_md
+                .iter()
+                .chain(rule.agents_md.iter())
+                .map(|rule| &rule.path)
+        })
+    }
     /// Finds the set of rules that are active in the given path and the set that are available to be applied.
     fn find_active_or_applicable_rules(&self, path: &Path) -> FindRulesResult {
         let mut active_rules = Vec::new();
@@ -100,26 +87,6 @@ impl ProjectRules {
         FindRulesResult {
             active_rules,
             available_rule_paths,
-        }
-    }
-
-    /// Remove a rule from the set of project rules. This returns the removed rule.
-    #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
-    fn remove_rule(&mut self, path: &Path) -> Option<ProjectRule> {
-        let parent = path.parent()?;
-        let file_name = path.file_name().and_then(|name| name.to_str())?;
-
-        let rule = self
-            .rules
-            .iter_mut()
-            .find(|rule| rule.parent_path == parent)?;
-
-        if file_name.to_lowercase() == "warp.md" {
-            rule.warp_md.take()
-        } else if file_name.to_lowercase() == "agents.md" {
-            rule.agents_md.take()
-        } else {
-            None
         }
     }
 
@@ -175,15 +142,11 @@ impl ProjectRules {
 pub struct ProjectContextModel {
     /// Mapping from directory path to list of rule files found in that directory
     path_to_rules: HashMap<PathBuf, ProjectRules>,
-    /// Queued repository updates for paths that have an in-flight processing task.
-    /// The presence of a key indicates an active async task for that path;
-    /// the Vec holds updates that arrived while that task was running.
+    /// Latest metadata-backed async refresh per project root.
     #[cfg(feature = "local_fs")]
-    pending_updates: HashMap<PathBuf, Vec<RepositoryUpdate>>,
-    /// Repo roots that already have a watcher registered, so we never
-    /// subscribe more than once per root.
+    rule_refresh_generations: HashMap<PathBuf, u64>,
     #[cfg(feature = "local_fs")]
-    watched_roots: HashSet<PathBuf>,
+    next_rule_refresh_generation: u64,
     /// File-based global rules and their local watcher state. Kept separate
     /// from `path_to_rules`, which is project-scoped.
     pub(super) global_rules: GlobalRules,
@@ -206,7 +169,7 @@ impl RulesDelta {
     /// This is important because consumers (e.g. persistence) apply the delta
     /// incrementally; a symmetric "cancel both sides" approach would silently
     /// drop real state changes.
-    #[cfg(any(feature = "local_fs", test))]
+    #[cfg(test)]
     fn merge(&mut self, other: RulesDelta) {
         // Each newly-discovered path supersedes any prior deletion or earlier
         // discovery of the same path.
@@ -248,26 +211,57 @@ impl ProjectContextModel {
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         #[cfg(feature = "local_fs")]
-        ctx.spawn(
-            async move { Self::read_persisted_rules(persisted_rules).await },
-            |me, mut res, ctx| {
-                for root in res.keys() {
-                    me.try_initialize_and_register_watcher(root, ctx);
-                }
+        {
+            ctx.subscribe_to_model(
+                &RepoMetadataModel::handle(ctx),
+                |me, event, ctx| match event {
+                    RepoMetadataEvent::RepositoryUpdated {
+                        id: RepositoryIdentifier::Local(repo_path),
+                    } => me.refresh_project_rules_for_repo(repo_path.clone(), ctx),
+                    RepoMetadataEvent::StandingQueryResultsUpdated {
+                        id: RepositoryIdentifier::Local(repo_path),
+                        delta,
+                    } => {
+                        if delta.project_rules_changed() {
+                            me.refresh_project_rules_for_repo(repo_path.clone(), ctx);
+                        }
+                    }
+                    RepoMetadataEvent::RepositoryRemoved {
+                        id: RepositoryIdentifier::Local(repo_path),
+                    } => me.remove_project_rules_for_repo(repo_path, ctx),
+                    RepoMetadataEvent::RepositoryUpdated {
+                        id: RepositoryIdentifier::Remote(_),
+                    }
+                    | RepoMetadataEvent::RepositoryRemoved {
+                        id: RepositoryIdentifier::Remote(_),
+                    }
+                    | RepoMetadataEvent::StandingQueryResultsUpdated {
+                        id: RepositoryIdentifier::Remote(_),
+                        ..
+                    }
+                    | RepoMetadataEvent::FileTreeUpdated { .. }
+                    | RepoMetadataEvent::FileTreeEntryUpdated { .. }
+                    | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
+                    | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
+                },
+            );
 
-                // If we have any rules detected before fully loading the persisted rules, we want to
-                // keep the detected rules since it's more up to date.
-                res.extend(me.path_to_rules.drain());
-                me.path_to_rules = res;
-                ctx.emit(ProjectContextModelEvent::PathIndexed);
-            },
-        );
+            ctx.spawn(
+                async move { Self::read_persisted_rules(persisted_rules).await },
+                |me, mut res, ctx| {
+                    // Metadata refreshes may have completed before persistence loads; retain
+                    // the fresher metadata-backed state for overlapping roots.
+                    res.extend(me.path_to_rules.drain());
+                    me.path_to_rules = res;
+                    ctx.emit(ProjectContextModelEvent::PathIndexed);
+                },
+            );
+        }
 
         Self::default()
     }
 
-    /// Index a path and find all rule files from that path up to the root directory
-    /// Returns a list of all rule files found
+    /// Reconciles project rule contents from the repository metadata standing result set.
     #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
     pub fn index_and_store_rules(
         &mut self,
@@ -276,215 +270,108 @@ impl ProjectContextModel {
     ) -> Result<()> {
         #[cfg(feature = "local_fs")]
         {
-            let root_clone = root_path.clone();
-
-            ctx.spawn(
-                async move { Self::scan_directory_for_rules(&root_path).await },
-                move |me, res: Result<ProjectRules>, ctx| match res {
-                    Ok(rule_files) => {
-                        me.register_watcher_for_path(&root_clone, ctx);
-
-                        // Persist the discovered rules.
-                        let delta = RulesDelta {
-                            discovered_rules: rule_files
-                                .rules
-                                .iter()
-                                .filter_map(|rule| {
-                                    rule.warp_md.as_ref().map(|rule| ProjectRulePath {
-                                        project_root: root_clone.clone(),
-                                        path: rule.path.clone(),
-                                    })
-                                })
-                                .chain(rule_files.rules.iter().filter_map(|rule| {
-                                    rule.agents_md.as_ref().map(|rule| ProjectRulePath {
-                                        project_root: root_clone.clone(),
-                                        path: rule.path.clone(),
-                                    })
-                                }))
-                                .collect(),
-                            deleted_rules: Default::default(),
-                        };
-                        ctx.emit(ProjectContextModelEvent::KnownRulesChanged(delta));
-
-                        me.path_to_rules.insert(root_clone, rule_files);
-                        ctx.emit(ProjectContextModelEvent::PathIndexed);
-                    }
-                    Err(e) => log::warn!(
-                        "Couldn't index rules for path {}: {}",
-                        root_clone.display(),
-                        e
-                    ),
-                },
-            );
+            let repo_path = StandardizedPath::from_local_canonicalized(&root_path)?;
+            let repo_id = RepositoryIdentifier::local(repo_path.clone());
+            if RepoMetadataModel::as_ref(ctx)
+                .standing_query_results(&repo_id, ctx)
+                .is_none()
+            {
+                RepoMetadataModel::handle(ctx).update(ctx, |metadata, ctx| {
+                    metadata.index_lazy_loaded_path(&repo_path, ctx)
+                })?;
+            }
+            self.refresh_project_rules_for_repo(repo_path, ctx);
         }
-
         Ok(())
     }
 
-    /// This should be used when we are bootstrapping project rules from persisted rule paths. In this case,
-    /// the actual repo watcher might not have been registered yet. We will attempt to register that repo watcher
-    /// if it doesn't yet exists.
     #[cfg(feature = "local_fs")]
-    fn try_initialize_and_register_watcher(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
-        use repo_metadata::repositories::DetectedRepositories;
-
-        let directory_watcher = DirectoryWatcher::handle(ctx);
-        if directory_watcher
-            .as_ref(ctx)
-            .get_watched_directory_for_path(path)
-            .is_some()
-        {
-            self.register_watcher_for_path(path, ctx);
-            return;
-        }
-
-        let fut = DetectedRepositories::handle(ctx).update(ctx, |model, ctx| {
-            model.detect_possible_local_git_repo(
-                &path.to_string_lossy(),
-                RepoDetectionSource::ProjectRulesIndexing,
-                ctx,
-            )
-        });
-
-        ctx.spawn(fut, move |me, repo_path_opt, ctx| {
-            if let Some(path) = repo_path_opt {
-                me.register_watcher_for_path(&path, ctx);
-            }
-        });
-    }
-
-    #[cfg(feature = "local_fs")]
-    fn register_watcher_for_path(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
-        if self.watched_roots.contains(path) {
-            return;
-        }
-
-        let Some(repository_model) =
-            DirectoryWatcher::as_ref(ctx).get_watched_directory_for_path(path)
-        else {
-            return;
-        };
-
-        self.watched_roots.insert(path.to_path_buf());
-
-        let (repository_update_tx, repository_update_rx) = async_channel::unbounded();
-        let start = repository_model.update(ctx, |repo, ctx| {
-            repo.start_watching(
-                Box::new(ProjectContextRepositorySubscriber {
-                    repository_update_tx,
-                }),
-                ctx,
-            )
-        });
-
-        let subscriber_id = start.subscriber_id;
-        let repository_model_for_cleanup = repository_model.downgrade();
-        let path_clone = path.to_path_buf();
-        let path_for_log = path_clone.clone();
-        ctx.spawn(start.registration_future, move |_, res, ctx| {
-            if let Err(err) = res {
-                log::warn!(
-                    "Failed to start watching repository for rule updates at {}: {err}",
-                    path_for_log.display()
-                );
-
-                if let Some(repository_model) = repository_model_for_cleanup.upgrade(ctx) {
-                    repository_model.update(ctx, |repo, ctx| {
-                        repo.stop_watching(subscriber_id, ctx);
-                    });
-                }
-            }
-        });
-
-        ctx.spawn_stream_local(
-            repository_update_rx.clone(),
-            move |me, update, ctx| {
-                if update.is_empty() {
-                    return;
-                }
-
-                // If there's already an in-flight task for this path, queue the update
-                // instead of spawning a concurrent task that could overwrite results.
-                if let Some(queued) = me.pending_updates.get_mut(&path_clone) {
-                    queued.push(update);
-                    return;
-                }
-
-                let Some(rules) = me.path_to_rules.get(&path_clone).cloned() else {
-                    return;
-                };
-
-                // Mark this path as having an in-flight task (empty queue).
-                me.pending_updates.insert(path_clone.clone(), Vec::new());
-
-                let repo_path = path_clone.clone();
-                let repo_path_for_closure = repo_path.clone();
-                ctx.spawn(
-                    async move { Self::process_repository_updates(update, rules, repo_path).await },
-                    move |me, (rules, rule_delta), ctx| {
-                        me.apply_update_result(&repo_path_for_closure, rules, rule_delta, ctx);
-                    },
-                );
-            },
-            |_, _| {},
-        );
-    }
-
-    /// Called when an async update task completes: emits events, stores the new rules,
-    /// and drains any updates that queued up while the task was in flight.
-    #[cfg(feature = "local_fs")]
-    fn apply_update_result(
+    fn refresh_project_rules_for_repo(
         &mut self,
-        path: &Path,
-        rules: ProjectRules,
-        rule_delta: RulesDelta,
+        repo_path: StandardizedPath,
         ctx: &mut ModelContext<Self>,
     ) {
-        ctx.emit(ProjectContextModelEvent::KnownRulesChanged(rule_delta));
-        self.path_to_rules.insert(path.to_path_buf(), rules);
-        self.drain_pending_updates(path, ctx);
-        ctx.emit(ProjectContextModelEvent::PathIndexed);
-    }
-
-    /// Processes any queued updates for a path after the previous async task completes.
-    /// Each batch runs sequentially against the latest rules, preventing stale-snapshot races.
-    #[cfg(feature = "local_fs")]
-    fn drain_pending_updates(&mut self, path: &Path, ctx: &mut ModelContext<Self>) {
-        let path_buf = path.to_path_buf();
-        let Some(queued) = self.pending_updates.get_mut(&path_buf) else {
+        let Some(project_root) = repo_path.to_local_path() else {
             return;
         };
+        let id = RepositoryIdentifier::local(repo_path);
+        let rule_paths = RepoMetadataModel::as_ref(ctx)
+            .standing_query_results(&id, ctx)
+            .into_iter()
+            .flat_map(|results| results.project_rules())
+            .filter(|content| !content.is_directory)
+            .filter_map(|content| content.path.to_local_path())
+            .collect::<Vec<_>>();
 
-        if queued.is_empty() {
-            self.pending_updates.remove(&path_buf);
-            return;
-        }
-
-        let updates = std::mem::take(queued);
-        let Some(rules) = self.path_to_rules.get(&path_buf).cloned() else {
-            self.pending_updates.remove(&path_buf);
-            return;
-        };
-
-        let repo_path = path_buf.clone();
-        let repo_path_for_closure = path_buf;
+        self.next_rule_refresh_generation += 1;
+        let refresh_generation = self.next_rule_refresh_generation;
+        self.rule_refresh_generations
+            .insert(project_root.clone(), refresh_generation);
+        let project_root_for_read = project_root.clone();
         ctx.spawn(
             async move {
-                let mut current_rules = rules;
-                let mut combined_delta = RulesDelta::default();
-                for update in updates {
-                    let (updated_rules, delta) =
-                        Self::process_repository_updates(update, current_rules, repo_path.clone())
-                            .await;
-                    current_rules = updated_rules;
-                    combined_delta.merge(delta);
+                let mut rules = ProjectRules::default();
+                for rule_path in rule_paths {
+                    match async_fs::read_to_string(&rule_path).await {
+                        Ok(content) => rules.upsert_rule(&rule_path, content),
+                        Err(error) => log::debug!(
+                            "Failed to read project rule file {}: {error}",
+                            rule_path.display()
+                        ),
+                    }
                 }
-                (current_rules, combined_delta)
+                rules
             },
-            move |me, (rules, rule_delta), ctx| {
-                me.apply_update_result(&repo_path_for_closure, rules, rule_delta, ctx);
+            move |me, rules, ctx| {
+                if me.rule_refresh_generations.get(&project_root_for_read)
+                    != Some(&refresh_generation)
+                {
+                    return;
+                }
+                let new_paths = rules.all_rule_paths().cloned().collect::<Vec<_>>();
+                let previous = me
+                    .path_to_rules
+                    .insert(project_root_for_read.clone(), rules)
+                    .unwrap_or_default();
+                let deleted_rules = previous
+                    .all_rule_paths()
+                    .filter(|path| !new_paths.contains(path))
+                    .cloned()
+                    .collect();
+                let discovered_rules = new_paths
+                    .into_iter()
+                    .map(|path| ProjectRulePath {
+                        path,
+                        project_root: project_root_for_read.clone(),
+                    })
+                    .collect();
+                ctx.emit(ProjectContextModelEvent::KnownRulesChanged(RulesDelta {
+                    discovered_rules,
+                    deleted_rules,
+                }));
+                ctx.emit(ProjectContextModelEvent::PathIndexed);
             },
         );
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn remove_project_rules_for_repo(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(project_root) = repo_path.to_local_path() else {
+            return;
+        };
+        self.rule_refresh_generations.remove(&project_root);
+        if let Some(rules) = self.path_to_rules.remove(&project_root) {
+            let deleted_rules = rules.all_rule_paths().cloned().collect();
+            ctx.emit(ProjectContextModelEvent::KnownRulesChanged(RulesDelta {
+                discovered_rules: Vec::new(),
+                deleted_rules,
+            }));
+            ctx.emit(ProjectContextModelEvent::PathIndexed);
+        }
     }
 
     /// Index all configured global rule sources.
@@ -574,155 +461,6 @@ impl ProjectContextModel {
     }
 
     #[cfg(feature = "local_fs")]
-    async fn process_repository_updates(
-        repository_update: RepositoryUpdate,
-        mut existing_rules: ProjectRules,
-        project_root: PathBuf,
-    ) -> (ProjectRules, RulesDelta) {
-        let mut rules_delta = RulesDelta::default();
-        // Handle deleted files - remove rules for deleted rule files
-        for target_file in &repository_update.deleted {
-            // Skip gitignored files
-            if target_file.is_ignored {
-                continue;
-            }
-            if let Some(file_name_str) = target_file.path.file_name().and_then(|name| name.to_str())
-            {
-                if matches_rules_pattern(file_name_str) {
-                    // Remove the rule from existing rules
-                    existing_rules.remove_rule(&target_file.path);
-                    rules_delta.deleted_rules.push(target_file.path.clone());
-
-                    log::debug!("Removed rule file: {}", target_file.path.display());
-                }
-            }
-        }
-
-        // Handle moved files - update paths for moved rule files
-        for (to_target, from_target) in &repository_update.moved {
-            // Skip gitignored files
-            if to_target.is_ignored || from_target.is_ignored {
-                continue;
-            }
-            if let Some(file_name_str) = to_target.path.file_name().and_then(|name| name.to_str()) {
-                if matches_rules_pattern(file_name_str) {
-                    // Find and update the rule with the old path
-                    if let Some(rule) = existing_rules.remove_rule(&from_target.path) {
-                        // Emit deletion event for old path
-                        rules_delta.deleted_rules.push(from_target.path.clone());
-
-                        existing_rules.upsert_rule(&to_target.path, rule.content);
-
-                        // Emit upsert event for new path
-                        rules_delta.discovered_rules.push(ProjectRulePath {
-                            path: to_target.path.clone(),
-                            project_root: project_root.clone(),
-                        });
-
-                        log::debug!(
-                            "Updated rule file path: {} -> {}",
-                            from_target.path.display(),
-                            to_target.path.display()
-                        );
-                    }
-                }
-            }
-        }
-
-        // Handle added/updated files - upsert rules for rule files
-        for target_file in repository_update.added_or_modified() {
-            // Skip gitignored files
-            if target_file.is_ignored {
-                continue;
-            }
-            if let Some(file_name_str) = target_file.path.file_name().and_then(|name| name.to_str())
-            {
-                if matches_rules_pattern(file_name_str) {
-                    // Read the content of the rule file
-                    match async_fs::read_to_string(&target_file.path).await {
-                        Ok(content) => {
-                            existing_rules.upsert_rule(&target_file.path, content);
-                            rules_delta.discovered_rules.push(ProjectRulePath {
-                                path: target_file.path.clone(),
-                                project_root: project_root.clone(),
-                            });
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "Failed to read updated rule file {}: {}",
-                                target_file.path.display(),
-                                e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        (existing_rules, rules_delta)
-    }
-
-    /// Scan a directory for rule files (currently WARP.md, extensible for future file types)
-    /// Uses repo_metadata::entry::build_tree for efficient directory traversal
-    #[cfg(feature = "local_fs")]
-    async fn scan_directory_for_rules(dir_path: &Path) -> Result<ProjectRules> {
-        use repo_metadata::entry::IgnoredPathStrategy;
-
-        let mut rule_files = ProjectRules::default();
-
-        if !async_fs::metadata(dir_path).await?.is_dir() {
-            return Ok(rule_files);
-        }
-
-        // Use build_tree to collect all files, then filter for rule files
-        let mut files = Vec::<FileMetadata>::new();
-        let mut gitignores = Vec::<Gitignore>::new();
-
-        // Collect patterns that should not be ignored
-        let override_ignore_patterns: Vec<String> =
-            RULES_FILE_PATTERN.iter().map(|s| s.to_string()).collect();
-        let mut file_limit = MAX_FILES_TO_SCAN;
-
-        // Build the file tree using repo_metadata's build_tree function
-        let ignore_behavior = IgnoredPathStrategy::IncludeOnly(override_ignore_patterns.clone());
-
-        let _ = Entry::build_tree(
-            dir_path,
-            &mut files,
-            &mut gitignores,
-            Some(&mut file_limit),
-            MAX_SCAN_DEPTH,
-            0,
-            &ignore_behavior,
-            BudgetExceededBehavior::StopAndLazyLoad,
-        )?;
-
-        // Filter files to only include those matching RULES_FILE_PATTERN
-        for file_metadata in files {
-            let path = &file_metadata.path;
-            let file_name = path.file_name();
-
-            if let Some(file_name_str) = file_name {
-                if matches_rules_pattern(file_name_str) {
-                    // Read the content of the rule file
-                    let local_path = file_metadata.path.to_local_path_lossy();
-                    let content = match async_fs::read_to_string(&local_path).await {
-                        Ok(content) => content,
-                        Err(e) => {
-                            log::warn!("Failed to read rule file {}: {e}", file_metadata.path,);
-                            break;
-                        }
-                    };
-
-                    rule_files.upsert_rule(&local_path, content);
-                }
-            }
-        }
-
-        Ok(rule_files)
-    }
-
-    #[cfg(feature = "local_fs")]
     async fn read_persisted_rules(
         rule_paths: Vec<ProjectRulePath>,
     ) -> HashMap<PathBuf, ProjectRules> {
@@ -784,37 +522,6 @@ impl Entity for ProjectContextModel {
 }
 
 impl SingletonEntity for ProjectContextModel {}
-
-#[cfg(feature = "local_fs")]
-struct ProjectContextRepositorySubscriber {
-    repository_update_tx: Sender<RepositoryUpdate>,
-}
-
-#[cfg(feature = "local_fs")]
-impl RepositorySubscriber for ProjectContextRepositorySubscriber {
-    fn on_scan(
-        &mut self,
-        _repository: &Repository,
-        _ctx: &mut ModelContext<Repository>,
-    ) -> std::pin::Pin<Box<dyn std::prelude::rust_2024::Future<Output = ()> + Send + 'static>> {
-        // The model can safely ignore the initial scan because the model only subscribes
-        // after the repository is already scanned.
-        Box::pin(async {})
-    }
-
-    fn on_files_updated(
-        &mut self,
-        _repository: &Repository,
-        update: &repo_metadata::RepositoryUpdate,
-        _ctx: &mut ModelContext<Repository>,
-    ) -> std::pin::Pin<Box<dyn std::prelude::rust_2024::Future<Output = ()> + Send + 'static>> {
-        let tx = self.repository_update_tx.clone();
-        let update = update.clone();
-        Box::pin(async move {
-            let _ = tx.send(update).await;
-        })
-    }
-}
 
 #[cfg(test)]
 #[path = "model_tests.rs"]

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -61,6 +61,7 @@ struct ProjectRules {
 }
 
 impl ProjectRules {
+    #[cfg(feature = "local_fs")]
     fn all_rule_paths(&self) -> impl Iterator<Item = &PathBuf> {
         self.rules.iter().flat_map(|rule| {
             rule.warp_md

--- a/crates/ai/src/project_context/model_tests.rs
+++ b/crates/ai/src/project_context/model_tests.rs
@@ -295,6 +295,38 @@ fn test_merge_rediscovery_keeps_latest() {
     assert_eq!(delta.discovered_rules.len(), 1);
     assert!(delta.deleted_rules.is_empty());
 }
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_failed_standing_rule_read_preserves_cached_content() {
+    let rule_path = PathBuf::from("/unavailable/project/WARP.md");
+    let mut existing_rules = ProjectRules::default();
+    existing_rules.upsert_rule(&rule_path, "cached content".to_string());
+
+    let rules = futures::executor::block_on(ProjectContextModel::read_standing_project_rules(
+        vec![rule_path.clone()],
+        existing_rules,
+    ));
+    let result = rules.find_active_or_applicable_rules(Path::new("/unavailable/project/main.rs"));
+
+    assert_eq!(result.active_rules.len(), 1);
+    assert_eq!(result.active_rules[0].path, rule_path);
+    assert_eq!(result.active_rules[0].content, "cached content");
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_rule_missing_from_standing_results_is_removed_from_cached_content() {
+    let rule_path = PathBuf::from("/unavailable/project/WARP.md");
+    let mut existing_rules = ProjectRules::default();
+    existing_rules.upsert_rule(&rule_path, "cached content".to_string());
+
+    let rules = futures::executor::block_on(ProjectContextModel::read_standing_project_rules(
+        Vec::new(),
+        existing_rules,
+    ));
+
+    assert!(rules.all_rule_paths().next().is_none());
+}
 
 // Helper for global-rules tests: inserts a synthetic global rule directly into
 // the model. Bypasses the watcher infrastructure (which requires the warpui

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -259,6 +259,18 @@ message RepoMetadataEntryUpdate {
   repeated RepoNodeMetadata subtree_metadata = 2;
 }
 
+message StandingQueryContent {
+  string path = 1;
+  bool is_directory = 2;
+}
+
+message StandingQueryResultsDelta {
+  repeated StandingQueryContent upserted_project_skills = 1;
+  repeated StandingQueryContent removed_project_skills = 2;
+  repeated StandingQueryContent upserted_project_rules = 3;
+  repeated StandingQueryContent removed_project_rules = 4;
+}
+
 // ── NavigatedToDirectory ──────────────────────────────────────────
 
 // Client → server: "I navigated to this directory, please index it."
@@ -482,6 +494,7 @@ message RepoMetadataSnapshot {
   string repo_path = 1;
   repeated RepoMetadataEntryUpdate entries = 2;
   bool sync_complete = 3;
+  StandingQueryResultsDelta standing_results = 4;
 }
 
 // Incremental repo metadata update. Mirrors RepoMetadataUpdate in Rust.
@@ -489,6 +502,7 @@ message RepoMetadataUpdatePush {
   string repo_path = 1;
   repeated string remove_entries = 2;
   repeated RepoMetadataEntryUpdate update_entries = 3;
+  StandingQueryResultsDelta standing_results_delta = 4;
 }
 
 // ── Buffer syncing ────────────────────────────────────────────────

--- a/crates/remote_server/src/repo_metadata_proto.rs
+++ b/crates/remote_server/src/repo_metadata_proto.rs
@@ -8,6 +8,7 @@ use repo_metadata::file_tree_update::{
     DirectoryNodeMetadata, FileNodeMetadata, FileTreeEntryUpdate, RepoMetadataUpdate,
     RepoNodeMetadata,
 };
+use repo_metadata::{StandingQueryContent, StandingQueryResultsDelta};
 use warp_util::standardized_path::StandardizedPath;
 
 use crate::proto;
@@ -27,6 +28,43 @@ impl From<&RepoMetadataUpdate> for proto::RepoMetadataUpdatePush {
                 .update_entries
                 .iter()
                 .map(proto::RepoMetadataEntryUpdate::from)
+                .collect(),
+            standing_results_delta: Some((&update.standing_results_delta).into()),
+        }
+    }
+}
+
+impl From<&StandingQueryContent> for proto::StandingQueryContent {
+    fn from(content: &StandingQueryContent) -> Self {
+        Self {
+            path: content.path.to_string(),
+            is_directory: content.is_directory,
+        }
+    }
+}
+
+impl From<&StandingQueryResultsDelta> for proto::StandingQueryResultsDelta {
+    fn from(delta: &StandingQueryResultsDelta) -> Self {
+        Self {
+            upserted_project_skills: delta
+                .upserted_project_skills
+                .iter()
+                .map(proto::StandingQueryContent::from)
+                .collect(),
+            removed_project_skills: delta
+                .removed_project_skills
+                .iter()
+                .map(proto::StandingQueryContent::from)
+                .collect(),
+            upserted_project_rules: delta
+                .upserted_project_rules
+                .iter()
+                .map(proto::StandingQueryContent::from)
+                .collect(),
+            removed_project_rules: delta
+                .removed_project_rules
+                .iter()
+                .map(proto::StandingQueryContent::from)
                 .collect(),
         }
     }
@@ -159,7 +197,48 @@ pub fn proto_to_repo_metadata_update(
         repo_path,
         remove_entries,
         update_entries,
+        standing_results_delta: push
+            .standing_results_delta
+            .as_ref()
+            .map(proto_to_standing_results_delta)
+            .unwrap_or_default(),
     })
+}
+
+fn proto_to_standing_query_content(
+    content: &proto::StandingQueryContent,
+) -> Option<StandingQueryContent> {
+    Some(StandingQueryContent {
+        path: StandardizedPath::try_new(&content.path).ok()?,
+        is_directory: content.is_directory,
+    })
+}
+
+fn proto_to_standing_results_delta(
+    delta: &proto::StandingQueryResultsDelta,
+) -> StandingQueryResultsDelta {
+    StandingQueryResultsDelta {
+        upserted_project_skills: delta
+            .upserted_project_skills
+            .iter()
+            .filter_map(proto_to_standing_query_content)
+            .collect(),
+        removed_project_skills: delta
+            .removed_project_skills
+            .iter()
+            .filter_map(proto_to_standing_query_content)
+            .collect(),
+        upserted_project_rules: delta
+            .upserted_project_rules
+            .iter()
+            .filter_map(proto_to_standing_query_content)
+            .collect(),
+        removed_project_rules: delta
+            .removed_project_rules
+            .iter()
+            .filter_map(proto_to_standing_query_content)
+            .collect(),
+    }
 }
 
 /// Converts a `RepoMetadataSnapshot` proto into a `RepoMetadataUpdate`
@@ -179,6 +258,11 @@ pub fn proto_snapshot_to_update(
         repo_path,
         remove_entries: Vec::new(),
         update_entries,
+        standing_results_delta: snapshot
+            .standing_results
+            .as_ref()
+            .map(proto_to_standing_results_delta)
+            .unwrap_or_default(),
     })
 }
 
@@ -216,6 +300,7 @@ pub fn proto_load_repo_metadata_directory_response_to_update(
         repo_path,
         remove_entries: Vec::new(),
         update_entries,
+        standing_results_delta: StandingQueryResultsDelta::default(),
     })
 }
 

--- a/crates/remote_server/src/repo_metadata_proto.rs
+++ b/crates/remote_server/src/repo_metadata_proto.rs
@@ -34,6 +34,10 @@ impl From<&RepoMetadataUpdate> for proto::RepoMetadataUpdatePush {
     }
 }
 
+#[cfg(test)]
+#[path = "repo_metadata_proto_tests.rs"]
+mod tests;
+
 impl From<&StandingQueryContent> for proto::StandingQueryContent {
     fn from(content: &StandingQueryContent) -> Self {
         Self {

--- a/crates/remote_server/src/repo_metadata_proto_tests.rs
+++ b/crates/remote_server/src/repo_metadata_proto_tests.rs
@@ -1,0 +1,58 @@
+use repo_metadata::file_tree_update::RepoMetadataUpdate;
+use repo_metadata::{StandingQueryContent, StandingQueryResultsDelta};
+use warp_util::standardized_path::StandardizedPath;
+
+use super::{proto_snapshot_to_update, proto_to_repo_metadata_update};
+use crate::proto;
+
+fn path(path: &str) -> StandardizedPath {
+    StandardizedPath::try_new(path).unwrap()
+}
+
+fn standing_delta() -> StandingQueryResultsDelta {
+    StandingQueryResultsDelta {
+        upserted_project_skills: vec![StandingQueryContent::file(path(
+            "/repo/.agents/skills/review/SKILL.md",
+        ))],
+        removed_project_skills: vec![StandingQueryContent::directory(path(
+            "/repo/.claude/skills",
+        ))],
+        upserted_project_rules: vec![StandingQueryContent::file(path("/repo/WARP.md"))],
+        removed_project_rules: vec![StandingQueryContent::file(path(
+            "/repo/packages/api/AGENTS.md",
+        ))],
+    }
+}
+
+#[test]
+fn incremental_update_round_trip_preserves_standing_results_delta() {
+    let update = RepoMetadataUpdate {
+        repo_path: path("/repo"),
+        remove_entries: Vec::new(),
+        update_entries: Vec::new(),
+        standing_results_delta: standing_delta(),
+    };
+
+    let proto_update = proto::RepoMetadataUpdatePush::from(&update);
+    let round_trip = proto_to_repo_metadata_update(&proto_update).unwrap();
+
+    assert_eq!(
+        round_trip.standing_results_delta,
+        update.standing_results_delta
+    );
+}
+
+#[test]
+fn snapshot_conversion_seeds_standing_results() {
+    let delta = standing_delta();
+    let snapshot = proto::RepoMetadataSnapshot {
+        repo_path: "/repo".to_string(),
+        entries: Vec::new(),
+        standing_results: Some((&delta).into()),
+        sync_complete: true,
+    };
+
+    let update = proto_snapshot_to_update(&snapshot).unwrap();
+
+    assert_eq!(update.standing_results_delta, delta);
+}

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -12,12 +12,15 @@ use ignore::gitignore::Gitignore;
 use notify_debouncer_full::notify::WatchFilter;
 use thiserror::Error;
 use warp_util::standardized_path::StandardizedPath;
+use crate::standing_queries::{StandingQueryDefinitions, StandingQueryResults};
 
 /// Maximum file size allowed for treesitter parsing (3MB).
 const MAX_FILE_SIZE: usize = 3 * 1000 * 1000;
 
 /// Maximum number of files to load when lazy-loading a directory
 pub const LAZY_LOAD_FILE_LIMIT: usize = 5000;
+/// Maximum relative depth to inspect below a lazy node for standing query matches.
+const STANDING_QUERY_MAX_DEPTH: usize = 3;
 
 #[derive(Debug, Error)]
 pub enum BuildTreeError {
@@ -76,6 +79,10 @@ pub(crate) struct BuildTreeOptions<'a> {
     pub ignored_path_interests: &'a [PathBuf],
     pub budget_exceeded_behavior: BudgetExceededBehavior,
 }
+struct StandingQueryBuildState<'a> {
+    results: &'a mut StandingQueryResults,
+    definitions: &'a StandingQueryDefinitions,
+}
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct FileId(usize);
@@ -95,6 +102,42 @@ impl Entry {
         match self {
             Self::File(file) => &file.path,
             Self::Directory(directory) => &directory.path,
+        }
+    }
+    fn collect_standing_descendants(
+        directory: &Path,
+        current_depth: usize,
+        state: &mut StandingQueryBuildState<'_>,
+    ) {
+        if current_depth >= STANDING_QUERY_MAX_DEPTH {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_symlink() && path.is_dir() {
+                continue;
+            }
+            let path = if path.is_symlink() {
+                path
+            } else {
+                match dunce::canonicalize(path) {
+                    Ok(path) => path,
+                    Err(_) => continue,
+                }
+            };
+            if is_git_internal_path(&path) {
+                continue;
+            }
+            let is_directory = path.is_dir();
+            state
+                .results
+                .record_path(&path, is_directory, state.definitions);
+            if is_directory {
+                Self::collect_standing_descendants(&path, current_depth + 1, state);
+            }
         }
     }
 
@@ -141,6 +184,31 @@ impl Entry {
                 budget_exceeded_behavior,
             },
             false,
+            None,
+        )
+    }
+    /// Builds the materialized tree and standing results during the same filesystem traversal.
+    pub(crate) fn build_tree_with_standing_queries(
+        path: impl Into<PathBuf>,
+        files: &mut Vec<FileMetadata>,
+        gitignores: &mut Vec<Gitignore>,
+        remaining_file_quota: Option<&mut usize>,
+        options: BuildTreeOptions<'_>,
+        standing_results: &mut StandingQueryResults,
+        definitions: &StandingQueryDefinitions,
+    ) -> Result<Self, BuildTreeError> {
+        let mut standing_queries = StandingQueryBuildState {
+            results: standing_results,
+            definitions,
+        };
+        Self::build_tree_with_ignored_path_interests_and_ancestor(
+            path,
+            files,
+            gitignores,
+            remaining_file_quota,
+            options,
+            false,
+            Some(&mut standing_queries),
         )
     }
 
@@ -160,6 +228,7 @@ impl Entry {
             remaining_file_quota,
             options,
             false,
+            None,
         )
     }
 
@@ -187,6 +256,7 @@ impl Entry {
                 budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
             },
             ancestor_is_ignored,
+            None,
         )
     }
 
@@ -198,6 +268,7 @@ impl Entry {
         remaining_file_quota: Option<&mut usize>,
         options: BuildTreeOptions<'_>,
         ancestor_is_ignored: bool,
+        mut standing_queries: Option<&mut StandingQueryBuildState<'_>>,
     ) -> Result<Self, BuildTreeError> {
         let root_path: PathBuf = path.into();
 
@@ -217,6 +288,11 @@ impl Entry {
         // Classify the root. Unlike child entries (which are simply omitted when
         // ignored/symlinked), a classification failure at the root propagates to
         // the caller, preserving existing error behavior.
+        if let Some(state) = standing_queries.as_deref_mut() {
+            state
+                .results
+                .record_path(&root_path, root_path.is_dir(), state.definitions);
+        }
         match evaluate_entry(
             &root_path,
             gitignores,
@@ -235,6 +311,11 @@ impl Entry {
                 Ok(Self::File(metadata))
             }
             EvaluatedEntry::Directory { ignored, lazy } => {
+                if lazy {
+                    if let Some(state) = standing_queries.as_deref_mut() {
+                        Self::collect_standing_descendants(&root_path, 0, state);
+                    }
+                }
                 nodes.push(Some(NodeBuilder::Dir {
                     path: root_path.clone(),
                     ignored,
@@ -273,6 +354,9 @@ impl Entry {
                         }
                     };
                     if !should_expand {
+                        if let Some(state) = standing_queries.as_deref_mut() {
+                            Self::collect_standing_descendants(&job.path, 0, state);
+                        }
                         continue;
                     }
 
@@ -315,6 +399,13 @@ impl Entry {
                         let Some(child_path) = canonical_path else {
                             continue;
                         };
+                        if let Some(state) = standing_queries.as_deref_mut() {
+                            state.results.record_path(
+                                &child_path,
+                                child_path.is_dir(),
+                                state.definitions,
+                            );
+                        }
 
                         match evaluate_entry(
                             &child_path,
@@ -349,7 +440,11 @@ impl Entry {
                                 // without a matching interest) stay unloaded.
                                 // Everything else is queued for expansion,
                                 // subject to the budget gate above.
-                                if !lazy {
+                                if lazy {
+                                    if let Some(state) = standing_queries.as_deref_mut() {
+                                        Self::collect_standing_descendants(&child_path, 0, state);
+                                    }
+                                } else {
                                     queue.push_back(DirJob {
                                         index: child_index,
                                         path: child_path,

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -12,6 +12,7 @@ use ignore::gitignore::Gitignore;
 use notify_debouncer_full::notify::WatchFilter;
 use thiserror::Error;
 use warp_util::standardized_path::StandardizedPath;
+
 use crate::standing_queries::{StandingQueryDefinitions, StandingQueryResults};
 
 /// Maximum file size allowed for treesitter parsing (3MB).
@@ -214,6 +215,7 @@ impl Entry {
 
     /// Builds a tree of entries from a given path, loading ignored paths that match
     /// one of the supplied component-sequence interests instead of leaving them lazy.
+    #[allow(dead_code)]
     pub(crate) fn build_tree_with_ignored_path_interests(
         path: impl Into<PathBuf>,
         files: &mut Vec<FileMetadata>,
@@ -261,7 +263,7 @@ impl Entry {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn build_tree_with_ignored_path_interests_and_ancestor(
+    fn build_tree_with_ignored_path_interests_and_ancestor(
         path: impl Into<PathBuf>,
         files: &mut Vec<FileMetadata>,
         gitignores: &mut Vec<Gitignore>,

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -3,6 +3,7 @@ use std::fs;
 use ignore::gitignore::Gitignore;
 
 use super::{Entry, IgnoredPathStrategy};
+use crate::{StandingQueryDefinitions, StandingQueryResults};
 #[test]
 fn test_git_path_filtering_allowlist() {
     use std::path::Path;
@@ -222,6 +223,49 @@ fn ignored_skill_file_is_loaded_for_registered_provider_path() {
         let skill_file = find_entry(&tree, &repo.join(".agents/skills/test/SKILL.md"))
             .expect("ignored skill file should be present");
         assert!(skill_file.ignored());
+    });
+}
+
+#[test]
+fn standing_queries_report_rules_below_an_unloaded_shallow_directory() {
+    virtual_fs::VirtualFS::test("standing_queries_report_shallow_rules", |dirs, mut vfs| {
+        vfs.mkdir("repo/src/deep")
+            .with_files(vec![virtual_fs::Stub::FileWithContent(
+                "repo/src/deep/WARP.md",
+                "project rules",
+            )]);
+        let repo = dirs.tests().join("repo");
+
+        let mut files = Vec::new();
+        let mut gitignores = Vec::new();
+        let mut results = StandingQueryResults::default();
+        let tree = Entry::build_tree_with_standing_queries(
+            &repo,
+            &mut files,
+            &mut gitignores,
+            None,
+            super::BuildTreeOptions {
+                max_depth: 1,
+                current_depth: 0,
+                ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
+                ignored_path_interests: &[],
+            },
+            &mut results,
+            &StandingQueryDefinitions::default(),
+        )
+        .unwrap();
+
+        let src = find_entry(&tree, &repo.join("src")).expect("src should be represented");
+        assert!(!src.loaded());
+        assert!(find_entry(&tree, &repo.join("src/deep/WARP.md")).is_none());
+
+        let rule_path = warp_util::standardized_path::StandardizedPath::try_from_local(
+            &repo.join("src/deep/WARP.md"),
+        )
+        .unwrap();
+        assert!(results
+            .project_rules()
+            .any(|content| content.path == rule_path));
     });
 }
 

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -188,41 +188,50 @@ fn find_entry<'a>(entry: &'a super::Entry, path: &std::path::Path) -> Option<&'a
         .find_map(|child| find_entry(child, path))
 }
 
-fn build_skill_tree_with_gitignore(root: &std::path::Path, gitignore: &str) -> super::Entry {
-    std::fs::write(root.join(".gitignore"), gitignore).unwrap();
-    let mut files = Vec::new();
-    let mut gitignores = Vec::new();
-    let mut file_limit = 1000;
-    super::Entry::build_tree_with_ignored_path_interests(
-        root,
-        &mut files,
-        &mut gitignores,
-        Some(&mut file_limit),
-        super::BuildTreeOptions {
-            max_depth: 200,
-            current_depth: 0,
-            ignored_path_strategy: &super::IgnoredPathStrategy::IncludeLazy,
-            ignored_path_interests: &[std::path::PathBuf::from(".agents/skills")],
-            budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
-        },
-    )
-    .unwrap()
-}
-
 #[test]
-fn ignored_skill_file_is_loaded_for_registered_provider_path() {
-    virtual_fs::VirtualFS::test("ignored_skill_file_loaded", |dirs, mut vfs| {
+fn standing_queries_report_skills_below_an_ignored_directory() {
+    virtual_fs::VirtualFS::test("standing_queries_report_ignored_skills", |dirs, mut vfs| {
         vfs.mkdir("repo/.agents/skills/test")
             .with_files(vec![virtual_fs::Stub::FileWithContent(
                 "repo/.agents/skills/test/SKILL.md",
                 "name: test",
             )]);
         let repo = dirs.tests().join("repo");
+        std::fs::write(repo.join(".gitignore"), ".agents/\n").unwrap();
 
-        let tree = build_skill_tree_with_gitignore(&repo, ".agents/skills/test/SKILL.md\n");
-        let skill_file = find_entry(&tree, &repo.join(".agents/skills/test/SKILL.md"))
-            .expect("ignored skill file should be present");
-        assert!(skill_file.ignored());
+        let mut files = Vec::new();
+        let mut gitignores = Vec::new();
+        let mut results = StandingQueryResults::default();
+        let mut definitions = StandingQueryDefinitions::default();
+        definitions.set_project_skill_provider_paths([std::path::PathBuf::from(".agents/skills")]);
+        let tree = Entry::build_tree_with_standing_queries(
+            &repo,
+            &mut files,
+            &mut gitignores,
+            None,
+            super::BuildTreeOptions {
+                max_depth: 200,
+                current_depth: 0,
+                ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
+                ignored_path_interests: &[std::path::PathBuf::from(".agents/skills")],
+                budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
+            },
+            &mut results,
+            &definitions,
+        )
+        .unwrap();
+
+        let agents = find_entry(&tree, &repo.join(".agents")).expect(".agents should be present");
+        assert!(agents.loaded());
+        assert!(find_entry(&tree, &repo.join(".agents/skills/test/SKILL.md")).is_some());
+
+        let skill_path = warp_util::standardized_path::StandardizedPath::try_from_local(
+            &repo.join(".agents/skills/test/SKILL.md"),
+        )
+        .unwrap();
+        assert!(results
+            .project_skills()
+            .any(|content| content.path == skill_path && !content.is_directory));
     });
 }
 
@@ -249,6 +258,7 @@ fn standing_queries_report_rules_below_an_unloaded_shallow_directory() {
                 current_depth: 0,
                 ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
                 ignored_path_interests: &[],
+                budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
             },
             &mut results,
             &StandingQueryDefinitions::default(),
@@ -270,77 +280,28 @@ fn standing_queries_report_rules_below_an_unloaded_shallow_directory() {
 }
 
 #[test]
-fn ignored_skill_directory_is_loaded_for_registered_provider_path() {
-    virtual_fs::VirtualFS::test("ignored_skill_dir_loaded", |dirs, mut vfs| {
-        vfs.mkdir("repo/.agents/skills/test")
+fn ignored_directory_stays_lazy() {
+    virtual_fs::VirtualFS::test("ignored_dir_lazy", |dirs, mut vfs| {
+        vfs.mkdir("repo/target/debug")
             .with_files(vec![virtual_fs::Stub::FileWithContent(
-                "repo/.agents/skills/test/SKILL.md",
-                "name: test",
+                "repo/target/debug/app",
+                "binary",
             )]);
         let repo = dirs.tests().join("repo");
-
-        let tree = build_skill_tree_with_gitignore(&repo, ".agents/skills/test/\n");
-        let skill_dir = find_entry(&tree, &repo.join(".agents/skills/test"))
-            .expect("ignored skill directory should be present");
-        assert!(skill_dir.ignored());
-        assert!(skill_dir.loaded());
-        assert!(find_entry(&tree, &repo.join(".agents/skills/test/SKILL.md")).is_some());
-    });
-}
-
-#[test]
-fn ignored_agents_directory_is_loaded_for_registered_provider_path() {
-    virtual_fs::VirtualFS::test("ignored_agents_dir_loaded", |dirs, mut vfs| {
-        vfs.mkdir("repo/.agents/skills/test")
-            .with_files(vec![virtual_fs::Stub::FileWithContent(
-                "repo/.agents/skills/test/SKILL.md",
-                "name: test",
-            )]);
-        let repo = dirs.tests().join("repo");
-
-        let tree = build_skill_tree_with_gitignore(&repo, ".agents/\n");
-        let agents_dir = find_entry(&tree, &repo.join(".agents"))
-            .expect("ignored .agents directory should be present");
-        assert!(agents_dir.ignored());
-        assert!(agents_dir.loaded());
-        assert!(find_entry(&tree, &repo.join(".agents/skills/test/SKILL.md")).is_some());
-    });
-}
-
-#[test]
-fn ignored_agents_skills_directory_is_loaded_for_registered_provider_path() {
-    virtual_fs::VirtualFS::test("ignored_agents_skills_dir_loaded", |dirs, mut vfs| {
-        vfs.mkdir("repo/.agents/skills/test")
-            .with_files(vec![virtual_fs::Stub::FileWithContent(
-                "repo/.agents/skills/test/SKILL.md",
-                "name: test",
-            )]);
-        let repo = dirs.tests().join("repo");
-
-        let tree = build_skill_tree_with_gitignore(&repo, ".agents/skills/\n");
-        let skills_dir = find_entry(&tree, &repo.join(".agents/skills"))
-            .expect("ignored .agents/skills directory should be present");
-        assert!(skills_dir.ignored());
-        assert!(skills_dir.loaded());
-        assert!(find_entry(&tree, &repo.join(".agents/skills/test/SKILL.md")).is_some());
-    });
-}
-
-#[test]
-fn unrelated_ignored_directory_stays_lazy_without_registered_interest() {
-    virtual_fs::VirtualFS::test("unrelated_ignored_dir_lazy", |dirs, mut vfs| {
-        vfs.mkdir("repo/.agents/skills/test")
-            .mkdir("repo/target/debug")
-            .with_files(vec![
-                virtual_fs::Stub::FileWithContent(
-                    "repo/.agents/skills/test/SKILL.md",
-                    "name: test",
-                ),
-                virtual_fs::Stub::FileWithContent("repo/target/debug/app", "binary"),
-            ]);
-        let repo = dirs.tests().join("repo");
-
-        let tree = build_skill_tree_with_gitignore(&repo, "target/\n");
+        std::fs::write(repo.join(".gitignore"), "target/\n").unwrap();
+        let mut files = Vec::new();
+        let mut gitignores = Vec::new();
+        let tree = Entry::build_tree(
+            &repo,
+            &mut files,
+            &mut gitignores,
+            None,
+            200,
+            0,
+            &IgnoredPathStrategy::IncludeLazy,
+            super::BudgetExceededBehavior::StopAndLazyLoad,
+        )
+        .unwrap();
         let target_dir = find_entry(&tree, &repo.join("target"))
             .expect("ignored unrelated directory should be present as lazy");
         assert!(target_dir.ignored());

--- a/crates/repo_metadata/src/file_tree_update.rs
+++ b/crates/repo_metadata/src/file_tree_update.rs
@@ -8,6 +8,7 @@
 use warp_util::standardized_path::StandardizedPath;
 
 use crate::entry::{DirectoryEntry, Entry, FileMetadata};
+use crate::standing_queries::StandingQueryResultsDelta;
 /// Describes how a file-tree entry update should be interpreted by consumers.
 #[derive(Debug, Clone)]
 pub enum MetadataUpdateType {
@@ -31,6 +32,8 @@ pub struct RepoMetadataUpdate {
     pub remove_entries: Vec<StandardizedPath>,
     /// Subtree patches to add or replace in the tree.
     pub update_entries: Vec<FileTreeEntryUpdate>,
+    /// Standing query changes synchronized with this tree change.
+    pub standing_results_delta: StandingQueryResultsDelta,
 }
 
 /// Mirrors `FileTreeEntry` proto.

--- a/crates/repo_metadata/src/file_tree_update_tests.rs
+++ b/crates/repo_metadata/src/file_tree_update_tests.rs
@@ -315,6 +315,7 @@ fn apply_complete_update_adds_files_and_directories() {
                 }),
             ],
         }],
+        standing_results_delta: Default::default(),
     };
 
     tree.apply_repo_metadata_update(&update);
@@ -361,6 +362,7 @@ fn apply_update_with_removals_and_additions() {
                 ignored: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
 
     tree.apply_repo_metadata_update(&update);
@@ -391,6 +393,7 @@ fn apply_incomplete_update_missing_children_subtree() {
                 loaded: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
 
     tree.apply_repo_metadata_update(&update);
@@ -419,6 +422,7 @@ fn apply_incomplete_update_missing_children_subtree() {
                 ignored: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
 
     tree.apply_repo_metadata_update(&followup);
@@ -446,6 +450,7 @@ fn apply_incomplete_update_missing_parent_from_undelivered_page() {
                 ignored: false,
             })],
         }],
+        standing_results_delta: Default::default(),
     };
 
     tree.apply_repo_metadata_update(&update);

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -43,6 +43,7 @@ pub mod remote_model;
 pub mod repositories;
 pub mod repository;
 pub mod repository_identifier;
+pub mod standing_queries;
 mod telemetry;
 pub mod watcher;
 pub mod wrapper_model;
@@ -76,6 +77,9 @@ pub use file_tree_update::{MetadataUpdateType, RepoMetadataUpdate};
 pub use local_model::{LocalRepoMetadataModel, RepoContent};
 pub use remote_model::RemoteRepoMetadataModel;
 pub use repository_identifier::{RemoteRepositoryIdentifier, RepositoryIdentifier};
+pub use standing_queries::{
+    StandingQueryContent, StandingQueryDefinitions, StandingQueryResults, StandingQueryResultsDelta,
+};
 pub use wrapper_model::{RepoMetadataEvent, RepoMetadataModel};
 
 /// A wrapper around PathBuf that ensures the path is canonicalized.

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -744,15 +744,6 @@ impl LocalRepoMetadataModel {
             if !path_to_add.exists() {
                 continue;
             }
-            // Directory symlinks are intentionally absent from the canonical tree.
-            // Re-hydrate only when the changed entry itself can introduce a
-            // symlinked skill; ordinary descendants should not wake consumers.
-            if path_to_add.is_symlink() && path_to_add.is_dir() {
-                standing_results.record_direct_project_skill_provider_child_change(
-                    path_to_add,
-                    standing_query_definitions,
-                );
-            }
 
             let is_ignored = Self::path_is_ignored(path_to_add, gitignores);
 
@@ -781,7 +772,15 @@ impl LocalRepoMetadataModel {
                             subtree,
                         });
                     }
-                    Err(BuildTreeError::Symlink) => {}
+                    Err(BuildTreeError::Symlink) => {
+                        // Directory symlinks are intentionally absent from the canonical tree.
+                        // Re-hydrate only when the changed entry itself can introduce a
+                        // symlinked skill; ordinary descendants should not wake consumers.
+                        standing_results.record_direct_project_skill_provider_child_change(
+                            path_to_add,
+                            standing_query_definitions,
+                        );
+                    }
                     Err(e) => {
                         log::warn!("Failed to build subtree for directory {path_to_add:?}: {e:?}");
                         mutations.push(FileTreeMutation::AddEmptyDirectory {

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -26,6 +26,9 @@ use crate::entry::{
     BudgetExceededBehavior, BuildTreeError, BuildTreeOptions, Entry, FileId, IgnoredPathStrategy,
 };
 use crate::repository::Repository;
+use crate::standing_queries::{
+    StandingQueryDefinitions, StandingQueryResults, StandingQueryResultsDelta,
+};
 use crate::telemetry::RepoMetadataTelemetryEvent;
 use crate::{gitignores_for_directory, matches_gitignores, RepoMetadataError};
 cfg_if::cfg_if! {
@@ -92,6 +95,11 @@ pub enum RepositoryMetadataEvent {
         /// refresh because the entry was replaced without one.
         update_type: MetadataUpdateType,
     },
+    /// The paths retained for standing queries changed.
+    StandingQueryResultsUpdated {
+        path: StandardizedPath,
+        delta: StandingQueryResultsDelta,
+    },
     UpdatingRepositoryFailed {
         path: StandardizedPath,
     },
@@ -150,6 +158,8 @@ impl IndexedRepoState {
 pub struct LocalRepoMetadataModel {
     /// Mapping from repository path to its indexed state.
     repositories: HashMap<StandardizedPath, IndexedRepoState>,
+    /// Stored context-discovery matches, independent from canonical tree materialization.
+    standing_results: HashMap<StandardizedPath, StandingQueryResults>,
     /// Refcounts for lazily-loaded standalone paths tracked in the model.
     lazy_loaded_paths: HashMap<StandardizedPath, usize>,
     /// File system watcher for monitoring changes.
@@ -163,6 +173,8 @@ pub struct LocalRepoMetadataModel {
     /// For example, a consumer can register `.foo/bar` so ignored `.foo`,
     /// `.foo/bar`, and descendants of `.foo/bar` are loaded into the tree.
     ignored_path_interests: Vec<PathBuf>,
+    /// Configured standing-query matchers.
+    standing_query_definitions: StandingQueryDefinitions,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -243,11 +255,13 @@ impl LocalRepoMetadataModel {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
         let mut model = Self {
             repositories: HashMap::new(),
+            standing_results: HashMap::new(),
             lazy_loaded_paths: HashMap::new(),
             #[cfg(feature = "local_fs")]
             watcher: None,
             emit_incremental_updates: false,
             ignored_path_interests: Vec::new(),
+            standing_query_definitions: StandingQueryDefinitions::default(),
         };
         cfg_if::cfg_if! {
             if #[cfg(feature = "local_fs")] {
@@ -303,6 +317,11 @@ impl LocalRepoMetadataModel {
         }
     }
 
+    pub fn set_project_skill_provider_paths(&mut self, paths: impl IntoIterator<Item = PathBuf>) {
+        self.standing_query_definitions
+            .set_project_skill_provider_paths(paths);
+    }
+
     /// Handles events from the BulkFilesystemWatcher.
     #[cfg(feature = "local_fs")]
     fn handle_watcher_event(
@@ -355,32 +374,55 @@ impl LocalRepoMetadataModel {
                 let repo_path_clone = repo_path.clone();
                 let gitignores_clone = state.gitignores.clone();
                 let ignored_path_interests = self.ignored_path_interests.clone();
+                let standing_query_definitions = self.standing_query_definitions.clone();
                 let lazy_load = self.lazy_loaded_paths.contains_key(&repo_path);
                 ctx.spawn(
                     async move {
-                        let mutations = Self::compute_file_tree_mutations(
-                            &repo_scoped_update,
-                            &gitignores_clone,
-                            &ignored_path_interests,
+                        let (mutations, standing_results, removed_roots) =
+                            Self::compute_file_tree_mutations(
+                                &repo_scoped_update,
+                                &gitignores_clone,
+                                &ignored_path_interests,
+                                &standing_query_definitions,
+                            )
+                            .await;
+                        (
+                            mutations,
+                            standing_results,
+                            removed_roots,
+                            repo_path_clone,
+                            lazy_load,
                         )
-                        .await;
-                        (mutations, repo_path_clone, lazy_load)
                     },
-                    |model, (mutations, repo_path, lazy_load), ctx| {
+                    |model,
+                     (mutations, discovered_results, removed_roots, repo_path, lazy_load),
+                     ctx| {
                         if let Some(IndexedRepoState::Indexed(state)) =
                             model.repositories.get_mut(&repo_path)
                         {
-                            let update = Self::apply_file_tree_mutations(
+                            let mut update = Self::apply_file_tree_mutations(
                                 &mut state.entry,
                                 mutations,
                                 lazy_load,
                                 true,
                             )
                             .expect("update tracking was enabled");
+                            let standing_delta = model
+                                .standing_results
+                                .entry(repo_path.clone())
+                                .or_default()
+                                .replace_subtrees(&removed_roots, discovered_results);
+                            update.standing_results_delta = standing_delta.clone();
                             ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
-                                path: repo_path,
+                                path: repo_path.clone(),
                                 update_type: MetadataUpdateType::IncrementalUpdate(update.clone()),
                             });
+                            if !standing_delta.is_empty() {
+                                ctx.emit(RepositoryMetadataEvent::StandingQueryResultsUpdated {
+                                    path: repo_path,
+                                    delta: standing_delta,
+                                });
+                            }
                             if model.emit_incremental_updates {
                                 ctx.emit(RepositoryMetadataEvent::IncrementalUpdateReady {
                                     update,
@@ -468,6 +510,7 @@ impl LocalRepoMetadataModel {
         ctx: &mut ModelContext<Self>,
     ) -> Result<(), RepoMetadataError> {
         if self.remove_repository_state(repo_path).is_some() {
+            self.standing_results.remove(repo_path);
             // Unregister from watcher
             #[cfg(feature = "local_fs")]
             {
@@ -496,6 +539,13 @@ impl LocalRepoMetadataModel {
             IndexedRepoState::Pending(_) => None,
             IndexedRepoState::Failed(_) => None,
         }
+    }
+
+    pub fn standing_query_results(
+        &self,
+        repo_path: &StandardizedPath,
+    ) -> Option<&StandingQueryResults> {
+        self.standing_results.get(repo_path)
     }
 
     /// Returns the current [`IndexedRepoState`] for the specified repository or `None` if the
@@ -553,22 +603,30 @@ impl LocalRepoMetadataModel {
             ));
         }
 
-        // Build first-level-only tree.
+        // Build first-level-only tree while collecting standing results across
+        // descendants that are not materialized in the lazy file tree.
         let mut files = Vec::new();
         let mut file_limit = MAX_FILES_PER_REPO;
-        let root_entry = Entry::build_tree(
+        let mut standing_results = StandingQueryResults::default();
+        let root_entry = Entry::build_tree_with_standing_queries(
             &local_path,
             &mut files,
             &mut vec![],
             Some(&mut file_limit),
-            1, // max_depth — only first level
-            0,
-            &IgnoredPathStrategy::Include,
-            BudgetExceededBehavior::StopAndLazyLoad,
+            BuildTreeOptions {
+                max_depth: 1, // Only first level.
+                current_depth: 0,
+                ignored_path_strategy: &IgnoredPathStrategy::Include,
+                ignored_path_interests: &self.ignored_path_interests,
+                budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
+            },
+            &mut standing_results,
+            &self.standing_query_definitions,
         )
         .map_err(RepoMetadataError::BuildTree)?;
 
         let state = FileTreeState::new_lazy_loaded(root_entry);
+        self.standing_results.insert(path.clone(), standing_results);
         self.add_repository_internal(path.clone(), state, ctx)?;
         self.lazy_loaded_paths.insert(path.clone(), 1);
         Ok(())
@@ -636,12 +694,22 @@ impl LocalRepoMetadataModel {
         update: &RepoUpdate,
         gitignores: &[Gitignore],
         ignored_path_interests: &[PathBuf],
-    ) -> Vec<FileTreeMutation> {
+        standing_query_definitions: &StandingQueryDefinitions,
+    ) -> (
+        Vec<FileTreeMutation>,
+        StandingQueryResults,
+        Vec<StandardizedPath>,
+    ) {
         let mut mutations = Vec::new();
+        let mut standing_results = StandingQueryResults::default();
+        let mut removed_roots = Vec::new();
 
         // Removals for deleted and moved-from paths
         for path_to_remove in update.deleted.iter().chain(update.moved.values()) {
             mutations.push(FileTreeMutation::Remove(path_to_remove.clone()));
+            if let Ok(path) = StandardizedPath::try_from_local(path_to_remove) {
+                removed_roots.push(path);
+            }
         }
 
         // Additions for new and moved-to paths
@@ -656,7 +724,7 @@ impl LocalRepoMetadataModel {
                 let mut files = Vec::new();
                 let mut gitignores = gitignores.to_owned();
                 let mut file_limit = MAX_FILES_PER_REPO;
-                match Entry::build_tree_with_ignored_path_interests_and_ancestor(
+                match Entry::build_tree_with_standing_queries(
                     path_to_add,
                     &mut files,
                     &mut gitignores,
@@ -668,7 +736,8 @@ impl LocalRepoMetadataModel {
                         ignored_path_interests,
                         budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
                     },
-                    is_ignored,
+                    &mut standing_results,
+                    standing_query_definitions,
                 ) {
                     Ok(subtree) => {
                         mutations.push(FileTreeMutation::AddDirectorySubtree {
@@ -685,6 +754,7 @@ impl LocalRepoMetadataModel {
                     }
                 }
             } else {
+                standing_results.record_path(path_to_add, false, standing_query_definitions);
                 let extension = path_to_add
                     .extension()
                     .and_then(|ext| ext.to_str().map(|s| s.to_owned()));
@@ -696,7 +766,7 @@ impl LocalRepoMetadataModel {
             }
         }
 
-        mutations
+        (mutations, standing_results, removed_roots)
     }
 
     /// Phase 2: Applies pre-computed mutations to the file tree on the main thread.
@@ -856,6 +926,7 @@ impl LocalRepoMetadataModel {
             repo_path: root_entry.root_directory().as_ref().clone(),
             remove_entries,
             update_entries,
+            standing_results_delta: StandingQueryResultsDelta::default(),
         })
     }
 
@@ -949,6 +1020,7 @@ impl LocalRepoMetadataModel {
         let repo_path_for_build = local_path;
         let gitignores_for_build = gitignores.clone();
         let ignored_path_interests = self.ignored_path_interests.clone();
+        let standing_query_definitions = self.standing_query_definitions.clone();
         let repo_path_str_for_log = std_path.to_string();
         let std_path_for_completion = std_path;
         let repository_handle_for_completion = repository_handle.clone();
@@ -957,6 +1029,7 @@ impl LocalRepoMetadataModel {
             async move {
                 let mut files: Vec<crate::entry::FileMetadata> = Vec::new();
                 let mut gitignores_for_build = gitignores_for_build;
+                let mut standing_results = StandingQueryResults::default();
 
                 // Budget for non-ignored files. When it is exhausted the builder
                 // stops descending breadth-first and leaves the remaining
@@ -966,7 +1039,7 @@ impl LocalRepoMetadataModel {
                 // both are handled inside the builder.
                 let mut file_limit = MAX_FILES_PER_REPO;
 
-                let build_result = Entry::build_tree_with_ignored_path_interests(
+                let build_result = Entry::build_tree_with_standing_queries(
                     &repo_path_for_build,
                     &mut files,
                     &mut gitignores_for_build,
@@ -978,6 +1051,8 @@ impl LocalRepoMetadataModel {
                         ignored_path_interests: &ignored_path_interests,
                         budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
                     },
+                    &mut standing_results,
+                    &standing_query_definitions,
                 );
 
                 // A fully-exhausted budget means the repo was too large to index
@@ -993,6 +1068,7 @@ impl LocalRepoMetadataModel {
                     std_path_for_completion,
                     repository_handle_for_completion,
                     indexed_with_limit,
+                    standing_results,
                 )
             },
             move |model: &mut LocalRepoMetadataModel,
@@ -1004,10 +1080,14 @@ impl LocalRepoMetadataModel {
                       std_repo_path,
                       repository_handle,
                       indexed_with_limit,
-                  ): (Result<Entry, _>, Vec<crate::entry::FileMetadata>, _, String, StandardizedPath, ModelHandle<Repository>, bool),
+                      standing_results,
+                  ): (Result<Entry, _>, Vec<crate::entry::FileMetadata>, _, String, StandardizedPath, ModelHandle<Repository>, bool, StandingQueryResults),
                   ctx| {
                 match build_result {
                     Ok(root_entry) => {
+                        model
+                            .standing_results
+                            .insert(std_repo_path.clone(), standing_results);
                         let state =
                             FileTreeState::new(root_entry, gitignores_for_build, Some(repository_handle));
 
@@ -1116,6 +1196,7 @@ impl LocalRepoMetadataModel {
         error: RepoMetadataError,
         ctx: &mut ModelContext<Self>,
     ) {
+        self.standing_results.remove(&repo_path);
         self.replace_repository_state(repo_path.clone(), IndexedRepoState::Failed(error));
         ctx.emit(RepositoryMetadataEvent::UpdatingRepositoryFailed { path: repo_path });
     }
@@ -1190,6 +1271,14 @@ impl LocalRepoMetadataModel {
     /// Insert a repository state directly for testing purposes.
     pub fn insert_test_state(&mut self, repo_path: StandardizedPath, state: FileTreeState) {
         self.replace_repository_state(repo_path, IndexedRepoState::Indexed(state));
+    }
+
+    pub fn insert_test_standing_results(
+        &mut self,
+        repo_path: StandardizedPath,
+        standing_results: StandingQueryResults,
+    ) {
+        self.standing_results.insert(repo_path, standing_results);
     }
 }
 

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -296,7 +296,6 @@ impl LocalRepoMetadataModel {
     pub fn set_emit_incremental_updates(&mut self, enabled: bool) {
         self.emit_incremental_updates = enabled;
     }
-
     /// Registers component-sequence paths that should be loaded even when ignored.
     ///
     /// This stays intentionally generic: consumers own the meaning of the paths,
@@ -334,7 +333,7 @@ impl LocalRepoMetadataModel {
 
         // Process added or updated files
         for path in event.added_or_updated_iter() {
-            if let Some(repo_path) = self.find_repository_for_path(path) {
+            if let Some(repo_path) = self.find_repository_for_watcher_entry_path(path) {
                 let repo_update = repo_updates.entry(repo_path).or_default();
                 repo_update.added.push(path.to_path_buf());
             }
@@ -354,7 +353,7 @@ impl LocalRepoMetadataModel {
 
         // Process moved files
         for (to_path, from_path) in &event.moved {
-            if let Some(repo_path) = self.find_repository_for_path(to_path) {
+            if let Some(repo_path) = self.find_repository_for_watcher_entry_path(to_path) {
                 let repo_update = repo_updates.entry(repo_path).or_default();
                 repo_update
                     .moved
@@ -448,9 +447,31 @@ impl LocalRepoMetadataModel {
     }
 
     #[cfg(feature = "local_fs")]
+    fn find_repository_for_standardized_path(
+        &self,
+        path: &StandardizedPath,
+    ) -> Option<StandardizedPath> {
+        self.repositories
+            .iter()
+            .filter(|(repo_path, state)| {
+                path.starts_with(repo_path) && matches!(state, IndexedRepoState::Indexed(_))
+            })
+            .max_by_key(|(repo_path, _)| repo_path.as_str().len())
+            .map(|(repo_path, _)| repo_path.clone())
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn find_repository_for_watcher_entry_path(&self, path: &Path) -> Option<StandardizedPath> {
+        StandardizedPath::try_from_local(path)
+            .ok()
+            .and_then(|path| self.find_repository_for_standardized_path(&path))
+            .or_else(|| self.find_repository_for_path(path))
+    }
+
+    #[cfg(feature = "local_fs")]
     pub fn find_repository_for_path(&self, path: &Path) -> Option<StandardizedPath> {
         match StandardizedPath::from_local_canonicalized(path) {
-            Ok(std_path) => self.find_repository_for_path_string(std_path.as_str()),
+            Ok(std_path) => self.find_repository_for_standardized_path(&std_path),
             Err(_) => None,
         }
     }
@@ -710,12 +731,27 @@ impl LocalRepoMetadataModel {
             if let Ok(path) = StandardizedPath::try_from_local(path_to_remove) {
                 removed_roots.push(path);
             }
+            // A removed direct provider child may have been a symlinked skill directory,
+            // which is intentionally absent from the canonical tree and standing file matches.
+            standing_results.record_direct_project_skill_provider_child_change(
+                path_to_remove,
+                standing_query_definitions,
+            );
         }
 
         // Additions for new and moved-to paths
         for path_to_add in update.added.iter().chain(update.moved.keys()) {
             if !path_to_add.exists() {
                 continue;
+            }
+            // Directory symlinks are intentionally absent from the canonical tree.
+            // Re-hydrate only when the changed entry itself can introduce a
+            // symlinked skill; ordinary descendants should not wake consumers.
+            if path_to_add.is_symlink() && path_to_add.is_dir() {
+                standing_results.record_direct_project_skill_provider_child_change(
+                    path_to_add,
+                    standing_query_definitions,
+                );
             }
 
             let is_ignored = Self::path_is_ignored(path_to_add, gitignores);
@@ -745,6 +781,7 @@ impl LocalRepoMetadataModel {
                             subtree,
                         });
                     }
+                    Err(BuildTreeError::Symlink) => {}
                     Err(e) => {
                         log::warn!("Failed to build subtree for directory {path_to_add:?}: {e:?}");
                         mutations.push(FileTreeMutation::AddEmptyDirectory {

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -28,11 +28,13 @@ impl LocalRepoMetadataModel {
     fn new_for_test() -> Self {
         Self {
             repositories: HashMap::new(),
+            standing_results: HashMap::new(),
             lazy_loaded_paths: Default::default(),
             #[cfg(feature = "local_fs")]
             watcher: Default::default(),
             emit_incremental_updates: false,
             ignored_path_interests: Vec::new(),
+            standing_query_definitions: Default::default(),
         }
     }
 }
@@ -352,6 +354,39 @@ fn test_lazy_loaded_path_registrations_are_refcounted() {
                 assert!(!model.has_repository(
                     &StandardizedPath::from_local_canonicalized(&shared_dir).unwrap()
                 ));
+            });
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_lazy_loaded_path_builds_standing_rule_results_below_shallow_tree() {
+    VirtualFS::test("lazy_loaded_path_standing_rules", |dirs, mut vfs| {
+        vfs.mkdir("workspace/src/deep")
+            .with_files(vec![Stub::FileWithContent(
+                "workspace/src/deep/WARP.md",
+                "project rules",
+            )]);
+
+        let workspace = dirs.tests().join("workspace");
+        App::test((), |mut app| async move {
+            let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
+            let workspace_path = StandardizedPath::from_local_canonicalized(&workspace).unwrap();
+            let rule_path =
+                StandardizedPath::try_from_local(&workspace.join("src/deep/WARP.md")).unwrap();
+
+            model_handle.update(&mut app, |model, ctx| {
+                model.index_lazy_loaded_path(&workspace_path, ctx).unwrap();
+            });
+
+            model_handle.read(&app, |model, _ctx| {
+                let results = model
+                    .standing_query_results(&workspace_path)
+                    .expect("lazy indexed paths should retain standing results");
+                assert!(results
+                    .project_rules()
+                    .any(|content| content.path == rule_path));
             });
         });
     });
@@ -730,10 +765,12 @@ fn test_update_file_tree_entry_respects_gitignore() {
         };
 
         // Compute mutations on the "background thread" then apply on the "main thread".
-        let mutations = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+        let standing_query_definitions = Default::default();
+        let (mutations, _, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
             &update,
             &gitignores,
             &[],
+            &standing_query_definitions,
         ));
         LocalRepoMetadataModel::apply_file_tree_mutations(&mut root, mutations, false, false);
 

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -14,6 +14,8 @@ use virtual_fs::{Stub, VirtualFS};
 use warp_util::standardized_path::StandardizedPath;
 use warpui_core::r#async::FutureExt as _;
 use warpui_core::App;
+#[cfg(all(unix, feature = "local_fs"))]
+use watcher::BulkFilesystemWatcherEvent;
 
 use crate::entry::{DirectoryEntry, Entry, FileMetadata};
 use crate::file_tree_store::{FileTreeEntry, FileTreeEntryState, FileTreeState};
@@ -22,7 +24,7 @@ use crate::local_model::{
 };
 use crate::repositories::DetectedRepositories;
 use crate::watcher::DirectoryWatcher;
-use crate::RepoMetadataError;
+use crate::{RepoMetadataError, StandingQueryContent, StandingQueryDefinitions};
 
 impl LocalRepoMetadataModel {
     fn new_for_test() -> Self {
@@ -33,7 +35,7 @@ impl LocalRepoMetadataModel {
             #[cfg(feature = "local_fs")]
             watcher: Default::default(),
             emit_incremental_updates: false,
-            ignored_path_interests: Vec::new(),
+            ignored_path_interests: Default::default(),
             standing_query_definitions: Default::default(),
         }
     }
@@ -1222,6 +1224,185 @@ fn collect_paths_recursive(
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn added_symlinked_skill_directory_refreshes_provider_without_canonical_tree_mutation() {
+    VirtualFS::test("added_symlinked_skill_directory", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills")
+            .mkdir("linked-skill-target")
+            .with_files(vec![Stub::FileWithContent(
+                "linked-skill-target/SKILL.md",
+                "linked skill",
+            )]);
+        let repo = dirs.tests().join("repo");
+        let provider = repo.join(".agents/skills");
+        let linked_skill = provider.join("linked-skill");
+        std::os::unix::fs::symlink(dirs.tests().join("linked-skill-target"), &linked_skill)
+            .unwrap();
+
+        let mut definitions = StandingQueryDefinitions::default();
+        definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+        let update = RepoUpdate {
+            added: vec![linked_skill],
+            ..Default::default()
+        };
+        let (mutations, discovered, removed_roots) = block_on(
+            LocalRepoMetadataModel::compute_file_tree_mutations(&update, &[], &[], &definitions),
+        );
+
+        assert!(mutations.is_empty());
+        assert!(removed_roots.is_empty());
+        assert!(discovered.project_skills().any(|content| {
+            content
+                == &StandingQueryContent::directory(
+                    StandardizedPath::try_from_local(&provider).unwrap(),
+                )
+        }));
+    });
+}
+
+#[test]
+fn unrelated_skill_support_file_does_not_refresh_project_skills() {
+    VirtualFS::test("unrelated_skill_support_file", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills/review")
+            .with_files(vec![Stub::FileWithContent(
+                "repo/.agents/skills/review/README.md",
+                "notes",
+            )]);
+        let repo = dirs.tests().join("repo");
+        let support_file = repo.join(".agents/skills/review/README.md");
+
+        let mut definitions = StandingQueryDefinitions::default();
+        definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+        let update = RepoUpdate {
+            added: vec![support_file],
+            ..Default::default()
+        };
+        let (_, discovered, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+            &update,
+            &[],
+            &[],
+            &definitions,
+        ));
+
+        assert!(discovered.project_skills().next().is_none());
+    });
+}
+
+#[test]
+fn removed_direct_skill_child_refreshes_provider_for_possible_symlink_removal() {
+    VirtualFS::test("removed_direct_skill_child", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills");
+        let provider = dirs.tests().join("repo/.agents/skills");
+
+        let mut definitions = StandingQueryDefinitions::default();
+        definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+        let update = RepoUpdate {
+            deleted: vec![provider.join("removed-skill")],
+            ..Default::default()
+        };
+        let (_, discovered, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+            &update,
+            &[],
+            &[],
+            &definitions,
+        ));
+
+        assert!(discovered.project_skills().any(|content| {
+            content
+                == &StandingQueryContent::directory(
+                    StandardizedPath::try_from_local(&provider).unwrap(),
+                )
+        }));
+    });
+}
+#[cfg(all(unix, feature = "local_fs"))]
+#[test]
+fn added_external_target_skill_symlink_routes_to_lexical_repository() {
+    VirtualFS::test(
+        "added_external_target_skill_symlink_routing",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.agents/skills")
+                .mkdir("outside/linked-skill")
+                .with_files(vec![Stub::FileWithContent(
+                    "outside/linked-skill/SKILL.md",
+                    "linked skill",
+                )]);
+            let repo = dirs.tests().join("repo");
+            let provider = repo.join(".agents/skills");
+            let linked_skill = provider.join("linked-skill");
+            std::os::unix::fs::symlink(dirs.tests().join("outside/linked-skill"), &linked_skill)
+                .unwrap();
+
+            App::test((), |mut app| async move {
+                let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
+                let provider_path = StandardizedPath::try_from_local(&provider).unwrap();
+                let model_handle = app.add_model(|_| {
+                    let mut model = LocalRepoMetadataModel::new_for_test();
+                    model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+                    model
+                });
+                model_handle.update(&mut app, |model, _ctx| {
+                    model.repositories.insert(
+                        repo_path.clone(),
+                        IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
+                    );
+                });
+
+                let (tx, rx) = oneshot::channel();
+                let received_delta = Rc::new(RefCell::new(Some(tx)));
+                let received_delta_for_event = received_delta.clone();
+                let repo_path_for_event = repo_path.clone();
+                let provider_path_for_event = provider_path.clone();
+                app.update(|ctx| {
+                    ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
+                        if let RepositoryMetadataEvent::StandingQueryResultsUpdated {
+                            path,
+                            delta,
+                        } = event
+                        {
+                            if path == &repo_path_for_event
+                                && delta.upserted_project_skills.iter().any(|content| {
+                                    content
+                                        == &StandingQueryContent::directory(
+                                            provider_path_for_event.clone(),
+                                        )
+                                })
+                            {
+                                if let Some(tx) = received_delta_for_event.borrow_mut().take() {
+                                    let _ = tx.send(());
+                                }
+                            }
+                        }
+                    });
+                });
+
+                model_handle.update(&mut app, |model, ctx| {
+                    model.handle_watcher_event(
+                        &BulkFilesystemWatcherEvent {
+                            added: std::collections::HashSet::from([linked_skill]),
+                            ..Default::default()
+                        },
+                        ctx,
+                    );
+                });
+                rx.with_timeout(Duration::from_secs(5))
+                    .await
+                    .expect("timed out waiting for standing project-skill update")
+                    .expect("standing project-skill update sender dropped");
+
+                model_handle.read(&app, |model, _ctx| {
+                    assert!(model
+                        .standing_query_results(&repo_path)
+                        .expect("standing results should be retained for the repository")
+                        .project_skills()
+                        .any(|content| content
+                            == &StandingQueryContent::directory(provider_path.clone())));
+                });
+            });
+        },
+    );
+}
 #[test]
 fn test_canonicalized_path_functionality() {
     use warp_util::standardized_path::StandardizedPath;

--- a/crates/repo_metadata/src/remote_model.rs
+++ b/crates/repo_metadata/src/remote_model.rs
@@ -300,3 +300,7 @@ impl RemoteRepoMetadataModel {
         self.replace_repository_state(id, IndexedRepoState::Indexed(state));
     }
 }
+
+#[cfg(test)]
+#[path = "remote_model_tests.rs"]
+mod tests;

--- a/crates/repo_metadata/src/remote_model.rs
+++ b/crates/repo_metadata/src/remote_model.rs
@@ -16,6 +16,7 @@ use crate::file_tree_store::{FileTreeEntry, FileTreeState};
 use crate::file_tree_update::{MetadataUpdateType, RepoMetadataUpdate};
 use crate::local_model::{GetContentsArgs, IndexedRepoState, RepoContent};
 use crate::repository_identifier::RemoteRepositoryIdentifier;
+use crate::standing_queries::{StandingQueryResults, StandingQueryResultsDelta};
 use crate::RepoMetadataError;
 
 /// Events emitted by the [`RemoteRepoMetadataModel`].
@@ -36,6 +37,10 @@ pub enum RemoteRepositoryMetadataEvent {
         /// replacement.
         update_type: MetadataUpdateType,
     },
+    StandingQueryResultsUpdated {
+        id: RemoteRepositoryIdentifier,
+        delta: StandingQueryResultsDelta,
+    },
 }
 
 /// Client-side model for remote repository metadata.
@@ -48,12 +53,14 @@ pub enum RemoteRepositoryMetadataEvent {
 /// wrapper rather than using this type directly.
 pub struct RemoteRepoMetadataModel {
     repositories: HashMap<RemoteRepositoryIdentifier, IndexedRepoState>,
+    standing_results: HashMap<RemoteRepositoryIdentifier, StandingQueryResults>,
 }
 
 impl RemoteRepoMetadataModel {
     pub fn new(_ctx: &mut ModelContext<Self>) -> Self {
         Self {
             repositories: HashMap::new(),
+            standing_results: HashMap::new(),
         }
     }
 
@@ -76,6 +83,13 @@ impl RemoteRepoMetadataModel {
             IndexedRepoState::Indexed(state) => Some(state),
             IndexedRepoState::Pending(_) | IndexedRepoState::Failed(_) => None,
         }
+    }
+
+    pub fn standing_query_results(
+        &self,
+        id: &RemoteRepositoryIdentifier,
+    ) -> Option<&StandingQueryResults> {
+        self.standing_results.get(id)
     }
 
     /// Returns whether the given remote repository is indexed.
@@ -185,6 +199,9 @@ impl RemoteRepoMetadataModel {
         entry.apply_repo_metadata_update(update);
         let state = FileTreeState::from_file_tree_entry(entry);
         let id = RemoteRepositoryIdentifier::new(host_id, update.repo_path.clone());
+        let mut standing_results = StandingQueryResults::default();
+        standing_results.apply_delta(&update.standing_results_delta);
+        self.standing_results.insert(id.clone(), standing_results);
         self.insert_repository(id, state, ctx);
     }
 
@@ -229,8 +246,18 @@ impl RemoteRepoMetadataModel {
         if let Some(IndexedRepoState::Indexed(state)) = self.repositories.get_mut(&id) {
             state.entry.apply_repo_metadata_update(update);
             ctx.emit(RemoteRepositoryMetadataEvent::FileTreeEntryUpdated {
-                id,
+                id: id.clone(),
                 update_type: MetadataUpdateType::IncrementalUpdate(update.clone()),
+            });
+        }
+        if !update.standing_results_delta.is_empty() {
+            self.standing_results
+                .entry(id.clone())
+                .or_default()
+                .apply_delta(&update.standing_results_delta);
+            ctx.emit(RemoteRepositoryMetadataEvent::StandingQueryResultsUpdated {
+                id,
+                delta: update.standing_results_delta.clone(),
             });
         }
     }
@@ -257,6 +284,7 @@ impl RemoteRepoMetadataModel {
         &mut self,
         id: &RemoteRepositoryIdentifier,
     ) -> Option<IndexedRepoState> {
+        self.standing_results.remove(id);
         let previous = self.repositories.remove(id);
         if let Some(previous) = &previous {
             previous.complete_if_pending();

--- a/crates/repo_metadata/src/remote_model_tests.rs
+++ b/crates/repo_metadata/src/remote_model_tests.rs
@@ -1,0 +1,53 @@
+use warp_util::standardized_path::StandardizedPath;
+use warpui_core::App;
+
+use super::*;
+use crate::StandingQueryContent;
+
+fn path(path: &str) -> StandardizedPath {
+    StandardizedPath::try_new(path).unwrap()
+}
+
+#[test]
+fn snapshot_and_incremental_update_maintain_remote_standing_results() {
+    App::test((), |mut app| async move {
+        let model = app.add_model(RemoteRepoMetadataModel::new);
+        let host = HostId::new("remote-host".to_string());
+        let repo_path = path("/repo");
+        let skill = StandingQueryContent::file(path("/repo/.agents/skills/review/SKILL.md"));
+        let rule = StandingQueryContent::file(path("/repo/WARP.md"));
+        let id = RemoteRepositoryIdentifier::new(host.clone(), repo_path.clone());
+        let snapshot = RepoMetadataUpdate {
+            repo_path: repo_path.clone(),
+            remove_entries: Vec::new(),
+            update_entries: Vec::new(),
+            standing_results_delta: StandingQueryResultsDelta {
+                upserted_project_skills: vec![skill.clone()],
+                ..Default::default()
+            },
+        };
+        model.update(&mut app, |model, ctx| {
+            model.insert_from_snapshot(host.clone(), &snapshot, ctx);
+        });
+
+        let incremental = RepoMetadataUpdate {
+            repo_path,
+            remove_entries: Vec::new(),
+            update_entries: Vec::new(),
+            standing_results_delta: StandingQueryResultsDelta {
+                removed_project_skills: vec![skill],
+                upserted_project_rules: vec![rule.clone()],
+                ..Default::default()
+            },
+        };
+        model.update(&mut app, |model, ctx| {
+            model.apply_incremental_update(&host, &incremental, ctx);
+        });
+
+        model.read(&app, |model, _ctx| {
+            let results = model.standing_query_results(&id).unwrap();
+            assert!(results.project_skills().next().is_none());
+            assert!(results.project_rules().any(|content| content == &rule));
+        });
+    });
+}

--- a/crates/repo_metadata/src/standing_queries.rs
+++ b/crates/repo_metadata/src/standing_queries.rs
@@ -43,6 +43,10 @@ impl StandingQueryDefinitions {
         path.ancestors()
             .find(|ancestor| self.is_project_skill_provider_directory(ancestor))
     }
+    fn is_direct_project_skill_provider_child(&self, path: &Path) -> bool {
+        path.parent()
+            .is_some_and(|parent| self.is_project_skill_provider_directory(parent))
+    }
 
     fn is_project_skill_file(&self, path: &Path) -> bool {
         path.file_name().and_then(|name| name.to_str()) == Some("SKILL.md")
@@ -122,14 +126,19 @@ impl StandingQueryResults {
             self.project_rules
                 .insert(StandingQueryContent::file(standardized));
         }
+    }
 
-        // Changes beneath a local skill provider directory need to wake consumers
-        // even when the changed path is a symlinked skill directory that is not
-        // represented in the canonical tree.
-        if let Some(provider_root) = definitions.project_skill_provider_ancestor(path) {
-            self.project_skills.insert(StandingQueryContent::directory(
-                StandardizedPath::from_local_absolute_unchecked(provider_root),
-            ));
+    pub(crate) fn record_direct_project_skill_provider_child_change(
+        &mut self,
+        path: &Path,
+        definitions: &StandingQueryDefinitions,
+    ) {
+        if definitions.is_direct_project_skill_provider_child(path) {
+            if let Some(provider_root) = definitions.project_skill_provider_ancestor(path) {
+                self.project_skills.insert(StandingQueryContent::directory(
+                    StandardizedPath::from_local_absolute_unchecked(provider_root),
+                ));
+            }
         }
     }
 
@@ -225,3 +234,7 @@ impl StandingQueryResultsDelta {
         !self.upserted_project_rules.is_empty() || !self.removed_project_rules.is_empty()
     }
 }
+
+#[cfg(test)]
+#[path = "standing_queries_tests.rs"]
+mod tests;

--- a/crates/repo_metadata/src/standing_queries.rs
+++ b/crates/repo_metadata/src/standing_queries.rs
@@ -1,0 +1,227 @@
+//! Standing repository queries maintained alongside the canonical file tree.
+//!
+//! These results contain project-derived context paths that must remain available
+//! even when the visible file tree is intentionally lazy or shallow.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use warp_util::standardized_path::StandardizedPath;
+
+/// Repository-scoped standing query configuration.
+#[derive(Debug, Clone)]
+pub struct StandingQueryDefinitions {
+    project_skill_provider_paths: Vec<PathBuf>,
+    project_rule_file_names: Vec<String>,
+}
+
+impl Default for StandingQueryDefinitions {
+    fn default() -> Self {
+        Self {
+            project_skill_provider_paths: Vec::new(),
+            project_rule_file_names: vec!["WARP.md".to_string(), "AGENTS.md".to_string()],
+        }
+    }
+}
+
+impl StandingQueryDefinitions {
+    pub fn set_project_skill_provider_paths(&mut self, paths: impl IntoIterator<Item = PathBuf>) {
+        self.project_skill_provider_paths = paths.into_iter().collect();
+    }
+
+    pub fn project_skill_provider_paths(&self) -> &[PathBuf] {
+        &self.project_skill_provider_paths
+    }
+
+    fn is_project_skill_provider_directory(&self, path: &Path) -> bool {
+        self.project_skill_provider_paths
+            .iter()
+            .any(|provider_path| path.ends_with(provider_path))
+    }
+
+    fn project_skill_provider_ancestor<'a>(&self, path: &'a Path) -> Option<&'a Path> {
+        path.ancestors()
+            .find(|ancestor| self.is_project_skill_provider_directory(ancestor))
+    }
+
+    fn is_project_skill_file(&self, path: &Path) -> bool {
+        path.file_name().and_then(|name| name.to_str()) == Some("SKILL.md")
+            && path
+                .parent()
+                .and_then(Path::parent)
+                .is_some_and(|skills_root| self.is_project_skill_provider_directory(skills_root))
+    }
+
+    fn is_project_rule_file(&self, path: &Path) -> bool {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|file_name| {
+                self.project_rule_file_names
+                    .iter()
+                    .any(|rule_name| file_name.eq_ignore_ascii_case(rule_name))
+            })
+    }
+}
+
+/// A path retained by a standing query.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StandingQueryContent {
+    pub path: StandardizedPath,
+    pub is_directory: bool,
+}
+
+impl StandingQueryContent {
+    pub fn file(path: StandardizedPath) -> Self {
+        Self {
+            path,
+            is_directory: false,
+        }
+    }
+
+    pub fn directory(path: StandardizedPath) -> Self {
+        Self {
+            path,
+            is_directory: true,
+        }
+    }
+}
+
+/// Current paths matching each standing repository query.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StandingQueryResults {
+    project_skills: HashSet<StandingQueryContent>,
+    project_rules: HashSet<StandingQueryContent>,
+}
+
+impl StandingQueryResults {
+    pub fn project_skills(&self) -> impl Iterator<Item = &StandingQueryContent> {
+        self.project_skills.iter()
+    }
+
+    pub fn project_rules(&self) -> impl Iterator<Item = &StandingQueryContent> {
+        self.project_rules.iter()
+    }
+
+    /// Records a path encountered while traversing the repository.
+    pub(crate) fn record_path(
+        &mut self,
+        path: &Path,
+        is_directory: bool,
+        definitions: &StandingQueryDefinitions,
+    ) {
+        let standardized = StandardizedPath::from_local_absolute_unchecked(path);
+        if is_directory && definitions.is_project_skill_provider_directory(path) {
+            self.project_skills
+                .insert(StandingQueryContent::directory(standardized.clone()));
+        }
+        if !is_directory && definitions.is_project_skill_file(path) {
+            self.project_skills
+                .insert(StandingQueryContent::file(standardized.clone()));
+        }
+        if !is_directory && definitions.is_project_rule_file(path) {
+            self.project_rules
+                .insert(StandingQueryContent::file(standardized));
+        }
+
+        // Changes beneath a local skill provider directory need to wake consumers
+        // even when the changed path is a symlinked skill directory that is not
+        // represented in the canonical tree.
+        if let Some(provider_root) = definitions.project_skill_provider_ancestor(path) {
+            self.project_skills.insert(StandingQueryContent::directory(
+                StandardizedPath::from_local_absolute_unchecked(provider_root),
+            ));
+        }
+    }
+
+    pub fn insert_project_skill(&mut self, content: StandingQueryContent) {
+        self.project_skills.insert(content);
+    }
+
+    pub fn insert_project_rule(&mut self, content: StandingQueryContent) {
+        self.project_rules.insert(content);
+    }
+
+    pub fn apply_delta(&mut self, delta: &StandingQueryResultsDelta) {
+        for removed in &delta.removed_project_skills {
+            self.project_skills.remove(removed);
+        }
+        for removed in &delta.removed_project_rules {
+            self.project_rules.remove(removed);
+        }
+        self.project_skills
+            .extend(delta.upserted_project_skills.iter().cloned());
+        self.project_rules
+            .extend(delta.upserted_project_rules.iter().cloned());
+    }
+
+    /// Replaces results beneath changed roots and returns the observable delta.
+    ///
+    /// Upserts are emitted even when a matching path already exists so consumers
+    /// reread modified skill and rules file contents.
+    pub fn replace_subtrees(
+        &mut self,
+        removed_roots: &[StandardizedPath],
+        discovered: StandingQueryResults,
+    ) -> StandingQueryResultsDelta {
+        let mut delta = StandingQueryResultsDelta::default();
+        for root in removed_roots {
+            let removed_skills = self
+                .project_skills
+                .iter()
+                .filter(|content| content.path.starts_with(root))
+                .cloned()
+                .collect::<Vec<_>>();
+            let removed_rules = self
+                .project_rules
+                .iter()
+                .filter(|content| content.path.starts_with(root))
+                .cloned()
+                .collect::<Vec<_>>();
+            delta.removed_project_skills.extend(removed_skills);
+            delta.removed_project_rules.extend(removed_rules);
+        }
+        delta
+            .upserted_project_skills
+            .extend(discovered.project_skills);
+        delta
+            .upserted_project_rules
+            .extend(discovered.project_rules);
+        self.apply_delta(&delta);
+        delta
+    }
+
+    pub fn as_snapshot_delta(&self) -> StandingQueryResultsDelta {
+        StandingQueryResultsDelta {
+            upserted_project_skills: self.project_skills.iter().cloned().collect(),
+            removed_project_skills: Vec::new(),
+            upserted_project_rules: self.project_rules.iter().cloned().collect(),
+            removed_project_rules: Vec::new(),
+        }
+    }
+}
+
+/// Changes to standing query results for one repository.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StandingQueryResultsDelta {
+    pub upserted_project_skills: Vec<StandingQueryContent>,
+    pub removed_project_skills: Vec<StandingQueryContent>,
+    pub upserted_project_rules: Vec<StandingQueryContent>,
+    pub removed_project_rules: Vec<StandingQueryContent>,
+}
+
+impl StandingQueryResultsDelta {
+    pub fn is_empty(&self) -> bool {
+        self.upserted_project_skills.is_empty()
+            && self.removed_project_skills.is_empty()
+            && self.upserted_project_rules.is_empty()
+            && self.removed_project_rules.is_empty()
+    }
+
+    pub fn project_skills_changed(&self) -> bool {
+        !self.upserted_project_skills.is_empty() || !self.removed_project_skills.is_empty()
+    }
+
+    pub fn project_rules_changed(&self) -> bool {
+        !self.upserted_project_rules.is_empty() || !self.removed_project_rules.is_empty()
+    }
+}

--- a/crates/repo_metadata/src/standing_queries_tests.rs
+++ b/crates/repo_metadata/src/standing_queries_tests.rs
@@ -1,7 +1,12 @@
 use super::*;
+fn repo_path(path: &str) -> PathBuf {
+    std::env::temp_dir()
+        .join("repo_metadata_standing_queries_tests")
+        .join(path)
+}
 
-fn path(path: &str) -> StandardizedPath {
-    StandardizedPath::try_new(path).unwrap()
+fn standardized(path: &Path) -> StandardizedPath {
+    StandardizedPath::try_from_local(path).unwrap()
 }
 
 fn definitions() -> StandingQueryDefinitions {
@@ -14,68 +19,64 @@ fn definitions() -> StandingQueryDefinitions {
 fn records_provider_skill_files_and_project_rules() {
     let definitions = definitions();
     let mut results = StandingQueryResults::default();
+    let skills_provider = repo_path(".agents/skills");
+    let skill_file = repo_path(".agents/skills/review/SKILL.md");
+    let root_rule = repo_path("WARP.md");
+    let nested_rule = repo_path("packages/api/AGENTS.md");
 
-    results.record_path(Path::new("/repo/.agents/skills"), true, &definitions);
-    results.record_path(
-        Path::new("/repo/.agents/skills/review/SKILL.md"),
-        false,
-        &definitions,
-    );
-    results.record_path(Path::new("/repo/WARP.md"), false, &definitions);
-    results.record_path(
-        Path::new("/repo/packages/api/AGENTS.md"),
-        false,
-        &definitions,
-    );
+    results.record_path(&skills_provider, true, &definitions);
+    results.record_path(&skill_file, false, &definitions);
+    results.record_path(&root_rule, false, &definitions);
+    results.record_path(&nested_rule, false, &definitions);
 
+    assert!(
+        results
+            .project_skills()
+            .any(|content| content
+                == &StandingQueryContent::directory(standardized(&skills_provider)))
+    );
     assert!(results
         .project_skills()
-        .any(|content| content == &StandingQueryContent::directory(path("/repo/.agents/skills"))));
-    assert!(results.project_skills().any(|content| {
-        content == &StandingQueryContent::file(path("/repo/.agents/skills/review/SKILL.md"))
-    }));
+        .any(|content| { content == &StandingQueryContent::file(standardized(&skill_file)) }));
     assert!(results
         .project_rules()
-        .any(|content| content == &StandingQueryContent::file(path("/repo/WARP.md"))));
-    assert!(results.project_rules().any(|content| {
-        content == &StandingQueryContent::file(path("/repo/packages/api/AGENTS.md"))
-    }));
+        .any(|content| content == &StandingQueryContent::file(standardized(&root_rule))));
+    assert!(results
+        .project_rules()
+        .any(|content| { content == &StandingQueryContent::file(standardized(&nested_rule)) }));
 }
 
 #[test]
 fn replacing_removed_direct_skill_child_can_reupsert_provider_for_hydration() {
     let definitions = definitions();
-    let provider = StandingQueryContent::directory(path("/repo/.agents/skills"));
-    let skill = StandingQueryContent::file(path("/repo/.agents/skills/review/SKILL.md"));
+    let provider_path = repo_path(".agents/skills");
+    let skill_path = repo_path(".agents/skills/review/SKILL.md");
+    let removed_skill_dir = repo_path(".agents/skills/review");
+    let provider = StandingQueryContent::directory(standardized(&provider_path));
+    let skill = StandingQueryContent::file(standardized(&skill_path));
     let mut results = StandingQueryResults::default();
     results.insert_project_skill(provider.clone());
     results.insert_project_skill(skill.clone());
 
     let mut discovered = StandingQueryResults::default();
-    discovered.record_direct_project_skill_provider_child_change(
-        Path::new("/repo/.agents/skills/review"),
-        &definitions,
-    );
-    let delta = results.replace_subtrees(&[path("/repo/.agents/skills/review")], discovered);
+    discovered.record_direct_project_skill_provider_child_change(&removed_skill_dir, &definitions);
+    let delta = results.replace_subtrees(&[standardized(&removed_skill_dir)], discovered);
 
     assert_eq!(delta.removed_project_skills, vec![skill]);
     assert_eq!(delta.upserted_project_skills, vec![provider.clone()]);
     assert!(results.project_skills().any(|content| content == &provider));
     assert!(!results
         .project_skills()
-        .any(|content| content.path == path("/repo/.agents/skills/review/SKILL.md")));
+        .any(|content| content.path == standardized(&skill_path)));
 }
 
 #[test]
 fn support_file_beneath_skill_does_not_synthesize_provider_update() {
     let definitions = definitions();
     let mut results = StandingQueryResults::default();
+    let support_file = repo_path(".agents/skills/review/README.md");
 
-    results.record_path(
-        Path::new("/repo/.agents/skills/review/README.md"),
-        false,
-        &definitions,
-    );
+    results.record_path(&support_file, false, &definitions);
 
     assert!(results.project_skills().next().is_none());
 }

--- a/crates/repo_metadata/src/standing_queries_tests.rs
+++ b/crates/repo_metadata/src/standing_queries_tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+fn path(path: &str) -> StandardizedPath {
+    StandardizedPath::try_new(path).unwrap()
+}
+
+fn definitions() -> StandingQueryDefinitions {
+    let mut definitions = StandingQueryDefinitions::default();
+    definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+    definitions
+}
+
+#[test]
+fn records_provider_skill_files_and_project_rules() {
+    let definitions = definitions();
+    let mut results = StandingQueryResults::default();
+
+    results.record_path(Path::new("/repo/.agents/skills"), true, &definitions);
+    results.record_path(
+        Path::new("/repo/.agents/skills/review/SKILL.md"),
+        false,
+        &definitions,
+    );
+    results.record_path(Path::new("/repo/WARP.md"), false, &definitions);
+    results.record_path(
+        Path::new("/repo/packages/api/AGENTS.md"),
+        false,
+        &definitions,
+    );
+
+    assert!(results
+        .project_skills()
+        .any(|content| content == &StandingQueryContent::directory(path("/repo/.agents/skills"))));
+    assert!(results.project_skills().any(|content| {
+        content == &StandingQueryContent::file(path("/repo/.agents/skills/review/SKILL.md"))
+    }));
+    assert!(results
+        .project_rules()
+        .any(|content| content == &StandingQueryContent::file(path("/repo/WARP.md"))));
+    assert!(results.project_rules().any(|content| {
+        content == &StandingQueryContent::file(path("/repo/packages/api/AGENTS.md"))
+    }));
+}
+
+#[test]
+fn replacing_removed_direct_skill_child_can_reupsert_provider_for_hydration() {
+    let definitions = definitions();
+    let provider = StandingQueryContent::directory(path("/repo/.agents/skills"));
+    let skill = StandingQueryContent::file(path("/repo/.agents/skills/review/SKILL.md"));
+    let mut results = StandingQueryResults::default();
+    results.insert_project_skill(provider.clone());
+    results.insert_project_skill(skill.clone());
+
+    let mut discovered = StandingQueryResults::default();
+    discovered.record_direct_project_skill_provider_child_change(
+        Path::new("/repo/.agents/skills/review"),
+        &definitions,
+    );
+    let delta = results.replace_subtrees(&[path("/repo/.agents/skills/review")], discovered);
+
+    assert_eq!(delta.removed_project_skills, vec![skill]);
+    assert_eq!(delta.upserted_project_skills, vec![provider.clone()]);
+    assert!(results.project_skills().any(|content| content == &provider));
+    assert!(!results
+        .project_skills()
+        .any(|content| content.path == path("/repo/.agents/skills/review/SKILL.md")));
+}
+
+#[test]
+fn support_file_beneath_skill_does_not_synthesize_provider_update() {
+    let definitions = definitions();
+    let mut results = StandingQueryResults::default();
+
+    results.record_path(
+        Path::new("/repo/.agents/skills/review/README.md"),
+        false,
+        &definitions,
+    );
+
+    assert!(results.project_skills().next().is_none());
+}

--- a/crates/repo_metadata/src/wrapper_model.rs
+++ b/crates/repo_metadata/src/wrapper_model.rs
@@ -19,7 +19,7 @@ use crate::local_model::{
 };
 use crate::remote_model::{RemoteRepoMetadataModel, RemoteRepositoryMetadataEvent};
 use crate::repository_identifier::{RemoteRepositoryIdentifier, RepositoryIdentifier};
-use crate::RepoMetadataError;
+use crate::{RepoMetadataError, StandingQueryResults, StandingQueryResultsDelta};
 
 /// Unified events emitted by the [`RepoMetadataModel`] wrapper.
 ///
@@ -39,6 +39,11 @@ pub enum RepoMetadataEvent {
         /// Specifies whether this event contains a precise delta or requires a conservative
         /// refresh because the entry was replaced without one.
         update_type: MetadataUpdateType,
+    },
+    /// Stored standing-query paths changed for a repository.
+    StandingQueryResultsUpdated {
+        id: RepositoryIdentifier,
+        delta: StandingQueryResultsDelta,
     },
     /// Updating a repository failed.
     UpdatingRepositoryFailed { id: RepositoryIdentifier },
@@ -121,6 +126,12 @@ impl RepoMetadataModel {
                     update_type: update_type.clone(),
                 }
             }
+            RepositoryMetadataEvent::StandingQueryResultsUpdated { path, delta } => {
+                RepoMetadataEvent::StandingQueryResultsUpdated {
+                    id: RepositoryIdentifier::local(path.clone()),
+                    delta: delta.clone(),
+                }
+            }
             RepositoryMetadataEvent::UpdatingRepositoryFailed { path } => {
                 RepoMetadataEvent::UpdatingRepositoryFailed {
                     id: RepositoryIdentifier::local(path.clone()),
@@ -166,6 +177,12 @@ impl RepoMetadataModel {
                     update_type: update_type.clone(),
                 }
             }
+            RemoteRepositoryMetadataEvent::StandingQueryResultsUpdated { id, delta } => {
+                RepoMetadataEvent::StandingQueryResultsUpdated {
+                    id: RepositoryIdentifier::Remote(id.clone()),
+                    delta: delta.clone(),
+                }
+            }
         };
         ctx.emit(unified);
     }
@@ -182,6 +199,21 @@ impl RepoMetadataModel {
             RepositoryIdentifier::Local(path) => self.local.as_ref(ctx).get_repository(path),
             RepositoryIdentifier::Remote(remote_id) => {
                 self.remote.as_ref(ctx).get_repository(remote_id)
+            }
+        }
+    }
+
+    pub fn standing_query_results<'a>(
+        &self,
+        id: &RepositoryIdentifier,
+        ctx: &'a AppContext,
+    ) -> Option<&'a StandingQueryResults> {
+        match id {
+            RepositoryIdentifier::Local(path) => {
+                self.local.as_ref(ctx).standing_query_results(path)
+            }
+            RepositoryIdentifier::Remote(remote_id) => {
+                self.remote.as_ref(ctx).standing_query_results(remote_id)
             }
         }
     }
@@ -321,6 +353,17 @@ impl RepoMetadataModel {
         });
     }
 
+    pub fn set_project_skill_provider_paths(
+        &self,
+        paths: impl IntoIterator<Item = std::path::PathBuf>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let paths: Vec<_> = paths.into_iter().collect();
+        self.local.update(ctx, |local, _| {
+            local.set_project_skill_provider_paths(paths);
+        });
+    }
+
     /// Removes a lazily-loaded local standalone path from tracking.
     #[cfg(feature = "local_fs")]
     pub fn remove_lazy_loaded_path(&self, path: &StandardizedPath, ctx: &mut ModelContext<Self>) {
@@ -422,6 +465,17 @@ impl RepoMetadataModel {
     ) {
         self.local.update(ctx, |local, _ctx| {
             local.insert_test_state(repo_path, state);
+        });
+    }
+
+    pub fn insert_test_standing_results(
+        &self,
+        repo_path: StandardizedPath,
+        standing_results: StandingQueryResults,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.local.update(ctx, |local, _ctx| {
+            local.insert_test_standing_results(repo_path, standing_results);
         });
     }
 }

--- a/crates/repo_metadata/src/wrapper_model.rs
+++ b/crates/repo_metadata/src/wrapper_model.rs
@@ -336,7 +336,6 @@ impl RepoMetadataModel {
             local.load_directory(&repo_root, &dir_path, ctx)
         })
     }
-
     /// Registers component-sequence paths that should be loaded even when ignored.
     ///
     /// This delegates to the local model because ignored-path matching happens


### PR DESCRIPTION
## Description

This PR moves project skill and project rule discovery onto standing results maintained by repo metadata, rather than issuing a new full-tree discovery scan whenever consumers need current results.

### Architecture
- Builds standing project-skill and project-rule results during the same traversal that initially indexes a repository, including matches below intentionally lazy/ignored canonical-tree nodes.
- Maintains those results incrementally from watcher mutations and synchronizes standing-result snapshots/deltas for remote repositories.
- Uses `SKILL_PROVIDER_DEFINITIONS` as the source of truth for supported project skill provider roots.
- Preserves existing project-rule matching for `WARP.md` and `AGENTS.md`.
- Removes obsolete ignored-path-interest/eager-materialization plumbing now that standing results remain complete independently of the visible file tree.

### Project skill consumption
- Local and remote metadata-backed project skills now share the same parse-and-emit pipeline; they branch only when reading markdown contents (local filesystem versus remote file-context RPC).
- Local filesystem discovery remains only as a fallback when repository metadata indexing fails.
- Project skills refresh from `RepositoryUpdated` and skill-relevant `StandingQueryResultsUpdated` events, rather than broad `FileTreeEntryUpdated` notifications.

### Performance behavior
- The successful indexed path no longer performs a repository-wide project-skill rescan after file-tree updates.
- Refresh work is bounded to standing-result reads, immediate local provider-directory enumeration for symlink hydration, and asynchronous reads of currently active skill files.
- Synthetic provider-directory refreshes are narrowly limited to direct structural events that can alter symlinked skills (direct provider-child symlink additions/updates or direct child removals).
- Unrelated files below a skill directory, such as `README.md` or examples, no longer re-trigger project skill hydration.

### Symlink behavior
- Directory symlinks remain intentionally excluded from the canonical repo metadata tree to avoid cycles, duplicate subtrees, and importing arbitrary external directories into repository metadata.
- Local project skill hydration still supports symlinked skill directories by enumerating immediate children of retained provider roots.
- Newly created or moved external-target symlinks are associated with their lexical repository path before canonical fallback, so they emit standing-result updates and become visible as project skills.
- Changes behind already discovered symlinked skills continue through existing symlink-target watchers.
- Removing a direct provider child conservatively refreshes the provider because a deleted entry can no longer be inspected to determine whether it was a symlinked skill.

## Linked Issue

No linked issue specified.

## Testing

- Added regression coverage for ignored/lazy standing-result discovery, local external-target symlink routing, symlink provider refresh behavior, suppressed refreshes for unrelated skill descendants, and remote standing-result transport/application.
- Before merging `master`, ran `./script/format`, focused `repo_metadata` and `warp` file-watcher tests, `cargo check -p repo_metadata -p remote_server -p ai --features local_fs -p warp --lib`, `cargo test -p repo_metadata -p remote_server -p ai --features local_fs`, `cargo clippy -p repo_metadata -p remote_server -p ai --features local_fs -p warp --lib -- -D warnings`, and `git --no-pager diff --check`.
- After resolving conflicts with `master`, ran `./script/format`, `cargo check -p repo_metadata -p remote_server -p ai --features local_fs -p warp --lib`, `cargo test -p repo_metadata -p remote_server -p ai --features local_fs`, `cargo test -p warp --lib file_watchers`, and staged diff whitespace checks.
- After synchronizing the final additional `master` commit, ran `./script/format`, `cargo test -p warp --lib sync_queue`, and staged diff whitespace checks.
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` was started after the merge but interrupted before completion and skipped for this update.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

