### PR TITLE
Spec: Jujutsu (jj) prompt chips (GH-11797)

### DIFF
--- a/specs/GH11797/product.md
+++ b/specs/GH11797/product.md
@@ -40,7 +40,7 @@ Warp currently supports prompt chips for Git and SVN but has no equivalent for `
 
 7. **JjDirtyItems — workspace changes.** The chip shows the number of files with outstanding changes in the working copy, as reported by `jj diff --summary`. When there are no changes, the chip is hidden. Example: `3` (three files changed).
 
-8. **Prompt rendering — JjBookmark.** The chip renders as `jj:(<value>)` in the prompt, using `input_prompt_branch` (or a new `input_prompt_jj` theme color if available) for the prefix `jj:(` and suffix `)`, and `input_prompt_branch` for the value text. The font weight is Semibold.
+8. **Prompt rendering — JjBookmark.** The chip renders as `jj:(<value>)` in the prompt, using `input_prompt_branch` for the prefix `jj:(`, suffix `)`, and value text. The font weight is Semibold.
 
 9. **Prompt rendering — JjDirtyItems.** The chip renders as `±<value>` using `input_prompt_svn` for the prefix and value color, mirroring `SvnDirtyItems`.
 

--- a/specs/GH11797/product.md
+++ b/specs/GH11797/product.md
@@ -48,6 +48,4 @@ Warp currently supports prompt chips for Git and SVN but has no equivalent for `
 
 11. **Placeholder values.** In the chip picker settings UI, the placeholder for `JjBookmark` is `jj-feature-bookmark` and for `JjDirtyItems` it is `3`.
 
-12. **Copy behavior.** Clicking a `JjBookmark` chip copies the raw text (e.g. `main` or `f3a2b1c0 on my-feature`). Clicking `JjDirtyItems` copies the integer count.
-
-13. **Icon.** Both chips reuse the existing Git/SVN icons: `Icon::GitBranch` for `JjBookmark` and `Icon::File` for `JjDirtyItems`.
+12. **Icon.** Both chips reuse the existing Git/SVN icons: `Icon::GitBranch` for `JjBookmark` and `Icon::File` for `JjDirtyItems`.

--- a/specs/GH11797/product.md
+++ b/specs/GH11797/product.md
@@ -1,0 +1,53 @@
+# PRODUCT.md — Jujutsu (jj) prompt chips
+
+**GitHub Issue:** [warpdotdev/warp#11797](https://github.com/warpdotdev/warp/issues/11797)
+
+## Summary
+
+Add two new prompt context chips for the `jj` (Jujutsu) VCS: `JjBookmark` (bookmark/change display) and `JjDirtyItems` (changed-file count), mirroring the existing `SvnBranch` / `SvnDirtyItems` chip pattern. Users can add these chips to their prompt via the existing chip picker UI.
+
+## Problem
+
+Warp currently supports prompt chips for Git and SVN but has no equivalent for `jj`. Users who rely on `jj` instead of Git lack VCS-aware prompt chips showing their current bookmark/change context and workspace dirtiness.
+
+## Goals
+
+1. Add a `JjBookmark` chip that displays the current `jj` bookmark or abbreviated change ID, wrapped as `jj:(...)` in the prompt.
+2. Add a `JjDirtyItems` chip that displays the number of changed files in the `jj` workspace.
+3. Mirror the SVN chip architecture (`builtins.rs` shell commands + `mod.rs` enum dispatch) so the implementation is minimal and consistent.
+4. Both chips degrade gracefully when `jj` is not installed or the working directory is outside a `jj` repository.
+
+## Non-goals
+
+- Full `jj` VCS support in Warp (tracked in #11774).
+- Bookmark-list menu on click (unlike Git branches, `jj` bookmarks don't have a native list command).
+- Configurable display format beyond the established `jj:(…)` / `±N` conventions.
+- Automatically tracking `jj` bookmark changes — both chips refresh on demand only.
+
+## Behavior
+
+1. **Chip availability.** `JjBookmark` and `JjDirtyItems` appear in the chip picker UI (`available_chips()`) alongside other VCS chips. Users can add, remove, and reorder them freely.
+
+2. **Runtime disable.** Both chips require the `jj` executable. When `jj` is absent from the session's `$PATH`, each chip is disabled with a tooltip: `Requires the \`jj\` command`.
+
+3. **JjBookmark — bookmarked change.** When the current change has one or more bookmarks, the chip shows `jj:(<bookmarks>)`. Bookmarks are space-separated when multiple exist. Example: `jj:(main)`, `jj:(my-feature stable)`.
+
+4. **JjBookmark — anonymous change, bookmarked ancestor exists.** When the current change is anonymous but an ancestor has bookmarks, the chip shows `jj:(<change_id_short8> on <bookmarks>)`. Example: `jj:(f3a2b1c0 on main)`.
+
+5. **JjBookmark — anonymous change, no bookmarked ancestor.** When neither the current change nor any ancestor has bookmarks, the chip shows `jj:(<change_id_short8>)`. Example: `jj:(f3a2b1c0)`.
+
+6. **JjBookmark — no `jj` repository.** When not inside a `jj` repository, the shell command produces no output and the chip is hidden (empty value, no rendered element).
+
+7. **JjDirtyItems — workspace changes.** The chip shows the number of files with outstanding changes in the working copy, as reported by `jj diff --summary`. When there are no changes, the chip is hidden. Example: `3` (three files changed).
+
+8. **Prompt rendering — JjBookmark.** The chip renders as `jj:(<value>)` in the prompt, using `input_prompt_branch` (or a new `input_prompt_jj` theme color if available) for the prefix `jj:(` and suffix `)`, and `input_prompt_branch` for the value text. The font weight is Semibold.
+
+9. **Prompt rendering — JjDirtyItems.** The chip renders as `±<value>` using `input_prompt_svn` for the prefix and value color, mirroring `SvnDirtyItems`.
+
+10. **Adjacent chip spacing.** When `JjBookmark` and `JjDirtyItems` are adjacent in the prompt (in either order), no space is inserted between them, matching the existing `SvnBranch`/`SvnDirtyItems` behavior.
+
+11. **Placeholder values.** In the chip picker settings UI, the placeholder for `JjBookmark` is `jj-feature-bookmark` and for `JjDirtyItems` it is `3`.
+
+12. **Copy behavior.** Clicking a `JjBookmark` chip copies the raw text (e.g. `main` or `f3a2b1c0 on my-feature`). Clicking `JjDirtyItems` copies the integer count.
+
+13. **Icon.** Both chips reuse the existing Git/SVN icons: `Icon::GitBranch` for `JjBookmark` and `Icon::File` for `JjDirtyItems`.

--- a/specs/GH11797/product.md
+++ b/specs/GH11797/product.md
@@ -20,7 +20,7 @@ Warp currently supports prompt chips for Git and SVN but has no equivalent for `
 ## Non-goals
 
 - Full `jj` VCS support in Warp (tracked in #11774).
-- Bookmark-list menu on click (unlike Git branches, `jj` bookmarks don't have a native list command).
+- Bookmark-list menu on click — intentionally out of scope for the initial implementation.
 - Configurable display format beyond the established `jj:(…)` / `±N` conventions.
 - Automatically tracking `jj` bookmark changes — both chips refresh on demand only.
 

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -84,25 +84,42 @@ Produces the count of changed files in the working copy:
 ```rust
 // Bash/Zsh:
 const SH_DIRTY_CMD: &str =
-    "count=$(jj diff --summary --ignore-working-copy 2>/dev/null | wc -l) && [ \"$count\" -gt 0 ] && echo \"$count\"";
+    "count=$(jj diff --summary 2>/dev/null | grep -cE '^[AMD] ') && [ \"$count\" -gt 0 ] && echo \"$count\"";
 ```
 
 ```rust
 // Fish:
-const FISH_DIRTY_CMD: &str = "set count (jj diff --summary --ignore-working-copy 2>/dev/null | wc -l) \
+const FISH_DIRTY_CMD: &str = "set count (jj diff --summary 2>/dev/null | grep -cE '^[AMD] ') \
     && test $count -gt 0 && string trim $count";
 ```
 
 ```rust
 // PowerShell:
-const PWSH_DIRTY_CMD: &str = "jj diff --summary --ignore-working-copy 2>$null | Measure-Object -Line | \
-    Where-Object { $_.Lines -gt 0 } | ForEach-Object { $_.Lines }";
+const PWSH_DIRTY_CMD: &str = "$count = (jj diff --summary 2>$null | Select-String -Pattern '^[AMD] ').Count; \
+    if ($count -gt 0) { $count }";
 ```
 
-`jj diff --summary` outputs one line per changed file. The `--ignore-working-copy` flag prevents
-auto-snapshotting during prompt rendering while still showing accurate file counts. The pipe to
-`wc -l` / `Measure-Object` gives an accurate count. When the workspace is clean (zero changes),
-the chip value is empty and the chip is hidden.
+#### `--ignore-working-copy` asymmetry
+
+This command **intentionally omits `--ignore-working-copy`**, unlike `jj_bookmark()`. Reason: with
+`--ignore-working-copy`, `jj diff` compares the last snapshot against the parent — it does not see
+filesystem edits made since the last `jj` invocation. The dirty-count chip would then show stale
+or zero values until the user ran some other jj command. Dropping the flag lets `jj diff` snapshot
+the working copy on each prompt render and report a live count.
+
+The cost is that each prompt render appends one operation log entry. jj is designed for frequent
+snapshots and the operation log is inexpensive (and garbage-collected). This is the same
+behavior `jj status` already does when users run it manually.
+
+The bookmark chip keeps `--ignore-working-copy` because reading bookmarks doesn't depend on the
+working-copy snapshot.
+
+#### Output parsing
+
+`jj diff --summary` outputs one line per changed file with an `A`/`M`/`D` prefix followed by a
+space (e.g., `M foo.rs`). The `grep -cE '^[AMD] '` pattern counts only those lines, which is
+robust against trailing-newline edge cases and any future status footer lines jj might add.
+When the workspace is clean (zero matches), the chip value is empty and the chip is hidden.
 
 ## Proposed changes
 

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -25,8 +25,7 @@ Produces the chip value text using `jj log` with output templates. `change_id.sh
 returns the change ID truncated to exactly 8 characters (e.g., `qquqvwzk`) — chosen over
 `shortest(8)` so the chip has a fixed visual width independent of repo size.
 `jj log` invocations include `--ignore-working-copy` to prevent unintentional auto-snapshots
-during prompt rendering (this command is read-only — see the `jj_dirty_items` section for
-the asymmetric case). Logic:
+during prompt rendering. Logic:
 
 1. Query bookmarks on `@` — if found, output them directly.
 2. Otherwise, get the change ID via `change_id.short(8)`.
@@ -90,35 +89,27 @@ Produces the count of changed files in the working copy:
 ```rust
 // Bash/Zsh:
 const SH_DIRTY_CMD: &str =
-    "count=$(jj diff --summary 2>/dev/null | grep -cE '^[AMD] ') && [ \"$count\" -gt 0 ] && echo \"$count\"";
+    "count=$(jj diff --summary --ignore-working-copy 2>/dev/null | grep -cE '^[AMD] ') && [ \"$count\" -gt 0 ] && echo \"$count\"";
 ```
 
 ```rust
 // Fish:
-const FISH_DIRTY_CMD: &str = "set count (jj diff --summary 2>/dev/null | grep -cE '^[AMD] ') \
+const FISH_DIRTY_CMD: &str = "set count (jj diff --summary --ignore-working-copy 2>/dev/null | grep -cE '^[AMD] ') \
     && test $count -gt 0 && string trim $count";
 ```
 
 ```rust
 // PowerShell:
-const PWSH_DIRTY_CMD: &str = "$count = (jj diff --summary 2>$null | Select-String -Pattern '^[AMD] ').Count; \
+const PWSH_DIRTY_CMD: &str = "$count = (jj diff --summary --ignore-working-copy 2>$null | Select-String -Pattern '^[AMD] ').Count; \
     if ($count -gt 0) { $count }";
 ```
 
-#### `--ignore-working-copy` asymmetry
+#### `--ignore-working-copy`
 
-This command **intentionally omits `--ignore-working-copy`**, unlike `jj_bookmark()`. Reason: with
-`--ignore-working-copy`, `jj diff` compares the last snapshot against the parent — it does not see
-filesystem edits made since the last `jj` invocation. The dirty-count chip would then show stale
-or zero values until the user ran some other jj command. Dropping the flag lets `jj diff` snapshot
-the working copy on each prompt render and report a live count.
-
-The cost is that each prompt render appends one operation log entry. jj is designed for frequent
-snapshots and the operation log is inexpensive (and garbage-collected). This is the same
-behavior `jj status` already does when users run it manually.
-
-The bookmark chip keeps `--ignore-working-copy` because reading bookmarks doesn't depend on the
-working-copy snapshot.
+All `jj diff` invocations use `--ignore-working-copy` to prevent operation-log spam
+when the prompt refreshes. The dirty count may lag a fraction of a second behind the
+filesystem, but it avoids thrashing the jj repo state on every render — standard
+practice for shell prompt chips.
 
 #### Output parsing
 

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -51,14 +51,20 @@ const SH_BOOKMARK_CMD: &str = "bookmarks=$(jj log -r '@' --no-graph --ignore-wor
 // Fish:
 const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
-    && if test -n \"$bookmarks\"; echo $bookmarks; \
-    else; set cid (jj log -r '@' --no-graph --ignore-working-copy \
-    -T 'change_id.short(8)' 2>/dev/null); \
-    set ancestor_bookmarks (jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
-    --ignore-working-copy \
-    -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1); \
-    if test -n \"$ancestor_bookmarks\"; echo \"${cid} on ${ancestor_bookmarks}\"; \
-    else; echo $cid; end; end";
+    if test -n \"$bookmarks\"
+        echo $bookmarks
+    else
+        set cid (jj log -r '@' --no-graph --ignore-working-copy \
+        -T 'change_id.short(8)' 2>/dev/null)
+        set ancestor_bookmarks (jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
+        --ignore-working-copy \
+        -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1)
+        if test -n \"$ancestor_bookmarks\"
+            echo \"$cid on $ancestor_bookmarks\"
+        else
+            echo $cid
+        end
+    end";
 ```
 
 ```powershell

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -21,13 +21,15 @@ The SVN chips (`SvnBranch`, `SvnDirtyItems`) are the closest analogue: shell-bas
 
 ### `jj_bookmark()`
 
-Produces the chip value text using `jj log` with output templates. `change_id.shortest(8)`
-returns the shortest unique prefix of the change ID, up to 8 characters (e.g., `qquqvwzk`).
-All `jj log` and `jj diff` invocations include `--ignore-working-copy` to prevent
-unintentional auto-snapshots during prompt rendering. Logic:
+Produces the chip value text using `jj log` with output templates. `change_id.short(8)`
+returns the change ID truncated to exactly 8 characters (e.g., `qquqvwzk`) — chosen over
+`shortest(8)` so the chip has a fixed visual width independent of repo size.
+`jj log` invocations include `--ignore-working-copy` to prevent unintentional auto-snapshots
+during prompt rendering (this command is read-only — see the `jj_dirty_items` section for
+the asymmetric case). Logic:
 
 1. Query bookmarks on `@` — if found, output them directly.
-2. Otherwise, get the change ID via `change_id.shortest(8)`.
+2. Otherwise, get the change ID via `change_id.short(8)`.
 3. Query the nearest bookmarked ancestor via `latest(ancestors(@) & bookmarks() ~ @)`.
 4. If an ancestor bookmark exists, output `"<change_id> on <bookmarks>"`; otherwise output just `<change_id>`.
 
@@ -37,7 +39,7 @@ const SH_BOOKMARK_CMD: &str = "bookmarks=$(jj log -r '@' --no-graph --ignore-wor
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
     && if [ -n \"$bookmarks\" ]; then echo \"$bookmarks\"; \
     else cid=$(jj log -r '@' --no-graph --ignore-working-copy \
-    -T 'change_id.shortest(8)' 2>/dev/null); \
+    -T 'change_id.short(8)' 2>/dev/null); \
     ancestor_bookmarks=$(jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
     --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1); \
@@ -51,7 +53,7 @@ const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph --ignor
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
     && if test -n \"$bookmarks\"; echo $bookmarks; \
     else; set cid (jj log -r '@' --no-graph --ignore-working-copy \
-    -T 'change_id.shortest(8)' 2>/dev/null); \
+    -T 'change_id.short(8)' 2>/dev/null); \
     set ancestor_bookmarks (jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
     --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1); \
@@ -65,7 +67,7 @@ const PWSH_BOOKMARK_CMD: &str = "$bookmarks = jj log -r '@' --no-graph --ignore-
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>$null; \
     if ($bookmarks) { $bookmarks } \
     else { $cid = jj log -r '@' --no-graph --ignore-working-copy \
-    -T 'change_id.shortest(8)' 2>$null; \
+    -T 'change_id.short(8)' 2>$null; \
     $ancestorBookmarks = jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
     --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>$null; \

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -59,13 +59,13 @@ end
 
 ```powershell
 # PowerShell:
-$_jj_bm = jj log -r @ --no-graph --ignore-working-copy \
+$_jj_bm = jj log -r @ --no-graph --ignore-working-copy `
     --template 'if(bookmarks,bookmarks,"")' 2>$null
 if ($_jj_bm) { $_jj_bm }
 else {
-    $_jj_cid = jj log -r @ --no-graph --ignore-working-copy \
+    $_jj_cid = jj log -r @ --no-graph --ignore-working-copy `
         --template 'change_id.short(8)' 2>$null
-    $_jj_abm = jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' \
+    $_jj_abm = jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' `
         --no-graph --ignore-working-copy --template 'bookmarks' 2>$null
     if ($_jj_abm) { "$_jj_cid on $_jj_abm" } else { $_jj_cid }
 }

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -21,7 +21,8 @@ The SVN chips (`SvnBranch`, `SvnDirtyItems`) are the closest analogue: shell-bas
 
 ### `jj_bookmark()`
 
-Produces the chip value text using `jj log` with output templates. Logic:
+Produces the chip value text using `jj log` with output templates. `change_id.shortest(8)`
+returns at most 8 hex chars that uniquely identify the change (e.g., `qquqvwzk`). Logic:
 
 1. Query bookmarks on `@` — if found, output them directly.
 2. Otherwise, get the change ID via `change_id.shortest(8)`.
@@ -165,7 +166,7 @@ For PowerShell variants, port the bash logic to PowerShell using `jj` commands d
 
 ### 3. No other files require changes
 
-- `display_chip.rs`: No changes — `JjBookmark` and `JjDirtyItems` produce plain `ChipValue::Text`, which renders via the generic text path.
+- `display_chip.rs`: No changes — `JjBookmark` and `JjDirtyItems` produce plain `ChipValue::Text`, which renders via the generic text path. Click-to-copy is not supported, matching the existing `SvnBranch`/`SvnDirtyItems` behavior (which are also plain-text chips with no click handler).
 - `current_prompt.rs`: No changes — `CurrentPrompt` uses `to_chip()` and `runtime_policy` generically.
 - `prompt.rs`: No changes — `Prompt` singleton handles all `ContextChipKind` variants uniformly.
 - `theme.rs`: No new colors needed — both chips reuse existing `input_prompt_branch` and `input_prompt_svn` colors.

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -116,7 +116,8 @@ Self::GitDiffStats | Self::SvnDirtyItems | Self::JjDirtyItems => Some(Icon::File
 
 ```rust
 (ContextChipKind::SvnBranch, Some(ContextChipKind::SvnDirtyItems))
-| (ContextChipKind::JjBookmark, Some(ContextChipKind::JjDirtyItems)) => (),
+| (ContextChipKind::JjBookmark, Some(ContextChipKind::JjDirtyItems))
+| (ContextChipKind::JjDirtyItems, Some(ContextChipKind::JjBookmark)) => (),
 ```
 
 ### 2. `app/src/context_chips/builtins.rs` — Add generator functions

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -22,7 +22,9 @@ The SVN chips (`SvnBranch`, `SvnDirtyItems`) are the closest analogue: shell-bas
 ### `jj_bookmark()`
 
 Produces the chip value text using `jj log` with output templates. `change_id.shortest(8)`
-returns at most 8 hex chars that uniquely identify the change (e.g., `qquqvwzk`). Logic:
+returns the shortest unique prefix of the change ID, up to 8 characters (e.g., `qquqvwzk`).
+All `jj log` and `jj diff` invocations include `--ignore-working-copy` to prevent
+unintentional auto-snapshots during prompt rendering. Logic:
 
 1. Query bookmarks on `@` — if found, output them directly.
 2. Otherwise, get the change ID via `change_id.shortest(8)`.
@@ -31,11 +33,13 @@ returns at most 8 hex chars that uniquely identify the change (e.g., `qquqvwzk`)
 
 ```rust
 // Bash/Zsh:
-const SH_BOOKMARK_CMD: &str = "bookmarks=$(jj log -r '@' --no-graph \
+const SH_BOOKMARK_CMD: &str = "bookmarks=$(jj log -r '@' --no-graph --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
     && if [ -n \"$bookmarks\" ]; then echo \"$bookmarks\"; \
-    else cid=$(jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null); \
+    else cid=$(jj log -r '@' --no-graph --ignore-working-copy \
+    -T 'change_id.shortest(8)' 2>/dev/null); \
     ancestor_bookmarks=$(jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
+    --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1); \
     if [ -n \"$ancestor_bookmarks\" ]; then echo \"${cid} on ${ancestor_bookmarks}\"; \
     else echo \"$cid\"; fi; fi";
@@ -43,11 +47,13 @@ const SH_BOOKMARK_CMD: &str = "bookmarks=$(jj log -r '@' --no-graph \
 
 ```fish
 // Fish:
-const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph \
+const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
     && if test -n \"$bookmarks\"; echo $bookmarks; \
-    else; set cid (jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null); \
+    else; set cid (jj log -r '@' --no-graph --ignore-working-copy \
+    -T 'change_id.shortest(8)' 2>/dev/null); \
     set ancestor_bookmarks (jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
+    --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1); \
     if test -n \"$ancestor_bookmarks\"; echo \"${cid} on ${ancestor_bookmarks}\"; \
     else; echo $cid; end; end";
@@ -55,11 +61,13 @@ const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph \
 
 ```powershell
 // PowerShell:
-const PWSH_BOOKMARK_CMD: &str = "$bookmarks = jj log -r '@' --no-graph \
+const PWSH_BOOKMARK_CMD: &str = "$bookmarks = jj log -r '@' --no-graph --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>$null; \
     if ($bookmarks) { $bookmarks } \
-    else { $cid = jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>$null; \
+    else { $cid = jj log -r '@' --no-graph --ignore-working-copy \
+    -T 'change_id.shortest(8)' 2>$null; \
     $ancestorBookmarks = jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
+    --ignore-working-copy \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>$null; \
     if ($ancestorBookmarks) { \"${cid} on ${ancestorBookmarks}\" } else { $cid } }";
 ```
@@ -74,24 +82,25 @@ Produces the count of changed files in the working copy:
 ```rust
 // Bash/Zsh:
 const SH_DIRTY_CMD: &str =
-    "count=$(jj diff --summary 2>/dev/null | wc -l) && [ \"$count\" -gt 0 ] && echo \"$count\"";
+    "count=$(jj diff --summary --ignore-working-copy 2>/dev/null | wc -l) && [ \"$count\" -gt 0 ] && echo \"$count\"";
 ```
 
 ```rust
 // Fish:
-const FISH_DIRTY_CMD: &str = "set count (jj diff --summary 2>/dev/null | wc -l) \
+const FISH_DIRTY_CMD: &str = "set count (jj diff --summary --ignore-working-copy 2>/dev/null | wc -l) \
     && test $count -gt 0 && string trim $count";
 ```
 
 ```rust
 // PowerShell:
-const PWSH_DIRTY_CMD: &str = "jj diff --summary 2>$null | Measure-Object -Line | \
+const PWSH_DIRTY_CMD: &str = "jj diff --summary --ignore-working-copy 2>$null | Measure-Object -Line | \
     Where-Object { $_.Lines -gt 0 } | ForEach-Object { $_.Lines }";
 ```
 
-`jj diff --summary` outputs one line per changed file. The pipe to `wc -l` / `Measure-Object` gives
-an accurate count. When the workspace is clean (zero changes), the chip value is empty and the chip
-is hidden.
+`jj diff --summary` outputs one line per changed file. The `--ignore-working-copy` flag prevents
+auto-snapshotting during prompt rendering while still showing accurate file counts. The pipe to
+`wc -l` / `Measure-Object` gives an accurate count. When the workspace is clean (zero changes),
+the chip value is empty and the chip is hidden.
 
 ## Proposed changes
 

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -21,24 +21,35 @@ The SVN chips (`SvnBranch`, `SvnDirtyItems`) are the closest analogue: shell-bas
 
 ### `jj_bookmark()`
 
-Produces the chip value text using `jj log` with output templates. Uses `bookmarks.map()`
-to list bookmarks on the current change, falling back to `change_id.shortest(8)` when
-anonymous.
+Produces the chip value text using `jj log` with output templates. Logic:
+
+1. Query bookmarks on `@` — if found, output them directly.
+2. Otherwise, get the change ID via `change_id.shortest(8)`.
+3. Query the nearest bookmarked ancestor via `latest(ancestors(@) & bookmarks() ~ @)`.
+4. If an ancestor bookmark exists, output `"<change_id> on <bookmarks>"`; otherwise output just `<change_id>`.
 
 ```rust
 // Bash/Zsh:
 const SH_BOOKMARK_CMD: &str = "bookmarks=$(jj log -r '@' --no-graph \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
     && if [ -n \"$bookmarks\" ]; then echo \"$bookmarks\"; \
-    else jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null; fi";
+    else cid=$(jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null); \
+    ancestor_bookmarks=$(jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
+    -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1); \
+    if [ -n \"$ancestor_bookmarks\" ]; then echo \"${cid} on ${ancestor_bookmarks}\"; \
+    else echo \"$cid\"; fi; fi";
 ```
 
 ```fish
-# Fish:
+// Fish:
 const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
     && if test -n \"$bookmarks\"; echo $bookmarks; \
-    else; jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null; end";
+    else; set cid (jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null); \
+    set ancestor_bookmarks (jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
+    -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1); \
+    if test -n \"$ancestor_bookmarks\"; echo \"${cid} on ${ancestor_bookmarks}\"; \
+    else; echo $cid; end; end";
 ```
 
 ```powershell
@@ -46,7 +57,10 @@ const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph \
 const PWSH_BOOKMARK_CMD: &str = "$bookmarks = jj log -r '@' --no-graph \
     -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>$null; \
     if ($bookmarks) { $bookmarks } \
-    else { jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>$null }";
+    else { $cid = jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>$null; \
+    $ancestorBookmarks = jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' --no-graph \
+    -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>$null; \
+    if ($ancestorBookmarks) { \"${cid} on ${ancestorBookmarks}\" } else { $cid } }";
 ```
 
 All three shell variants use `ShellCommand::shell_specific([...])` with per-shell entries,

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -1,0 +1,144 @@
+# TECH.md — Jujutsu (jj) prompt chips
+
+**GitHub Issue:** [warpdotdev/warp#11797](https://github.com/warpdotdev/warp/issues/11797)
+**Product Spec:** `specs/GH11797/product.md`
+
+## Context
+
+Warp's prompt context chip system is organized around four key files:
+
+- **`app/src/context_chips/mod.rs`**: Defines the `ContextChipKind` enum (line 158) with variants for every chip type, and `to_chip()` (line 188) which maps each variant to a `ContextChip` struct (generator + policy). Also contains `available_chips()` (line 527), `display_value()` (line 445), `render_text_from_kind()` (line 616), `chips_to_string()` (line 580), and `placeholder_value()` (line 368).
+
+- **`app/src/context_chips/builtins.rs`**: Contains the shell command generator functions (`ShellCommandGenerator`) for VCS-backed chips (git, svn, kubectl). Each function returns a `ShellCommandGenerator` with a shell command and optional dependency list.
+
+- **`app/src/context_chips/context_chip.rs`**: Defines `ContextChip`, `ShellCommandGenerator`, `ChipRuntimePolicy`, and `ShellCommand` types.
+
+- **`app/src/themes/theme.rs`**: Defines `PromptColors` struct with per-chip color fields.
+
+The SVN chips (`SvnBranch`, `SvnDirtyItems`) are the closest analogue: shell-based, on-demand refresh, `jj:()` / `±N` rendering, and adjacent-chip spacing logic. The implementation will mirror their pattern exactly.
+
+## New JJ shell commands
+
+### `jj_bookmark()`
+
+Produces the chip value text using the prototype command from the issue body:
+
+```rust
+const SH_COMMAND: &str = concat!(
+    "_jj_bm=$(jj log -r @ --no-graph --ignore-working-copy",
+    " --template 'if(bookmarks,bookmarks,\"\")' 2>/dev/null);",
+    " if [ -n \"$_jj_bm\" ]; then echo \"$_jj_bm\";",
+    " else _jj_cid=$(jj log -r @ --no-graph --ignore-working-copy",
+    " --template 'change_id.short(8)' 2>/dev/null);",
+    " _jj_abm=$(jj log -r 'latest(ancestors(@) & bookmarks() ~ @)'",
+    " --no-graph --ignore-working-copy --template 'bookmarks' 2>/dev/null);",
+    " [ -n \"$_jj_abm\" ] && echo \"$_jj_cid on $_jj_abm\" || echo \"$_jj_cid\"; fi",
+);
+```
+
+This single shell command handles all five bookmark/change states listed in the issue description. The PowerShell variant wraps the same logic in a multi-line script.
+
+### `jj_dirty_items()`
+
+Produces the count of changed files in the working copy:
+
+```bash
+# Bash/Zsh:
+count=$(jj diff --summary 2>/dev/null | wc -l) && (( $count > 0 )) && echo $(( $count ))
+
+# Fish:
+set count (jj diff --summary 2>/dev/null | wc -l); test $count -gt 0 && string trim $count
+
+# PowerShell:
+$count = (jj diff --summary 2>$null | Measure-Object -line).Lines; if ($count -gt 0) { $count }
+```
+
+`jj diff --summary` outputs one line per changed file and produces no output when the workspace is clean, so `wc -l` gives an accurate count without header noise.
+
+## Proposed changes
+
+### 1. `app/src/context_chips/mod.rs` — Add `JjBookmark` and `JjDirtyItems` variants
+
+**1a. Enum definition (~line 176):** Add `JjBookmark,` and `JjDirtyItems,` after `SvnDirtyItems`.
+
+**1b. `to_chip()` (~line 320):** Add match arms mirroring `SvnBranch`/`SvnDirtyItems`:
+
+```rust
+Self::JjBookmark => Some(ContextChip::shell_builtin(
+    "Jj Bookmark",
+    builtins::jj_bookmark(),
+    None,
+    RefreshConfig::OnDemandOnly,
+)),
+Self::JjDirtyItems => Some(ContextChip::shell_builtin(
+    "Jj Uncommitted File Count",
+    builtins::jj_dirty_items(),
+    None,
+    RefreshConfig::OnDemandOnly,
+)),
+```
+
+**1c. `placeholder_value()` (~line 384):** Add:
+
+```rust
+Self::JjBookmark => ChipValue::Text("jj-feature-bookmark".to_string()),
+Self::JjDirtyItems => ChipValue::Text("3".to_string()),
+```
+
+**1d. `default_styles()` (~line 416):** Map to theme colors:
+
+```rust
+Self::JjBookmark => prompt_colors.input_prompt_branch,
+Self::JjDirtyItems => prompt_colors.input_prompt_svn,
+```
+
+**1e. `display_value()` (~line 451):** Add wrappers:
+
+```rust
+Self::JjBookmark => format!("jj:({text})"),
+Self::JjDirtyItems => format!("±{text}"),
+```
+
+**1f. `udi_icon()` (~line 509):** Update existing arm to include JjBookmark:
+
+```rust
+Self::ShellGitBranch | Self::SvnBranch | Self::JjBookmark => Some(Icon::GitBranch),
+Self::GitDiffStats | Self::SvnDirtyItems | Self::JjDirtyItems => Some(Icon::File),
+```
+
+**1g. `render_text_from_kind()` (~line 627):** Add match arms for both variants, mirroring `SvnBranch`/`SvnDirtyItems` rendering with `input_prompt_svn` color.
+
+**1h. `available_chips()` (~line 539):** Add `ContextChipKind::JjBookmark,` and `ContextChipKind::JjDirtyItems,` to the list.
+
+**1i. `chips_to_string()` (~line 593):** Extend the adjacent-chip spacing arm:
+
+```rust
+(ContextChipKind::SvnBranch, Some(ContextChipKind::SvnDirtyItems))
+| (ContextChipKind::JjBookmark, Some(ContextChipKind::JjDirtyItems)) => (),
+```
+
+### 2. `app/src/context_chips/builtins.rs` — Add generator functions
+
+Add two new public functions: `jj_bookmark()` and `jj_dirty_items()`, each returning a `ShellCommandGenerator` with dependencies `vec!["jj".to_owned()]`.
+
+For PowerShell variants, port the bash logic to PowerShell using `jj` commands directly (the prototype bash script is POSIX-only; PowerShell needs its own). Multi-line scripts are acceptable per the existing `svn_dirty_items()` precedent.
+
+### 3. No other files require changes
+
+- `display_chip.rs`: No changes — `JjBookmark` and `JjDirtyItems` produce plain `ChipValue::Text`, which renders via the generic text path.
+- `current_prompt.rs`: No changes — `CurrentPrompt` uses `to_chip()` and `runtime_policy` generically.
+- `prompt.rs`: No changes — `Prompt` singleton handles all `ContextChipKind` variants uniformly.
+- `theme.rs`: No new colors needed — both chips reuse existing `input_prompt_branch` and `input_prompt_svn` colors.
+
+## Testing and validation
+
+| Product invariant | Test approach |
+|---|---|
+| 1. Chips appear in picker UI | Unit test in `builtins_tests.rs`: verify `available_chips()` includes both new variants |
+| 2. Runtime disable when `jj` absent | Unit test in `current_prompt_tests.rs`: mirror `test_shell_chip_disabled_when_executable_is_missing` for `jj` |
+| 3–5. JjBookmark display text | Shell command test: run `jj log` in a `jj` repo with various states and verify output format |
+| 6. Empty when no jj repo | Manual: `cd /tmp && warp` — chip should not render |
+| 7. JjDirtyItems count | Shell command test: run `jj diff --summary` in a repo with known changes and verify count |
+| 8–9. Rendering | Unit test in `display_chip_tests.rs` or `renderer_tests.rs`: verify `render_text_from_kind` produces correct styled spans |
+| 10. Adjacent spacing | Unit test in `prompt_tests.rs` or `mod.rs` test: verify `chips_to_string` omits space between `JjBookmark`/`JjDirtyItems` |
+| 13. Icons | Unit test: verify `udi_icon()` returns correct icon for both variants |

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -36,7 +36,40 @@ const SH_COMMAND: &str = concat!(
 );
 ```
 
-This single shell command handles all five bookmark/change states listed in the issue description. The PowerShell variant wraps the same logic in a multi-line script.
+This single shell command handles all five bookmark/change states listed in the issue description. Fish and PowerShell need their own variants:
+
+```fish
+# Fish:
+set _jj_bm (jj log -r @ --no-graph --ignore-working-copy \
+    --template 'if(bookmarks,bookmarks,"")' 2>/dev/null)
+if test -n "$_jj_bm"
+    echo "$_jj_bm"
+else
+    set _jj_cid (jj log -r @ --no-graph --ignore-working-copy \
+        --template 'change_id.short(8)' 2>/dev/null)
+    set _jj_abm (jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' \
+        --no-graph --ignore-working-copy --template 'bookmarks' 2>/dev/null)
+    if test -n "$_jj_abm"
+        echo "$_jj_cid on $_jj_abm"
+    else
+        echo "$_jj_cid"
+    end
+end
+```
+
+```powershell
+# PowerShell:
+$_jj_bm = jj log -r @ --no-graph --ignore-working-copy \
+    --template 'if(bookmarks,bookmarks,"")' 2>$null
+if ($_jj_bm) { $_jj_bm }
+else {
+    $_jj_cid = jj log -r @ --no-graph --ignore-working-copy \
+        --template 'change_id.short(8)' 2>$null
+    $_jj_abm = jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' \
+        --no-graph --ignore-working-copy --template 'bookmarks' 2>$null
+    if ($_jj_abm) { "$_jj_cid on $_jj_abm" } else { $_jj_cid }
+}
+```
 
 ### `jj_dirty_items()`
 

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -106,7 +106,9 @@ Self::ShellGitBranch | Self::SvnBranch | Self::JjBookmark => Some(Icon::GitBranc
 Self::GitDiffStats | Self::SvnDirtyItems | Self::JjDirtyItems => Some(Icon::File),
 ```
 
-**1g. `render_text_from_kind()` (~line 627):** Add match arms for both variants, mirroring `SvnBranch`/`SvnDirtyItems` rendering with `input_prompt_svn` color.
+**1g. `render_text_from_kind()` (~line 627):** Add match arms for both variants, mirroring `SvnBranch`/`SvnDirtyItems` rendering:
+- `JjBookmark`: prefix `jj:(` and suffix `)` use `input_prompt_branch` (matching `ShellGitBranch`'s use of `input_prompt_git`).
+- `JjDirtyItems`: prefix `±` uses `input_prompt_svn`.
 
 **1h. `available_chips()` (~line 539):** Add `ContextChipKind::JjBookmark,` and `ContextChipKind::JjDirtyItems,` to the list.
 

--- a/specs/GH11797/tech.md
+++ b/specs/GH11797/tech.md
@@ -21,72 +21,62 @@ The SVN chips (`SvnBranch`, `SvnDirtyItems`) are the closest analogue: shell-bas
 
 ### `jj_bookmark()`
 
-Produces the chip value text using the prototype command from the issue body:
+Produces the chip value text using `jj log` with output templates. Uses `bookmarks.map()`
+to list bookmarks on the current change, falling back to `change_id.shortest(8)` when
+anonymous.
 
 ```rust
-const SH_COMMAND: &str = concat!(
-    "_jj_bm=$(jj log -r @ --no-graph --ignore-working-copy",
-    " --template 'if(bookmarks,bookmarks,\"\")' 2>/dev/null);",
-    " if [ -n \"$_jj_bm\" ]; then echo \"$_jj_bm\";",
-    " else _jj_cid=$(jj log -r @ --no-graph --ignore-working-copy",
-    " --template 'change_id.short(8)' 2>/dev/null);",
-    " _jj_abm=$(jj log -r 'latest(ancestors(@) & bookmarks() ~ @)'",
-    " --no-graph --ignore-working-copy --template 'bookmarks' 2>/dev/null);",
-    " [ -n \"$_jj_abm\" ] && echo \"$_jj_cid on $_jj_abm\" || echo \"$_jj_cid\"; fi",
-);
+// Bash/Zsh:
+const SH_BOOKMARK_CMD: &str = "bookmarks=$(jj log -r '@' --no-graph \
+    -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
+    && if [ -n \"$bookmarks\" ]; then echo \"$bookmarks\"; \
+    else jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null; fi";
 ```
-
-This single shell command handles all five bookmark/change states listed in the issue description. Fish and PowerShell need their own variants:
 
 ```fish
 # Fish:
-set _jj_bm (jj log -r @ --no-graph --ignore-working-copy \
-    --template 'if(bookmarks,bookmarks,"")' 2>/dev/null)
-if test -n "$_jj_bm"
-    echo "$_jj_bm"
-else
-    set _jj_cid (jj log -r @ --no-graph --ignore-working-copy \
-        --template 'change_id.short(8)' 2>/dev/null)
-    set _jj_abm (jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' \
-        --no-graph --ignore-working-copy --template 'bookmarks' 2>/dev/null)
-    if test -n "$_jj_abm"
-        echo "$_jj_cid on $_jj_abm"
-    else
-        echo "$_jj_cid"
-    end
-end
+const FISH_BOOKMARK_CMD: &str = "set bookmarks (jj log -r '@' --no-graph \
+    -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>/dev/null | head -1) \
+    && if test -n \"$bookmarks\"; echo $bookmarks; \
+    else; jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>/dev/null; end";
 ```
 
 ```powershell
-# PowerShell:
-$_jj_bm = jj log -r @ --no-graph --ignore-working-copy `
-    --template 'if(bookmarks,bookmarks,"")' 2>$null
-if ($_jj_bm) { $_jj_bm }
-else {
-    $_jj_cid = jj log -r @ --no-graph --ignore-working-copy `
-        --template 'change_id.short(8)' 2>$null
-    $_jj_abm = jj log -r 'latest(ancestors(@) & bookmarks() ~ @)' `
-        --no-graph --ignore-working-copy --template 'bookmarks' 2>$null
-    if ($_jj_abm) { "$_jj_cid on $_jj_abm" } else { $_jj_cid }
-}
+// PowerShell:
+const PWSH_BOOKMARK_CMD: &str = "$bookmarks = jj log -r '@' --no-graph \
+    -T 'separate(\" \", bookmarks.map(|x| x.name()))' 2>$null; \
+    if ($bookmarks) { $bookmarks } \
+    else { jj log -r '@' --no-graph -T 'change_id.shortest(8)' 2>$null }";
 ```
+
+All three shell variants use `ShellCommand::shell_specific([...])` with per-shell entries,
+following the `svn_branch_context()` / `svn_dirty_items()` pattern.
 
 ### `jj_dirty_items()`
 
 Produces the count of changed files in the working copy:
 
-```bash
-# Bash/Zsh:
-count=$(jj diff --summary 2>/dev/null | wc -l) && (( $count > 0 )) && echo $(( $count ))
-
-# Fish:
-set count (jj diff --summary 2>/dev/null | wc -l); test $count -gt 0 && string trim $count
-
-# PowerShell:
-$count = (jj diff --summary 2>$null | Measure-Object -line).Lines; if ($count -gt 0) { $count }
+```rust
+// Bash/Zsh:
+const SH_DIRTY_CMD: &str =
+    "count=$(jj diff --summary 2>/dev/null | wc -l) && [ \"$count\" -gt 0 ] && echo \"$count\"";
 ```
 
-`jj diff --summary` outputs one line per changed file and produces no output when the workspace is clean, so `wc -l` gives an accurate count without header noise.
+```rust
+// Fish:
+const FISH_DIRTY_CMD: &str = "set count (jj diff --summary 2>/dev/null | wc -l) \
+    && test $count -gt 0 && string trim $count";
+```
+
+```rust
+// PowerShell:
+const PWSH_DIRTY_CMD: &str = "jj diff --summary 2>$null | Measure-Object -Line | \
+    Where-Object { $_.Lines -gt 0 } | ForEach-Object { $_.Lines }";
+```
+
+`jj diff --summary` outputs one line per changed file. The pipe to `wc -l` / `Measure-Object` gives
+an accurate count. When the workspace is clean (zero changes), the chip value is empty and the chip
+is hidden.
 
 ## Proposed changes
 
@@ -140,7 +130,7 @@ Self::GitDiffStats | Self::SvnDirtyItems | Self::JjDirtyItems => Some(Icon::File
 ```
 
 **1g. `render_text_from_kind()` (~line 627):** Add match arms for both variants, mirroring `SvnBranch`/`SvnDirtyItems` rendering:
-- `JjBookmark`: prefix `jj:(` and suffix `)` use `input_prompt_branch` (matching `ShellGitBranch`'s use of `input_prompt_git`).
+- `JjBookmark`: prefix `jj:(` and suffix `)` use `input_prompt_branch`.
 - `JjDirtyItems`: prefix `±` uses `input_prompt_svn`.
 
 **1h. `available_chips()` (~line 539):** Add `ContextChipKind::JjBookmark,` and `ContextChipKind::JjDirtyItems,` to the list.
@@ -168,13 +158,17 @@ For PowerShell variants, port the bash logic to PowerShell using `jj` commands d
 
 ## Testing and validation
 
+Each shell-specific command variant (Bash/Zsh, Fish, PowerShell) should be exercised to ensure
+the template string escaping is correct across all platforms.
+
 | Product invariant | Test approach |
 |---|---|
-| 1. Chips appear in picker UI | Unit test in `builtins_tests.rs`: verify `available_chips()` includes both new variants |
-| 2. Runtime disable when `jj` absent | Unit test in `current_prompt_tests.rs`: mirror `test_shell_chip_disabled_when_executable_is_missing` for `jj` |
+| 1. Chips appear in picker UI | Unit test: `available_chips()` includes `JjBookmark` and `JjDirtyItems` |
+| 2. Runtime disable when `jj` absent | Unit test: `dependencies()` returns `["jj"]`; ChipRuntimePolicy disables chip |
 | 3–5. JjBookmark display text | Shell command test: run `jj log` in a `jj` repo with various states and verify output format |
 | 6. Empty when no jj repo | Manual: `cd /tmp && warp` — chip should not render |
 | 7. JjDirtyItems count | Shell command test: run `jj diff --summary` in a repo with known changes and verify count |
-| 8–9. Rendering | Unit test in `display_chip_tests.rs` or `renderer_tests.rs`: verify `render_text_from_kind` produces correct styled spans |
-| 10. Adjacent spacing | Unit test in `prompt_tests.rs` or `mod.rs` test: verify `chips_to_string` omits space between `JjBookmark`/`JjDirtyItems` |
-| 13. Icons | Unit test: verify `udi_icon()` returns correct icon for both variants |
+| 8–9. Rendering | Unit test: verify `render_text_from_kind` produces correct prefix/suffix styled spans |
+| 10. Adjacent spacing | Unit test: verify `chips_to_string` omits space between `JjBookmark`/`JjDirtyItems` in both orders |
+| 11. Placeholders | Unit test: `placeholder_value()` returns `jj-feature-bookmark` and `3` |
+| 12. Icons | Unit test: `udi_icon()` returns `Icon::GitBranch` / `Icon::File` |


### PR DESCRIPTION
## Summary

Add two new prompt context chips for the `jj` (Jujutsu) VCS: JjBookmark (bookmark/change display) and JjDirtyItems (changed-file count), mirroring the existing SvnBranch / SvnDirtyItems chip pattern.

Closes #11797.

## Files

- `specs/GH11797/product.md` — 13 behavior invariants
- `specs/GH11797/tech.md` — implementation plan with file:line references