### PR TITLE
Support remote symlinked project skills

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -371,11 +371,11 @@ fn test_refresh_project_skills_for_repo_loads_indexed_and_symlinked_skill_direct
                 project_state(&repo, Some(&indexed_skill)),
                 ctx,
             );
-            model.insert_test_standing_results(
-                repo_key,
-                project_standing_results(&repo, Some(&indexed_skill)),
-                ctx,
-            );
+            let mut standing_results = project_standing_results(&repo, Some(&indexed_skill));
+            standing_results.insert_project_skill(StandingQueryContent::file(
+                StandardizedPath::try_from_local(&skill_local_path(&expected_skill)).unwrap(),
+            ));
+            model.insert_test_standing_results(repo_key, standing_results, ctx);
         });
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -54,11 +54,14 @@ pub(super) fn find_project_skill_files_in_tree(
         }
     }
 
-    skill_files.extend(
+    for symlinked_skill_file in
         find_symlinked_skill_files_in_local_provider_directories(local_provider_directories)
-            .into_iter()
-            .map(LocalOrRemotePath::Local),
-    );
+    {
+        let symlinked_skill_file = LocalOrRemotePath::Local(symlinked_skill_file);
+        if !skill_files.contains(&symlinked_skill_file) {
+            skill_files.push(symlinked_skill_file);
+        }
+    }
     skill_files
 }
 

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -26,43 +26,23 @@ fn local_or_remote_path_for_repo_path(
     }
 }
 
-/// Finds project skill files and local symlinked skill files from stored standing results.
+/// Finds project skill files from stored standing results.
 ///
-/// Local provider directories are included in the metadata query so filesystem hydration can
-/// supplement indexed files with directory symlinks. Remote repositories only return indexed
-/// skill files because their filesystems are unavailable to the client.
+/// Symlinked project skills are resolved while evaluating standing queries on the process that
+/// owns the repository. This consumer treats those results as authoritative for both local and
+/// remote repositories; direct filesystem discovery remains confined to metadata-failure fallback.
 pub(super) fn find_project_skill_files_in_tree(
     repo_id: &RepositoryIdentifier,
     repo_metadata: &RepoMetadataModel,
     ctx: &AppContext,
 ) -> Vec<LocalOrRemotePath> {
-    let mut skill_files = Vec::new();
-    let mut local_provider_directories = Vec::new();
-    for content in repo_metadata
+    repo_metadata
         .standing_query_results(repo_id, ctx)
         .into_iter()
         .flat_map(|results| results.project_skills())
-    {
-        if content.is_directory {
-            if matches!(repo_id, RepositoryIdentifier::Local(_)) {
-                if let Some(path) = content.path.to_local_path() {
-                    local_provider_directories.push(path);
-                }
-            }
-        } else {
-            skill_files.push(local_or_remote_path_for_repo_path(repo_id, &content.path));
-        }
-    }
-
-    for symlinked_skill_file in
-        find_symlinked_skill_files_in_local_provider_directories(local_provider_directories)
-    {
-        let symlinked_skill_file = LocalOrRemotePath::Local(symlinked_skill_file);
-        if !skill_files.contains(&symlinked_skill_file) {
-            skill_files.push(symlinked_skill_file);
-        }
-    }
-    skill_files
+        .filter(|content| !content.is_directory)
+        .map(|content| local_or_remote_path_for_repo_path(repo_id, &content.path))
+        .collect()
 }
 
 /// Finds local project skill files by discovering provider directories on the filesystem.
@@ -119,35 +99,6 @@ fn find_local_provider_directories_on_filesystem(scan_root: &Path) -> Vec<PathBu
 
 fn is_ignored_fallback_scan_entry(entry: &DirEntry) -> bool {
     entry.file_name().to_str() == Some(".git")
-}
-
-/// Finds symlinked skill directories under loaded local provider directories in a repository.
-///
-/// Repo metadata intentionally skips directory symlinks to avoid duplicate trees/cycles. Project
-/// skill refreshes are still triggered by repo metadata, but local hydration supplements the tree
-/// with `SKILL.md` files from symlinked skill directories so existing symlink handling is preserved.
-fn find_symlinked_skill_files_in_local_provider_directories(
-    provider_dirs: Vec<PathBuf>,
-) -> Vec<PathBuf> {
-    provider_dirs
-        .into_iter()
-        .flat_map(|provider_dir| {
-            std::fs::read_dir(provider_dir)
-                .into_iter()
-                .flatten()
-                .filter_map(|entry| entry.ok())
-                .filter_map(|entry| {
-                    let skill_dir = entry.path();
-                    if skill_dir.is_symlink() && skill_dir.is_dir() {
-                        let skill_file = skill_dir.join("SKILL.md");
-                        if skill_file.exists() {
-                            return Some(skill_file);
-                        }
-                    }
-                    None
-                })
-        })
-        .collect()
 }
 
 fn is_project_provider_path(path: &Path) -> bool {

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -822,9 +822,9 @@ fn find_skill_files_in_tree_returns_remote_skill_paths_for_remote_repos() {
 
 #[cfg(unix)]
 #[test]
-fn find_skill_files_in_tree_deduplicates_locally_hydrated_symlink_results() {
+fn find_skill_files_in_tree_does_not_rescan_local_provider_directories() {
     VirtualFS::test(
-        "find_local_symlinked_skill_deduplication",
+        "find_local_symlinked_skills_from_standing_results_only",
         |dirs, mut vfs| {
             vfs.mkdir("repo/.agents/skills")
                 .mkdir("target")
@@ -835,7 +835,6 @@ fn find_skill_files_in_tree_deduplicates_locally_hydrated_symlink_results() {
             let repo = dirs.tests().join("repo");
             let provider = repo.join(".agents/skills");
             let linked_directory = provider.join("linked");
-            let linked_file = linked_directory.join("SKILL.md");
             std::os::unix::fs::symlink(dirs.tests().join("target"), &linked_directory).unwrap();
 
             App::test((), |mut app| async move {
@@ -843,10 +842,7 @@ fn find_skill_files_in_tree_deduplicates_locally_hydrated_symlink_results() {
                 let model_handle = app.add_singleton_model(RepoMetadataModel::new);
                 model_handle.update(&mut app, |model, ctx| {
                     let key = StandardizedPath::from_local_canonicalized(&repo).unwrap();
-                    let mut results =
-                        project_standing_results([
-                            StandardizedPath::try_from_local(&linked_file).unwrap()
-                        ]);
+                    let mut results = StandingQueryResults::default();
                     results.insert_project_skill(StandingQueryContent::directory(
                         StandardizedPath::try_from_local(&provider).unwrap(),
                     ));
@@ -855,10 +851,7 @@ fn find_skill_files_in_tree_deduplicates_locally_hydrated_symlink_results() {
 
                 model_handle.read(&app, |model, ctx| {
                     let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
-                    assert_eq!(
-                        find_project_skill_files_in_tree(&repo_id, model, ctx),
-                        vec![LocalOrRemotePath::Local(linked_file)]
-                    );
+                    assert!(find_project_skill_files_in_tree(&repo_id, model, ctx).is_empty());
                 });
             });
         },

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -820,6 +820,50 @@ fn find_skill_files_in_tree_returns_remote_skill_paths_for_remote_repos() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn find_skill_files_in_tree_deduplicates_locally_hydrated_symlink_results() {
+    VirtualFS::test(
+        "find_local_symlinked_skill_deduplication",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.agents/skills")
+                .mkdir("target")
+                .with_files(vec![Stub::FileWithContent(
+                    "target/SKILL.md",
+                    "---\nname: linked\ndescription: test\n---\n# linked",
+                )]);
+            let repo = dirs.tests().join("repo");
+            let provider = repo.join(".agents/skills");
+            let linked_directory = provider.join("linked");
+            let linked_file = linked_directory.join("SKILL.md");
+            std::os::unix::fs::symlink(dirs.tests().join("target"), &linked_directory).unwrap();
+
+            App::test((), |mut app| async move {
+                app.add_singleton_model(|_| DetectedRepositories::default());
+                let model_handle = app.add_singleton_model(RepoMetadataModel::new);
+                model_handle.update(&mut app, |model, ctx| {
+                    let key = StandardizedPath::from_local_canonicalized(&repo).unwrap();
+                    let mut results =
+                        project_standing_results([
+                            StandardizedPath::try_from_local(&linked_file).unwrap()
+                        ]);
+                    results.insert_project_skill(StandingQueryContent::directory(
+                        StandardizedPath::try_from_local(&provider).unwrap(),
+                    ));
+                    model.insert_test_standing_results(key, results, ctx);
+                });
+
+                model_handle.read(&app, |model, ctx| {
+                    let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+                    assert_eq!(
+                        find_project_skill_files_in_tree(&repo_id, model, ctx),
+                        vec![LocalOrRemotePath::Local(linked_file)]
+                    );
+                });
+            });
+        },
+    );
+}
 #[test]
 fn find_skill_files_in_tree_includes_ignored_skill_files() {
     VirtualFS::test("find_skills_ignored", |dirs, mut vfs| {

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -121,7 +121,7 @@ impl Entry {
             if path.is_symlink() && path.is_dir() {
                 state
                     .results
-                    .record_symlinked_project_skill_directory(&path, state.definitions);
+                    .record_followed_project_skill_directory(&path, state.definitions);
                 continue;
             }
             let path = if path.is_symlink() {
@@ -389,13 +389,13 @@ impl Entry {
                         };
                         let entry_path = entry.path();
 
-                        // Skip symlinks to folders before canonicalization to
-                        // prevent duplicates. Symlinks to files are kept as-is,
-                        // since canonicalization would point at the real file.
+                        // Do not materialize directory symlinks in the canonical tree. Standing
+                        // project-skill queries still follow eligible provider children locally
+                        // and retain their lexical paths in the result set.
                         let canonical_path = if entry_path.is_symlink() {
                             if entry_path.is_dir() {
                                 if let Some(state) = standing_queries.as_deref_mut() {
-                                    state.results.record_symlinked_project_skill_directory(
+                                    state.results.record_followed_project_skill_directory(
                                         &entry_path,
                                         state.definitions,
                                     );

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -119,6 +119,9 @@ impl Entry {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_symlink() && path.is_dir() {
+                state
+                    .results
+                    .record_symlinked_project_skill_directory(&path, state.definitions);
                 continue;
             }
             let path = if path.is_symlink() {
@@ -391,6 +394,12 @@ impl Entry {
                         // since canonicalization would point at the real file.
                         let canonical_path = if entry_path.is_symlink() {
                             if entry_path.is_dir() {
+                                if let Some(state) = standing_queries.as_deref_mut() {
+                                    state.results.record_symlinked_project_skill_directory(
+                                        &entry_path,
+                                        state.definitions,
+                                    );
+                                }
                                 None
                             } else {
                                 Some(entry_path)

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -443,7 +443,7 @@ fn standing_queries_report_symlinked_skills_without_materializing_symlinked_dire
                     max_depth: 200,
                     current_depth: 0,
                     ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
-                    ignored_path_interests: &[],
+                    force_included_paths: &[],
                     budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
                 },
                 &mut results,

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -3,7 +3,9 @@ use std::fs;
 use ignore::gitignore::Gitignore;
 
 use super::{matches_gitignores, Entry, IgnoredPathStrategy};
-use crate::{StandingQueryContent, StandingQueryDefinitions, StandingQueryResults};
+#[cfg(unix)]
+use crate::StandingQueryContent;
+use crate::{StandingQueryDefinitions, StandingQueryResults};
 #[test]
 fn test_git_path_filtering_allowlist() {
     use std::path::Path;

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -443,6 +443,8 @@ fn standing_queries_report_symlinked_skills_without_materializing_symlinked_dire
                     max_depth: 200,
                     current_depth: 0,
                     ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
+                    ignored_path_interests: &[],
+                    budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
                 },
                 &mut results,
                 &definitions,

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -3,7 +3,7 @@ use std::fs;
 use ignore::gitignore::Gitignore;
 
 use super::{matches_gitignores, Entry, IgnoredPathStrategy};
-use crate::{StandingQueryDefinitions, StandingQueryResults};
+use crate::{StandingQueryContent, StandingQueryDefinitions, StandingQueryResults};
 #[test]
 fn test_git_path_filtering_allowlist() {
     use std::path::Path;
@@ -411,6 +411,57 @@ fn standing_queries_report_skills_below_an_ignored_directory() {
     });
 }
 
+#[cfg(unix)]
+#[test]
+fn standing_queries_report_symlinked_skills_without_materializing_symlinked_directories() {
+    virtual_fs::VirtualFS::test(
+        "standing_queries_report_symlinked_skills",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.agents/skills")
+                .mkdir("targets/linked")
+                .with_files(vec![virtual_fs::Stub::FileWithContent(
+                    "targets/linked/SKILL.md",
+                    "name: linked",
+                )]);
+            let repo = dirs.tests().join("repo");
+            let linked_directory = repo.join(".agents/skills/linked");
+            std::os::unix::fs::symlink(dirs.tests().join("targets/linked"), &linked_directory)
+                .unwrap();
+
+            let mut files = Vec::new();
+            let mut gitignores = Vec::new();
+            let mut results = StandingQueryResults::default();
+            let mut definitions = StandingQueryDefinitions::default();
+            definitions
+                .set_project_skill_provider_paths([std::path::PathBuf::from(".agents/skills")]);
+            let tree = Entry::build_tree_with_standing_queries(
+                &repo,
+                &mut files,
+                &mut gitignores,
+                None,
+                super::BuildTreeOptions {
+                    max_depth: 200,
+                    current_depth: 0,
+                    ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
+                },
+                &mut results,
+                &definitions,
+            )
+            .unwrap();
+
+            assert!(find_entry(&tree, &linked_directory).is_none());
+            assert!(results.project_skills().any(|content| {
+                content
+                    == &StandingQueryContent::file(
+                        warp_util::standardized_path::StandardizedPath::try_from_local(
+                            &linked_directory.join("SKILL.md"),
+                        )
+                        .unwrap(),
+                    )
+            }));
+        },
+    );
+}
 #[test]
 fn standing_queries_report_rules_below_an_unloaded_shallow_directory() {
     virtual_fs::VirtualFS::test("standing_queries_report_shallow_rules", |dirs, mut vfs| {

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -5,6 +5,8 @@
 //! all repositories tracked by Warp.
 
 use std::collections::HashMap;
+#[cfg(feature = "local_fs")]
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -140,7 +142,9 @@ impl IndexedRepoState {
             }
         }
     }
+}
 
+impl IndexedRepoState {
     pub(crate) fn complete_if_pending(&self) {
         if let Self::Pending(condition) = self {
             condition.set();
@@ -176,6 +180,13 @@ pub struct LocalRepoMetadataModel {
     force_included_paths: Vec<PathBuf>,
     /// Configured standing-query matchers.
     standing_query_definitions: StandingQueryDefinitions,
+    /// Resolved target `SKILL.md` paths for standing project-skill results reached through
+    /// lexical symlinks, mapped back to the logical repository path that consumers read.
+    #[cfg(feature = "local_fs")]
+    project_skill_symlink_dependencies: HashMap<PathBuf, HashSet<ProjectSkillSymlinkDependency>>,
+    /// Resolved target directories registered with the filesystem watcher.
+    #[cfg(feature = "local_fs")]
+    watched_project_skill_symlink_target_dirs: HashSet<PathBuf>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -183,6 +194,12 @@ struct RepoUpdate {
     added: Vec<PathBuf>,
     deleted: Vec<PathBuf>,
     moved: HashMap<PathBuf, PathBuf>,
+}
+#[cfg(feature = "local_fs")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ProjectSkillSymlinkDependency {
+    repo_path: StandardizedPath,
+    logical_skill_path: StandardizedPath,
 }
 
 /// Describes a single file-tree mutation computed on a background thread.
@@ -263,6 +280,10 @@ impl LocalRepoMetadataModel {
             emit_incremental_updates: false,
             force_included_paths: Vec::new(),
             standing_query_definitions: StandingQueryDefinitions::default(),
+            #[cfg(feature = "local_fs")]
+            project_skill_symlink_dependencies: HashMap::new(),
+            #[cfg(feature = "local_fs")]
+            watched_project_skill_symlink_target_dirs: HashSet::new(),
         };
         cfg_if::cfg_if! {
             if #[cfg(feature = "local_fs")] {
@@ -321,6 +342,159 @@ impl LocalRepoMetadataModel {
             .set_project_skill_provider_paths(paths);
     }
 
+    /// Invalidates standing project-skill results whose resolved symlink target changed.
+    ///
+    /// The logical result path remains stable while the resolved file contents change, so an
+    /// upsert causes both local consumers and remote clients to reread the lexical skill path.
+    #[cfg(feature = "local_fs")]
+    fn handle_project_skill_symlink_target_event(
+        &mut self,
+        event: &BulkFilesystemWatcherEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let mut deltas_by_repo = HashMap::<StandardizedPath, StandingQueryResultsDelta>::new();
+        let mut append_dependencies = |target_path: &Path, removed: bool| {
+            let Some(dependencies) = self.project_skill_symlink_dependencies.get(target_path)
+            else {
+                return;
+            };
+            for dependency in dependencies {
+                let content =
+                    crate::StandingQueryContent::file(dependency.logical_skill_path.clone());
+                let delta = deltas_by_repo
+                    .entry(dependency.repo_path.clone())
+                    .or_default();
+                let entries = if removed {
+                    &mut delta.removed_project_skills
+                } else {
+                    &mut delta.upserted_project_skills
+                };
+                if !entries.contains(&content) {
+                    entries.push(content);
+                }
+            }
+        };
+
+        for path in event.added_or_updated_iter() {
+            append_dependencies(path, false);
+        }
+        for path in &event.deleted {
+            append_dependencies(path, true);
+        }
+        for (to_path, from_path) in &event.moved {
+            append_dependencies(from_path, true);
+            append_dependencies(to_path, false);
+        }
+
+        for (repo_path, delta) in deltas_by_repo {
+            let Some(results) = self.standing_results.get_mut(&repo_path) else {
+                continue;
+            };
+            results.apply_delta(&delta);
+            ctx.emit(RepositoryMetadataEvent::StandingQueryResultsUpdated {
+                path: repo_path.clone(),
+                delta: delta.clone(),
+            });
+            if self.emit_incremental_updates {
+                ctx.emit(RepositoryMetadataEvent::IncrementalUpdateReady {
+                    update: RepoMetadataUpdate {
+                        repo_path,
+                        remove_entries: Vec::new(),
+                        update_entries: Vec::new(),
+                        standing_results_delta: delta,
+                    },
+                });
+            }
+        }
+    }
+
+    /// Synchronizes producer-side target watches for symlinked standing project skills.
+    ///
+    /// Existing dependencies remain eligible after their `SKILL.md` target file is removed so
+    /// recreation of that file can emit an upsert without requiring a repository-tree change.
+    #[cfg(feature = "local_fs")]
+    fn refresh_project_skill_symlink_dependencies(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if !self.emit_incremental_updates {
+            return;
+        }
+        let mut logical_skill_paths = self
+            .standing_results
+            .get(repo_path)
+            .into_iter()
+            .flat_map(StandingQueryResults::project_skills)
+            .filter(|content| !content.is_directory)
+            .map(|content| content.path.clone())
+            .collect::<HashSet<_>>();
+        logical_skill_paths.extend(
+            self.project_skill_symlink_dependencies
+                .values()
+                .flatten()
+                .filter(|dependency| &dependency.repo_path == repo_path)
+                .map(|dependency| dependency.logical_skill_path.clone()),
+        );
+
+        for dependencies in self.project_skill_symlink_dependencies.values_mut() {
+            dependencies.retain(|dependency| &dependency.repo_path != repo_path);
+        }
+        self.project_skill_symlink_dependencies
+            .retain(|_, dependencies| !dependencies.is_empty());
+
+        for logical_skill_path in logical_skill_paths {
+            let Some(logical_path) = logical_skill_path.to_local_path() else {
+                continue;
+            };
+            let Some(logical_skill_dir) = logical_path.parent() else {
+                continue;
+            };
+            if !logical_skill_dir.is_symlink() {
+                continue;
+            }
+            let Ok(target_skill_dir) = dunce::canonicalize(logical_skill_dir) else {
+                continue;
+            };
+            let target_skill_path = target_skill_dir.join("SKILL.md");
+            self.project_skill_symlink_dependencies
+                .entry(target_skill_path)
+                .or_default()
+                .insert(ProjectSkillSymlinkDependency {
+                    repo_path: repo_path.clone(),
+                    logical_skill_path,
+                });
+        }
+
+        let desired_target_dirs = self
+            .project_skill_symlink_dependencies
+            .keys()
+            .filter_map(|path| path.parent().map(Path::to_path_buf))
+            .collect::<HashSet<_>>();
+        if let Some(ref watcher) = self.watcher {
+            for target_dir in
+                desired_target_dirs.difference(&self.watched_project_skill_symlink_target_dirs)
+            {
+                watcher.update(ctx, |watcher, _ctx| {
+                    std::mem::drop(watcher.register_path(
+                        target_dir,
+                        repo_watch_filter(),
+                        RecursiveMode::NonRecursive,
+                    ));
+                });
+            }
+            for target_dir in self
+                .watched_project_skill_symlink_target_dirs
+                .difference(&desired_target_dirs)
+            {
+                watcher.update(ctx, |watcher, _ctx| {
+                    std::mem::drop(watcher.unregister_path(target_dir));
+                });
+            }
+        }
+        self.watched_project_skill_symlink_target_dirs = desired_target_dirs;
+    }
+
     /// Handles events from the BulkFilesystemWatcher.
     #[cfg(feature = "local_fs")]
     fn handle_watcher_event(
@@ -328,6 +502,7 @@ impl LocalRepoMetadataModel {
         event: &BulkFilesystemWatcherEvent,
         ctx: &mut ModelContext<Self>,
     ) {
+        self.handle_project_skill_symlink_target_event(event, ctx);
         // Create a map to collect changes per repository
         let mut repo_updates: HashMap<StandardizedPath, RepoUpdate> = HashMap::new();
 
@@ -346,7 +521,7 @@ impl LocalRepoMetadataModel {
             {
                 let repo_update = repo_updates.entry(repo_path).or_default();
                 repo_update.deleted.push(path.to_path_buf());
-            } else {
+            } else if !self.project_skill_symlink_dependencies.contains_key(path) {
                 log::warn!("Deleted file not found in any repo: {path:?} not found in any repo");
             }
         }
@@ -411,6 +586,7 @@ impl LocalRepoMetadataModel {
                                 .entry(repo_path.clone())
                                 .or_default()
                                 .replace_subtrees(&removed_roots, discovered_results);
+                            model.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
                             update.standing_results_delta = standing_delta.clone();
                             ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
                                 path: repo_path.clone(),
@@ -522,6 +698,8 @@ impl LocalRepoMetadataModel {
         // Insert the repository state into the map
         let repo_path_for_event = repo_path.clone();
         self.replace_repository_state(repo_path, IndexedRepoState::Indexed(state));
+        #[cfg(feature = "local_fs")]
+        self.refresh_project_skill_symlink_dependencies(&repo_path_for_event, ctx);
 
         ctx.emit(RepositoryMetadataEvent::RepositoryUpdated {
             path: repo_path_for_event,
@@ -538,6 +716,8 @@ impl LocalRepoMetadataModel {
     ) -> Result<(), RepoMetadataError> {
         if self.remove_repository_state(repo_path).is_some() {
             self.standing_results.remove(repo_path);
+            #[cfg(feature = "local_fs")]
+            self.refresh_project_skill_symlink_dependencies(repo_path, ctx);
             // Unregister from watcher
             #[cfg(feature = "local_fs")]
             {
@@ -786,7 +966,7 @@ impl LocalRepoMetadataModel {
                             path_to_add,
                             standing_query_definitions,
                         );
-                        standing_results.record_symlinked_project_skill_directory(
+                        standing_results.record_followed_project_skill_directory(
                             path_to_add,
                             standing_query_definitions,
                         );
@@ -1243,6 +1423,8 @@ impl LocalRepoMetadataModel {
         ctx: &mut ModelContext<Self>,
     ) {
         self.standing_results.remove(&repo_path);
+        #[cfg(feature = "local_fs")]
+        self.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
         self.replace_repository_state(repo_path.clone(), IndexedRepoState::Failed(error));
         ctx.emit(RepositoryMetadataEvent::UpdatingRepositoryFailed { path: repo_path });
     }

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -180,13 +180,12 @@ pub struct LocalRepoMetadataModel {
     force_included_paths: Vec<PathBuf>,
     /// Configured standing-query matchers.
     standing_query_definitions: StandingQueryDefinitions,
-    /// Resolved target `SKILL.md` paths for standing project-skill results reached through
-    /// lexical symlinks, mapped back to the logical repository path that consumers read.
+    /// Resolved symlink target directories for direct children of ignored-path interests.
+    ///
+    /// One resolved target may be referenced by multiple lexical symlinks, so retain every
+    /// alias rather than using a one-to-one bidirectional map.
     #[cfg(feature = "local_fs")]
-    project_skill_symlink_dependencies: HashMap<PathBuf, HashSet<ProjectSkillSymlinkDependency>>,
-    /// Resolved target directories registered with the filesystem watcher.
-    #[cfg(feature = "local_fs")]
-    watched_project_skill_symlink_target_dirs: HashSet<PathBuf>,
+    symlink_targets: HashMap<PathBuf, HashSet<SymlinkTarget>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -197,9 +196,9 @@ struct RepoUpdate {
 }
 #[cfg(feature = "local_fs")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ProjectSkillSymlinkDependency {
+struct SymlinkTarget {
     repo_path: StandardizedPath,
-    logical_skill_path: StandardizedPath,
+    current_path: PathBuf,
 }
 
 /// Describes a single file-tree mutation computed on a background thread.
@@ -281,9 +280,7 @@ impl LocalRepoMetadataModel {
             force_included_paths: Vec::new(),
             standing_query_definitions: StandingQueryDefinitions::default(),
             #[cfg(feature = "local_fs")]
-            project_skill_symlink_dependencies: HashMap::new(),
-            #[cfg(feature = "local_fs")]
-            watched_project_skill_symlink_target_dirs: HashSet::new(),
+            symlink_targets: HashMap::new(),
         };
         cfg_if::cfg_if! {
             if #[cfg(feature = "local_fs")] {
@@ -327,6 +324,10 @@ impl LocalRepoMetadataModel {
     /// be represented eagerly instead of as lazy placeholders.
     pub fn register_force_included_paths(&mut self, paths: impl IntoIterator<Item = PathBuf>) {
         for path in paths {
+            assert!(
+                !path.is_absolute(),
+                "force-included paths must be repository-relative"
+            );
             if !self
                 .force_included_paths
                 .iter()
@@ -342,78 +343,52 @@ impl LocalRepoMetadataModel {
             .set_project_skill_provider_paths(paths);
     }
 
-    /// Invalidates standing project-skill results whose resolved symlink target changed.
+    /// Adds synthetic lexical repository updates for changes beneath resolved symlink targets.
     ///
-    /// The logical result path remains stable while the resolved file contents change, so an
-    /// upsert causes both local consumers and remote clients to reread the lexical skill path.
+    /// Directory symlinks are intentionally absent from the canonical tree, so target changes
+    /// must be replayed through their lexical paths to refresh standing-query results.
     #[cfg(feature = "local_fs")]
-    fn handle_project_skill_symlink_target_event(
-        &mut self,
+    fn add_symlink_target_updates(
+        &self,
         event: &BulkFilesystemWatcherEvent,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let mut deltas_by_repo = HashMap::<StandardizedPath, StandingQueryResultsDelta>::new();
-        let mut append_dependencies = |target_path: &Path, removed: bool| {
-            let Some(dependencies) = self.project_skill_symlink_dependencies.get(target_path)
-            else {
-                return;
-            };
-            for dependency in dependencies {
-                let content =
-                    crate::StandingQueryContent::file(dependency.logical_skill_path.clone());
-                let delta = deltas_by_repo
-                    .entry(dependency.repo_path.clone())
-                    .or_default();
-                let entries = if removed {
-                    &mut delta.removed_project_skills
-                } else {
-                    &mut delta.upserted_project_skills
-                };
-                if !entries.contains(&content) {
-                    entries.push(content);
+        repo_updates: &mut HashMap<StandardizedPath, RepoUpdate>,
+    ) -> HashSet<PathBuf> {
+        let mut matched_paths = HashSet::new();
+        let mut append_updates = |path: &Path| {
+            for (original_path, targets) in &self.symlink_targets {
+                if path != original_path && !path.starts_with(original_path) {
+                    continue;
+                }
+                matched_paths.insert(path.to_path_buf());
+                for target in targets {
+                    let update = repo_updates.entry(target.repo_path.clone()).or_default();
+                    if !update.deleted.contains(&target.current_path) {
+                        update.deleted.push(target.current_path.clone());
+                    }
+                    if target.current_path.is_dir() && !update.added.contains(&target.current_path)
+                    {
+                        update.added.push(target.current_path.clone());
+                    }
                 }
             }
         };
 
         for path in event.added_or_updated_iter() {
-            append_dependencies(path, false);
+            append_updates(path);
         }
         for path in &event.deleted {
-            append_dependencies(path, true);
+            append_updates(path);
         }
         for (to_path, from_path) in &event.moved {
-            append_dependencies(from_path, true);
-            append_dependencies(to_path, false);
+            append_updates(from_path);
+            append_updates(to_path);
         }
-
-        for (repo_path, delta) in deltas_by_repo {
-            let Some(results) = self.standing_results.get_mut(&repo_path) else {
-                continue;
-            };
-            results.apply_delta(&delta);
-            ctx.emit(RepositoryMetadataEvent::StandingQueryResultsUpdated {
-                path: repo_path.clone(),
-                delta: delta.clone(),
-            });
-            if self.emit_incremental_updates {
-                ctx.emit(RepositoryMetadataEvent::IncrementalUpdateReady {
-                    update: RepoMetadataUpdate {
-                        repo_path,
-                        remove_entries: Vec::new(),
-                        update_entries: Vec::new(),
-                        standing_results_delta: delta,
-                    },
-                });
-            }
-        }
+        matched_paths
     }
 
-    /// Synchronizes producer-side target watches for symlinked standing project skills.
-    ///
-    /// Existing dependencies remain eligible after their `SKILL.md` target file is removed so
-    /// recreation of that file can emit an upsert without requiring a repository-tree change.
+    /// Synchronizes producer-side target watches for symlinked children of ignored-path interests.
     #[cfg(feature = "local_fs")]
-    fn refresh_project_skill_symlink_dependencies(
+    fn refresh_symlink_targets(
         &mut self,
         repo_path: &StandardizedPath,
         ctx: &mut ModelContext<Self>,
@@ -421,60 +396,64 @@ impl LocalRepoMetadataModel {
         if !self.emit_incremental_updates {
             return;
         }
-        let mut logical_skill_paths = self
-            .standing_results
-            .get(repo_path)
-            .into_iter()
-            .flat_map(StandingQueryResults::project_skills)
-            .filter(|content| !content.is_directory)
-            .map(|content| content.path.clone())
-            .collect::<HashSet<_>>();
-        logical_skill_paths.extend(
-            self.project_skill_symlink_dependencies
-                .values()
-                .flatten()
-                .filter(|dependency| &dependency.repo_path == repo_path)
-                .map(|dependency| dependency.logical_skill_path.clone()),
-        );
-
-        for dependencies in self.project_skill_symlink_dependencies.values_mut() {
-            dependencies.retain(|dependency| &dependency.repo_path != repo_path);
-        }
-        self.project_skill_symlink_dependencies
-            .retain(|_, dependencies| !dependencies.is_empty());
-
-        for logical_skill_path in logical_skill_paths {
-            let Some(logical_path) = logical_skill_path.to_local_path() else {
+        let previously_watched = self.symlink_targets.keys().cloned().collect::<HashSet<_>>();
+        self.remove_symlink_targets_for_repo(repo_path);
+        let Some(local_repo_path) = repo_path.to_local_path() else {
+            return;
+        };
+        for interest in &self.force_included_paths {
+            let Ok(entries) = std::fs::read_dir(local_repo_path.join(interest)) else {
                 continue;
             };
-            let Some(logical_skill_dir) = logical_path.parent() else {
-                continue;
-            };
-            if !logical_skill_dir.is_symlink() {
-                continue;
+            for entry in entries.flatten() {
+                let current_path = entry.path();
+                if !current_path.is_symlink() || !current_path.is_dir() {
+                    continue;
+                }
+                let Ok(original_path) = dunce::canonicalize(&current_path) else {
+                    continue;
+                };
+                self.symlink_targets
+                    .entry(original_path)
+                    .or_default()
+                    .insert(SymlinkTarget {
+                        repo_path: repo_path.clone(),
+                        current_path,
+                    });
             }
-            let Ok(target_skill_dir) = dunce::canonicalize(logical_skill_dir) else {
-                continue;
-            };
-            let target_skill_path = target_skill_dir.join("SKILL.md");
-            self.project_skill_symlink_dependencies
-                .entry(target_skill_path)
-                .or_default()
-                .insert(ProjectSkillSymlinkDependency {
-                    repo_path: repo_path.clone(),
-                    logical_skill_path,
-                });
         }
+        self.sync_symlink_target_watches(previously_watched, ctx);
+    }
 
-        let desired_target_dirs = self
-            .project_skill_symlink_dependencies
-            .keys()
-            .filter_map(|path| path.parent().map(Path::to_path_buf))
-            .collect::<HashSet<_>>();
+    #[cfg(feature = "local_fs")]
+    fn remove_symlink_targets_for_repo(&mut self, repo_path: &StandardizedPath) {
+        for targets in self.symlink_targets.values_mut() {
+            targets.retain(|target| &target.repo_path != repo_path);
+        }
+        self.symlink_targets
+            .retain(|_, targets| !targets.is_empty());
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn clear_symlink_targets_for_repo(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let previously_watched = self.symlink_targets.keys().cloned().collect();
+        self.remove_symlink_targets_for_repo(repo_path);
+        self.sync_symlink_target_watches(previously_watched, ctx);
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn sync_symlink_target_watches(
+        &self,
+        previously_watched: HashSet<PathBuf>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let desired_target_dirs = self.symlink_targets.keys().cloned().collect::<HashSet<_>>();
         if let Some(ref watcher) = self.watcher {
-            for target_dir in
-                desired_target_dirs.difference(&self.watched_project_skill_symlink_target_dirs)
-            {
+            for target_dir in desired_target_dirs.difference(&previously_watched) {
                 watcher.update(ctx, |watcher, _ctx| {
                     std::mem::drop(watcher.register_path(
                         target_dir,
@@ -483,16 +462,12 @@ impl LocalRepoMetadataModel {
                     ));
                 });
             }
-            for target_dir in self
-                .watched_project_skill_symlink_target_dirs
-                .difference(&desired_target_dirs)
-            {
+            for target_dir in previously_watched.difference(&desired_target_dirs) {
                 watcher.update(ctx, |watcher, _ctx| {
                     std::mem::drop(watcher.unregister_path(target_dir));
                 });
             }
         }
-        self.watched_project_skill_symlink_target_dirs = desired_target_dirs;
     }
 
     /// Handles events from the BulkFilesystemWatcher.
@@ -502,9 +477,9 @@ impl LocalRepoMetadataModel {
         event: &BulkFilesystemWatcherEvent,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.handle_project_skill_symlink_target_event(event, ctx);
         // Create a map to collect changes per repository
         let mut repo_updates: HashMap<StandardizedPath, RepoUpdate> = HashMap::new();
+        let symlink_target_paths = self.add_symlink_target_updates(event, &mut repo_updates);
 
         // Process added or updated files
         for path in event.added_or_updated_iter() {
@@ -521,7 +496,7 @@ impl LocalRepoMetadataModel {
             {
                 let repo_update = repo_updates.entry(repo_path).or_default();
                 repo_update.deleted.push(path.to_path_buf());
-            } else if !self.project_skill_symlink_dependencies.contains_key(path) {
+            } else if !symlink_target_paths.contains(path) {
                 log::warn!("Deleted file not found in any repo: {path:?} not found in any repo");
             }
         }
@@ -586,7 +561,7 @@ impl LocalRepoMetadataModel {
                                 .entry(repo_path.clone())
                                 .or_default()
                                 .replace_subtrees(&removed_roots, discovered_results);
-                            model.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
+                            model.refresh_symlink_targets(&repo_path, ctx);
                             update.standing_results_delta = standing_delta.clone();
                             ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
                                 path: repo_path.clone(),
@@ -699,7 +674,7 @@ impl LocalRepoMetadataModel {
         let repo_path_for_event = repo_path.clone();
         self.replace_repository_state(repo_path, IndexedRepoState::Indexed(state));
         #[cfg(feature = "local_fs")]
-        self.refresh_project_skill_symlink_dependencies(&repo_path_for_event, ctx);
+        self.refresh_symlink_targets(&repo_path_for_event, ctx);
 
         ctx.emit(RepositoryMetadataEvent::RepositoryUpdated {
             path: repo_path_for_event,
@@ -717,7 +692,7 @@ impl LocalRepoMetadataModel {
         if self.remove_repository_state(repo_path).is_some() {
             self.standing_results.remove(repo_path);
             #[cfg(feature = "local_fs")]
-            self.refresh_project_skill_symlink_dependencies(repo_path, ctx);
+            self.clear_symlink_targets_for_repo(repo_path, ctx);
             // Unregister from watcher
             #[cfg(feature = "local_fs")]
             {
@@ -1424,7 +1399,7 @@ impl LocalRepoMetadataModel {
     ) {
         self.standing_results.remove(&repo_path);
         #[cfg(feature = "local_fs")]
-        self.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
+        self.clear_symlink_targets_for_repo(&repo_path, ctx);
         self.replace_repository_state(repo_path.clone(), IndexedRepoState::Failed(error));
         ctx.emit(RepositoryMetadataEvent::UpdatingRepositoryFailed { path: repo_path });
     }

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -786,6 +786,10 @@ impl LocalRepoMetadataModel {
                             path_to_add,
                             standing_query_definitions,
                         );
+                        standing_results.record_symlinked_project_skill_directory(
+                            path_to_add,
+                            standing_query_definitions,
+                        );
                     }
                     Err(e) => {
                         log::warn!("Failed to build subtree for directory {path_to_add:?}: {e:?}");

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -457,7 +457,7 @@ impl LocalRepoMetadataModel {
                 watcher.update(ctx, |watcher, _ctx| {
                     std::mem::drop(watcher.register_path(
                         target_dir,
-                        repo_watch_filter(),
+                        repo_watch_filter(Vec::new(), Vec::new()),
                         RecursiveMode::NonRecursive,
                     ));
                 });

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -24,7 +24,9 @@ use crate::local_model::{
 };
 use crate::repositories::DetectedRepositories;
 use crate::watcher::DirectoryWatcher;
-use crate::{RepoMetadataError, StandingQueryContent, StandingQueryDefinitions};
+use crate::{
+    RepoMetadataError, StandingQueryContent, StandingQueryDefinitions, StandingQueryResults,
+};
 
 impl LocalRepoMetadataModel {
     fn new_for_test() -> Self {
@@ -37,6 +39,10 @@ impl LocalRepoMetadataModel {
             emit_incremental_updates: false,
             force_included_paths: Default::default(),
             standing_query_definitions: Default::default(),
+            #[cfg(feature = "local_fs")]
+            project_skill_symlink_dependencies: Default::default(),
+            #[cfg(feature = "local_fs")]
+            watched_project_skill_symlink_target_dirs: Default::default(),
         }
     }
 }
@@ -1405,6 +1411,220 @@ fn added_external_target_skill_symlink_routes_to_lexical_repository() {
                         .any(|content| content
                             == &StandingQueryContent::directory(provider_path.clone())));
                 });
+            });
+        },
+    );
+}
+#[cfg(all(unix, feature = "local_fs"))]
+#[test]
+fn modified_external_symlink_target_upserts_lexical_project_skill() {
+    VirtualFS::test(
+        "modified_external_symlink_target_upserts_lexical_project_skill",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.agents/skills")
+                .mkdir("outside/linked-skill")
+                .with_files(vec![Stub::FileWithContent(
+                    "outside/linked-skill/SKILL.md",
+                    "linked skill",
+                )]);
+            let repo = dirs.tests().join("repo");
+            let logical_skill_dir = repo.join(".agents/skills/linked-skill");
+            let logical_skill_path = logical_skill_dir.join("SKILL.md");
+            let target_skill_path = dirs.tests().join("outside/linked-skill/SKILL.md");
+            std::os::unix::fs::symlink(
+                dirs.tests().join("outside/linked-skill"),
+                &logical_skill_dir,
+            )
+            .unwrap();
+
+            App::test((), |mut app| async move {
+                let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
+                let logical_skill_path =
+                    StandardizedPath::try_from_local(&logical_skill_path).unwrap();
+                let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
+                model_handle.update(&mut app, |model, ctx| {
+                    model.set_emit_incremental_updates(true);
+                    model.repositories.insert(
+                        repo_path.clone(),
+                        IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
+                    );
+                    let mut results = StandingQueryResults::default();
+                    results.insert_project_skill(StandingQueryContent::file(
+                        logical_skill_path.clone(),
+                    ));
+                    model.standing_results.insert(repo_path.clone(), results);
+                    model.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
+                });
+
+                let (tx, rx) = oneshot::channel();
+                let received_delta = Rc::new(RefCell::new(Some(tx)));
+                let received_delta_for_event = received_delta.clone();
+                let logical_skill_path_for_event = logical_skill_path.clone();
+                app.update(|ctx| {
+                    ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
+                        if let RepositoryMetadataEvent::IncrementalUpdateReady { update } = event {
+                            if update
+                                .standing_results_delta
+                                .upserted_project_skills
+                                .iter()
+                                .any(|content| {
+                                    content
+                                        == &StandingQueryContent::file(
+                                            logical_skill_path_for_event.clone(),
+                                        )
+                                })
+                            {
+                                if let Some(tx) = received_delta_for_event.borrow_mut().take() {
+                                    let _ = tx.send(());
+                                }
+                            }
+                        }
+                    });
+                });
+
+                model_handle.update(&mut app, |model, ctx| {
+                    model.handle_watcher_event(
+                        &BulkFilesystemWatcherEvent {
+                            modified: std::collections::HashSet::from([target_skill_path]),
+                            ..Default::default()
+                        },
+                        ctx,
+                    );
+                });
+
+                rx.with_timeout(Duration::from_secs(5))
+                    .await
+                    .expect("timed out waiting for symlink target upsert")
+                    .expect("symlink target upsert sender dropped");
+            });
+        },
+    );
+}
+
+#[cfg(all(unix, feature = "local_fs"))]
+#[test]
+fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skill() {
+    VirtualFS::test(
+        "removed_then_recreated_external_symlink_target_refreshes_lexical_project_skill",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.agents/skills")
+                .mkdir("outside/linked-skill")
+                .with_files(vec![Stub::FileWithContent(
+                    "outside/linked-skill/SKILL.md",
+                    "linked skill",
+                )]);
+            let repo = dirs.tests().join("repo");
+            let logical_skill_dir = repo.join(".agents/skills/linked-skill");
+            let logical_skill_path = logical_skill_dir.join("SKILL.md");
+            let target_skill_path = dirs.tests().join("outside/linked-skill/SKILL.md");
+            std::os::unix::fs::symlink(
+                dirs.tests().join("outside/linked-skill"),
+                &logical_skill_dir,
+            )
+            .unwrap();
+
+            App::test((), |mut app| async move {
+                let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
+                let logical_skill_path =
+                    StandardizedPath::try_from_local(&logical_skill_path).unwrap();
+                let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
+                model_handle.update(&mut app, |model, ctx| {
+                    model.set_emit_incremental_updates(true);
+                    model.repositories.insert(
+                        repo_path.clone(),
+                        IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
+                    );
+                    let mut results = StandingQueryResults::default();
+                    results.insert_project_skill(StandingQueryContent::file(
+                        logical_skill_path.clone(),
+                    ));
+                    model.standing_results.insert(repo_path.clone(), results);
+                    model.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
+                });
+
+                let (tx, rx) = oneshot::channel();
+                let received_delta = Rc::new(RefCell::new(Some(tx)));
+                let received_delta_for_event = received_delta.clone();
+                let logical_skill_path_for_event = logical_skill_path.clone();
+                app.update(|ctx| {
+                    ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
+                        if let RepositoryMetadataEvent::StandingQueryResultsUpdated {
+                            delta, ..
+                        } = event
+                        {
+                            if delta.removed_project_skills.iter().any(|content| {
+                                content
+                                    == &StandingQueryContent::file(
+                                        logical_skill_path_for_event.clone(),
+                                    )
+                            }) {
+                                if let Some(tx) = received_delta_for_event.borrow_mut().take() {
+                                    let _ = tx.send(());
+                                }
+                            }
+                        }
+                    });
+                });
+
+                model_handle.update(&mut app, |model, ctx| {
+                    model.handle_watcher_event(
+                        &BulkFilesystemWatcherEvent {
+                            deleted: std::collections::HashSet::from([target_skill_path.clone()]),
+                            ..Default::default()
+                        },
+                        ctx,
+                    );
+                });
+
+                rx.with_timeout(Duration::from_secs(5))
+                    .await
+                    .expect("timed out waiting for symlink target removal")
+                    .expect("symlink target removal sender dropped");
+                model_handle.read(&app, |model, _ctx| {
+                    assert!(model
+                        .standing_query_results(&repo_path)
+                        .expect("standing results should remain tracked")
+                        .project_skills()
+                        .all(|content| content
+                            != &StandingQueryContent::file(logical_skill_path.clone())));
+                });
+
+                let (tx, rx) = oneshot::channel();
+                let received_delta = Rc::new(RefCell::new(Some(tx)));
+                let received_delta_for_event = received_delta.clone();
+                let logical_skill_path_for_event = logical_skill_path.clone();
+                app.update(|ctx| {
+                    ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
+                        if let RepositoryMetadataEvent::StandingQueryResultsUpdated {
+                            delta, ..
+                        } = event
+                        {
+                            if delta.upserted_project_skills.iter().any(|content| {
+                                content
+                                    == &StandingQueryContent::file(
+                                        logical_skill_path_for_event.clone(),
+                                    )
+                            }) {
+                                if let Some(tx) = received_delta_for_event.borrow_mut().take() {
+                                    let _ = tx.send(());
+                                }
+                            }
+                        }
+                    });
+                });
+                model_handle.update(&mut app, |model, ctx| {
+                    model.handle_watcher_event(
+                        &BulkFilesystemWatcherEvent {
+                            added: std::collections::HashSet::from([target_skill_path]),
+                            ..Default::default()
+                        },
+                        ctx,
+                    );
+                });
+                rx.with_timeout(Duration::from_secs(5))
+                    .await
+                    .expect("timed out waiting for recreated symlink target upsert")
+                    .expect("recreated symlink target upsert sender dropped");
             });
         },
     );

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -24,9 +24,9 @@ use crate::local_model::{
 };
 use crate::repositories::DetectedRepositories;
 use crate::watcher::DirectoryWatcher;
-use crate::{
-    RepoMetadataError, StandingQueryContent, StandingQueryDefinitions, StandingQueryResults,
-};
+#[cfg(all(unix, feature = "local_fs"))]
+use crate::StandingQueryResults;
+use crate::{RepoMetadataError, StandingQueryContent, StandingQueryDefinitions};
 
 impl LocalRepoMetadataModel {
     fn new_for_test() -> Self {
@@ -49,7 +49,7 @@ impl LocalRepoMetadataModel {
 #[should_panic(expected = "force-included paths must be repository-relative")]
 fn force_included_paths_must_be_relative() {
     let mut model = LocalRepoMetadataModel::new_for_test();
-    model.register_force_included_paths([PathBuf::from("/absolute/path")]);
+    model.register_force_included_paths([std::env::temp_dir().join("absolute/path")]);
 }
 fn empty_repo_state(repo_path: &StandardizedPath) -> FileTreeState {
     let root = Entry::Directory(DirectoryEntry {

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -40,13 +40,17 @@ impl LocalRepoMetadataModel {
             force_included_paths: Default::default(),
             standing_query_definitions: Default::default(),
             #[cfg(feature = "local_fs")]
-            project_skill_symlink_dependencies: Default::default(),
-            #[cfg(feature = "local_fs")]
-            watched_project_skill_symlink_target_dirs: Default::default(),
+            symlink_targets: Default::default(),
         }
     }
 }
 
+#[test]
+#[should_panic(expected = "ignored path interests must be repository-relative")]
+fn force_included_paths_must_be_relative() {
+    let mut model = LocalRepoMetadataModel::new_for_test();
+    model.register_force_included_paths([PathBuf::from("/absolute/path")]);
+}
 fn empty_repo_state(repo_path: &StandardizedPath) -> FileTreeState {
     let root = Entry::Directory(DirectoryEntry {
         path: repo_path.clone(),
@@ -452,7 +456,6 @@ fn test_index_directory_upgrades_lazy_loaded_path_to_repo() {
                     .entry
                     .contains(&StandardizedPath::try_from_local(&source_file).unwrap()));
             });
-
             let (tx, rx) = oneshot::channel();
             let repo_root_for_event = repo_root.clone();
             let upgrade_completed = Rc::new(RefCell::new(Some(tx)));
@@ -1444,6 +1447,8 @@ fn modified_external_symlink_target_upserts_lexical_project_skill() {
                 let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
                 model_handle.update(&mut app, |model, ctx| {
                     model.set_emit_incremental_updates(true);
+                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
+                    model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
                     model.repositories.insert(
                         repo_path.clone(),
                         IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
@@ -1453,7 +1458,7 @@ fn modified_external_symlink_target_upserts_lexical_project_skill() {
                         logical_skill_path.clone(),
                     ));
                     model.standing_results.insert(repo_path.clone(), results);
-                    model.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
+                    model.refresh_symlink_targets(&repo_path, ctx);
                 });
 
                 let (tx, rx) = oneshot::channel();
@@ -1530,6 +1535,8 @@ fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skil
                 let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
                 model_handle.update(&mut app, |model, ctx| {
                     model.set_emit_incremental_updates(true);
+                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
+                    model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
                     model.repositories.insert(
                         repo_path.clone(),
                         IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
@@ -1539,7 +1546,7 @@ fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skil
                         logical_skill_path.clone(),
                     ));
                     model.standing_results.insert(repo_path.clone(), results);
-                    model.refresh_project_skill_symlink_dependencies(&repo_path, ctx);
+                    model.refresh_symlink_targets(&repo_path, ctx);
                 });
 
                 let (tx, rx) = oneshot::channel();
@@ -1566,6 +1573,7 @@ fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skil
                     });
                 });
 
+                std::fs::remove_file(&target_skill_path).unwrap();
                 model_handle.update(&mut app, |model, ctx| {
                     model.handle_watcher_event(
                         &BulkFilesystemWatcherEvent {
@@ -1612,6 +1620,7 @@ fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skil
                         }
                     });
                 });
+                std::fs::write(&target_skill_path, "linked skill").unwrap();
                 model_handle.update(&mut app, |model, ctx| {
                     model.handle_watcher_event(
                         &BulkFilesystemWatcherEvent {
@@ -1625,6 +1634,130 @@ fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skil
                     .await
                     .expect("timed out waiting for recreated symlink target upsert")
                     .expect("recreated symlink target upsert sender dropped");
+            });
+        },
+    );
+}
+
+#[cfg(all(unix, feature = "local_fs"))]
+#[test]
+fn symlink_targets_retain_aliases_and_clear_for_removed_or_failed_repositories() {
+    VirtualFS::test(
+        "symlink_targets_retain_aliases_and_clear_for_removed_or_failed_repositories",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.agents/skills")
+                .mkdir("outside/shared-skill")
+                .with_files(vec![Stub::FileWithContent(
+                    "outside/shared-skill/SKILL.md",
+                    "shared skill",
+                )]);
+            let repo = dirs.tests().join("repo");
+            let target = dirs.tests().join("outside/shared-skill");
+            std::os::unix::fs::symlink(&target, repo.join(".agents/skills/first")).unwrap();
+            std::os::unix::fs::symlink(&target, repo.join(".agents/skills/second")).unwrap();
+
+            App::test((), |mut app| async move {
+                let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
+                let target = dunce::canonicalize(target).unwrap();
+                let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
+                model_handle.update(&mut app, |model, ctx| {
+                    model.set_emit_incremental_updates(true);
+                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
+                    model.repositories.insert(
+                        repo_path.clone(),
+                        IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
+                    );
+                    model.refresh_symlink_targets(&repo_path, ctx);
+                });
+
+                model_handle.read(&app, |model, _ctx| {
+                    assert_eq!(
+                        model
+                            .symlink_targets
+                            .get(&target)
+                            .expect("resolved target should be tracked")
+                            .len(),
+                        2
+                    );
+                });
+
+                model_handle.update(&mut app, |model, ctx| {
+                    model
+                        .remove_repository(&repo_path, ctx)
+                        .expect("repository should be removed");
+                });
+                model_handle.read(&app, |model, _ctx| {
+                    assert!(model.symlink_targets.is_empty());
+                });
+
+                model_handle.update(&mut app, |model, ctx| {
+                    model.repositories.insert(
+                        repo_path.clone(),
+                        IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
+                    );
+                    model.refresh_symlink_targets(&repo_path, ctx);
+                    model.mark_repository_failed(
+                        repo_path.clone(),
+                        RepoMetadataError::RepoNotFound(repo_path.to_string()),
+                        ctx,
+                    );
+                });
+                model_handle.read(&app, |model, _ctx| {
+                    assert!(model.symlink_targets.is_empty());
+                });
+            });
+        },
+    );
+}
+
+#[cfg(all(unix, feature = "local_fs"))]
+#[test]
+fn removed_external_symlink_target_directory_queues_lexical_removal_and_clears_mapping() {
+    VirtualFS::test(
+        "removed_external_symlink_target_directory_queues_lexical_removal_and_clears_mapping",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.agents/skills")
+                .mkdir("outside/linked-skill")
+                .with_files(vec![Stub::FileWithContent(
+                    "outside/linked-skill/SKILL.md",
+                    "linked skill",
+                )]);
+            let repo = dirs.tests().join("repo");
+            let logical_skill_dir = repo.join(".agents/skills/linked-skill");
+            let target_skill_dir = dirs.tests().join("outside/linked-skill");
+            std::os::unix::fs::symlink(&target_skill_dir, &logical_skill_dir).unwrap();
+
+            App::test((), |mut app| async move {
+                let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
+                let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
+                model_handle.update(&mut app, |model, ctx| {
+                    model.set_emit_incremental_updates(true);
+                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
+                    model.repositories.insert(
+                        repo_path.clone(),
+                        IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
+                    );
+                    model.refresh_symlink_targets(&repo_path, ctx);
+                });
+
+                std::fs::remove_dir_all(&target_skill_dir).unwrap();
+                model_handle.update(&mut app, |model, ctx| {
+                    let mut repo_updates = HashMap::new();
+                    let event = BulkFilesystemWatcherEvent {
+                        deleted: std::collections::HashSet::from([target_skill_dir.clone()]),
+                        ..Default::default()
+                    };
+                    let matched_paths = model.add_symlink_target_updates(&event, &mut repo_updates);
+                    assert!(matched_paths.contains(&target_skill_dir));
+                    let update = repo_updates
+                        .get(&repo_path)
+                        .expect("target directory deletion should queue a lexical refresh");
+                    assert_eq!(update.deleted, vec![logical_skill_dir.clone()]);
+                    assert!(update.added.is_empty());
+
+                    model.refresh_symlink_targets(&repo_path, ctx);
+                    assert!(model.symlink_targets.is_empty());
+                });
             });
         },
     );

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -1243,7 +1243,7 @@ fn added_symlinked_skill_directory_refreshes_provider_without_canonical_tree_mut
         let mut definitions = StandingQueryDefinitions::default();
         definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
         let update = RepoUpdate {
-            added: vec![linked_skill],
+            added: vec![linked_skill.clone()],
             ..Default::default()
         };
         let (mutations, discovered, removed_roots) = block_on(
@@ -1256,6 +1256,12 @@ fn added_symlinked_skill_directory_refreshes_provider_without_canonical_tree_mut
             content
                 == &StandingQueryContent::directory(
                     StandardizedPath::try_from_local(&provider).unwrap(),
+                )
+        }));
+        assert!(discovered.project_skills().any(|content| {
+            content
+                == &StandingQueryContent::file(
+                    StandardizedPath::try_from_local(&linked_skill.join("SKILL.md")).unwrap(),
                 )
         }));
     });

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -46,7 +46,7 @@ impl LocalRepoMetadataModel {
 }
 
 #[test]
-#[should_panic(expected = "ignored path interests must be repository-relative")]
+#[should_panic(expected = "force-included paths must be repository-relative")]
 fn force_included_paths_must_be_relative() {
     let mut model = LocalRepoMetadataModel::new_for_test();
     model.register_force_included_paths([PathBuf::from("/absolute/path")]);

--- a/crates/repo_metadata/src/standing_queries.rs
+++ b/crates/repo_metadata/src/standing_queries.rs
@@ -142,6 +142,22 @@ impl StandingQueryResults {
         }
     }
 
+    pub(crate) fn record_symlinked_project_skill_directory(
+        &mut self,
+        path: &Path,
+        definitions: &StandingQueryDefinitions,
+    ) {
+        if !definitions.is_direct_project_skill_provider_child(path) {
+            return;
+        }
+
+        let skill_file = path.join("SKILL.md");
+        if skill_file.is_file() {
+            self.project_skills.insert(StandingQueryContent::file(
+                StandardizedPath::from_local_absolute_unchecked(&skill_file),
+            ));
+        }
+    }
     pub fn insert_project_skill(&mut self, content: StandingQueryContent) {
         self.project_skills.insert(content);
     }

--- a/crates/repo_metadata/src/standing_queries.rs
+++ b/crates/repo_metadata/src/standing_queries.rs
@@ -142,7 +142,10 @@ impl StandingQueryResults {
         }
     }
 
-    pub(crate) fn record_symlinked_project_skill_directory(
+    /// Records an eligible project skill reached through a directory symlink during standing
+    /// query evaluation. The lexical path is intentionally retained so consumers address the
+    /// skill through the provider entry rather than the symlink target.
+    pub(crate) fn record_followed_project_skill_directory(
         &mut self,
         path: &Path,
         definitions: &StandingQueryDefinitions,
@@ -153,9 +156,7 @@ impl StandingQueryResults {
 
         let skill_file = path.join("SKILL.md");
         if skill_file.is_file() {
-            self.project_skills.insert(StandingQueryContent::file(
-                StandardizedPath::from_local_absolute_unchecked(&skill_file),
-            ));
+            self.record_path(&skill_file, false, definitions);
         }
     }
     pub fn insert_project_skill(&mut self, content: StandingQueryContent) {


### PR DESCRIPTION
## Description
- Add host-side discovery of symlinked project skills for authoritative repository metadata queries, including remote repositories.
- Keep canonical metadata trees unchanged while preserving remote symlink paths in project-skill results.
- Treat provider-directory updates as refresh-relevant for remote repositories now that discovery runs on the repository host.
- Stacked on #12047.

## Testing
- `./script/format`
- `cargo test --manifest-path Cargo.toml -p repo_metadata --features local_fs --lib wrapper_model`
- `cargo test --manifest-path Cargo.toml -p warp --lib update_relevance_detects_remote_skill_and_provider_directory_updates`
- `cargo test --manifest-path Cargo.toml -p warp --lib authoritative_project_skill_contents_preserve_remote_symlink_paths`
- Additional validation skipped at requester direction before submitting the stack.
<img width="595" height="561" alt="Screenshot 2026-06-01 at 11 06 23 PM" src="https://github.com/user-attachments/assets/e7d590d3-c788-432f-9997-003746f8dba4" />

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix discovery and refresh of symlinked project skills in remote repositories.

Co-Authored-By: Oz <oz-agent@warp.dev>
