### PR TITLE
Fix 3p agent prompt queueing bugs during Cloud Mode setup

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -189,11 +189,8 @@ pub(crate) struct Props<'a> {
     pub(super) thinking_display_mode: crate::settings::ThinkingDisplayMode,
     pub(super) conversation_has_imported_comments: bool,
     pub(super) ask_user_question_view: Option<&'a ViewHandle<AskUserQuestionView>>,
-    /// `true` when this block belongs to a cloud agent pane that is still in its setup
-    /// phase (running environment startup commands before the first agent turn). Used to
-    /// hide the response footer (thumbs up/down, credit usage, fork) until the agent has
-    /// produced real output — otherwise the footer renders awkwardly above the still-
-    /// pending optimistic user prompt.
+    /// `true` when this block belongs to a cloud agent pane that is still in its setup phase
+    /// (running environment startup commands before the first agent turn).
     pub(super) is_cloud_agent_pre_first_exchange: bool,
 }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -13423,6 +13423,9 @@ impl Input {
                 ambient_agent_model.is_ambient_agent()
                     && !ambient_agent_model.is_configuring_ambient_agent()
                     && !ambient_agent_model.is_agent_running()
+                    // Third-party (non-Oz) harnesses don't support prompt queueing, so leave the
+                    // input alone; the submission then falls through to being blocked during setup.
+                    && !ambient_agent_model.is_third_party_harness()
             });
         if !should_queue {
             return false;

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -130,7 +130,9 @@ use super::shell::ShellType;
 use super::universal_developer_input::{
     UniversalDeveloperInputButtonBar, UniversalDeveloperInputButtonBarEvent,
 };
-use super::view::ambient_agent::{AmbientAgentViewModel, AmbientAgentViewModelEvent};
+use super::view::ambient_agent::{
+    is_cloud_agent_pre_first_exchange, AmbientAgentViewModel, AmbientAgentViewModelEvent,
+};
 use super::view::inline_banner::{
     PromptSuggestionBannerState, ZeroStatePromptSuggestionTriggeredFrom,
     ZeroStatePromptSuggestionType,
@@ -6650,20 +6652,6 @@ impl Input {
         });
     }
 
-    fn should_block_cloud_mode_setup_submission(&self, app: &AppContext) -> bool {
-        if !FeatureFlag::CloudModeSetupV2.is_enabled() {
-            return false;
-        }
-
-        self.ambient_agent_view_model()
-            .is_some_and(|ambient_agent_model| {
-                let ambient_agent_model = ambient_agent_model.as_ref(app);
-                ambient_agent_model.is_ambient_agent()
-                    && !ambient_agent_model.is_configuring_ambient_agent()
-                    && !ambient_agent_model.is_agent_running()
-            })
-    }
-
     /// Try to execute a command in the local session that was
     /// requested by a shared session participant (sharer or viewer).
     ///
@@ -11183,9 +11171,26 @@ impl Input {
             pending_command_execution_request: None,
         });
 
-        // Set the server-assigned replica ID on the input buffer.
+        // Reinitializing for the server replica ID empties the buffer. During cloud setup the
+        // sharer's input sync is skipped, so preserve the viewer's in-progress follow-up instead
+        // of discarding it.
+        let cloud_setup_pre_first_exchange = FeatureFlag::CloudModeSetupV2.is_enabled()
+            && is_cloud_agent_pre_first_exchange(
+                self.ambient_agent_view_model(),
+                &self.agent_view_controller,
+                &self.model.lock(),
+                ctx,
+            );
+        let preserved_text = if cloud_setup_pre_first_exchange {
+            self.editor().as_ref(ctx).buffer_text(ctx)
+        } else {
+            String::new()
+        };
         self.editor().update(ctx, |editor, ctx| {
             editor.reinitialize_buffer(Some(replica_id), ctx);
+            if !preserved_text.is_empty() {
+                editor.set_buffer_text(&preserved_text, ctx);
+            }
         });
     }
 
@@ -12717,7 +12722,16 @@ impl Input {
             self.input_suggestions.update(ctx, |suggestions, ctx| {
                 suggestions.confirm(ctx);
             });
-        } else if self.should_block_cloud_mode_setup_submission(ctx) {
+        } else if FeatureFlag::CloudModeSetupV2.is_enabled()
+            && is_cloud_agent_pre_first_exchange(
+                self.ambient_agent_view_model(),
+                &self.agent_view_controller,
+                &self.model.lock(),
+                ctx,
+            )
+        {
+            // During cloud-mode setup, non-queued submissions (e.g. third-party harness runs that
+            // don't queue) are dropped rather than sent as live prompts the sharer can't accept.
             return;
         } else if FeatureFlag::HandoffCloudCloud.is_enabled()
             && self
@@ -13416,17 +13430,20 @@ impl Input {
             return false;
         }
 
-        let should_queue = self
-            .ambient_agent_view_model()
-            .is_some_and(|ambient_agent_model| {
-                let ambient_agent_model = ambient_agent_model.as_ref(ctx);
-                ambient_agent_model.is_ambient_agent()
-                    && !ambient_agent_model.is_configuring_ambient_agent()
-                    && !ambient_agent_model.is_agent_running()
-                    // Third-party (non-Oz) harnesses don't support prompt queueing, so leave the
-                    // input alone; the submission then falls through to being blocked during setup.
-                    && !ambient_agent_model.is_third_party_harness()
-            });
+        // Third-party (non-Oz) harnesses don't support prompt queueing, so leave the input
+        // alone; the submission then falls through to being blocked during setup.
+        let is_third_party_harness =
+            self.ambient_agent_view_model()
+                .is_some_and(|ambient_agent_model| {
+                    ambient_agent_model.as_ref(ctx).is_third_party_harness()
+                });
+        let should_queue = !is_third_party_harness
+            && is_cloud_agent_pre_first_exchange(
+                self.ambient_agent_view_model(),
+                &self.agent_view_controller,
+                &self.model.lock(),
+                ctx,
+            );
         if !should_queue {
             return false;
         }
@@ -14216,8 +14233,20 @@ impl Input {
         // off the screen because we were forcing the long running command to be the same
         // size of the cleared input box.
         if let BlockType::User(user_block) = &block_completed_event.block_type {
+            // During cloud-mode setup (before the first exchange) the cloud agent (sharer) runs
+            // environment setup commands the viewer never requested. Each completed setup block
+            // would otherwise reinitialize the buffer and wipe a follow-up the viewer is composing,
+            // so skip the clear for that window.
+            let cloud_setup_pre_first_exchange = FeatureFlag::CloudModeSetupV2.is_enabled()
+                && is_cloud_agent_pre_first_exchange(
+                    self.ambient_agent_view_model(),
+                    &self.agent_view_controller,
+                    &self.model.lock(),
+                    ctx,
+                );
             // Only clear the input buffer for user-executed commands, not agent-executed ones.
-            let should_clear_buffer = !user_block.was_part_of_agent_interaction;
+            let should_clear_buffer =
+                !user_block.was_part_of_agent_interaction && !cloud_setup_pre_first_exchange;
             let latest_block_id = self.model.lock().block_list().active_block_id().clone();
             let input_contents_before_prompt_chip_command =
                 self.input_contents_before_prompt_chip_command.take();

--- a/app/src/terminal/shared_session/viewer/event_loop.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop.rs
@@ -17,6 +17,7 @@ use crate::terminal::model::ansi::{self};
 use crate::terminal::model::block::AgentInteractionMetadata;
 use crate::terminal::shared_session::ai_agent::decode_agent_response_event;
 use crate::terminal::shared_session::{decode_scrollback, SharedSessionStatus};
+use crate::terminal::view::ambient_agent::is_cloud_agent_pre_first_exchange;
 use crate::terminal::{TerminalModel, TerminalView};
 
 /// If we end up buffering more than this many events,
@@ -191,6 +192,22 @@ impl EventLoop {
                     if ai_metadata.is_none() {
                         if let Some(view) = self.terminal_view.upgrade(ctx) {
                             view.update(ctx, |view, ctx| {
+                                // During cloud-mode setup the cloud agent (sharer) runs setup
+                                // commands the viewer never requested. Skip the clear so a
+                                // follow-up the viewer is composing isn't wiped on every setup
+                                // command. Mirrors the `InputUpdated` guard in the viewer's
+                                // network-event handler.
+                                if FeatureFlag::CloudModeSetupV2.is_enabled() && {
+                                    let model = view.model.lock();
+                                    is_cloud_agent_pre_first_exchange(
+                                        view.ambient_agent_view_model(),
+                                        view.agent_view_controller(),
+                                        &model,
+                                        ctx,
+                                    )
+                                } {
+                                    return;
+                                }
                                 view.input().update(ctx, |input, ctx| {
                                     input.unfreeze_and_clear_agent_input(ctx);
                                 });

--- a/app/src/terminal/shared_session/viewer/event_loop.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop.rs
@@ -192,20 +192,20 @@ impl EventLoop {
                     if ai_metadata.is_none() {
                         if let Some(view) = self.terminal_view.upgrade(ctx) {
                             view.update(ctx, |view, ctx| {
-                                // During cloud-mode setup the cloud agent (sharer) runs setup
-                                // commands the viewer never requested. Skip the clear so a
-                                // follow-up the viewer is composing isn't wiped on every setup
-                                // command. Mirrors the `InputUpdated` guard in the viewer's
-                                // network-event handler.
-                                if FeatureFlag::CloudModeSetupV2.is_enabled() && {
-                                    let model = view.model.lock();
-                                    is_cloud_agent_pre_first_exchange(
-                                        view.ambient_agent_view_model(),
-                                        view.agent_view_controller(),
-                                        &model,
-                                        ctx,
-                                    )
-                                } {
+                                // Skip during cloud setup: clearing on every setup command would
+                                // wipe a follow-up the viewer is composing. Mirrors the
+                                // `InputUpdated` guard.
+                                let skip_clear_during_setup =
+                                    FeatureFlag::CloudModeSetupV2.is_enabled() && {
+                                        let model = view.model.lock();
+                                        is_cloud_agent_pre_first_exchange(
+                                            view.ambient_agent_view_model(),
+                                            view.agent_view_controller(),
+                                            &model,
+                                            ctx,
+                                        )
+                                    };
+                                if skip_clear_during_setup {
                                     return;
                                 }
                                 view.input().update(ctx, |input, ctx| {

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1095,17 +1095,16 @@ impl TerminalManager {
                     // In cloud-mode startup (before the first exchange), shared-session input
                     // sync reflects environment setup commands. Skip applying remote edits so
                     // the visible input isn't populated with setup-command text.
-                    if FeatureFlag::CloudModeSetupV2.is_enabled()
-                        && {
-                            let model = view.model.lock();
-                            is_cloud_agent_pre_first_exchange(
-                                view.ambient_agent_view_model(),
-                                view.agent_view_controller(),
-                                &model,
-                                ctx,
-                            )
-                        }
-                    {
+                    let skip_during_setup = FeatureFlag::CloudModeSetupV2.is_enabled() && {
+                        let model = view.model.lock();
+                        is_cloud_agent_pre_first_exchange(
+                            view.ambient_agent_view_model(),
+                            view.agent_view_controller(),
+                            &model,
+                            ctx,
+                        )
+                    };
+                    if skip_during_setup {
                         return;
                     }
                     view.apply_viewer_shared_session_input_update(block_id, operations.clone(), ctx);

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -139,15 +139,9 @@ pub fn create_cloud_mode_view(
     (terminal_view, terminal_manager)
 }
 
-/// Returns `true` when a cloud agent is in any pre-first-exchange phase: first-time setup
-/// (`Setup`), still spawning (`WaitingForSession`, loading screen), or running env-setup
-/// commands before the first agent turn (`AgentRunning` with the startup-command flag).
-///
-/// This is the single predicate for "this cloud run hasn't produced its first exchange yet."
-/// It gates hiding the interactive input, rendering the loading footer, suppressing
-/// sharer-driven input sync / buffer clears, and holding back user submissions (queued for
-/// Oz, dropped for third-party). It requires a genuine cloud-agent/handoff pane and exits
-/// once a third-party harness CLI has started.
+/// Returns `true` when a cloud agent shared session is in any pre-first-exchange phase —
+/// either still spawning (loading screen) or running setup commands before the first
+/// agent turn. In this state, we hide the interactive input and render a loading footer.
 pub fn is_cloud_agent_pre_first_exchange(
     ambient_agent_view_model: Option<&ModelHandle<AmbientAgentViewModel>>,
     agent_view_controller: &ModelHandle<AgentViewController>,
@@ -166,7 +160,7 @@ pub fn is_cloud_agent_pre_first_exchange(
 
     let is_in_pre_first_exchange_status = matches!(
         view_model.status(),
-        Status::Setup | Status::WaitingForSession { .. } | Status::AgentRunning
+        Status::WaitingForSession { .. } | Status::AgentRunning
     );
     if !is_in_pre_first_exchange_status {
         return false;
@@ -191,12 +185,9 @@ pub fn is_cloud_agent_pre_first_exchange(
         return false;
     }
 
-    // Setup / loading phases (`Setup`, `WaitingForSession`): no env-setup commands have started
-    // yet, but we're still pre-first-exchange. Skip the block-list flag check.
-    if matches!(
-        view_model.status(),
-        Status::Setup | Status::WaitingForSession { .. }
-    ) {
+    // Loading phase (`WaitingForSession`): no setup commands have started yet, but we're
+    // still pre-first-exchange. Skip the block-list flag check.
+    if matches!(view_model.status(), Status::WaitingForSession { .. }) {
         return true;
     }
 

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -139,9 +139,15 @@ pub fn create_cloud_mode_view(
     (terminal_view, terminal_manager)
 }
 
-/// Returns `true` when a cloud agent shared session is in any pre-first-exchange phase —
-/// either still spawning (loading screen) or running setup commands before the first
-/// agent turn. In this state, we hide the interactive input and render a loading footer.
+/// Returns `true` when a cloud agent is in any pre-first-exchange phase: first-time setup
+/// (`Setup`), still spawning (`WaitingForSession`, loading screen), or running env-setup
+/// commands before the first agent turn (`AgentRunning` with the startup-command flag).
+///
+/// This is the single predicate for "this cloud run hasn't produced its first exchange yet."
+/// It gates hiding the interactive input, rendering the loading footer, suppressing
+/// sharer-driven input sync / buffer clears, and holding back user submissions (queued for
+/// Oz, dropped for third-party). It requires a genuine cloud-agent/handoff pane and exits
+/// once a third-party harness CLI has started.
 pub fn is_cloud_agent_pre_first_exchange(
     ambient_agent_view_model: Option<&ModelHandle<AmbientAgentViewModel>>,
     agent_view_controller: &ModelHandle<AgentViewController>,
@@ -160,7 +166,7 @@ pub fn is_cloud_agent_pre_first_exchange(
 
     let is_in_pre_first_exchange_status = matches!(
         view_model.status(),
-        Status::WaitingForSession { .. } | Status::AgentRunning
+        Status::Setup | Status::WaitingForSession { .. } | Status::AgentRunning
     );
     if !is_in_pre_first_exchange_status {
         return false;
@@ -185,9 +191,12 @@ pub fn is_cloud_agent_pre_first_exchange(
         return false;
     }
 
-    // Loading phase (`WaitingForSession`): no setup commands have started yet, but we're
-    // still pre-first-exchange. Skip the block-list flag check.
-    if matches!(view_model.status(), Status::WaitingForSession { .. }) {
+    // Setup / loading phases (`Setup`, `WaitingForSession`): no env-setup commands have started
+    // yet, but we're still pre-first-exchange. Skip the block-list flag check.
+    if matches!(
+        view_model.status(),
+        Status::Setup | Status::WaitingForSession { .. }
+    ) {
         return true;
     }
 

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -519,7 +519,7 @@ impl AmbientAgentViewModel {
 
     /// True when the run is configured to use a non-Oz execution harness and the
     /// required feature flags are enabled.
-    pub(in crate::terminal) fn is_third_party_harness(&self) -> bool {
+    pub fn is_third_party_harness(&self) -> bool {
         FeatureFlag::AgentHarness.is_enabled() && self.selected_harness() != Harness::Oz
     }
 

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -519,7 +519,7 @@ impl AmbientAgentViewModel {
 
     /// True when the run is configured to use a non-Oz execution harness and the
     /// required feature flags are enabled.
-    pub(super) fn is_third_party_harness(&self) -> bool {
+    pub(in crate::terminal) fn is_third_party_harness(&self) -> bool {
         FeatureFlag::AgentHarness.is_enabled() && self.selected_harness() != Harness::Oz
     }
 

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::str::FromStr;
 
+use warp_cli::agent::Harness;
 use warpui::platform::WindowStyle;
 use warpui::{App, SingletonEntity, TypedActionView, ViewContext, ViewHandle};
 
@@ -329,6 +330,42 @@ fn cloud_setup_enter_queues_followup_input_when_v2_is_enabled() {
                 text == "queue this next" && *origin == QueuedQueryOrigin::AutoQueueToggle
             }));
             assert!(view.input.as_ref(ctx).buffer_text(ctx).is_empty());
+        });
+    });
+}
+
+#[test]
+fn cloud_setup_enter_does_not_queue_followup_for_third_party_harness() {
+    // Third-party (non-Oz) harness runs don't support prompt queueing, so an enter during
+    // setup must not queue the follow-up. It falls through to being blocked, leaving the
+    // typed text in the buffer (same observable outcome as the V2-disabled path).
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let _queued_prompts_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(true);
+        let _agent_harness = FeatureFlag::AgentHarness.override_enabled(true);
+
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id = enter_cloud_setup_with_conversation(view, ctx);
+            view.ambient_agent_view_model()
+                .expect("cloud terminal should have an ambient model")
+                .update(ctx, |model, ctx| {
+                    model.spawn_agent_with_request(cloud_spawn_request("initial"), ctx);
+                    model.set_harness(Harness::Claude, ctx);
+                });
+
+            view.input.update(ctx, |input, ctx| {
+                input.replace_buffer_content("do not queue this", ctx);
+                input.input_enter(ctx);
+            });
+
+            assert!(QueuedQueryModel::as_ref(ctx)
+                .queue(conversation_id)
+                .is_empty());
+            assert_eq!(view.input.as_ref(ctx).buffer_text(ctx), "do not queue this");
         });
     });
 }

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -371,6 +371,49 @@ fn cloud_setup_enter_does_not_queue_followup_for_third_party_harness() {
 }
 
 #[test]
+fn cloud_setup_enter_queues_followup_while_setup_commands_run() {
+    // Once the cloud session starts, the run is `AgentRunning` while environment setup
+    // commands execute (still pre-first-exchange). Submitting in this window must queue the
+    // follow-up, not send it as a live prompt the sharer would drop.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+        let _cloud_mode = FeatureFlag::CloudMode.override_enabled(true);
+        let _cloud_mode_setup_v2 = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+        let _queued_prompts_v2 = FeatureFlag::QueuedPromptsV2.override_enabled(true);
+
+        let task_id = AmbientAgentTaskId::from_str("123e4567-e89b-12d3-a456-426614174000")
+            .expect("valid task id");
+        let terminal = add_window_with_cloud_mode_terminal(&mut app);
+        terminal.update(&mut app, |view, ctx| {
+            enter_cloud_setup_with_conversation(view, ctx);
+            view.ambient_agent_view_model()
+                .expect("cloud terminal should have an ambient model")
+                .update(ctx, |model, ctx| {
+                    // Session has started: the run moves to AgentRunning.
+                    model.enter_viewing_existing_session(task_id, ctx);
+                });
+            // Environment setup commands are running (pre-first-exchange).
+            view.model
+                .lock()
+                .block_list_mut()
+                .set_is_executing_oz_environment_startup_commands(true);
+
+            view.input.update(ctx, |input, ctx| {
+                input.replace_buffer_content("queue during setup", ctx);
+                input.input_enter(ctx);
+            });
+
+            let queued_rows = queue_texts(view, ctx);
+            assert!(queued_rows.iter().any(|(text, origin)| {
+                text == "queue during setup" && *origin == QueuedQueryOrigin::AutoQueueToggle
+            }));
+            assert!(view.input.as_ref(ctx).buffer_text(ctx).is_empty());
+        });
+    });
+}
+
+#[test]
 fn cloud_setup_enter_remains_blocked_when_v2_is_disabled() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);


### PR DESCRIPTION
## Description

There were a few small bugs with prompt queueing for cloud mode setup that this PR fixes:

1. We don't support prompt queueing for 3p agents, so we shouldn't allow you to queue multiple prompts for 3p agents during cloud mode setup

2. Kind of unrelatedly (but I noticed this when testing this PR), during Cloud Mode setup, the cloud agent (sharer) runs environment setup commands and emits a `CommandExecutionStarted` event per command. The shared-session viewer handled every non-agent `CommandExecutionStarted` by calling `unfreeze_and_clear_agent_input`, which cleared the editor buffer — wiping any follow-up the user was composing after each setup command. The viewer now skips that clear while it is a cloud-agent viewer in the pre-first-exchange phase so that your input isn't wiped during setup

## Testing
- [x] I have manually tested my changes locally with `./script/run`

https://www.loom.com/share/f7837d6db0a84753937b62fbf66369a8

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/452cc86b-c930-407a-8861-7952013c7b1f_
_Run: https://oz.staging.warp.dev/runs/019e88ba-800b-7d87-bf93-d1e5cefd3e97_

_This PR was generated with [Oz](https://warp.dev/oz)._
