### PR TITLE
Fix crash when trying to use the microphone on macOS.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8755,7 +8755,7 @@ dependencies = [
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -8790,10 +8790,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-avf-audio"
-version = "0.3.0"
+name = "objc2-av-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fe5d8f6b9904a2028e9168bbdc77d06f944a39a0aef7076857db09f1298c9a"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.9.4",
+ "block2 0.6.2",
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
  "objc2 0.6.3",
  "objc2-foundation 0.3.2",
@@ -8900,6 +8922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8909,6 +8941,34 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.9.4",
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.9.4",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -8944,6 +9004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-io-kit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8974,6 +9045,18 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
 ]
 
 [[package]]
@@ -9048,7 +9131,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-image 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
@@ -15270,6 +15353,7 @@ dependencies = [
  "objc",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
+ "objc2-av-foundation",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
  "objc2-quartz-core 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8755,7 +8755,7 @@ dependencies = [
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
- "objc2-core-image 0.2.2",
+ "objc2-core-image",
  "objc2-foundation 0.2.2",
  "objc2-quartz-core 0.2.2",
 ]
@@ -8796,19 +8796,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
  "bitflags 2.9.4",
- "block2 0.6.2",
- "dispatch2",
  "objc2 0.6.3",
- "objc2-avf-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image 0.3.2",
- "objc2-core-video",
  "objc2-foundation 0.3.2",
- "objc2-image-io",
- "objc2-media-toolbox",
- "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -8922,16 +8911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2 0.6.3",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8941,34 +8920,6 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-core-media"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
-dependencies = [
- "bitflags 2.9.4",
- "dispatch2",
- "objc2 0.6.3",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-core-video",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.9.4",
- "objc2 0.6.3",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
 ]
 
 [[package]]
@@ -9004,17 +8955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-image-io"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
-dependencies = [
- "objc2 0.6.3",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
 name = "objc2-io-kit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9045,18 +8985,6 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "objc2-media-toolbox"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
-dependencies = [
- "objc2 0.6.3",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-core-media",
 ]
 
 [[package]]
@@ -9131,7 +9059,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
- "objc2-core-image 0.2.2",
+ "objc2-core-image",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ mockall = "0.13.1"
 objc = "0.2"
 objc2 = "0.6.3"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSScreen", "objc2-core-foundation"] }
-objc2-av-foundation = "0.3.2"
+objc2-av-foundation = { version = "0.3.2", default-features = false }
 objc2-core-foundation = "0.3.2"
 objc2-core-graphics = "0.3.2"
 objc2-foundation = { version = "0.3", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ mockall = "0.13.1"
 objc = "0.2"
 objc2 = "0.6.3"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSScreen", "objc2-core-foundation"] }
+objc2-av-foundation = "0.3.2"
 objc2-core-foundation = "0.3.2"
 objc2-core-graphics = "0.3.2"
 objc2-foundation = { version = "0.3", default-features = false, features = ["std"] }

--- a/crates/warpui/Cargo.toml
+++ b/crates/warpui/Cargo.toml
@@ -93,6 +93,7 @@ objc2-app-kit = { workspace = true, features = [
     "NSWindow",
     "objc2-quartz-core",
 ] }
+objc2-av-foundation = { workspace = true, features = ["AVCaptureDevice", "AVMediaFormat"] }
 objc2-foundation = { workspace = true, features = [
     "NSArray",
     "NSData",

--- a/crates/warpui/src/platform/mac/delegate.rs
+++ b/crates/warpui/src/platform/mac/delegate.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use cocoa::base::{id, nil, BOOL, NO, YES};
-use objc2::runtime::AnyClass;
 use objc2::{msg_send, MainThreadMarker};
 use objc2_app_kit::{NSApplication, NSCursor, NSRequestUserAttentionType};
-use objc2_foundation::{NSString, NSUInteger};
+use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
+use objc2_foundation::NSUInteger;
 use warpui_core::accessibility::AccessibilityContent;
 use warpui_core::clipboard::InMemoryClipboard;
 use warpui_core::keymap::Keystroke;
@@ -425,26 +425,19 @@ impl platform::Delegate for AppDelegate {
     }
 
     fn microphone_access_state(&self) -> MicrophoneAccessState {
-        // "soun" is not a typo, it's the correct constant name.
-        let media_type_audio = NSString::from_str("soun");
-
-        // AVAuthorizationStatus constants:
-        // 0 = AVAuthorizationStatusNotDetermined - User has not yet made a choice
-        // 1 = AVAuthorizationStatusRestricted - Restricted by system settings/parental controls
-        // 2 = AVAuthorizationStatusDenied - User explicitly denied access
-        // 3 = AVAuthorizationStatusAuthorized - User granted access
-        // SAFETY: `AVCaptureDevice` is provided by AVFoundation at runtime, and
-        // `authorizationStatusForMediaType:` returns an `AVAuthorizationStatus` (an `i32`).
-        let status: i32 = unsafe {
-            let cls =
-                AnyClass::get(c"AVCaptureDevice").expect("AVCaptureDevice class is available");
-            msg_send![cls, authorizationStatusForMediaType: &*media_type_audio]
+        // SAFETY: this is a global static variable, but simply reading it should be safe.
+        let media_type = unsafe { AVMediaTypeAudio };
+        let Some(media_type) = media_type else {
+            return MicrophoneAccessState::NotDetermined;
         };
+
+        // SAFETY: this can raise an exception if you pass an invalid media type, but we're only
+        // ever passing AVMediaTypeAudio here.
+        let status = unsafe { AVCaptureDevice::authorizationStatusForMediaType(media_type) };
         match status {
-            0 => MicrophoneAccessState::NotDetermined,
-            1 => MicrophoneAccessState::Restricted,
-            2 => MicrophoneAccessState::Denied,
-            3 => MicrophoneAccessState::Authorized,
+            AVAuthorizationStatus::Restricted => MicrophoneAccessState::Restricted,
+            AVAuthorizationStatus::Denied => MicrophoneAccessState::Denied,
+            AVAuthorizationStatus::Authorized => MicrophoneAccessState::Authorized,
             _ => MicrophoneAccessState::NotDetermined, // fallback
         }
     }


### PR DESCRIPTION
## Description

The `authorizationStatusForMediaType` API returns an unsigned 64-bit integer, but our code was storing the result as a `i32`.  When we moved from using the `objc` crate to the `objc2` crate, I think the new crate performs more careful checking of these types, and started to produce a runtime error as a result of the type mismatch.

The `objc2` crate family includes `objc2-av-foundation`, which includes concrete APIs for all of the code here.  I've moved over to using that, improving safety and clarity.

## Testing

- [x] Manually tested that accessing the microphone crashes on `master` but succeeds on this branch.