### PR TITLE
Promote prompt queueing (/queue + QueuedPromptsV2) to Preview

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -935,8 +935,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::SummarizationViaMessageReplacement,
     FeatureFlag::LocalComputerUse,
     FeatureFlag::OzLaunchModal,
-    FeatureFlag::QueueSlashCommand,
-    FeatureFlag::QueuedPromptsV2,
     // These are enabled via 100% experiment on prod warp-server,
     // but we need to enable here for dogfood builds.
     FeatureFlag::CrossRepoContext,
@@ -960,7 +958,8 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
-pub const PREVIEW_FLAGS: &[FeatureFlag] = &[];
+pub const PREVIEW_FLAGS: &[FeatureFlag] =
+    &[FeatureFlag::QueueSlashCommand, FeatureFlag::QueuedPromptsV2];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).
 /// NOTE: if you are promoting a feature from Preview to launch, you'll likely
@@ -1055,6 +1054,7 @@ impl FeatureFlag {
             SettingsFile => Some("Enables configuring Warp via a user-editable `settings.toml` file, with hot reload and error reporting for invalid values."),
             GitOperationsInCodeReview => Some("Enables commit, push, and create-PR actions directly from the code review panel."),
             OrchestrationV2 => Some("Enables orchestration of teams of agents with dedicated UI, lifecycle events and inter-agent messaging."),
+            QueueSlashCommand => Some("Queue follow-up prompts while the agent is working, then view, edit, reorder, and remove them from a dedicated panel. Works in both Agent Mode and Cloud Mode."),
             _ => None,
         }
     }


### PR DESCRIPTION
## Description
Promotes the prompt queueing feature from Dogfood to Preview by moving both of its runtime flags into `PREVIEW_FLAGS`:

- `FeatureFlag::QueueSlashCommand` — the `/queue` slash command, auto-queue toggle, and the queued-prompts panel (regular Agent Mode).
- `FeatureFlag::QueuedPromptsV2` — extends the same panel to Cloud Mode setup/follow-up draining and to `/compact-and` / `/fork-and-compact`.

Both flags previously lived in `DOGFOOD_FLAGS`. Because `PREVIEW_FLAGS` are automatically included in dogfood (WarpDev) and local builds (see `app/src/bin/dev.rs` and `app/src/bin/local.rs`), dev/local behavior is unchanged; the only effective change is that Preview (Friends of Warp) builds now enable prompt queueing. Stable is intentionally untouched — these flags are not in `app/Cargo.toml`'s `default` set, so nothing ships to Stable yet.

The queueing code is always compiled in and gated at runtime via `FeatureFlag::*.is_enabled()` (per `specs/APP-4041`, `specs/REMOTE-1543`, `specs/APP-4562`, `specs/APP-4594`), so adding the flags to `PREVIEW_FLAGS` (applied at startup via `ChannelState::additional_features()`) is sufficient to enable the feature in Preview.

`PendingUserQueryIndicator` is intentionally left as-is: per `specs/REMOTE-1543/PRODUCT.md`, it is compatibility infrastructure for the legacy pending-user-query placeholders, not a rollout switch for the queue panel.

A single Preview-exclusive changelog description is added on `QueueSlashCommand` so the feature shows up once in the Preview in-app changelog (`app/src/changelog_model.rs`).

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

No single GitHub issue; this rollout covers the prompt queueing specs `APP-4041`, `REMOTE-1543`, `APP-4562`, and `APP-4594`.

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

This is a feature-flag rollout change (no logic change). Validated with:
- `cargo fmt -p warp_features` (clean)
- `cargo clippy -p warp_features --all-targets --all-features --tests -- -D warnings` (clean)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

CHANGELOG-NONE

---
_Conversation: https://staging.warp.dev/conversation/9f00be34-baba-4543-94f4-79f4915048e2_
_Run: https://oz.staging.warp.dev/runs/019e8907-7c15-7554-86f5-79544f94774b_

_This PR was generated with [Oz](https://warp.dev/oz)._
