### PR TITLE
Fix mouse_down dispatching when event already handled

### DIFF
--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -4617,7 +4617,7 @@ impl Element for BlockListElement {
                 is_first_mouse,
                 modifiers,
                 ..
-            } => self.mouse_down(
+            } if !handled => self.mouse_down(
                 *position,
                 *click_count,
                 *is_first_mouse,


### PR DESCRIPTION
## Description
Skip `mouse_down` processing in `BlockListElement` when the event has already been handled by a child element. This adds an `if !handled` guard to the `MouseDown` match arm, preventing duplicate handling of mouse clicks.

## Linked Issue
Fixes https://github.com/warpdotdev/warp/issues/10289

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>