### PR TITLE
Release prompt queueing to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -670,6 +670,8 @@ default = [
     "orchestration_viewer_pill_bar",
     "run_agents_tool",
     "pending_user_query_indicator",
+    "queue_slash_command",
+    "queued_prompts_v2",
     "cloud_mode_input_v2",
     "cloud_mode_setup_v2",
     "handoff_cloud_cloud",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -935,8 +935,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::SummarizationViaMessageReplacement,
     FeatureFlag::LocalComputerUse,
     FeatureFlag::OzLaunchModal,
-    FeatureFlag::QueueSlashCommand,
-    FeatureFlag::QueuedPromptsV2,
     // These are enabled via 100% experiment on prod warp-server,
     // but we need to enable here for dogfood builds.
     FeatureFlag::CrossRepoContext,


### PR DESCRIPTION
## Description

WISOTT

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NEW-FEATURE: Queue multiple follow-up prompts while the agent is working either by using the /queue command, prompt queueing mode (activated via a chip in the warping line), and/or by changing your default prompt submission mode to "Queue until response finishes" in settings.

---
_Conversation: https://staging.warp.dev/conversation/9f00be34-baba-4543-94f4-79f4915048e2_
_Run: https://oz.staging.warp.dev/runs/019e8907-7c15-7554-86f5-79544f94774b_

_This PR was generated with [Oz](https://warp.dev/oz)._

