### PR TITLE
QUALITY-780: client-side handling of wait_for_events yields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15053,7 +15053,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=c67de64fc4949f693a679552dc88cebc9f7d0180#c67de64fc4949f693a679552dc88cebc9f7d0180"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=9699b0d00d4fefd287311f744f1af9fda6672f7d#9699b0d00d4fefd287311f744f1af9fda6672f7d"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,7 +319,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "c67de64fc4949f693a679552dc88cebc9f7d0180" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "9699b0d00d4fefd287311f744f1af9fda6672f7d" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1652,6 +1652,7 @@ pub(crate) fn convert_tool_call_result_to_input(
             log::warn!("No result present for tool call ID: {tool_call_id}");
             None
         }
+        Some(ToolCallResultType::WaitForEvents(_)) => None,
     }
 }
 
@@ -1784,6 +1785,9 @@ fn create_cancelled_result_for_tool_call(
         }
         // These tools are deprecated.
         ToolType::SuggestCreatePlan(_) | ToolType::SuggestPlan(_) => return None,
+        ToolType::WaitForEvents(_) => {
+            return None;
+        }
     };
 
     Some(AIAgentInput::ActionResult {

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -884,6 +884,12 @@ impl ConvertAPIToolCallToAIAgentAction for api::message::ToolCall {
             api::message::tool_call::Tool::Server(_) => {
                 Ok(MaybeAIAgentAction::NoClientRepresentation)
             }
+            api::message::tool_call::Tool::WaitForEvents(payload) => {
+                create_standard_action(AIAgentActionType::WaitForEvents {
+                    tool_call_id: self.tool_call_id.clone(),
+                    idle_timeout_seconds: payload.idle_timeout_seconds,
+                })
+            }
             _ => Err(ToolToAIAgentActionError::UnexpectedTool),
         }
     }

--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -706,6 +706,9 @@ impl TryFrom<AIAgentActionResult> for api::request::input::user_inputs::user_inp
             AIAgentActionResultType::RunAgents(orchestrate_result) => {
                 Some(orchestrate_result.try_into()?)
             }
+            AIAgentActionResultType::WaitForEvents(wait_for_events_result) => {
+                Some(wait_for_events_result.try_into()?)
+            }
         };
         Ok(
             api::request::input::user_inputs::user_input::Input::ToolCallResult(

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -102,6 +102,7 @@ pub async fn generate_multi_agent_output(
             supports_research_agent: params.research_agent_enabled,
             supports_orchestration_v2: supports_orchestration_v2(params.orchestration_enabled),
             custom_model_providers: params.custom_model_providers,
+            supports_background_computer_use: false,
         }),
         metadata: Some(api::request::Metadata {
             logging: logging_metadata,
@@ -233,6 +234,9 @@ fn get_supported_tools(params: &RequestParams) -> Vec<api::ToolType> {
 
     if params.orchestration_enabled {
         supported_tools.extend([api::ToolType::RunAgents, api::ToolType::SendMessageToAgent]);
+        // Declare client-handled wait_for_events so the server doesn't
+        // fall back to the legacy server-handled form.
+        supported_tools.push(api::ToolType::WaitForEvents);
     }
 
     if FeatureFlag::AskUserQuestion.is_enabled() && params.ask_user_question_enabled {

--- a/app/src/ai/agent/api/impl_tests.rs
+++ b/app/src/ai/agent/api/impl_tests.rs
@@ -88,6 +88,7 @@ fn api_keys_with_warp_credit_fallback_setting_preserves_existing_keys() {
             open_router: String::new(),
             allow_use_of_warp_credits: false,
             aws_credentials: None,
+            google_cloud_credentials: None,
         }),
         true,
     )

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -4191,6 +4191,10 @@ pub enum ConversationStatus {
 
     /// The last turn of the agent resulted in an action whose execution is blocked by the user.
     Blocked { blocked_action: String },
+
+    /// Agent yielded via wait_for_events and is listening for inbound
+    /// input. Quiescent but not terminal.
+    WaitingForEvents,
 }
 
 impl std::fmt::Display for ConversationStatus {
@@ -4201,6 +4205,7 @@ impl std::fmt::Display for ConversationStatus {
             ConversationStatus::Error => write!(f, "Error"),
             ConversationStatus::Cancelled => write!(f, "Cancelled"),
             ConversationStatus::Blocked { .. } => write!(f, "Blocked"),
+            ConversationStatus::WaitingForEvents => write!(f, "Waiting"),
         }
     }
 }
@@ -4213,6 +4218,7 @@ impl ConversationStatus {
             ConversationStatus::Blocked { .. } => yellow_stop_icon(appearance),
             ConversationStatus::Error => failed_icon(appearance),
             ConversationStatus::Cancelled => gray_stop_icon(appearance),
+            ConversationStatus::WaitingForEvents => in_progress_icon(appearance),
         }
     }
 
@@ -4251,6 +4257,13 @@ impl ConversationStatus {
                     StatusColorStyle::Cloud => theme.ansi_bg_yellow(),
                 },
             ),
+            ConversationStatus::WaitingForEvents => (
+                Icon::ClockLoader,
+                match color_style {
+                    StatusColorStyle::Standard => theme.ansi_fg_magenta(),
+                    StatusColorStyle::Cloud => theme.ansi_bg_magenta(),
+                },
+            ),
         }
     }
 
@@ -4266,11 +4279,18 @@ impl ConversationStatus {
         matches!(self, ConversationStatus::Cancelled)
     }
 
+    /// True iff the run is finished and cannot resume on its own.
     pub fn is_done(&self) -> bool {
         matches!(
             self,
             ConversationStatus::Success | ConversationStatus::Error | ConversationStatus::Cancelled
         )
+    }
+
+    /// True iff the agent has yielded via `wait_for_events` and is listening
+    /// for inbound input.
+    pub fn is_waiting_for_events(&self) -> bool {
+        matches!(self, ConversationStatus::WaitingForEvents)
     }
 
     pub fn is_error(&self) -> bool {

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -649,3 +649,59 @@ fn fork_artifacts_adds_file_artifacts_to_conversation() {
         })
     );
 }
+
+#[test]
+fn waiting_for_events_display_label_is_waiting() {
+    assert_eq!(
+        format!("{}", ConversationStatus::WaitingForEvents),
+        "Waiting"
+    );
+}
+
+/// `is_done` returns true only for `Success | Error | Cancelled`;
+/// `WaitingForEvents` and `Blocked` are not done because the run can still
+/// resume on its own.
+#[test]
+fn is_done_only_includes_success_error_cancelled() {
+    assert!(ConversationStatus::Success.is_done());
+    assert!(ConversationStatus::Error.is_done());
+    assert!(ConversationStatus::Cancelled.is_done());
+
+    assert!(!ConversationStatus::InProgress.is_done());
+    assert!(!ConversationStatus::Blocked {
+        blocked_action: "approve".to_string()
+    }
+    .is_done());
+    assert!(!ConversationStatus::WaitingForEvents.is_done());
+}
+
+/// `is_waiting_for_events` is true only for the new variant.
+#[test]
+fn is_waiting_for_events_returns_true_only_for_waiting_for_events_variant() {
+    assert!(ConversationStatus::WaitingForEvents.is_waiting_for_events());
+
+    assert!(!ConversationStatus::InProgress.is_waiting_for_events());
+    assert!(!ConversationStatus::Success.is_waiting_for_events());
+    assert!(!ConversationStatus::Error.is_waiting_for_events());
+    assert!(!ConversationStatus::Cancelled.is_waiting_for_events());
+    assert!(!ConversationStatus::Blocked {
+        blocked_action: "approve".to_string()
+    }
+    .is_waiting_for_events());
+}
+
+/// A conversation that was yielded via `wait_for_events` at shutdown
+/// restores as whatever `derive_status_from_root_task` returns (Success
+/// for a cleanly-streamed last exchange). The unresolved tool call stays
+/// in the transcript as an orphan; the next outbound request triggers
+/// the server's existing supersede mechanism to synthesize the matching
+/// `Cancel`. The waiting state itself is not durable across restart.
+#[test]
+fn restored_conversation_does_not_re_enter_waiting_for_events() {
+    let conversation_data: AgentConversationData =
+        serde_json::from_str(r#"{"server_conversation_token":null}"#).unwrap();
+
+    let conversation = restored_conversation(Some(conversation_data));
+
+    assert_eq!(conversation.status(), &ConversationStatus::Success);
+}

--- a/app/src/ai/agent/conversation_yaml.rs
+++ b/app/src/ai/agent/conversation_yaml.rs
@@ -532,7 +532,8 @@ fn write_tool_call_args(out: &mut String, tool: &Tool) {
         | Tool::InitProject(_)
         | Tool::Server(_)
         | Tool::Subagent(_)
-        | Tool::TransferShellCommandControlToUser(_) => {}
+        | Tool::TransferShellCommandControlToUser(_)
+        | Tool::WaitForEvents(_) => {}
     }
 }
 
@@ -599,6 +600,7 @@ fn write_tool_call_result_content(out: &mut String, result: &ToolCallResultType)
             }
             None => {}
         },
+        ToolCallResultType::WaitForEvents(_) => {}
         ToolCallResultType::RunShellCommand(r) => {
             if let Some(res) = &r.result {
                 use api::run_shell_command_result::Result;

--- a/app/src/ai/agent/redaction.rs
+++ b/app/src/ai/agent/redaction.rs
@@ -263,7 +263,8 @@ pub(crate) fn redact_inputs(inputs: &mut [AIAgentInput]) {
                     }
                     // Orchestrate results contain agent IDs / canonical error
                     // strings only; no user-provided text to redact.
-                    AIAgentActionResultType::RunAgents(_) => {}
+                    AIAgentActionResultType::RunAgents(_)
+                    | AIAgentActionResultType::WaitForEvents(_) => {}
                 }
             }
             AIAgentInput::FetchReviewComments { repo_path, context } => {

--- a/app/src/ai/agent/task/helper.rs
+++ b/app/src/ai/agent/task/helper.rs
@@ -140,6 +140,9 @@ impl ToolExt for api::message::tool_call::Tool {
             Tool::SendMessageToAgent(_) => "send_message_to_agent",
             Tool::TransferShellCommandControlToUser(_) => "transfer_shell_command_control",
             Tool::RunAgents(_) => "orchestrate",
+            // Matches the legacy server-handled name so analytics don't
+            // double-count the rollout.
+            Tool::WaitForEvents(_) => "wait_for_events",
         }
     }
 }

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -367,6 +367,9 @@ impl AgentRunDisplayStatus {
             ConversationStatus::Blocked { blocked_action } => Self::ConversationBlocked {
                 blocked_action: blocked_action.clone(),
             },
+            // Treat a yielded conversation as still in progress for the
+            // agent-run list display so it stays in the working bucket.
+            ConversationStatus::WaitingForEvents => Self::ConversationInProgress,
         }
     }
 

--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -385,6 +385,12 @@ impl AgentNotificationsModel {
                     ctx,
                 );
             }
+            // Yielded conversations are still active; mirror the
+            // InProgress arm and clear any stale notification for this
+            // origin.
+            ConversationStatus::WaitingForEvents => {
+                self.remove_notification_by_source(origin, ctx);
+            }
         }
     }
 
@@ -471,13 +477,20 @@ pub enum AgentManagementEvent {
 impl ConversationStatus {
     /// Returns true if the updating the conversation with this status should trigger some
     /// notification to the user.
+    ///
+    /// Exhaustive match so a new `ConversationStatus` variant forces a
+    /// deliberate decision about whether it should fire a notification.
     pub fn should_trigger_notification(&self) -> bool {
-        matches!(
-            self,
+        match self {
             ConversationStatus::Success
-                | ConversationStatus::Blocked { .. }
-                | ConversationStatus::Error
-        )
+            | ConversationStatus::Blocked { .. }
+            | ConversationStatus::Error => true,
+            // Streaming hasn't reached a notable state; a yielded wait is
+            // still active; user-cancellations are self-evident.
+            ConversationStatus::InProgress
+            | ConversationStatus::WaitingForEvents
+            | ConversationStatus::Cancelled => false,
+        }
     }
 }
 

--- a/app/src/ai/agent_management/agent_management_model_tests.rs
+++ b/app/src/ai/agent_management/agent_management_model_tests.rs
@@ -4,7 +4,7 @@ use warpui::{App, EntityId, ModelHandle, SingletonEntity};
 
 use super::AgentNotificationsModel;
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::agent_management::notifications::{
     NotificationCategory, NotificationFilter, NotificationOrigin, NotificationSourceAgent,
 };
@@ -253,6 +253,181 @@ fn separate_conversations_have_independent_pending_artifacts() {
             let b = model.flush_pending_artifacts(conv_b);
             assert_eq!(b.len(), 1);
             assert!(matches!(&b[0], Artifact::Plan { title: Some(t), .. } if t == "Plan B"));
+        });
+    });
+}
+
+// should_trigger_notification: pure-function tests pinning which statuses
+// fire user-facing notifications. Terminal-error and blocked surface;
+// in-progress, waiting-for-events, and user-cancelled do not.
+
+#[test]
+fn should_trigger_notification_returns_true_for_success() {
+    assert!(ConversationStatus::Success.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_true_for_blocked() {
+    assert!(ConversationStatus::Blocked {
+        blocked_action: "approve diff".to_owned(),
+    }
+    .should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_true_for_error() {
+    assert!(ConversationStatus::Error.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_false_for_in_progress() {
+    assert!(!ConversationStatus::InProgress.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_false_for_waiting_for_events() {
+    assert!(!ConversationStatus::WaitingForEvents.should_trigger_notification());
+}
+
+#[test]
+fn should_trigger_notification_returns_false_for_cancelled() {
+    assert!(!ConversationStatus::Cancelled.should_trigger_notification());
+}
+
+// Mailbox suppression for non-terminal status updates. In App::test the
+// `is_conversation_open` gate always returns false, so the
+// WaitingForEvents and InProgress arms both clear stale notifications
+// regardless of status; this still pins the user-visible contract that
+// no stale "Task completed" toast survives a non-terminal transition.
+
+/// Disables `show_agent_notifications` so subsequent `add_notification`
+/// calls skip the `send_telemetry_from_ctx!` branch — the test app does
+/// not register a `TelemetryContextProvider` singleton and the macro
+/// would otherwise panic.
+fn disable_telemetry_path(app: &mut App) {
+    AISettings::handle(app).update(app, |settings, ctx| {
+        report_if_error!(settings.show_agent_notifications.set_value(false, ctx));
+    });
+}
+
+/// Pre-populates a `Complete` notification for `conversation_id` so that a
+/// subsequent non-terminal status update has something to clear.
+fn seed_stale_notification(
+    notifications: &ModelHandle<AgentNotificationsModel>,
+    app: &mut App,
+    conversation_id: AIConversationId,
+    terminal_view_id: EntityId,
+) {
+    notifications.update(app, |model, ctx| {
+        model.add_notification(
+            "Agent task".to_owned(),
+            "Task completed.".to_owned(),
+            NotificationCategory::Complete,
+            NotificationSourceAgent::Oz { is_ambient: false },
+            NotificationOrigin::Conversation(conversation_id),
+            terminal_view_id,
+            vec![],
+            None,
+            ctx,
+        );
+    });
+}
+
+#[test]
+fn waiting_for_events_clears_stale_notification_and_adds_none() {
+    App::test((), |mut app| async move {
+        let _guard = FeatureFlag::HOANotifications.override_enabled(true);
+        let (history, notifications) = setup_app(&mut app);
+        disable_telemetry_path(&mut app);
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = EntityId::new();
+        history.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        seed_stale_notification(&notifications, &mut app, conversation_id, terminal_view_id);
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                1,
+                "precondition: one stale notification queued"
+            );
+        });
+
+        history.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.update_status(ConversationStatus::WaitingForEvents, terminal_view_id, ctx);
+        });
+
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                0,
+                "WaitingForEvents must clear stale notifications and add no new toast"
+            );
+        });
+    });
+}
+
+#[test]
+fn in_progress_resume_clears_stale_notification_and_adds_none() {
+    App::test((), |mut app| async move {
+        let _guard = FeatureFlag::HOANotifications.override_enabled(true);
+        let (history, notifications) = setup_app(&mut app);
+        disable_telemetry_path(&mut app);
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = EntityId::new();
+        history.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        // First move the conversation into WaitingForEvents, then back into
+        // InProgress. The second transition is the resume signal that
+        // PRODUCT.md (18) requires not to fire a notification.
+        history.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.update_status(ConversationStatus::WaitingForEvents, terminal_view_id, ctx);
+        });
+
+        seed_stale_notification(&notifications, &mut app, conversation_id, terminal_view_id);
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                1,
+                "precondition: one stale notification queued before the resume transition"
+            );
+        });
+
+        history.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation still exists");
+            conv.update_status(ConversationStatus::InProgress, terminal_view_id, ctx);
+        });
+
+        notifications.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .notifications()
+                    .filtered_count(NotificationFilter::All),
+                0,
+                "WaitingForEvents → InProgress resume must not fire a notification \
+                 (covers PRODUCT.md (18))"
+            );
         });
     });
 }

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2781,12 +2781,20 @@ impl AgentDriver {
                     };
 
                     if conversation.status().is_in_progress() {
-                        // Conversation resumed or a new one started; cancel any pending idle timeout.
+                        // Conversation resumed or a new one started; cancel any
+                        // pending idle timeout.
                         log::info!(
                             "Ambient agent idle lifecycle: event=idle_timeout_cancel_requested task_id={:?} terminal_view_id={terminal_id:?} trigger=conversation_in_progress",
                             me.task_id
                         );
                         run_exit.cancel_idle_timeout();
+                        return;
+                    }
+
+                    // wait_for_events keeps the run alive via the
+                    // action_model's running_actions; the executor owns
+                    // the watchdog. Don't resolve run_exit.
+                    if conversation.status().is_waiting_for_events() {
                         return;
                     }
 

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -302,6 +302,8 @@ pub mod text {
                 AIAgentActionResultType::AskUserQuestion(_) => Ok(()),
                 // RunAgents is a desktop-client-only action; not used in the SDK.
                 AIAgentActionResultType::RunAgents(_) => Ok(()),
+                // No user-visible payload to emit.
+                AIAgentActionResultType::WaitForEvents(_) => Ok(()),
             },
         }
     }
@@ -428,6 +430,7 @@ pub mod text {
                     AIAgentActionType::AskUserQuestion { .. } => (),
                     // RunAgents is desktop-client-only; SDK driver renders nothing.
                     AIAgentActionType::RunAgents(_) => (),
+                    AIAgentActionType::WaitForEvents { .. } => (),
                 },
                 AIAgentOutputMessageType::TodoOperation(operation) => match operation {
                     TodoOperation::UpdateTodos { todos } => {
@@ -1109,6 +1112,7 @@ pub mod json {
                     // RunAgents is desktop-client-only; SDK has no JSON
                     // representation for it.
                     AIAgentActionType::RunAgents(_) => None,
+                    AIAgentActionType::WaitForEvents { .. } => None,
                 },
                 AIAgentOutputMessageType::TodoOperation(operation) => match operation {
                     TodoOperation::UpdateTodos { todos } => Some(JsonMessage::UpdateTodos {

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -866,18 +866,25 @@ impl BlocklistAIActionModel {
 
         let action_id = action.id.clone();
         let phase = self.action_phase_for_action(&action, ctx);
+        // WaitForEvents owns its own status transition; skip the default
+        // in-progress update.
+        let is_wait_for_events = matches!(action.action, AIAgentActionType::WaitForEvents { .. });
         let execute_result = self.executor.update(ctx, |executor, ctx| {
             executor.try_to_execute_action(action, conversation_id, is_user_initiated, ctx)
         });
 
         match execute_result {
             TryExecuteResult::ExecutedAsync => {
-                self.update_conversation_in_progress_status(conversation_id, ctx);
+                if !is_wait_for_events {
+                    self.update_conversation_in_progress_status(conversation_id, ctx);
+                }
                 self.add_running_action(conversation_id, action_id, phase);
                 Some(StartedAction::Async { phase })
             }
             TryExecuteResult::ExecutedSync => {
-                self.update_conversation_in_progress_status(conversation_id, ctx);
+                if !is_wait_for_events {
+                    self.update_conversation_in_progress_status(conversation_id, ctx);
+                }
                 Some(StartedAction::Sync)
             }
             TryExecuteResult::NotExecuted { reason, action } => {
@@ -1044,6 +1051,27 @@ impl BlocklistAIActionModel {
                     self.cancel_pending_action(conversation_id, action, Some(reason), ctx);
                 }
             }
+        }
+    }
+
+    /// Cancels any in-flight WaitForEvents action for the given conversation.
+    pub fn cancel_wait_for_events_for_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let action_id = self.executor.update(ctx, |executor, _| {
+            executor.find_running_wait_for_events(conversation_id)
+        });
+        if let Some(action_id) = action_id {
+            self.cancel_action_with_id(
+                conversation_id,
+                &action_id,
+                CancellationReason::FollowUpSubmitted {
+                    is_for_same_conversation: true,
+                },
+                ctx,
+            );
         }
     }
 

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -20,6 +20,7 @@ pub(super) mod suggest_new_conversation;
 pub(super) mod suggest_prompt;
 pub(super) mod upload_artifact;
 pub(super) mod use_computer;
+pub(super) mod wait_for_events;
 
 use std::any::Any;
 use std::path::PathBuf;
@@ -66,6 +67,7 @@ use suggest_new_conversation::SuggestNewConversationExecutor;
 pub use suggest_prompt::PromptSuggestionExecutor;
 use upload_artifact::UploadArtifactExecutor;
 use use_computer::UseComputerExecutor;
+use wait_for_events::WaitForEventsExecutor;
 use warp_core::execution_mode::AppExecutionMode;
 use warp_core::features::FeatureFlag;
 #[cfg(feature = "local_fs")]
@@ -264,6 +266,7 @@ pub struct BlocklistAIActionExecutor {
     run_agents_executor: ModelHandle<RunAgentsExecutor>,
     send_message_executor: ModelHandle<SendMessageToAgentExecutor>,
     ask_user_question_executor: ModelHandle<AskUserQuestionExecutor>,
+    wait_for_events_executor: ModelHandle<WaitForEventsExecutor>,
     /// The actions currently executing asynchronously, keyed by action ID.
     /// We track them per action rather than as a single slot so multiple actions from the same
     /// parallel phase can complete independently.
@@ -332,6 +335,8 @@ impl BlocklistAIActionExecutor {
         let send_message_executor = ctx.add_model(|_| SendMessageToAgentExecutor::new());
         let ask_user_question_executor =
             ctx.add_model(|_| AskUserQuestionExecutor::new(terminal_view_id));
+        let wait_for_events_executor =
+            ctx.add_model(|ctx| WaitForEventsExecutor::new(terminal_view_id, ctx));
         Self {
             shell_command_executor,
             read_files_executor,
@@ -357,6 +362,7 @@ impl BlocklistAIActionExecutor {
             run_agents_executor,
             send_message_executor,
             ask_user_question_executor,
+            wait_for_events_executor,
         }
     }
 
@@ -364,6 +370,29 @@ impl BlocklistAIActionExecutor {
         self.async_executing_actions
             .get(action_id)
             .map(|running| &running.action)
+    }
+
+    /// Returns the action_id of any running WaitForEvents action for the
+    /// given conversation. There is at most one (wait_for_events is
+    /// documented as exclusive within a turn).
+    pub(super) fn find_running_wait_for_events(
+        &self,
+        conversation_id: AIConversationId,
+    ) -> Option<AIAgentActionId> {
+        self.async_executing_actions
+            .iter()
+            .find_map(|(action_id, running)| {
+                if running.conversation_id == conversation_id
+                    && matches!(
+                        running.action.action,
+                        AIAgentActionType::WaitForEvents { .. }
+                    )
+                {
+                    Some(action_id.clone())
+                } else {
+                    None
+                }
+            })
     }
 
     pub fn shell_command_executor(&self) -> &ModelHandle<ShellCommandExecutor> {
@@ -530,6 +559,9 @@ impl BlocklistAIActionExecutor {
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
             AIAgentActionType::RunAgents(_) => self
                 .run_agents_executor
+                .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
+            AIAgentActionType::WaitForEvents { .. } => self
+                .wait_for_events_executor
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
         }
     }
@@ -720,6 +752,10 @@ impl BlocklistAIActionExecutor {
                 .run_agents_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
                 .into(),
+            AIAgentActionType::WaitForEvents { .. } => self
+                .wait_for_events_executor
+                .update(ctx, |executor, ctx| executor.execute(input, ctx))
+                .into(),
         };
 
         let action_id = action_clone.id.clone();
@@ -827,6 +863,15 @@ impl BlocklistAIActionExecutor {
                 self.run_agents_executor.update(ctx, |executor, ctx| {
                     executor.cancel_execution(&running.action.id, ctx);
                 });
+            } else if let AIAgentActionType::WaitForEvents { tool_call_id, .. } =
+                &running.action.action
+            {
+                // Drop the executor's pending entry; the shared cancel
+                // path emits FinishedAction(Cancelled).
+                let tool_call_id = tool_call_id.clone();
+                self.wait_for_events_executor.update(ctx, |executor, _| {
+                    executor.cancel_execution(&tool_call_id);
+                });
             }
             ctx.emit(BlocklistAIActionExecutorEvent::FinishedAction {
                 result: Arc::new(AIAgentActionResult {
@@ -931,6 +976,9 @@ impl BlocklistAIActionExecutor {
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
             AIAgentActionType::RunAgents(_) => self
                 .run_agents_executor
+                .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
+            AIAgentActionType::WaitForEvents { .. } => self
+                .wait_for_events_executor
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
         }
     }

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -577,7 +577,14 @@ fn start_agent_error_message_for_status(
                 blocked_action.to_string()
             })
         }
-        ConversationStatus::InProgress | ConversationStatus::Success => None,
+        // `WaitingForEvents` is treated like `InProgress`/`Success` here:
+        // a child that's actively waiting for events has, by definition,
+        // already initialized successfully and is not an error case.
+        // The agent run is still in flight, so we don't surface an error
+        // message for the start path.
+        ConversationStatus::InProgress
+        | ConversationStatus::Success
+        | ConversationStatus::WaitingForEvents => None,
     }
 }
 

--- a/app/src/ai/blocklist/action_model/execute/wait_for_events.rs
+++ b/app/src/ai/blocklist/action_model/execute/wait_for_events.rs
@@ -1,0 +1,255 @@
+//! Executor for `AIAgentActionType::WaitForEvents`.
+//!
+//! Schedules a watchdog timer so that the wait completes with `Completed`
+//! if no events arrive within the idle window.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use warpui::r#async::SpawnedFutureHandle;
+use warpui::{Entity, EntityId, ModelContext, SingletonEntity};
+
+use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
+use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::{AIAgentActionResultType, AIAgentActionType, WaitForEventsResult};
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+
+/// Fallback when `idle_timeout_seconds` is unset (0). Matches the worker
+/// VM idle ceiling.
+pub(crate) const DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS: i32 = 30 * 60;
+
+/// Subtracted from the server-supplied timeout so the client closes the
+/// wait before the worker idle-shutdown.
+pub(crate) const CLIENT_WATCHDOG_SAFETY_MARGIN: Duration = Duration::from_secs(30);
+
+/// Lower bound after the safety-margin subtraction; keeps tiny stamped
+/// values from clamping to 0.
+pub(crate) const HARD_FLOOR: Duration = Duration::from_secs(5);
+
+/// Apply the safety margin and hard floor. Non-positive input falls back
+/// to the default.
+pub(crate) fn watchdog_timeout_for_stamped_seconds(stamped_seconds: i32) -> Duration {
+    let seconds = if stamped_seconds <= 0 {
+        DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS
+    } else {
+        stamped_seconds
+    };
+    let stamped = Duration::from_secs(seconds as u64);
+    stamped
+        .checked_sub(CLIENT_WATCHDOG_SAFETY_MARGIN)
+        .filter(|d| *d >= HARD_FLOOR)
+        .unwrap_or(HARD_FLOOR)
+}
+
+/// Currently-in-flight WaitForEvents action state.
+struct PendingWait {
+    tool_call_id: String,
+    sender: async_channel::Sender<WaitForEventsResult>,
+    /// Handle to the watchdog timer. Aborted on cancel so the future
+    /// doesn't survive up to ~30 minutes past supersede.
+    watchdog_handle: SpawnedFutureHandle,
+}
+
+pub struct WaitForEventsExecutor {
+    terminal_view_id: EntityId,
+    /// Bumped on each fresh execute(); stale watchdog closures no-op when
+    /// they fire.
+    conversation_generation: HashMap<AIConversationId, usize>,
+    pending: HashMap<AIConversationId, PendingWait>,
+}
+
+impl WaitForEventsExecutor {
+    pub fn new(terminal_view_id: EntityId, _ctx: &mut ModelContext<Self>) -> Self {
+        Self {
+            terminal_view_id,
+            conversation_generation: HashMap::new(),
+            pending: HashMap::new(),
+        }
+    }
+
+    pub(super) fn should_autoexecute(
+        &self,
+        _input: ExecuteActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        // Synthesized from a server-emitted tool call; no confirmation.
+        true
+    }
+
+    pub(super) fn preprocess_action(
+        &mut self,
+        _action: PreprocessActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> BoxFuture<'static, ()> {
+        futures::future::ready(()).boxed()
+    }
+
+    pub(super) fn execute(
+        &mut self,
+        input: ExecuteActionInput,
+        ctx: &mut ModelContext<Self>,
+    ) -> impl Into<AnyActionExecution> {
+        let AIAgentActionType::WaitForEvents {
+            tool_call_id,
+            idle_timeout_seconds,
+        } = &input.action.action
+        else {
+            return ActionExecution::InvalidAction;
+        };
+
+        let tool_call_id = tool_call_id.clone();
+        let conversation_id = input.conversation_id;
+        let timeout = watchdog_timeout_for_stamped_seconds(*idle_timeout_seconds);
+
+        // Bump the counter so any prior watchdog closure observes a
+        // stale generation.
+        let generation = self
+            .conversation_generation
+            .entry(conversation_id)
+            .or_insert(0);
+        *generation += 1;
+        let expected_generation = *generation;
+
+        // Schedule the watchdog first so we can store its handle in the
+        // pending entry. The closure no-ops on a stale generation.
+        let watchdog_tool_call_id = tool_call_id.clone();
+        let watchdog_handle = ctx.spawn(
+            async move {
+                warpui::r#async::Timer::after(timeout).await;
+            },
+            move |me, (), ctx| {
+                me.fire_watchdog_if_current(
+                    conversation_id,
+                    &watchdog_tool_call_id,
+                    expected_generation,
+                    ctx,
+                );
+            },
+        );
+
+        // Replace any prior pending entry. Dropping the prior sender wakes
+        // its receiver with Err and the prior watchdog is aborted so it
+        // can't fire after the new wait starts.
+        let (sender, receiver) = async_channel::bounded(1);
+        if let Some(prev) = self.pending.insert(
+            conversation_id,
+            PendingWait {
+                tool_call_id: tool_call_id.clone(),
+                sender,
+                watchdog_handle,
+            },
+        ) {
+            prev.watchdog_handle.abort();
+            drop(prev.sender);
+        }
+
+        // Flip the conversation into WaitingForEvents before returning so
+        // downstream subscribers see the yield immediately.
+        let terminal_view_id = self.terminal_view_id;
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, move |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                conversation_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+        });
+
+        ActionExecution::new_async(async move { receiver.recv().await }, move |result, _ctx| {
+            let wait_result = match result {
+                Ok(result) => result,
+                // Sender dropped via external cancellation (e.g. resume
+                // injection, user query). The action_model removed this
+                // action from `async_executing_actions` before dropping
+                // the sender, so the spawn callback that wraps this
+                // closure will suppress the result. The value here is
+                // unobservable in that path; pick `Completed` defensively.
+                Err(_) => WaitForEventsResult::Completed,
+            };
+            AIAgentActionResultType::WaitForEvents(wait_result)
+        })
+    }
+
+    /// Drop the in-flight wait so a later watchdog fire is a no-op.
+    /// Caller (`BlocklistAIActionExecutor::cancel_running_async_action`)
+    /// has already removed the action from `async_executing_actions`, so
+    /// the spawn callback will silently discard the result that surfaces
+    /// from the dropped sender.
+    pub(crate) fn cancel_execution(&mut self, tool_call_id: &str) {
+        let Some(conversation_id) = self
+            .pending
+            .iter()
+            .find(|(_, pending)| pending.tool_call_id == tool_call_id)
+            .map(|(id, _)| *id)
+        else {
+            return;
+        };
+        let Some(pending) = self.pending.remove(&conversation_id) else {
+            return;
+        };
+        if let Some(gen) = self.conversation_generation.get_mut(&conversation_id) {
+            *gen += 1;
+        }
+        pending.watchdog_handle.abort();
+        drop(pending.sender);
+    }
+
+    fn fire_watchdog_if_current(
+        &mut self,
+        conversation_id: AIConversationId,
+        tool_call_id: &str,
+        expected_generation: usize,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self
+            .conversation_generation
+            .get(&conversation_id)
+            .copied()
+            .unwrap_or(0)
+            != expected_generation
+        {
+            return;
+        }
+        let Some(pending) = self.pending.get(&conversation_id) else {
+            return;
+        };
+        if pending.tool_call_id != tool_call_id {
+            return;
+        }
+        // Defensive: only fire if the conversation is still waiting. If
+        // some other path transitioned the conversation out of
+        // `WaitingForEvents` without going through `cancel_execution`,
+        // sending `Completed` now would inject a stale tool-call result
+        // into a conversation the server has long since moved past.
+        let still_waiting = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .is_some_and(|c| matches!(c.status(), ConversationStatus::WaitingForEvents));
+        if !still_waiting {
+            log::info!(
+                "WaitForEventsExecutor: watchdog stale (conversation no longer waiting); \
+                 dropping pending entry conversation_id={conversation_id:?} \
+                 tool_call_id={tool_call_id}"
+            );
+            self.pending.remove(&conversation_id);
+            return;
+        }
+        let Some(pending) = self.pending.remove(&conversation_id) else {
+            return;
+        };
+        log::info!(
+            "WaitForEventsExecutor: watchdog fired conversation_id={conversation_id:?} \
+             tool_call_id={tool_call_id}"
+        );
+        let _ = pending.sender.try_send(WaitForEventsResult::Completed);
+    }
+}
+
+impl Entity for WaitForEventsExecutor {
+    type Event = ();
+}
+
+#[cfg(test)]
+#[path = "wait_for_events_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/action_model/execute/wait_for_events_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/wait_for_events_tests.rs
@@ -1,0 +1,69 @@
+//! Unit tests for the pure helpers in `wait_for_events`.
+
+use std::time::Duration;
+
+use super::{
+    watchdog_timeout_for_stamped_seconds, CLIENT_WATCHDOG_SAFETY_MARGIN,
+    DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS, HARD_FLOOR,
+};
+
+#[test]
+fn watchdog_timeout_constants_match_documented_values() {
+    // The behavioural tests below assert the contract; this trips if
+    // someone moves a constant without updating the documented intent.
+    assert_eq!(DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS, 30 * 60);
+    assert_eq!(CLIENT_WATCHDOG_SAFETY_MARGIN, Duration::from_secs(30));
+    assert_eq!(HARD_FLOOR, Duration::from_secs(5));
+}
+
+#[test]
+fn watchdog_timeout_subtracts_margin_for_stamped_minute() {
+    // A 60s stamped timeout has 30s of headroom after subtracting the
+    // safety margin — that's the canonical "happy path" the safety
+    // margin is designed for.
+    assert_eq!(
+        watchdog_timeout_for_stamped_seconds(60),
+        Duration::from_secs(30)
+    );
+}
+
+#[test]
+fn watchdog_timeout_clamps_to_hard_floor_when_stamped_value_is_too_small() {
+    // A 10s stamped timeout would become negative after subtracting the
+    // 30s safety margin — the hard floor kicks in so the watchdog still
+    // fires after a finite delay.
+    assert_eq!(
+        watchdog_timeout_for_stamped_seconds(10),
+        HARD_FLOOR,
+        "stamped 10s should clamp to HARD_FLOOR after subtracting the safety margin"
+    );
+}
+
+#[test]
+fn watchdog_timeout_falls_back_to_default_minus_margin_when_unset() {
+    // Prost flattens scalars, so the proto's "unset" looks like `0` on
+    // the Rust side; treat that as "use the default minus margin".
+    let expected = Duration::from_secs(DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS as u64)
+        - CLIENT_WATCHDOG_SAFETY_MARGIN;
+    assert_eq!(watchdog_timeout_for_stamped_seconds(0), expected);
+}
+
+#[test]
+fn watchdog_timeout_clamps_negative_value_to_default_minus_margin() {
+    // Defense against a buggy or malicious payload. `Duration::from_secs`
+    // takes a `u64`; a negative value would underflow without the clamp.
+    let expected = Duration::from_secs(DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS as u64)
+        - CLIENT_WATCHDOG_SAFETY_MARGIN;
+    assert_eq!(watchdog_timeout_for_stamped_seconds(-42), expected);
+}
+
+#[test]
+fn watchdog_timeout_preserves_large_stamped_value() {
+    // Server-supplied values well above the margin pass through as
+    // (stamped - margin). 15 minutes stays at 14m30s after the
+    // subtraction.
+    assert_eq!(
+        watchdog_timeout_for_stamped_seconds(900),
+        Duration::from_secs(900) - CLIENT_WATCHDOG_SAFETY_MARGIN
+    );
+}

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -1635,8 +1635,14 @@ impl BlocklistAIController {
             );
             return false;
         };
-        let is_success = matches!(conversation.status(), ConversationStatus::Success);
-        if !owns || has_active_stream || !is_success {
+        // WaitingForEvents is treated as Success here: pending events
+        // drain via the next outbound request and the server-side
+        // supersede emits the resume signal.
+        let is_ready_status = matches!(
+            conversation.status(),
+            ConversationStatus::Success | ConversationStatus::WaitingForEvents,
+        );
+        if !owns || has_active_stream || !is_ready_status {
             log::info!(
                 "Pending events are not ready: conversation_id={conversation_id:?} owns_conversation={owns} has_active_stream={has_active_stream} status={:?}",
                 conversation.status()
@@ -1849,6 +1855,11 @@ impl BlocklistAIController {
             return;
         };
 
+        // The resume request supersedes any in-flight wait_for_events.
+        self.action_model.update(ctx, |action_model, ctx| {
+            action_model.cancel_wait_for_events_for_conversation(conversation_id, ctx);
+        });
+
         if self
             .send_request_input(
                 RequestInput::for_task(
@@ -1868,6 +1879,14 @@ impl BlocklistAIController {
             )
             .is_err()
         {
+            // TODO: surface retry exhaustion. The existing requeue
+            // re-emits `EventsReady` until `MAX_RETRY_ATTEMPTS` is hit,
+            // after which events are dropped silently and the wait has
+            // already been cancelled — the conversation can end up stuck
+            // with no executor pending entry, no watchdog, and no
+            // in-flight stream. Follow-up: park-on-exhaust the events
+            // and transition the conversation to `Error` so the next
+            // user resume can carry them along.
             OrchestrationEventService::handle(ctx).update(ctx, |svc, ctx| {
                 svc.requeue_awaiting_events(conversation_id, ctx);
             });

--- a/app/src/ai/blocklist/handoff/touched_repos.rs
+++ b/app/src/ai/blocklist/handoff/touched_repos.rs
@@ -381,7 +381,8 @@ fn extract_action_paths(
         | AIAgentActionType::SendMessageToAgent { .. }
         | AIAgentActionType::TransferShellCommandControlToUser { .. }
         | AIAgentActionType::AskUserQuestion { .. }
-        | AIAgentActionType::RunAgents(_) => {}
+        | AIAgentActionType::RunAgents(_)
+        | AIAgentActionType::WaitForEvents { .. } => {}
     }
 }
 

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -3094,6 +3094,68 @@ fn test_fork_conversation_preserves_task_ids_when_requested() {
     });
 }
 
+/// Set up settings and the global resource handles required for the
+/// `WaitingForEvents` status tests.
+fn setup_app_for_history_model_tests(app: &mut App) {
+    initialize_settings_for_tests(app);
+    let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(8);
+    let mut global_resource_handles = GlobalResourceHandles::mock(app);
+    global_resource_handles.model_event_sender = Some(sender);
+    app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+}
+
+/// A newly started conversation in a terminal view that previously held a
+/// `WaitingForEvents` conversation does not inherit the waiting state.
+/// Each fresh `start_new_conversation` begins in the default
+/// in-progress-ready state.
+#[test]
+fn test_new_conversation_does_not_inherit_waiting_for_events() {
+    use crate::ai::agent::conversation::ConversationStatus;
+
+    App::test((), |mut app| async move {
+        setup_app_for_history_model_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+
+        // First conversation enters the waiting state via the normal
+        // status-update path used by `WaitForEventsExecutor::execute`.
+        let first_id = history_model.update(&mut app, |model, ctx| {
+            let id = model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            model.update_conversation_status(
+                terminal_view_id,
+                id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            id
+        });
+        history_model.read(&app, |model, _| {
+            let first = model.conversation(&first_id).expect("first should exist");
+            assert!(matches!(
+                first.status(),
+                ConversationStatus::WaitingForEvents
+            ));
+        });
+
+        // Starting a new conversation in the same terminal view must not
+        // copy the waiting state forward.
+        let second_id = history_model.update(&mut app, |model, ctx| {
+            model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        assert_ne!(
+            first_id, second_id,
+            "a fresh conversation should have a distinct id",
+        );
+        history_model.read(&app, |model, _| {
+            let second = model.conversation(&second_id).expect("second should exist");
+            assert!(
+                !matches!(second.status(), ConversationStatus::WaitingForEvents),
+                "a newly started conversation must not start in WaitingForEvents",
+            );
+        });
+    });
+}
+
 #[test]
 fn test_fork_conversation_title_override_replaces_prefix() {
     use crate::ai::agent::conversation::AIConversation;

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -316,6 +316,9 @@ fn map_conversation_status(
 ) -> (AgentTaskState, Option<TaskStatusUpdate>) {
     match conversation.status() {
         ConversationStatus::InProgress => (AgentTaskState::InProgress, None),
+        // Report WaitingForEvents as IN_PROGRESS so the server task state
+        // matches the local view.
+        ConversationStatus::WaitingForEvents => (AgentTaskState::InProgress, None),
         ConversationStatus::Success => (AgentTaskState::Succeeded, None),
         ConversationStatus::Error => {
             // Extract the specific RenderableAIError from the last exchange to

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -7,8 +7,11 @@ use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 use warpui::App;
 
 use super::super::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
-use super::{classify_renderable_error, map_cli_session_status, LocalAgentTaskSyncModel};
-use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+use super::{
+    classify_renderable_error, map_cli_session_status, map_conversation_status,
+    LocalAgentTaskSyncModel,
+};
+use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::agent::RenderableAIError;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::server::server_api::ai::{AIClient, MockAIClient, TaskStatusUpdate};
@@ -120,6 +123,57 @@ fn other_error_is_error_with_internal() {
         Some(PlatformErrorCode::InternalError),
         Some("something broke"),
     );
+}
+
+// --- map_conversation_status ---
+
+/// A yielded conversation must report `IN_PROGRESS` to the task service
+/// so the task row stays active across the yield. No status message is
+/// attached because the yield is an internal state.
+#[test]
+fn map_conversation_status_waiting_for_events_reports_in_progress_with_no_message() {
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+        history_model.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.update_status(ConversationStatus::WaitingForEvents, terminal_view_id, ctx);
+        });
+
+        history_model.read(&app, |model, _| {
+            let conv = model.conversation(&conversation_id).unwrap();
+            assert_eq!(conv.status(), &ConversationStatus::WaitingForEvents);
+            let (state, update) = map_conversation_status(conv);
+            assert_eq!(state, AgentTaskState::InProgress);
+            assert!(
+                update.is_none(),
+                "WaitingForEvents must not attach a status message"
+            );
+        });
+    });
+}
+
+#[test]
+fn map_conversation_status_in_progress_reports_in_progress_with_no_message() {
+    let conversation = AIConversation::new(false, false);
+    assert_eq!(
+        conversation.status(),
+        &ConversationStatus::InProgress,
+        "freshly constructed conversation should start in InProgress"
+    );
+
+    let (state, update) = map_conversation_status(&conversation);
+
+    assert_eq!(state, AgentTaskState::InProgress);
+    assert!(update.is_none());
 }
 
 // --- map_cli_session_status ---

--- a/app/src/ai/blocklist/orchestration_events.rs
+++ b/app/src/ai/blocklist/orchestration_events.rs
@@ -174,7 +174,18 @@ impl OrchestrationEventService {
             .pending_events
             .get(&conversation_id)
             .is_some_and(|events| !events.is_empty());
-        if !is_restored && matches!(&current_status, ConversationStatus::Success) && has_pending {
+        // Re-fire EventsReady whenever the conversation reaches a status
+        // that `conversation_ready_for_pending_events` would accept, so
+        // events queued while the stream was in flight drain as soon as
+        // the stream finishes — either to `Success` or to
+        // `WaitingForEvents` via a `wait_for_events` yield.
+        if !is_restored
+            && matches!(
+                &current_status,
+                ConversationStatus::Success | ConversationStatus::WaitingForEvents
+            )
+            && has_pending
+        {
             ctx.emit(OrchestrationEventServiceEvent::EventsReady { conversation_id });
         }
     }

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -21,7 +21,7 @@ fn pill_status_sort_key(status: Option<&ConversationStatus>) -> u8 {
     match status {
         Some(ConversationStatus::Blocked { .. }) => 0,
         Some(ConversationStatus::Error) => 1,
-        Some(ConversationStatus::InProgress) => 2,
+        Some(ConversationStatus::InProgress) | Some(ConversationStatus::WaitingForEvents) => 2,
         Some(ConversationStatus::Cancelled) | Some(ConversationStatus::Success) => DONE_STATUS_KEY,
         None => 2,
     }
@@ -161,33 +161,48 @@ pub fn adjacent_orchestration_child_conversation_id(
 /// in flight.
 ///
 /// Aggregation precedence (highest wins):
-///   1. `InProgress` — any node in the tree is actively running.
+///   1. `InProgress` — any node in the tree is actively running, **unless**
+///      the orchestrator itself yielded into `WaitingForEvents`. The parent's
+///      waiting state is a more specific and useful signal to the user than
+///      "something somewhere is running".
 ///   2. `Blocked` — at least one node is waiting on user input. The
 ///      `blocked_action` from the first blocked node encountered is preserved
 ///      so callers can display it.
-///   3. `Error` — at least one node finished with an error.
-///   4. `Cancelled` — at least one node was cancelled.
-///   5. `Success` — everything finished successfully.
+///   3. `WaitingForEvents` — at least one node yielded via `wait_for_events`
+///      and is listening for inbound input. The run is quiescent but not
+///      terminal — the driver stays alive until something resumes it.
+///      Carve-out: when the orchestrator itself is `Cancelled` or `Error`,
+///      the parent's terminal status wins over a descendant `WaitingForEvents`
+///      so the pill does not falsely advertise a resumable run.
+///   4. `Error` — at least one node finished with an error.
+///   5. `Cancelled` — at least one node was cancelled.
+///   6. `Success` — everything finished successfully.
 ///
 /// Returns `Success` if the orchestrator is not loaded and has no descendants.
 pub fn aggregated_orchestrator_status(
     history: &BlocklistAIHistoryModel,
     orchestrator_id: AIConversationId,
 ) -> ConversationStatus {
-    let statuses = std::iter::once(orchestrator_id)
-        .chain(descendant_conversation_ids_in_spawn_order(
-            history,
-            orchestrator_id,
-        ))
-        .filter_map(|id| history.conversation(&id).map(|c| c.status().clone()));
-
+    let mut orchestrator_status: Option<ConversationStatus> = None;
     let mut first_blocked: Option<ConversationStatus> = None;
     let mut any_in_progress = false;
+    let mut any_waiting = false;
     let mut any_error = false;
     let mut any_cancelled = false;
-    for status in statuses {
+
+    for id in std::iter::once(orchestrator_id).chain(descendant_conversation_ids_in_spawn_order(
+        history,
+        orchestrator_id,
+    )) {
+        let Some(status) = history.conversation(&id).map(|c| c.status().clone()) else {
+            continue;
+        };
+        if id == orchestrator_id {
+            orchestrator_status = Some(status.clone());
+        }
         match status {
             ConversationStatus::InProgress => any_in_progress = true,
+            ConversationStatus::WaitingForEvents => any_waiting = true,
             ConversationStatus::Blocked { .. } => {
                 if first_blocked.is_none() {
                     first_blocked = Some(status);
@@ -200,10 +215,27 @@ pub fn aggregated_orchestrator_status(
     }
 
     if any_in_progress {
+        // Parent's own waiting state outranks descendant in-progress so
+        // the pill reflects that THIS conversation is paused.
+        if matches!(
+            orchestrator_status,
+            Some(ConversationStatus::WaitingForEvents)
+        ) {
+            return ConversationStatus::WaitingForEvents;
+        }
         return ConversationStatus::InProgress;
     }
     if let Some(blocked) = first_blocked {
         return blocked;
+    }
+    if any_waiting {
+        // Parent's terminal status beats descendant waiting — a
+        // finalized run can't resume, so surface the parent's outcome.
+        match orchestrator_status {
+            Some(ConversationStatus::Cancelled) => return ConversationStatus::Cancelled,
+            Some(ConversationStatus::Error) => return ConversationStatus::Error,
+            _ => return ConversationStatus::WaitingForEvents,
+        }
     }
     if any_error {
         return ConversationStatus::Error;

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -656,3 +656,299 @@ fn aggregated_status_respects_orchestrator_own_in_progress_state() {
         });
     });
 }
+
+// Aggregation precedence: `InProgress > Blocked > WaitingForEvents > Error >
+// Cancelled > Success`. Two carve-outs are pinned below: orchestrator
+// `WaitingForEvents` outranks descendant `InProgress`, and a terminal
+// orchestrator (`Cancelled`/`Error`) outranks a descendant `WaitingForEvents`.
+
+#[test]
+fn aggregated_status_is_waiting_when_orchestrator_yields_and_children_succeeded() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Orchestrator yielded via `wait_for_events`; all children finished
+        // cleanly. The tree is quiescent but not terminal — the aggregator
+        // must report WaitingForEvents so the pill bar reflects that the
+        // run is listening for inbound input.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::Success,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::WaitingForEvents,
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_parent_waiting_over_descendant_in_progress() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Parent waiting outranks descendant in-progress.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::WaitingForEvents,
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_cancelled_parent_over_descendant_waiting_for_events() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Terminal parent beats descendant waiting: a Cancelled orchestrator
+        // with a child still listening for events must surface as Cancelled
+        // — the run can't resume on its own once the parent is finalized.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::Cancelled,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::Cancelled,
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_errored_parent_over_descendant_waiting_for_events() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Symmetric to the Cancelled case: an Errored parent still wins over
+        // a descendant WaitingForEvents.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::Error,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::Error,
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_returns_in_progress_when_parent_is_in_progress_too() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // The parent-waits carve-out only kicks in when the orchestrator
+        // itself is `WaitingForEvents`. If the orchestrator is actively
+        // in progress alongside its children, `InProgress` wins (this
+        // is the original aggregation precedence).
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::InProgress,
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_blocked_over_waiting_for_events() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Orchestrator is waiting for events, but a child is blocked on user
+        // input. Blocked outranks WaitingForEvents because the user needs to
+        // unblock the tree before it can make progress.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::Blocked {
+                    blocked_action: "approve_command".to_string(),
+                },
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::Blocked {
+                    blocked_action: "approve_command".to_string(),
+                },
+            );
+        });
+    });
+}
+
+#[test]
+fn aggregated_status_prefers_waiting_for_events_over_error() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        // Orchestrator is waiting; one child errored. `WaitingForEvents`
+        // outranks `Error` because the run is not terminal — it may still
+        // resume on its own and the user shouldn't see a terminal
+        // "Error" pill while the driver is still alive.
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::WaitingForEvents,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::Error,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                aggregated_orchestrator_status(history_model, orchestrator_id),
+                ConversationStatus::WaitingForEvents,
+            );
+        });
+    });
+}

--- a/app/src/ai/blocklist/persistence.rs
+++ b/app/src/ai/blocklist/persistence.rs
@@ -320,6 +320,10 @@ impl From<&AIAgentActionType> for PersistedAIAgentActionType {
             // Orchestrate is rendered from the in-history tool call message;
             // there is no per-action state we need to persist locally.
             AIAgentActionType::RunAgents(_) => Self::NotPersisted,
+            // The wait is dropped on restart; the unresolved tool call
+            // stays in the transcript as an orphan until the next
+            // outbound request triggers the server's supersede.
+            AIAgentActionType::WaitForEvents { .. } => Self::NotPersisted,
         }
     }
 }

--- a/app/src/search/command_palette/conversations/search_item.rs
+++ b/app/src/search/command_palette/conversations/search_item.rs
@@ -204,7 +204,8 @@ impl ConversationSearchItem {
             .finish();
 
         // We only want to show the fork button if the conversation is completed
-        // (i.e. the agent has finished responding and there are no blocked commands).
+        // (i.e. the agent has finished responding and there are no blocked commands
+        // and is not yielded waiting for events).
         let conversation_is_done = BlocklistAIHistoryModel::as_ref(app)
             .conversation(&conversation.id())
             .map(|c| c.status().is_done())

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6263,7 +6263,9 @@ impl TerminalView {
                         ConversationStatus::Success => Some(FinishReason::Complete),
                         ConversationStatus::Error => Some(FinishReason::Error),
                         ConversationStatus::Cancelled => Some(FinishReason::Cancelled),
-                        ConversationStatus::InProgress | ConversationStatus::Blocked { .. } => None,
+                        ConversationStatus::InProgress
+                        | ConversationStatus::Blocked { .. }
+                        | ConversationStatus::WaitingForEvents => None,
                     };
                     if let Some(finish_reason) = finish_reason {
                         self.handle_finished_conversation(*conversation_id, finish_reason, ctx);

--- a/app/src/workspace/view/conversation_list/view.rs
+++ b/app/src/workspace/view/conversation_list/view.rs
@@ -872,6 +872,7 @@ impl TypedActionView for ConversationListView {
                 terminal_view_id,
             } => {
                 let window_id = ctx.window_id();
+                // A conversation can only be deleted once it's done.
                 let conversation_is_done = BlocklistAIHistoryModel::as_ref(ctx)
                     .conversation(conversation_id)
                     .is_none_or(|c| c.status().is_done());
@@ -1036,6 +1037,7 @@ impl TypedActionView for ConversationListView {
                     BlocklistAIHistoryModel::as_ref(ctx).conversation(&ai_conversation_id);
 
                 if let Some(conversation) = conversation {
+                    // Same gate as the deletion path above.
                     if !conversation.status().is_done() && !conversation.is_empty() {
                         let window_id = ctx.window_id();
                         ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -20,7 +20,7 @@ use crate::agent::action_result::{
     RequestComputerUseResult, RequestFileEditsResult, RunAgentsResult, SearchCodebaseResult,
     SendMessageToAgentResult, StartAgentResult, StartAgentVersion, SuggestNewConversationResult,
     SuggestPromptResult, TransferShellCommandControlToUserResult, UploadArtifactResult,
-    UseComputerResult, WriteToLongRunningShellCommandResult,
+    UseComputerResult, WaitForEventsResult, WriteToLongRunningShellCommandResult,
 };
 use crate::agent::{AIAgentCitation, FileLocations};
 use crate::diff_validation::ParsedDiff;
@@ -174,6 +174,17 @@ pub enum AIAgentActionType {
     /// `base_prompt + "\n\n" + agent_run_configs[i].prompt` (or just
     /// `base_prompt` when the per-agent `prompt` is empty).
     RunAgents(RunAgentsRequest),
+
+    /// Synthesized from a server-emitted Message::ToolCall::WaitForEvents;
+    /// dispatched by WaitForEventsExecutor.
+    WaitForEvents {
+        /// tool_call_id of the unresolved WaitForEvents call; used to
+        /// match inbound resume signals.
+        tool_call_id: String,
+        /// 0 means "unset" (prost flat-scalar convention); the executor
+        /// falls back to a default.
+        idle_timeout_seconds: i32,
+    },
 }
 
 /// Run-wide + per-agent configuration for a `RunAgents` tool call.
@@ -384,6 +395,9 @@ impl AIAgentActionType {
                 AIAgentActionResultType::AskUserQuestion(AskUserQuestionResult::Cancelled)
             }
             Self::RunAgents(_) => AIAgentActionResultType::RunAgents(RunAgentsResult::Cancelled),
+            Self::WaitForEvents { .. } => {
+                AIAgentActionResultType::WaitForEvents(WaitForEventsResult::Cancelled)
+            }
         }
     }
 
@@ -432,6 +446,7 @@ impl AIAgentActionType {
             Self::RunAgents(req) => {
                 format!("Orchestrate {} agent(s)", req.agent_run_configs.len())
             }
+            Self::WaitForEvents { .. } => "Wait for events".to_string(),
         }
     }
 }
@@ -612,6 +627,15 @@ impl Display for AIAgentActionType {
                     .collect::<Vec<_>>()
                     .join(", ");
                 write!(f, "Orchestrate: summary='{}' agents=[{names}]", req.summary,)
+            }
+            AIAgentActionType::WaitForEvents {
+                tool_call_id,
+                idle_timeout_seconds,
+            } => {
+                write!(
+                    f,
+                    "WaitForEvents: tool_call_id={tool_call_id} idle_timeout_seconds={idle_timeout_seconds}"
+                )
             }
         }
     }

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -989,6 +989,7 @@ impl TryFrom<RequestComputerUseResult> for api::request::input::tool_call_result
                                     height: screenshot.height as i32,
                                 }),
                                 platform: convert_platform(platform).into(),
+                                windows: vec![],
                             },
                         )),
                     },
@@ -1033,6 +1034,8 @@ impl TryFrom<UseComputerResult> for api::request::input::tool_call_result::Resul
                                     height: s.height as i32,
                                 }),
                                 cursor_position: result.cursor_position.map(vec_to_coordinates),
+                                captured_window: None,
+                                windows: vec![],
                             },
                         )),
                     },
@@ -1448,6 +1451,22 @@ impl TryFrom<InsertReviewCommentsResult> for api::request::input::tool_call_resu
                 ),
             ),
             InsertReviewCommentsResult::Cancelled => Err(ConvertToAPITypeError::Ignore),
+        }
+    }
+}
+
+impl TryFrom<WaitForEventsResult> for api::request::input::tool_call_result::Result {
+    type Error = ConvertToAPITypeError;
+
+    /// Completed → wire form; Cancelled → drop (mirrors RunAgents).
+    fn try_from(result: WaitForEventsResult) -> Result<Self, Self::Error> {
+        match result {
+            WaitForEventsResult::Completed => Ok(
+                api::request::input::tool_call_result::Result::WaitForEvents(
+                    api::WaitForEventsResult {},
+                ),
+            ),
+            WaitForEventsResult::Cancelled => Err(ConvertToAPITypeError::Ignore),
         }
     }
 }

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -100,6 +100,10 @@ pub enum AIAgentActionResultType {
     /// The result of an orchestrate tool call: launched (with per-agent
     /// outcomes), launch denied (Stage 2), failure, or cancelled.
     RunAgents(RunAgentsResult),
+
+    /// Result of the client-side wait_for_events watchdog or inbound
+    /// resume.
+    WaitForEvents(WaitForEventsResult),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -167,6 +171,7 @@ impl Display for AIAgentActionResultType {
             AIAgentActionResultType::TransferShellCommandControlToUser(result) => result.fmt(f),
             AIAgentActionResultType::AskUserQuestion(result) => result.fmt(f),
             AIAgentActionResultType::RunAgents(result) => result.fmt(f),
+            AIAgentActionResultType::WaitForEvents(result) => result.fmt(f),
             AIAgentActionResultType::OpenCodeReview | AIAgentActionResultType::InitProject => {
                 Ok(())
             }
@@ -768,6 +773,9 @@ impl AIAgentActionResultType {
             AIAgentActionResultType::RunAgents(_) => {
                 "The result of an orchestrate batch of child agents"
             }
+            AIAgentActionResultType::WaitForEvents(_) => {
+                "The local watchdog timed out while waiting for inbound events"
+            }
         }
     }
 
@@ -806,6 +814,7 @@ impl AIAgentActionResultType {
             ) => true,
             Self::AskUserQuestion(AskUserQuestionResult::Success { .. }) => true,
             Self::RunAgents(RunAgentsResult::Launched { .. }) => true,
+            Self::WaitForEvents(WaitForEventsResult::Completed) => true,
             _ => false,
         }
     }
@@ -880,7 +889,8 @@ impl AIAgentActionResultType {
             | Self::SendMessageToAgent(SendMessageToAgentResult::Cancelled)
             // SkippedByAutoApprove is intentionally excluded: the agent should continue.
             | Self::AskUserQuestion(AskUserQuestionResult::Cancelled)
-            | Self::RunAgents(RunAgentsResult::Cancelled) => true,
+            | Self::RunAgents(RunAgentsResult::Cancelled)
+            | Self::WaitForEvents(WaitForEventsResult::Cancelled) => true,
             _ => false,
         }
     }
@@ -1454,6 +1464,27 @@ impl Display for AskUserQuestionResult {
                     question_ids.len()
                 )
             }
+        }
+    }
+}
+
+/// Result of a client-side wait_for_events action.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum WaitForEventsResult {
+    /// Watchdog fired or an inbound resume signal closed the wait. The
+    /// agent's next turn observes an empty WaitForEvents result on the
+    /// wire and decides how to proceed.
+    Completed,
+    /// User cancelled the conversation while waiting. Mirrors
+    /// RunAgents::Cancelled: no tool-call result is sent on the wire.
+    Cancelled,
+}
+
+impl Display for WaitForEventsResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Completed => write!(f, "Wait for events completed"),
+            Self::Cancelled => write!(f, "Wait for events cancelled"),
         }
     }
 }

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -342,6 +342,7 @@ impl ApiKeyManager {
                 open_router,
                 allow_use_of_warp_credits: false,
                 aws_credentials,
+                google_cloud_credentials: None,
             })
         }
     }

--- a/specs/QUALITY-780/PRODUCT.md
+++ b/specs/QUALITY-780/PRODUCT.md
@@ -1,0 +1,92 @@
+# Client Awareness of `wait_for_events` Yields
+
+## Summary
+When an Oz cloud agent calls the server-side `wait_for_events` tool, the agent has not finished its work — it has yielded the turn and is waiting on an inbound message or lifecycle event. The Warp client must observe this yield, keep the run alive, suppress completion-shaped UI (notifications, success badges), and surface a distinct "waiting for events" presentation in the orchestration UI.
+
+## Problem
+Today the client cannot tell a `wait_for_events` yield apart from real completion. The model turn ends cleanly, the local conversation status flips to `Success`, and two things go wrong as a result:
+
+1. The Oz CLI driver treats `Success` as run completion and schedules the process exit through its `--idle-on-complete` timer. For cloud agents, this means the worker can exit seconds after yielding, even though child events were expected. Server-side compensations (`shouldPreserveInProgressOnClientSuccess`, `ExtendTaskIdleTimeout`) preserve task state in the database but do not keep the running process alive, so the inbound event has no agent to wake.
+2. The notifications mailbox fires `NotificationCategory::Complete` ("Task completed.") on every `Success` transition. Orchestrators that yield between turns produce spammy "Task completed" toasts that users have complained about.
+
+A fix has to come from the client: server-side preservation cannot keep a local process alive and cannot suppress local notifications.
+
+Note on orchestration badges: in current one-level orchestration the pill bar aggregator already returns `InProgress` whenever any child is still active, so a yielded orchestrator with children-in-flight does not display a green check today. The new state still drives a distinct badge in the narrower case where an orchestrator yields with no descendants (or with all descendants terminal) and in any future multi-level orchestration; see invariants 21–24.
+
+## Goals
+1. The client distinguishes a `wait_for_events` yield from real completion using a first-class state.
+2. While yielded, the agent run stays alive, the conversation reads as non-terminal, completion notifications do not fire, and orchestration UI surfaces a distinct "waiting" badge.
+3. The yield state clears automatically when the next user input or inbound event resumes the agent.
+
+## Non-goals
+1. Changing how `wait_for_events` is invoked by the model, or its tool contract from the agent's perspective.
+2. Adding a new mechanism for the user to manually pause / resume a run.
+3. Redesigning the orchestration pill bar visual language; the new state reuses existing badge primitives with a new color/icon.
+4. Re-architecting `ConversationStatus` consumers beyond what is required to add the new variant exhaustively.
+
+## Figma
+Figma: none provided. The new badge should reuse the existing `render_avatar_with_status_overlay` / `status_icon_and_color` plumbing with a distinct color and icon for `WaitingForEvents` so it is visually distinguishable from `Success`, `Blocked`, and `InProgress`.
+
+## Behavior
+
+### Terms
+1. A **`wait_for_events` yield** is the act of the agent calling the server-side `wait_for_events` tool. The yield ends the current model turn but does not end the run.
+2. A **waiting run** is an agent run whose most recent turn ended via a `wait_for_events` yield and which has not yet received any resume input — user query or other conversation input, inbound message, inbound lifecycle event, cancellation, or watchdog timeout — that ends the waiting state.
+3. A **terminal status** is one of `Success`, `Error`, `Cancelled`. These mean the run is finished.
+4. A **quiescent status** is a status in which the agent is not actively streaming output. `Success`, `Error`, `Cancelled`, `Blocked`, and the new `WaitingForEvents` are all quiescent. `InProgress` is not quiescent.
+
+### Conversation status
+5. The client adds a new `ConversationStatus::WaitingForEvents` value alongside the existing `InProgress`, `Success`, `Blocked`, `Error`, and `Cancelled` values.
+6. `WaitingForEvents` is **quiescent but not terminal**: the agent is not actively streaming, but the run is still alive and may resume.
+7. When the current model turn ends via a `wait_for_events` yield, the conversation status transitions to `WaitingForEvents`, not `Success`.
+8. When the agent resumes, the conversation status transitions back to `InProgress` and the waiting state is cleared. Any of the following triggers a resume: the user submits a new query or other conversation input; the user invokes a slash command or other action that adds a new exchange; the orchestration event stream delivers a message or lifecycle event the agent will consume on its next turn.
+9. `WaitingForEvents` may only be reached from `InProgress`. It may transition to `InProgress`, `Cancelled`, `Error`, or `Success` (if a follow-up turn completes the run conventionally). It must not transition directly to another `WaitingForEvents` without re-entering `InProgress` first.
+10. The waiting state is **not** durable across restart. Shutting the app down ends the wait; on the next start the conversation restores as whatever its last-exchange status implies (typically `Success`, since the yielding stream finished cleanly). The unresolved `wait_for_events` tool call stays in the transcript as an orphan, and the next outbound request triggers the server's existing supersede mechanism to synthesize the matching `Cancel`. The user can re-engage manually if they want to resume the conversation.
+
+### Run lifecycle
+11. A waiting Oz cloud agent run does not trigger CLI driver process exit. The local CLI driver only schedules its `--idle-on-complete` exit timer on a true terminal status, not on `WaitingForEvents`.
+12. A waiting run may still bound its lifetime: if **no resume input arrives** within an upper bound — no user query or other input, and no inbound message or lifecycle event — the client emits an empty `WaitForEventsResult` as a new tool-call-result input on the agent's behalf, closing the unresolved `wait_for_events` call. The agent's next turn observes the empty timeout result and decides how to proceed (commonly `finish_task`, but the agent may also re-yield via another `wait_for_events`, ask the user, or take other action). The run does **not** auto-cancel on timeout; the agent owns the post-timeout decision. The upper bound is read from the server-supplied `idle_timeout_seconds` on the `wait_for_events` tool call, falling back to a built-in client default if the server did not supply one.
+13. The watchdog used in (12) is distinct from the completion idle timer. A `WaitingForEvents` run does not enter the completion-idle path even when the configured `--idle-on-complete` value is shorter than the waiting watchdog.
+14. The user can cancel a waiting run through any existing cancel affordance. Cancellation transitions to `Cancelled` immediately.
+15. The local `ai_tasks` row reported via `LocalAgentTaskSyncModel.update_agent_task` reports `IN_PROGRESS` while the conversation is `WaitingForEvents`. The client does not report `SUCCEEDED` for a yielded conversation.
+
+### Notifications
+16. A transition into `WaitingForEvents` does not produce any notification (no toast, no badge in the notification mailbox).
+17. A pre-existing stale notification for the same conversation origin (e.g. a leftover "task in progress" item) is cleared on entry to `WaitingForEvents`, the same way `InProgress` clears it today.
+18. A subsequent transition from `WaitingForEvents` back to `InProgress` (because the agent resumed) does not produce a notification on its own.
+19. A subsequent transition from `WaitingForEvents` to a terminal status (`Success`, `Error`, `Cancelled`) produces the same notification that the same transition from `InProgress` would have produced.
+20. An orchestrator's notifications on `Success`, `Cancelled`, and `Error` fire as they do today. If the orchestrator itself reaches `Success` (or another terminal status) it is treating itself as done; the mailbox does not second-guess that based on the state of descendants. The known "orchestrator notification spam" case is the one where the orchestrator yielded via `wait_for_events` between turns — that case is already handled by (16), because the orchestrator's status is `WaitingForEvents`, not `Success`, while it is waiting.
+
+### Orchestration pill bar and avatar badges
+21. A child pill whose conversation status is `WaitingForEvents` renders with the new "waiting" badge (icon + color distinct from `Success`, `Blocked`, and `InProgress`).
+22. The orchestrator pill bar badge is driven by `aggregated_orchestrator_status` over the orchestration tree. The aggregator's precedence is `InProgress > Blocked > WaitingForEvents > Error > Cancelled > Success`, with one carve-out: when the orchestrator itself yielded into `WaitingForEvents`, its own waiting state outranks any descendant `InProgress`. Rationale:
+    - `InProgress` wins when the orchestrator itself is active or when no node is yielded, because something is actively streaming.
+    - When the orchestrator's own status is `WaitingForEvents` but a descendant is still running, the parent's waiting state is the more useful signal: the user sees that THIS conversation is paused waiting on inbound input even while work continues in the tree.
+    - `Blocked` outranks `WaitingForEvents` because a blocked node needs user action and must not be masked by a quiescent parent.
+    - `WaitingForEvents` outranks terminal statuses because the parent is explicitly still alive and listening; the orchestration is not done.
+23. The hover details card and the orchestration breadcrumb avatars use the same badge mapping. There is no per-surface override for `WaitingForEvents`.
+24. The pill sort order treats `WaitingForEvents` as part of the "active-ish" section of the bar, not the "done" bucket. A waiting child does not drift to the right of completed siblings.
+
+### Other client surfaces
+25. The block status bar and any "is the agent thinking" indicator must not show a streaming spinner for `WaitingForEvents`. Waiting is quiescent: no spinner, no Stop button, no live-streaming affordances.
+26. Conversation input is enabled while in `WaitingForEvents`: the user can submit a new query, run a slash command, or any other action that produces a new exchange. Doing so clears the waiting state and starts a new turn (transitioning to `InProgress`). The user does not need to wait for an inbound event before submitting input.
+27. The block status bar may show an unobtrusive "waiting for events" affordance when the conversation is in `WaitingForEvents`. The exact copy is up to design; this spec only requires it not be styled as completion.
+28. `ConversationStatus::is_done()` keeps its existing semantics — `Success | Error | Cancelled` — and so returns `false` for `WaitingForEvents`. No new helper is introduced.
+
+### Resume and clearing the waiting state
+29. The waiting state is cleared (i.e., the conversation leaves `WaitingForEvents`) when any of the following happens. The agent itself cannot self-resume from `WaitingForEvents`; resume always requires input from outside the agent's own decision-making — user input, the orchestration event stream, the client-side watchdog acting on the agent's behalf, or user cancellation.
+    - The user submits a new query, runs a slash command, or otherwise adds a new exchange to the conversation. A user query is a first-class resume path — it does not require an inbound event to arrive first. The server's existing supersede mechanism emits a generic `Cancel` tool-call result for the unresolved `wait_for_events` call; the agent's next turn sees both the cancel and the new input.
+    - The orchestration event stream delivers a message or lifecycle event that the agent will consume in its next turn. Same server-side supersede path as the user-input case.
+    - The user cancels the run; the conversation transitions to `Cancelled`. Pending tool calls are not retroactively cancelled — the unresolved `wait_for_events` tool-call message stays in transcript history as an orphan.
+    - The watchdog from (12) fires; the client emits an empty `WaitForEventsResult` on the agent's behalf, closing the unresolved call. The conversation transitions back to `InProgress` while the agent's next turn decides how to proceed (per (12)). The pending tool call is *not* orphaned by the watchdog path because the client-emitted result closes it.
+30. Clearing the waiting state is observable: a transition out of `WaitingForEvents` must produce a status update event so subscribers (task sync, notifications, pill bar) re-evaluate.
+31. The waiting state must not survive across distinct agent runs. Starting a new conversation never inherits `WaitingForEvents` from a prior conversation.
+
+### Backwards compatibility and rollout
+This fix requires a coordinated release across the proto contract (`warp-proto-apis`), the server (`warp-server`), and the client (`warp`). The user-visible behavior during the rollout is bounded by the following invariants.
+
+32. The fix is gated by a server-side feature flag. When the flag is **off** for a `wait_for_events` call, the legacy behavior is unchanged: the client treats the conversation as `Success`, the CLI driver exits per `--idle-on-complete`, and the existing server-side preservation (`shouldPreserveInProgressOnClientSuccess`, `ExtendTaskIdleTimeout`) keeps the task `IN_PROGRESS` on the server. This is the pre-fix bug and is acceptable during rollout.
+33. When the server flag is **on** and the client build includes the new `WaitingForEvents` support, all behavior in this spec applies. The flag flips per `wait_for_events` call (not per conversation), so an individual call's behavior is determined by the flag state at yield time.
+34. The flag may flip mid-conversation. A single conversation can legitimately contain both legacy (pre-flag) and new (post-flag) `wait_for_events` yields. The new yields activate the `WaitingForEvents` flow; legacy yields stay on the existing path. The user-visible expectation is that new yields show the "waiting" badge and suppress completion notifications, while legacy yields look the same as today. Both produce the same final outcome (the run resumes correctly when the next inbound event arrives) because the server-side gates protect task state on both paths.
+35. A new client receiving a transcript that contains only legacy `wait_for_events` yields (e.g. restored from a pre-flag persistence record) treats the conversation as it does today — no retroactive reclassification is attempted. The legacy server-handled tool call is opaque to the client and cannot be detected.
+36. A new client receiving the new public `WaitForEvents` tool-call variant from any server with the flag on activates the full fix. There is no separate client-side feature flag.

--- a/specs/QUALITY-780/TECH.md
+++ b/specs/QUALITY-780/TECH.md
@@ -1,0 +1,382 @@
+# Client Awareness of `wait_for_events` Yields — Tech Spec
+## Context
+See `specs/QUALITY-780/PRODUCT.md` for user-visible behavior. This spec maps the product invariants onto the existing conversation status, driver lifecycle, task sync, notifications, and orchestration pill bar code paths in the Warp client, and identifies the server-side change needed so the client can actually observe a `wait_for_events` yield. The server-side spec lives at `warp-server/specs/QUALITY-780/TECH.md`.
+
+### Today's behavior in the bug
+The end-to-end path that produces the bug is:
+
+1. The model calls the server-handled `wait_for_events` tool. `HandleWaitForEvents` in `warp-server/logic/ai/multi_agent/runtime/ambient_agents.go` returns a `ServerToolCallResult::WaitForEventsResult` and side-effects `MarkActiveExecutionYieldedForWaitForEvents` and `ExtendTaskIdleTimeout`.
+2. The current model turn ends; the agent's response stream finishes successfully.
+3. `Message::ToolCallResult` messages (including the legacy server-handled `WaitForEventsResult`) are applied to the local conversation in the `response_event::Type::ClientActions(...)` arm of `BlocklistAIController::handle_response_stream_event` at `app/src/ai/blocklist/controller.rs:2614-2631`, which calls `history_model.apply_client_actions(...)`. The conversation's `ConversationStatus::Success` transition itself fires later when the `BlocklistAIActionEvent` subscriber at `app/src/ai/blocklist/controller.rs:495-518` observes that no follow-up action is queued and marks the response stream completed successfully. (The `AfterStreamFinished` arm at `controller.rs:2680+` is post-stream cleanup; it does not apply `ClientActions`.)
+4. `LocalAgentTaskSyncModel.handle_history_event` (`app/src/ai/blocklist/local_agent_task_sync_model.rs:119-151`) maps `Success` → `AgentTaskState::Succeeded` and fires `update_agent_task`.
+5. The server's `ApplyClientUpdates` path calls `shouldPreserveInProgressOnClientSuccess` from the `AgentTaskStateSucceeded` arm at `warp-server/logic/ai/ambient_agents/dispatcher.go:2013` (the predicate itself lives at `dispatcher.go:2110-2146`). It sees the `wait_for_events` marker and clears `in_progress_since` rather than transitioning the task to `SUCCEEDED`. The server **task state** remains preserved.
+6. But on the client, `AgentDriver`'s subscription to `BlocklistAIHistoryEvent::UpdatedConversationStatus` (`app/src/ai/agent_sdk/driver.rs:2600-2683`) sees `Success` and either calls `run_exit.end_run_now(...)` (no `idle_on_complete` configured) or schedules `run_exit.end_run_after(idle_timeout, ...)` (idle timeout configured). When that future resolves, the Oz CLI driver process exits via `ctx.terminate_app(...)`.
+7. `AgentNotificationsModel.handle_history_event_for_mailbox` (`app/src/ai/agent_management/agent_management_model.rs:304-389`) fires `NotificationCategory::Complete` ("Task completed.") on the same `Success` transition.
+8. `aggregated_orchestrator_status` (`app/src/ai/blocklist/orchestration_topology.rs:64-106`) returns `Success` when no node is `InProgress`/`Blocked`/`Error`/`Cancelled`, so the orchestration pill bar's orchestrator badge renders the green check via `render_avatar_with_status_overlay`.
+
+The combined effect is the bug report: an Oz cloud agent worker exits seconds after yielding for events and fires a misleading "Task completed" toast. The orchestration pill bar badge is also wrong in the narrower case where an orchestrator yields with no active descendants (today's one-level orchestration means active children already drive the aggregator to `InProgress`; the badge fix matters for the no-descendants case and is forward-compatible with any future multi-level orchestration).
+
+### Relevant files
+
+#### Conversation status and persistence
+- `app/src/ai/agent/conversation.rs:4067-4168` — `ConversationStatus` enum, `status_icon_and_color`, `render_icon`, `is_in_progress`, `is_blocked`, `is_cancelled`, `is_done`, `is_error`.
+- `app/src/ai/agent/conversation.rs:777-814` — `status()`, `update_status_with_error_message`.
+- `app/src/ai/agent/conversation.rs:195-323` — `AIConversation` struct definition with all durable fields including `parent_agent_id`, `agent_name`, `last_event_sequence`, `pinned`.
+- `app/src/ai/agent/conversation.rs:3038-3128` — `write_updated_conversation_state` constructs `AgentConversationData` for SQLite persistence.
+- `app/src/ai/agent/conversation.rs:700-720` — `derive_status_from_root_task` reconstructs status from last-exchange output on restore. Today, a successful exchange always derives `Success`. Note: this function takes only `root_task: &Option<&Task>` — it has no access to `AgentConversationData` and is called from the restore path at `conversation.rs:542`.
+- `app/src/persistence/model/...` — `AgentConversationData` struct definition (the SQLite schema for restored conversations).
+
+#### Driver / process lifecycle
+- `app/src/ai/agent_sdk/driver.rs:147-202` — `IdleTimeoutSender` (the generation-based oneshot that drives Oz CLI exit timing).
+- `app/src/ai/agent_sdk/driver.rs:720-812` — `AgentDriver::run`; tx/rx oneshot that signals the CLI to terminate the process. The async block that wraps `run_internal` (defined separately at `driver.rs:1594+`) is spawned here.
+- `app/src/ai/agent_sdk/driver.rs:1879-1914` — `HarnessKind::Oz` branch awaits `status_rx` from `execute_run()`; on resolution sleeps 1s then returns the conversation status.
+- `app/src/ai/agent_sdk/driver.rs:2429-2709` — `execute_run`, which subscribes to `BlocklistAIHistoryEvent::UpdatedConversationStatus` and maps `Success | Blocked | Cancelled` to either immediate or idle-on-complete-delayed run exit.
+- `app/src/ai/agent_sdk/driver.rs:2861-2949` — `subscribe_to_cli_agent_session_events`; the same `Success | Blocked` → exit mapping for third-party harnesses.
+- `app/src/ai/agent_sdk/mod.rs:1415` — `ctx.terminate_app(TerminationMode::ForceTerminate, None)` when `driver.run` returns `Ok(())`.
+
+#### Task sync model
+- `app/src/ai/blocklist/local_agent_task_sync_model.rs:119-151` — `handle_history_event` reacts to `UpdatedConversationStatus`.
+- `app/src/ai/blocklist/local_agent_task_sync_model.rs:314-355` — `map_conversation_status` maps `ConversationStatus` to `AgentTaskState`.
+
+#### Notifications
+- `app/src/ai/agent_management/agent_management_model.rs:209-302` — `handle_history_event` and `handle_history_event_for_mailbox`.
+- `app/src/ai/agent_management/agent_management_model.rs:304-389` — Per-status notification branches.
+- `app/src/ai/agent_management/agent_management_model.rs:471-482` — `ConversationStatus::should_trigger_notification`.
+
+#### Orchestration pill bar and topology
+- `app/src/ai/blocklist/orchestration_topology.rs:64-106` — `aggregated_orchestrator_status` with precedence `InProgress > Blocked > Error > Cancelled > Success` (precedence to be updated).
+- `app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs:119-151` — `pill_status_sort_key`, `pill_secondary_sort_key`, `DONE_STATUS_KEY`.
+- `app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs:631-705` — `pill_specs` constructs pill data; orchestrator gets aggregated status, children use their own status.
+- `app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs:1390-1397` — Hover card uses aggregated status for orchestrators.
+- `app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs:2112-2156` — `render_avatar_with_status_overlay`.
+
+#### Server tool-call result handling
+- `app/src/ai/blocklist/controller.rs:2614-2631` — the `response_event::Type::ClientActions(actions)` arm of `BlocklistAIController::handle_response_stream_event`. This is where `AddMessagesToTask` actions (which carry the tool-call-result messages, including any new `WaitForEvents` tool-call result) are dispatched into the conversation via `history_model.apply_client_actions(...)`.
+- `app/src/ai/blocklist/controller.rs:495-518` — `BlocklistAIActionEvent` subscriber that drives the conversation's `Success` transition after no follow-up action is queued. Not the same code path as `AfterStreamFinished`.
+- `app/src/ai/blocklist/controller.rs:2680+` — `ResponseStreamEvent::AfterStreamFinished` handler; post-stream cleanup. Does **not** apply `ClientActions`.
+- `app/src/ai/blocklist/history_model.rs:1484` — `apply_client_actions` (the function that adds `AddMessagesToTask` actions to a conversation; the natural hook point for the new `WaitForEvents` tool-call detection).
+- Search for `WaitForEventsResult` in the client today: no hits. The legacy server tool-call result is opaque to clients (carried in the `Message::ToolCallResult::ServerResult { serialized_result: <opaque string> }` variant per `warp-proto-apis/apis/multi_agent/v1/task.proto:939-941`).
+
+## Design options
+Three were considered. We are recommending Option B (first-class variant) because the existing exhaustive-matching conventions make it the safest change to land cleanly; the others are documented for context.
+
+### Option A — Marker on `AIConversation`, status stays `Success`
+Add a boolean `waiting_for_events: bool` on `AIConversation` (and persist it on `AgentConversationData`). Conversation status still flips to `Success` on stream finish, but every status-consuming surface that cares (`LocalAgentTaskSyncModel`, `AgentDriver`, notifications, pill bar aggregator) reads the marker alongside the status.
+
+- Pros: smallest blast radius; no enum-variant churn; `match conversation.status()` sites that don't care about waiting keep working unchanged.
+- Cons: invisible to exhaustive matching, which is how the original bug propagated in the first place. Any new consumer of `ConversationStatus::Success` will silently treat a waiting conversation as done. The "is this a real success?" check has to be repeated at every site that needs it; we cannot rely on the compiler to enumerate them.
+- Verdict: rejected. The whole reason the bug exists is that `Success` is overloaded.
+
+### Option B — First-class `ConversationStatus::WaitingForEvents` variant (recommended)
+Add a new variant alongside `InProgress`, `Success`, `Blocked`, `Error`, `Cancelled`.
+
+- Pros: exhaustive matching enumerates every site that needs to make a deliberate decision. Existing `match conversation.status()` arms (icon, color, telemetry, sort key, mailbox) fail to compile until they decide what to do, which is the exact failure mode we want the compiler to catch. Models the state accurately: quiescent but not terminal, like `Blocked`.
+- Cons: touches more files (every `match conversation.status()`).
+- Verdict: chosen.
+
+### Option C — Reuse `ConversationStatus::InProgress`
+Have the conversation stay `InProgress` while yielded.
+
+- Pros: trivially keeps the driver alive (the existing `is_in_progress()` branch already cancels idle timers) and naturally satisfies orchestration aggregation precedence.
+- Cons: `InProgress` carries an implicit "actively streaming" meaning throughout the codebase — block status bar shows a spinner, the Stop button is enabled, the input is disabled in some flows, "thinking" UI animates. A yielded run is none of those things. Every UI site that keys off `InProgress` would either misfire or need a new way to ask "is the agent really doing anything?"
+- Verdict: rejected. The overload is even worse than Option A.
+
+## Proposed changes
+
+### 1. `ConversationStatus::WaitingForEvents` variant
+In `app/src/ai/agent/conversation.rs:4067-4168`:
+
+```rust path=null start=null
+pub enum ConversationStatus {
+    InProgress,
+    Success,
+    Error,
+    Cancelled,
+    Blocked { blocked_action: String },
+    // New:
+    WaitingForEvents,
+}
+```
+
+Update `Display`, `render_icon`, and `status_icon_and_color` exhaustively. The new badge needs a color and icon distinct from every existing status. Explicit collisions to avoid:
+- `Success` uses `theme.ansi_fg_green()` and `Icon::Check` (`conversation.rs:4121-4127`).
+- `InProgress` uses `theme.ansi_fg_magenta()` and `Icon::ClockLoader` (`conversation.rs:4114-4120`).
+- `Blocked` uses `theme.ansi_fg_yellow()` and `Icon::StopFilled` (`conversation.rs:4136-4142`).
+
+Recommended palette: `theme.ansi_fg_blue()` with a "listening" or "hourglass" icon. Final choice deferred to design with a `TODO(design)` placeholder; this spec only requires that the visual be unambiguous against the three quiescent-non-terminal-adjacent siblings above.
+
+### 2. `ConversationStatus::is_done()` is unchanged
+`is_done()` keeps its existing semantics — `Success | Error | Cancelled` — so it already returns `false` for `WaitingForEvents`. No predicate split is needed; the existing five `is_done()` call sites (search row, conversation-list sections, `/cost`, fork data source) all want "the run is finished and cannot resume", which is exactly what `is_done()` already conveys. `should_trigger_notification` adds `WaitingForEvents => false`.
+
+### 3. Persistence and restore
+The `WaitingForEvents` status is **not** durable. The agent execution that the wait keeps alive is in-process state by definition; an app shutdown ends the wait the same way it ends every other running tool call.
+
+Concretely:
+- `AgentConversationData` carries no `waiting_for_events` field. There is nothing new to write in `write_updated_conversation_state`.
+- `derive_status_from_root_task` is the sole authority on restore status. A conversation that was yielded at shutdown restores as `Success` because the yielding response stream finished cleanly.
+- The unresolved `wait_for_events` tool-call message stays in the persisted transcript as an orphan. The next outbound request from the user re-engaging the conversation reaches the server with no result for that tool call, and the server's existing pending-tool-call supersede mechanism synthesizes the matching `Cancel`. From the agent's perspective the yield is just another inbound supersede.
+- The `LocalAgentTaskSyncModel` flips back to reporting `Succeeded` on restore. The server's `shouldPreserveInProgressOnClientSuccess` gate (server TECH §1.1) handles this safely: the marker is still on the server's task row, so the dispatcher keeps the task `IN_PROGRESS` for the rollout window during which the gate exists.
+
+Alternative considered (and rejected): persist `waiting_for_events: bool` on `AgentConversationData` and override `derive_status_from_root_task` on restore. Rejected because it added durable state for an in-process concept and introduced a stale-state risk (an offline client missing a resume signal could come back showing a multi-day "waiting" badge for a long-since-reaped server task). The honest model — "the wait ends when the app dies" — has a smaller surface area and degrades gracefully.
+
+### 4. Wait-for-events action and executor
+`wait_for_events` is modeled as a first-class `action_model` action so the watchdog, the conversation status transition, and the follow-up request all flow through the executor's lifecycle. This avoids a thicket of guards that would otherwise be needed to keep `WaitingForEvents` from being clobbered by code paths that treat "the response stream finished" as "the conversation succeeded".
+#### 4.1 Action variant and result
+Add `AIAgentActionType::WaitForEvents { tool_call_id: String, idle_timeout_seconds: i32 }` in the shared `ai` crate and a matching `AIAgentActionResultType::WaitForEvents(WaitForEventsResult)` result variant. `WaitForEventsResult` is an enum with two cases:
+- `Completed` — watchdog timed out, or an inbound resume signal cleared the wait. Wire form is the empty proto `WaitForEventsResult{}` carried on `Request::Input::ToolCallResult.result`.
+- `Cancelled` — user cancelled the wait. Wire conversion drops it (`Err(ConvertToAPITypeError::Ignore)`) so no result is sent for the unresolved tool call; the server's existing supersede mechanism synthesizes the matching `Cancel` instead, mirroring how `RunAgents::Cancelled` is handled.
+`AIAgentActionResultType::WaitForEvents(Completed)` returns `true` from `is_successful()` so the controller's auto-follow-up triggers a follow-up request on completion. `Cancelled` returns `true` from `is_cancelled()` so the controller transitions the conversation to `Cancelled` per the standard cancellation path.
+#### 4.2 Inbound conversion
+`app/src/ai/agent/api/convert_from.rs`'s `Tool::WaitForEvents` arm produces an `AIAgentAction { action: WaitForEvents { tool_call_id, idle_timeout_seconds } }`. Because this is a real action, the exchange's `output.actions()` contains it, which means `AIConversation::mark_request_completed` sees `has_new_actions = true` and does not transition the conversation to `Success` on the yield stream. No explicit `Success`-guard is needed in `mark_request_completed`.
+#### 4.3 Executor
+`app/src/ai/blocklist/action_model/execute/wait_for_events.rs` implements `WaitForEventsExecutor`. Responsibilities:
+- `try_to_execute_action` bumps a per-conversation generation counter, stores a `PendingWait { tool_call_id, sender, watchdog_handle }`, transitions the conversation to `ConversationStatus::WaitingForEvents` via a direct `BlocklistAIHistoryModel::update_conversation_status(WaitingForEvents)` call, spawns the watchdog future and stores its `SpawnedFutureHandle` on the pending entry, and returns `TryExecuteResult::ExecutedAsync`. The action sits in `running_actions` for the entire wait. The `tool_call_id` is held in the executor's `pending` map, not on the conversation — the only owner of the in-flight wait's identity is the executor.
+- The `start_pending_action_by_id` action-model plumbing is updated to skip the default `update_conversation_in_progress_status` call for `WaitForEvents` so the executor's `WaitingForEvents` transition is not immediately clobbered with `InProgress`.
+- `cancel_execution(tool_call_id)` is invoked from the executor dispatch's cancel path. It drops the pending entry, aborts the watchdog `SpawnedFutureHandle`, bumps the generation counter, and drops the channel sender. The caller (`BlocklistAIActionExecutor::cancel_running_async_action`) has already removed the action from `async_executing_actions`, so the spawn callback that wraps the channel receiver silently discards the result — no `FinishedAction` is emitted, no tool-call result reaches the wire.
+- The watchdog firing path (`fire_watchdog_if_current`) is the only path that emits a `WaitForEventsResult::Completed`. It defensively re-checks that the conversation is still in `WaitingForEvents` before firing, so a watchdog that survives an out-of-band status transition does not inject a stale result.
+#### 4.4 Watchdog timing and the client-side safety margin
+The watchdog timeout is computed by `watchdog_timeout_for_stamped_seconds(idle_timeout_seconds)`:
+- If `idle_timeout_seconds <= 0` (prost's "unset" sentinel), fall back to `DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS = 30 min`.
+- Subtract `CLIENT_WATCHDOG_SAFETY_MARGIN = 30 s` to reserve a recovery window before the worker-side idle-shutdown fires (see server TECH §1.1).
+- Floor the result at `HARD_FLOOR = 5 s` so small testing values still let the watchdog fire on a sane schedule.
+The margin contract is the time budget for the recovery cycle: client watchdog fires → `complete_wait_action` → `FinishedAction` → controller auto-follow-up → outbound request with `WaitForEventsResult` → server `BeginTaskProgress` → next agent turn starts producing activity, which resets the worker idle counter. The corresponding server-side margin (subtract from the stamped value in `RecordWaitForEventsYield`) is tracked as a follow-up.
+#### 4.5 CLI driver lifecycle
+`app/src/ai/agent_sdk/driver.rs`'s `execute_run` keeps its `UpdatedConversationStatus` subscriber's two early-return arms intact: the `is_in_progress()` arm still cancels the idle timer when the run resumes, and a `WaitingForEvents` arm returns without resolving `run_exit` (the driver keeps the process alive). The driver does **not** own a separate watchdog; the executor's watchdog and follow-up flow drive recovery regardless of whether the conversation is hosted under an `AgentDriver` or in the GUI's local-local pane.
+`subscribe_to_cli_agent_session_events` is unaffected because third-party harnesses don't emit `wait_for_events`; exhaustive match against `CLIAgentSessionStatus` confirms this.
+
+### 5. Task sync model
+Update `map_conversation_status` in `app/src/ai/blocklist/local_agent_task_sync_model.rs:314-355`:
+
+```rust path=null start=null
+ConversationStatus::WaitingForEvents => (AgentTaskState::InProgress, None),
+```
+
+This means the client actively reports `IN_PROGRESS` for yielded runs rather than relying on `shouldPreserveInProgressOnClientSuccess` server-side. The server backstop stays in place for older clients and edge cases (see server TECH §"Server-side gates remain as a backstop").
+
+### 6. Notifications
+Two changes in `app/src/ai/agent_management/agent_management_model.rs`, both targeted at the `WaitingForEvents` yield case. The orchestrator-aware suppression that an earlier draft considered (consulting `aggregated_orchestrator_status` on the orchestrator's own `Success`) is **out of scope** per PRODUCT.md (20): if the orchestrator itself reaches a terminal status, that's its own assessment and the notification fires as today. The known orchestrator notification spam is the case where the orchestrator yielded via `wait_for_events` between turns, which the `WaitingForEvents` status (and the suppression below) covers directly.
+
+- `ConversationStatus::should_trigger_notification` (line 471): add `WaitingForEvents => false`. (Note: the function uses `matches!` today, which means a new variant returns `false` by default. Rewrite the function as an exhaustive `match` so future variants force a deliberate decision.)
+- `handle_history_event_for_mailbox` (line 304): add an explicit `WaitingForEvents` arm that mirrors the `InProgress` arm at line 330 — it clears any stale notification for this origin via `remove_notification_by_source`.
+
+### 7. Orchestration pill bar and aggregation
+`app/src/ai/blocklist/orchestration_topology.rs`:
+- `aggregated_orchestrator_status` precedence: `InProgress > Blocked > WaitingForEvents > Error > Cancelled > Success`, with one carve-out: when the orchestrator itself yielded into `WaitingForEvents`, its own waiting state outranks any descendant `InProgress`. This keeps the orchestrator pill honest about "THIS conversation is paused" even while child agents continue working. A descendant in `Blocked` still beats the parent's `WaitingForEvents` because Blocked needs user attention.
+- Implementation: scan the tree for `any_in_progress`, `first_blocked`, `any_waiting`, `any_error`, `any_cancelled` as before. When `any_in_progress` is set, check whether the orchestrator's own status is `WaitingForEvents` and return `WaitingForEvents` in that case; otherwise return `InProgress`. The remaining precedence steps are unchanged.
+- Update the doc-comment precedence list to match.
+
+`app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs:119-151`:
+- `pill_status_sort_key`: give `WaitingForEvents` its own slot in the "active-ish" half of the bar; do not lump it into `DONE_STATUS_KEY`. Recommended order: `Blocked = 0`, `Error = 1`, `InProgress = 2`, `WaitingForEvents = 2` (same bucket as `InProgress`, sorts left of the done section), `Cancelled | Success = DONE_STATUS_KEY (3)`.
+- Update the existing comment at lines 119-124 ("Cancelled and Success share one 'done' bucket") to also mention that `WaitingForEvents` shares the `InProgress` bucket. Future readers should not have to re-derive this.
+- `render_avatar_with_status_overlay` (lines 2112-2156) and the hover card (lines 1390-1397) pick up the new badge automatically because they consume `ConversationStatus::status_icon_and_color`.
+
+### 8. Wiring `wait_for_events` and resume signals through the action model
+This section covers how the client discovers a yield and how a resume reaches the executor. The server-side spec adds a first-class `WaitForEvents` variant to the public proto's `Message::ToolCall::tool` oneof and an accompanying `WaitForEventsResult` variant to `Message::ToolCallResult::result`. The client pattern-matches the public variant directly; no payload-sniffing of the opaque `Message::ToolCall::Server` is needed (and would not work, since that payload is opaque per `task.proto:405-407`).
+#### 8.1 Yield path: inbound `Tool::WaitForEvents` becomes an action
+The yield arrives as a `Tool::WaitForEvents` tool-call message inside the response stream. `convert_from.rs` (§4.2) translates it into an `AIAgentAction::WaitForEvents` that lands in the exchange's `output.actions()`. When the response stream finishes, `BlocklistAIController::handle_response_stream_event` collects new actions from finished exchanges and forwards them to `BlocklistAIActionModel::queue_actions`, which dispatches the `WaitForEvents` action through the executor described in §4.3. The executor's `try_to_execute_action` is the single place that transitions the conversation to `WaitingForEvents` and arms the watchdog — there is no separate detection-point helper on `BlocklistAIHistoryModel`.
+#### 8.2 Resume path: silent dismissal via the standard cancellation path
+Two inbound signals can close the unresolved `WaitForEvents` tool call and resume the agent:
+1. **Generic `Cancel` tool-call result (inbound supersede).** When new user input, an inbound message, or an inbound lifecycle event arrives on the waiting task, the server's pending-tool-call supersede mechanism appends a generic `Cancel` tool-call-result referencing the unresolved `WaitForEvents` id (server TECH §1.1).
+2. **`WaitForEventsResult` tool-call result (echoed timeout).** The client's own watchdog emitted this result on a follow-up request and the server echoed it back through the next stream.
+In both cases, the inbound message is just transcript data — `apply_client_actions` appends it to the conversation transcript with no special handling. The client-side teardown of the running wait is driven by the **outbound** side, before the server is asked to do anything.
+For the **orchestration-event case**, `BlocklistAIController::inject_pending_events_for_request` calls `BlocklistAIActionModel::cancel_wait_for_events_for_conversation(conversation_id)` immediately before `send_request_input`. The cancel goes through the standard `cancel_running_async_action` path: the action is removed from `async_executing_actions`, `WaitForEventsExecutor::cancel_execution` aborts the watchdog handle and drops the channel sender, and the spawn callback's `async_executing_actions.remove` returns `None` so the result is silently discarded. **No `FinishedAction` is emitted and no `WaitForEventsResult` is sent.** The server's `collectCancelledResultsForIncompleteToolCalls` synthesizes the matching `Cancel` for the unresolved tool call so the message log stays consistent. Subsequent paths that cancel pending actions (e.g. `cancel_conversation_progress`, `send_query`) reuse the same machinery and behave identically.
+For the **user-typed-query case** the existing `send_query` path already calls `cancel_all_pending_actions` before sending; the wait is cancelled by the same silent-dismissal path described above.
+For the **watchdog-timeout case**, no outbound request precedes the firing. `fire_watchdog_if_current` produces a `Completed` result through the channel; the action_model emits `FinishedAction(Completed)`, the controller's auto-follow-up subscriber sends a follow-up request carrying the empty `WaitForEventsResult{}`, and the server's next stream echoes the result back as transcript data.
+#### 8.3 Persistence and restart behavior
+Nothing about the wait is persisted (§3). On restart, a previously-yielded conversation restores as `Success` per `derive_status_from_root_task`; the unresolved `Tool::WaitForEvents` tool call stays in the transcript as an orphan. When the user re-engages, the next outbound request omits a result for it and the server's existing supersede mechanism synthesizes the matching `Cancel`. There is no in-memory wait to clear and no transcript-scan fallback — the executor's `pending` map is the canonical source of truth, and after restart it is empty.
+#### 8.4 Inbound orchestration events while waiting
+When an orchestration event for a waiting conversation reaches `OrchestrationEventService::EventsReady`, `BlocklistAIController::handle_pending_events_ready` drains the queued events and sends them as the next outbound request via `inject_pending_events_for_request` → `send_request_input`. The readiness check `conversation_ready_for_pending_events` treats `WaitingForEvents` the same as `Success` so events can be injected while the wait is in flight. The outbound request's `send_request_input` flips status to `InProgress`, which completes the wait per §8.2; the request contains the new event inputs but no `WaitForEvents` tool-call result, so the server synthesizes a `Cancel` on the next response stream as transcript data.
+#### 8.5 Why there is no `detect`/`clear` helper for the resume signal
+An earlier version of this design routed the resume through `BlocklistAIHistoryModel::detect_wait_for_events_transitions` + `clear_conversation_waiting_for_events_if_matches` inside `apply_client_actions`. The detect/clear pair scanned inbound `ToolCallResult` messages for `WaitForEvents` / `Cancel` variants and flipped status to `InProgress` directly. Both helpers, the `waiting_for_events_tool_call_id` field on `AIConversation`, the `mark_conversation_waiting_for_events` setter, and the transcript-scan fallback `find_unresolved_wait_for_events_tool_call_id` have been removed: every reachable production resume path is preceded by an outbound `send_request_input` that already flips status, so the detect/clear was a no-op in every observable flow (the `if !matches!(status, WaitingForEvents) { return; }` early return at `clear_conversation_waiting_for_events_if_matches` fired before the detect/clear could do any work). Removing the machinery aligns the implementation with the natural request/response lifecycle: status transitions are driven by outbound requests and action lifecycle, not by inbound message-shape inspection.
+**Known limitation, intentionally undocumented as a server contract.** If a future code path arranges for an inbound resume signal to arrive **without** any preceding outbound request that flips status (e.g. a server push synthesized without the client driving it, or a viewer flow that mirrors a sharer's status differently from how viewers currently work — see the shared-session viewer note below), the executor's `UpdatedConversationStatus` subscription would not fire and the wait would only complete via the watchdog timeout. The fix in that case would be to re-introduce a targeted detect/clear at the new entry point or to ensure the new entry point flips status explicitly. Shared-session viewers are not affected today: `try_to_execute_action` short-circuits with `NotExecuted::WaitingOnSharer` (`action_model/execute.rs:557-563`), so a viewer never has a pending wait to complete.
+
+### 9. Coordinated rollout and backwards compatibility
+No client-side feature flag is required. The signal that activates the client-side fix is the presence of the new public `Message::ToolCall::WaitForEvents` variant in a received message. Because the legacy `Message::ToolCall::Server` payload is opaque to clients (`task.proto:405-407`), there is no way for the client to detect a legacy `wait_for_events` call, and no sniff fallback exists.
+
+Rollout sequencing (mirrors server TECH §"Backwards compatibility and coordinated rollout"):
+
+1. **`warp-proto-apis` release.** The proto additions ship first as a no-op (no producer or consumer yet). Wire-compatible: older deserializers ignore the new variants.
+2. **`warp` rev bump.** Cargo.toml in `warp` is bumped to the new release. The client adds the `WaitForEvents` detection and the `WaitingForEvents` flow. Without a server emitting the variant, the new code stays dormant.
+3. **`warp-server` rev bump + flag-on rollout.** The server side ships the new emission path behind a feature flag. Flipping the flag for a tenant/workspace activates the client-side fix for that scope.
+4. **Steady state.** Both repos ship the new path; the server-side flag is at 100%. The legacy server-handled `wait_for_events` path stays compiled for one release window and is then removed (server TECH §"Cleanup").
+
+#### Behavior during the rollout window
+- **Client old, server old.** Legacy bug: `Success` is reported, the CLI driver exits, the server's `shouldPreserveInProgressOnClientSuccess` keeps the task `IN_PROGRESS`. Unchanged from today.
+- **Client old, server new.** Client sees the new `WaitForEvents` variant as an unknown field (proto's forward-compatibility) and ignores it. The conversation still goes to `Success` locally; same as the legacy bug. The server-side gates protect the task.
+- **Client new, server old.** Server is still emitting via `Message::ToolCall::Server { payload: <opaque> }`. The client sees only the opaque variant and treats the conversation as `Success` (same as today). The server-side gates protect the task.
+- **Client new, server new.** Full fix: `WaitForEvents` variant emitted by server, pattern-matched by client, conversation transitions to `WaitingForEvents`, driver stays alive, no toast, correct pill-bar badge.
+
+#### Mixed-mode within a single conversation
+The server-side feature flag is evaluated per `wait_for_events` call, so one conversation can contain both legacy and new yields. The client handles this gracefully: legacy yields produce opaque server tool-call messages that the client ignores; new yields activate the `WaitingForEvents` path. There is no client-side state that needs to track which mode a conversation is in.
+
+## End-to-end flow
+After the changes, a `wait_for_events` cycle looks like:
+
+1. Model calls `wait_for_events`.
+2. Server emits `Message::ToolCall { tool: WaitForEvents }` in the public proto, fires `recordWaitForEventsYield` to extend `VMIdleTimeoutMinutes`, and finishes the response stream without emitting a tool-call result.
+3. Client receives the stream. `convert_from.rs` turns the `Tool::WaitForEvents` message into an `AIAgentAction::WaitForEvents { tool_call_id, idle_timeout_seconds }` in the exchange's `output.actions()` (§8.1). Because `has_new_actions = true`, `mark_request_completed` does not transition the conversation to `Success`.
+4. When the response stream finishes, `BlocklistAIController` collects the new actions and calls `BlocklistAIActionModel::queue_actions`. The wait action is dispatched to `WaitForEventsExecutor::try_to_execute_action`.
+5. The executor (§4.3) bumps its per-conversation generation counter, stores a `PendingWait { tool_call_id, sender }`, transitions the conversation to `WaitingForEvents` via `BlocklistAIHistoryModel::update_conversation_status(WaitingForEvents)`, spawns the watchdog with `watchdog_timeout_for_stamped_seconds`, and returns `ExecutedAsync`. The action sits in `running_actions`.
+6. `LocalAgentTaskSyncModel` maps `WaitingForEvents` → `AgentTaskState::InProgress` and fires `update_agent_task`.
+7. `AgentNotificationsModel` does not fire a toast for the `WaitingForEvents` transition (§6). The orchestrator's own `Success`/`Cancelled`/`Error` notifications continue to fire as today.
+8. The orchestration pill bar's orchestrator badge renders the waiting state via the updated aggregator precedence (§7).
+9. **Resume by inbound supersede.** Inbound user input, an inbound message, or an inbound lifecycle event arrives. The resume is driven by an outbound request from the client (the user's message submission, an `inject_pending_events_for_request` drain triggered by `EventsReady`, etc.). That code path calls `cancel_wait_for_events_for_conversation` before `send_request_input`; the wait is silently dismissed through the standard `cancel_running_async_action` machinery, no `FinishedAction` fires, and no tool-call result is sent on the wire. The server-synthesized `Cancel` arrives in the response stream that follows and is appended to the transcript as ordinary message data by `apply_client_action(AddMessagesToTask)`.
+10. **Resume by watchdog timeout.** If no inbound input arrives before the watchdog fires, the executor's timer callback verifies the generation counter still matches and that the conversation is still in `WaitingForEvents`, then sends `Completed` on the channel. The action_model emits `FinishedAction`; the auto-follow-up subscriber sends a follow-up request whose input includes the empty `WaitForEventsResult` produced by the action's result conversion. The server echoes the result through the next stream; the agent's next turn observes the empty timeout result and decides how to proceed (commonly `finish_task`, but the agent may also re-yield, ask the user, or take other action). The run is **not** auto-cancelled on timeout; the agent owns the decision.
+
+## Diagram
+```mermaid
+flowchart LR
+    Streaming([Model emits wait_for_events tool call]) -->|public Tool::WaitForEvents| Convert["convert_from.rs:<br/>build AIAgentAction::WaitForEvents"]
+    Convert --> Queue["queue_actions on stream finish:<br/>dispatch to WaitForEventsExecutor"]
+    Queue --> Exec["Executor try_to_execute_action:<br/>update_conversation_status(WaitingForEvents),<br/>spawn watchdog,<br/>action runs async"]
+    Exec --> Sync["LocalAgentTaskSyncModel:<br/>update_agent_task(IN_PROGRESS)"]
+    Exec --> Notif["NotificationsModel:<br/>no toast for WaitingForEvents,<br/>clear stale items"]
+    Exec --> Pill["Orchestration pill bar:<br/>waiting badge via aggregator"]
+    Exec -->|inbound user/event:<br/>outbound request via send_request_input| StatusFlip["send_request_input:<br/>status → InProgress"]
+    Exec -->|watchdog fires| Complete["Executor complete_wait_action:<br/>Completed result on channel"]
+    StatusFlip -->|UpdatedConversationStatus| ExecSub["Executor subscription:<br/>complete_wait_action(Completed)"]
+    ExecSub --> Complete
+    Complete --> Finished["FinishedAction event"]
+    Finished --> FollowUp["Controller auto-follow-up:<br/>has_active_stream ⇒ bail<br/>(else send next outbound request)"]
+    StatusFlip --> NextTurn([Next agent turn])
+    FollowUp --> NextTurn
+```
+
+## Testing and validation
+Map each `PRODUCT.md` invariant to a concrete test or manual verification. Numbers in parentheses reference `specs/QUALITY-780/PRODUCT.md`.
+
+### Unit tests
+- `conversation_tests.rs` — `ConversationStatus::is_done()` returns true exactly for `Success | Error | Cancelled` and `false` for `WaitingForEvents`. Covers (3), (4), (28).
+- `conversation_tests.rs` — `should_trigger_notification` returns `false` for `WaitingForEvents` and `InProgress`, true for `Success | Blocked | Error`. Covers (16), (19).
+- `conversation_tests.rs` — Restore: a conversation that was yielded via `wait_for_events` at shutdown restores as `Success` (not `WaitingForEvents`), the orphan tool call stays in the transcript, and no waiting state is rebuilt. Covers (10).
+- `conversation_tests.rs` — Transition matrix: assert the only legal transitions into `WaitingForEvents` are from `InProgress`; transitions out of `WaitingForEvents` are to `InProgress`, `Cancelled`, `Error`, or `Success`; a direct `WaitingForEvents` → `WaitingForEvents` is not reachable (must re-enter `InProgress` first). Covers PRODUCT.md (9).
+- `conversation_tests.rs` — Cancellation from `WaitingForEvents`: invoking the existing cancel path on a `WaitingForEvents` conversation transitions to `Cancelled` immediately and emits a status update. Covers PRODUCT.md (14).
+- `local_agent_task_sync_model_tests.rs` — `map_conversation_status(WaitingForEvents)` returns `(AgentTaskState::InProgress, None)`. Covers (15).
+- `agent_management_model_tests.rs` — `handle_history_event_for_mailbox` for `WaitingForEvents` does not call `add_notification` and removes any existing notification for the origin. Covers (16), (17).
+- `agent_management_model_tests.rs` — No notification fires on the `WaitingForEvents` → `InProgress` resume transition. Covers PRODUCT.md (18).
+- `agent_management_model_tests.rs` — Orchestrator's own terminal status fires the existing notification: an orchestrator with non-terminal descendants reaching `Success` (or `Cancelled` / `Error`) still produces the `Complete` (or matching) toast — the mailbox does not inspect descendant state. Covers PRODUCT.md (20).
+- `orchestration_topology_tests.rs` — `aggregated_orchestrator_status` precedence including the parent-waits carve-out: orchestrator `WaitingForEvents` + all children `Success` → `WaitingForEvents`; orchestrator `WaitingForEvents` + one child `InProgress` → `WaitingForEvents` (carve-out); orchestrator `InProgress` + one child `InProgress` → `InProgress`; orchestrator `WaitingForEvents` + one child `Blocked` → `Blocked`; orchestrator `WaitingForEvents` + one child `Error` → `WaitingForEvents`. Covers (22).
+- `orchestration_pill_bar_tests.rs` — `pill_status_sort_key(WaitingForEvents)` returns a value strictly less than `DONE_STATUS_KEY`. Covers (24).
+- `wait_for_events_tests.rs` — `watchdog_timeout_for_stamped_seconds` math: stamped 0 → default minus margin; stamped 60 → 30 s; stamped 10 → `HARD_FLOOR`; stamped negative → default minus margin. Plus named-constant checks for `DEFAULT_ORCHESTRATED_IDLE_TIMEOUT_SECONDS`, `CLIENT_WATCHDOG_SAFETY_MARGIN`, and `HARD_FLOOR`. Covers (11), (12).
+- `input_tests.rs` or `agent_message_bar_tests.rs` — With the conversation in `WaitingForEvents`, the input is enabled and submitting a follow-up clears the waiting state and transitions to `InProgress`. Covers PRODUCT.md (26).
+- `history_model_tests.rs` — Starting a new conversation in a terminal view that previously held a `WaitingForEvents` conversation does not inherit the wait state. Covers PRODUCT.md (31).
+
+### Integration tests
+- Add an integration test in `crates/integration/` that drives an Oz CLI agent with `--idle-on-complete=5s` against a fake server emitting the new public `WaitForEvents` variant; assert the process does not exit within 30 seconds. Covers PRODUCT.md (11).
+- Timeout-path integration test: drive an Oz CLI agent against a fake server, let the client watchdog fire, assert the client emits `Message::ToolCallResult { result: WaitForEvents(WaitForEventsResult{}) }` against the unresolved `WaitForEvents` tool-call id and the run does **not** transition to `Cancelled`. The fake server echoes the result back; assert the conversation transitions to `InProgress` and the simulated agent's next turn fires. Covers PRODUCT.md (12), (29).
+- Coordinated-rollout matrix: a flag-off fake server emits the legacy server tool call; the client treats the conversation as `Success` (legacy bug) and the server's `shouldPreserveInProgressOnClientSuccess` keeps the task `IN_PROGRESS`. A flag-on fake server emits the new variant; the client transitions to `WaitingForEvents`. Covers PRODUCT.md (32), (33).
+- Extend `agent_conversations_model_tests.rs` to assert that a conversation entering `WaitingForEvents` does not propagate `Success` semantics to consumers that check `is_done()`. Covers (28).
+
+### Manual validation
+- Run a local Oz orchestrator that spawns one child agent and yields via `wait_for_events`. Verify:
+  1. The orchestration pill bar's orchestrator badge shows the "waiting" icon/color (not green check). (21), (22)
+  2. No "Task completed" toast appears. (16), (20)
+  3. The CLI worker process stays alive until the child message arrives. (11)
+  4. After the inbound message resumes the agent, the badge transitions back to active and the conversation eventually completes. (8), (30)
+- Repeat with the orchestrator in the foreground and minimized to confirm notification behavior matches.
+- Restart Warp while a conversation is `WaitingForEvents`. Confirm the conversation restores as `Success` (the yield does not survive restart, per §3), the orphan `wait_for_events` tool call is visible in the transcript, and re-engaging the conversation cleanly synthesizes the supersede. (10)
+- Submit a follow-up while in `WaitingForEvents`. Confirm the input accepts the message, the conversation transitions to `InProgress`, and no notification fires for the transition. (26), (18)
+
+### Regression coverage
+- Audit every `match conversation.status()` site for an explicit `WaitingForEvents` arm. The exhaustive-matching rule from `WARP.md` should already enforce this; the test suite confirms.
+- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` and `./script/presubmit` pass.
+
+## Orchestration
+This section is the canonical cross-spec orchestration plan for QUALITY-780. The same text appears in both `warp/specs/QUALITY-780/TECH.md` and `warp-server/specs/QUALITY-780/TECH.md` so each spec is self-contained for the agent implementing it.
+
+### Decision
+Implementation is fanned out across multiple AI agents working in parallel git worktrees. The work spans three repositories (`warp-proto-apis`, `warp-server`, `warp`), and the proto change is a hard prerequisite for everything else because both the server and client implementations consume the new generated bindings. After the proto release, the server-side and client-side core work can run in parallel; once the client core lands, the remaining client work fans out further. AI agents complete each subtask in minutes, not days — the bottleneck is wave ordering, not per-agent effort.
+
+### Worktree layout
+Per the `~/src/QUALITY-780/` task-directory convention:
+- `~/src/QUALITY-780/warp-proto-apis` — proto agent.
+- `~/src/QUALITY-780/warp-server` — server-impl agent.
+- `~/src/QUALITY-780/warp` — client-core agent and final integrator.
+- `~/src/QUALITY-780/warp-driver`, `~/src/QUALITY-780/warp-sync-notif`, `~/src/QUALITY-780/warp-pill-bar`, `~/src/QUALITY-780/warp-detection` — additional `warp` worktrees for the four Wave 2 client fan-out agents.
+
+All branches use the `matthew/` prefix.
+
+### Dependencies and ordering (three waves)
+- **Wave 0 — Proto release (single agent, sequential).** `proto` adds the new variants to `warp-proto-apis/apis/multi_agent/v1/task.proto` and publishes a release tag. All downstream waves block on this completing.
+- **Wave 1 — Core scaffold + server (two agents in parallel, after Wave 0).** `server-impl` and `client-core` run concurrently because they live in different repositories and share no compilation dependency. The client core is sized to be the minimum scaffold that downstream client agents need to compile against (status variant, exhaustive match arms in shared files, predicate split, persistence, restore-site).
+- **Wave 2 — Client fan-out (four agents in parallel, after Wave 1's client-core branch is pushed).** `client-driver`, `client-sync-notif`, `client-pill-bar`, `client-detection` branch from `client-core`'s branch and modify disjoint client subsystems. They do not touch the files client-core owns.
+- **Wave 3 — Integration (orchestrator).** Orchestrator merges all four Wave 2 branches into the client-core branch, runs `cargo fmt` / `cargo clippy` / `./script/presubmit`, and opens a single draft PR for `warp`. `server-impl` independently opens a draft PR for `warp-server`. The proto release tag from Wave 0 is referenced from both implementation PR descriptions.
+
+### Launch config
+Run-wide settings (execution mode, model, harness) are documented in the orchestration config attached to this plan. Defaults:
+- Execution mode: **local** for every agent. The agents touch code paths exercised by `./script/presubmit` and other local toolchains, and each works in a user-visible git worktree.
+- Model: inherits from the orchestrator (not pinned in the config).
+- Harness: default Oz.
+
+Each wave launches as its own `run_agents` batch. Do not pre-launch downstream waves — wait for each wave's lifecycle events before fanning out the next.
+
+### Child agents
+- **proto — `warp-proto-apis` proto additions (Wave 0).**
+  - Worktree: `~/src/QUALITY-780/warp-proto-apis`. Branch: `matthew/QUALITY-780-proto-additions`.
+  - Owns: the proto additions in `apis/multi_agent/v1/task.proto` per server TECH §0.
+  - Output: pushes branch, opens draft PR, publishes a release tag/version. Reports the released version string + git ref to the orchestrator.
+- **server-impl — `warp-server` emission path + flag (Wave 1).**
+  - Worktree: `~/src/QUALITY-780/warp-server`. Branch: `matthew/QUALITY-780-server`.
+  - Owns: server TECH §0–§1 implementation: `WaitForEventsToolCall::ProduceActions`, `isWaitForEventsAction`, refactor of `HandleWaitForEvents` → `recordWaitForEventsYield`, finalizer hook in `RunPrimaryAgent`, gating of the `ExecuteServerHandledToolCall` arm, the new `WaitForEventsClientToolEnabled` feature flag, and the unit/integration tests in server TECH §"Testing and validation".
+  - Validation: `go fmt ./...`, `go vet ./...`, `./script/presubmit` before opening the PR.
+  - PR: draft, using `.github/pull_request_template.md`.
+- **client-core — `warp` status variant + predicates + persistence (Wave 1).**
+  - Worktree: `~/src/QUALITY-780/warp`. Branch: `matthew/QUALITY-780-client-core`.
+  - Owns: §1 (`ConversationStatus::WaitingForEvents` variant + all match arms in `conversation.rs` `Display` / `render_icon` / `status_icon_and_color`); §2 (`is_done` stays as-is, with the new variant correctly returning `false`); §3 (persistence field on `AgentConversationData` + restore-site check in `new_restored` at `conversation.rs:542`). For files that Wave 2 agents own (driver, sync/notif, pill bar, detection), client-core leaves their match arms with conservative `WaitingForEvents` placeholders (e.g. treat like `InProgress` for the clear-stale notification path, like `Blocked` for the not-currently-streaming question) so the tree compiles and existing tests pass. Wave 2 agents replace the placeholders with their final implementations.
+  - Validation: `cargo fmt`, `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`, `./script/presubmit`.
+  - Hand-off: pushes the branch and reports the branch name so Wave 2 agents can rebase from a known-good commit.
+- **client-driver — `warp` driver lifecycle (Wave 2).**
+  - Worktree: `~/src/QUALITY-780/warp-driver`. Branch: `matthew/QUALITY-780-client-driver` (off `matthew/QUALITY-780-client-core`).
+  - Owns: §4 (`app/src/ai/agent_sdk/driver.rs` — `IdleTimeoutSender` reuse pattern, `execute_run`'s `UpdatedConversationStatus` handler, `subscribe_to_cli_agent_session_events` no-op verification, watchdog emission of `WaitForEventsResult`).
+- **client-sync-notif — `warp` task sync + notifications (Wave 2).**
+  - Worktree: `~/src/QUALITY-780/warp-sync-notif`. Branch: `matthew/QUALITY-780-client-sync-notif` (off `matthew/QUALITY-780-client-core`).
+  - Owns: §5 (`local_agent_task_sync_model.rs` — `map_conversation_status`) and §6 (`agent_management_model.rs` — `should_trigger_notification` exhaustive rewrite, `handle_history_event_for_mailbox` `WaitingForEvents` arm).
+- **client-pill-bar — `warp` orchestration aggregation + pill bar (Wave 2).**
+  - Worktree: `~/src/QUALITY-780/warp-pill-bar`. Branch: `matthew/QUALITY-780-client-pill-bar` (off `matthew/QUALITY-780-client-core`).
+  - Owns: §7 (`orchestration_topology.rs` — `aggregated_orchestrator_status` precedence + `any_waiting` accumulator + doc-comment, `orchestration_pill_bar.rs` — `pill_status_sort_key` + sort-bucket comment).
+- **client-detection — `warp` tool-call detection + ordering rule (Wave 2).**
+  - Worktree: `~/src/QUALITY-780/warp-detection`. Branch: `matthew/QUALITY-780-client-detection` (off `matthew/QUALITY-780-client-core`).
+  - Originally owned the inbound-resume detect/clear path in `history_model.rs`. After the simplification in §8.5, no detect/clear helpers exist; the resume is driven entirely by the natural status flip in `send_request_input`. This agent's remaining responsibility is the client-side rollout notes in §9 and any `controller.rs` ordering guards required to keep the response-stream `Success` transition from clobbering an active wait.
+
+### Merge strategy
+- Each Wave 2 client agent reports its branch name and a brief summary of changed files. Each agent runs its own `cargo fmt` / `cargo clippy` / `./script/presubmit` before reporting.
+- Orchestrator integrates Wave 2 into client-core in `~/src/QUALITY-780/warp`:
+  1. Check out `matthew/QUALITY-780-client-core`.
+  2. Merge each Wave 2 branch in sequence (driver → sync-notif → pill-bar → detection). Conflicts should be limited to client-core's placeholder arms in fan-out-owned files; each Wave 2 agent replaces only its own placeholders, so per-file conflicts are localized.
+  3. Re-run `cargo fmt`, `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`, `./script/presubmit` on the integrated branch.
+  4. Push `matthew/QUALITY-780-client-core` and open a single draft PR for `warp`.
+- `server-impl` opens its own draft PR for `warp-server` directly from its branch.
+- Final state: three branches across three repos, three draft PRs (`warp-proto-apis`, `warp-server`, `warp`). The two implementation PRs link to the proto release.
+
+### Diagram
+```mermaid
+flowchart LR
+    Plan([Plan + orchestration config approved]) --> Proto["Wave 0:<br/>proto — warp-proto-apis<br/>add variants + cut release"]
+    Proto --> Server["Wave 1:<br/>server-impl — warp-server<br/>emission + flag + tests"]
+    Proto --> ClientCore["Wave 1:<br/>client-core — warp<br/>status variant + predicates + persistence"]
+    ClientCore --> Driver["Wave 2:<br/>client-driver"]
+    ClientCore --> SyncNotif["Wave 2:<br/>client-sync-notif"]
+    ClientCore --> PillBar["Wave 2:<br/>client-pill-bar"]
+    ClientCore --> Detection["Wave 2:<br/>client-detection"]
+    Server --> ServerPR([warp-server draft PR])
+    Driver --> Integrate["Wave 3:<br/>Orchestrator integrates<br/>+ presubmit"]
+    SyncNotif --> Integrate
+    PillBar --> Integrate
+    Detection --> Integrate
+    Integrate --> ClientPR([warp draft PR])
+    Proto --> ProtoPR([warp-proto-apis draft PR])
+```
+
+## Risks and mitigations
+- **Risk: A previously-yielded conversation restores as `Success` and the user thinks it is done.** Mitigation: this is by design (§3). The orphan tool call sits in the transcript so the conversation can be re-engaged at any time, at which point the server-side supersede mechanism naturally drives the resume. Cosmetically the badge is `Success` instead of `Waiting` for the offline-and-restarted case; the user can resume manually.
+- **Risk: The waiting watchdog races the resume signal.** An inbound event arrives at almost the same time as the timeout. Mitigation: the executor's per-conversation generation counter (§4.3) makes cancellation atomic with respect to the timer fire — a still-pending watchdog whose generation no longer matches no-ops.
+- **Risk: Orphaned `WaitForEvents` tool-call message in transcript history.** When the conversation transitions to `Cancelled` via user cancel, the unresolved tool call stays in transcript history — pending tool calls are not retroactively cancelled (per PRODUCT.md (29)). The client-side watchdog path does *not* orphan the call: the watchdog emits a `WaitForEventsResult` that closes it before the agent decides what to do next. The only remaining orphan case is the worker-side safety-net idle-shutdown (server TECH §1.1) firing because the client is offline; that path transitions the task to `CANCELLED` without a result message. Mitigation: this is intentional and harmless. Terminal conversations are read-only, so an orphan tool call is just historical metadata and does not affect any live behavior.
+- **Risk: Visual badge for `WaitingForEvents` collides with `Blocked`, `InProgress`, or `Success`.** Mitigation: §1 enumerates the existing color/icon assignments. Until design lands a dedicated visual the placeholder reuses the `InProgress` icon and color so the badge never collides with `Success` / `Blocked`.
+- **Risk: Client watchdog races the worker idle-shutdown.** If the stamped `idle_timeout_seconds` matches the worker's `VMIdleTimeoutMinutes` exactly, the worker can shut down before the client watchdog has time to fire and send the follow-up. Mitigation: the client subtracts `CLIENT_WATCHDOG_SAFETY_MARGIN` (and floors at `HARD_FLOOR`) before scheduling (§4.4). A corresponding server-side margin is tracked as a follow-up so the stamped value the client observes is already below the worker ceiling.
+- **Risk: Coordinated rollout regression.** A misordered release sequence (e.g. client builds without the new proto bindings) could break deserialization. Mitigation: ship `warp-proto-apis` first as a no-op; bump revs in `warp` and `warp-server` only after. Server TECH §"Coordinated rollout" tracks the sequence end-to-end.
+
+## Follow-ups
+- Once the server-side feature flag is at 100% and the legacy `ExecuteServerHandledToolCall` arm is removed (server TECH §"Cleanup"), audit the client for any remaining references to the legacy server-handled `wait_for_events` shape and drop them.
+- Audit the block status bar for any remaining "spinner shows for `WaitingForEvents`" cases — most likely the change in §1 makes this fall out for free, but worth confirming.
+- Evaluate whether the third-party harness path (`subscribe_to_cli_agent_session_events`) ever needs to model a yield analogously. Today no third-party harness emits `wait_for_events`, but if one starts to we want a clear extension point.
+- Once the new client surface is stable, look at adding a richer transcript affordance ("waiting for events from agent X") that distinguishes inbound-resume (generic `Cancel` arriving with new inputs) from watchdog-timeout (`WaitForEventsResult` arriving alone) for display purposes. Out of scope for QUALITY-780 itself.


### PR DESCRIPTION
## Description

When an Oz cloud agent yields via the `wait_for_events` tool, the client now recognizes the yield and keeps the run alive in a new `WaitingForEvents` status until inbound input arrives (user query, child agent event, or watchdog timeout). Previously the client misinterpreted the yield as `Success`: the CLI driver exited per `--idle-on-complete`, completion notifications fired, and the orchestration pill bar showed the run as done while child events were still expected.

Depends on:
- Proto: https://github.com/warpdotdev/warp-proto-apis/pull/315
- Server: https://github.com/warpdotdev/warp-server/pull/11563

### Mechanics

- A `Tool::WaitForEvents` arrives → synthesized as an `AIAgentAction::WaitForEvents` so the standard action lifecycle keeps the run from completing.
- `WaitForEventsExecutor` transitions the conversation to `ConversationStatus::WaitingForEvents` and schedules a watchdog using the server-supplied `idle_timeout_seconds` (30s safety margin, 5s hard floor).
- When inbound events arrive, `inject_pending_events_for_request` cancels the wait via the standard `cancel_running_async_action` path before sending the resume. The server's pending-tool-call supersede synthesizes the matching `Cancel`, so the client never sends a redundant `tool_call_result` on the wire.
- On watchdog fire the client emits an empty `WaitForEventsResult{}` so the agent's next turn observes a clean timeout result.
- `LocalAgentTaskSyncModel` maps `WaitingForEvents` → `AgentTaskState::InProgress` so the server's task row stays accurate.
- The pill bar aggregator gives the orchestrator's own `WaitingForEvents` priority over a descendant `InProgress`.
- The driver keeps the CLI worker process alive while the conversation is `WaitingForEvents`.

### Not persisted

The waiting state is in-process only. A conversation yielded at shutdown restores as `Success`; the unresolved `wait_for_events` tool call sits in the transcript as an orphan and the server's existing supersede synthesizes a `Cancel` on the next outbound request.

## Testing

- Unit tests cover the executor, watchdog math, status transitions, restore behavior, and the aggregator carve-out.
- Manual end-to-end with a local Oz orchestrator + child confirmed the orchestrator stays alive, resumes correctly, and sends no stale `tool_call_result`s.
- `cargo fmt` + `cargo clippy -p warp --all-targets --tests -- -D warnings` + targeted `cargo nextest run -p warp` all pass.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Cloud agents that pause to wait for inbound events from child agents are now correctly held in a "waiting" state instead of being prematurely treated as completed.
-->

_Conversation: https://staging.warp.dev/conversation/4ac3cfa6-3506-4d2a-8eb0-b01b1bcd9e77_
_Run: https://oz.staging.warp.dev/runs/019e8983-97a9-76ca-8e7a-a81337be6235_

_This PR was generated with [Oz](https://warp.dev/oz)._
