### PR TITLE
Fix underflow in flat storage `RowIterator` after a clear.

### DIFF
--- a/crates/warp_terminal/src/model/grid/flat_storage/index.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/index.rs
@@ -99,13 +99,13 @@ impl Index {
     pub fn rebuild(old_index: &Index, columns: usize) -> Self {
         let mut index = Self::new(columns, Some(old_index.len()));
         // Update the content length to be the start offset of the first row,
-        // to ensure we properly handle resizing after truncation.
+        // or preserve the old content offset if no rows remain, to ensure we
+        // properly handle resizing after truncation.
         index.content_len = old_index
             .rows
             .front()
-            .map(|entry| entry.content_offset)
-            .unwrap_or_default()
-            .as_usize();
+            .map(|entry| entry.content_offset.as_usize())
+            .unwrap_or(old_index.content_len);
 
         let mut entry_builder = EntryBuilder::new();
 

--- a/crates/warp_terminal/src/model/grid/flat_storage/mod_tests.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/mod_tests.rs
@@ -251,3 +251,27 @@ fn test_clear_after_truncate_front() {
         '2'
     );
 }
+
+#[test]
+fn test_clear_after_truncate_front_then_resize_and_push_does_not_panic() {
+    let old_cols = 20;
+    let new_cols = 21;
+    let initial_content = "abcdefghijklmnopqrst\n".repeat(100);
+    let rows = initial_content.as_str().to_rows(old_cols);
+
+    let mut storage = FlatStorage::new(old_cols, Some(1), None);
+    storage.push_rows(&rows);
+    assert_eq!(storage.total_rows(), 1);
+
+    storage.clear();
+    storage.set_columns(new_cols);
+
+    let new_rows = "new output\n".to_rows(new_cols);
+    storage.push_rows(&new_rows);
+
+    let row = storage
+        .rows_from(0)
+        .next()
+        .expect("should materialize a row after clearing and resizing storage");
+    assert_eq!(row[0].c, 'n');
+}


### PR DESCRIPTION
## Description
Fixes the crash reported in [Sentry issue WARP-CLIENT-BETA-STABLE-7TK6](https://warpdotdev.sentry.io/issues/7521941673/).

When flat storage had discarded prior scrollback, clearing all rows and then resizing rebuilt an empty row index with a zero content offset while the underlying content buffer retained its absolute offset. Materializing the next row could then underflow while indexing content and panic in `RowIterator::next`.

This preserves the existing absolute content offset when rebuilding an empty index and adds a regression test covering truncate-front, clear, resize, push, and row materialization.

## Linked Issue
- Sentry: [WARP-CLIENT-BETA-STABLE-7TK6](https://warpdotdev.sentry.io/issues/7521941673/)

## Testing
- Verified the new regression test fails before the fix in release mode with the expected `range start index ... out of range for slice of length 1024` panic.
- `cargo nextest run --manifest-path /Users/david/src/warp-2/Cargo.toml -p warp_terminal -E 'test(test_clear_after_truncate_front_then_resize_and_push_does_not_panic)'`
- `cargo nextest run --release --manifest-path /Users/david/src/warp-2/Cargo.toml -p warp_terminal -E 'test(test_clear_after_truncate_front_then_resize_and_push_does_not_panic)'`
- `cargo fmt --manifest-path /Users/david/src/warp-2/Cargo.toml -p warp_terminal -- --check`

Manual validation and screenshots are not included because this fixes an internal flat-storage invariant that is directly reproduced by the unit regression test.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed a crash that could occur after clearing and resizing a terminal with scrollback.

Co-Authored-By: Oz <oz-agent@warp.dev>