### PR TITLE
Add metal rendering printlines for debugging.

### DIFF
--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -7,6 +7,7 @@ use std::ptr::NonNull;
 use std::sync::Once;
 
 use dispatch2::DispatchData;
+use instant::Instant;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSString;
@@ -1062,12 +1063,14 @@ impl super::super::Renderer for Renderer {
             return;
         };
         let metal_device: &ProtocolObject<dyn MTLDevice> = metal_device;
+        let frame_start = Instant::now();
 
         let metal_layer = window.metal_layer();
         let presents_with_transaction = metal_layer.presentsWithTransaction();
         let drawable = metal_layer
             .nextDrawable()
             .expect("CAMetalLayer with allowsNextDrawableTimeout disabled always vends a drawable");
+        let drawable_ready_at = Instant::now();
 
         let ctx = &MetalDrawContext {
             device: metal_device,
@@ -1090,6 +1093,16 @@ impl super::super::Renderer for Renderer {
         let capture_callback = window.capture_callback.borrow_mut().take();
         let should_capture = capture_callback.is_some();
         let captured = Self::render(self, scene, ctx, should_capture, presents_with_transaction);
+        let render_done_at = Instant::now();
+        let drawable_wait_ms = drawable_ready_at.duration_since(frame_start).as_secs_f64() * 1000.;
+        let after_drawable_ms = render_done_at
+            .duration_since(drawable_ready_at)
+            .as_secs_f64()
+            * 1000.;
+        let total_ms = render_done_at.duration_since(frame_start).as_secs_f64() * 1000.;
+        println!(
+            "Metal frame: total={total_ms:.3} ms drawable_wait={drawable_wait_ms:.3} ms after_drawable={after_drawable_ms:.3} ms capture={should_capture} transactional_present={presents_with_transaction}"
+        );
         if let (Some(frame), Some(callback)) = (captured, capture_callback) {
             callback(frame);
         }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
