### PR TITLE
Improve metal rendering performance.

### DIFF
--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -38,6 +38,9 @@ use crate::rendering::{get_best_dash_gap, GlyphCache, GlyphRasterBoundsFn, Raste
 const METAL_LIB_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shaders.metallib"));
 /// Metal recommends inline byte bindings only for dynamic data smaller than 4 KiB.
 const MAX_INLINE_VERTEX_BYTES_LENGTH: usize = 4 * 1024;
+const QUAD_VERTICES_VERTEX_BUFFER_INDEX: usize = 0;
+const INSTANCE_UNIFORMS_VERTEX_BUFFER_INDEX: usize = 1;
+const VIEWPORT_UNIFORMS_VERTEX_BUFFER_INDEX: usize = 2;
 static WRITE_LIB_TO_FILE: Once = Once::new();
 
 /// A structure to help manage a single rendering pass.
@@ -341,6 +344,23 @@ impl<'a> Frame<'a> {
             znear: 0.0,
             zfar: 1.0,
         });
+        let uniforms = shader::Uniforms::new(self.ctx.drawable_size.into());
+        let uniforms_ptr = NonNull::from(&uniforms).cast::<c_void>();
+        let uniforms_len = mem::size_of::<shader::Uniforms>();
+        // SAFETY: The shared quad buffer outlives every draw call in this frame, and Metal
+        // copies the frame-invariant viewport uniforms while encoding this binding.
+        unsafe {
+            self.command_encoder.setVertexBuffer_offset_atIndex(
+                Some(&self.resources.quad_vertices),
+                0,
+                QUAD_VERTICES_VERTEX_BUFFER_INDEX,
+            );
+            self.command_encoder.setVertexBytes_length_atIndex(
+                uniforms_ptr,
+                uniforms_len,
+                VIEWPORT_UNIFORMS_VERTEX_BUFFER_INDEX,
+            );
+        }
 
         for layer in self.scene.layers() {
             if let Some(bounds) = layer.clip_bounds {
@@ -435,20 +455,10 @@ impl<'a> Frame<'a> {
             0.,
             vec2f(0.0, 0.0).into(),
         );
-        let _per_rect_uniforms_buffer =
-            self.bind_dynamic_vertex_data(std::slice::from_ref(&per_rect_uniforms), 1);
-
-        let uniforms = shader::Uniforms::new(self.ctx.drawable_size.into());
-        let uniforms_ptr = NonNull::from(&uniforms).cast::<c_void>();
-        let uniforms_len = mem::size_of::<shader::Uniforms>();
-        // SAFETY: `uniforms` outlives this encoded draw call, and the bound byte sizes and
-        // indices match the shader bindings.
-        unsafe {
-            self.command_encoder
-                .setVertexBytes_length_atIndex(uniforms_ptr, uniforms_len, 2);
-            self.command_encoder
-                .setFragmentBytes_length_atIndex(uniforms_ptr, uniforms_len, 0);
-        }
+        let _per_rect_uniforms_buffer = self.bind_dynamic_vertex_data(
+            std::slice::from_ref(&per_rect_uniforms),
+            INSTANCE_UNIFORMS_VERTEX_BUFFER_INDEX,
+        );
 
         let (_, texture) = self
             .resources
@@ -519,14 +529,6 @@ impl<'a> Frame<'a> {
 
         self.command_encoder
             .setRenderPipelineState(&self.resources.draw_images_pipeline_state);
-        // SAFETY: index 0 binds the shared quad vertex buffer, which outlives the draw calls.
-        unsafe {
-            self.command_encoder.setVertexBuffer_offset_atIndex(
-                Some(&self.resources.quad_vertices),
-                0,
-                0,
-            );
-        }
 
         for image in &layer.images {
             self.render_image_or_icon(Some(image), None);
@@ -546,14 +548,6 @@ impl<'a> Frame<'a> {
 
         self.command_encoder
             .setRenderPipelineState(&self.resources.draw_rects_pipeline_state);
-        // SAFETY: index 0 binds the shared quad vertex buffer, which outlives the draw call.
-        unsafe {
-            self.command_encoder.setVertexBuffer_offset_atIndex(
-                Some(&self.resources.quad_vertices),
-                0,
-                0,
-            );
-        }
 
         let mut per_rect_uniforms = Vec::new();
         for rect in &layer.rects {
@@ -651,20 +645,11 @@ impl<'a> Frame<'a> {
                 gap_lengths.into(),
             ));
         }
-        let _per_rect_uniforms_buffer = self.bind_dynamic_vertex_data(&per_rect_uniforms, 1);
+        let _per_rect_uniforms_buffer = self
+            .bind_dynamic_vertex_data(&per_rect_uniforms, INSTANCE_UNIFORMS_VERTEX_BUFFER_INDEX);
 
-        let uniforms = shader::Uniforms::new(self.ctx.drawable_size.into());
-        let uniforms_ptr = NonNull::from(&uniforms).cast::<c_void>();
-        let uniforms_len = mem::size_of::<shader::Uniforms>();
-
-        // SAFETY: `uniforms` outlives this encoded draw call, and the bound byte sizes and
-        // indices match the shader bindings.
+        // SAFETY: The quad index buffer outlives this encoded draw call.
         unsafe {
-            self.command_encoder
-                .setVertexBytes_length_atIndex(uniforms_ptr, uniforms_len, 2);
-            self.command_encoder
-                .setFragmentBytes_length_atIndex(uniforms_ptr, uniforms_len, 0);
-
             self.command_encoder
                 .drawIndexedPrimitives_indexCount_indexType_indexBuffer_indexBufferOffset_instanceCount(
                     MTLPrimitiveType::Triangle,
@@ -685,14 +670,6 @@ impl<'a> Frame<'a> {
 
         self.command_encoder
             .setRenderPipelineState(&self.resources.draw_glyphs_pipeline_state);
-        // SAFETY: index 0 binds the shared quad vertex buffer, which outlives the draw calls.
-        unsafe {
-            self.command_encoder.setVertexBuffer_offset_atIndex(
-                Some(&self.resources.quad_vertices),
-                0,
-                0,
-            );
-        }
 
         let scale_factor = self.scene.scale_factor();
 
@@ -772,11 +749,10 @@ impl<'a> Frame<'a> {
         }
 
         for (texture_id, per_glyph_uniforms) in texture_to_glyph {
-            let _per_glyph_uniforms_buffer = self.bind_dynamic_vertex_data(&per_glyph_uniforms, 1);
-
-            let uniforms = shader::Uniforms::new(self.ctx.drawable_size.into());
-            let uniforms_ptr = NonNull::from(&uniforms).cast::<c_void>();
-            let uniforms_len = mem::size_of::<shader::Uniforms>();
+            let _per_glyph_uniforms_buffer = self.bind_dynamic_vertex_data(
+                &per_glyph_uniforms,
+                INSTANCE_UNIFORMS_VERTEX_BUFFER_INDEX,
+            );
 
             let texture = self
                 .resources
@@ -784,11 +760,9 @@ impl<'a> Frame<'a> {
                 .texture(&texture_id)
                 .expect("texture ID should be in atlas");
 
-            // SAFETY: `uniforms`, the bound texture, and the quad index buffer outlive this
-            // encoded draw call, and the bound sizes/indices match the shader bindings.
+            // SAFETY: The bound texture and quad index buffer outlive this encoded draw call,
+            // and the bound index matches the shader binding.
             unsafe {
-                self.command_encoder
-                    .setVertexBytes_length_atIndex(uniforms_ptr, uniforms_len, 2);
                 self.command_encoder
                     .setFragmentTexture_atIndex(Some(&**texture), 0);
                 self.command_encoder

--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -990,7 +990,6 @@ mod shader {
                 fade_start,
                 fade_end,
                 is_emoji: is_emoji as i32,
-                __bindgen_padding_0: Default::default(),
             }
         }
     }

--- a/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
+++ b/crates/warpui/src/platform/mac/rendering/metal/renderer.rs
@@ -36,6 +36,8 @@ use crate::rendering::atlas::{AllocatedRegion, TextureId};
 use crate::rendering::{get_best_dash_gap, GlyphCache, GlyphRasterBoundsFn, RasterizeGlyphFn};
 
 const METAL_LIB_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shaders.metallib"));
+/// Metal recommends inline byte bindings only for dynamic data smaller than 4 KiB.
+const MAX_INLINE_VERTEX_BYTES_LENGTH: usize = 4 * 1024;
 static WRITE_LIB_TO_FILE: Once = Once::new();
 
 /// A structure to help manage a single rendering pass.
@@ -400,7 +402,6 @@ impl<'a> Frame<'a> {
             ui_corner_radius = CornerRadius::default();
         }
 
-        let mut per_rect_uniforms = Vec::new();
         let scale_factor = self.scene.scale_factor();
         let bounds = bounds * scale_factor;
         let min_dimension = f32::min(bounds.height(), bounds.width());
@@ -409,7 +410,7 @@ impl<'a> Frame<'a> {
             scale_factor,
             min_dimension,
         );
-        per_rect_uniforms.push(shader::PerRectUniforms::new(
+        let per_rect_uniforms = shader::PerRectUniforms::new(
             bounds.origin().into(),
             bounds.size().into(),
             corner_radius,
@@ -433,25 +434,16 @@ impl<'a> Frame<'a> {
             0_f32,
             0.,
             vec2f(0.0, 0.0).into(),
-        ));
-        let per_rect_uniforms_buffer = new_metal_buffer(
-            self.ctx.device,
-            &per_rect_uniforms,
-            MTLResourceOptions::StorageModeManaged,
         );
+        let _per_rect_uniforms_buffer =
+            self.bind_dynamic_vertex_data(std::slice::from_ref(&per_rect_uniforms), 1);
 
         let uniforms = shader::Uniforms::new(self.ctx.drawable_size.into());
         let uniforms_ptr = NonNull::from(&uniforms).cast::<c_void>();
         let uniforms_len = mem::size_of::<shader::Uniforms>();
-
-        // SAFETY: the per-rect uniform buffer and `uniforms` value outlive this encoded draw
-        // call, and the bound buffer/byte sizes and indices match the shader bindings.
+        // SAFETY: `uniforms` outlives this encoded draw call, and the bound byte sizes and
+        // indices match the shader bindings.
         unsafe {
-            self.command_encoder.setVertexBuffer_offset_atIndex(
-                Some(&per_rect_uniforms_buffer),
-                0,
-                1,
-            );
             self.command_encoder
                 .setVertexBytes_length_atIndex(uniforms_ptr, uniforms_len, 2);
             self.command_encoder
@@ -514,7 +506,7 @@ impl<'a> Frame<'a> {
                     MTLIndexType::UInt16,
                     &self.resources.quad_indices,
                     0,
-                    per_rect_uniforms.len(),
+                    1,
                 );
         }
     }
@@ -659,24 +651,15 @@ impl<'a> Frame<'a> {
                 gap_lengths.into(),
             ));
         }
-        let per_rect_uniforms_buffer = new_metal_buffer(
-            self.ctx.device,
-            &per_rect_uniforms,
-            MTLResourceOptions::StorageModeManaged,
-        );
+        let _per_rect_uniforms_buffer = self.bind_dynamic_vertex_data(&per_rect_uniforms, 1);
 
         let uniforms = shader::Uniforms::new(self.ctx.drawable_size.into());
         let uniforms_ptr = NonNull::from(&uniforms).cast::<c_void>();
         let uniforms_len = mem::size_of::<shader::Uniforms>();
 
-        // SAFETY: the per-rect uniform buffer and `uniforms` value outlive this encoded draw
-        // call, and the bound buffer/byte sizes and indices match the shader bindings.
+        // SAFETY: `uniforms` outlives this encoded draw call, and the bound byte sizes and
+        // indices match the shader bindings.
         unsafe {
-            self.command_encoder.setVertexBuffer_offset_atIndex(
-                Some(&per_rect_uniforms_buffer),
-                0,
-                1,
-            );
             self.command_encoder
                 .setVertexBytes_length_atIndex(uniforms_ptr, uniforms_len, 2);
             self.command_encoder
@@ -789,11 +772,7 @@ impl<'a> Frame<'a> {
         }
 
         for (texture_id, per_glyph_uniforms) in texture_to_glyph {
-            let per_glyph_uniforms_buffer = new_metal_buffer(
-                self.ctx.device,
-                &per_glyph_uniforms,
-                MTLResourceOptions::StorageModeManaged,
-            );
+            let _per_glyph_uniforms_buffer = self.bind_dynamic_vertex_data(&per_glyph_uniforms, 1);
 
             let uniforms = shader::Uniforms::new(self.ctx.drawable_size.into());
             let uniforms_ptr = NonNull::from(&uniforms).cast::<c_void>();
@@ -805,15 +784,9 @@ impl<'a> Frame<'a> {
                 .texture(&texture_id)
                 .expect("texture ID should be in atlas");
 
-            // SAFETY: the per-glyph uniform buffer, `uniforms` value, bound texture, and quad
-            // index buffer outlive this encoded draw call, and the bound sizes/indices match the
-            // shader bindings.
+            // SAFETY: `uniforms`, the bound texture, and the quad index buffer outlive this
+            // encoded draw call, and the bound sizes/indices match the shader bindings.
             unsafe {
-                self.command_encoder.setVertexBuffer_offset_atIndex(
-                    Some(&per_glyph_uniforms_buffer),
-                    0,
-                    1,
-                );
                 self.command_encoder
                     .setVertexBytes_length_atIndex(uniforms_ptr, uniforms_len, 2);
                 self.command_encoder
@@ -828,6 +801,43 @@ impl<'a> Frame<'a> {
                         per_glyph_uniforms.len(),
                     );
             }
+        }
+    }
+
+    /// Binds small dynamic uniform arrays inline and retains allocated buffers for larger arrays.
+    fn bind_dynamic_vertex_data<T>(
+        &self,
+        data: &[T],
+        index: usize,
+    ) -> Option<Retained<ProtocolObject<dyn MTLBuffer>>> {
+        debug_assert!(!data.is_empty());
+
+        let data_len = mem::size_of_val(data);
+        if data_len < MAX_INLINE_VERTEX_BYTES_LENGTH {
+            // SAFETY: Metal copies inline bytes during encoding, `data` is non-empty, and
+            // `data_len` is the initialized byte length of the slice.
+            unsafe {
+                self.command_encoder.setVertexBytes_length_atIndex(
+                    NonNull::new(data.as_ptr() as *mut c_void)
+                        .expect("dynamic vertex bytes pointer is non-null"),
+                    data_len,
+                    index,
+                );
+            }
+            None
+        } else {
+            let buffer = new_metal_buffer(
+                self.ctx.device,
+                data,
+                MTLResourceOptions::StorageModeManaged,
+            );
+            // SAFETY: The returned retained buffer is held by the caller until after its draw
+            // call has been encoded, and the binding index matches the vertex shader input.
+            unsafe {
+                self.command_encoder
+                    .setVertexBuffer_offset_atIndex(Some(&buffer), 0, index);
+            }
+            Some(buffer)
         }
     }
 }

--- a/crates/warpui/src/platform/mac/rendering/metal/shaders/shader_types.h
+++ b/crates/warpui/src/platform/mac/rendering/metal/shaders/shader_types.h
@@ -10,6 +10,18 @@ typedef struct {
 typedef struct {
   vector_float2 origin;
   vector_float2 size;
+  vector_float4 background_start_color;
+  vector_float4 background_end_color;
+  vector_float4 border_start_color;
+  vector_float4 border_end_color;
+  vector_float4 icon_color;
+  vector_float4 drop_shadow_color;
+  vector_float2 background_start;
+  vector_float2 background_end;
+  vector_float2 border_start;
+  vector_float2 border_end;
+  vector_float2 drop_shadow_offsets;
+  vector_float2 gap_lengths;
   float corner_radius_top_left;
   float corner_radius_top_right;
   float corner_radius_bottom_left;
@@ -18,34 +30,22 @@ typedef struct {
   float border_right;
   float border_bottom;
   float border_left;
-  vector_float2 background_start;
-  vector_float2 background_end;
-  vector_float4 background_start_color;
-  vector_float4 background_end_color;
-  vector_float2 border_start;
-  vector_float2 border_end;
-  vector_float4 border_start_color;
-  vector_float4 border_end_color;
-  vector_float4 icon_color;
   int is_icon;
-  vector_float2 drop_shadow_offsets;
-  vector_float4 drop_shadow_color;
   float drop_shadow_sigma;
   float drop_shadow_padding_factor;
   float dash_length;
-  vector_float2 gap_lengths;
 } PerRectUniforms;
 
 typedef struct {
   vector_float2 origin;
   vector_float2 size;
+  vector_float4 color;
   float uv_left;
   float uv_top;
   float uv_width;
   float uv_height;
   float fade_start;
   float fade_end;
-  vector_float4 color;
   int is_emoji;
 } PerGlyphUniforms;
 

--- a/crates/warpui/src/platform/mac/rendering/metal/shaders/shaders.metal
+++ b/crates/warpui/src/platform/mac/rendering/metal/shaders/shaders.metal
@@ -165,8 +165,7 @@ float roundedBoxShadow(float2 lower, float2 upper, float2 point, float sigma, fl
 }
 
 fragment float4 rect_fragment_shader(
-    RectFragmentData in [[stage_in]],
-    constant Uniforms *uniforms [[buffer(0)]])
+    RectFragmentData in [[stage_in]])
 {
     float outer_distance;
     float inner_distance;


### PR DESCRIPTION
## Description
Improve macOS Metal renderer submission overhead after profiling showed that simple UI rendering was spending avoidable CPU time preparing draw calls and allocating large instance-data buffers.

- Submit small dynamic instance-uniform payloads inline with `setVertexBytes` rather than allocating a new `MTLBuffer` for each image/icon draw or small rect/glyph batch.
- Bind frame-invariant quad geometry and viewport uniforms once per render pass, rather than redundantly rebinding them for each rendering category or draw.
- Remove an unused rectangle fragment-shader uniform binding and name the shared vertex buffer slots to clarify the CPU/shader contract.
- Reorder rect and glyph instance fields by alignment to eliminate padding without reducing precision or changing shader behavior, reducing `PerRectUniforms` from 224 to 208 bytes and `PerGlyphUniforms` from 80 to 64 bytes.

In manual testing of a text-heavy scrolling view, the initial submission/binding changes reduced average `after_drawable` frame time from approximately **0.5 ms** to **0.3 ms**. The subsequent field packing reduces large instance-buffer payload sizes; its incremental timing impact is difficult to isolate in local profiling.

## Linked Issue
N/A — this optimization was identified through renderer profiling.

## Testing
- [x] Manually tested locally in a release build with `./script/run --release`, scrolling a text-heavy view while comparing Metal frame timings and profiling allocations in Instruments.
- [x] Verified packed shared-ABI sizes: `PerRectUniforms` = 208 bytes and `PerGlyphUniforms` = 64 bytes.
- [x] `cargo fmt --manifest-path /Users/david/src/warp/Cargo.toml -p warpui`
- [x] `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warpui --lib`
- [x] `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warpui --example frame-capture-test`
- [x] `cargo clippy --manifest-path /Users/david/src/warp/Cargo.toml -p warpui --lib -- -D warnings`

CHANGELOG-IMPROVEMENT: Improved macOS rendering performance for text- and icon-heavy windows.

Co-Authored-By: Oz <oz-agent@warp.dev>
