### PR TITLE
Add basic tab group rendering for horizontal tabs

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -764,6 +764,8 @@ pub struct TabComponent<'a> {
     ///     flicker), and
     ///   * does not act as its own draggable / drop target.
     for_drag_ghost: bool,
+    /// Set when rendered as a member of a horizontal tab group.
+    grouped_member: bool,
 }
 
 /// Structure that holds TabComponent styles.
@@ -924,6 +926,7 @@ impl<'a> TabComponent<'a> {
             is_drag_target,
             background_opacity,
             for_drag_ghost: false,
+            grouped_member: false,
         }
     }
 
@@ -931,6 +934,13 @@ impl<'a> TabComponent<'a> {
     /// cross-window tab drag overlay. See [`TabComponent::for_drag_ghost`].
     pub fn for_drag_ghost(mut self) -> Self {
         self.for_drag_ghost = true;
+        self
+    }
+
+    /// Marks this tab as a member of a horizontal tab group. See the
+    /// [`TabComponent`] `grouped_member` field for the rendering differences.
+    pub fn for_grouped_member(mut self) -> Self {
+        self.grouped_member = true;
         self
     }
 
@@ -1452,9 +1462,13 @@ impl<'a> TabComponent<'a> {
                 )
                 .finish(),
             );
-            Container::new(flex_row.finish())
-                .with_horizontal_padding(8.)
-                .finish()
+            let mut container = Container::new(flex_row.finish()).with_horizontal_padding(8.);
+            // Pad inside the Stack so the close-button overlay (anchored to
+            // the Stack) stays vertically centered within the visible pill.
+            if self.grouped_member {
+                container = container.with_vertical_padding(5.);
+            }
+            container.finish()
         };
 
         let compact_icon = {
@@ -1591,6 +1605,19 @@ impl<'a> TabComponent<'a> {
         )
         .finish();
 
+        // Grouped member: inset rounded highlight, no side dividers, no
+        // drop target (members can't be dragged currently).
+        if self.grouped_member {
+            let highlight = Container::new(stack)
+                .with_background(background_color)
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.0)))
+                .finish();
+            return Container::new(highlight)
+                .with_vertical_padding(3.)
+                .with_horizontal_padding(3.)
+                .finish();
+        }
+
         let mut tab = Container::new(stack)
             .with_vertical_padding(2.)
             .with_background(background_color);
@@ -1657,6 +1684,7 @@ impl UiComponent for TabComponent<'_> {
         let mouse_close_state = self.tab.close_mouse_state.clone();
         // Capture before `self` is moved into the Hoverable closure below.
         let for_drag_ghost = self.for_drag_ghost;
+        let grouped_member = self.grouped_member;
 
         // Extract values before moving self into closure
         let tooltip_text = self.tooltip_message.clone();
@@ -1849,6 +1877,10 @@ impl UiComponent for TabComponent<'_> {
         // position cache, breaking `tab_insertion_index_for_cursor`.
         let full_tab: Box<dyn Element> = if for_drag_ghost {
             constrained_tab
+        } else if grouped_member {
+            // Skipping dragging within a group for now.
+            // TODO(johnturcoo) support dragging tabs within a group.
+            SavePosition::new(constrained_tab, &tab_position_id(tab_index)).finish()
         } else {
             let draggable = Draggable::new(draggable_state, constrained_tab)
                 .on_drag_start(|ctx, _, _| ctx.dispatch_typed_action(WorkspaceAction::StartTabDrag))

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -110,8 +110,8 @@ use warpui::{
 use self::vertical_tabs::telemetry::{VerticalTabsDisplayOption, VerticalTabsTelemetryEvent};
 use self::vertical_tabs::{
     pane_summary_kind, render_detail_sidecar, render_settings_popup,
-    render_summary_pane_kind_icon_circle, render_summary_pane_kind_icons,
-    vtab_group_position_id, SummaryPaneKind, SummaryPaneKindIcons, VerticalTabsPanelState,
+    render_summary_pane_kind_icon_circle, render_summary_pane_kind_icons, vtab_group_position_id,
+    SummaryPaneKind, SummaryPaneKindIcons, VerticalTabsPanelState,
     VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -18921,7 +18921,7 @@ impl Workspace {
         header = header.on_double_click(move |ctx, _, _| {
             ctx.dispatch_typed_action(WorkspaceAction::RenameTabGroup(group_id));
         });
-    
+
         header = header.on_right_click(move |ctx, _, position| {
             ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupRightClickMenu {
                 group_id,
@@ -19649,8 +19649,7 @@ impl Workspace {
             let mut slots: Vec<TabBarSlot> = Vec::with_capacity(self.tabs.len());
             for (idx, tab) in self.tabs.iter().enumerate() {
                 let group_id = if grouped_tabs_enabled {
-                    tab.group_id
-                        .filter(|gid| self.tab_groups.contains_key(gid))
+                    tab.group_id.filter(|gid| self.tab_groups.contains_key(gid))
                 } else {
                     None
                 };
@@ -19685,7 +19684,10 @@ impl Workspace {
                 };
                 // Insert ghost slot before this slot's first tab if the drag
                 // would land here.
-                if ghost.as_ref().is_some_and(|g| g.insertion_index == start_index) {
+                if ghost
+                    .as_ref()
+                    .is_some_and(|g| g.insertion_index == start_index)
+                {
                     tab_bar.add_child(self.render_ghost_tab_slot(appearance, ctx));
                 }
 
@@ -19711,20 +19713,23 @@ impl Workspace {
                         let i = *index;
                         let is_transferred = transferred_tab_index == Some(i);
                         if !is_transferred
-                            && self.hovered_tab_index.as_ref().is_some_and(|hovered_index| {
-                                match hovered_index {
+                            && self
+                                .hovered_tab_index
+                                .as_ref()
+                                .is_some_and(|hovered_index| match hovered_index {
                                     TabBarHoverIndex::BeforeTab(idx) => i == *idx,
                                     TabBarHoverIndex::OverTab(_) => false,
-                                }
-                            })
+                                })
                         {
                             tab_bar.add_child(self.render_tab_hover_indicator(appearance));
                         }
                         if is_transferred {
                             tab_bar.add_child(
-                                ConstrainedBox::new(
-                                    self.render_tab_in_tab_bar(i, tab_bar_state, ctx),
-                                )
+                                ConstrainedBox::new(self.render_tab_in_tab_bar(
+                                    i,
+                                    tab_bar_state,
+                                    ctx,
+                                ))
                                 .with_width(0.)
                                 .finish(),
                             );

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19666,7 +19666,7 @@ impl Workspace {
                             if *last_gid == group_id {
                                 *run_len += 1;
                                 continue;
-                                // Current tab is part of the last existing group, 
+                                // Current tab is part of the last existing group,
                                 // continue building this groups 'slot'.
                             }
                         }
@@ -26996,7 +26996,7 @@ fn render_group_member_icon_collage(
             GROUP_ICON_COLLAGE_MINI_SIZE,
             appearance,
         );
-        // Placement mapping for each icon. 
+        // Placement mapping for each icon.
         // (number of icons, index of icon) -> position.
         let offset = match (count, idx) {
             (3, 0) => vec2f(-diag, -diag),

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20,6 +20,7 @@ mod vertical_tabs;
 #[cfg(target_family = "wasm")]
 mod wasm_view;
 
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "local_fs")]
@@ -108,7 +109,9 @@ use warpui::{
 
 use self::vertical_tabs::telemetry::{VerticalTabsDisplayOption, VerticalTabsTelemetryEvent};
 use self::vertical_tabs::{
-    render_detail_sidecar, render_settings_popup, vtab_group_position_id, VerticalTabsPanelState,
+    pane_summary_kind, render_detail_sidecar, render_settings_popup,
+    render_summary_pane_kind_icon_circle, render_summary_pane_kind_icons,
+    vtab_group_position_id, SummaryPaneKind, SummaryPaneKindIcons, VerticalTabsPanelState,
     VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
@@ -933,6 +936,25 @@ pub struct TransferredTab {
     pub draggable_state: DraggableState,
 }
 
+/// Per-`TabGroupId` hover state for the horizontal tab bar header.
+#[derive(Clone, Default)]
+struct HorizontalTabGroupMouseStates {
+    header: MouseStateHandle,
+}
+
+/// A unit the horizontal tab bar renders: either a single ungrouped tab or a
+/// contiguous run of same-group tabs collapsed into one group container.
+enum TabBarSlot {
+    Single {
+        index: usize,
+    },
+    Group {
+        group_id: TabGroupId,
+        first_index: usize,
+        run_len: usize,
+    },
+}
+
 pub struct Workspace {
     window_id: WindowId,
     pub(crate) tabs: Vec<TabData>,
@@ -946,6 +968,8 @@ pub struct Workspace {
     traffic_light_mouse_states: TrafficLightMouseStates,
     /// Tab groups in this workspace, keyed by id.
     pub(crate) tab_groups: HashMap<TabGroupId, TabGroup>,
+    /// Per-group hover state for the horizontal tab bar.
+    horizontal_tab_group_mouse_states: RefCell<HashMap<TabGroupId, HorizontalTabGroupMouseStates>>,
     tab_rename_editor: ViewHandle<EditorView>,
     pane_rename_editor: ViewHandle<EditorView>,
     tab_group_rename_editor: ViewHandle<EditorView>,
@@ -3203,6 +3227,7 @@ impl Workspace {
             tab_bar_hover_state: Default::default(),
             traffic_light_mouse_states: Default::default(),
             tab_groups: HashMap::new(),
+            horizontal_tab_group_mouse_states: RefCell::default(),
             tab_rename_editor: Self::tab_rename_editor(ctx),
             pane_rename_editor: Self::pane_rename_editor(ctx),
             tab_group_rename_editor: Self::tab_group_rename_editor(ctx),
@@ -6895,6 +6920,7 @@ impl Workspace {
             self.prune_empty_tab_group(prev, ctx);
         }
 
+        self.focus_active_tab(ctx);
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
     }
@@ -6920,6 +6946,7 @@ impl Workspace {
 
         self.prune_empty_tab_group(previous_group_id, ctx);
 
+        self.focus_active_tab(ctx);
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
     }
@@ -7290,7 +7317,7 @@ impl Workspace {
             return;
         }
 
-        let menu_items = self.tab_group_menu_items(group_id);
+        let menu_items = self.tab_group_menu_items(group_id, uses_vertical_tabs(ctx));
         ctx.update_view(&self.tab_right_click_menu, |context_menu, view_ctx| {
             context_menu.set_items(menu_items, view_ctx);
         });
@@ -9294,8 +9321,13 @@ impl Workspace {
         }
     }
 
-    /// Builds the tab group more-options menu items, grouped into sections.
-    fn tab_group_menu_items(&self, group_id: TabGroupId) -> Vec<MenuItem<WorkspaceAction>> {
+    /// Move/close directional labels read "up/down/above/below" in vertical
+    /// tabs and "left/right" in horizontal tabs; actions are unchanged.
+    fn tab_group_menu_items(
+        &self,
+        group_id: TabGroupId,
+        is_vertical: bool,
+    ) -> Vec<MenuItem<WorkspaceAction>> {
         let Some((first, last)) = group_member_index_range(&self.tabs, group_id) else {
             return vec![];
         };
@@ -9306,15 +9338,25 @@ impl Workspace {
         let move_section = {
             let mut items = vec![];
             if has_tabs_above {
+                let label = if is_vertical {
+                    "Move group up"
+                } else {
+                    "Move group left"
+                };
                 items.push(
-                    MenuItemFields::new("Move group up")
+                    MenuItemFields::new(label)
                         .with_on_select_action(WorkspaceAction::MoveTabGroupUp(group_id))
                         .into_item(),
                 );
             }
             if has_tabs_below {
+                let label = if is_vertical {
+                    "Move group down"
+                } else {
+                    "Move group right"
+                };
                 items.push(
-                    MenuItemFields::new("Move group down")
+                    MenuItemFields::new(label)
                         .with_on_select_action(WorkspaceAction::MoveTabGroupDown(group_id))
                         .into_item(),
                 );
@@ -9334,15 +9376,25 @@ impl Workspace {
                 );
             }
             if has_tabs_above {
+                let label = if is_vertical {
+                    "Close tabs above"
+                } else {
+                    "Close tabs to the left"
+                };
                 items.push(
-                    MenuItemFields::new("Close tabs above")
+                    MenuItemFields::new(label)
                         .with_on_select_action(WorkspaceAction::CloseTabsAboveGroup(group_id))
                         .into_item(),
                 );
             }
             if has_tabs_below {
+                let label = if is_vertical {
+                    "Close tabs below"
+                } else {
+                    "Close tabs to the right"
+                };
                 items.push(
-                    MenuItemFields::new("Close tabs below")
+                    MenuItemFields::new(label)
                         .with_on_select_action(WorkspaceAction::CloseTabsBelowGroup(group_id))
                         .into_item(),
                 );
@@ -18712,6 +18764,209 @@ impl Workspace {
         .finish()
     }
 
+    /// Renders a contiguous run of grouped tabs as one tab-bar slot: header
+    /// + (when expanded) member tabs.
+    #[allow(clippy::too_many_arguments)]
+    fn render_horizontal_tab_group(
+        &self,
+        group: &TabGroup,
+        first_index: usize,
+        run_len: usize,
+        tab_bar_state: TabBarState,
+        is_first_in_bar: bool,
+        appearance: &Appearance,
+        ctx: &AppContext,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let is_collapsed = group.collapsed;
+
+        let mouse_states = self
+            .horizontal_tab_group_mouse_states
+            .borrow_mut()
+            .entry(group.id)
+            .or_default()
+            .clone();
+
+        let member_range = first_index..first_index + run_len;
+        let any_member_active = !self.current_workspace_state.is_agent_management_view_open
+            && member_range.contains(&self.active_tab_index);
+
+        let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
+        row.add_child(self.render_horizontal_tab_group_header(
+            group,
+            &mouse_states,
+            is_collapsed,
+            any_member_active,
+            appearance,
+            ctx,
+        ));
+
+        if !is_collapsed {
+            let close_button_position = if FeatureFlag::TabCloseButtonOnLeft.is_enabled() {
+                TabSettings::as_ref(ctx).close_button_position
+            } else {
+                TabCloseButtonPosition::default()
+            };
+            for idx in member_range {
+                let tab = &self.tabs[idx];
+                let member = TabComponent::new(
+                    idx,
+                    tab_bar_state,
+                    tab,
+                    self.tab_rename_editor.clone(),
+                    close_button_position,
+                    false,
+                    ctx,
+                )
+                .for_grouped_member()
+                .build()
+                .finish();
+                row.add_child(member);
+            }
+        }
+
+        let container = Container::new(row.finish()).with_border(
+            Border::all(1.)
+                // Left border only on the first slot to avoid double borders.
+                .with_sides(false, is_first_in_bar, false, true)
+                .with_border_fill(internal_colors::fg_overlay_1(theme)),
+        );
+        // Flex = header + one per member so the group shrinks proportionally
+        // with sibling tabs.
+        let group_flex = 1.0 + run_len as f32;
+        Shrinkable::new(group_flex, container.finish()).finish()
+    }
+
+    /// Header (icon collage + name) for a horizontal tab group. Click
+    /// toggles collapse; double-click renames; right-click opens the menu.
+    fn render_horizontal_tab_group_header(
+        &self,
+        group: &TabGroup,
+        mouse_states: &HorizontalTabGroupMouseStates,
+        is_collapsed: bool,
+        any_member_active: bool,
+        appearance: &Appearance,
+        ctx: &AppContext,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let group_id = group.id;
+        let font_family = appearance.ui_font_family();
+        let main_text_color = theme.main_text_color(theme.background());
+
+        // When collapsed with an active hidden member, highlight the header
+        // so the active state stays visible.
+        let header_selected = is_collapsed && any_member_active;
+
+        let member_kinds = self.compute_group_member_kinds(group.id, ctx);
+        let icon_circle = render_group_member_icon_collage(&member_kinds, appearance);
+
+        let is_being_renamed = self
+            .current_workspace_state
+            .is_tab_group_being_renamed(group_id);
+        let name_element: Box<dyn Element> = if is_being_renamed {
+            ConstrainedBox::new(vertical_tabs::render_inline_tab_rename_editor(
+                &self.tab_group_rename_editor,
+                appearance,
+                ctx,
+            ))
+            .with_max_width(150.)
+            .finish()
+        } else {
+            let title = group
+                .name
+                .clone()
+                .unwrap_or_else(|| "New Group".to_string());
+            // Cap width so long names ellipsize and the tab bar's unbounded
+            // measurement stays finite.
+            ConstrainedBox::new(
+                Text::new_inline(title, font_family, 12.)
+                    .with_clip(ClipConfig::ellipsis())
+                    .with_color(main_text_color.into())
+                    .finish(),
+            )
+            .with_max_width(150.)
+            .finish()
+        };
+
+        let row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(6.)
+            .with_child(icon_circle)
+            .with_child(name_element)
+            .finish();
+
+        let header_active_bg = internal_colors::fg_overlay_2(theme);
+        let header_hover_bg = internal_colors::fg_overlay_1(theme);
+        let mut header = Hoverable::new(mouse_states.header.clone(), move |state| {
+            let bg: ElementFill = if header_selected {
+                header_active_bg.into()
+            } else if state.is_hovered() {
+                header_hover_bg.into()
+            } else {
+                ElementFill::None
+            };
+
+            Container::new(row)
+                .with_horizontal_padding(8.)
+                .with_vertical_padding(6.)
+                .with_background(bg)
+                .finish()
+        })
+        .with_cursor(Cursor::PointingHand)
+        .with_defer_events_to_children();
+
+        header = header.on_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupCollapsed(group_id));
+        });
+        header = header.on_double_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(WorkspaceAction::RenameTabGroup(group_id));
+        });
+    
+        header = header.on_right_click(move |ctx, _, position| {
+            ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupRightClickMenu {
+                group_id,
+                anchor: TabContextMenuAnchor::Pointer(position),
+            });
+        });
+        header.finish()
+    }
+
+    /// Up to 4 distinct pane icons for the group's collage. Each member tab
+    /// first contributes its own Summary-mode pair (up to 2 earliest-created
+    /// distinct kinds), and those pairs are then concatenated in tab order
+    /// and deduped across tabs. This guarantees the collage is always a
+    /// subset of the union of icons shown by the member tabs' Summary views.
+    fn compute_group_member_kinds(
+        &self,
+        group_id: TabGroupId,
+        ctx: &AppContext,
+    ) -> Vec<SummaryPaneKind> {
+        let mut kinds: Vec<SummaryPaneKind> = Vec::new();
+        for idx in group_member_indices(&self.tabs, group_id) {
+            let tab = &self.tabs[idx];
+            let pane_group = tab.pane_group.as_ref(ctx);
+            let pane_kinds: Vec<(EntityId, SummaryPaneKind)> = pane_group
+                .visible_pane_ids()
+                .iter()
+                .map(|pane_id| {
+                    (
+                        pane_id.creation_order_id(),
+                        pane_summary_kind(pane_group, *pane_id, ctx),
+                    )
+                })
+                .collect();
+            for kind in select_unique_pane_kinds(pane_kinds, 2) {
+                if !kinds.contains(&kind) {
+                    kinds.push(kind);
+                    if kinds.len() >= 4 {
+                        return kinds;
+                    }
+                }
+            }
+        }
+        kinds
+    }
+
     /// Renders the tab at `tab_index` using the same render code path the live
     /// tab bar uses, so the floating chip during a cross-window tab drag
     /// matches the source tab exactly. Dispatches to the vertical tab group
@@ -19388,31 +19643,95 @@ impl Workspace {
             // Ghost state for cross-window drag hovering over this tab bar.
             let ghost = drag_model.ghost_state_for_window(self.window_id);
 
-            for i in 0..self.tabs.len() {
-                // Insert ghost slot before tab `i` if the drag would land here.
-                if ghost.as_ref().is_some_and(|g| g.insertion_index == i) {
+            // Build a slot list: each ungrouped tab is a `Single`, and each
+            // contiguous run of same-group tabs collapses into one `Group`.
+            let grouped_tabs_enabled = FeatureFlag::GroupedTabs.is_enabled();
+            let mut slots: Vec<TabBarSlot> = Vec::with_capacity(self.tabs.len());
+            for (idx, tab) in self.tabs.iter().enumerate() {
+                let group_id = if grouped_tabs_enabled {
+                    tab.group_id
+                        .filter(|gid| self.tab_groups.contains_key(gid))
+                } else {
+                    None
+                };
+                match group_id {
+                    Some(group_id) => {
+                        if let Some(TabBarSlot::Group {
+                            group_id: last_gid,
+                            run_len,
+                            ..
+                        }) = slots.last_mut()
+                        {
+                            if *last_gid == group_id {
+                                *run_len += 1;
+                                continue;
+                            }
+                        }
+                        slots.push(TabBarSlot::Group {
+                            group_id,
+                            first_index: idx,
+                            run_len: 1,
+                        });
+                    }
+                    None => slots.push(TabBarSlot::Single { index: idx }),
+                }
+            }
+
+            // Render each slot in the tab bar, either an indiovidual tab or tab group.
+            for slot in &slots {
+                let start_index = match slot {
+                    TabBarSlot::Single { index } => *index,
+                    TabBarSlot::Group { first_index, .. } => *first_index,
+                };
+                // Insert ghost slot before this slot's first tab if the drag
+                // would land here.
+                if ghost.as_ref().is_some_and(|g| g.insertion_index == start_index) {
                     tab_bar.add_child(self.render_ghost_tab_slot(appearance, ctx));
                 }
-                let is_transferred = transferred_tab_index == Some(i);
-                if !is_transferred
-                    && self
-                        .hovered_tab_index
-                        .as_ref()
-                        .is_some_and(|hovered_index| match hovered_index {
-                            TabBarHoverIndex::BeforeTab(idx) => i == *idx,
-                            TabBarHoverIndex::OverTab(_) => false,
-                        })
-                {
-                    tab_bar.add_child(self.render_tab_hover_indicator(appearance));
-                }
-                if is_transferred {
-                    tab_bar.add_child(
-                        ConstrainedBox::new(self.render_tab_in_tab_bar(i, tab_bar_state, ctx))
-                            .with_width(0.)
-                            .finish(),
-                    );
-                } else {
-                    tab_bar.add_child(self.render_tab_in_tab_bar(i, tab_bar_state, ctx));
+
+                match slot {
+                    TabBarSlot::Group {
+                        group_id,
+                        first_index,
+                        run_len,
+                    } => {
+                        // Filtered above; the group must exist in `tab_groups`.
+                        let group = self.tab_groups[group_id].clone();
+                        tab_bar.add_child(self.render_horizontal_tab_group(
+                            &group,
+                            *first_index,
+                            *run_len,
+                            tab_bar_state,
+                            *first_index == 0,
+                            appearance,
+                            ctx,
+                        ));
+                    }
+                    TabBarSlot::Single { index } => {
+                        let i = *index;
+                        let is_transferred = transferred_tab_index == Some(i);
+                        if !is_transferred
+                            && self.hovered_tab_index.as_ref().is_some_and(|hovered_index| {
+                                match hovered_index {
+                                    TabBarHoverIndex::BeforeTab(idx) => i == *idx,
+                                    TabBarHoverIndex::OverTab(_) => false,
+                                }
+                            })
+                        {
+                            tab_bar.add_child(self.render_tab_hover_indicator(appearance));
+                        }
+                        if is_transferred {
+                            tab_bar.add_child(
+                                ConstrainedBox::new(
+                                    self.render_tab_in_tab_bar(i, tab_bar_state, ctx),
+                                )
+                                .with_width(0.)
+                                .finish(),
+                            );
+                        } else {
+                            tab_bar.add_child(self.render_tab_in_tab_bar(i, tab_bar_state, ctx));
+                        }
+                    }
                 }
             }
 
@@ -24820,34 +25139,48 @@ impl View for Workspace {
             let is_vertical = FeatureFlag::VerticalTabs.is_enabled()
                 && *TabSettings::as_ref(app).use_vertical_tabs
                 && self.vertical_tabs_panel_open;
-            if is_vertical {
-                let positioning = match anchor {
-                    TabContextMenuAnchor::VerticalTabsKebab => {
-                        let tabs_side = Self::tabs_panel_side(
-                            &TabSettings::as_ref(app).header_toolbar_chip_selection,
-                        );
-                        let (anchor, child_anchor) = if tabs_side == PanelPosition::Left {
-                            (PositionedElementAnchor::BottomLeft, ChildAnchor::TopLeft)
-                        } else {
-                            (PositionedElementAnchor::BottomRight, ChildAnchor::TopRight)
-                        };
-                        OffsetPositioning::offset_from_save_position_element(
-                            vertical_tabs::vtab_group_kebab_position_id(group_id),
-                            vec2f(0., 4.),
-                            PositionedElementOffsetBounds::WindowByPosition,
-                            anchor,
-                            child_anchor,
-                        )
-                    }
-                    TabContextMenuAnchor::Pointer(position) => {
+            let positioning = match (is_vertical, anchor) {
+                (true, TabContextMenuAnchor::VerticalTabsKebab) => {
+                    let tabs_side = Self::tabs_panel_side(
+                        &TabSettings::as_ref(app).header_toolbar_chip_selection,
+                    );
+                    let (anchor, child_anchor) = if tabs_side == PanelPosition::Left {
+                        (PositionedElementAnchor::BottomLeft, ChildAnchor::TopLeft)
+                    } else {
+                        (PositionedElementAnchor::BottomRight, ChildAnchor::TopRight)
+                    };
+                    Some(OffsetPositioning::offset_from_save_position_element(
+                        vertical_tabs::vtab_group_kebab_position_id(group_id),
+                        vec2f(0., 4.),
+                        PositionedElementOffsetBounds::WindowByPosition,
+                        anchor,
+                        child_anchor,
+                    ))
+                }
+                (true, TabContextMenuAnchor::Pointer(position)) => {
+                    Some(OffsetPositioning::offset_from_parent(
+                        position,
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::TopLeft,
+                        ChildAnchor::TopLeft,
+                    ))
+                }
+                // Horizontal tab bar: the group header's right-click opens the
+                // menu at the pointer (matching the per-tab menu's Pointer arm).
+                (false, TabContextMenuAnchor::Pointer(position)) => {
+                    tab_bar_mode.has_tab_bar().then(|| {
                         OffsetPositioning::offset_from_parent(
                             position,
-                            ParentOffsetBounds::WindowByPosition,
+                            ParentOffsetBounds::Unbounded,
                             ParentAnchor::TopLeft,
                             ChildAnchor::TopLeft,
                         )
-                    }
-                };
+                    })
+                }
+                // The kebab anchor only exists in the vertical tabs panel.
+                (false, TabContextMenuAnchor::VerticalTabsKebab) => None,
+            };
+            if let Some(positioning) = positioning {
                 stack.add_positioned_overlay_child(
                     ChildView::new(&self.tab_right_click_menu).finish(),
                     positioning,
@@ -26589,6 +26922,108 @@ impl Workspace {
 
 fn should_reserve_traffic_light_space_in_tab_bar(side: TrafficLightSide) -> bool {
     side == TrafficLightSide::Right
+}
+
+/// Total width/height of the collage area in the group header.
+const GROUP_ICON_COLLAGE_SIZE: f32 = 22.0;
+/// Size of each icon when the collage shows 3 or 4 of them.
+const GROUP_ICON_COLLAGE_MINI_SIZE: f32 = 12.0;
+/// How far inside the collage area each mini icon's center sits.
+const GROUP_ICON_COLLAGE_CENTER_INSET: f32 = 2.0;
+
+/// Renders the icon block for a tab-group header from 0-4 deduped pane kinds.
+/// 1 or 2 icons reuse the vertical Summary `Single`/`Pair` layout so the
+/// group's icons read like a tab Summary view. 3 or 4 icons fall back to a
+/// corner collage (triangle for 3, 2x2 grid for 4) since Summary doesn't
+/// define a layout beyond 2 icons.
+fn render_group_member_icon_collage(
+    kinds: &[SummaryPaneKind],
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let count = kinds.len().min(4);
+    if count == 0 {
+        return ConstrainedBox::new(Empty::new().finish())
+            .with_width(GROUP_ICON_COLLAGE_SIZE)
+            .with_height(GROUP_ICON_COLLAGE_SIZE)
+            .finish();
+    }
+    if count == 1 {
+        return render_summary_pane_kind_icons(
+            SummaryPaneKindIcons::Single(kinds[0].clone()),
+            GROUP_ICON_COLLAGE_SIZE,
+            appearance,
+        );
+    }
+    if count == 2 {
+        return render_summary_pane_kind_icons(
+            SummaryPaneKindIcons::Pair {
+                primary: kinds[0].clone(),
+                secondary: kinds[1].clone(),
+            },
+            GROUP_ICON_COLLAGE_SIZE,
+            appearance,
+        );
+    }
+
+    // Corners at radius/sqrt(2) on each axis; bottom-middle (3-icon) at radius.
+    let radius = GROUP_ICON_COLLAGE_SIZE / 2.0 - GROUP_ICON_COLLAGE_CENTER_INSET;
+    let diag = radius / std::f32::consts::SQRT_2;
+
+    let mut stack = Stack::new().with_child(
+        ConstrainedBox::new(Empty::new().finish())
+            .with_width(GROUP_ICON_COLLAGE_SIZE)
+            .with_height(GROUP_ICON_COLLAGE_SIZE)
+            .finish(),
+    );
+    for (idx, kind) in kinds.iter().take(count).enumerate() {
+        let mini = render_summary_pane_kind_icon_circle(
+            kind.clone(),
+            GROUP_ICON_COLLAGE_MINI_SIZE,
+            appearance,
+        );
+        let offset = match (count, idx) {
+            (3, 0) => vec2f(-diag, -diag),
+            (3, 1) => vec2f(diag, -diag),
+            (3, 2) => vec2f(0.0, radius),
+            (4, 0) => vec2f(-diag, -diag),
+            (4, 1) => vec2f(diag, -diag),
+            (4, 2) => vec2f(-diag, diag),
+            (4, 3) => vec2f(diag, diag),
+            _ => vec2f(0.0, 0.0),
+        };
+        stack.add_positioned_child(
+            mini,
+            OffsetPositioning::offset_from_parent(
+                offset,
+                ParentOffsetBounds::Unbounded,
+                ParentAnchor::Center,
+                ChildAnchor::Center,
+            ),
+        );
+    }
+    stack.finish()
+}
+
+/// Dedupes pane kinds by `SummaryPaneKind` equality, ordered by
+/// `creation_order_id`, and takes the first `max_count`. Shared between
+/// the vertical-tabs Summary icon pair and the horizontal tab-group collage
+/// so both views select icons consistently for the same panes.
+pub(super) fn select_unique_pane_kinds(
+    pane_kinds: impl IntoIterator<Item = (EntityId, SummaryPaneKind)>,
+    max_count: usize,
+) -> Vec<SummaryPaneKind> {
+    let mut pane_kinds: Vec<(EntityId, SummaryPaneKind)> = pane_kinds.into_iter().collect();
+    pane_kinds.sort_by_key(|(creation_order_id, _)| *creation_order_id);
+    let mut unique = Vec::new();
+    for (_, kind) in pane_kinds {
+        if !unique.contains(&kind) {
+            unique.push(kind);
+            if unique.len() >= max_count {
+                break;
+            }
+        }
+    }
+    unique
 }
 
 /// Returns the indices of every tab in `tabs` that belongs to `group_id`,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18948,11 +18948,9 @@ impl Workspace {
             let pane_kinds: Vec<(EntityId, SummaryPaneKind)> = pane_group
                 .visible_pane_ids()
                 .iter()
-                .map(|pane_id| {
-                    (
-                        pane_id.creation_order_id(),
-                        pane_summary_kind(pane_group, *pane_id, ctx),
-                    )
+                .filter_map(|pane_id| {
+                    pane_summary_kind(pane_group, *pane_id, ctx)
+                        .map(|kind| (pane_id.creation_order_id(), kind))
                 })
                 .collect();
             for kind in select_unique_pane_kinds(pane_kinds, 2) {
@@ -27013,7 +27011,7 @@ fn render_group_member_icon_collage(
 /// `creation_order_id`, and takes the first `max_count`. Shared between
 /// the vertical-tabs Summary icon pair and the horizontal tab-group collage
 /// so both views select icons consistently for the same panes.
-pub(super) fn select_unique_pane_kinds(
+fn select_unique_pane_kinds(
     pane_kinds: impl IntoIterator<Item = (EntityId, SummaryPaneKind)>,
     max_count: usize,
 ) -> Vec<SummaryPaneKind> {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18931,11 +18931,15 @@ impl Workspace {
         header.finish()
     }
 
-    /// Up to 4 distinct pane icons for the group's collage. Each member tab
-    /// first contributes its own Summary-mode pair (up to 2 earliest-created
-    /// distinct kinds), and those pairs are then concatenated in tab order
-    /// and deduped across tabs. This guarantees the collage is always a
-    /// subset of the union of icons shown by the member tabs' Summary views.
+    /// Returns up to 4 distinct pane-kind icons for the group's collage.
+    ///
+    /// Icons are drawn from the same pool each member tab's Summary view
+    /// uses, so the collage is always a subset of what's already visible on
+    /// the member tabs themselves — collapsing or expanding the group never
+    /// surfaces icons the user hasn't seen on a member tab.
+    ///
+    /// Example: two member tabs whose Summary views show `[Terminal, Code]`
+    /// and `[Code, Notebook]` produce a collage of `[Terminal, Code, Notebook]`.
     fn compute_group_member_kinds(
         &self,
         group_id: TabGroupId,
@@ -19662,6 +19666,8 @@ impl Workspace {
                             if *last_gid == group_id {
                                 *run_len += 1;
                                 continue;
+                                // Current tab is part of the last existing group, 
+                                // continue building this groups 'slot'.
                             }
                         }
                         slots.push(TabBarSlot::Group {
@@ -19674,7 +19680,7 @@ impl Workspace {
                 }
             }
 
-            // Render each slot in the tab bar, either an indiovidual tab or tab group.
+            // Render each slot in the tab bar, either an individual tab or tab group.
             for slot in &slots {
                 let start_index = match slot {
                     TabBarSlot::Single { index } => *index,
@@ -25051,42 +25057,48 @@ impl View for Workspace {
                 && *TabSettings::as_ref(app).use_vertical_tabs
                 && self.vertical_tabs_panel_open;
             if tab_bar_mode.has_tab_bar() || is_vertical {
-                let positioning = match (is_vertical, right_click_menu_anchor) {
-                    (true, TabContextMenuAnchor::VerticalTabsKebab) => {
-                        // Anchor depends on which side the tabs panel is configured on.
-                        let tabs_side = Self::tabs_panel_side(
-                            &TabSettings::as_ref(app).header_toolbar_chip_selection,
-                        );
-                        let (anchor, child_anchor) = if tabs_side == PanelPosition::Left {
-                            (PositionedElementAnchor::BottomLeft, ChildAnchor::TopLeft)
-                        } else {
-                            (PositionedElementAnchor::BottomRight, ChildAnchor::TopRight)
-                        };
-                        Some(OffsetPositioning::offset_from_save_position_element(
-                            vertical_tabs::vtab_action_buttons_position_id(tab_idx),
-                            vec2f(0., 4.),
-                            PositionedElementOffsetBounds::WindowByPosition,
-                            anchor,
-                            child_anchor,
-                        ))
+                let positioning = if is_vertical {
+                    match right_click_menu_anchor {
+                        TabContextMenuAnchor::VerticalTabsKebab => {
+                            // Anchor depends on which side the tabs panel is configured on.
+                            let tabs_side = Self::tabs_panel_side(
+                                &TabSettings::as_ref(app).header_toolbar_chip_selection,
+                            );
+                            let (anchor, child_anchor) = if tabs_side == PanelPosition::Left {
+                                (PositionedElementAnchor::BottomLeft, ChildAnchor::TopLeft)
+                            } else {
+                                (PositionedElementAnchor::BottomRight, ChildAnchor::TopRight)
+                            };
+                            Some(OffsetPositioning::offset_from_save_position_element(
+                                vertical_tabs::vtab_action_buttons_position_id(tab_idx),
+                                vec2f(0., 4.),
+                                PositionedElementOffsetBounds::WindowByPosition,
+                                anchor,
+                                child_anchor,
+                            ))
+                        }
+                        TabContextMenuAnchor::Pointer(position) => {
+                            Some(OffsetPositioning::offset_from_parent(
+                                position,
+                                ParentOffsetBounds::WindowByPosition,
+                                ParentAnchor::TopLeft,
+                                ChildAnchor::TopLeft,
+                            ))
+                        }
                     }
-                    (true, TabContextMenuAnchor::Pointer(position)) => {
-                        Some(OffsetPositioning::offset_from_parent(
-                            position,
-                            ParentOffsetBounds::WindowByPosition,
-                            ParentAnchor::TopLeft,
-                            ChildAnchor::TopLeft,
-                        ))
+                } else {
+                    match right_click_menu_anchor {
+                        TabContextMenuAnchor::Pointer(position) => {
+                            Some(OffsetPositioning::offset_from_parent(
+                                position,
+                                ParentOffsetBounds::Unbounded,
+                                ParentAnchor::TopLeft,
+                                ChildAnchor::TopLeft,
+                            ))
+                        }
+                        // The kebab anchor only exists in the vertical tabs panel.
+                        TabContextMenuAnchor::VerticalTabsKebab => None,
                     }
-                    (false, TabContextMenuAnchor::Pointer(position)) => {
-                        Some(OffsetPositioning::offset_from_parent(
-                            position,
-                            ParentOffsetBounds::Unbounded,
-                            ParentAnchor::TopLeft,
-                            ChildAnchor::TopLeft,
-                        ))
-                    }
-                    (false, TabContextMenuAnchor::VerticalTabsKebab) => None,
                 };
                 if let Some(positioning) = positioning {
                     stack.add_positioned_overlay_child(
@@ -26984,6 +26996,8 @@ fn render_group_member_icon_collage(
             GROUP_ICON_COLLAGE_MINI_SIZE,
             appearance,
         );
+        // Placement mapping for each icon. 
+        // (number of icons, index of icon) -> position.
         let offset = match (count, idx) {
             (3, 0) => vec2f(-diag, -diag),
             (3, 1) => vec2f(diag, -diag),

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -35,6 +35,7 @@ use warpui::ui_components::components::{UiComponent, UiComponentStyles};
 use warpui::ui_components::text_input::TextInput;
 use warpui::{AppContext, EntityId, SingletonEntity, ViewHandle, WindowId};
 
+use super::select_unique_pane_kinds;
 use crate::ai::agent::conversation::{ConversationStatus, StatusColorStyle};
 use crate::ai::agent_management::AgentNotificationsModel;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
@@ -764,7 +765,7 @@ enum VerticalTabsResolvedMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum SummaryPaneKind {
+pub(super) enum SummaryPaneKind {
     Terminal,
     OzAgent { is_ambient: bool },
     CLIAgent { agent: CLIAgent, is_ambient: bool },
@@ -998,9 +999,9 @@ fn summary_search_text_fragments(
 fn select_summary_pane_kind_icons(
     pane_kinds: impl IntoIterator<Item = (EntityId, SummaryPaneKind)>,
 ) -> Option<SummaryPaneKindIcons> {
-    let mut kinds = super::select_unique_pane_kinds(pane_kinds, 2).into_iter();
-    let primary = kinds.next()?;
-    match kinds.next() {
+    let mut unique_kinds = select_unique_pane_kinds(pane_kinds, 2).into_iter();
+    let primary = unique_kinds.next()?;
+    match unique_kinds.next() {
         Some(secondary) => Some(SummaryPaneKindIcons::Pair { primary, secondary }),
         None => Some(SummaryPaneKindIcons::Single(primary)),
     }
@@ -1012,15 +1013,8 @@ fn resolve_summary_pane_kind_icons(
     app: &AppContext,
 ) -> Option<SummaryPaneKindIcons> {
     select_summary_pane_kind_icons(visible_pane_ids.iter().filter_map(|pane_id| {
-        pane_group.pane_by_id(*pane_id).map(|pane| {
-            let pane_configuration = pane.pane_configuration();
-            let pane_configuration = pane_configuration.as_ref(app);
-            let typed = pane_group.resolve_pane_type(*pane_id, app);
-            (
-                pane_id.creation_order_id(),
-                typed.summary_pane_kind(pane_configuration.title().trim(), app),
-            )
-        })
+        let kind = pane_summary_kind(pane_group, *pane_id, app)?;
+        Some((pane_id.creation_order_id(), kind))
     }))
 }
 
@@ -3760,20 +3754,21 @@ impl PaneGroup {
 /// Summary mode. For Terminal panes, distinguishes Oz vs Oz cloud vs each
 /// known CLI agent (Claude, Codex, …) by routing through
 /// `terminal_view_agent_icon_variant`; for other pane types it falls back
-/// to `TypedPane::summary_pane_kind`.
-pub(crate) fn pane_summary_kind(
+/// to `TypedPane::summary_pane_kind`. Returns `None` when `pane_id` does
+/// not resolve to a pane in `pane_group` so callers can skip stale ids
+/// via `filter_map`; note this is distinct from a known pane that
+/// classifies as `SummaryPaneKind::Other`.
+pub(super) fn pane_summary_kind(
     pane_group: &PaneGroup,
     pane_id: PaneId,
     app: &AppContext,
-) -> SummaryPaneKind {
-    let Some(pane) = pane_group.pane_by_id(pane_id) else {
-        return SummaryPaneKind::Other;
-    };
+) -> Option<SummaryPaneKind> {
+    let pane = pane_group.pane_by_id(pane_id)?;
     let pane_configuration = pane.pane_configuration();
     let pane_configuration = pane_configuration.as_ref(app);
     let title = pane_configuration.title().trim();
     let typed = pane_group.resolve_pane_type(pane_id, app);
-    typed.summary_pane_kind(title, app)
+    Some(typed.summary_pane_kind(title, app))
 }
 
 /// Returns the best available working-directory string for a terminal pane,
@@ -4433,7 +4428,7 @@ pub(super) fn render_summary_pane_kind_icons(
 const SUMMARY_INLINE_ICON_RATIO: f32 = 2. / 3.;
 const SUMMARY_INLINE_PADDING_RATIO: f32 = (1. - SUMMARY_INLINE_ICON_RATIO) / 2.;
 
-pub(crate) fn render_summary_pane_kind_icon_circle(
+pub(super) fn render_summary_pane_kind_icon_circle(
     kind: SummaryPaneKind,
     total_size: f32,
     appearance: &Appearance,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -764,7 +764,7 @@ enum VerticalTabsResolvedMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum SummaryPaneKind {
+pub(crate) enum SummaryPaneKind {
     Terminal,
     OzAgent { is_ambient: bool },
     CLIAgent { agent: CLIAgent, is_ambient: bool },
@@ -783,7 +783,7 @@ enum SummaryPaneKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum SummaryPaneKindIcons {
+pub(super) enum SummaryPaneKindIcons {
     Single(SummaryPaneKind),
     Pair {
         primary: SummaryPaneKind,
@@ -998,26 +998,12 @@ fn summary_search_text_fragments(
 fn select_summary_pane_kind_icons(
     pane_kinds: impl IntoIterator<Item = (EntityId, SummaryPaneKind)>,
 ) -> Option<SummaryPaneKindIcons> {
-    let mut pane_kinds: Vec<(EntityId, SummaryPaneKind)> = pane_kinds.into_iter().collect();
-    pane_kinds.sort_by_key(|(creation_order_id, _)| *creation_order_id);
-
-    let mut unique_kinds = Vec::new();
-    for (_, pane_kind) in pane_kinds {
-        if !unique_kinds.contains(&pane_kind) {
-            unique_kinds.push(pane_kind);
-        }
-        if unique_kinds.len() == 2 {
-            return Some(SummaryPaneKindIcons::Pair {
-                primary: unique_kinds[0].clone(),
-                secondary: unique_kinds[1].clone(),
-            });
-        }
+    let mut kinds = super::select_unique_pane_kinds(pane_kinds, 2).into_iter();
+    let primary = kinds.next()?;
+    match kinds.next() {
+        Some(secondary) => Some(SummaryPaneKindIcons::Pair { primary, secondary }),
+        None => Some(SummaryPaneKindIcons::Single(primary)),
     }
-
-    unique_kinds
-        .first()
-        .cloned()
-        .map(SummaryPaneKindIcons::Single)
 }
 
 fn resolve_summary_pane_kind_icons(
@@ -3769,6 +3755,27 @@ impl PaneGroup {
     }
 }
 
+/// Returns the [`SummaryPaneKind`] representing how the given pane should
+/// be rendered visually, matching the treatment used by vertical tabs
+/// Summary mode. For Terminal panes, distinguishes Oz vs Oz cloud vs each
+/// known CLI agent (Claude, Codex, …) by routing through
+/// `terminal_view_agent_icon_variant`; for other pane types it falls back
+/// to `TypedPane::summary_pane_kind`.
+pub(crate) fn pane_summary_kind(
+    pane_group: &PaneGroup,
+    pane_id: PaneId,
+    app: &AppContext,
+) -> SummaryPaneKind {
+    let Some(pane) = pane_group.pane_by_id(pane_id) else {
+        return SummaryPaneKind::Other;
+    };
+    let pane_configuration = pane.pane_configuration();
+    let pane_configuration = pane_configuration.as_ref(app);
+    let title = pane_configuration.title().trim();
+    let typed = pane_group.resolve_pane_type(pane_id, app);
+    typed.summary_pane_kind(title, app)
+}
+
 /// Returns the best available working-directory string for a terminal pane,
 /// incorporating cloud environment name and setup status for ambient agent sessions.
 fn resolved_terminal_working_directory(
@@ -4029,7 +4036,7 @@ fn render_text_line(
         .finish()
 }
 
-fn render_inline_tab_rename_editor(
+pub(crate) fn render_inline_tab_rename_editor(
     rename_editor: &ViewHandle<EditorView>,
     appearance: &Appearance,
     app: &AppContext,
@@ -4136,7 +4143,7 @@ fn render_summary_tab_item(
     let main_text_color = theme.main_text_color(theme.background());
     let sub_text_color = theme.sub_text_color(theme.background());
     let icon = summary_pane_kind_icons
-        .map(|icons| render_summary_pane_kind_icons(icons, appearance))
+        .map(|icons| render_summary_pane_kind_icons(icons, VERTICAL_TABS_ICON_SIZE, appearance))
         .unwrap_or_else(|| {
             render_pane_icon_with_status(
                 resolve_icon_with_status_variant(&props.typed, &props.title, appearance, app),
@@ -4363,20 +4370,21 @@ fn render_summary_overflow_line(
     .finish()
 }
 
-fn render_summary_pane_kind_icons(
+pub(super) fn render_summary_pane_kind_icons(
     icons: SummaryPaneKindIcons,
+    total_size: f32,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
     match icons {
         SummaryPaneKindIcons::Single(kind) => {
-            render_summary_pane_kind_icon_circle(kind, VERTICAL_TABS_ICON_SIZE, appearance)
+            render_summary_pane_kind_icon_circle(kind, total_size, appearance)
         }
         SummaryPaneKindIcons::Pair { primary, secondary } => {
             // The secondary icon sits at the BR of the primary at roughly badge
             // proportions, with a small cutout ring separating it from the primary.
-            let primary_total = VERTICAL_TABS_ICON_SIZE;
-            let secondary_total = VERTICAL_TABS_ICON_SIZE * 0.5;
+            let primary_total = total_size;
+            let secondary_total = total_size * 0.5;
             let ring_padding = secondary_total * 0.1;
             let primary_icon =
                 render_summary_pane_kind_icon_circle(primary, primary_total, appearance);
@@ -4425,7 +4433,7 @@ fn render_summary_pane_kind_icons(
 const SUMMARY_INLINE_ICON_RATIO: f32 = 2. / 3.;
 const SUMMARY_INLINE_PADDING_RATIO: f32 = (1. - SUMMARY_INLINE_ICON_RATIO) / 2.;
 
-fn render_summary_pane_kind_icon_circle(
+pub(crate) fn render_summary_pane_kind_icon_circle(
     kind: SummaryPaneKind,
     total_size: f32,
     appearance: &Appearance,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1733,6 +1733,7 @@ fn render_groups(
     }
 
     // Consecutive tabs sharing a group_id collapse into a single group container.
+    // TODO(johnturcoo) adopt horizontal tabs 'tab slot' pattern to remove this while loop.
     let total_visible = visible_tabs.len();
     let mut i = 0;
     while i < total_visible {


### PR DESCRIPTION
## Description
Adds basic rendering for **horizontal tab groups** in the top tab bar, on top of the existing vertical tab grouping data model. A group renders as a single tab-bar slot containing a header (icon collage + name) followed by its member tabs.

- Click the header → collapse/expand the group (collapsed shows just the header).
- Double-click the header → rename inline.
- Right-click the header → open the group context menu (labels adapt to "left/right" for horizontal layouts, "up/down/above/below" for vertical).
- Right-click a member tab → standard tab menu, including "Remove from group".

Dragging is out of scope for this PR — neither groups nor members can be dragged yet.

All new behavior is gated behind `FeatureFlag::GroupedTabs`; when the flag is off, the horizontal tab bar renders exactly as before.

## Changes
**`workspace/view.rs`**
- Added `TabBarSlot { Single | Group }` enum and a preprocessing pass in `render_tab_bar_contents` that turns the flat tab list into a list of slots (ungrouped tabs become `Single`, contiguous same-group runs collapse into `Group`).
- Added `render_horizontal_tab_group` (container + member tabs) and `render_horizontal_tab_group_header` (icon collage + name + click/double-click/right-click handlers).
- Added `compute_group_member_kinds` — picks up to 4 distinct pane icons for a group by reusing each member tab's "Summary pair" selection, so the group icons are always a subset of what the member tabs would show in vertical Summary.
- Added `render_group_member_icon_collage` — 1 or 2 icons reuse vertical Summary's `Single`/`Pair` layout for visual parity; 3 or 4 fall back to a corner collage. Designs for reference: 
<img width="222" height="92" alt="Screenshot 2026-06-02 at 4 14 24 PM" src="https://github.com/user-attachments/assets/53a04f14-6ff9-4385-8236-878ca8630947" />
<img width="193" height="80" alt="Screenshot 2026-06-02 at 4 14 52 PM" src="https://github.com/user-attachments/assets/d0016562-10c3-4226-8828-ef16fb295511" />


- Added `select_unique_pane_kinds` — shared selection helper used by both vertical Summary (`select_summary_pane_kind_icons`) and the horizontal collage.
- Added per-group hover state map (`horizontal_tab_group_mouse_states`) on `Workspace`.
- `tab_group_menu_items` now takes `is_vertical: bool` so labels adapt to layout.

**`tab.rs`**
- `TabComponent` gained a `grouped_member` flag and `.for_grouped_member()` builder. In that mode the tab skips side dividers, paints an inset rounded highlight, and skips the `Draggable` wrapper (member dragging is a follow-up).

**`workspace/view/vertical_tabs.rs`**
- `render_summary_pane_kind_icons` and `SummaryPaneKindIcons` are now `pub(super)` and accept a `total_size` parameter so the horizontal collage can reuse them at its own sizing.
- `select_summary_pane_kind_icons` now delegates to the shared `select_unique_pane_kinds` helper.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4641/horizontal-tab-grouping-basic-rendering


## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

[Demo Video](https://www.loom.com/share/fff045cca12841bab0abd6b9764d89b9)