### PR TITLE
Add telemetry to cloud handoff settings toggles

### DIFF
--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -3642,6 +3642,13 @@ impl TypedActionView for AISettingsPageView {
                     report_if_error!(settings
                         .should_force_disable_cloud_handoff
                         .toggle_and_save_value(ctx));
+                    send_telemetry_from_ctx!(
+                        TelemetryEvent::FeaturesPageAction {
+                            action: "ToggleCloudHandoff".to_string(),
+                            value: format!("{}", !*settings.should_force_disable_cloud_handoff),
+                        },
+                        ctx
+                    );
                 });
                 ctx.notify();
             }
@@ -3650,6 +3657,13 @@ impl TypedActionView for AISettingsPageView {
                     report_if_error!(settings
                         .should_force_disable_ampersand_handoff
                         .toggle_and_save_value(ctx));
+                    send_telemetry_from_ctx!(
+                        TelemetryEvent::FeaturesPageAction {
+                            action: "ToggleAmpersandHandoff".to_string(),
+                            value: format!("{}", !*settings.should_force_disable_ampersand_handoff),
+                        },
+                        ctx
+                    );
                 });
                 ctx.notify();
             }
@@ -3658,6 +3672,13 @@ impl TypedActionView for AISettingsPageView {
                     report_if_error!(settings
                         .auto_handoff_on_sleep_enabled
                         .toggle_and_save_value(ctx));
+                    send_telemetry_from_ctx!(
+                        TelemetryEvent::FeaturesPageAction {
+                            action: "ToggleAutoHandoffOnSleep".to_string(),
+                            value: format!("{}", *settings.auto_handoff_on_sleep_enabled),
+                        },
+                        ctx
+                    );
                 });
                 ctx.notify();
             }


### PR DESCRIPTION
## Description
Port of warpdotdev/warp-internal#26149. Add `FeaturesPageAction` telemetry events to the Cloud Handoff, Ampersand Handoff, and Auto Handoff on Sleep settings toggles. When users toggle these settings, we now fire events with:
- `action`: `"ToggleCloudHandoff"`, `"ToggleAmpersandHandoff"`, or `"ToggleAutoHandoffOnSleep"`
- `value`: the user-facing enabled state

These events land in BigQuery as `featurespage.action` in `stg_terminal_events`.

## Linked Issue
N/A — instrumentation for auto-handoff rollout tracking.

## Testing
- [x] Verified `cargo check` compiles cleanly

### No new tests needed
Telemetry-only change adding `send_telemetry_from_ctx!` calls inside existing toggle handlers, following the same pattern as other AI settings toggles.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>

CHANGELOG-NONE
