### PR TITLE
Add MCP startup failure details to Oz errors

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::future::Future;
@@ -203,6 +202,14 @@ impl<T: Send + 'static> IdleTimeoutSender<T> {
     }
 }
 
+fn mcp_startup_failed_error(details: Vec<MCPStartupFailureDetail>) -> AgentDriverError {
+    let details = sorted_mcp_startup_failure_details(details);
+    AgentDriverError::MCPStartupFailed {
+        summary: format_mcp_startup_failure_details(&details),
+        details,
+    }
+}
+
 /// How to resume an existing conversation when starting an agent run.
 ///
 /// The Oz harness restores the full conversation transcript into the terminal pane and treats
@@ -355,6 +362,163 @@ pub struct Task {
     /// Which harness to use for executing the agent run.
     pub harness: HarnessKind,
 }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MCPStartupFailureDetail {
+    server_name: String,
+    reason: String,
+}
+
+impl MCPStartupFailureDetail {
+    fn new(server_name: String, reason: String) -> Self {
+        Self {
+            server_name: sanitize_mcp_server_name_for_error(&server_name),
+            reason,
+        }
+    }
+}
+
+fn sanitize_mcp_server_name_for_error(server_name: &str) -> String {
+    const MAX_SERVER_NAME_LEN: usize = 120;
+
+    let sanitized = server_name
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect::<String>();
+    let trimmed = sanitized.trim();
+    if trimmed.is_empty() {
+        return "<unknown>".to_string();
+    }
+    trimmed.chars().take(MAX_SERVER_NAME_LEN).collect()
+}
+
+struct MCPStartupWaitState {
+    pending_servers: HashMap<Uuid, String>,
+    failed_servers: Vec<MCPStartupFailureDetail>,
+}
+
+impl MCPStartupWaitState {
+    fn new(server_names: HashMap<Uuid, String>) -> Self {
+        Self {
+            pending_servers: server_names,
+            failed_servers: Vec::new(),
+        }
+    }
+
+    fn final_result(&self) -> Result<(), AgentDriverError> {
+        if self.failed_servers.is_empty() {
+            Ok(())
+        } else {
+            Err(mcp_startup_failed_error(self.failed_servers.clone()))
+        }
+    }
+
+    fn timeout_result(&self) -> AgentDriverError {
+        let mut details = self.failed_servers.clone();
+        details.extend(self.pending_servers.values().map(|server_name| {
+            MCPStartupFailureDetail::new(
+                server_name.clone(),
+                mcp_startup_timeout_reason().to_string(),
+            )
+        }));
+        mcp_startup_failed_error(details)
+    }
+}
+
+fn sorted_mcp_startup_failure_details(
+    mut details: Vec<MCPStartupFailureDetail>,
+) -> Vec<MCPStartupFailureDetail> {
+    details.sort_by(|a, b| {
+        a.server_name
+            .cmp(&b.server_name)
+            .then_with(|| a.reason.cmp(&b.reason))
+    });
+    details
+}
+
+fn format_mcp_startup_failure_details(details: &[MCPStartupFailureDetail]) -> String {
+    if details.is_empty() {
+        return "No per-server failure details were available.".to_string();
+    }
+
+    details
+        .iter()
+        .map(|detail| format!("{} ({})", detail.server_name, detail.reason))
+        .join(", ")
+}
+
+fn mcp_startup_timeout_reason() -> &'static str {
+    "startup timed out before the server completed MCP initialization"
+}
+
+fn sanitize_mcp_startup_failure_reason(
+    raw_reason: Option<&str>,
+    state: Option<MCPServerState>,
+) -> String {
+    let Some(raw_reason) = raw_reason
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty())
+    else {
+        return match state {
+            Some(MCPServerState::Starting) => mcp_startup_timeout_reason().to_string(),
+            Some(MCPServerState::FailedToStart) => {
+                "startup failed before Warp received a safe failure reason".to_string()
+            }
+            _ => "startup did not complete before Warp received a safe failure reason".to_string(),
+        };
+    };
+    let lower = raw_reason.to_lowercase();
+    match () {
+        _ if lower.contains("path required")
+            || lower.contains("path not available")
+            || lower.contains("unknown path") =>
+        {
+            "PATH was unavailable when Warp tried to launch the MCP command".to_string()
+        }
+        _ if lower.contains("no such file")
+            || lower.contains("not found")
+            || lower.contains("command not found") =>
+        {
+            "the configured MCP command could not be found in the agent environment".to_string()
+        }
+        _ if lower.contains("permission denied") => {
+            "the configured MCP command could not be executed because of file permissions"
+                .to_string()
+        }
+        _ if lower.contains("timed out") || lower.contains("timeout") => {
+            mcp_startup_timeout_reason().to_string()
+        }
+        _ if lower.contains("connection closed")
+            || lower.contains("closed unexpectedly")
+            || lower.contains("server may have crashed") =>
+        {
+            "the MCP server process exited or closed the connection during initialization"
+                .to_string()
+        }
+        _ if lower.contains("failed to establish connection")
+            || lower.contains("transport")
+            || lower.contains("connection") =>
+        {
+            "Warp could not establish the MCP transport connection".to_string()
+        }
+        _ if lower.contains("failed to initialize client")
+            || lower.contains("failed to initialize server")
+            || lower.contains("unexpected response")
+            || lower.contains("incompatible") =>
+        {
+            "MCP protocol initialization failed".to_string()
+        }
+        _ if lower.contains("server returned an error") || lower.contains("mcp error") => {
+            "the MCP server returned an error during startup".to_string()
+        }
+        _ if lower.contains("parse")
+            || lower.contains("json")
+            || lower.contains("template contains no servers") =>
+        {
+            "the MCP server JSON configuration is invalid".to_string()
+        }
+        _ => "startup failed before Warp received a safe failure reason".to_string(),
+    }
+}
 
 struct GlobalSkillResolution {
     specs: Vec<SkillSpec>,
@@ -385,8 +549,11 @@ pub enum AgentDriverError {
     InvalidRuntimeState,
     #[error("Requested MCP server not found: {0}")]
     MCPServerNotFound(uuid::Uuid),
-    #[error("Failed to start MCP servers")]
-    MCPStartupFailed,
+    #[error("Failed to start MCP servers: {summary}")]
+    MCPStartupFailed {
+        summary: String,
+        details: Vec<MCPStartupFailureDetail>,
+    },
     #[error("Failed to parse MCP server JSON: {0}")]
     MCPJsonParseError(String),
     #[error("MCP server configuration is missing required variables")]
@@ -993,41 +1160,122 @@ impl AgentDriver {
         Ok(servers_to_start)
     }
 
+    fn mcp_server_name_for_uuid(uuid: Uuid, ctx: &ModelContext<Self>) -> String {
+        TemplatableMCPServerManager::as_ref(ctx)
+            .get_installed_server(&uuid)
+            .map(|installation| installation.templatable_mcp_server().name.clone())
+            .or_else(|| {
+                FileBasedMCPManager::as_ref(ctx)
+                    .get_installation_by_uuid(uuid)
+                    .map(|installation| installation.templatable_mcp_server().name.clone())
+            })
+            .unwrap_or_else(|| uuid.to_string())
+    }
+
+    fn mcp_startup_failure_detail(
+        uuid: Uuid,
+        server_name: String,
+        ctx: &ModelContext<Self>,
+    ) -> MCPStartupFailureDetail {
+        let manager = TemplatableMCPServerManager::as_ref(ctx);
+        let reason = sanitize_mcp_startup_failure_reason(
+            manager.get_server_error_message(uuid),
+            manager.get_server_state(uuid),
+        );
+        MCPStartupFailureDetail::new(server_name, reason)
+    }
+
+    fn mcp_startup_timeout_result(
+        wait_state: &Arc<Mutex<MCPStartupWaitState>>,
+    ) -> AgentDriverError {
+        if let Ok(state) = wait_state.lock() {
+            state.timeout_result()
+        } else {
+            AgentDriverError::MCPStartupFailed {
+                summary: "No per-server failure details were available.".to_string(),
+                details: Vec::new(),
+            }
+        }
+    }
+
+    fn mcp_startup_final_result(
+        wait_state: &Arc<Mutex<MCPStartupWaitState>>,
+    ) -> Result<(), AgentDriverError> {
+        if let Ok(state) = wait_state.lock() {
+            state.final_result()
+        } else {
+            Err(AgentDriverError::InvalidRuntimeState)
+        }
+    }
+
+    fn mcp_server_names_for_uuids(
+        uuids: &HashSet<Uuid>,
+        ctx: &ModelContext<Self>,
+    ) -> HashMap<Uuid, String> {
+        uuids
+            .iter()
+            .map(|uuid| (*uuid, Self::mcp_server_name_for_uuid(*uuid, ctx)))
+            .collect()
+    }
+
     fn subscribe_to_mcp_managers(
         &self,
         tx: Sender<Result<(), AgentDriverError>>,
-        servers_to_start: HashSet<Uuid>,
+        wait_state: Arc<Mutex<MCPStartupWaitState>>,
         ctx: &mut ModelContext<Self>,
     ) {
-        use std::rc::Rc;
-
         let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
-        let mcp_to_start = Rc::new(RefCell::new(servers_to_start));
         let manager_clone = templatable_mcp_manager.clone();
         let mut tx = Some(tx);
         ctx.subscribe_to_model(
             &templatable_mcp_manager,
             move |_me, event, ctx| match event {
                 TemplatableMCPServerManagerEvent::StateChanged { uuid, state } => {
-                    let mut pending_ids = mcp_to_start.borrow_mut();
-                    if !pending_ids.contains(uuid) {
+                    let server_name = wait_state
+                        .lock()
+                        .ok()
+                        .and_then(|state| state.pending_servers.get(uuid).cloned());
+                    let Some(server_name) = server_name else {
                         return;
-                    }
+                    };
                     match state {
                         MCPServerState::Running => {
-                            pending_ids.remove(uuid);
-                            if pending_ids.is_empty() {
-                                log::info!("All MCP servers started");
+                            let pending_empty = wait_state
+                                .lock()
+                                .map(|mut state| {
+                                    state.pending_servers.remove(uuid);
+                                    state.pending_servers.is_empty()
+                                })
+                                .unwrap_or(false);
+                            if pending_empty {
+                                let result = Self::mcp_startup_final_result(&wait_state);
+                                if result.is_ok() {
+                                    log::info!("All MCP servers started");
+                                } else {
+                                    log::warn!("One or more MCP servers failed to start");
+                                }
                                 if let Some(sender) = tx.take() {
-                                    let _ = sender.send(Ok(()));
+                                    let _ = sender.send(result);
                                 }
                                 ctx.unsubscribe_from_model(&manager_clone);
                             }
                         }
                         MCPServerState::FailedToStart => {
                             log::warn!("Failed to start MCP server {uuid}");
+                            let detail = Self::mcp_startup_failure_detail(*uuid, server_name, ctx);
+                            let pending_empty = wait_state
+                                .lock()
+                                .map(|mut state| {
+                                    state.pending_servers.remove(uuid);
+                                    state.failed_servers.push(detail);
+                                    state.pending_servers.is_empty()
+                                })
+                                .unwrap_or(false);
+                            if !pending_empty {
+                                return;
+                            }
                             if let Some(sender) = tx.take() {
-                                let _ = sender.send(Err(AgentDriverError::MCPStartupFailed));
+                                let _ = sender.send(Self::mcp_startup_final_result(&wait_state));
                             }
                             ctx.unsubscribe_from_model(&manager_clone);
                         }
@@ -1075,7 +1323,10 @@ impl AgentDriver {
 
         log::info!("Starting {} MCP servers...", servers_to_start.len());
 
-        self.subscribe_to_mcp_managers(tx, servers_to_start.clone(), ctx);
+        let server_names = Self::mcp_server_names_for_uuids(&servers_to_start, ctx);
+        let wait_state = Arc::new(Mutex::new(MCPStartupWaitState::new(server_names)));
+
+        self.subscribe_to_mcp_managers(tx, Arc::clone(&wait_state), ctx);
 
         self.spawn_inactive_servers(servers_to_start, ctx);
 
@@ -1088,7 +1339,7 @@ impl AgentDriver {
                 }
                 Err(TimeoutError) => {
                     log::error!("Timed out waiting for MCP servers to start");
-                    Err(AgentDriverError::MCPStartupFailed)
+                    Err(Self::mcp_startup_timeout_result(&wait_state))
                 }
             }
         })
@@ -1111,44 +1362,23 @@ impl AgentDriver {
         }
 
         let (tx, rx) = oneshot::channel();
-        let mut tx = Some(tx);
-        let mut uuids_to_start: HashSet<Uuid> = installations.iter().map(|i| i.uuid()).collect();
+        let server_names: HashMap<Uuid, String> = installations
+            .iter()
+            .map(|installation| {
+                (
+                    installation.uuid(),
+                    installation.templatable_mcp_server().name.clone(),
+                )
+            })
+            .collect();
+        let wait_state = Arc::new(Mutex::new(MCPStartupWaitState::new(server_names)));
 
         log::info!("Starting {} ephemeral MCP servers...", installations.len());
 
-        // Subscribe to state changes for these ephemeral servers.
-        let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
-        let manager_clone = templatable_mcp_manager.clone();
-
-        ctx.subscribe_to_model(&templatable_mcp_manager, move |_me, event, ctx| {
-            if let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event {
-                if !uuids_to_start.contains(uuid) {
-                    return;
-                }
-                match state {
-                    MCPServerState::Running => {
-                        uuids_to_start.remove(uuid);
-                        if uuids_to_start.is_empty() {
-                            log::info!("All ephemeral MCP servers started");
-                            if let Some(sender) = tx.take() {
-                                let _ = sender.send(Ok(()));
-                            }
-                            ctx.unsubscribe_from_model(&manager_clone);
-                        }
-                    }
-                    MCPServerState::FailedToStart => {
-                        log::warn!("Failed to start ephemeral MCP server {uuid}");
-                        if let Some(sender) = tx.take() {
-                            let _ = sender.send(Err(AgentDriverError::MCPStartupFailed));
-                        }
-                        ctx.unsubscribe_from_model(&manager_clone);
-                    }
-                    _ => {}
-                }
-            }
-        });
+        self.subscribe_to_mcp_managers(tx, Arc::clone(&wait_state), ctx);
 
         // Spawn the ephemeral servers.
+        let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
         templatable_mcp_manager.update(ctx, move |manager, ctx| {
             for installation in installations {
                 manager.spawn_cli_ephemeral_server(installation, ctx);
@@ -1164,7 +1394,7 @@ impl AgentDriver {
                 }
                 Err(TimeoutError) => {
                     log::error!("Timed out waiting for ephemeral MCP servers to start");
-                    Err(AgentDriverError::MCPStartupFailed)
+                    Err(Self::mcp_startup_timeout_result(&wait_state))
                 }
             }
         })

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -1,7 +1,7 @@
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::terminal::ShareSessionError;
-use super::AgentDriverError;
+use super::{format_mcp_startup_failure_details, AgentDriverError};
 use crate::ai::blocklist::local_agent_task_sync_model::classify_renderable_error;
 use crate::server::server_api::ai::TaskStatusUpdate;
 
@@ -100,10 +100,15 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
-        AgentDriverError::MCPStartupFailed => (
+        AgentDriverError::MCPStartupFailed { details, .. } => (
             AgentTaskState::Failed,
             TaskStatusUpdate::with_error_code(
-                "One or more MCP servers failed to start. Check that your MCP server configuration is valid and the server process is runnable.",
+                format!(
+                    "One or more MCP servers failed to start. Failed servers: {}. \
+                     MCP logs are not included because they may contain sensitive data. \
+                     Check the named server configuration, command/URL, required environment variables or secrets, and whether the command is available in the cloud agent environment.",
+                    format_mcp_startup_failure_details(details)
+                ),
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -2,7 +2,7 @@ use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::classify_driver_error;
 use crate::ai::agent_sdk::driver::terminal::ShareSessionError;
-use crate::ai::agent_sdk::driver::AgentDriverError;
+use crate::ai::agent_sdk::driver::{AgentDriverError, MCPStartupFailureDetail};
 
 fn assert_state_and_code(
     error: AgentDriverError,
@@ -70,6 +70,40 @@ fn mcp_server_not_found_is_failed_with_env_setup() {
         AgentTaskState::Failed,
         Some(PlatformErrorCode::EnvironmentSetupFailed),
     );
+}
+#[test]
+fn mcp_startup_failed_includes_safe_server_details() {
+    let error = AgentDriverError::MCPStartupFailed {
+        summary: "github (the configured MCP command could not be found in the agent environment), notion (startup timed out before the server completed MCP initialization)".to_string(),
+        details: vec![
+            MCPStartupFailureDetail::new(
+                "github".to_string(),
+                "the configured MCP command could not be found in the agent environment"
+                    .to_string(),
+            ),
+            MCPStartupFailureDetail::new(
+                "notion".to_string(),
+                "startup timed out before the server completed MCP initialization".to_string(),
+            ),
+        ],
+    };
+    let display_message = error.to_string();
+    assert!(display_message.contains("github"));
+    assert!(display_message.contains("notion"));
+    assert!(display_message.contains("command could not be found"));
+
+    let (state, update) = classify_driver_error(&error);
+
+    assert_eq!(state, AgentTaskState::Failed);
+    assert_eq!(
+        update.error_code,
+        Some(PlatformErrorCode::EnvironmentSetupFailed)
+    );
+    assert!(update.message.contains("github"));
+    assert!(update.message.contains("notion"));
+    assert!(update.message.contains("command could not be found"));
+    assert!(update.message.contains("timed out"));
+    assert!(update.message.contains("MCP logs are not included"));
 }
 
 #[test]

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -675,6 +675,10 @@ impl TemplatableMCPServerManager {
             log::error!(
                 "No templatable MCP installation found for installation_uuid {installation_uuid}; cannot resolve template variables"
             );
+            self.server_error_messages.insert(
+                installation_uuid,
+                "MCP server installation could not be found".to_string(),
+            );
 
             self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
             return;
@@ -713,6 +717,10 @@ impl TemplatableMCPServerManager {
                     log::error!(
                         "Templatable MCP server template contains no servers: {template_uuid}",
                     );
+                    self.server_error_messages.insert(
+                        installation_uuid,
+                        "MCP server JSON configuration did not contain any servers".to_string(),
+                    );
                     self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
                     if mode.is_reconnect() {
                         self.notify_reconnect_waiters(
@@ -726,6 +734,10 @@ impl TemplatableMCPServerManager {
             Err(err) => {
                 log::error!(
                     "Failed to parse resolved MCP server JSON for '{template_uuid}': {err:#}",
+                );
+                self.server_error_messages.insert(
+                    installation_uuid,
+                    "MCP server JSON configuration could not be parsed".to_string(),
                 );
                 self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
                 if mode.is_reconnect() {
@@ -747,6 +759,10 @@ impl TemplatableMCPServerManager {
                 // without ever having had a successfully bootstrapped session, which
                 // should basically never happen.
                 log::warn!("Unknown PATH when trying to launch MCP command.");
+                self.server_error_messages.insert(
+                    installation_uuid,
+                    "PATH was unavailable when trying to launch the MCP command".to_string(),
+                );
 
                 self.change_server_state(installation_uuid, MCPServerState::FailedToStart, ctx);
 


### PR DESCRIPTION
## Description
Adds safe, actionable MCP startup details to Oz/cloud-agent task errors. When requested or profile MCP servers fail to start, the agent driver now accumulates failed/timed-out server names and sanitized reason categories instead of reporting only a generic MCP startup failure.

The reported task error intentionally does not include MCP logs or raw process output, but it does include guidance to check the named server configuration, command/URL, required env vars/secrets, and whether the command exists in the cloud agent environment.

## Linked Issue
Slack request: MCP server startup failures in cloud agent runs should include more actionable info without leaking sensitive logs.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp mcp_startup_failed_includes_safe_server_details`
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp ai::agent_sdk::driver::error_classification::tests`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not applicable; this is cloud-agent error reporting behavior without a local UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: MCP startup failures in cloud agent runs now show failed server names and safe, actionable reasons without including sensitive MCP logs.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/93f382d7-d946-4c83-9db9-83ca659f2933_
_Run: https://oz.staging.warp.dev/runs/019e8a3b-ba1f-7802-936f-4d2ba28b81e3_
_This PR was generated with [Oz](https://warp.dev/oz)._
