### PR TITLE
Fix logic error causing unnecessary repeated SVG rasterization.

### DIFF
--- a/crates/warpui_core/src/image_cache.rs
+++ b/crates/warpui_core/src/image_cache.rs
@@ -793,12 +793,13 @@ impl FitTo {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct RenderedImageCacheKey {
     bounds: Vector2I,
+    fit_type: FitType,
     animated_image_behavior: AnimatedImageBehavior,
 }
 
 #[derive(Default)]
 pub struct ImageCache {
-    /// Map of images of any ImageType already scaled to a certain size.
+    /// Map of rendered images of any ImageType already materialized for a certain size and fit.
     /// Uses the hashed AssetSource and rendered-image properties as a key.
     images: RwLock<HashMap<u64, HashMap<RenderedImageCacheKey, Rc<Image>>>>,
 }
@@ -818,16 +819,16 @@ impl ImageCache {
         cache.remove(&cache_key);
     }
 
-    /// Removes a single cached size entry for an asset.
+    /// Removes a single cached rendered entry for an asset.
     ///
     /// When the removed `Rc<Image>` is the last strong holder of the inner
     /// `Arc<StaticImage>`, that `Arc`'s strong count drops to zero. On the
     /// next call to `TextureCache::end_frame()`, the corresponding GPU texture
     /// will be evicted automatically via the `Weak<StaticImage>` it holds.
     ///
-    /// `bounds` must match the resolved bounds used as the cache key inside
-    /// `image()` (i.e., after any `max_dimension` adjustment), not the
-    /// originally requested bounds.
+    /// `bounds` and `fit_type` must match the resolved values used as the
+    /// cache key inside `image()` (i.e., after any `max_dimension`
+    /// adjustment), not only the originally requested bounds.
     // Called by the debounce eviction pass added in the main changeset.
     /// TODO(APP-3877): remove `#[allow(dead_code)]` once the debounce eviction pass wires this up.
     #[allow(dead_code)]
@@ -835,6 +836,7 @@ impl ImageCache {
         &self,
         asset_source: &AssetSource,
         bounds: Vector2I,
+        fit_type: FitType,
         animated_image_behavior: AnimatedImageBehavior,
     ) {
         let mut s = DefaultHasher::new();
@@ -843,6 +845,7 @@ impl ImageCache {
 
         let rendered_key = RenderedImageCacheKey {
             bounds,
+            fit_type,
             animated_image_behavior,
         };
 
@@ -870,16 +873,15 @@ impl ImageCache {
         asset_source.hash(&mut s);
         let cache_key = s.finish();
 
-        match asset_cache.load_asset::<ImageType>(asset_source) {
+        match asset_cache.load_asset::<ImageType>(asset_source.clone()) {
             AssetState::Loading { handle } => AssetState::Loading { handle },
             AssetState::Evicted => AssetState::Evicted,
             AssetState::FailedToLoad(err) => AssetState::FailedToLoad(err),
             AssetState::Loaded { data } => {
                 let (mut needs_resize, mut bounds) = match cache_option {
                     CacheOption::BySize => {
-                        // Only store a resized copy of the source asset if a
-                        // specific size was requested and it doesn't match the
-                        // source asset's size.
+                        // Only resize the source asset if a specific size was requested and it
+                        // does not match the source asset's size.
                         let needs_resize = data.image_size() != Some(bounds);
                         (needs_resize, bounds)
                     }
@@ -919,19 +921,32 @@ impl ImageCache {
 
                 let rendered_image_cache_key = RenderedImageCacheKey {
                     bounds,
+                    fit_type,
                     animated_image_behavior,
                 };
+                // SVG sources always have to be rasterized, even when rendered at their
+                // intrinsic size. Cache those materialized pixels alongside resized images.
+                let should_cache_rendered_image =
+                    needs_resize || matches!(data.as_ref(), ImageType::Svg { .. });
 
-                // If it's already in the image cache at the target size,
-                // return it.
-                let cache = self.images.upgradable_read();
-                if let Some(inner_map) = cache.get(&cache_key) {
-                    if let Some(image) = inner_map.get(&rendered_image_cache_key) {
-                        return AssetState::Loaded {
-                            data: image.clone(),
-                        };
+                // If it is already in the image cache at the target size and fit, return it.
+                let cache = if should_cache_rendered_image {
+                    let cache = self.images.upgradable_read();
+                    if let Some(inner_map) = cache.get(&cache_key) {
+                        if let Some(image) = inner_map.get(&rendered_image_cache_key) {
+                            return AssetState::Loaded {
+                                data: image.clone(),
+                            };
+                        }
                     }
-                }
+
+                    log::info!(
+                        "converting image to bitmap with size {bounds:?} from source: {asset_source:?}"
+                    );
+                    Some(cache)
+                } else {
+                    None
+                };
 
                 // Otherwise, create the correctly-sized image struct and
                 // insert it into the cache (if necessary).
@@ -940,7 +955,7 @@ impl ImageCache {
                         Ok(image) => Rc::new(image),
                         Err(err) => return AssetState::FailedToLoad(Rc::new(err)),
                     };
-                if needs_resize {
+                if let Some(cache) = cache {
                     let mut images_cache = RwLockUpgradableReadGuard::upgrade(cache);
                     images_cache
                         .entry(cache_key)

--- a/crates/warpui_core/src/image_cache.rs
+++ b/crates/warpui_core/src/image_cache.rs
@@ -939,10 +939,6 @@ impl ImageCache {
                             };
                         }
                     }
-
-                    log::info!(
-                        "converting image to bitmap with size {bounds:?} from source: {asset_source:?}"
-                    );
                     Some(cache)
                 } else {
                     None

--- a/crates/warpui_core/src/image_cache_tests.rs
+++ b/crates/warpui_core/src/image_cache_tests.rs
@@ -16,6 +16,12 @@ impl AssetProvider for Assets {
     fn get(&self, path: &str) -> Result<Cow<'_, [u8]>> {
         match path {
             "animated.webp" => Ok(Cow::Borrowed(include_bytes!("../test_data/animated.webp"))),
+            "cache-test.svg" => Ok(Cow::Borrowed(
+                br##"<svg width="20" height="10" viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg"><rect width="20" height="10" fill="#ffffff"/></svg>"##,
+            )),
+            "fit-test.rgba" => Ok(Cow::Borrowed(
+                b"warp-img:rgba:4:2:\xff\x00\x00\xff\xff\x00\x00\xff\x00\x00\xff\xff\x00\x00\xff\xff\x00\xff\x00\xff\x00\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+            )),
             "numbers-1000ms.gif" => Ok(Cow::Borrowed(include_bytes!(
                 "../../warpui/examples/assets/numbers-1000ms.gif"
             ))),
@@ -133,6 +139,66 @@ fn test_passes_through_asset_cache_original_when_target_size_matches_source_size
     // in the asset cache point to the same underlying data (i.e.: there were
     // no copies made).
     assert!(image_asset_weak.ptr_eq(&Arc::downgrade(image)));
+}
+
+#[test]
+fn test_caches_svg_rendered_at_intrinsic_size() {
+    let asset_cache = new_asset_cache();
+    let image_cache = ImageCache::new();
+    let bounds = Vector2I::new(20, 10);
+
+    let image = load_bundled_image(
+        &image_cache,
+        &asset_cache,
+        "cache-test.svg",
+        bounds,
+        FitType::Contain,
+        AnimatedImageBehavior::FullAnimation,
+    );
+    let image_again = load_bundled_image(
+        &image_cache,
+        &asset_cache,
+        "cache-test.svg",
+        bounds,
+        FitType::Contain,
+        AnimatedImageBehavior::FullAnimation,
+    );
+
+    assert!(Rc::ptr_eq(&image, &image_again));
+}
+
+#[test]
+fn test_different_fit_types_do_not_collide_in_rendered_image_cache() {
+    let asset_cache = new_asset_cache();
+    let image_cache = ImageCache::new();
+    let bounds = Vector2I::new(8, 8);
+
+    let cover = load_bundled_image(
+        &image_cache,
+        &asset_cache,
+        "fit-test.rgba",
+        bounds,
+        FitType::Cover,
+        AnimatedImageBehavior::FullAnimation,
+    );
+    let stretch = load_bundled_image(
+        &image_cache,
+        &asset_cache,
+        "fit-test.rgba",
+        bounds,
+        FitType::Stretch,
+        AnimatedImageBehavior::FullAnimation,
+    );
+    assert!(!Rc::ptr_eq(&cover, &stretch));
+    let Image::Static(cover) = cover.as_ref() else {
+        panic!("Expected static image but got animated image!");
+    };
+    let Image::Static(stretch) = stretch.as_ref() else {
+        panic!("Expected static image but got animated image!");
+    };
+    assert_eq!(cover.img.dimensions(), (8, 8));
+    assert_eq!(stretch.img.dimensions(), (8, 8));
+    assert_ne!(cover.rgba_bytes(), stretch.rgba_bytes());
 }
 
 #[test]
@@ -531,7 +597,12 @@ fn test_evict_size_drops_arc_only_for_targeted_entry() {
     assert_eq!(weak_large.strong_count(), 1);
 
     // Evict only the small size entry.
-    image_cache.evict_size(&source, small_bounds, AnimatedImageBehavior::FullAnimation);
+    image_cache.evict_size(
+        &source,
+        small_bounds,
+        FitType::Cover,
+        AnimatedImageBehavior::FullAnimation,
+    );
 
     assert_eq!(
         weak_small.strong_count(),


### PR DESCRIPTION
## Description
Fixes an `ImageCache` hole that caused SVGs rendered at their intrinsic size to be rasterized again on every frame instead of reusing a cached rendered image. This also makes rendered-cache identity include fit behavior, because different fit modes can produce different pixels at the same final dimensions.

Adds regression coverage for intrinsic-size SVG reuse and for distinct same-size bitmap results produced by different fit modes.

## Linked Issue
No linked issue.

## Testing
- [x] `./script/run` — verified SVG conversion logging occurred during initial materialization rather than repeating across subsequent rendered frames; the temporary diagnostic log was removed before submitting.
- [x] `./script/format`
- [x] `cargo check -p warpui_core`
- [x] `cargo nextest run -p warpui_core -E 'test(test_caches_svg_rendered_at_intrinsic_size) | test(test_different_fit_types_do_not_collide_in_rendered_image_cache) | test(test_evict_size_drops_arc_only_for_targeted_entry)'`

### Screenshots / Videos
Not applicable; this fixes internal rendering-cache behavior without changing the UI.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
