### PR TITLE
Fix queued prompt paper cuts

### DIFF
--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -414,7 +414,6 @@ pub static QUEUE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     icon_path: "bundled/svg/clock-plus.svg",
     availability: Availability::AGENT_VIEW
         | Availability::ACTIVE_CONVERSATION
-        | Availability::NO_LRC_CONTROL
         | Availability::AI_ENABLED
         | Availability::NOT_CLOUD_AGENT,
     auto_enter_ai_mode: true,

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3486,7 +3486,7 @@ impl Input {
             BlocklistAIStatusBar::new(
                 ai_controller.clone(),
                 agent_view_controller.clone(),
-                cli_subagent_controller,
+                cli_subagent_controller.clone(),
                 ai_action_model.clone(),
                 ai_context_model.clone(),
                 ai_input_model.clone(),
@@ -3505,8 +3505,14 @@ impl Input {
         });
 
         let queued_prompts_panel = FeatureFlag::QueueSlashCommand.is_enabled().then(|| {
+            let cli_subagent_controller = cli_subagent_controller.clone();
             let panel = ctx.add_typed_action_view(|ctx| {
-                QueuedPromptsPanelView::new(terminal_view_id, suggestions_mode_model.clone(), ctx)
+                QueuedPromptsPanelView::new(
+                    terminal_view_id,
+                    suggestions_mode_model.clone(),
+                    cli_subagent_controller,
+                    ctx,
+                )
             });
             ctx.subscribe_to_view(&panel, |me, _, event, ctx| {
                 me.handle_queued_prompts_panel_event(event, ctx);
@@ -3686,10 +3692,7 @@ impl Input {
                 self.submit_queued_prompt_for_active_pane(text.clone(), ctx);
                 self.focus_input_box(ctx);
             }
-            QueuedPromptsPanelEvent::RowDeleted { text } => {
-                if self.buffer_text(ctx).is_empty() {
-                    self.replace_buffer_content(text, ctx);
-                }
+            QueuedPromptsPanelEvent::RowDeleted => {
                 self.focus_input_box(ctx);
             }
             QueuedPromptsPanelEvent::EditEnded => {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1063,9 +1063,12 @@ impl Input {
                 let history = BlocklistAIHistoryModel::handle(ctx);
                 // An empty conversation defaults to `InProgress` even though nothing is
                 // running, so exclude it here to auto-send rather than queue.
-                let should_queue = history.as_ref(ctx).conversation(&conversation_id).is_some_and(
-                    |c| !c.is_empty() && (c.status().is_in_progress() || c.status().is_blocked()),
-                );
+                let should_queue = history
+                    .as_ref(ctx)
+                    .conversation(&conversation_id)
+                    .is_some_and(|c| {
+                        !c.is_empty() && (c.status().is_in_progress() || c.status().is_blocked())
+                    });
 
                 if should_queue {
                     QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1061,12 +1061,13 @@ impl Input {
                 };
 
                 let history = BlocklistAIHistoryModel::handle(ctx);
-                let is_in_progress = history
-                    .as_ref(ctx)
-                    .conversation(&conversation_id)
-                    .is_some_and(|c| c.status().is_in_progress() || c.status().is_blocked());
+                // An empty conversation defaults to `InProgress` even though nothing is
+                // running, so exclude it here to auto-send rather than queue.
+                let should_queue = history.as_ref(ctx).conversation(&conversation_id).is_some_and(
+                    |c| !c.is_empty() && (c.status().is_in_progress() || c.status().is_blocked()),
+                );
 
-                if is_in_progress {
+                if should_queue {
                     QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
                         model.append(
                             conversation_id,

--- a/app/src/terminal/view/queued_prompts_panel.rs
+++ b/app/src/terminal/view/queued_prompts_panel.rs
@@ -30,6 +30,7 @@ use warpui::{
 };
 
 use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::blocklist::block::cli_controller::{CLISubagentController, CLISubagentEvent};
 use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, QueuedQueryEvent, QueuedQueryId,
     QueuedQueryModel, QueuedQueryOrigin,
@@ -50,6 +51,7 @@ const MAX_PROMPT_LINES: f32 = 5.;
 const INITIAL_CLOUD_MODE_PROMPT_TOOLTIP: &str = "The first cloud-mode prompt cannot be changed.";
 const SEND_NOW_DURING_CLOUD_SETUP_TOOLTIP: &str =
     "Prompts cannot be sent until environment setup is complete.";
+const SEND_NOW_TO_FULL_TERMINAL_USE_AGENT_TOOLTIP: &str = "Send to full terminal use agent";
 
 /// Returns the position-cache id used to look up a row's bounding rect during a drag.
 /// Indexed by the row's current visual index so swaps maintain stable lookups.
@@ -154,6 +156,9 @@ pub struct QueuedPromptsPanelView {
     row_states: HashMap<QueuedQueryId, QueuedPromptRowState>,
     dragging_query_id: Option<QueuedQueryId>,
     drag_start_index: Option<usize>,
+    /// Controller for the active long-running-command subagent (the "full terminal use agent").
+    /// Used to retarget the send-now tooltip while that subagent is in control.
+    cli_subagent_controller: ModelHandle<CLISubagentController>,
 }
 
 #[derive(Clone, Debug)]
@@ -172,9 +177,8 @@ pub enum QueuedPromptsPanelAction {
 pub enum QueuedPromptsPanelEvent {
     /// A row was removed via its send-now button. The host should immediately submit `text`.
     SendNow { text: String },
-    /// A row was deleted via the trash button. The host should place `text` into the input editor
-    /// when the editor is empty, and focus the input.
-    RowDeleted { text: String },
+    /// A row was deleted via the trash button. The host should refocus the input.
+    RowDeleted,
     /// An inline edit was committed or cancelled. The host should refocus the input.
     EditEnded,
 }
@@ -187,6 +191,7 @@ impl QueuedPromptsPanelView {
     pub fn new(
         terminal_view_id: EntityId,
         suggestions_mode_model: ModelHandle<InputSuggestionsModeModel>,
+        cli_subagent_controller: ModelHandle<CLISubagentController>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let edit_editor = build_edit_editor(ctx);
@@ -208,6 +213,10 @@ impl QueuedPromptsPanelView {
             me.handle_queued_query_event(event, ctx);
         });
 
+        ctx.subscribe_to_model(&cli_subagent_controller, |me, _, event, ctx| {
+            me.handle_cli_subagent_event(event, ctx);
+        });
+
         let mut me = Self {
             view_id: ctx.view_id(),
             terminal_view_id,
@@ -221,6 +230,7 @@ impl QueuedPromptsPanelView {
             row_states: HashMap::new(),
             dragging_query_id: None,
             drag_start_index: None,
+            cli_subagent_controller,
         };
         if let Some(conv_id) = active_conversation_id {
             me.seed_row_states_for(conv_id, ctx);
@@ -253,7 +263,9 @@ impl QueuedPromptsPanelView {
     /// Updates each row's "send now" button: disabled, with a tooltip explaining the wait, for the
     /// locked initial cloud-mode prompt and for every row while that locked row sits at the head of
     /// the queue — i.e. while the cloud environment is still setting up, with no live agent yet to
-    /// receive an immediate submission. Otherwise it is enabled with the default "Send now" tooltip.
+    /// receive an immediate submission. When a long-running-command subagent (the "full terminal
+    /// use agent") is in control, the enabled tooltip explains that send-now targets that subagent.
+    /// Otherwise it is enabled with the default "Send now" tooltip.
     fn update_send_now_availability(&mut self, ctx: &mut ViewContext<Self>) {
         let Some(conv_id) = self.active_conversation_id else {
             return;
@@ -267,6 +279,10 @@ impl QueuedPromptsPanelView {
         let cloud_setup_in_progress = rows
             .first()
             .is_some_and(|(_, origin)| *origin == QueuedQueryOrigin::InitialCloudMode);
+        let lrc_subagent_in_progress = self
+            .cli_subagent_controller
+            .as_ref(ctx)
+            .is_agent_in_control();
         for (query_id, origin) in &rows {
             let Some(send_now_button) = self
                 .row_states
@@ -279,6 +295,8 @@ impl QueuedPromptsPanelView {
                 *origin == QueuedQueryOrigin::InitialCloudMode || cloud_setup_in_progress;
             let tooltip = if disabled {
                 SEND_NOW_DURING_CLOUD_SETUP_TOOLTIP
+            } else if lrc_subagent_in_progress {
+                SEND_NOW_TO_FULL_TERMINAL_USE_AGENT_TOOLTIP
             } else {
                 "Send now"
             };
@@ -286,6 +304,21 @@ impl QueuedPromptsPanelView {
                 button.set_disabled(disabled, ctx);
                 button.set_tooltip(Some(tooltip), ctx);
             });
+        }
+    }
+
+    /// Recomputes send-now availability when the long-running-command subagent's control state
+    /// changes, so the send-now tooltip stays in sync with whether the full terminal use agent
+    /// is currently in control.
+    fn handle_cli_subagent_event(&mut self, event: &CLISubagentEvent, ctx: &mut ViewContext<Self>) {
+        match event {
+            CLISubagentEvent::SpawnedSubagent { .. }
+            | CLISubagentEvent::FinishedSubagent { .. }
+            | CLISubagentEvent::UpdatedControl { .. }
+            | CLISubagentEvent::ControlHandedBackAfterTransfer => {
+                self.update_send_now_availability(ctx);
+            }
+            CLISubagentEvent::UpdatedLastSnapshot | CLISubagentEvent::ToggledHideResponses => {}
         }
     }
 
@@ -368,7 +401,6 @@ impl QueuedPromptsPanelView {
                 self.edit_editor_is_single_logical_line = !initial_text.contains('\n');
                 self.edit_editor.update(ctx, |editor, ctx| {
                     editor.system_reset_buffer_text(&initial_text, ctx);
-                    editor.select_all(ctx);
                 });
                 ctx.focus(&self.edit_editor);
             }
@@ -561,9 +593,7 @@ impl TypedActionView for QueuedPromptsPanelView {
                         },
                         ctx
                     );
-                    ctx.emit(QueuedPromptsPanelEvent::RowDeleted {
-                        text: removed.text().to_owned(),
-                    });
+                    ctx.emit(QueuedPromptsPanelEvent::RowDeleted);
                 }
             }
             QueuedPromptsPanelAction::StartDrag(query_id) => {

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -772,9 +772,16 @@ fn send_now_action_removes_row_and_emits_send_now_event() {
             let input = terminal.read(&app, |view, _| view.input.clone());
             input.read(&app, |input, _| input.suggestions_mode_model().clone())
         };
+        let cli_subagent_controller =
+            terminal.read(&app, |view, _| view.cli_subagent_controller.clone());
         let panel = terminal.update(&mut app, |_, ctx| {
             ctx.add_view(move |ctx| {
-                QueuedPromptsPanelView::new(terminal_view_id, suggestions_mode_model, ctx)
+                QueuedPromptsPanelView::new(
+                    terminal_view_id,
+                    suggestions_mode_model,
+                    cli_subagent_controller,
+                    ctx,
+                )
             })
         });
 
@@ -826,9 +833,16 @@ fn send_now_disabled_for_all_rows_while_initial_cloud_mode_row_is_present() {
             let input = terminal.read(&app, |view, _| view.input.clone());
             input.read(&app, |input, _| input.suggestions_mode_model().clone())
         };
+        let cli_subagent_controller =
+            terminal.read(&app, |view, _| view.cli_subagent_controller.clone());
         let panel = terminal.update(&mut app, |_, ctx| {
             ctx.add_view(move |ctx| {
-                QueuedPromptsPanelView::new(terminal_view_id, suggestions_mode_model, ctx)
+                QueuedPromptsPanelView::new(
+                    terminal_view_id,
+                    suggestions_mode_model,
+                    cli_subagent_controller,
+                    ctx,
+                )
             })
         });
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There were a few small issues w/ queued prompts that I bundled into this PR (from the bug bash). The issues that are fixed here were:
* /queue would queue a prompt if you ran it in an empty conversation. It should just auto-send the prompt, as the conversation is not in progress
* /queue (specifically the slash command, not the queue mode) didn't work during an LRC. This was because the slash command was not allowed in LRCs, but it should be
* deleting a queued prompt would re-insert it into your input. This was intentional before the send-now button, but is not not necessary
* all of the text in the queued prompt was auto-highlighted when you started editing the prompt. Again, this was intentional (following prior art from the vertical tabs), but doesn't make as much sense for regular prompt editing (where you're less likely to be deleting the entire prompt)
* The "send now" button should make it clear that, durring an LRC, the prompt will be sent to the sub-agent. The copy now reads "Send to full terminal use agent" while an LRC is in-progress.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/560c3dcabda246caa5bba8312747af90

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode