### PR TITLE
Don't steal focus while navigating an AI block's code diff

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8209,15 +8209,14 @@ impl TerminalView {
             return;
         }
         let target_needs_attention = block.as_ref(ctx).is_blocked_on_user_confirmation(ctx);
-        if !target_needs_attention && self.is_navigating_ai_block(ctx) {
-            return;
+        if target_needs_attention || !self.is_any_ai_block_focused(ctx) {
+            block.update(ctx, |block, ctx| block.try_steal_focus(ctx));
         }
-        block.update(ctx, |block, ctx| block.try_steal_focus(ctx));
     }
 
     /// Returns `true` if focus is inside any AI block (e.g. the user is arrowing
     /// through a code diff's hunks).
-    fn is_navigating_ai_block(&self, ctx: &mut ViewContext<Self>) -> bool {
+    fn is_any_ai_block_focused(&self, ctx: &mut ViewContext<Self>) -> bool {
         self.rich_content_views.iter().any(|rich_content| {
             rich_content
                 .ai_block_metadata()
@@ -10796,7 +10795,7 @@ impl TerminalView {
         let reset_focus = ctx.is_self_or_child_focused()
             && !self.find_bar.is_self_or_child_focused(ctx)
             && !self.block_filter_editor.is_self_or_child_focused(ctx)
-            && !self.is_navigating_ai_block(ctx);
+            && !self.is_any_ai_block_focused(ctx);
         if reset_focus {
             self.redetermine_global_focus(ctx);
         }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8194,6 +8194,9 @@ impl TerminalView {
     /// don't steal focus from the user if they've focused another part of the app
     /// (e.g. another session).
     ///
+    /// Skips the steal when the user is navigating another AI block / code diff
+    /// (e.g. arrowing diff hunks), unless the target block is blocked on user input.
+    ///
     /// Warning: this should not be called when focusing the [`TerminalView`]. It could
     /// lead to a focus cycle because [`AIBlock::try_focus`] conditionally yields focus
     /// back to the [`TerminalView`].
@@ -8202,9 +8205,24 @@ impl TerminalView {
         block: &ViewHandle<AIBlock>,
         ctx: &mut ViewContext<Self>,
     ) {
-        if ctx.is_self_or_child_focused() {
-            block.update(ctx, |block, ctx| block.try_steal_focus(ctx));
+        if !ctx.is_self_or_child_focused() {
+            return;
         }
+        let target_needs_attention = block.as_ref(ctx).is_blocked_on_user_confirmation(ctx);
+        if !target_needs_attention && self.is_navigating_ai_block(ctx) {
+            return;
+        }
+        block.update(ctx, |block, ctx| block.try_steal_focus(ctx));
+    }
+
+    /// Returns `true` if focus is inside any AI block (e.g. the user is arrowing
+    /// through a code diff's hunks).
+    fn is_navigating_ai_block(&self, ctx: &mut ViewContext<Self>) -> bool {
+        self.rich_content_views.iter().any(|rich_content| {
+            rich_content
+                .ai_block_metadata()
+                .is_some_and(|metadata| metadata.ai_block_handle.is_self_or_child_focused(ctx))
+        })
     }
 
     #[cfg(not(windows))]
@@ -10773,11 +10791,12 @@ impl TerminalView {
     ///
     /// See [`Self::redetermine_global_focus`] to change focus without checking that the terminal is focused.
     fn redetermine_terminal_focus(&mut self, ctx: &mut ViewContext<Self>) -> bool {
-        // Only reset the focus if this terminal is currently focused, don't steal it from
-        // another part of the app
+        // Only reset focus if this terminal is focused; don't steal it from another part
+        // of the app, or from an AI block / code diff the user is navigating.
         let reset_focus = ctx.is_self_or_child_focused()
             && !self.find_bar.is_self_or_child_focused(ctx)
-            && !self.block_filter_editor.is_self_or_child_focused(ctx);
+            && !self.block_filter_editor.is_self_or_child_focused(ctx)
+            && !self.is_navigating_ai_block(ctx);
         if reset_focus {
             self.redetermine_global_focus(ctx);
         }


### PR DESCRIPTION
Loom: https://www.loom.com/share/e957af04b66c40639ee7eb8498b485cc

## Description
Fixes focus being stolen to the prompt input while navigating an AI block's code diff hunks (up/down) during an agent turn.

At a "request boundary" mid-turn (one response stream finishes / a new exchange streams in), automatic focus handling re-targeted the *active* AI block; since that block has nothing actionable and the input is visible during streaming, focus bounced to the input — interrupting diff-hunk navigation on an earlier block. The same happened at end-of-turn via `redetermine_terminal_focus`.

**How:**
- Added `TerminalView::is_navigating_ai_block`.
- `focus_ai_block_if_self_focused` skips the steal when focus is inside an AI block, unless the target block is blocked on user input (so approval gates still grab focus).
- `redetermine_terminal_focus` excludes the "navigating an AI block" case, alongside the existing find-bar / block-filter exclusions.
- `try_steal_focus` is intentionally left unchanged.

This appears to be a long-standing issue (the focus code predates the public-release squash), not a regression from prompt queueing.

## Linked Issue
N/A — surfaced via internal Slack report (focus stealing while reviewing agent code diffs).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

`cargo fmt` and `cargo clippy -p warp -- -D warnings` pass.

CHANGELOG-BUG-FIX: Fixed focus jumping to the prompt input while navigating an AI block's code diff hunks with the arrow keys during an agent turn.

Co-Authored-By: Oz <oz-agent@warp.dev>
