### PR TITLE
Guard Mermaid rendering against dagre panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "dagre_rust"
 version = "0.0.5"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=81551775746cd86bdeec29cb96ba278fd08c9074#81551775746cd86bdeec29cb96ba278fd08c9074"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=4286175dc6e3a90d3c20773c8c4803296bac23bc#4286175dc6e3a90d3c20773c8c4803296bac23bc"
 dependencies = [
  "graphlib_rust",
  "ordered_hashmap",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "mermaid_to_svg"
 version = "0.1.0"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=81551775746cd86bdeec29cb96ba278fd08c9074#81551775746cd86bdeec29cb96ba278fd08c9074"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=4286175dc6e3a90d3c20773c8c4803296bac23bc#4286175dc6e3a90d3c20773c8c4803296bac23bc"
 dependencies = [
  "dagre_rust",
  "graphlib_rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ lazy_static = "1.4.0"
 libc = "0.2.81"
 line-ending = "1.4.0"
 log = { version = "0.4", features = ["serde", "std"] }
-mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "81551775746cd86bdeec29cb96ba278fd08c9074" }
+mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "4286175dc6e3a90d3c20773c8c4803296bac23bc" }
 mime_guess = "2.0"
 minimp4 = "0.1.2"
 nix = { version = "0.26.4", default-features = false, features = ["signal"] }

--- a/crates/editor/src/content/mermaid_diagram.rs
+++ b/crates/editor/src/content/mermaid_diagram.rs
@@ -1,8 +1,11 @@
+use anyhow::anyhow;
+use std::any::Any;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use bytes::Bytes;
-use mermaid_to_svg::MermaidTheme;
+use mermaid_to_svg::{MermaidError, MermaidTheme};
 use warpui_core::assets::asset_cache::{
     AssetCache, AssetSource, AssetState, AsyncAssetId, AsyncAssetType,
 };
@@ -31,15 +34,43 @@ pub fn mermaid_asset_source(source: &str) -> AssetSource {
         id: AsyncAssetId::new::<MermaidDiagramAsset>(id),
         fetch: Arc::new(move || {
             let source = fetch_source.clone();
-            Box::pin(async move {
-                mermaid_to_svg::render_mermaid_to_svg(&source, Some(&MermaidTheme::light()))
-                    .map(|svg| Bytes::from(svg.into_bytes()))
-                    .map_err(Into::into)
-            })
+            Box::pin(async move { render_mermaid_asset_bytes(&source) })
         }),
     }
 }
 
+fn render_mermaid_asset_bytes(source: &str) -> anyhow::Result<Bytes> {
+    render_mermaid_asset_bytes_with(source, |source, theme| {
+        mermaid_to_svg::render_mermaid_to_svg(source, Some(theme))
+    })
+}
+
+fn render_mermaid_asset_bytes_with(
+    source: &str,
+    render: impl FnOnce(&str, &MermaidTheme) -> Result<String, MermaidError>,
+) -> anyhow::Result<Bytes> {
+    let theme = MermaidTheme::light();
+    let svg = catch_unwind(AssertUnwindSafe(|| render(source, &theme))).map_err(|payload| {
+        anyhow!(
+            "Mermaid renderer panicked: {}",
+            panic_message(payload.as_ref())
+        )
+    })??;
+
+    Ok(Bytes::from(svg.into_bytes()))
+}
+
+fn panic_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        return message.to_string();
+    }
+
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+
+    "unknown panic payload".to_string()
+}
 pub fn mermaid_diagram_layout(
     source: &str,
     layout: &TextLayout,

--- a/crates/editor/src/content/mermaid_diagram_tests.rs
+++ b/crates/editor/src/content/mermaid_diagram_tests.rs
@@ -38,6 +38,19 @@ fn loading_mermaid_layout_uses_default_height() {
 }
 
 #[test]
+fn mermaid_renderer_panic_returns_error() {
+    let err = render_mermaid_asset_bytes_with("graph TD\nA --> B\n", |_source, _theme| {
+        panic!("dagre failed to find an intersection")
+    })
+    .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "Mermaid renderer panicked: dagre failed to find an intersection"
+    );
+}
+
+#[test]
 fn failed_mermaid_layout_uses_compact_height() {
     App::test((), |app| async move {
         app.read(|ctx| {


### PR DESCRIPTION
## Description
- Bump `mermaid_to_svg` to a commit that makes `dagre_rust::intersect_rect` handle degenerate center-point intersections without panicking.
- Add a Warp-side guard around Mermaid SVG rendering so future renderer panics become failed Mermaid assets instead of crashing the client.
- Add unit coverage for the Warp-side panic-to-error path.

Upstream dependency PR: https://github.com/warpdotdev/mermaid-to-svg/pull/16

No new log statements were added.

## Linked Issue
N/A - Slack crash-cluster investigation from `#dev-crash-clusters`.

## Testing
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all --check`
- `CARGO_BUILD_JOBS=1 cargo nextest run --manifest-path /workspace/warp/Cargo.toml --no-fail-fast --workspace mermaid_renderer_panic_returns_error`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path /workspace/warp/Cargo.toml -p warp_editor`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp_editor --no-deps`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A - crash containment/dependency fix with automated coverage.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a Mermaid rendering crash caused by degenerate Dagre edge intersections.

_Conversation: https://staging.warp.dev/conversation/2381ce85-50ab-49ff-a15b-1f8d84dc3196_
_Run: https://oz.staging.warp.dev/runs/019e8a8d-7abf-793f-9859-6dbd1ac7de30_
_This PR was generated with [Oz](https://warp.dev/oz)._
