### PR TITLE
[APP-4652] Fix cloud agent input chip wrapping

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -942,27 +942,31 @@ impl AgentInputFooter {
         #[cfg(not(feature = "voice_input"))]
         let _ = app;
 
-        let mut left = Flex::row()
+        let mut left = Wrap::row()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_alignment(MainAxisAlignment::Start)
+            .with_run_spacing(CLOUD_MODE_V2_FOOTER_GAP)
             .with_spacing(CLOUD_MODE_V2_FOOTER_GAP);
         if let Some(environment_selector) = self.environment_selector.as_ref() {
-            left = left.with_child(ChildView::new(environment_selector).finish());
+            left.add_child(ChildView::new(environment_selector).finish());
         }
 
-        let mut right = Flex::row()
+        let mut right = Wrap::row()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_alignment(MainAxisAlignment::Start)
+            .with_run_spacing(CLOUD_MODE_V2_FOOTER_GAP)
             .with_spacing(CLOUD_MODE_V2_FOOTER_GAP);
 
         // Only show the mic button when voice input is compiled in *and* the
         // user has voice input enabled in settings, matching V1's behavior.
         #[cfg(feature = "voice_input")]
         if AISettings::as_ref(app).is_voice_input_enabled(app) {
-            right = right.with_child(ChildView::new(&self.mic_button).finish());
+            right.add_child(ChildView::new(&self.mic_button).finish());
         }
 
-        right = right.with_child(ChildView::new(&self.file_button).finish());
+        right.add_child(ChildView::new(&self.file_button).finish());
 
         if let Some(model_selector) = self.v2_model_selector.as_ref() {
             // Only show the model selector when the active harness has available models.
@@ -978,16 +982,18 @@ impl AgentInputFooter {
                         .is_some_and(|models| !models.is_empty()),
                 });
             if show_selector {
-                right = right.with_child(ChildView::new(model_selector).finish());
+                right.add_child(ChildView::new(model_selector).finish());
             }
         }
 
-        Flex::row()
+        Wrap::row()
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(left.finish())
-            .with_child(right.finish())
+            .with_spacing(CLOUD_MODE_V2_FOOTER_GAP)
+            .with_run_spacing(context_chips::spacing::UDI_ROW_RUN_SPACING)
+            .with_child(WrapFill::new(0., left.finish()).finish())
+            .with_child(WrapFill::new(0., right.finish()).finish())
             .finish()
     }
 


### PR DESCRIPTION
## Description

Fixes APP-4652.

This updates the Cloud Mode V2 agent input footer so the environment selector, voice/add buttons, and model selector use wrapping rows instead of fixed non-wrapping flex rows. Long environment/context chips now keep the same 4px spacing as the adjacent buttons and wrap within the input footer instead of forcing the right-side controls outside the input box.

## Validation

- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --package warp`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `cargo clippy --manifest-path /workspace/warp/Cargo.toml -p warp --all-targets`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/c52c0e5d-a06c-4e11-a041-e68158f2c7e4_
_Run: https://oz.staging.warp.dev/runs/019e8b02-61a8-7306-9d4b-35d113c58e4c_
_This PR was generated with [Oz](https://warp.dev/oz)._
