### PR TITLE
Fix "cannot detect diffs" error

### DIFF
--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -79,6 +79,10 @@ const BIDI_CHARS: [char; 9] = [
 /// and changes against the main branch.
 #[derive(Clone, Default)]
 enum InternalDiffState {
+    /// Repo detection has been kicked off but hasn't completed yet.
+    /// We don't yet know whether the path is inside a git repository, so this is
+    /// surfaced as a loading state rather than a premature "not a repository" verdict.
+    Detecting,
     #[default]
     NotInRepository,
     Loading,
@@ -257,7 +261,11 @@ impl LocalDiffStateModel {
 
         let model = Self {
             repository: None,
-            state: InternalDiffState::default(),
+            state: if repo_path.is_some() {
+                InternalDiffState::Detecting
+            } else {
+                InternalDiffState::NotInRepository
+            },
             subscriber_id: None,
             mode: DiffMode::default(),
             metadata: None,
@@ -290,6 +298,7 @@ impl LocalDiffStateModel {
                 // Repo detection completed but found no repository.
                 // Emit so subscribers (e.g. the server model) can drain
                 // pending responses with the NotInRepository state.
+                me.state = InternalDiffState::NotInRepository;
                 me.tracked_diff_load_start_time = None;
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed {
                     diffs: None,
@@ -315,8 +324,8 @@ impl LocalDiffStateModel {
 
     pub fn get(&self) -> DiffState {
         match &self.state {
+            InternalDiffState::Detecting | InternalDiffState::Loading => DiffState::Loading,
             InternalDiffState::NotInRepository => DiffState::NotInRepository,
-            InternalDiffState::Loading => DiffState::Loading,
             InternalDiffState::Loaded(diffs) => match &diffs.changes {
                 Ok(_) => DiffState::Loaded,
                 Err(err) => DiffState::Error(err.clone()),


### PR DESCRIPTION
## Description
* This fixes an issue where the code review view would occasionally flash the "cannot detect diffs" error despite being in a git repo with valid diffs to render 
* The bug is that a local diff state model defaults to `DiffState::NotInRepository` on creation which the view maps to this error message
  * This used to work when the view also treated `NotInRepository` as a loading state if `repo_path.is_some()`, but with the refactors made to support a remote diff state model, the semantics for `NotInRepository` changed to be a valid error where the path was definitively not inside a git repo
* The fix introduces a new starting state where `DiffState::Detecting` explicitly means that we're actively detecting the repo before loading the diffs 

## Linked Issue
Reported in: 
* https://github.com/warpdotdev/warp/issues/11914
* https://warpdev.slack.com/archives/C08KTPNQN65/p1780093159997789
* https://warpdev.slack.com/archives/C08KTPNQN65/p1780349380531869

## Testing
https://www.loom.com/share/7bab61e0fe624f4d8a5cdfc440e28258
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
