### PR TITLE
Downgrade headless delegate event loop log

### DIFF
--- a/crates/warpui/src/platform/headless/delegate.rs
+++ b/crates/warpui/src/platform/headless/delegate.rs
@@ -40,7 +40,7 @@ impl AppDelegate {
 
     fn send_event(&self, event: AppEvent) {
         if self.event_sender.send(event).is_err() {
-            log::warn!("Tried to send event, but event loop is no longer running");
+            log::debug!("Tried to send event, but event loop is no longer running");
         }
     }
 }
@@ -210,7 +210,7 @@ impl platform::DispatchDelegate for DispatchDelegate {
             .send(AppEvent::RunTask(ManuallyDrop::new(task)))
             .is_err()
         {
-            log::warn!("Tried to send event, but event loop is no longer running");
+            log::debug!("Tried to send event, but event loop is no longer running");
         }
     }
 }


### PR DESCRIPTION
## Summary

Downgrade headless delegate event-loop send failure logs from WARN to DEBUG. These are expected as the CLI is exiting, and are fairly noisy.

## Validation
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all --check`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warpui`

_Conversation: https://staging.warp.dev/conversation/4a70c61c-4e2f-45e2-a6cb-de9c23f58db0_
_Run: https://oz.staging.warp.dev/runs/019e8d51-7828-7ed2-ac8c-65214b233d4d_

_This PR was generated with [Oz](https://warp.dev/oz)._
