### PR TITLE
Make summary PR chips clickable

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -586,6 +586,8 @@ pub(super) struct VerticalTabsPanelState {
     pane_row_mouse_states: RefCell<HashMap<PaneId, MouseStateHandle>>,
     pane_title_mouse_states: RefCell<HashMap<PaneId, MouseStateHandle>>,
     pane_badge_mouse_states: RefCell<HashMap<PaneId, PaneRowBadgeMouseStates>>,
+    summary_branch_pull_request_mouse_states:
+        RefCell<HashMap<(EntityId, PathBuf, String), MouseStateHandle>>,
     detail_pane_badge_mouse_states: RefCell<HashMap<PaneId, PaneRowBadgeMouseStates>>,
     detail_scroll_state: ClippedScrollStateHandle,
     detail_sidecar_mouse_state: MouseStateHandle,
@@ -623,6 +625,7 @@ impl Default for VerticalTabsPanelState {
             pane_row_mouse_states: RefCell::default(),
             pane_title_mouse_states: RefCell::default(),
             pane_badge_mouse_states: RefCell::default(),
+            summary_branch_pull_request_mouse_states: RefCell::default(),
             detail_pane_badge_mouse_states: RefCell::default(),
             detail_scroll_state: ClippedScrollStateHandle::default(),
             detail_sidecar_mouse_state: Default::default(),
@@ -653,6 +656,22 @@ impl Default for VerticalTabsPanelState {
 }
 
 impl VerticalTabsPanelState {
+    fn summary_branch_pull_request_mouse_state(
+        &self,
+        pane_group_id: EntityId,
+        entry: &VerticalTabsSummaryBranchEntry,
+    ) -> MouseStateHandle {
+        self.summary_branch_pull_request_mouse_states
+            .borrow_mut()
+            .entry((
+                pane_group_id,
+                entry.repo_path.clone(),
+                entry.branch_name.clone(),
+            ))
+            .or_default()
+            .clone()
+    }
+
     /// Returns a lightweight handle bundle for workspace-level visibility reconciliation while the
     /// detail sidecar is active.
     pub(super) fn detail_hover_state(&self, window_id: WindowId) -> VerticalTabsDetailHoverState {
@@ -797,6 +816,7 @@ struct VerticalTabsSummaryBranchEntry {
     branch_name: String,
     diff_stats: Option<GitLineChanges>,
     pull_request_label: Option<String>,
+    pull_request_url: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -955,6 +975,9 @@ fn coalesce_summary_branch_entries(
             }
             if existing.pull_request_label.is_none() {
                 existing.pull_request_label = entry.pull_request_label;
+            }
+            if existing.pull_request_url.is_none() {
+                existing.pull_request_url = entry.pull_request_url;
             }
         } else {
             indices.insert(key, coalesced.len());
@@ -2017,6 +2040,7 @@ fn render_tab_group_internal(
                     return Empty::new().finish();
                 };
                 rows.add_child(render_summary_tab_item(
+                    state,
                     pane_props,
                     summary
                         .as_ref()
@@ -3286,15 +3310,17 @@ fn build_vertical_tabs_summary_data(
                         .current_git_branch(app)
                         .and_then(|branch| normalize_summary_text(&branch)),
                 ) {
+                    let pull_request_url = terminal_view.current_pull_request_url(app);
                     branch_entries.push(VerticalTabsSummaryBranchEntry {
                         repo_path,
                         branch_name,
                         diff_stats: terminal_view.current_diff_line_changes(app),
-                        pull_request_label: terminal_view
-                            .current_pull_request_url(app)
+                        pull_request_label: pull_request_url
                             .as_deref()
                             .map(terminal_pull_request_badge_label)
                             .and_then(|label| normalize_summary_text(&label)),
+                        pull_request_url: pull_request_url
+                            .and_then(|url| normalize_summary_text(&url)),
                     });
                 }
             }
@@ -4118,6 +4144,7 @@ fn render_pane_title_slot(
 }
 
 fn render_summary_tab_item(
+    state: &VerticalTabsPanelState,
     props: PaneProps<'_>,
     summary: &VerticalTabsSummaryData,
     summary_pane_kind_icons: Option<SummaryPaneKindIcons>,
@@ -4276,10 +4303,17 @@ fn render_summary_tab_item(
 
     // Branch region. Each branch line gets the existing 4px top margin from APP-3875.
     for branch_entry in summary.branch_entries.iter().take(MAX_VISIBLE_BRANCH_LINES) {
+        let pull_request_mouse_state = branch_entry.pull_request_url.as_ref().map(|_| {
+            state.summary_branch_pull_request_mouse_state(props.pane_group_id, branch_entry)
+        });
         text_col.add_child(
-            Container::new(render_summary_branch_line(branch_entry, appearance))
-                .with_margin_top(REGION_GAP)
-                .finish(),
+            Container::new(render_summary_branch_line(
+                branch_entry,
+                pull_request_mouse_state,
+                appearance,
+            ))
+            .with_margin_top(REGION_GAP)
+            .finish(),
         );
     }
 
@@ -4589,6 +4623,7 @@ fn summary_pane_kind_icon(
 
 fn render_summary_branch_line(
     entry: &VerticalTabsSummaryBranchEntry,
+    pull_request_mouse_state: Option<MouseStateHandle>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
@@ -4616,8 +4651,10 @@ fn render_summary_branch_line(
         has_right_badges = true;
     }
     if let Some(pull_request_label) = &entry.pull_request_label {
-        right_badges.add_child(render_passive_terminal_pull_request_badge(
+        right_badges.add_child(render_summary_pull_request_badge(
             pull_request_label,
+            entry.pull_request_url.as_deref(),
+            pull_request_mouse_state,
             appearance,
         ));
         has_right_badges = true;
@@ -4906,6 +4943,24 @@ fn render_passive_terminal_pull_request_badge(
         render_pull_request_badge_content(label, appearance),
         internal_colors::fg_overlay_1(appearance.theme()),
     )
+}
+
+fn render_summary_pull_request_badge(
+    label: &str,
+    url: Option<&str>,
+    mouse_state: Option<MouseStateHandle>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    match (url, mouse_state) {
+        (Some(url), Some(mouse_state)) => render_terminal_pull_request_badge(
+            label.to_string(),
+            url.to_string(),
+            VerticalTabsChipEntrypoint::Tab,
+            mouse_state,
+            appearance,
+        ),
+        _ => render_passive_terminal_pull_request_badge(label, appearance),
+    }
 }
 
 fn render_compact_non_terminal_title(

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -916,6 +916,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
             branch_name: "main".to_string(),
             diff_stats: None,
             pull_request_label: None,
+            pull_request_url: None,
         },
         VerticalTabsSummaryBranchEntry {
             repo_path: repo_a.clone(),
@@ -926,6 +927,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                 lines_removed: 3,
             }),
             pull_request_label: Some("#123".to_string()),
+            pull_request_url: None,
         },
         VerticalTabsSummaryBranchEntry {
             repo_path: repo_b.clone(),
@@ -936,6 +938,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                 lines_removed: 6,
             }),
             pull_request_label: Some("#456".to_string()),
+            pull_request_url: None,
         },
     ];
 
@@ -951,6 +954,7 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                     lines_removed: 3,
                 }),
                 pull_request_label: Some("#123".to_string()),
+                pull_request_url: None,
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: repo_b,
@@ -961,8 +965,42 @@ fn coalesce_summary_branch_entries_groups_by_repo_and_branch() {
                     lines_removed: 6,
                 }),
                 pull_request_label: Some("#456".to_string()),
+                pull_request_url: None,
             },
         ]
+    );
+}
+
+#[test]
+fn coalesce_summary_branch_entries_preserves_pull_request_url() {
+    let repo = PathBuf::from("/tmp/repo-a");
+    let pull_request_url = "https://github.com/warpdotdev/warp/pull/11334".to_string();
+    let entries = vec![
+        VerticalTabsSummaryBranchEntry {
+            repo_path: repo.clone(),
+            branch_name: "main".to_string(),
+            diff_stats: None,
+            pull_request_label: None,
+            pull_request_url: None,
+        },
+        VerticalTabsSummaryBranchEntry {
+            repo_path: repo.clone(),
+            branch_name: "main".to_string(),
+            diff_stats: None,
+            pull_request_label: Some("#11334".to_string()),
+            pull_request_url: Some(pull_request_url.clone()),
+        },
+    ];
+
+    assert_eq!(
+        coalesce_summary_branch_entries(entries),
+        vec![VerticalTabsSummaryBranchEntry {
+            repo_path: repo,
+            branch_name: "main".to_string(),
+            diff_stats: None,
+            pull_request_label: Some("#11334".to_string()),
+            pull_request_url: Some(pull_request_url),
+        }]
     );
 }
 
@@ -1109,24 +1147,28 @@ fn summary_search_fragments_include_hidden_overflow_values() {
                     lines_removed: 3,
                 }),
                 pull_request_label: Some("#123".to_string()),
+                pull_request_url: None,
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: PathBuf::from("/tmp/repo-b"),
                 branch_name: "feature/hidden".to_string(),
                 diff_stats: None,
                 pull_request_label: None,
+                pull_request_url: None,
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: PathBuf::from("/tmp/repo-c"),
                 branch_name: "cleanup".to_string(),
                 diff_stats: None,
                 pull_request_label: None,
+                pull_request_url: None,
             },
             VerticalTabsSummaryBranchEntry {
                 repo_path: PathBuf::from("/tmp/repo-d"),
                 branch_name: "hidden-branch".to_string(),
                 diff_stats: None,
                 pull_request_label: Some("#789".to_string()),
+                pull_request_url: None,
             },
         ],
         has_unread_activity: false,


### PR DESCRIPTION

## Description
Fixes summary-mode PR chips in vertical tabs so they use the existing clickable PR badge behavior instead of rendering as passive text.

This preserves PR URLs while coalescing summary branch entries, stores stable mouse state for summary PR chips, and routes clickable summary chips through the same badge renderer used by terminal branch chips.

## Linked Issue
Fixes #11334

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] Added regression coverage for preserving `pull_request_url` during summary branch coalescing.
- [x] `cargo test -p warp coalesce_summary_branch_entries_preserves_pull_request_url`
- [x] `cargo test -p warp vertical_tabs`
- [x] `cargo fmt -p warp`
- [x] `git diff --check`
- [ ] `./script/presubmit` completed locally

`./script/presubmit` result: formatting, inline Rust test module check, clippy, clang-format, and wgslfmt completed. `cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2` ran 7335 tests: 7329 passed, 6 failed, 85 skipped. The failures were local environment issues: 5 SSH/GCP IAP integration tests failed with authorization errors, and one API-key unit test failed because this shell had `OPENAI_API_KEY` set. The API-key unit test passed when rerun with that env var unset.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Draft PR: manual UI proof still needs to be attached before marking ready for review.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp AI Agent Mode

CHANGELOG-BUG-FIX: Fixed summary-mode PR chips in vertical tabs so clicking them opens the associated pull request.
