### PR TITLE
Try using `assignees` field in dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
+    assignees:
       - "warpdotdev/tech-leads"
     registries:
       - github-private
@@ -17,7 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
+    assignees:
       - "warpdotdev/tech-leads"
     cooldown:
       # Don't update to any action release that is less than two weeks old.


### PR DESCRIPTION
## Description

Seems like `reviewers` is deprecated, but `assignees` still exists.  Documentation indicates that it is used for individual assignment, but maybe we get lucky and can give it a team and things will work.