### PR TITLE
Keep ssh-host (and other generator) completions when one Include fails (fixes #9417)

### DIFF
--- a/crates/warp_completer/src/completer/engine/argument/legacy.rs
+++ b/crates/warp_completer/src/completer/engine/argument/legacy.rs
@@ -718,36 +718,37 @@ async fn generate_suggestions_for_argument_type(
                 return vec![];
             };
 
-            match output.status {
-                CommandExitStatus::Success => {
-                    let Ok(output_string) = output.to_string() else {
-                        return vec![];
-                    };
+            // A generator command can exit non-zero yet still have written
+            // usable output before failing. The motivating case (#9417) is the
+            // ssh-host generator: it `cat`s `~/.ssh/config` and every `Include`d
+            // file, so one unreadable `Include` (e.g. a Windows `C:\Users\...`
+            // path the POSIX generator mis-resolves) fails the whole command --
+            // even though the readable hosts are already on stdout. Parse what
+            // we got instead of dropping every suggestion; only bail when a
+            // failing command produced nothing to parse.
+            let Ok(output_string) = output.to_string() else {
+                return vec![];
+            };
+            if output.status == CommandExitStatus::Failure && output_string.trim().is_empty() {
+                return vec![];
+            }
 
-                    let results = generator.on_complete(&output_string);
+            let results = generator.on_complete(&output_string);
 
-                    let internal_suggestions = results
-                        .suggestions
-                        .into_iter()
-                        .map(Into::into)
-                        .filter_map(|suggestion: Suggestion| {
-                            let match_type = matcher
-                                .get_match_type(parsed_token.as_str(), suggestion.display.as_str());
-                            match_type
-                                .map(|match_type| MatchedSuggestion::new(suggestion, match_type))
-                        });
+            let internal_suggestions = results.suggestions.into_iter().map(Into::into).filter_map(
+                |suggestion: Suggestion| {
+                    let match_type =
+                        matcher.get_match_type(parsed_token.as_str(), suggestion.display.as_str());
+                    match_type.map(|match_type| MatchedSuggestion::new(suggestion, match_type))
+                },
+            );
 
-                    if results.is_ordered {
-                        internal_suggestions.collect()
-                    } else {
-                        internal_suggestions
-                            .sorted_by(MatchedSuggestion::cmp_by_display)
-                            .collect()
-                    }
-                }
-                CommandExitStatus::Failure => {
-                    vec![]
-                }
+            if results.is_ordered {
+                internal_suggestions.collect()
+            } else {
+                internal_suggestions
+                    .sorted_by(MatchedSuggestion::cmp_by_display)
+                    .collect()
             }
         }
         _ => vec![],

--- a/crates/warp_completer/src/completer/engine/argument/v2.rs
+++ b/crates/warp_completer/src/completer/engine/argument/v2.rs
@@ -664,59 +664,58 @@ async fn generate_suggestions_for_argument_value(
                 return vec![];
             };
 
-            match output.status {
-                CommandExitStatus::Success => {
-                    let Ok(output_string) = output.to_string() else {
+            // A generator command can exit non-zero yet still have written
+            // usable output before failing (see #9417: the ssh-host generator
+            // `cat`s `~/.ssh/config` plus every `Include`d file, so one
+            // unreadable `Include` fails the whole command while the readable
+            // hosts are already on stdout). Parse what we got instead of
+            // dropping every suggestion; only bail when a failing command
+            // produced nothing to parse.
+            let Ok(output_string) = output.to_string() else {
+                return vec![];
+            };
+            if output.status == CommandExitStatus::Failure && output_string.trim().is_empty() {
+                return vec![];
+            }
+
+            let results = match post_process {
+                Some(js_fn) => {
+                    let Ok(results) = call_js_function(&output_string, js_fn, js_ctx).await else {
                         return vec![];
                     };
+                    results
+                }
+                None => {
+                    let suggestions: Vec<signatures::Suggestion> = output_string
+                        .lines()
+                        .map(|line| signatures::Suggestion {
+                            value: line.to_owned(),
+                            display_value: None,
+                            description: None,
+                            priority: signatures::Priority::default(),
+                        })
+                        .collect();
 
-                    let results = match post_process {
-                        Some(js_fn) => {
-                            let Ok(results) = call_js_function(&output_string, js_fn, js_ctx).await
-                            else {
-                                return vec![];
-                            };
-                            results
-                        }
-                        None => {
-                            let suggestions: Vec<signatures::Suggestion> = output_string
-                                .lines()
-                                .map(|line| signatures::Suggestion {
-                                    value: line.to_owned(),
-                                    display_value: None,
-                                    description: None,
-                                    priority: signatures::Priority::default(),
-                                })
-                                .collect();
-
-                            GeneratorResults {
-                                suggestions,
-                                is_ordered: true,
-                            }
-                        }
-                    };
-                    let internal_suggestions = results
-                        .suggestions
-                        .into_iter()
-                        .map(Into::into)
-                        .filter_map(|suggestion: Suggestion| {
-                            let match_type = matcher
-                                .get_match_type(parsed_token.as_str(), suggestion.display.as_str());
-                            match_type
-                                .map(|match_type| MatchedSuggestion::new(suggestion, match_type))
-                        });
-
-                    if results.is_ordered {
-                        internal_suggestions.collect()
-                    } else {
-                        internal_suggestions
-                            .sorted_by(MatchedSuggestion::cmp_by_display)
-                            .collect()
+                    GeneratorResults {
+                        suggestions,
+                        is_ordered: true,
                     }
                 }
-                CommandExitStatus::Failure => {
-                    vec![]
-                }
+            };
+            let internal_suggestions = results.suggestions.into_iter().map(Into::into).filter_map(
+                |suggestion: Suggestion| {
+                    let match_type =
+                        matcher.get_match_type(parsed_token.as_str(), suggestion.display.as_str());
+                    match_type.map(|match_type| MatchedSuggestion::new(suggestion, match_type))
+                },
+            );
+
+            if results.is_ordered {
+                internal_suggestions.collect()
+            } else {
+                internal_suggestions
+                    .sorted_by(MatchedSuggestion::cmp_by_display)
+                    .collect()
             }
         }
         _ => {

--- a/crates/warp_completer/src/completer/suggest/test.rs
+++ b/crates/warp_completer/src/completer/suggest/test.rs
@@ -16,6 +16,7 @@ use crate::meta::Span;
 use crate::signatures::testing::{
     cd_signature, create_test_command_registry, fuzzy_signature, git_signature, java_signature,
     ls_signature, npm_signature, signature_with_empty_positional, test_signature,
+    TEST_GENERATOR_1_COMMAND,
 };
 use crate::signatures::CommandRegistry;
 
@@ -1754,6 +1755,73 @@ fn test_completes_with_multiple_generators() {
             // so we should respect the order in which the generators were specified.
             "bar", "foo", // The first generator is not ordered, so we sort it.
             "def", "abc", // The second generator is already ordered.
+        ]
+    );
+}
+
+/// Regression test for warpdotdev/warp#9417.
+///
+/// When a generator's command exits non-zero it can still have written usable
+/// output to stdout before failing. The real-world case: the embedded ssh-host
+/// completion generator `cat`s `~/.ssh/config` and every `Include`d file, then
+/// pipes the result through awk. On Windows/Git Bash an `Include C:\Users\...`
+/// drive-letter path is mis-resolved as a relative path, so that one `cat`
+/// fails and the whole command exits non-zero -- even though the readable hosts
+/// are already on stdout. The engine currently maps `CommandExitStatus::Failure`
+/// to an empty result, so a single bad `Include` wipes out *all* ssh host
+/// suggestions instead of degrading to the hosts it could read.
+///
+/// Here `test five` runs two generators (`test1`, `test2`). We make only
+/// `test1`'s command fail-with-output; `test2` still succeeds. `test2`'s
+/// suggestions must survive and `test1`'s partial output is still parsed,
+/// yielding the same result as the all-success case.
+///
+/// Before the fix the failing generator contributed nothing (only
+/// `["def", "abc"]` came back); now the `CommandExitStatus::Failure` branch
+/// parses non-empty stdout instead of discarding it.
+#[test]
+fn test_generator_failure_with_partial_output_still_suggests() {
+    let registry = create_test_command_registry([test_signature()]);
+    // `test1`'s command exits non-zero but still printed "1" before failing;
+    // `test2` succeeds normally (set up by `for_test_signature`).
+    let generator_ctx = MockGeneratorContext::for_test_signature()
+        .with_failing_command(TEST_GENERATOR_1_COMMAND, "1");
+    let ctx = FakeCompletionContext::new(registry).with_generator_context(generator_ctx);
+
+    assert_eq!(
+        complete_at_end_of_line_with_options("test five ", MatchStrategy::CaseInsensitive, &ctx),
+        vec![
+            // test1 exited non-zero but produced output, so its suggestions
+            // should still be parsed rather than dropped wholesale...
+            "bar", "foo", // test1 is unordered, so we sort it.
+            // ...and test2 (which succeeded) must not be collateral damage.
+            "def", "abc", // test2 is already ordered.
+        ]
+    );
+}
+
+/// Companion to [`test_generator_failure_with_partial_output_still_suggests`],
+/// covering the other side of the #9417 guard: a generator whose command
+/// exits non-zero with *no usable* stdout must still contribute nothing, and
+/// must not become collateral damage for the generators that did succeed.
+///
+/// `test1`'s command fails while printing only whitespace -- this also pins the
+/// `trim()` in the guard: a bare `is_empty()` check would let `"  \n "` through
+/// and (on the line-splitting path) leak a bogus empty-value suggestion. Only
+/// `test2`'s ordered suggestions should come back.
+#[test]
+fn test_generator_failure_with_blank_output_suggests_nothing() {
+    let registry = create_test_command_registry([test_signature()]);
+    let generator_ctx = MockGeneratorContext::for_test_signature()
+        .with_failing_command(TEST_GENERATOR_1_COMMAND, "  \n ");
+    let ctx = FakeCompletionContext::new(registry).with_generator_context(generator_ctx);
+
+    assert_eq!(
+        complete_at_end_of_line_with_options("test five ", MatchStrategy::CaseInsensitive, &ctx),
+        vec![
+            // test1 failed with only-whitespace output, so it bails entirely...
+            // ...and test2 (which succeeded) is unaffected.
+            "def", "abc", // test2 is already ordered.
         ]
     );
 }

--- a/crates/warp_completer/src/completer/testing/mod.rs
+++ b/crates/warp_completer/src/completer/testing/mod.rs
@@ -75,12 +75,20 @@ impl MatchedSuggestion {
 #[derive(Default)]
 pub struct MockGeneratorContext {
     expected_commands_to_output: HashMap<String, String>,
+    /// Commands that exit non-zero but still emit (partial) stdout, mapped to
+    /// that stdout. Models a generator whose underlying command partially
+    /// failed -- e.g. an ssh-host generator that `cat`s `~/.ssh/config` plus
+    /// its `Include`d files and hits one unreadable path (a Windows-style
+    /// `Include C:\Users\...` that the POSIX generator mis-resolves). The
+    /// command exits non-zero, yet the readable hosts are already on stdout.
+    failing_commands_to_output: HashMap<String, String>,
 }
 
 impl MockGeneratorContext {
     pub fn new() -> Self {
         Self {
             expected_commands_to_output: HashMap::new(),
+            failing_commands_to_output: HashMap::new(),
         }
     }
 
@@ -102,6 +110,20 @@ impl MockGeneratorContext {
             .insert(command.into(), output.into());
         self
     }
+
+    /// Register a command that exits non-zero while still producing the given
+    /// stdout. Takes precedence over [`Self::with_expected_command`] for the
+    /// same command, so a command registered by [`Self::for_test_signature`]
+    /// can be turned into a partial-failure for a single test.
+    pub fn with_failing_command(
+        mut self,
+        command: impl Into<String>,
+        partial_stdout: impl Into<String>,
+    ) -> Self {
+        self.failing_commands_to_output
+            .insert(command.into(), partial_stdout.into());
+        self
+    }
 }
 
 #[async_trait]
@@ -111,6 +133,15 @@ impl GeneratorContext for MockGeneratorContext {
         shell_command: &str,
         _session_env_vars: Option<HashMap<String, String>>,
     ) -> anyhow::Result<CommandOutput> {
+        if let Some(partial_stdout) = self.failing_commands_to_output.get(shell_command) {
+            return Ok(CommandOutput {
+                stdout: partial_stdout.clone().into_bytes(),
+                stderr: Vec::new(),
+                status: CommandExitStatus::Failure,
+                exit_code: Some(ExitCode::from(1)),
+            });
+        }
+
         Ok(CommandOutput {
             stdout: self
                 .expected_commands_to_output


### PR DESCRIPTION
## Summary

Fixes #9417. On Windows + Git Bash with Windows `ssh.exe`, an `~/.ssh/config`
containing a Windows-style `Include C:\Users\...\extra_config` line caused Warp
to show **no** ssh host completions at all. This makes the completion engine
degrade gracefully: a generator command that exits non-zero but still wrote
usable output now keeps that output instead of discarding every suggestion.

## Root cause

Warp's ssh-host completion generator `cat`s `~/.ssh/config` plus every
`Include`d file and pipes the result through `awk`. On Windows/Git Bash a
drive-letter `Include C:\Users\...` path is mis-resolved by the POSIX generator
as a relative path, so that one `cat` fails and the **whole** command exits
non-zero — even though the readable hosts were already written to stdout.

In both the legacy and v2 generator argument paths the engine mapped
`CommandExitStatus::Failure` straight to an empty result
(`crates/warp_completer/src/completer/engine/argument/{legacy,v2}.rs`), so a
single unreadable `Include` wiped out **all** ssh host completions instead of
degrading to the hosts it could read.

## Fix

Always parse whatever made it to stdout, and only bail when a failing command
produced nothing usable (empty or whitespace-only stdout). The success path is
unchanged; on failure we now surface the partial output rather than dropping it.
`output.to_string()` reads stdout only (never stderr), so no error text leaks
into completions. Applied identically to the legacy and v2 paths.

## Tests

- `test_generator_failure_with_partial_output_still_suggests` — a generator
  whose command fails-with-output no longer drops its suggestions, and a sibling
  generator that succeeded is unaffected. Fails before the fix, passes after.
- `test_generator_failure_with_blank_output_suggests_nothing` — a failure with
  only-whitespace stdout still suggests nothing (guards the `trim()` check so no
  bogus empty completion leaks).
- Extends `MockGeneratorContext` with `with_failing_command(...)` to model a
  command that exits non-zero with partial stdout.

Local: `cargo test -p warp_completer` green, `cargo fmt --check` clean,
`cargo clippy -p warp_completer --all-targets` clean.

## Scope

Intentionally **not** adding Windows drive-letter path resolution to the
generator — this PR implements option (a) from the issue ("ignore an Include
that doesn't resolve, but still propose completions from the rest"). The hosts
in the unreadable Windows-style `Include` remain uncompletable; the readable
hosts now survive instead of taking the whole list down with them. Native
Windows-path Include support can be a follow-up.

Note this graceful-degrade applies to *all* script generators, not just
ssh-host: any generator whose command exits non-zero with stdout content now
has that content parsed. In practice failing commands write diagnostics to
stderr, not stdout, so this is the desired behavior.

Co-Authored-By: Warp <agent@warp.dev>
