### PR TITLE
Fix rewind prefill for slash commands

### DIFF
--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -530,7 +530,7 @@ fn test_invoke_skill_arguments_round_trip() {
                 Some("arg1 arg2")
             );
             assert_eq!(
-                exchanges[0].input[0].user_query().as_deref(),
+                exchanges[0].input[0].display_query().as_deref(),
                 Some("/test-skill arg1 arg2")
             );
         }
@@ -574,7 +574,7 @@ fn test_invoke_skill_missing_user_query_maps_to_none() {
             assert_eq!(skill.name, "test-skill");
             assert_eq!(user_query, &None);
             assert_eq!(
-                exchanges[0].input[0].user_query().as_deref(),
+                exchanges[0].input[0].display_query().as_deref(),
                 Some("/test-skill")
             );
         }

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1549,7 +1549,7 @@ impl AIConversation {
         self.root_task_exchanges()
             .flat_map(|exchange| exchange.input.iter())
             .find_map(|input| {
-                AIAgentInput::user_query(input)
+                AIAgentInput::display_query(input)
                     .or_else(|| AIAgentInput::auto_code_diff_query(input).map(|s| s.to_string()))
                     .or_else(|| AIAgentInput::prompt_suggestion_result(input).cloned())
             })
@@ -1558,7 +1558,7 @@ impl AIConversation {
     pub fn initial_user_query(&self) -> Option<String> {
         self.root_task_exchanges()
             .flat_map(|exchange| exchange.input.iter())
-            .find_map(AIAgentInput::user_query)
+            .find_map(AIAgentInput::display_query)
     }
 
     /// Export the conversation to markdown format.
@@ -1586,7 +1586,7 @@ impl AIConversation {
     pub fn latest_user_query(&self) -> Option<String> {
         self.exchanges_reversed().find_map(|exchange| {
             exchange.input.iter().rev().find_map(|input| {
-                AIAgentInput::user_query(input)
+                AIAgentInput::display_query(input)
                     .map(|query| query.trim().to_owned())
                     .filter(|query| !query.is_empty())
             })

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -2642,7 +2642,7 @@ impl Display for AIAgentInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::UserQuery { .. } => {
-                write!(f, "UserQuery: {}", self.user_query().unwrap_or_default())
+                write!(f, "UserQuery: {}", self.display_query().unwrap_or_default())
             }
             Self::AutoCodeDiffQuery { query, .. } => {
                 write!(f, "AutoCodeDiffQuery: {query}")
@@ -2684,7 +2684,11 @@ impl Display for AIAgentInput {
 }
 
 impl AIAgentInput {
-    pub fn user_query(&self) -> Option<String> {
+    /// Display text for any input that surfaces a prompt-like query in the UI
+    /// (typed queries, slash commands, skill invocations, etc.). Unlike
+    /// [`Self::is_user_query`], which strictly matches the `UserQuery` variant,
+    /// this returns `Some` for several input variants.
+    pub fn display_query(&self) -> Option<String> {
         match self {
             Self::UserQuery {
                 query,
@@ -2747,7 +2751,7 @@ impl AIAgentInput {
         &self,
         initial_conversation_query: Option<&String>,
     ) -> Option<String> {
-        let mut query = self.user_query()?;
+        let mut query = self.display_query()?;
         if self
             .user_query_mode()
             .is_none_or(|mode| matches!(mode, UserQueryMode::Normal))
@@ -2974,7 +2978,7 @@ impl AIAgentExchange {
         let user_queries: Vec<String> = self
             .input
             .iter()
-            .filter_map(|input| input.user_query())
+            .filter_map(|input| input.display_query())
             .collect();
         user_queries.join("\n")
     }
@@ -3024,7 +3028,9 @@ impl AIAgentExchange {
     }
 
     pub fn has_user_query(&self) -> bool {
-        self.input.iter().any(|input| input.user_query().is_some())
+        self.input
+            .iter()
+            .any(|input| input.display_query().is_some())
     }
 
     pub fn has_accepted_file_edit(&self) -> bool {

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -4211,7 +4211,7 @@ impl AIBlock {
         self.model
             .inputs_to_render(app)
             .iter()
-            .any(|input| input.user_query().is_some())
+            .any(|input| input.display_query().is_some())
     }
 
     /// `true` if the AI block is "finished".
@@ -5355,7 +5355,7 @@ impl AIBlock {
         self.model
             .inputs_to_render(app)
             .iter()
-            .filter_map(|input| input.user_query())
+            .filter_map(|input| input.display_query())
             .collect::<Vec<_>>()
             .join("\n")
     }

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -410,7 +410,9 @@ impl InputQuery {
     fn query(&self) -> String {
         match &self.input_query {
             InputQueryType::UserSubmittedQueryFromInput { query, .. } => query.clone(),
-            InputQueryType::AIInputType { ai_input } => ai_input.user_query().unwrap_or_default(),
+            InputQueryType::AIInputType { ai_input } => {
+                ai_input.display_query().unwrap_or_default()
+            }
         }
     }
 }

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -2876,7 +2876,7 @@ fn ai_exchange_to_query_history(
     value: &AIAgentExchange,
     history_order: HistoryOrder,
 ) -> Option<AIQueryHistory> {
-    let query = value.input.iter().find_map(AIAgentInput::user_query)?;
+    let query = value.input.iter().find_map(AIAgentInput::display_query)?;
 
     Some(AIQueryHistory {
         query_text: query,

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -1522,7 +1522,7 @@ impl View for RequestedCommandView {
                                     !exchange
                                         .input
                                         .iter()
-                                        .any(|input| input.user_query().is_some())
+                                        .any(|input| input.display_query().is_some())
                                 })
                     }))
                 && !is_input_pinned_to_top);

--- a/app/src/ai/request_usage_model.rs
+++ b/app/src/ai/request_usage_model.rs
@@ -305,7 +305,7 @@ impl AIRequestUsageModel {
                         if exchange
                             .input
                             .iter()
-                            .any(|input| input.user_query().is_some())
+                            .any(|input| input.display_query().is_some())
                         {
                             break;
                         }

--- a/app/src/terminal/input/rewind/data_source.rs
+++ b/app/src/terminal/input/rewind/data_source.rs
@@ -116,7 +116,7 @@ impl SyncDataSource for RewindDataSource {
             let query_text = exchange
                 .input
                 .iter()
-                .find_map(AIAgentInput::user_query)
+                .find_map(AIAgentInput::display_query)
                 .unwrap_or_default();
 
             // Find the end of this "block" - either the next user query or end of exchanges

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -1901,7 +1901,7 @@ fn test_shared_followup_on_existing_conversation_converts_user_query_input() {
                 .and_then(|exchange| exchange.input.first())
                 .expect("shared-session replay should reconstruct the user query input");
             assert!(matches!(input, AIAgentInput::UserQuery { .. }));
-            assert_eq!(input.user_query().as_deref(), Some(followup_query));
+            assert_eq!(input.display_query().as_deref(), Some(followup_query));
         });
     });
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -150,7 +150,7 @@ use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::agent::CancellationReason;
-use crate::ai::agent::EntrypointType;
+use crate::ai::agent::{AIAgentInput, EntrypointType};
 #[cfg(target_family = "wasm")]
 use crate::ai::agent_conversations_model::AgentConversationsModelEvent;
 use crate::ai::agent_conversations_model::{
@@ -915,6 +915,10 @@ enum PendingSessionConfigTabConfigChipTutorial {
     AfterSetupCommands {
         intention: OnboardingIntention,
     },
+}
+
+fn query_for_rewind_prefill(inputs: &[AIAgentInput]) -> Option<String> {
+    inputs.iter().find_map(AIAgentInput::user_query)
 }
 
 /// Snapshot of a tab used to move it between workspaces or into a new window.
@@ -24142,12 +24146,7 @@ impl TypedActionView for Workspace {
                 let user_query = BlocklistAIHistoryModel::as_ref(ctx)
                     .conversation(conversation_id)
                     .and_then(|c| c.root_task_exchanges().find(|e| e.id == *exchange_id))
-                    .and_then(|e| {
-                        e.input
-                            .iter()
-                            .find(|i| i.is_user_query())
-                            .and_then(|i| i.user_query())
-                    });
+                    .and_then(|e| query_for_rewind_prefill(&e.input));
 
                 // Dispatch to the active terminal to execute the rewind
                 if let Some(terminal_view) = self

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -918,7 +918,7 @@ enum PendingSessionConfigTabConfigChipTutorial {
 }
 
 fn query_for_rewind_prefill(inputs: &[AIAgentInput]) -> Option<String> {
-    inputs.iter().find_map(AIAgentInput::user_query)
+    inputs.iter().find_map(AIAgentInput::display_query)
 }
 
 /// Snapshot of a tab used to move it between workspaces or into a new window.

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -87,6 +87,23 @@ use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::{
     experiments, workspace, AgentNotificationsModel, GlobalResourceHandlesProvider, ObjectActions,
 };
+#[test]
+fn query_for_rewind_prefill_uses_custom_display_query_inputs() {
+    let context: std::sync::Arc<[crate::ai::agent::AIAgentContext]> = Vec::new().into();
+    let input = crate::ai::agent::AIAgentInput::FetchReviewComments {
+        repo_path: "/repo".to_string(),
+        context,
+    };
+
+    assert_eq!(
+        query_for_rewind_prefill(&[input]),
+        Some(
+            crate::search::slash_command_menu::static_commands::commands::PR_COMMENTS
+                .name
+                .to_string()
+        )
+    );
+}
 
 fn initialize_app(app: &mut App) {
     initialize_settings_for_tests(app);


### PR DESCRIPTION
## Description
Fixes rewind prefill for agent exchanges that are displayable user queries but not stored as `AIAgentInput::UserQuery`, such as skill invocations and custom slash-command inputs.

Previously the rewind handler restored text only from exact `UserQuery` inputs, while the rewind menu already displayed labels via `AIAgentInput::user_query()`. This made the input appear empty after rewinding a slash/skill command exchange. The handler now uses the same display-query path as the menu.

## Linked Issue
Slack feedback thread in `#feedback-app`.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Demo [here](https://www.loom.com/share/c3239d808ce044588fcfe9e416212128)!
- `cargo test --manifest-path /workspace/warp/app/Cargo.toml query_for_rewind_prefill_uses_custom_display_query_inputs --lib`

- [X] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; validated with a focused regression test for custom slash-command display-query restoration.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed rewind restoring an empty input after slash/skill-command agent prompts.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/e18aa6db-71bb-4923-b5fb-4e67935af082_
_Run: https://oz.staging.warp.dev/runs/019e8e75-f987-733f-9c3b-bac197f840a9_
_This PR was generated with [Oz](https://warp.dev/oz)._
