### PR TITLE
Fix changelog attribution for Warp members

### DIFF
--- a/.agents/skills/changelog-draft/SKILL.md
+++ b/.agents/skills/changelog-draft/SKILL.md
@@ -55,6 +55,8 @@ The script outputs JSON to stdout with this structure:
       "url": "https://github.com/warpdotdev/warp/pull/1234",
       "title": "...",
       "author": "username",
+      "author_association": "CONTRIBUTOR",
+      "author_is_bot": false,
       "body": "...",
       "labels": ["..."],
       "merged_at": "2026-05-01T...",
@@ -76,7 +78,7 @@ The script outputs JSON to stdout with this structure:
 }
 ```
 
-Use the top-level `number`, `url`, `author`, `body`, `labels`, `changed_files`, and `source_repo` fields as the source of truth. `internal_pr` is audit-only and must never be used for contributor attribution or user-facing changelog links. If `url` is empty, omit the PR link from user-facing markdown rather than synthesizing one.
+Use the top-level `number`, `url`, `author`, `author_association`, `author_is_bot`, `body`, `labels`, `changed_files`, and `source_repo` fields as the source of truth. `internal_pr` is audit-only and must never be used for contributor attribution or user-facing changelog links. If `url` is empty, omit the PR link from user-facing markdown rather than synthesizing one.
 
 ### Step 3 — Classify contributors
 
@@ -175,6 +177,7 @@ For each unmarked PR, produce a classification:
 **Feature-flag detection:** Use the `changed_files` list from Step 2 to check if any PR touches `crates/warp_features/src/lib.rs` or references a `FeatureFlag` variant in its title/body. Cross-reference with the flag lists from Step 4 to determine channel visibility.
 
 **Unknown contributors:** Authors in the `unknown` bucket (org membership check failed due to auth) should be treated conservatively — do not attribute them as external. Note them in the output for manual verification.
+**Repo members and bots:** Treat `author_association` values `MEMBER`, `OWNER`, and `COLLABORATOR` as internal, regardless of the classifier output. Treat `author_is_bot: true`, `app/...` authors, and `...[bot]` authors as bots. Internal and bot authors' changelog fixes should remain in the main sections with their PR links, but they must not receive linked profile attribution or Community credit.
 
 ### Step 7 — Assemble the draft
 
@@ -187,7 +190,7 @@ Combine explicit entries (Step 2) and inferred entries (Step 6) into the final r
 
 PRs marked with `CHANGELOG-NONE` are explicitly opted out and must never appear in the changelog markdown.
 
-When creating entries, copy `pr_number`, `url`, `author`, `source_repo`, and `internal_pr` from the normalized PR record. The release JSON converter uses `url` directly; do not invent public PR URLs from PR numbers.
+When creating entries, copy `pr_number`, `url`, `author`, `author_association`, `author_is_bot`, `source_repo`, and `internal_pr` from the normalized PR record. The release JSON converter uses `url` directly; do not invent public PR URLs from PR numbers.
 
 ### Step 8 — Write output files
 
@@ -239,6 +242,8 @@ The markdown draft must **not** include "Needs Review" or "Skipped PRs" sections
       "text": "Added dark mode",
       "source": "explicit",
       "author": "external-contributor",
+      "author_association": "CONTRIBUTOR",
+      "author_is_bot": false,
       "is_external": true,
       "confidence": "high",
       "rationale": null,

--- a/.agents/skills/changelog-draft/scripts/convert_to_release_json.py
+++ b/.agents/skills/changelog-draft/scripts/convert_to_release_json.py
@@ -20,6 +20,8 @@ The output schema:
 
 import argparse
 import json
+import re
+import subprocess
 import sys
 
 # Map from changelog-draft.json category names to release JSON keys.
@@ -31,10 +33,73 @@ CATEGORY_MAP = {
     "IMAGE": "images",
 }
 
+INTERNAL_AUTHOR_ASSOCIATIONS = frozenset({"COLLABORATOR", "MEMBER", "OWNER"})
+PR_URL_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)$")
+
 
 def github_profile_link(username: str) -> str:
     """Format a GitHub username as a markdown profile link."""
     return f"[@{username}](https://github.com/{username})"
+
+
+def is_bot_author(author: str, entry: dict) -> bool:
+    """Return whether an entry author is a bot or GitHub App account."""
+    return (
+        bool(entry.get("author_is_bot"))
+        or author.endswith("[bot]")
+        or author.startswith("app/")
+    )
+
+
+def fetch_author_metadata(entry: dict) -> dict:
+    """Fetch author association metadata for an entry's PR URL via gh api.
+
+    This is a best-effort safety net for older or incomplete draft artifacts.
+    If the lookup fails, return the original entry unchanged.
+    """
+    if entry.get("author_association") or entry.get("author_is_bot"):
+        return entry
+
+    url = entry.get("url") or entry.get("pr_url") or ""
+    match = PR_URL_RE.match(url)
+    if match is None:
+        return entry
+
+    owner, repo, number = match.groups()
+    result = subprocess.run(
+        ["gh", "api", f"repos/{owner}/{repo}/pulls/{number}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return entry
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return entry
+
+    enriched = dict(entry)
+    enriched["author_association"] = data.get("author_association", "")
+    user = data.get("user") if isinstance(data.get("user"), dict) else {}
+    enriched["author_is_bot"] = user.get("type") == "Bot"
+    return enriched
+
+
+def should_attribute_author(entry: dict) -> bool:
+    """Return whether a changelog entry should credit its author publicly."""
+    author = entry.get("author")
+    if not entry.get("is_external") or not author:
+        return False
+    if is_bot_author(author, entry):
+        return False
+
+    author_association = str(entry.get("author_association", "")).upper()
+    if author_association in INTERNAL_AUTHOR_ASSOCIATIONS:
+        return False
+
+    return True
 
 
 def format_entry(entry: dict) -> str:
@@ -51,12 +116,12 @@ def format_entry(entry: dict) -> str:
         link = f" ([#{pr_number}]({url}))"
 
     attribution = ""
-    if entry.get("is_external") and entry.get("author"):
+    if should_attribute_author(entry):
         attribution = f" — {github_profile_link(entry['author'])} ✨"
     return f"{text}{link}{attribution}"
 
 
-def convert(draft: dict) -> dict:
+def convert(draft: dict, *, resolve_author_metadata: bool = False) -> dict:
     """Convert a changelog-draft.json dict to changelog-release.json dict."""
     release: dict[str, list[str]] = {
         "newFeatures": [],
@@ -66,7 +131,8 @@ def convert(draft: dict) -> dict:
         "oz_updates": [],
     }
 
-    for entry in draft.get("entries", []):
+    for raw_entry in draft.get("entries", []):
+        entry = fetch_author_metadata(raw_entry) if resolve_author_metadata else raw_entry
         category = entry.get("category", "")
         release_key = CATEGORY_MAP.get(category)
         if release_key is None:
@@ -95,12 +161,20 @@ def main() -> None:
         required=True,
         help="Path to write changelog-release.json",
     )
+    parser.add_argument(
+        "--resolve-author-metadata",
+        action="store_true",
+        help=(
+            "Best-effort lookup of missing PR author association metadata via gh api "
+            "before rendering contributor attribution"
+        ),
+    )
     args = parser.parse_args()
 
     with open(args.input) as f:
         draft = json.load(f)
 
-    release = convert(draft)
+    release = convert(draft, resolve_author_metadata=args.resolve_author_metadata)
 
     with open(args.output, "w") as f:
         json.dump(release, f, indent=2)

--- a/.agents/skills/changelog-draft/scripts/fetch_prs.py
+++ b/.agents/skills/changelog-draft/scripts/fetch_prs.py
@@ -14,6 +14,7 @@ import json
 import re
 import subprocess
 import sys
+from typing import Any
 
 # Matches lines like: CHANGELOG-NEW-FEATURE: Added dark mode
 MARKER_RE = re.compile(
@@ -98,6 +99,26 @@ def get_merged_commits(sha: str) -> list[str]:
     return log.splitlines()
 
 
+def fetch_pr_rest_metadata(repo: str, pr_number: int) -> dict[str, Any]:
+    """Fetch PR metadata only exposed by the REST API."""
+    raw = run(
+        ["gh", "api", f"repos/{repo}/pulls/{pr_number}"],
+        check=False,
+    )
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+    user = data.get("user") if isinstance(data.get("user"), dict) else {}
+    return {
+        "author_association": data.get("author_association", ""),
+        "author_is_bot": user.get("type") == "Bot",
+    }
+
+
 def fetch_pr_data(repo: str, pr_number: int) -> dict | None:
     """Fetch PR metadata and changed file paths via gh CLI."""
     fields = "number,title,author,body,labels,mergedAt,files,url"
@@ -108,9 +129,11 @@ def fetch_pr_data(repo: str, pr_number: int) -> dict | None:
     if not raw:
         return None
     try:
-        return json.loads(raw)
+        data = json.loads(raw)
     except json.JSONDecodeError:
         return None
+    data.update(fetch_pr_rest_metadata(repo, pr_number))
+    return data
 
 
 def fetch_pr_commit_messages(repo: str, pr_number: int) -> list[str]:
@@ -145,6 +168,17 @@ def get_author_login(data: dict) -> str:
     if isinstance(data.get("author"), str):
         return data["author"]
     return ""
+
+def get_author_is_bot(data: dict) -> bool:
+    """Return whether a gh PR JSON object's author is a bot/app account."""
+    author = data.get("author")
+    if isinstance(author, dict) and author.get("is_bot"):
+        return True
+    if data.get("author_is_bot"):
+        return True
+
+    login = get_author_login(data)
+    return login.endswith("[bot]") or login.startswith("app/")
 
 
 def get_label_names(data: dict) -> list[str]:
@@ -318,6 +352,8 @@ def main() -> None:
             "url": data.get("url", "") if source_repo == PUBLIC_REPO else "",
             "title": data.get("title", ""),
             "author": author_login,
+            "author_association": data.get("author_association", ""),
+            "author_is_bot": get_author_is_bot(data),
             "body": body,
             "labels": label_names,
             "merged_at": data.get("mergedAt", ""),

--- a/.agents/skills/changelog-draft/scripts/test_convert_to_release_json.py
+++ b/.agents/skills/changelog-draft/scripts/test_convert_to_release_json.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for changelog release JSON conversion."""
+
+import unittest
+from unittest import mock
+
+import convert_to_release_json as converter
+
+
+class ConvertToReleaseJsonTest(unittest.TestCase):
+    def test_external_contributor_is_attributed(self) -> None:
+        entry = {
+            "category": "IMPROVEMENT",
+            "text": "Added shell completions",
+            "pr_number": 11764,
+            "url": "https://github.com/warpdotdev/warp/pull/11764",
+            "author": "external-user",
+            "author_association": "CONTRIBUTOR",
+            "author_is_bot": False,
+            "is_external": True,
+        }
+
+        self.assertEqual(
+            converter.format_entry(entry),
+            "Added shell completions ([#11764](https://github.com/warpdotdev/warp/pull/11764)) — [@external-user](https://github.com/external-user) ✨",
+        )
+
+    def test_internal_member_keeps_pr_link_without_author_attribution(self) -> None:
+        entry = {
+            "category": "BUG-FIX",
+            "text": "Fixed queued prompt hover state",
+            "pr_number": 12067,
+            "url": "https://github.com/warpdotdev/warp/pull/12067",
+            "author": "harryalbert",
+            "author_association": "MEMBER",
+            "author_is_bot": False,
+            "is_external": True,
+        }
+
+        self.assertEqual(
+            converter.format_entry(entry),
+            "Fixed queued prompt hover state ([#12067](https://github.com/warpdotdev/warp/pull/12067))",
+        )
+
+    def test_app_author_keeps_pr_link_without_author_attribution(self) -> None:
+        entry = {
+            "category": "BUG-FIX",
+            "text": "AI responses that contain Markdown tables now render as structured tables",
+            "pr_number": 10683,
+            "url": "https://github.com/warpdotdev/warp/pull/10683",
+            "author": "app/oz-for-oss",
+            "author_association": "CONTRIBUTOR",
+            "author_is_bot": True,
+            "is_external": True,
+        }
+
+        self.assertEqual(
+            converter.format_entry(entry),
+            "AI responses that contain Markdown tables now render as structured tables ([#10683](https://github.com/warpdotdev/warp/pull/10683))",
+        )
+
+    def test_convert_can_resolve_missing_internal_author_metadata(self) -> None:
+        draft = {
+            "entries": [
+                {
+                    "category": "NEW-FEATURE",
+                    "text": "Queue multiple follow-up prompts",
+                    "pr_number": 12081,
+                    "url": "https://github.com/warpdotdev/warp/pull/12081",
+                    "author": "harryalbert",
+                    "is_external": True,
+                }
+            ]
+        }
+
+        with mock.patch.object(
+            converter,
+            "fetch_author_metadata",
+            return_value={
+                **draft["entries"][0],
+                "author_association": "MEMBER",
+                "author_is_bot": False,
+            },
+        ):
+            release = converter.convert(draft, resolve_author_metadata=True)
+
+        self.assertEqual(
+            release["newFeatures"],
+            [
+                "Queue multiple follow-up prompts ([#12081](https://github.com/warpdotdev/warp/pull/12081))"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1680,9 +1680,12 @@ jobs:
       - name: Convert draft JSON to release format (stable only)
         if: inputs.channel == 'stable'
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           python3 .agents/skills/changelog-draft/scripts/convert_to_release_json.py \
             --input "${{ runner.temp }}/changelog-draft/changelog-draft.json" \
+            --resolve-author-metadata \
             --output "${{ runner.temp }}/changelog-draft/changelog-release.json"
 
       - name: Obtain a GitHub App Installation Access Token (non-stable only)


### PR DESCRIPTION
## Description
Fixes the changelog release pipeline so Warp GitHub members and bot/app authors are not rendered as community contributor attributions in Slack or in-app release JSON.

What changed:
- Fetch public PR `author_association` and bot metadata from the GitHub REST API during changelog PR collection.
- Carry `author_association` and `author_is_bot` through the changelog draft schema/instructions.
- Add a deterministic conversion guard that keeps the changelog entry and PR link, but suppresses linked profile attribution/sparkles for `MEMBER`, `OWNER`, `COLLABORATOR`, bot, and GitHub App authors.
- Add a metadata-resolution fallback in the stable release workflow so older/incomplete draft artifacts are still protected before Slack payload generation.

## Linked Issue
Slack thread in `#release`: internal Warp GitHub members were being linked/credited as community contributors in the generated Stable changelog.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `python3 -m py_compile /workspace/warp/.agents/skills/changelog-draft/scripts/*.py`
- `python3 -m unittest discover -s /workspace/warp/.agents/skills/changelog-draft/scripts -p 'test_*.py'`
- Sample conversion with reported internal/member/app authors confirmed entries keep PR links without author attribution.
- Sample conversion with a known external contributor confirmed linked profile attribution still appears.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not applicable; release tooling only.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/68f87f22-7bb5-42b5-a0a3-e420e38fee8d_
_Run: https://oz.staging.warp.dev/runs/019e8e83-c61d-7486-b7b8-accc4908b0b1_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
