### PR TITLE
Bump Mermaid renderer dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "dagre_rust"
 version = "0.0.5"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=81551775746cd86bdeec29cb96ba278fd08c9074#81551775746cd86bdeec29cb96ba278fd08c9074"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=40cecf2be376e47e15053eadbfb782a531777420#40cecf2be376e47e15053eadbfb782a531777420"
 dependencies = [
  "graphlib_rust",
  "ordered_hashmap",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "mermaid_to_svg"
 version = "0.1.0"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=81551775746cd86bdeec29cb96ba278fd08c9074#81551775746cd86bdeec29cb96ba278fd08c9074"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=40cecf2be376e47e15053eadbfb782a531777420#40cecf2be376e47e15053eadbfb782a531777420"
 dependencies = [
  "dagre_rust",
  "graphlib_rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ lazy_static = "1.4.0"
 libc = "0.2.81"
 line-ending = "1.4.0"
 log = { version = "0.4", features = ["serde", "std"] }
-mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "81551775746cd86bdeec29cb96ba278fd08c9074" }
+mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "40cecf2be376e47e15053eadbfb782a531777420" }
 mime_guess = "2.0"
 minimp4 = "0.1.2"
 nix = { version = "0.26.4", default-features = false, features = ["signal"] }

--- a/crates/editor/src/content/mermaid_diagram.rs
+++ b/crates/editor/src/content/mermaid_diagram.rs
@@ -2,7 +2,6 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 
 use bytes::Bytes;
-use mermaid_to_svg::MermaidTheme;
 use warpui_core::assets::asset_cache::{
     AssetCache, AssetSource, AssetState, AsyncAssetId, AsyncAssetType,
 };
@@ -24,7 +23,7 @@ pub fn mermaid_asset_source(source: &str) -> AssetSource {
     let source = source.to_string();
     let mut hasher = DefaultHasher::new();
     source.hash(&mut hasher);
-    let id = format!("light:{:x}", hasher.finish());
+    let id = format!("configured:{:x}", hasher.finish());
     let fetch_source = source.clone();
 
     AssetSource::Async {
@@ -32,7 +31,7 @@ pub fn mermaid_asset_source(source: &str) -> AssetSource {
         fetch: Arc::new(move || {
             let source = fetch_source.clone();
             Box::pin(async move {
-                mermaid_to_svg::render_mermaid_to_svg(&source, Some(&MermaidTheme::light()))
+                mermaid_to_svg::render_mermaid_to_svg(&source, None)
                     .map(|svg| Bytes::from(svg.into_bytes()))
                     .map_err(Into::into)
             })

--- a/crates/editor/src/content/mermaid_diagram_tests.rs
+++ b/crates/editor/src/content/mermaid_diagram_tests.rs
@@ -38,6 +38,40 @@ fn loading_mermaid_layout_uses_default_height() {
 }
 
 #[test]
+fn mermaid_asset_source_renders_frontmatter_formatting_directives() {
+    let source = r##"---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#ff0000"
+  fontFamily: Inter
+  fontSize: 18px
+  flowchart:
+    curve: linear
+    nodeSpacing: 80
+---
+flowchart TD
+  A[Start] --> B[Done]
+"##;
+
+    let AssetSource::Async { fetch, .. } = mermaid_asset_source(source) else {
+        panic!("expected Mermaid diagrams to be async assets");
+    };
+    let bytes = match futures_lite::future::block_on(fetch()) {
+        Ok(bytes) => bytes,
+        Err(error) => panic!("expected frontmatter directives to render: {error:#}"),
+    };
+    let svg = match String::from_utf8(bytes.to_vec()) {
+        Ok(svg) => svg,
+        Err(error) => panic!("expected Mermaid SVG to be valid UTF-8: {error}"),
+    };
+
+    assert!(svg.contains("<svg "));
+    assert!(svg.contains(r##"fill="#ff0000""##));
+    assert!(svg.contains(r#"font-family="Inter""#));
+}
+
+#[test]
 fn failed_mermaid_layout_uses_compact_height() {
     App::test((), |app| async move {
         app.read(|ctx| {


### PR DESCRIPTION
## Description
Bumps `mermaid_to_svg` to the latest merged `warpdotdev/mermaid-to-svg` main commit, which includes Mermaid frontmatter/config handling and the rasterizable SVG background change from PR 17.

Also updates Warp's Mermaid asset renderer to let `mermaid-to-svg` apply diagram-level frontmatter formatting directives instead of forcing the light theme at the call site. This preserves the default light rendering behavior while allowing supported per-diagram config like theme variables and font settings to take effect.

Adds a regression test that renders a Mermaid diagram containing frontmatter formatting directives and verifies the generated SVG includes the configured fill and font family.

Agent conversation: https://staging.warp.dev/conversation/43adc087-dbf8-47b2-a476-6981e71ad10c

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Related:
- https://github.com/warpdotdev/mermaid-to-svg/pull/17
- https://github.com/warpdotdev/mermaid-to-svg/pull/15
- https://github.com/warpdotdev/warp/pull/11249

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- `./script/format`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo nextest run --no-fail-fast --workspace mermaid_asset_source_renders_frontmatter_formatting_directives`

### Screenshots / Videos
Not included; this PR is covered by a focused SVG-rendering regression test rather than screenshot comparison.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Mermaid diagrams now tolerate and apply supported frontmatter formatting directives when rendered in Warp.

Co-Authored-By: Oz <oz-agent@warp.dev>
