### PR TITLE
Improve telemetry for the diff state model

### DIFF
--- a/app/src/code_review/diff_state/error.rs
+++ b/app/src/code_review/diff_state/error.rs
@@ -9,14 +9,11 @@
 //! so a single classifier keeps the code DRY and ensures every site reports failures the same way.
 //!
 //! A [`DiffStateError`] pairs a sanitized [`DiffStateErrorKind`] with the raw
-//! underlying error and routes each half to the right place:
+//! underlying error, but only the sanitized half is ever emitted off-device:
 //! - [`std::fmt::Display`] renders only the sanitized `kind`, so passing this
-//!   through [`warp_core::report_error!`] keeps logs / Sentry free of repo
-//!   paths, refs, or command output. The raw cause is never exposed via
-//!   `Display` or `source`.
-//! - [`DiffStateError::raw_message`] returns the unsanitized text and is used
-//!   ONLY for telemetry, where the extra detail is needed to spot new failure
-//!   patterns and promote them to dedicated [`DiffStateErrorKind`] variants.
+//!   through [`warp_core::report_error!`] or code-review telemetry keeps logs,
+//!   Sentry, and analytics free of repo paths, refs, command output, or
+//!   secrets. The raw cause is never exposed via `Display` or `source`.
 //!
 //! For [`DiffStateErrorKind::Unknown`] the raw cause is additionally consulted
 //! via [`AnyhowErrorExt::is_actionable`] so registered non-actionable causes
@@ -124,10 +121,9 @@ impl DiffStateErrorKind {
 #[error("{kind}")]
 pub(crate) struct DiffStateError {
     kind: DiffStateErrorKind,
-    /// Raw underlying error. Surfaced ONLY through [`Self::raw_message`] for
-    /// telemetry, and consulted for [`DiffStateErrorKind::Unknown`]
-    /// actionability. Never exposed via `Display` or `source`, so logs and
-    /// Sentry only ever see the sanitized `kind`.
+    /// Raw underlying error. Consulted only for [`DiffStateErrorKind::Unknown`]
+    /// actionability and never exposed via `Display`, `source`, or telemetry,
+    /// so logs, Sentry, and analytics only ever see the sanitized `kind`.
     cause: anyhow::Error,
 }
 
@@ -149,14 +145,6 @@ impl DiffStateError {
         let kind = DiffStateErrorKind::EmptyDiffData;
         let cause = anyhow::anyhow!("{kind}");
         Self { kind, cause }
-    }
-
-    /// Raw, unsanitized error text, for telemetry ONLY. Not used for logs or
-    /// Sentry — those go through `Display`, which renders only the sanitized
-    /// `kind`. The extra detail lets us spot unclassified failures and promote
-    /// them to dedicated [`DiffStateErrorKind`] variants.
-    pub(crate) fn raw_message(&self) -> String {
-        format!("{:#}", self.cause)
     }
 }
 

--- a/app/src/code_review/diff_state/error.rs
+++ b/app/src/code_review/diff_state/error.rs
@@ -1,0 +1,227 @@
+//! Typed errors for diff state operations.
+//!
+//! [`DiffStateError`] is the single error type used across every diff-state operation:
+//! - per-file invalidation
+//! - full diff load
+//! - metadata load
+//! - remote-daemon snapshot/error responses
+//! The same pool of git / filesystem failures can surface in any of these operations,
+//! so a single classifier keeps the code DRY and ensures every site reports failures the same way.
+//!
+//! A [`DiffStateError`] pairs a sanitized [`DiffStateErrorKind`] with the raw
+//! underlying error and routes each half to the right place:
+//! - [`std::fmt::Display`] renders only the sanitized `kind`, so passing this
+//!   through [`warp_core::report_error!`] keeps logs / Sentry free of repo
+//!   paths, refs, or command output. The raw cause is never exposed via
+//!   `Display` or `source`.
+//! - [`DiffStateError::raw_message`] returns the unsanitized text and is used
+//!   ONLY for telemetry, where the extra detail is needed to spot new failure
+//!   patterns and promote them to dedicated [`DiffStateErrorKind`] variants.
+//!
+//! For [`DiffStateErrorKind::Unknown`] the raw cause is additionally consulted
+//! via [`AnyhowErrorExt::is_actionable`] so registered non-actionable causes
+//! (transient I/O, network, etc.) auto-demote it to a warning instead of a
+//! Sentry capture.
+//!
+//! Use the operation tag [`super::DiffOperation`] alongside this error in telemetry to distinguish where a given failure originated.
+
+use warp_core::errors::{AnyhowErrorExt, ErrorExt};
+use warp_core::sync_queue::IsTransientError;
+
+/// Sanitized classification of a [`DiffStateError`]. Every variant has a
+/// fixed, PII-free [`std::fmt::Display`] string that is safe to send to logs
+/// and Sentry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum DiffStateErrorKind {
+    // ── Git environment / repository state ──────────────────────────────
+    #[error("git rejected repository ownership")]
+    GitRejectedRepositoryOwnership,
+    #[error("git is unavailable")]
+    GitUnavailable,
+    #[error("git lfs is unavailable")]
+    GitLfsUnavailable,
+    #[error("xcode license is not accepted")]
+    XcodeLicenseNotAccepted,
+    #[error("invalid empty pathspec")]
+    InvalidEmptyPathspec,
+    #[error("path is outside repository")]
+    PathOutsideRepository,
+    #[error("path is not a git repository")]
+    NotGitRepository,
+    #[error("repository is not a work tree")]
+    NotWorkTree,
+    #[error("repository resource is not accessible")]
+    RepositoryPathNotAccessible,
+    #[error("path is not valid UTF-8")]
+    NonUtf8Path,
+    #[error("git revision is unavailable")]
+    GitRevisionUnavailable,
+    #[error("git head tree is invalid")]
+    GitHeadTreeInvalid,
+    #[error("git status output is invalid")]
+    InvalidGitStatusOutput,
+    #[error("repository path is invalid")]
+    RepositoryPathInvalid,
+
+    // ── Remote daemon application-level outcomes ────────────────────────
+    /// The remote daemon reported `DiffState::Loaded` but no `GitDiffData`
+    /// accompanied it. Only constructed by `RemoteDiffStateModel`.
+    #[error("server returned empty diff data")]
+    EmptyDiffData,
+
+    // ── Unclassified ────────────────────────────────────────────────────
+    /// Unrecognized error. Add a dedicated variant once a new pattern is
+    /// identified from the raw text recorded in telemetry.
+    #[error("unknown diff state error")]
+    Unknown,
+}
+
+impl DiffStateErrorKind {
+    fn classify(message: &str) -> Option<Self> {
+        if message.contains("detected dubious ownership in repository") {
+            Some(Self::GitRejectedRepositoryOwnership)
+        } else if message.contains("No such file or directory")
+            || message.contains("program not found")
+            || message.contains("No developer tools were found")
+        {
+            Some(Self::GitUnavailable)
+        } else if message.contains("git-lfs: command not found") {
+            Some(Self::GitLfsUnavailable)
+        } else if message.contains("Xcode license agreements") {
+            Some(Self::XcodeLicenseNotAccepted)
+        } else if message.contains("empty string is not a valid pathspec") {
+            Some(Self::InvalidEmptyPathspec)
+        } else if message.contains("outside repository") {
+            Some(Self::PathOutsideRepository)
+        } else if message.contains("not a git repository") {
+            Some(Self::NotGitRepository)
+        } else if message.contains("this operation must be run in a work tree") {
+            Some(Self::NotWorkTree)
+        } else if message.contains("Operation not permitted")
+            || message.contains("Permission denied")
+        {
+            Some(Self::RepositoryPathNotAccessible)
+        } else if message.contains("non-UTF-8 path") {
+            Some(Self::NonUtf8Path)
+        } else if message.contains("bad revision") || message.contains("unknown revision") {
+            Some(Self::GitRevisionUnavailable)
+        } else if message.contains("bad tree object HEAD") {
+            Some(Self::GitHeadTreeInvalid)
+        } else if message.contains("os error 267") {
+            Some(Self::RepositoryPathInvalid)
+        } else if message.contains("Invalid status code") {
+            Some(Self::InvalidGitStatusOutput)
+        } else {
+            None
+        }
+    }
+}
+
+/// A diff-state failure: a sanitized [`DiffStateErrorKind`] paired with the
+/// raw underlying error. See the module docs for how the two halves are
+/// routed to telemetry vs. logs / Sentry.
+#[derive(Debug, thiserror::Error)]
+#[error("{kind}")]
+pub(crate) struct DiffStateError {
+    kind: DiffStateErrorKind,
+    /// Raw underlying error. Surfaced ONLY through [`Self::raw_message`] for
+    /// telemetry, and consulted for [`DiffStateErrorKind::Unknown`]
+    /// actionability. Never exposed via `Display` or `source`, so logs and
+    /// Sentry only ever see the sanitized `kind`.
+    cause: anyhow::Error,
+}
+
+impl DiffStateError {
+    /// Build a `DiffStateError` from a plain error message string. Used when
+    /// the source error has already been flattened to a `String` (e.g. by
+    /// `DiffsWithBaseContent::changes`, or by the remote daemon over the
+    /// wire).
+    pub(crate) fn from_message(message: &str) -> Self {
+        Self {
+            kind: DiffStateErrorKind::classify(message).unwrap_or(DiffStateErrorKind::Unknown),
+            cause: anyhow::anyhow!("{message}"),
+        }
+    }
+
+    /// Build the [`DiffStateErrorKind::EmptyDiffData`] error, reported when the
+    /// remote daemon claims `DiffState::Loaded` but sends no diff data.
+    pub(crate) fn empty_diff_data() -> Self {
+        let kind = DiffStateErrorKind::EmptyDiffData;
+        let cause = anyhow::anyhow!("{kind}");
+        Self { kind, cause }
+    }
+
+    /// Raw, unsanitized error text, for telemetry ONLY. Not used for logs or
+    /// Sentry — those go through `Display`, which renders only the sanitized
+    /// `kind`. The extra detail lets us spot unclassified failures and promote
+    /// them to dedicated [`DiffStateErrorKind`] variants.
+    pub(crate) fn raw_message(&self) -> String {
+        format!("{:#}", self.cause)
+    }
+}
+
+impl From<anyhow::Error> for DiffStateError {
+    fn from(cause: anyhow::Error) -> Self {
+        let kind = DiffStateErrorKind::classify(&format!("{cause:#}"))
+            .unwrap_or(DiffStateErrorKind::Unknown);
+        Self { kind, cause }
+    }
+}
+
+impl ErrorExt for DiffStateError {
+    fn is_actionable(&self) -> bool {
+        match self.kind {
+            // Caller / engineering bugs — surface to Sentry at error level.
+            DiffStateErrorKind::InvalidEmptyPathspec
+            | DiffStateErrorKind::InvalidGitStatusOutput
+            | DiffStateErrorKind::EmptyDiffData => true,
+            // Unknown errors defer to the anyhow chain so registered
+            // transient/non-actionable causes (network, transient I/O, etc.)
+            // log at warn level instead of paging us via Sentry.
+            DiffStateErrorKind::Unknown => self.cause.is_actionable(),
+            // User environment failures — not our bug; log as warning.
+            DiffStateErrorKind::GitRejectedRepositoryOwnership
+            | DiffStateErrorKind::GitUnavailable
+            | DiffStateErrorKind::GitLfsUnavailable
+            | DiffStateErrorKind::XcodeLicenseNotAccepted
+            | DiffStateErrorKind::PathOutsideRepository
+            | DiffStateErrorKind::NotGitRepository
+            | DiffStateErrorKind::NotWorkTree
+            | DiffStateErrorKind::RepositoryPathNotAccessible
+            | DiffStateErrorKind::NonUtf8Path
+            | DiffStateErrorKind::GitRevisionUnavailable
+            | DiffStateErrorKind::GitHeadTreeInvalid
+            | DiffStateErrorKind::RepositoryPathInvalid => false,
+        }
+    }
+}
+warp_core::errors::register_error!(DiffStateError);
+
+impl IsTransientError for DiffStateError {
+    fn is_transient(&self) -> bool {
+        match self.kind {
+            // Repo / filesystem state can briefly churn while the queue is
+            // processing invalidations, so these are worth the sync queue's
+            // short retry budget.
+            DiffStateErrorKind::RepositoryPathNotAccessible
+            | DiffStateErrorKind::GitRevisionUnavailable
+            | DiffStateErrorKind::GitHeadTreeInvalid
+            | DiffStateErrorKind::EmptyDiffData
+            | DiffStateErrorKind::Unknown => true,
+            // Caller bugs, invalid inputs, missing tools, and user-actionable
+            // environment setup issues won't resolve by retrying the same
+            // operation a few seconds later.
+            DiffStateErrorKind::GitRejectedRepositoryOwnership
+            | DiffStateErrorKind::GitUnavailable
+            | DiffStateErrorKind::GitLfsUnavailable
+            | DiffStateErrorKind::XcodeLicenseNotAccepted
+            | DiffStateErrorKind::InvalidEmptyPathspec
+            | DiffStateErrorKind::PathOutsideRepository
+            | DiffStateErrorKind::NotGitRepository
+            | DiffStateErrorKind::NotWorkTree
+            | DiffStateErrorKind::NonUtf8Path
+            | DiffStateErrorKind::RepositoryPathInvalid
+            | DiffStateErrorKind::InvalidGitStatusOutput => false,
+        }
+    }
+}

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -252,7 +252,7 @@ impl LocalDiffStateModel {
                                 backend_origin: me.backend_origin,
                                 operation: DiffOperation::FileInvalidation,
                                 mode: me.mode.clone(),
-                                error: err.raw_message(),
+                                error: err.to_string(),
                                 // Per-file invalidation errors are not tied to a full
                                 // tracked load, so `load_duration` is intentionally `None`.
                                 load_duration: None,
@@ -1420,7 +1420,7 @@ impl LocalDiffStateModel {
                     CodeReviewTelemetryEvent::LoadMetadataFailed {
                         backend_origin: self.backend_origin,
                         mode: self.mode.clone(),
-                        error: err.raw_message(),
+                        error: err.to_string(),
                     },
                     ctx
                 );
@@ -1468,7 +1468,7 @@ impl LocalDiffStateModel {
                         backend_origin: self.backend_origin,
                         operation: DiffOperation::DiffLoad,
                         mode: self.mode.clone(),
-                        error: err.raw_message(),
+                        error: err.to_string(),
                         load_duration,
                     },
                     ctx

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -55,9 +55,11 @@ cfg_if::cfg_if! {
         use warpui::{ModelHandle, SingletonEntity};
     }
 }
+#[cfg(feature = "local_fs")]
+use super::DiffOperation;
 use super::{
     BackendOrigin, DiffHunk, DiffLine, DiffLineType, DiffMetadata, DiffMetadataAgainstBase,
-    DiffMode, DiffOperation, DiffState, DiffStateError, DiffStateModelEvent, DiffStats, FileDiff,
+    DiffMode, DiffState, DiffStateError, DiffStateModelEvent, DiffStats, FileDiff,
     FileDiffAndContent, FileStatusInfo, GitDiffData, GitDiffWithBaseContent, GitFileStatus,
 };
 

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -45,7 +45,7 @@ use crate::util::git::{
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         use std::collections::HashSet;
-        use crate::code_review::file_invalidation_queue::{FileInvalidationError, FileInvalidationTask};
+        use crate::code_review::file_invalidation_queue::FileInvalidationTask;
         use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
         use repo_metadata::{
             repository::{RepositorySubscriber, SubscriberId},
@@ -56,9 +56,9 @@ cfg_if::cfg_if! {
     }
 }
 use super::{
-    DiffHunk, DiffLine, DiffLineType, DiffMetadata, DiffMetadataAgainstBase, DiffMode, DiffState,
-    DiffStateModelEvent, DiffStats, FileDiff, FileDiffAndContent, FileStatusInfo, GitDiffData,
-    GitDiffWithBaseContent, GitFileStatus,
+    BackendOrigin, DiffHunk, DiffLine, DiffLineType, DiffMetadata, DiffMetadataAgainstBase,
+    DiffMode, DiffOperation, DiffState, DiffStateError, DiffStateModelEvent, DiffStats, FileDiff,
+    FileDiffAndContent, FileStatusInfo, GitDiffData, GitDiffWithBaseContent, GitFileStatus,
 };
 
 // Unicode bidirectional characters that should be flagged
@@ -189,6 +189,7 @@ pub struct LocalDiffStateModel {
     #[cfg(feature = "local_fs")]
     subscriber_id: Option<SubscriberId>,
     state: InternalDiffState,
+    backend_origin: BackendOrigin,
     mode: DiffMode,
     metadata: Option<DiffMetadata>,
     computing_diffs_abort_handle: Option<SpawnedFutureHandle>,
@@ -216,7 +217,11 @@ struct GitNumStatMetadata {
 
 impl LocalDiffStateModel {
     #[cfg(feature = "local_fs")]
-    pub fn new(repo_path: Option<String>, ctx: &mut ModelContext<Self>) -> Self {
+    pub fn new(
+        repo_path: Option<String>,
+        backend_origin: BackendOrigin,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
         // Set up file invalidation queue and subscribe to results
         // so the model can emit SingleFileUpdated events.
         let queue = SyncQueue::new_streaming(&ctx.background_executor());
@@ -224,7 +229,7 @@ impl LocalDiffStateModel {
 
         ctx.spawn_stream_local(
             rx,
-            |me, broadcast_result: Result<_, Arc<FileInvalidationError>>, ctx| {
+            |me, broadcast_result: Result<_, Arc<DiffStateError>>, ctx| {
                 if me.file_invalidation.invalidate_all_pending {
                     return;
                 }
@@ -244,9 +249,10 @@ impl LocalDiffStateModel {
                         warp_core::report_error!(err.as_ref());
                         send_telemetry_from_ctx!(
                             CodeReviewTelemetryEvent::LoadDiffFailed {
-                                is_local: Some(true),
+                                backend_origin: me.backend_origin,
+                                operation: DiffOperation::FileInvalidation,
                                 mode: me.mode.clone(),
-                                error: err.kind.to_string(),
+                                error: err.raw_message(),
                                 // Per-file invalidation errors are not tied to a full
                                 // tracked load, so `load_duration` is intentionally `None`.
                                 load_duration: None,
@@ -268,6 +274,7 @@ impl LocalDiffStateModel {
             },
             subscriber_id: None,
             mode: DiffMode::default(),
+            backend_origin,
             metadata: None,
             computing_diffs_abort_handle: None,
             computing_metadata_abort_handle: None,
@@ -310,9 +317,14 @@ impl LocalDiffStateModel {
     }
 
     #[cfg(not(feature = "local_fs"))]
-    pub fn new(_repo_path: Option<String>, _ctx: &mut ModelContext<Self>) -> Self {
+    pub fn new(
+        _repo_path: Option<String>,
+        backend_origin: BackendOrigin,
+        _ctx: &mut ModelContext<Self>,
+    ) -> Self {
         Self {
             state: InternalDiffState::default(),
+            backend_origin,
             mode: DiffMode::default(),
             metadata: None,
             computing_diffs_abort_handle: None,
@@ -1402,11 +1414,13 @@ impl LocalDiffStateModel {
                 self.metadata = Some(metadata);
             }
             Err(e) => {
+                let err = DiffStateError::from(e);
+                warp_core::report_error!(&err);
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadMetadataFailed {
-                        is_local: Some(true),
+                        backend_origin: self.backend_origin,
                         mode: self.mode.clone(),
-                        error: e.to_string(),
+                        error: err.raw_message(),
                     },
                     ctx
                 );
@@ -1447,11 +1461,14 @@ impl LocalDiffStateModel {
                     .tracked_diff_load_start_time
                     .take()
                     .map(|start| start.elapsed());
+                let err = DiffStateError::from_message(e);
+                warp_core::report_error!(&err);
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadDiffFailed {
-                        is_local: Some(true),
+                        backend_origin: self.backend_origin,
+                        operation: DiffOperation::DiffLoad,
                         mode: self.mode.clone(),
-                        error: e.to_string(),
+                        error: err.raw_message(),
                         load_duration,
                     },
                     ctx
@@ -2656,6 +2673,7 @@ impl LocalDiffStateModel {
             state: InternalDiffState::default(),
             #[cfg(feature = "local_fs")]
             subscriber_id: None,
+            backend_origin: BackendOrigin::ClientLocal,
             mode: DiffMode::default(),
             metadata: None,
             computing_diffs_abort_handle: None,

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -26,6 +26,50 @@ pub use local::LocalDiffStateModel;
 mod remote;
 pub use remote::RemoteDiffStateModel;
 
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+mod error;
+pub(crate) use error::DiffStateError;
+
+/// Identifies the host of a [`DiffStateModel`] so failure telemetry can be
+/// attributed to where the model actually ran. This is more specific than the
+/// local/remote split already encoded by `is_local`: a [`LocalDiffStateModel`]
+/// can be instantiated on the user's client (`ClientLocal`) or on a remote
+/// daemon (`RemoteDaemon`) serving subscribers, and only the host knows which.
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+pub enum BackendOrigin {
+    /// `LocalDiffStateModel` running on the user's client against local files.
+    #[serde(rename = "client_local")]
+    ClientLocal,
+    /// `RemoteDiffStateModel` running on the user's client; talks to a daemon.
+    #[serde(rename = "client_remote")]
+    ClientRemote,
+    /// `LocalDiffStateModel` running on a remote daemon, serving subscribers.
+    #[serde(rename = "remote_daemon")]
+    RemoteDaemon,
+}
+
+/// Identifies the diff-state operation that produced a [`DiffStateError`]
+/// on the `LoadDiffFailed` telemetry path. Carried alongside the error so
+/// failures can be sliced by originating operation — every operation shares
+/// the same failure pool, so the error variant alone doesn't reveal where
+/// it came from.
+///
+/// Metadata-load failures are reported through a dedicated
+/// `LoadMetadataFailed` event and therefore don't need a variant here.
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+pub enum DiffOperation {
+    /// Per-file diff refresh triggered by the file-invalidation queue.
+    #[serde(rename = "file_invalidation")]
+    FileInvalidation,
+    /// Full repo-wide diff snapshot load.
+    #[serde(rename = "diff_load")]
+    DiffLoad,
+    /// Client-side reaction to a remote daemon's diff-state response.
+    #[serde(rename = "remote_diff")]
+    RemoteDiff,
+}
+
 // -- Shared types ──────────────────────────────────────────────────────
 
 /// Represents the status of a file in the git working directory
@@ -349,7 +393,8 @@ impl DiffStateModel {
     /// to the inner model so it can forward events.
     pub fn new_local(path: PathBuf, ctx: &mut ModelContext<Self>) -> Self {
         let repo_path = Some(path.display().to_string());
-        let local = ctx.add_model(|ctx| LocalDiffStateModel::new(repo_path, ctx));
+        let local = ctx
+            .add_model(|ctx| LocalDiffStateModel::new(repo_path, BackendOrigin::ClientLocal, ctx));
         ctx.subscribe_to_model(&local, Self::forward_event);
         Self::Local(local)
     }

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -333,7 +333,7 @@ impl RemoteDiffStateModel {
                         backend_origin: BackendOrigin::ClientRemote,
                         operation: DiffOperation::RemoteDiff,
                         mode: self.mode.clone(),
-                        error: err.raw_message(),
+                        error: err.to_string(),
                         load_duration,
                     },
                     ctx
@@ -357,7 +357,7 @@ impl RemoteDiffStateModel {
                             backend_origin: BackendOrigin::ClientRemote,
                             operation: DiffOperation::RemoteDiff,
                             mode: self.mode.clone(),
-                            error: err.raw_message(),
+                            error: err.to_string(),
                             load_duration,
                         },
                         ctx

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -18,8 +18,8 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::{ModelContext, SingletonEntity};
 
 use super::{
-    DiffMetadata, DiffMode, DiffState, DiffStateModelEvent, DiffStats, FileDiffAndContent,
-    GitDiffData, GitDiffWithBaseContent,
+    BackendOrigin, DiffMetadata, DiffMode, DiffOperation, DiffState, DiffStateError,
+    DiffStateModelEvent, DiffStats, FileDiffAndContent, GitDiffData, GitDiffWithBaseContent,
 };
 use crate::code_review::telemetry_event::CodeReviewTelemetryEvent;
 use crate::remote_server::diff_state_proto::{try_decode_file_delta, try_decode_snapshot};
@@ -326,11 +326,14 @@ impl RemoteDiffStateModel {
                     .tracked_diff_load_start_time
                     .take()
                     .map(|start| start.elapsed());
+                let err = DiffStateError::from_message(&msg);
+                warp_core::report_error!(&err);
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadDiffFailed {
-                        is_local: Some(false),
+                        backend_origin: BackendOrigin::ClientRemote,
+                        operation: DiffOperation::RemoteDiff,
                         mode: self.mode.clone(),
-                        error: "Server reported diff error".to_string(),
+                        error: err.raw_message(),
                         load_duration,
                     },
                     ctx
@@ -343,22 +346,23 @@ impl RemoteDiffStateModel {
             }
             DiffState::Loaded => {
                 let Some(base_content) = diffs else {
-                    let error =
-                        "Server reported loaded state but no diff data was available".to_string();
                     let load_duration = self
                         .tracked_diff_load_start_time
                         .take()
                         .map(|start| start.elapsed());
+                    let err = DiffStateError::empty_diff_data();
+                    warp_core::report_error!(&err);
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::LoadDiffFailed {
-                            is_local: Some(false),
+                            backend_origin: BackendOrigin::ClientRemote,
+                            operation: DiffOperation::RemoteDiff,
                             mode: self.mode.clone(),
-                            error: "Empty diff data".to_string(),
+                            error: err.raw_message(),
                             load_duration,
                         },
                         ctx
                     );
-                    self.state = InternalRemoteDiffState::Error(error);
+                    self.state = InternalRemoteDiffState::Error(err.to_string());
                     ctx.emit(DiffStateModelEvent::NewDiffsComputed {
                         diffs: None,
                         load_duration: None,

--- a/app/src/code_review/file_invalidation_queue.rs
+++ b/app/src/code_review/file_invalidation_queue.rs
@@ -3,138 +3,19 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use warp_core::errors::{AnyhowErrorExt as _, ErrorExt};
-use warp_core::sync_queue::{IsTransientError, SyncQueueTaskTrait};
+use warp_core::sync_queue::SyncQueueTaskTrait;
 
-use super::diff_state::{DiffMode, FileDiffAndContent, LocalDiffStateModel};
-#[derive(Debug, Clone, Copy, thiserror::Error)]
-pub(crate) enum FileInvalidationErrorKind {
-    #[error("git rejected repository ownership")]
-    GitRejectedRepositoryOwnership,
-    #[error("git is unavailable")]
-    GitUnavailable,
-    #[error("git lfs is unavailable")]
-    GitLfsUnavailable,
-    #[error("xcode license is not accepted")]
-    XcodeLicenseNotAccepted,
-    #[error("invalid empty pathspec")]
-    InvalidEmptyPathspec,
-    #[error("path is outside repository")]
-    PathOutsideRepository,
-    #[error("path is not a git repository")]
-    NotGitRepository,
-    #[error("repository is not a work tree")]
-    NotWorkTree,
-    #[error("repository path is not accessible")]
-    RepositoryPathNotAccessible,
-    #[error("path is not valid UTF-8")]
-    NonUtf8Path,
-    #[error("git revision is unavailable")]
-    GitRevisionUnavailable,
-    #[error("git head tree is invalid")]
-    GitHeadTreeInvalid,
-    #[error("git status output is invalid")]
-    InvalidGitStatusOutput,
-    #[error("repository path is invalid")]
-    RepositoryPathInvalid,
-    #[error("unknown file invalidation error")]
-    Unknown,
-}
+use super::diff_state::{DiffMode, DiffStateError, FileDiffAndContent, LocalDiffStateModel};
 
-impl FileInvalidationErrorKind {
-    fn from_message(message: &str) -> Self {
-        if message.contains("detected dubious ownership in repository") {
-            Self::GitRejectedRepositoryOwnership
-        } else if message.contains("No such file or directory")
-            || message.contains("program not found")
-            || message.contains("No developer tools were found")
-        {
-            Self::GitUnavailable
-        } else if message.contains("git-lfs: command not found") {
-            Self::GitLfsUnavailable
-        } else if message.contains("Xcode license agreements") {
-            Self::XcodeLicenseNotAccepted
-        } else if message.contains("empty string is not a valid pathspec") {
-            Self::InvalidEmptyPathspec
-        } else if message.contains("outside repository") {
-            Self::PathOutsideRepository
-        } else if message.contains("not a git repository") {
-            Self::NotGitRepository
-        } else if message.contains("this operation must be run in a work tree") {
-            Self::NotWorkTree
-        } else if message.contains("Operation not permitted")
-            || message.contains("Permission denied")
-        {
-            Self::RepositoryPathNotAccessible
-        } else if message.contains("non-UTF-8 path") {
-            Self::NonUtf8Path
-        } else if message.contains("bad revision") || message.contains("unknown revision") {
-            Self::GitRevisionUnavailable
-        } else if message.contains("bad tree object HEAD") {
-            Self::GitHeadTreeInvalid
-        } else if message.contains("Invalid status code") {
-            Self::InvalidGitStatusOutput
-        } else if message.contains("os error 267") {
-            Self::RepositoryPathInvalid
-        } else {
-            Self::Unknown
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("{kind}")]
-pub struct FileInvalidationError {
-    pub(crate) kind: FileInvalidationErrorKind,
-    error: anyhow::Error,
-}
-
-impl From<anyhow::Error> for FileInvalidationError {
-    fn from(error: anyhow::Error) -> Self {
-        let message = format!("{error:#}");
-        let kind = FileInvalidationErrorKind::from_message(&message);
-        Self { kind, error }
-    }
-}
-
-impl ErrorExt for FileInvalidationError {
-    fn is_actionable(&self) -> bool {
-        match self.kind {
-            FileInvalidationErrorKind::InvalidEmptyPathspec
-            | FileInvalidationErrorKind::InvalidGitStatusOutput => true,
-            FileInvalidationErrorKind::Unknown => self.error.is_actionable(),
-            FileInvalidationErrorKind::GitRejectedRepositoryOwnership
-            | FileInvalidationErrorKind::GitUnavailable
-            | FileInvalidationErrorKind::GitLfsUnavailable
-            | FileInvalidationErrorKind::XcodeLicenseNotAccepted
-            | FileInvalidationErrorKind::PathOutsideRepository
-            | FileInvalidationErrorKind::NotGitRepository
-            | FileInvalidationErrorKind::NotWorkTree
-            | FileInvalidationErrorKind::RepositoryPathNotAccessible
-            | FileInvalidationErrorKind::NonUtf8Path
-            | FileInvalidationErrorKind::GitRevisionUnavailable
-            | FileInvalidationErrorKind::GitHeadTreeInvalid
-            | FileInvalidationErrorKind::RepositoryPathInvalid => false,
-        }
-    }
-}
-warp_core::errors::register_error!(FileInvalidationError);
-
-impl IsTransientError for FileInvalidationError {
-    fn is_transient(&self) -> bool {
-        true
-    }
-}
-
-pub struct FileInvalidationTask {
-    pub file: PathBuf,
-    pub repo_path: PathBuf,
-    pub mode: DiffMode,
-    pub merge_base: Option<String>,
+pub(crate) struct FileInvalidationTask {
+    pub(crate) file: PathBuf,
+    pub(crate) repo_path: PathBuf,
+    pub(crate) mode: DiffMode,
+    pub(crate) merge_base: Option<String>,
 }
 
 impl SyncQueueTaskTrait for FileInvalidationTask {
-    type Error = FileInvalidationError;
+    type Error = DiffStateError;
     /// The first element is the repo-relative path of the updated file.
     type Result = (String, Option<Arc<FileDiffAndContent>>);
     #[cfg(not(target_arch = "wasm32"))]
@@ -158,7 +39,7 @@ impl SyncQueueTaskTrait for FileInvalidationTask {
                 merge_base.as_deref(),
             )
             .await
-            .map_err(FileInvalidationError::from)
+            .map_err(DiffStateError::from)
         })
     }
 }

--- a/app/src/code_review/telemetry_event.rs
+++ b/app/src/code_review/telemetry_event.rs
@@ -7,7 +7,7 @@ use serde_with::SerializeDisplay;
 use strum_macros::{EnumDiscriminants, EnumIter};
 use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
 
-use crate::code_review::diff_state::DiffMode;
+use crate::code_review::diff_state::{BackendOrigin, DiffMode, DiffOperation};
 use crate::features::FeatureFlag;
 use crate::server::telemetry::CLIAgentType;
 use crate::view_components::find::FindDirection;
@@ -214,13 +214,16 @@ pub enum CodeReviewTelemetryEvent {
     },
     /// Failure when we are calculating the diff metadata.
     LoadMetadataFailed {
-        is_local: Option<bool>,
+        backend_origin: BackendOrigin,
         mode: DiffMode,
         error: String,
     },
-    /// Failure when we are loading the actual diff content.
+    /// Failure when we are loading the actual diff content. Shared across
+    /// file-invalidation, full diff load, and remote diff paths; the
+    /// `operation` field distinguishes which one produced the failure.
     LoadDiffFailed {
-        is_local: Option<bool>,
+        backend_origin: BackendOrigin,
+        operation: DiffOperation,
         mode: DiffMode,
         error: String,
         /// Time elapsed between when the tracked diff load was requested and
@@ -382,17 +385,23 @@ impl TelemetryEvent for CodeReviewTelemetryEvent {
                 Some(json!({ "is_local": is_local, "mode": mode }))
             }
             CodeReviewTelemetryEvent::LoadMetadataFailed {
-                is_local,
+                backend_origin,
                 mode,
                 error,
-            } => Some(json!({ "is_local": is_local, "mode": mode, "error": error })),
+            } => Some(json!({
+                "backend_origin": backend_origin,
+                "mode": mode,
+                "error": error,
+            })),
             CodeReviewTelemetryEvent::LoadDiffFailed {
-                is_local,
+                backend_origin,
+                operation,
                 mode,
                 error,
                 load_duration,
             } => Some(json!({
-                "is_local": is_local,
+                "backend_origin": backend_origin,
+                "operation": operation,
                 "mode": mode,
                 "error": error,
                 "load_duration": load_duration,

--- a/app/src/remote_server/diff_state_tracker.rs
+++ b/app/src/remote_server/diff_state_tracker.rs
@@ -17,7 +17,7 @@ use warpui::{AppContext, Entity, ModelContext, ModelHandle};
 use super::protocol::RequestId;
 use super::server_model::ConnectionId;
 use crate::code_review::diff_state::{
-    DiffMetadata, DiffMode, DiffState, DiffStateModelEvent, FileDiffAndContent,
+    BackendOrigin, DiffMetadata, DiffMode, DiffState, DiffStateModelEvent, FileDiffAndContent,
     GitDiffWithBaseContent, LocalDiffStateModel,
 };
 
@@ -279,7 +279,8 @@ impl RemoteDiffStateManager {
             let repo_path_str = key.repo_path.to_string();
             let mode = key.mode.clone();
             let model = ctx.add_model(|ctx| {
-                let mut m = LocalDiffStateModel::new(Some(repo_path_str), ctx);
+                let mut m =
+                    LocalDiffStateModel::new(Some(repo_path_str), BackendOrigin::RemoteDaemon, ctx);
                 m.set_diff_mode(mode, false, false, ctx);
                 m.set_code_review_metadata_refresh_enabled(true, ctx);
                 m

--- a/app/src/remote_server/diff_state_tracker_tests.rs
+++ b/app/src/remote_server/diff_state_tracker_tests.rs
@@ -3,7 +3,7 @@ use warp_util::standardized_path::StandardizedPath;
 use super::super::protocol::RequestId;
 use super::super::server_model::ConnectionId;
 use super::{DiffModelKey, RemoteDiffStateManager};
-use crate::code_review::diff_state::DiffMode;
+use crate::code_review::diff_state::{BackendOrigin, DiffMode, LocalDiffStateModel};
 
 /// Uses `try_new` instead of `try_from_local` so that Unix-style paths
 /// like `/repo` are recognised as absolute on all platforms (including Windows).
@@ -79,8 +79,8 @@ fn unsubscribe_last_connection_removes_model() {
 
     // Simulate model insertion + subscription (what handle_get_diff_state does).
     warpui::App::test((), |mut app| async move {
-        let handle = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let handle =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key.clone(), handle);
         model.subscribe_connection(key.clone(), conn);
 
@@ -99,8 +99,8 @@ fn unsubscribe_one_of_two_keeps_model() {
     let conn_b = new_conn();
 
     warpui::App::test((), |mut app| async move {
-        let handle = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let handle =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key.clone(), handle);
         model.subscribe_connection(key.clone(), conn_a);
         model.subscribe_connection(key.clone(), conn_b);
@@ -120,8 +120,8 @@ fn unsubscribe_clears_pending_responses_for_that_connection() {
     let conn_b = new_conn();
 
     warpui::App::test((), |mut app| async move {
-        let handle = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let handle =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key.clone(), handle);
         model.subscribe_connection(key.clone(), conn_a);
         model.subscribe_connection(key.clone(), conn_b);
@@ -147,10 +147,10 @@ fn remove_connection_unsubscribes_from_all_keys() {
     let conn = new_conn();
 
     warpui::App::test((), |mut app| async move {
-        let h1 = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
-        let h2 = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let h1 =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
+        let h2 =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key_head.clone(), h1);
         model.insert_model(key_main.clone(), h2);
         model.subscribe_connection(key_head.clone(), conn);
@@ -172,8 +172,8 @@ fn remove_connection_keeps_models_with_other_subscribers() {
     let conn_b = new_conn();
 
     warpui::App::test((), |mut app| async move {
-        let handle = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let handle =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key.clone(), handle);
         model.subscribe_connection(key.clone(), conn_a);
         model.subscribe_connection(key.clone(), conn_b);
@@ -192,8 +192,8 @@ fn remove_connection_clears_pending_responses() {
     let conn = new_conn();
 
     warpui::App::test((), |mut app| async move {
-        let handle = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let handle =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key.clone(), handle);
         model.subscribe_connection(key.clone(), conn);
         model.add_pending_response(key.clone(), RequestId::new(), conn);
@@ -274,8 +274,8 @@ fn insert_and_get_model() {
     let key = test_key("/repo", DiffMode::Head);
 
     warpui::App::test((), |mut app| async move {
-        let handle = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let handle =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key.clone(), handle);
 
         assert!(model.get_model(&key).is_some());
@@ -289,8 +289,8 @@ fn remove_model_clears_pending_and_subscriptions() {
     let conn = new_conn();
 
     warpui::App::test((), |mut app| async move {
-        let handle = app
-            .add_model(|ctx| crate::code_review::diff_state::LocalDiffStateModel::new(None, ctx));
+        let handle =
+            app.add_model(|ctx| LocalDiffStateModel::new(None, BackendOrigin::ClientLocal, ctx));
         model.insert_model(key.clone(), handle);
         model.subscribe_connection(key.clone(), conn);
         model.add_pending_response(key.clone(), RequestId::new(), conn);


### PR DESCRIPTION
## Description
* With the launch of remote support for the code review view, we want better insights into how users are interacting with the feature and what kind of errors they're running into. 
  * This PR introduces a more generic `DiffStateError` type to help classify the different kinds of errors a user can run into when loading diffs/running git commands  
    * This helps not only sanitize the logs/errors that get reported to Sentry but also makes it more explicit which category of errors are expected/retry-able/transient 
* This also introduces a backend origin so that we can better differentiate between a local and remote clients 
  * Previously we were only using `is_local` which also returns true for a diff state model running on the remote daemon, this made it hard to parse which errors were actually from a local machine vs. remote machine 

## Linked Issue
[APP-4634](https://linear.app/warpdotdev/issue/APP-4634/investigate-generally-high-diff-load-failure-rates)
[APP-4631](https://linear.app/warpdotdev/issue/APP-4631/git-command-failed-no-such-filedir)
* Example: we were getting sentry errors that were reporting `File invalidation error: Failed to execute git command: No such file or directory` which is typically an expected user/environment error that signifies git is not installed on a user's machine 

## Testing
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode