### PR TITLE
Allow partial build of repo metadata for repos exceeding max limits

### DIFF
--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -60,8 +60,6 @@ use crate::util::openable_file_type::{
 use crate::util::openable_file_type::{
     resolve_file_target_to_open_in_warp, resolve_file_target_with_editor_choice,
 };
-use crate::view_components::DismissibleToast;
-use crate::workspace::ToastStack;
 
 mod editing;
 mod render;
@@ -1416,14 +1414,6 @@ impl FileTreeView {
                 .update(ctx, |model: &mut RepoMetadataModel, ctx| {
                     model.load_directory(&backing_root, &dir_path, ctx)
                 });
-        if matches!(
-            load_result,
-            Err(repo_metadata::RepoMetadataError::BuildTree(
-                repo_metadata::BuildTreeError::ExceededMaxFileLimit,
-            ))
-        ) {
-            Self::show_exceeded_file_limit_toast(ctx);
-        }
         if let Err(error) = load_result {
             log::warn!("Failed to load directory {dir_path}: {error}");
         }
@@ -1557,14 +1547,6 @@ impl FileTreeView {
                 .update(ctx, |model: &mut RepoMetadataModel, ctx| {
                     model.index_lazy_loaded_path(path, ctx)
                 });
-            if matches!(
-                index_result,
-                Err(repo_metadata::RepoMetadataError::BuildTree(
-                    repo_metadata::BuildTreeError::ExceededMaxFileLimit,
-                ))
-            ) {
-                Self::show_exceeded_file_limit_toast(ctx);
-            }
             if let Err(error) = &index_result {
                 log::warn!("Failed to index lazy-loaded path {path}: {error}");
             }
@@ -1594,17 +1576,6 @@ impl FileTreeView {
 
     fn create_empty_entry(path: &StandardizedPath) -> FileTreeEntry {
         FileTreeEntry::new_for_directory(Arc::new(path.clone()))
-    }
-
-    fn show_exceeded_file_limit_toast(ctx: &mut ViewContext<Self>) {
-        let window_id = ctx.window_id();
-        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-            let toast = DismissibleToast::error(String::from(
-                "Folder has too many files to display in the file explorer.",
-            ))
-            .with_object_id("file_tree_exceeded_file_limit".to_string());
-            toast_stack.add_ephemeral_toast(toast, window_id, ctx);
-        });
     }
 
     /// Rebuilds the flattened items list for a single root directory only,

--- a/crates/ai/src/index/file_outline/native.rs
+++ b/crates/ai/src/index/file_outline/native.rs
@@ -8,7 +8,7 @@ use futures::channel::oneshot;
 use ignore::gitignore::Gitignore;
 use itertools::Itertools;
 use rayon::prelude::*;
-use repo_metadata::entry::{is_file_parsable, IgnoredPathStrategy};
+use repo_metadata::entry::{is_file_parsable, BudgetExceededBehavior, IgnoredPathStrategy};
 use repo_metadata::RepositoryUpdate;
 use streaming_iterator::StreamingIterator;
 use syntax_tree::TextSlice;
@@ -55,6 +55,7 @@ pub async fn build_outline(
         MAX_DEPTH,
         0,
         &IgnoredPathStrategy::Exclude, // override_ignore_for_files
+        BudgetExceededBehavior::StopAndLazyLoad,
     )?;
 
     let (sender, receiver) = oneshot::channel();

--- a/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
+++ b/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
@@ -11,7 +11,7 @@ use futures::stream::AbortHandle;
 use ignore::gitignore::Gitignore;
 use instant::Instant;
 #[cfg(feature = "local_fs")]
-use repo_metadata::entry::IgnoredPathStrategy;
+use repo_metadata::entry::{BudgetExceededBehavior, IgnoredPathStrategy};
 use repo_metadata::Repository;
 use warp_core::safe_error;
 use warpui_core::{Entity, ModelContext, ModelHandle};
@@ -936,6 +936,9 @@ impl CodebaseIndex {
         // First traverse the repo path to retrieve all files we want to parse.
         let mut files = Vec::new();
         let mut remaining_file_quotas = max_num_files_limit;
+        // Codebase embedding must not operate on a partial tree: the file limit
+        // is an intentional cost cap, so exceeding it fails the build rather
+        // than silently indexing a breadth-first subset of the repository.
         let entry = Entry::build_tree(
             &repo_path,
             &mut files,
@@ -944,6 +947,7 @@ impl CodebaseIndex {
             MAX_DEPTH,
             0,
             &IgnoredPathStrategy::Exclude, // override_ignore_for_files
+            BudgetExceededBehavior::FailFast,
         )?;
 
         Ok(BuildFileTreeResult {

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -14,7 +14,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         use async_channel::Sender;
         use ignore::gitignore::Gitignore;
-        use repo_metadata::entry::{Entry, FileMetadata};
+        use repo_metadata::entry::{BudgetExceededBehavior, Entry, FileMetadata};
         use repo_metadata::repository::RepositorySubscriber;
         use repo_metadata::{DirectoryWatcher, Repository, RepositoryUpdate};
 
@@ -694,6 +694,7 @@ impl ProjectContextModel {
             MAX_SCAN_DEPTH,
             0,
             &ignore_behavior,
+            BudgetExceededBehavior::StopAndLazyLoad,
         )?;
 
         // Filter files to only include those matching RULES_FILE_PATTERN

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 
+use std::collections::VecDeque;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -47,6 +48,20 @@ pub enum IgnoredPathStrategy {
     Include,
 }
 
+/// What the tree builder does when the per-build file budget is exhausted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BudgetExceededBehavior {
+    /// Stop descending and leave the remaining directories as unloaded
+    /// placeholders (lazy-loaded on demand). The build still succeeds with a
+    /// partial, breadth-first tree. This is the default for the shared file
+    /// tree, `@`-context, and skill discovery.
+    StopAndLazyLoad,
+    /// Abort the build and return [`BuildTreeError::ExceededMaxFileLimit`].
+    /// Use this for consumers that must not operate on a partial tree — e.g.
+    /// codebase embedding, where the file limit is an intentional cost cap.
+    FailFast,
+}
+
 /// Filesystem entry.
 #[derive(Debug, Clone)]
 pub enum Entry {
@@ -59,15 +74,7 @@ pub(crate) struct BuildTreeOptions<'a> {
     pub current_depth: usize,
     pub ignored_path_strategy: &'a IgnoredPathStrategy,
     pub ignored_path_interests: &'a [PathBuf],
-}
-
-impl<'a> BuildTreeOptions<'a> {
-    fn child(self) -> Self {
-        Self {
-            current_depth: self.current_depth + 1,
-            ..self
-        }
-    }
+    pub budget_exceeded_behavior: BudgetExceededBehavior,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
@@ -108,6 +115,9 @@ impl Entry {
     /// Builds a tree of entries from a given path, handling gitignored files and directories.
     /// After max_depth is reached, all children are lazy-loaded to prevent deeply nested trees.
     /// IgnoredPathStrategy determines what happens when ignored files are encountered.
+    /// `budget_exceeded_behavior` controls what happens once the file budget is
+    /// exhausted (see [`BudgetExceededBehavior`]).
+    #[allow(clippy::too_many_arguments)]
     pub fn build_tree(
         path: impl Into<PathBuf>,
         files: &mut Vec<FileMetadata>,
@@ -116,6 +126,7 @@ impl Entry {
         max_depth: usize,
         current_depth: usize,
         ignored_path_strategy: &IgnoredPathStrategy,
+        budget_exceeded_behavior: BudgetExceededBehavior,
     ) -> Result<Self, BuildTreeError> {
         Self::build_tree_with_ignored_path_interests_and_ancestor(
             path,
@@ -127,6 +138,7 @@ impl Entry {
                 current_depth,
                 ignored_path_strategy,
                 ignored_path_interests: &[],
+                budget_exceeded_behavior,
             },
             false,
         )
@@ -172,6 +184,7 @@ impl Entry {
                 current_depth,
                 ignored_path_strategy,
                 ignored_path_interests: &[],
+                budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
             },
             ancestor_is_ignored,
         )
@@ -182,85 +195,114 @@ impl Entry {
         path: impl Into<PathBuf>,
         files: &mut Vec<FileMetadata>,
         gitignores: &mut Vec<Gitignore>,
-        mut remaining_file_quota: Option<&mut usize>,
+        remaining_file_quota: Option<&mut usize>,
         options: BuildTreeOptions<'_>,
         ancestor_is_ignored: bool,
     ) -> Result<Self, BuildTreeError> {
-        let curr_path: PathBuf = path.into();
-        let is_dir = curr_path.is_dir();
+        let root_path: PathBuf = path.into();
 
-        // Only ignore symlinks to directories. Symlinks to files are preserved (e.g. WARP.md).
-        if curr_path.is_symlink() && is_dir {
-            return Err(BuildTreeError::Symlink);
-        }
+        // Local copy of the file budget. The builder spends it breadth-first;
+        // once it is exhausted, any remaining directories are left as unloaded
+        // placeholders (lazy-loaded on demand) instead of aborting the whole
+        // build. This keeps coverage even and shallow-biased rather than
+        // collapsing the entire tree to a single level.
+        let mut quota: Option<usize> = remaining_file_quota.as_deref().copied();
 
-        let gitignore_path = curr_path.join(".gitignore");
-        if gitignore_path.exists() {
-            let (gitignore, _) = Gitignore::new(gitignore_path);
-            gitignores.push(gitignore);
-        }
+        // Arena of partially-built nodes. A child is always discovered (and
+        // pushed) while expanding its parent, so a child's index is always
+        // greater than its parent's and the nested tree can be assembled
+        // bottom-up at the end.
+        let mut nodes: Vec<Option<NodeBuilder>> = Vec::new();
 
-        let path_is_ignored = ancestor_is_ignored
-            || is_git_internal_path(&curr_path)
-            || matches_gitignores(
-                &curr_path,
-                is_dir,
-                &*gitignores,
-                false, /* check_ancestors */
-            );
-
-        // If we've reached the max depth, force lazy-loading even of non-ignored folders.
-        let mut lazy_load = options.current_depth >= options.max_depth;
-
-        if path_is_ignored {
-            match options.ignored_path_strategy {
-                IgnoredPathStrategy::Exclude => {
-                    return Err(BuildTreeError::Ignored);
-                }
-                IgnoredPathStrategy::IncludeOnly(patterns) => {
-                    if let Some(file_name) = curr_path.file_name().and_then(|n| n.to_str()) {
-                        if !patterns.iter().any(|pattern| file_name == pattern) {
-                            return Err(BuildTreeError::Ignored);
-                        }
-                    }
-                }
-                IgnoredPathStrategy::IncludeLazy => {
-                    lazy_load =
-                        !matches_ignored_path_interest(&curr_path, options.ignored_path_interests);
-                }
-                IgnoredPathStrategy::Include => {}
-            }
-        }
-
-        if is_dir {
-            if lazy_load {
-                return Ok(Self::Directory(DirectoryEntry {
-                    children: vec![],
-                    path: StandardizedPath::from_local_absolute_unchecked(&curr_path),
-                    ignored: path_is_ignored,
-                    loaded: false,
-                }));
-            }
-
-            // If the path is a directory, process all the children under it.
-            let entries = std::fs::read_dir(&curr_path)?;
-            let mut children = Vec::new();
-
-            for entry in entries {
-                if remaining_file_quota
-                    .as_ref()
-                    .is_some_and(|x| **x < children.len())
+        // Classify the root. Unlike child entries (which are simply omitted when
+        // ignored/symlinked), a classification failure at the root propagates to
+        // the caller, preserving existing error behavior.
+        match evaluate_entry(
+            &root_path,
+            gitignores,
+            &options,
+            options.current_depth,
+            ancestor_is_ignored,
+        )? {
+            EvaluatedEntry::File { ignored } => {
+                if quota == Some(0)
+                    && options.budget_exceeded_behavior == BudgetExceededBehavior::FailFast
                 {
                     return Err(BuildTreeError::ExceededMaxFileLimit);
                 }
+                let metadata = consume_file(&root_path, ignored, files, &mut quota);
+                write_back_quota(remaining_file_quota, quota);
+                Ok(Self::File(metadata))
+            }
+            EvaluatedEntry::Directory { ignored, lazy } => {
+                nodes.push(Some(NodeBuilder::Dir {
+                    path: root_path.clone(),
+                    ignored,
+                    loaded: false,
+                    children: Vec::new(),
+                }));
 
-                if let Some(entry) = match entry {
-                    Ok(entry) => {
+                let mut queue: VecDeque<DirJob> = VecDeque::new();
+                if !lazy {
+                    queue.push_back(DirJob {
+                        index: 0,
+                        path: root_path,
+                        depth: options.current_depth,
+                        ignored,
+                        is_root: true,
+                    });
+                }
+
+                while let Some(job) = queue.pop_front() {
+                    // Budget handling. With `StopAndLazyLoad` (the default), once
+                    // the file quota is exhausted we stop expanding directories
+                    // and leave them as unloaded placeholders; directories on the
+                    // path to a registered ignored-path interest (e.g. skill
+                    // provider directories) are always expanded so
+                    // discovery-critical files stay reachable. With `FailFast` we
+                    // keep descending and abort below as soon as a file would
+                    // exceed the budget.
+                    let should_expand = match options.budget_exceeded_behavior {
+                        BudgetExceededBehavior::FailFast => true,
+                        BudgetExceededBehavior::StopAndLazyLoad => {
+                            quota.is_none_or(|remaining| remaining > 0)
+                                || matches_ignored_path_interest(
+                                    &job.path,
+                                    options.ignored_path_interests,
+                                )
+                        }
+                    };
+                    if !should_expand {
+                        continue;
+                    }
+
+                    let entries = match std::fs::read_dir(&job.path) {
+                        Ok(entries) => entries,
+                        Err(e) => {
+                            // Preserve existing behavior: failing to read the
+                            // root directory propagates, while an unreadable
+                            // nested directory is left as an unloaded placeholder.
+                            if job.is_root {
+                                return Err(BuildTreeError::IOError(e));
+                            }
+                            continue;
+                        }
+                    };
+
+                    if let Some(NodeBuilder::Dir { loaded, .. }) = nodes[job.index].as_mut() {
+                        *loaded = true;
+                    }
+
+                    let child_depth = job.depth + 1;
+                    for entry in entries {
+                        let Ok(entry) = entry else {
+                            continue;
+                        };
                         let entry_path = entry.path();
 
-                        // Skip symlinks to folders before canonicalization to prevent duplicates.
-                        // If it's a symlink to a file, we keep the path as is since canonicalization would
-                        // point its path to the actual file.
+                        // Skip symlinks to folders before canonicalization to
+                        // prevent duplicates. Symlinks to files are kept as-is,
+                        // since canonicalization would point at the real file.
                         let canonical_path = if entry_path.is_symlink() {
                             if entry_path.is_dir() {
                                 None
@@ -270,51 +312,64 @@ impl Entry {
                         } else {
                             dunce::canonicalize(entry_path).ok()
                         };
+                        let Some(child_path) = canonical_path else {
+                            continue;
+                        };
 
-                        if let Some(canonical_path) = canonical_path {
-                            match Entry::build_tree_with_ignored_path_interests_and_ancestor(
-                                canonical_path,
-                                files,
-                                gitignores,
-                                remaining_file_quota.as_deref_mut(),
-                                options.child(),
-                                path_is_ignored,
-                            ) {
-                                Ok(entry) => Some(entry),
-                                Err(BuildTreeError::ExceededMaxFileLimit) => {
-                                    return Err(BuildTreeError::ExceededMaxFileLimit)
+                        match evaluate_entry(
+                            &child_path,
+                            gitignores,
+                            &options,
+                            child_depth,
+                            job.ignored,
+                        ) {
+                            Ok(EvaluatedEntry::File { ignored }) => {
+                                if quota == Some(0)
+                                    && options.budget_exceeded_behavior
+                                        == BudgetExceededBehavior::FailFast
+                                {
+                                    return Err(BuildTreeError::ExceededMaxFileLimit);
                                 }
-                                Err(_) => None,
+                                let metadata =
+                                    consume_file(&child_path, ignored, files, &mut quota);
+                                let child_index = nodes.len();
+                                nodes.push(Some(NodeBuilder::File(metadata)));
+                                push_child(&mut nodes, job.index, child_index);
                             }
-                        } else {
-                            None
+                            Ok(EvaluatedEntry::Directory { ignored, lazy }) => {
+                                let child_index = nodes.len();
+                                nodes.push(Some(NodeBuilder::Dir {
+                                    path: child_path.clone(),
+                                    ignored,
+                                    loaded: false,
+                                    children: Vec::new(),
+                                }));
+                                push_child(&mut nodes, job.index, child_index);
+                                // Lazy directories (past max depth, or ignored
+                                // without a matching interest) stay unloaded.
+                                // Everything else is queued for expansion,
+                                // subject to the budget gate above.
+                                if !lazy {
+                                    queue.push_back(DirJob {
+                                        index: child_index,
+                                        path: child_path,
+                                        depth: child_depth,
+                                        ignored,
+                                        is_root: false,
+                                    });
+                                }
+                            }
+                            Err(_) => {
+                                // Ignored / excluded / symlinked-directory entries
+                                // are omitted from the tree.
+                            }
                         }
                     }
-                    Err(_) => None,
-                } {
-                    children.push(entry);
-                }
-            }
-
-            Ok(Self::Directory(DirectoryEntry {
-                children,
-                path: StandardizedPath::from_local_absolute_unchecked(&curr_path),
-                ignored: path_is_ignored,
-                loaded: true,
-            }))
-        } else if curr_path.is_file() {
-            if let Some(remaining_file_quota) = remaining_file_quota {
-                if *remaining_file_quota == 0 {
-                    return Err(BuildTreeError::ExceededMaxFileLimit);
                 }
 
-                *remaining_file_quota -= 1
+                write_back_quota(remaining_file_quota, quota);
+                Ok(assemble_node(&mut nodes, 0))
             }
-            let metadata = FileMetadata::new(curr_path, path_is_ignored);
-            files.push(metadata.clone());
-            Ok(Self::File(metadata))
-        } else {
-            Err(BuildTreeError::Symlink)
         }
     }
 
@@ -409,6 +464,158 @@ impl Entry {
 
         log::debug!("target path not found under the current directory node");
         None
+    }
+}
+
+/// A node in the breadth-first build arena. Directory children are referenced by
+/// arena index so the nested [`Entry`] tree can be assembled bottom-up.
+enum NodeBuilder {
+    File(FileMetadata),
+    Dir {
+        path: PathBuf,
+        ignored: bool,
+        loaded: bool,
+        children: Vec<usize>,
+    },
+}
+
+/// A directory queued for expansion during the breadth-first build.
+struct DirJob {
+    index: usize,
+    path: PathBuf,
+    depth: usize,
+    ignored: bool,
+    is_root: bool,
+}
+
+/// Classification of a single filesystem entry.
+enum EvaluatedEntry {
+    File { ignored: bool },
+    Directory { ignored: bool, lazy: bool },
+}
+
+/// Classifies a single path: rejects directory symlinks, loads any local
+/// `.gitignore`, computes gitignore status, and applies the ignored-path
+/// strategy. Returns `Err(Ignored)`/`Err(Symlink)` for entries that should be
+/// omitted; callers decide whether that is fatal (root) or a skip (child).
+fn evaluate_entry(
+    curr_path: &Path,
+    gitignores: &mut Vec<Gitignore>,
+    options: &BuildTreeOptions<'_>,
+    current_depth: usize,
+    ancestor_is_ignored: bool,
+) -> Result<EvaluatedEntry, BuildTreeError> {
+    let is_dir = curr_path.is_dir();
+
+    // Only ignore symlinks to directories. Symlinks to files are preserved (e.g. WARP.md).
+    if curr_path.is_symlink() && is_dir {
+        return Err(BuildTreeError::Symlink);
+    }
+
+    let gitignore_path = curr_path.join(".gitignore");
+    if gitignore_path.exists() {
+        let (gitignore, _) = Gitignore::new(gitignore_path);
+        gitignores.push(gitignore);
+    }
+
+    let path_is_ignored = ancestor_is_ignored
+        || is_git_internal_path(curr_path)
+        || matches_gitignores(
+            curr_path,
+            is_dir,
+            &*gitignores,
+            false, /* check_ancestors */
+        );
+
+    // If we've reached the max depth, force lazy-loading even of non-ignored folders.
+    let mut lazy = current_depth >= options.max_depth;
+
+    if path_is_ignored {
+        match options.ignored_path_strategy {
+            IgnoredPathStrategy::Exclude => return Err(BuildTreeError::Ignored),
+            IgnoredPathStrategy::IncludeOnly(patterns) => {
+                if let Some(file_name) = curr_path.file_name().and_then(|n| n.to_str()) {
+                    if !patterns.iter().any(|pattern| file_name == pattern) {
+                        return Err(BuildTreeError::Ignored);
+                    }
+                }
+            }
+            IgnoredPathStrategy::IncludeLazy => {
+                lazy = !matches_ignored_path_interest(curr_path, options.ignored_path_interests);
+            }
+            IgnoredPathStrategy::Include => {}
+        }
+    }
+
+    if is_dir {
+        Ok(EvaluatedEntry::Directory {
+            ignored: path_is_ignored,
+            lazy,
+        })
+    } else if curr_path.is_file() {
+        Ok(EvaluatedEntry::File {
+            ignored: path_is_ignored,
+        })
+    } else {
+        Err(BuildTreeError::Symlink)
+    }
+}
+
+/// Records a file: decrements the budget (saturating), constructs metadata, and
+/// appends it to the flat `files` list.
+fn consume_file(
+    path: &Path,
+    ignored: bool,
+    files: &mut Vec<FileMetadata>,
+    quota: &mut Option<usize>,
+) -> FileMetadata {
+    if let Some(remaining) = quota.as_mut() {
+        *remaining = remaining.saturating_sub(1);
+    }
+    let metadata = FileMetadata::new(path.to_path_buf(), ignored);
+    files.push(metadata.clone());
+    metadata
+}
+
+/// Appends `child` to `parent`'s child list in the build arena.
+fn push_child(nodes: &mut [Option<NodeBuilder>], parent: usize, child: usize) {
+    if let Some(NodeBuilder::Dir { children, .. }) = nodes[parent].as_mut() {
+        children.push(child);
+    }
+}
+
+/// Recursively assembles the nested [`Entry`] tree from the build arena.
+/// Recursion depth is bounded by `BuildTreeOptions::max_depth`.
+fn assemble_node(nodes: &mut [Option<NodeBuilder>], index: usize) -> Entry {
+    match nodes[index]
+        .take()
+        .expect("each arena node is assembled exactly once")
+    {
+        NodeBuilder::File(metadata) => Entry::File(metadata),
+        NodeBuilder::Dir {
+            path,
+            ignored,
+            loaded,
+            children,
+        } => {
+            let children = children
+                .into_iter()
+                .map(|child| assemble_node(nodes, child))
+                .collect();
+            Entry::Directory(DirectoryEntry {
+                path: StandardizedPath::from_local_absolute_unchecked(&path),
+                children,
+                ignored,
+                loaded,
+            })
+        }
+    }
+}
+
+/// Writes the remaining budget back into the caller-provided slot, if any.
+fn write_back_quota(remaining_file_quota: Option<&mut usize>, quota: Option<usize>) {
+    if let (Some(slot), Some(value)) = (remaining_file_quota, quota) {
+        *slot = value;
     }
 }
 

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -202,6 +202,7 @@ fn build_skill_tree_with_gitignore(root: &std::path::Path, gitignore: &str) -> s
             current_depth: 0,
             ignored_path_strategy: &super::IgnoredPathStrategy::IncludeLazy,
             ignored_path_interests: &[std::path::PathBuf::from(".agents/skills")],
+            budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
         },
     )
     .unwrap()
@@ -322,6 +323,7 @@ fn build_tree_marks_descendants_of_ignored_directory_as_ignored() {
         10,
         0,
         &IgnoredPathStrategy::Include,
+        super::BudgetExceededBehavior::StopAndLazyLoad,
     )
     .unwrap();
 
@@ -364,6 +366,7 @@ fn lazy_loaded_ignored_directory_marks_loaded_children_as_ignored() {
         10,
         0,
         &IgnoredPathStrategy::IncludeLazy,
+        super::BudgetExceededBehavior::StopAndLazyLoad,
     )
     .unwrap();
 
@@ -513,4 +516,230 @@ fn test_extract_worktree_git_dir() {
         extract_worktree_git_dir(Path::new("/repo/.git/worktrees/foo")),
         None
     );
+}
+
+/// Builds a tree with an explicit file budget and ignored-path interests using
+/// the lazy ignored-path strategy.
+fn build_with_budget(
+    root: &std::path::Path,
+    budget: usize,
+    interests: &[std::path::PathBuf],
+) -> super::Entry {
+    let mut files = Vec::new();
+    let mut gitignores = Vec::new();
+    let mut file_limit = budget;
+    super::Entry::build_tree_with_ignored_path_interests(
+        root,
+        &mut files,
+        &mut gitignores,
+        Some(&mut file_limit),
+        super::BuildTreeOptions {
+            max_depth: 200,
+            current_depth: 0,
+            ignored_path_strategy: &super::IgnoredPathStrategy::IncludeLazy,
+            ignored_path_interests: interests,
+            budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn build_tree_budget_covers_breadth_first_and_leaves_remainder_unloaded() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+
+    // 5 top-level dirs, each with 2 direct files and a `sub` dir of 3 files.
+    for i in 0..5 {
+        let d = root.join(format!("d{i}"));
+        fs::create_dir(&d).unwrap();
+        fs::write(d.join("f0.txt"), "").unwrap();
+        fs::write(d.join("f1.txt"), "").unwrap();
+        let sub = d.join("sub");
+        fs::create_dir(&sub).unwrap();
+        for j in 0..3 {
+            fs::write(sub.join(format!("g{j}.txt")), "").unwrap();
+        }
+    }
+
+    // Budget exactly covers the 10 level-1 files; level-2 `sub` dirs are cut.
+    let tree = build_with_budget(&root, 10, &[]);
+
+    // Root stays loaded (no whole-tree depth-1 collapse on budget exhaustion).
+    let Entry::Directory(root_dir) = &tree else {
+        panic!("root should be a directory");
+    };
+    assert!(root_dir.loaded);
+
+    for i in 0..5 {
+        let d_path = root.join(format!("d{i}"));
+        let d = find_entry(&tree, &d_path).expect("level-1 dir present");
+        // All level-1 dirs are expanded before the budget is spent on level 2.
+        assert!(d.loaded(), "all level-1 dirs are covered breadth-first");
+        assert!(find_entry(&tree, &d_path.join("f0.txt")).is_some());
+
+        // Level-2 dirs beyond the budget remain unloaded placeholders.
+        let sub = find_entry(&tree, &d_path.join("sub")).expect("sub placeholder present");
+        assert!(
+            !sub.loaded(),
+            "level-2 dirs beyond the budget stay unloaded"
+        );
+        assert!(find_entry(&tree, &d_path.join("sub").join("g0.txt")).is_none());
+    }
+}
+
+#[test]
+fn build_tree_budget_does_not_prune_interest_paths() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+
+    // Files at the root so the budget is exhausted almost immediately.
+    for i in 0..5 {
+        fs::write(root.join(format!("f{i}.txt")), "").unwrap();
+    }
+    // A skill provider directory nested several levels under the root.
+    let skill_dir = root.join(".agents").join("skills").join("test");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "name: test").unwrap();
+
+    // Tiny budget: the root expands and is immediately exhausted, but the
+    // registered interest path must still be loaded all the way down.
+    let interests = [std::path::PathBuf::from(".agents/skills")];
+    let tree = build_with_budget(&root, 1, &interests);
+
+    assert!(
+        find_entry(&tree, &skill_dir.join("SKILL.md")).is_some(),
+        "interest-path files must load even when the budget is exhausted"
+    );
+}
+
+#[test]
+fn build_tree_full_coverage_reaches_full_depth_within_budget() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+
+    // Nested chain a/b/c/d with a file at the deepest level.
+    let deep = root.join("a").join("b").join("c").join("d");
+    fs::create_dir_all(&deep).unwrap();
+    fs::write(deep.join("leaf.txt"), "").unwrap();
+    fs::write(root.join("top.txt"), "").unwrap();
+
+    // A generous budget must fully cover this small tree to its full depth.
+    let tree = build_with_budget(&root, 1000, &[]);
+
+    for dir in [
+        root.join("a"),
+        root.join("a").join("b"),
+        root.join("a").join("b").join("c"),
+        deep.clone(),
+    ] {
+        let entry = find_entry(&tree, &dir).expect("dir present");
+        assert!(
+            entry.loaded(),
+            "dirs are fully loaded under a generous budget"
+        );
+    }
+    assert!(find_entry(&tree, &deep.join("leaf.txt")).is_some());
+    assert!(find_entry(&tree, &root.join("top.txt")).is_some());
+}
+
+#[test]
+fn build_tree_directories_do_not_consume_budget() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+
+    // A deep chain of empty directories (no files at all).
+    let deep = root.join("l1").join("l2").join("l3").join("l4");
+    fs::create_dir_all(&deep).unwrap();
+
+    // Even a budget of 1 fully expands the tree, because only files — not
+    // directories — draw down the budget.
+    let tree = build_with_budget(&root, 1, &[]);
+    let leaf = find_entry(&tree, &deep).expect("deepest dir present");
+    assert!(
+        leaf.loaded(),
+        "directories must not consume the file budget"
+    );
+}
+
+#[test]
+fn build_tree_gitignored_files_do_not_consume_budget() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+    fs::write(root.join(".gitignore"), "ignored/\n").unwrap();
+
+    // A gitignored directory with many files (e.g. node_modules/target).
+    let ignored = root.join("ignored");
+    fs::create_dir(&ignored).unwrap();
+    for i in 0..50 {
+        fs::write(ignored.join(format!("big{i}.txt")), "").unwrap();
+    }
+    // Plus the tracked files at the root (`.gitignore` itself counts as one).
+    fs::write(root.join("tracked0.txt"), "").unwrap();
+    fs::write(root.join("tracked1.txt"), "").unwrap();
+
+    // Budget only covers the 3 tracked root files. The 50 gitignored files must
+    // not draw it down, so both tracked files are still indexed and the ignored
+    // directory stays a lazy (unloaded) placeholder.
+    let tree = build_with_budget(&root, 3, &[]);
+
+    assert!(find_entry(&tree, &root.join("tracked0.txt")).is_some());
+    assert!(find_entry(&tree, &root.join("tracked1.txt")).is_some());
+    let ignored_dir = find_entry(&tree, &ignored).expect("ignored dir placeholder present");
+    assert!(ignored_dir.ignored());
+    assert!(
+        !ignored_dir.loaded(),
+        "gitignored dirs stay lazy and never consume the budget"
+    );
+}
+
+#[test]
+fn build_tree_fail_fast_errors_when_budget_exceeded() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+    for i in 0..10 {
+        fs::write(root.join(format!("f{i}.txt")), "").unwrap();
+    }
+
+    let mut files = Vec::new();
+    let mut gitignores = Vec::new();
+    let mut file_limit = 5;
+    let result = Entry::build_tree(
+        &root,
+        &mut files,
+        &mut gitignores,
+        Some(&mut file_limit),
+        200,
+        0,
+        &IgnoredPathStrategy::Exclude,
+        super::BudgetExceededBehavior::FailFast,
+    );
+    assert!(
+        matches!(result, Err(super::BuildTreeError::ExceededMaxFileLimit)),
+        "FailFast must abort when the file budget is exceeded"
+    );
+}
+
+#[test]
+fn build_tree_fail_fast_succeeds_within_budget() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+    for i in 0..3 {
+        fs::write(root.join(format!("f{i}.txt")), "").unwrap();
+    }
+
+    let mut files = Vec::new();
+    let mut gitignores = Vec::new();
+    let mut file_limit = 10;
+    let result = Entry::build_tree(
+        &root,
+        &mut files,
+        &mut gitignores,
+        Some(&mut file_limit),
+        200,
+        0,
+        &IgnoredPathStrategy::Exclude,
+        super::BudgetExceededBehavior::FailFast,
+    );
+    assert!(result.is_ok(), "FailFast must succeed when within budget");
 }

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -22,7 +22,9 @@ pub enum RepoContent<'a> {
 
 use warp_util::standardized_path::StandardizedPath;
 
-use crate::entry::{BuildTreeError, BuildTreeOptions, Entry, FileId, IgnoredPathStrategy};
+use crate::entry::{
+    BudgetExceededBehavior, BuildTreeError, BuildTreeOptions, Entry, FileId, IgnoredPathStrategy,
+};
 use crate::repository::Repository;
 use crate::telemetry::RepoMetadataTelemetryEvent;
 use crate::{gitignores_for_directory, matches_gitignores, RepoMetadataError};
@@ -54,8 +56,15 @@ use crate::file_tree_update::{
 /// Maximum depth to traverse when building file trees
 const MAX_TREE_DEPTH: usize = 200;
 
-/// Maximum number of files to index per repository to guard against really large codebases
-const MAX_FILES_PER_REPO: usize = 100_000;
+/// Maximum number of non-ignored files to index eagerly per repository.
+///
+/// This is a high safety ceiling, not the common case: gitignored directories
+/// are lazy placeholders and never consume this budget, so only repositories
+/// with an enormous number of *tracked* files reach it. When the budget is
+/// exhausted the builder stops descending breadth-first and leaves the
+/// remaining directories as unloaded placeholders (lazy-loaded on demand)
+/// rather than failing or collapsing the tree to a single level.
+const MAX_FILES_PER_REPO: usize = 200_000;
 
 /// Maximum number of results to return from get_repo_contents to prevent accidentally
 /// materializing the entire repository
@@ -555,6 +564,7 @@ impl LocalRepoMetadataModel {
             1, // max_depth — only first level
             0,
             &IgnoredPathStrategy::Include,
+            BudgetExceededBehavior::StopAndLazyLoad,
         )
         .map_err(RepoMetadataError::BuildTree)?;
 
@@ -656,6 +666,7 @@ impl LocalRepoMetadataModel {
                         current_depth: 0,
                         ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
                         ignored_path_interests,
+                        budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
                     },
                     is_ignored,
                 ) {
@@ -946,14 +957,16 @@ impl LocalRepoMetadataModel {
             async move {
                 let mut files: Vec<crate::entry::FileMetadata> = Vec::new();
                 let mut gitignores_for_build = gitignores_for_build;
-                // Snapshot the initial gitignores so we can retry from a clean
-                // state if the full-depth build is partially populated before
-                // it hits the file limit.
-                let initial_gitignores = gitignores_for_build.clone();
 
+                // Budget for non-ignored files. When it is exhausted the builder
+                // stops descending breadth-first and leaves the remaining
+                // directories as unloaded placeholders (lazy-loaded on demand)
+                // instead of failing the whole build. Gitignored subtrees stay
+                // lazy and registered ignored-path interests are always loaded;
+                // both are handled inside the builder.
                 let mut file_limit = MAX_FILES_PER_REPO;
 
-                let mut build_result = Entry::build_tree_with_ignored_path_interests(
+                let build_result = Entry::build_tree_with_ignored_path_interests(
                     &repo_path_for_build,
                     &mut files,
                     &mut gitignores_for_build,
@@ -963,37 +976,14 @@ impl LocalRepoMetadataModel {
                         current_depth: 0,
                         ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
                         ignored_path_interests: &ignored_path_interests,
+                        budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
                     },
                 );
 
-                // Repos with more than MAX_FILES_PER_REPO tracked files can't
-                // be indexed at full depth. Fall back to a single-level scan
-                // (with the file quota disabled — direct-child files at
-                // depth=1 still consume the quota, so reusing it would
-                // re-trigger ExceededMaxFileLimit on repos with >MAX_FILES_PER_REPO
-                // files directly under the root) so the user can still browse
-                // the tree; subdirectories are loaded on expand via
-                // LAZY_LOAD_FILE_LIMIT.
-                let mut indexed_with_limit = false;
-                if matches!(build_result, Err(BuildTreeError::ExceededMaxFileLimit)) {
-                    files.clear();
-                    gitignores_for_build = initial_gitignores;
-                    build_result = Entry::build_tree_with_ignored_path_interests(
-                        &repo_path_for_build,
-                        &mut files,
-                        &mut gitignores_for_build,
-                        None,
-                        BuildTreeOptions {
-                            max_depth: 1, // Only first level.
-                            current_depth: 0,
-                            ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
-                            ignored_path_interests: &ignored_path_interests,
-                        },
-                    );
-                    if build_result.is_ok() {
-                        indexed_with_limit = true;
-                    }
-                }
+                // A fully-exhausted budget means the repo was too large to index
+                // eagerly: the tree is partial (with a lazy-loaded remainder)
+                // but still browsable and searchable as far as it goes.
+                let indexed_with_limit = file_limit == 0;
 
                 (
                     build_result,
@@ -1029,8 +1019,8 @@ impl LocalRepoMetadataModel {
                             model.mark_repository_failed(std_repo_path, e, ctx);
                         } else if indexed_with_limit {
                             safe_warn!(
-                                safe: ("Repository exceeded max file limit; indexed in degraded mode"),
-                                full: ("Repository {repo_path_str} exceeded max file limit ({MAX_FILES_PER_REPO}); indexed only first level — subdirectories load on expand")
+                                safe: ("Repository exceeded max file budget; indexed with partial coverage"),
+                                full: ("Repository {repo_path_str} exceeded the max file budget ({MAX_FILES_PER_REPO}); indexed breadth-first up to the budget — remaining directories load on expand")
                             );
                             send_telemetry_from_ctx!(RepoMetadataTelemetryEvent::BuildTreeFailed { error: format!("{:#}", BuildTreeError::ExceededMaxFileLimit) }, ctx);
                         } else {


### PR DESCRIPTION
## Description
This makes `repo_metadata` build a **partial** file tree for git repos that exceed the indexing file limit, instead of falling back to a shallow `depth=1` tree.

### Motivation
- **The `depth=1` fallback is awkward to build on.** Today, when a repo exceeds `MAX_FILES_PER_REPO`, we rebuild the entire repo as a shallow `depth=1` tree with lazily-loaded subdirectories. That shape is hard for downstream consumers to use: migrating skills discovery and project-context/rules onto repo metadata would each need to implement custom, on-demand expansion of a lazily-loaded tree just to find files below the first level. A partial-but-real tree removes that burden.
- **It unblocks non-recursive watcher registration for lazily-loaded repos.** As we move toward registering file watchers non-recursively for lazily-loaded directories, a budgeted/partial tree gives us much better watcher behavior on large repos (we watch what we actually loaded rather than the whole tree).

### Approach
- **Conservative, bounded "unbounded" indexing.** Other popular editors (VSCode, Zed) effectively index the whole non-ignored tree with no hard cap. We move in that direction but stay conservative for now with an upper bound (`MAX_FILES_PER_REPO`), since gitignored directories are already lazy and don't count toward it.
- **Load everything until the budget, then mark the rest lazy.** When the file budget is exhausted, the builder stops descending and leaves the remaining directories as unloaded placeholders (lazy-loaded on demand) instead of erroring or collapsing the whole repo to a single level. Every node scanned before the budget is kept.
- **BFS instead of DFS.** The builder now does a queue-driven, level-order breadth-first traversal rather than recursive depth-first. This spends the budget evenly and shallow-first (all of level 1, then level 2, …), which is far more useful for the file tree / `@`-context / file search than DFS's "first subtree fully, rest empty," and matches Zed's queue-based scan order.
- **Paths of interest are always included.** Registered `ignored_path_interests` (e.g. skill provider directories like `.agents/skills`) are always expanded, even past the budget, so discovery-critical files stay reachable regardless of repo size.

Consumers that must not operate on a partial tree can opt into the previous behavior: `Entry::build_tree` now takes a `BudgetExceededBehavior` parameter, and codebase embedding passes `FailFast` (the file limit there is an intentional cost cap).

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added `repo_metadata` unit tests covering: breadth-first coverage with the remainder left unloaded on budget exhaustion, interest paths loading past the budget, directories/gitignored files not consuming the budget, full coverage within budget, and `FailFast` erroring vs. succeeding.
- `cargo nextest run -p repo_metadata --features local_fs` passes; `cargo clippy` clean on `repo_metadata` + `ai`; `cargo check -p warp` builds.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
CHANGELOG-NONE
