### PR TITLE
Ensure that the correct path is used for git call

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1102,6 +1102,11 @@ pub(crate) fn initialize_app(
     ensure_warp_watch_roots_exist();
     ctx.add_singleton_model(WarpManagedPathsWatcher::new);
 
+    // Build the system command search PATH so that child processes can
+    // find user-installed binaries (e.g. git-lfs) even when Warp is
+    // launched from the Dock/Spotlight with a minimal inherited PATH.
+    ctx.add_singleton_model(util::command_search_path::CommandSearchPathModel::new);
+
     ctx.add_singleton_model(WarpConfig::new);
     ctx.add_singleton_model(|_ctx| SettingsManager::default());
 

--- a/app/src/util/command_search_path.rs
+++ b/app/src/util/command_search_path.rs
@@ -1,0 +1,33 @@
+/// Singleton model that computes and caches the system command search
+/// PATH at startup.
+///
+/// On macOS, this reads `/etc/paths` and `/etc/paths.d/*` (the same
+/// mechanism `path_helper` uses for login shells) so that child processes
+/// can find user-installed binaries like `git-lfs` even when Warp is
+/// launched from the Dock with a minimal launchd PATH.
+///
+/// The computed PATH is stored in [`warp_util::command_search_path`] and
+/// consumed by `run_git_command` and other subprocess helpers.
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+pub struct CommandSearchPathModel;
+
+impl CommandSearchPathModel {
+    pub fn new(_ctx: &mut ModelContext<Self>) -> Self {
+        #[cfg(target_os = "macos")]
+        if let Some(path) = warp_util::command_search_path::build_macos_system_path() {
+            log::info!(
+                "CommandSearchPathModel: setting system PATH ({} entries)",
+                path.split(':').count()
+            );
+            warp_util::command_search_path::set_path(path);
+        }
+        Self
+    }
+}
+
+impl Entity for CommandSearchPathModel {
+    type Event = ();
+}
+
+impl SingletonEntity for CommandSearchPathModel {}

--- a/app/src/util/mod.rs
+++ b/app/src/util/mod.rs
@@ -5,6 +5,7 @@ pub mod extensions;
 #[cfg(feature = "local_fs")]
 pub mod file;
 pub mod git;
+pub mod command_search_path;
 pub mod image;
 pub(crate) mod link_detection;
 pub mod links;

--- a/crates/warp_util/src/command_search_path.rs
+++ b/crates/warp_util/src/command_search_path.rs
@@ -1,0 +1,84 @@
+//! Builds and caches the system command search PATH so that child processes
+//! spawned by Warp can find user-installed binaries even when Warp is
+//! launched from a GUI (Dock, Spotlight, Start menu) with a minimal
+//! inherited PATH.
+//!
+//! Currently macOS-only: reads `/etc/paths` and `/etc/paths.d/*`, the same
+//! mechanism macOS's `path_helper` uses for login shells. Other platforms
+//! are a no-op for now (Windows inherits the full registry PATH
+//! automatically; Linux support can be added later).
+
+#[cfg(not(target_family = "wasm"))]
+use std::sync::OnceLock;
+
+/// Cached system PATH. Set once at startup via [`set_path`]; read by
+/// consumers like `warp_util::git::run_git_command`.
+#[cfg(not(target_family = "wasm"))]
+static SYSTEM_PATH: OnceLock<String> = OnceLock::new();
+
+/// Returns the cached system PATH, if one has been set.
+#[cfg(not(target_family = "wasm"))]
+pub fn path() -> Option<&'static str> {
+    SYSTEM_PATH.get().map(|s| s.as_str())
+}
+
+/// Sets the system PATH that consumers will read. Only the first call
+/// takes effect (`OnceLock`).
+#[cfg(not(target_family = "wasm"))]
+pub fn set_path(path: String) {
+    let _ = SYSTEM_PATH.set(path);
+}
+
+/// Reads `/etc/paths` and `/etc/paths.d/*` to build the macOS system PATH,
+/// the same way `path_helper` does for login shells. Appends the current
+/// process PATH so nothing the launcher provided is lost.
+///
+/// Returns `None` if no entries were found (unlikely on a real macOS system).
+#[cfg(target_os = "macos")]
+pub fn build_macos_system_path() -> Option<String> {
+    use std::fs;
+
+    let mut dirs: Vec<String> = Vec::new();
+
+    // /etc/paths — one directory per line
+    if let Ok(contents) = fs::read_to_string("/etc/paths") {
+        for line in contents.lines() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                dirs.push(trimmed.to_string());
+            }
+        }
+    }
+
+    // /etc/paths.d/* — each file has one directory per line
+    if let Ok(entries) = fs::read_dir("/etc/paths.d") {
+        let mut paths_d_files: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+        paths_d_files.sort_by_key(|e| e.file_name());
+        for entry in paths_d_files {
+            if let Ok(contents) = fs::read_to_string(entry.path()) {
+                for line in contents.lines() {
+                    let trimmed = line.trim();
+                    if !trimmed.is_empty() && !dirs.contains(&trimmed.to_string()) {
+                        dirs.push(trimmed.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    if dirs.is_empty() {
+        return None;
+    }
+
+    // Append any entries from the inherited process PATH that aren't
+    // already covered, so we never lose anything the launcher provided.
+    if let Ok(current) = std::env::var("PATH") {
+        for entry in current.split(':') {
+            if !entry.is_empty() && !dirs.iter().any(|d| d == entry) {
+                dirs.push(entry.to_string());
+            }
+        }
+    }
+
+    Some(dirs.join(":"))
+}

--- a/crates/warp_util/src/git.rs
+++ b/crates/warp_util/src/git.rs
@@ -3,10 +3,12 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 
 /// Runs a git command and returns the output as a string.
-/// Thin wrapper over [`run_git_command_with_env`] with no `PATH` override.
+/// Uses the system command search PATH (see [`crate::command_search_path`])
+/// so that user-installed binaries like `git-lfs` are always reachable,
+/// even when Warp is launched from the Dock with a minimal launchd PATH.
 #[cfg(not(target_family = "wasm"))]
 pub async fn run_git_command(repo_path: &Path, args: &[&str]) -> Result<String> {
-    run_git_command_with_env(repo_path, args, None).await
+    run_git_command_with_env(repo_path, args, crate::command_search_path::path()).await
 }
 
 /// Like [`run_git_command`] but sets `PATH` on the child when `path_env` is

--- a/crates/warp_util/src/lib.rs
+++ b/crates/warp_util/src/lib.rs
@@ -4,6 +4,7 @@
 //! Generally, if a given function/abstraction is useful outside of a single warp-internal crate
 //! but isn't large/complex enough to warrant its own crate, it belongs here.
 pub mod assets;
+pub mod command_search_path;
 pub mod content_version;
 pub mod file;
 pub mod file_type;

--- a/hey.txt
+++ b/hey.txt
@@ -1,0 +1,3 @@
+hey
+hello world
+goodbye world


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
