### PR TITLE
[REMOTE-1848] Fix AI block telemetry duration panic

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1801,10 +1801,10 @@ impl AIBlock {
         let time_to_first_token_ms = self
             .time_to_first_token
             .get()
-            .map(|duration| duration.num_milliseconds() as u128);
+            .and_then(|duration| u128::try_from(duration.num_milliseconds()).ok());
         let time_to_last_token_ms = self
             .time_to_last_token
-            .map(|duration| duration.num_milliseconds() as u128);
+            .and_then(|duration| u128::try_from(duration.num_milliseconds()).ok());
         let status = self.model.status(ctx);
         let is_udi_enabled = InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx);
 

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -3558,17 +3558,22 @@ impl TelemetryEvent {
                 cancelled,
                 conversation_id,
                 is_udi_enabled,
-            } => Some(json!({
-                "client_exchange_id": client_exchange_id,
-                "server_output_id": server_output_id,
-                "was_autodetected_ai_query": was_autodetected_ai_query,
-                "time_to_first_token_ms": time_to_first_token_ms,
-                "time_to_last_token_ms": time_to_last_token_ms,
-                "was_user_facing_error": was_user_facing_error,
-                "cancelled": cancelled,
-                "conversation_id": conversation_id,
-                "is_udi_enabled": is_udi_enabled,
-            })),
+            } => {
+                let time_to_first_token_ms = json_number_safe_duration_ms(*time_to_first_token_ms);
+                let time_to_last_token_ms = json_number_safe_duration_ms(*time_to_last_token_ms);
+
+                Some(json!({
+                    "client_exchange_id": client_exchange_id,
+                    "server_output_id": server_output_id,
+                    "was_autodetected_ai_query": was_autodetected_ai_query,
+                    "time_to_first_token_ms": time_to_first_token_ms,
+                    "time_to_last_token_ms": time_to_last_token_ms,
+                    "was_user_facing_error": was_user_facing_error,
+                    "cancelled": cancelled,
+                    "conversation_id": conversation_id,
+                    "is_udi_enabled": is_udi_enabled,
+                }))
+            }
             TelemetryEvent::TierLimitHit(event) => Some(json!(event)),
             TelemetryEvent::AgentModeUserAttemptedQueryAtRequestLimit { limit } => {
                 Some(json!({"limit": limit}))
@@ -5313,6 +5318,9 @@ impl TelemetryEvent {
     }
 }
 
+fn json_number_safe_duration_ms(duration_ms: Option<u128>) -> Option<u64> {
+    duration_ms.and_then(|duration_ms| u64::try_from(duration_ms).ok())
+}
 impl TelemetryEventDesc for TelemetryEventDiscriminants {
     fn enablement_state(&self) -> EnablementState {
         // We disallow the wildcard statement to prevent us from accidentally ignoring any

--- a/app/src/server/telemetry/events_tests.rs
+++ b/app/src/server/telemetry/events_tests.rs
@@ -1,3 +1,5 @@
+use super::TelemetryEvent;
+use crate::ai::agent::conversation::AIConversationId;
 use warp_core::telemetry::TelemetryEventDesc;
 
 #[derive(Debug)]
@@ -25,4 +27,27 @@ fn telemetry_events_have_nonempty_name_and_description() -> Result<(), Telemetry
         }
     }
     Ok(())
+}
+
+#[test]
+fn agent_mode_created_ai_block_payload_drops_out_of_range_duration_ms() {
+    let payload = TelemetryEvent::AgentModeCreatedAIBlock {
+        client_exchange_id: "client-exchange-id".to_string(),
+        server_output_id: None,
+        was_autodetected_ai_query: false,
+        time_to_first_token_ms: Some(u128::MAX),
+        time_to_last_token_ms: Some(u64::MAX as u128),
+        was_user_facing_error: true,
+        cancelled: false,
+        conversation_id: AIConversationId::new(),
+        is_udi_enabled: false,
+    }
+    .payload()
+    .expect("event should have a payload");
+
+    assert!(payload["time_to_first_token_ms"].is_null());
+    assert_eq!(
+        payload["time_to_last_token_ms"],
+        serde_json::json!(u64::MAX),
+    );
 }


### PR DESCRIPTION
## Description
Fixes REMOTE-1848.

Prevents `AgentMode.CreatedAIBlock` telemetry from crashing the web client when token timing values are invalid or too large to serialize as JSON numbers. The fix avoids wrapping negative `chrono` durations into huge `u128` values and safely downcasts telemetry duration fields to `u64`, dropping out-of-range values to `null` instead of letting `serde_json::json!` panic.

## Linked Issue
Linear: REMOTE-1848

## Testing
- `cargo fmt --manifest-path /workspace/warp/app/Cargo.toml`
- `cargo test --manifest-path /workspace/warp/app/Cargo.toml agent_mode_created_ai_block_payload_drops_out_of_range_duration_ms`
- `cargo check --manifest-path /workspace/warp/app/Cargo.toml`
- `cargo clippy --manifest-path /workspace/warp/app/Cargo.toml --all-targets -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not applicable; this is a telemetry serialization crash fix covered by a regression test.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a web client crash that could occur when continuing a cloud-mode conversation with invalid telemetry timing data.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/2bd56248-0a24-4eff-857c-7858a1f903ea_
_Run: https://oz.staging.warp.dev/runs/019e8f4f-57df-7db7-b100-2bdbac0e9342_
_This PR was generated with [Oz](https://warp.dev/oz)._
