### PR TITLE
[QUALITY-793] Reduce agent event stream error log spam

### DIFF
--- a/app/src/ai/agent_events/driver.rs
+++ b/app/src/ai/agent_events/driver.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use futures::future::Either;
 use futures::StreamExt;
 use instant::Instant;
+use warp_core::errors::AnyhowErrorExt as _;
 use warpui::r#async::Timer;
 
 use crate::server::retry_strategies::is_transient_http_error;
@@ -69,7 +70,7 @@ pub(crate) struct AgentEventDriverConfig {
     /// before upstream infrastructure times it out (for example, before Cloud
     /// Run's 20-minute streaming timeout).
     pub proactive_reconnect_after: Option<Duration>,
-    /// Failure count at which reconnect logging is escalated from debug to warn.
+    /// Failure count at which actionable reconnect failures are reported at Error level.
     /// This only affects log severity; retry behavior stays the same.
     pub failures_before_error_log: usize,
 }
@@ -214,16 +215,25 @@ impl AgentEventSource for ServerApiAgentEventSource {
                     }
                 }
                 Err(err) => {
-                    let anyhow_err = match &err {
-                        reqwest_eventsource::Error::InvalidStatusCode(status_code, _) => {
+                    let anyhow_err = match err {
+                        reqwest_eventsource::Error::InvalidStatusCode(status_code, response) => {
+                            let body = response
+                                .text()
+                                .await
+                                .unwrap_or_else(|err| format!("(no response body: {err:#})"));
                             let status_err = HttpStatusError {
                                 status: status_code.as_u16(),
-                                body: format!("{err:?}"),
+                                body: body.clone(),
                             };
-                            anyhow::Error::new(status_err)
-                                .context(format!("SSE stream error: {err:?}"))
+                            anyhow::Error::new(status_err).context(format!(
+                                "SSE stream error: invalid status code {status_code}: {body}"
+                            ))
                         }
-                        _ => anyhow!("SSE stream error: {err:?}"),
+                        #[cfg(not(target_family = "wasm"))]
+                        reqwest_eventsource::Error::Transport(err) => {
+                            anyhow::Error::new(err).context("SSE stream error")
+                        }
+                        err => anyhow!("SSE stream error: {err:?}"),
                     };
                     Some(Err(anyhow_err))
                 }
@@ -445,12 +455,14 @@ fn log_stream_failure(
     failures_before_error_log: usize,
 ) {
     let label = filter.log_label();
-    if agent_event_failures_exceeded_threshold(failures, failures_before_error_log) {
+    if agent_event_failure_should_log_error(err, failures, failures_before_error_log) {
         log::error!(
             "Agent event stream failed {failures} consecutive times for {label}, retrying in {backoff:?}: {err:#}"
         );
     } else {
-        log::warn!("Agent event stream failed for {label}, retrying in {backoff:?}: {err:#}");
+        log::warn!(
+            "Agent event stream failed {failures} consecutive times for {label}, retrying in {backoff:?}: {err:#}"
+        );
     }
 }
 
@@ -464,6 +476,15 @@ pub(crate) fn agent_event_backoff(failures: usize, backoff_steps: &[u64]) -> Dur
     Duration::from_secs(safe_steps[index])
 }
 
+#[cfg(test)]
 pub(crate) fn agent_event_failures_exceeded_threshold(failures: usize, threshold: usize) -> bool {
     failures >= threshold
+}
+
+pub(crate) fn agent_event_failure_should_log_error(
+    err: &anyhow::Error,
+    failures: usize,
+    threshold: usize,
+) -> bool {
+    threshold > 0 && failures == threshold && err.is_actionable()
 }

--- a/app/src/ai/agent_events/driver_tests.rs
+++ b/app/src/ai/agent_events/driver_tests.rs
@@ -6,9 +6,12 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
+use warp_core::errors::AnyhowErrorExt as _;
 
 use super::*;
+use crate::ai::agent_events::driver::agent_event_failure_should_log_error;
 use crate::server::server_api::ai::AgentRunEvent;
+use crate::server::server_api::presigned_upload::HttpStatusError;
 
 const ZERO_BACKOFF_STEPS: &[u64] = &[0];
 
@@ -357,12 +360,47 @@ fn failure_threshold_is_reached_at_and_above_limit() {
 }
 
 fn make_http_status_error(status: u16) -> anyhow::Error {
-    use crate::server::server_api::presigned_upload::HttpStatusError;
     anyhow::Error::new(HttpStatusError {
         status,
         body: "not found".to_string(),
     })
     .context("SSE stream error")
+}
+
+#[test]
+fn actionable_stream_status_reports_only_at_threshold_crossing() {
+    let err = make_http_status_error(400);
+    assert_eq!(
+        [
+            agent_event_failure_should_log_error(&err, 4, 5),
+            agent_event_failure_should_log_error(&err, 5, 5),
+            agent_event_failure_should_log_error(&err, 6, 5),
+        ],
+        [false, true, false]
+    );
+}
+
+#[test]
+fn zero_threshold_disables_stream_error_escalation() {
+    let err = make_http_status_error(400);
+    assert!(!agent_event_failure_should_log_error(&err, 1, 0));
+}
+
+#[test]
+fn non_actionable_stream_statuses_do_not_report_at_threshold() {
+    for status in [408, 429, 500, 503] {
+        let err = make_http_status_error(status);
+        assert!(
+            !agent_event_failure_should_log_error(&err, 5, 5),
+            "status {status}"
+        );
+    }
+}
+
+#[test]
+fn http_status_error_actionability_follows_status_classification() {
+    assert!(make_http_status_error(400).is_actionable());
+    assert!(!make_http_status_error(500).is_actionable());
 }
 
 #[tokio::test]

--- a/app/src/ai/agent_events/driver_tests.rs
+++ b/app/src/ai/agent_events/driver_tests.rs
@@ -388,7 +388,7 @@ fn zero_threshold_disables_stream_error_escalation() {
 
 #[test]
 fn non_actionable_stream_statuses_do_not_report_at_threshold() {
-    for status in [408, 429, 500, 503] {
+    for status in [408, 429] {
         let err = make_http_status_error(status);
         assert!(
             !agent_event_failure_should_log_error(&err, 5, 5),
@@ -398,9 +398,16 @@ fn non_actionable_stream_statuses_do_not_report_at_threshold() {
 }
 
 #[test]
+fn server_error_status_reports_at_threshold_crossing() {
+    let err = make_http_status_error(500);
+    assert!(agent_event_failure_should_log_error(&err, 5, 5));
+}
+
+#[test]
 fn http_status_error_actionability_follows_status_classification() {
     assert!(make_http_status_error(400).is_actionable());
-    assert!(!make_http_status_error(500).is_actionable());
+    assert!(make_http_status_error(500).is_actionable());
+    assert!(!make_http_status_error(429).is_actionable());
 }
 
 #[tokio::test]

--- a/app/src/server/server_api/presigned_upload.rs
+++ b/app/src/server/server_api/presigned_upload.rs
@@ -29,7 +29,7 @@ pub struct HttpStatusError {
 
 impl ErrorExt for HttpStatusError {
     fn is_actionable(&self) -> bool {
-        !matches!(self.status, 408 | 429 | 500..=599)
+        !matches!(self.status, 408 | 429)
     }
 }
 register_error!(HttpStatusError);

--- a/app/src/server/server_api/presigned_upload.rs
+++ b/app/src/server/server_api/presigned_upload.rs
@@ -8,6 +8,7 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 #[cfg(not(target_family = "wasm"))]
 use crc::{Crc, CRC_32_ISCSI};
 use thiserror::Error;
+use warp_core::errors::{register_error, ErrorExt};
 
 #[cfg(feature = "local_fs")]
 use super::ai::FileArtifactUploadTargetInfo;
@@ -25,6 +26,13 @@ pub struct HttpStatusError {
     pub status: u16,
     pub body: String,
 }
+
+impl ErrorExt for HttpStatusError {
+    fn is_actionable(&self) -> bool {
+        !matches!(self.status, 408 | 429 | 500..=599)
+    }
+}
+register_error!(HttpStatusError);
 
 #[cfg(not(target_family = "wasm"))]
 pub(crate) static CRC32C: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);


### PR DESCRIPTION
## Description
Reduce client-side Error-level log spam from the reconnecting agent event SSE stream.

What changed:
- Gate agent event stream Error-level retry logs on error actionability.
- Emit Error only once when a failure streak crosses the configured threshold; later retries in the same streak remain Warn-level until recovery.
- Preserve typed SSE transport/status errors so non-actionable network/server conditions are classified correctly.
- Register `HttpStatusError` with `ErrorExt`, classifying 408, 429, and 5xx as non-actionable.

Why:
- Fixes QUALITY-793, where prolonged network or server-side failures could produce repeated client Error-level logs such as “Agent event stream failed 732 consecutive times”.

Plan: https://staging.warp.dev/drive/notebook/Xwz7CpHzilfHd1N5YbAllp
Conversation: https://staging.warp.dev/conversation/2bbce176-bb87-44f0-bcc2-9bcfc3fbce4e

## Linked Issue
https://linear.app/warpdotdev/issue/QUALITY-793/reduce-frequency-of-client-error-logging

## Testing
- `cargo fmt --all --check`
- `./script/format --check`
- `cargo test -p warp agent_events::driver_tests`
- `cargo check -p warp`
- `PATH=/tmp/warp-corepack:$PATH cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `PATH=/tmp/warp-corepack:$PATH cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `git --no-pager diff --check`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
