### PR TITLE
Support multi tab selection in vertical tabs

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -154,6 +154,8 @@ pub struct TabData {
     pub detached: bool,
     /// Tab group this tab belongs to, if any
     pub group_id: Option<TabGroupId>,
+    /// True while this tab is in the active shift-click range selection.
+    pub in_range_selected: bool,
 }
 
 const TAB_COLOR_ICON_PATH: &str = "bundled/svg/ellipse.svg";
@@ -172,6 +174,7 @@ impl TabData {
             indicator_hover_state: Default::default(),
             detached: false,
             group_id: None,
+            in_range_selected: false,
         }
     }
 

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -154,8 +154,9 @@ pub struct TabData {
     pub detached: bool,
     /// Tab group this tab belongs to, if any
     pub group_id: Option<TabGroupId>,
-    /// True while this tab is in the active shift-click range selection.
-    pub in_range_selected: bool,
+    /// True while this tab is in the active multi-selection (shift-click range
+    /// or cmd-click toggle).
+    pub in_multi_selection: bool,
 }
 
 const TAB_COLOR_ICON_PATH: &str = "bundled/svg/ellipse.svg";
@@ -174,7 +175,7 @@ impl TabData {
             indicator_hover_state: Default::default(),
             detached: false,
             group_id: None,
-            in_range_selected: false,
+            in_multi_selection: false,
         }
     }
 

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -190,6 +190,11 @@ pub enum WorkspaceAction {
     ShiftSelectTabRange {
         locator: PaneViewLocator,
     },
+    /// Toggles whether the tab at `locator` is part of the active multi-selection.
+    /// Dispatched on cmd-click of a vertical tab row.
+    ToggleTabMultiSelection {
+        locator: PaneViewLocator,
+    },
     ToggleTabGroupRightClickMenu {
         group_id: TabGroupId,
         anchor: TabContextMenuAnchor,
@@ -1017,6 +1022,7 @@ impl WorkspaceAction {
             | FocusTerminalViewInWorkspace { .. }
             | FocusPane(..)
             | ShiftSelectTabRange { .. }
+            | ToggleTabMultiSelection { .. }
             | StartNewConversation { .. }
             | UndoRevertInCodeReviewPane { .. }
             | JumpToLatestToast

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -186,6 +186,10 @@ pub enum WorkspaceAction {
     },
     /// Removes the tab at the given index from its current group.
     RemoveTabFromGroup(usize),
+    /// Selects every tab between the active tab and the shift-clicked row (inclusive).
+    ShiftSelectTabRange {
+        locator: PaneViewLocator,
+    },
     ToggleTabGroupRightClickMenu {
         group_id: TabGroupId,
         anchor: TabContextMenuAnchor,
@@ -1012,6 +1016,7 @@ impl WorkspaceAction {
             | OpenMCPServerCollection
             | FocusTerminalViewInWorkspace { .. }
             | FocusPane(..)
+            | ShiftSelectTabRange { .. }
             | StartNewConversation { .. }
             | UndoRevertInCodeReviewPane { .. }
             | JumpToLatestToast

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5198,8 +5198,8 @@ impl Workspace {
         self.active_tab_index = index;
 
         // The range selection's anchor is the active tab, so any change to
-        // the active tab makes the existing range stale; clear it.
-        self.clear_tab_range_selection(ctx);
+        // the active tab makes the existing selection stale; clear it.
+        self.clear_tab_multi_selection(ctx);
 
         if let Some(tab) = self.tabs.get(index) {
             let pane_group_id = tab.pane_group.id();
@@ -22674,6 +22674,7 @@ impl TypedActionView for Workspace {
             } => self.move_tab_to_group(*tab_index, *group_id, ctx),
             RemoveTabFromGroup(tab_index) => self.remove_tab_from_group(*tab_index, ctx),
             ShiftSelectTabRange { locator } => self.shift_select_tab_range(*locator, ctx),
+            ToggleTabMultiSelection { locator } => self.toggle_tab_multi_selection(*locator, ctx),
             ToggleTabGroupRightClickMenu { group_id, anchor } => {
                 self.toggle_tab_group_right_click_menu(*group_id, *anchor, ctx)
             }
@@ -23230,14 +23231,14 @@ impl TypedActionView for Workspace {
             ToggleScrollReporting => self.toggle_scroll_reporting(ctx),
             ToggleFocusReporting => self.toggle_focus_reporting(ctx),
             StartTabDrag => {
-                // Drag supersedes any range selection; clear it to avoid stale highlights.
-                self.clear_tab_range_selection(ctx);
+                // Drag supersedes any multi-selection; clear it to avoid stale highlights.
+                self.clear_tab_multi_selection(ctx);
                 // If we are renaming a tab, finish the rename before dragging.
                 self.finish_tab_rename(ctx);
                 self.current_workspace_state.is_tab_being_dragged = true;
             }
             StartGroupDrag(_group_id) => {
-                self.clear_tab_range_selection(ctx);
+                self.clear_tab_multi_selection(ctx);
                 self.finish_tab_group_rename(ctx);
             }
             DragGroup { group_id, position } => {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -13,6 +13,7 @@ pub(crate) mod openwarp_launch_modal;
 pub(crate) mod orchestration_launch_modal;
 pub(crate) mod right_panel;
 mod startup_directory;
+mod tab_grouping;
 #[cfg(test)]
 #[path = "view_tests.rs"]
 pub(crate) mod tests;
@@ -5195,6 +5196,10 @@ impl Workspace {
         };
 
         self.active_tab_index = index;
+
+        // The range selection's anchor is the active tab, so any change to
+        // the active tab makes the existing range stale; clear it.
+        self.clear_tab_range_selection(ctx);
 
         if let Some(tab) = self.tabs.get(index) {
             let pane_group_id = tab.pane_group.id();
@@ -22668,6 +22673,7 @@ impl TypedActionView for Workspace {
                 group_id,
             } => self.move_tab_to_group(*tab_index, *group_id, ctx),
             RemoveTabFromGroup(tab_index) => self.remove_tab_from_group(*tab_index, ctx),
+            ShiftSelectTabRange { locator } => self.shift_select_tab_range(*locator, ctx),
             ToggleTabGroupRightClickMenu { group_id, anchor } => {
                 self.toggle_tab_group_right_click_menu(*group_id, *anchor, ctx)
             }
@@ -23224,11 +23230,14 @@ impl TypedActionView for Workspace {
             ToggleScrollReporting => self.toggle_scroll_reporting(ctx),
             ToggleFocusReporting => self.toggle_focus_reporting(ctx),
             StartTabDrag => {
+                // Drag supersedes any range selection; clear it to avoid stale highlights.
+                self.clear_tab_range_selection(ctx);
                 // If we are renaming a tab, finish the rename before dragging.
                 self.finish_tab_rename(ctx);
                 self.current_workspace_state.is_tab_being_dragged = true;
             }
             StartGroupDrag(_group_id) => {
+                self.clear_tab_range_selection(ctx);
                 self.finish_tab_group_rename(ctx);
             }
             DragGroup { group_id, position } => {

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -1,0 +1,87 @@
+use std::collections::HashSet;
+use warp_core::features::FeatureFlag;
+use warpui::ViewContext;
+
+use super::Workspace;
+use crate::workspace::tab_group::TabGroupId;
+use crate::workspace::util::PaneViewLocator;
+
+// TODO(johnturcoo) move tab grouping helpers here from workspace/view.rs.
+impl Workspace {
+    /// Clears the range selection.
+    pub(super) fn clear_tab_range_selection(&mut self, ctx: &mut ViewContext<Self>) {
+        let mut changed = false;
+        for tab in &mut self.tabs {
+            if tab.in_range_selected {
+                tab.in_range_selected = false;
+                changed = true;
+            }
+        }
+        if changed {
+            ctx.notify();
+        }
+    }
+
+    /// Selects the inclusive range between `anchor_index` and `clicked_index`,
+    /// expanding any collapsed groups the range crosses.
+    fn set_tab_range_selection(
+        &mut self,
+        anchor_index: usize,
+        clicked_index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        // Determine the bounds for our range selection.
+        let lo = anchor_index.min(clicked_index);
+        let hi = anchor_index.max(clicked_index);
+
+        // Identify groups in the selection range.
+        let crossed_group_ids: HashSet<TabGroupId> = self
+            .tabs
+            .get(lo..=hi)
+            .into_iter()
+            .flatten()
+            .filter_map(|tab| tab.group_id)
+            .collect();
+        let mut expanded_any = false;
+
+        // Expand any groups within the selected range, so user can see what they are selecting.
+        for group_id in crossed_group_ids {
+            if let Some(group) = self.tab_groups.get_mut(&group_id) {
+                if group.collapsed {
+                    group.collapsed = false;
+                    expanded_any = true;
+                }
+            }
+        }
+
+        // Update flag for all tabs that are in the selected range.
+        for (index, tab) in self.tabs.iter_mut().enumerate() {
+            tab.in_range_selected = index >= lo && index <= hi;
+        }
+        if expanded_any {
+            ctx.dispatch_global_action("workspace:save_app", ());
+        }
+        ctx.notify();
+    }
+
+    /// Shift-click on a vertical tab row: selects every tab between the
+    /// active tab and `locator` (inclusive).
+    pub(super) fn shift_select_tab_range(
+        &mut self,
+        locator: PaneViewLocator,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        // Identify index of the tab that was shift-clicked.
+        let Some(clicked_index) = self
+            .tabs
+            .iter()
+            .position(|tab| tab.pane_group.id() == locator.pane_group_id)
+        else {
+            return;
+        };
+        self.set_tab_range_selection(self.active_tab_index, clicked_index, ctx);
+    }
+}

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -78,7 +78,7 @@ impl Workspace {
     }
 
     /// Cmd-click on a tab: toggles the multi-selection flag
-    /// for a single tab. 
+    /// for a single tab.
     pub(super) fn toggle_tab_multi_selection(
         &mut self,
         locator: PaneViewLocator,

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+
 use warp_core::features::FeatureFlag;
 use warpui::ViewContext;
 
@@ -8,22 +9,18 @@ use crate::workspace::util::PaneViewLocator;
 
 // TODO(johnturcoo) move tab grouping helpers here from workspace/view.rs.
 impl Workspace {
-    /// Clears the range selection.
-    pub(super) fn clear_tab_range_selection(&mut self, ctx: &mut ViewContext<Self>) {
-        let mut changed = false;
+    /// Clears the multi-selection on every tab.
+    pub(super) fn clear_tab_multi_selection(&mut self, ctx: &mut ViewContext<Self>) {
         for tab in &mut self.tabs {
-            if tab.in_range_selected {
-                tab.in_range_selected = false;
-                changed = true;
-            }
+            tab.in_multi_selection = false;
         }
-        if changed {
-            ctx.notify();
-        }
+        ctx.notify();
     }
 
-    /// Selects the inclusive range between `anchor_index` and `clicked_index`,
-    /// expanding any collapsed groups the range crosses.
+    /// Adds the inclusive range between `anchor_index` and `clicked_index` to
+    /// the multi-selection, expanding any collapsed groups the range crosses.
+    /// Existing multi-selection outside the range is preserved (additive
+    /// semantics), so cmd-click selections survive a subsequent shift-click.
     fn set_tab_range_selection(
         &mut self,
         anchor_index: usize,
@@ -31,36 +28,32 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         // Determine the bounds for our range selection.
-        let lo = anchor_index.min(clicked_index);
-        let hi = anchor_index.max(clicked_index);
+        let lo_index = anchor_index.min(clicked_index);
+        let hi_index = anchor_index.max(clicked_index);
 
         // Identify groups in the selection range.
         let crossed_group_ids: HashSet<TabGroupId> = self
             .tabs
-            .get(lo..=hi)
+            .get(lo_index..=hi_index)
             .into_iter()
             .flatten()
             .filter_map(|tab| tab.group_id)
             .collect();
-        let mut expanded_any = false;
 
         // Expand any groups within the selected range, so user can see what they are selecting.
-        for group_id in crossed_group_ids {
-            if let Some(group) = self.tab_groups.get_mut(&group_id) {
-                if group.collapsed {
-                    group.collapsed = false;
-                    expanded_any = true;
-                }
-            }
-        }
+        self.tab_groups
+            .iter_mut()
+            .filter(|(group_id, _)| crossed_group_ids.contains(group_id))
+            .for_each(|(_, group)| group.collapsed = false);
 
-        // Update flag for all tabs that are in the selected range.
-        for (index, tab) in self.tabs.iter_mut().enumerate() {
-            tab.in_range_selected = index >= lo && index <= hi;
-        }
-        if expanded_any {
-            ctx.dispatch_global_action("workspace:save_app", ());
-        }
+        // Add tabs in the selected range to the multi-selection.
+        self.tabs
+            .iter_mut()
+            .enumerate()
+            .filter(|(index, _)| (lo_index..=hi_index).contains(index))
+            .for_each(|(_, tab)| tab.in_multi_selection = true);
+
+        ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
     }
 
@@ -75,13 +68,33 @@ impl Workspace {
             return;
         }
         // Identify index of the tab that was shift-clicked.
-        let Some(clicked_index) = self
+        if let Some(clicked_index) = self
             .tabs
             .iter()
             .position(|tab| tab.pane_group.id() == locator.pane_group_id)
-        else {
+        {
+            self.set_tab_range_selection(self.active_tab_index, clicked_index, ctx);
+        }
+    }
+
+    /// Cmd-click on a tab: toggles the multi-selection flag
+    /// for a single tab. 
+    pub(super) fn toggle_tab_multi_selection(
+        &mut self,
+        locator: PaneViewLocator,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
-        };
-        self.set_tab_range_selection(self.active_tab_index, clicked_index, ctx);
+        }
+        if let Some(tab) = self
+            .tabs
+            .iter_mut()
+            .find(|tab| tab.pane_group.id() == locator.pane_group_id)
+        {
+            // Toggle multi selection flag for this tab.
+            tab.in_multi_selection = !tab.in_multi_selection;
+            ctx.notify();
+        }
     }
 }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -304,13 +304,13 @@ struct TabGroupMouseStates {
 fn pane_row_background(
     pane_color: Option<ThemeFill>,
     is_selected: bool,
-    is_range_selected: bool,
+    is_in_multi_selection: bool,
     is_hovered: bool,
     is_being_dragged: bool,
     theme: &WarpTheme,
 ) -> Option<ThemeFill> {
     if let Some(color) = pane_color {
-        let opacity = if is_selected || is_hovered || is_range_selected {
+        let opacity = if is_selected || is_hovered || is_in_multi_selection {
             TAB_COLOR_HOVER_OPACITY
         } else {
             TAB_COLOR_OPACITY
@@ -318,11 +318,11 @@ fn pane_row_background(
         Some(color.with_opacity(opacity))
     } else if is_selected {
         Some(internal_colors::fg_overlay_2(theme))
-    } else if is_range_selected && is_hovered {
-        // Hovering a range-selected row steps one shade darker so the hover
-        // stays visually distinguishable from the in-range highlight.
+    } else if is_in_multi_selection && is_hovered {
+        // Hovering a multi-selected row steps one shade darker so the hover
+        // stays visually distinguishable from the in-selection highlight.
         Some(internal_colors::fg_overlay_2(theme))
-    } else if is_range_selected || is_being_dragged || is_hovered {
+    } else if is_in_multi_selection || is_being_dragged || is_hovered {
         Some(internal_colors::fg_overlay_1(theme))
     } else {
         None
@@ -357,7 +357,7 @@ fn render_pane_row_element(
         is_focused,
         typed: _,
         is_being_dragged,
-        is_range_selected,
+        is_in_multi_selection,
         pane_color,
         badge_mouse_states: _,
         detail_hover_state,
@@ -378,7 +378,7 @@ fn render_pane_row_element(
         if let Some(background) = pane_row_background(
             pane_color,
             is_selected,
-            is_range_selected,
+            is_in_multi_selection,
             state.is_hovered(),
             is_being_dragged,
             theme,
@@ -399,9 +399,12 @@ fn render_pane_row_element(
             pane_group_id,
             pane_id,
         };
-        // Shift-click extends the range selection; plain click focuses the pane.
+        // Shift-click extends the range selection; cmd/ctrl-click toggles a
+        // single tab in/out of the selection; plain click focuses the pane.
         if modifiers.shift && FeatureFlag::GroupedTabs.is_enabled() {
             ctx.dispatch_typed_action(WorkspaceAction::ShiftSelectTabRange { locator });
+        } else if modifiers.cmd && FeatureFlag::GroupedTabs.is_enabled() {
+            ctx.dispatch_typed_action(WorkspaceAction::ToggleTabMultiSelection { locator });
         } else {
             ctx.dispatch_typed_action(WorkspaceAction::FocusPane(locator));
         }
@@ -732,8 +735,9 @@ struct PaneProps<'a> {
     is_focused: bool,
     typed: TypedPane<'a>,
     is_being_dragged: bool,
-    /// True when this row's tab is part of the active range selection.
-    is_range_selected: bool,
+    /// True when this row's tab is part of the active multi-selection
+    /// (shift-click range or cmd-click toggle).
+    is_in_multi_selection: bool,
     pane_color: Option<ThemeFill>,
     badge_mouse_states: PaneRowBadgeMouseStates,
     detail_hover_state: VerticalTabsDetailHoverState,
@@ -1953,8 +1957,8 @@ fn render_tab_group_internal(
     let is_first_tab = tab_index == 0;
     let is_last_tab = tab_index + 1 == workspace.tabs.len();
     let is_this_tab_dragging = tab.draggable_state.is_dragging();
-    // Ensure panes inherit range selection status from the tab they belong to.
-    let is_range_selected = tab.in_range_selected;
+    // Panes inherit multi-selection status from the tab they belong to.
+    let is_in_multi_selection = tab.in_multi_selection;
     let color_mode = compute_tab_group_color_mode(tab, pane_group, &visible_pane_ids, theme, app);
     let per_pane_colors = color_mode.into_per_pane_colors(&visible_pane_ids);
     let is_being_renamed = is_active && workspace.current_workspace_state.is_tab_being_renamed();
@@ -2002,7 +2006,7 @@ fn render_tab_group_internal(
                     *pane_id,
                     pane_group_id,
                     is_active,
-                    is_range_selected,
+                    is_in_multi_selection,
                     PaneRowState {
                         mouse_state: row_mouse_state.clone(),
                         title_mouse_state: None,
@@ -2056,7 +2060,7 @@ fn render_tab_group_internal(
                     *pane_id,
                     pane_group_id,
                     is_active,
-                    is_range_selected,
+                    is_in_multi_selection,
                     PaneRowState {
                         mouse_state: row_mouse_state.clone(),
                         title_mouse_state: title_mouse_states.get(pane_id).cloned(),
@@ -3357,7 +3361,7 @@ impl<'a> PaneProps<'a> {
         pane_id: PaneId,
         pane_group_id: EntityId,
         is_active_tab: bool,
-        is_range_selected: bool,
+        is_in_multi_selection: bool,
         pane_row_state: PaneRowState,
         detail_hover_state: VerticalTabsDetailHoverState,
         display_granularity: VerticalTabsDisplayGranularity,
@@ -3408,7 +3412,7 @@ impl<'a> PaneProps<'a> {
             is_focused: pane_group.focused_pane_id(app) == pane_id,
             typed,
             is_being_dragged: pane.is_pane_being_dragged(app),
-            is_range_selected,
+            is_in_multi_selection,
             pane_color: pane_row_state.pane_color,
             badge_mouse_states: pane_row_state.badge_mouse_states,
             detail_hover_state,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -304,12 +304,13 @@ struct TabGroupMouseStates {
 fn pane_row_background(
     pane_color: Option<ThemeFill>,
     is_selected: bool,
+    is_range_selected: bool,
     is_hovered: bool,
     is_being_dragged: bool,
     theme: &WarpTheme,
 ) -> Option<ThemeFill> {
     if let Some(color) = pane_color {
-        let opacity = if is_selected || is_hovered {
+        let opacity = if is_selected || is_hovered || is_range_selected {
             TAB_COLOR_HOVER_OPACITY
         } else {
             TAB_COLOR_OPACITY
@@ -317,7 +318,11 @@ fn pane_row_background(
         Some(color.with_opacity(opacity))
     } else if is_selected {
         Some(internal_colors::fg_overlay_2(theme))
-    } else if is_being_dragged || is_hovered {
+    } else if is_range_selected && is_hovered {
+        // Hovering a range-selected row steps one shade darker so the hover
+        // stays visually distinguishable from the in-range highlight.
+        Some(internal_colors::fg_overlay_2(theme))
+    } else if is_range_selected || is_being_dragged || is_hovered {
         Some(internal_colors::fg_overlay_1(theme))
     } else {
         None
@@ -352,6 +357,7 @@ fn render_pane_row_element(
         is_focused,
         typed: _,
         is_being_dragged,
+        is_range_selected,
         pane_color,
         badge_mouse_states: _,
         detail_hover_state,
@@ -372,6 +378,7 @@ fn render_pane_row_element(
         if let Some(background) = pane_row_background(
             pane_color,
             is_selected,
+            is_range_selected,
             state.is_hovered(),
             is_being_dragged,
             theme,
@@ -387,11 +394,17 @@ fn render_pane_row_element(
             }))
             .finish()
     })
-    .on_click(move |ctx, _, _| {
-        ctx.dispatch_typed_action(WorkspaceAction::FocusPane(PaneViewLocator {
+    .on_click_with_modifiers(move |ctx, _, _, modifiers| {
+        let locator = PaneViewLocator {
             pane_group_id,
             pane_id,
-        }));
+        };
+        // Shift-click extends the range selection; plain click focuses the pane.
+        if modifiers.shift && FeatureFlag::GroupedTabs.is_enabled() {
+            ctx.dispatch_typed_action(WorkspaceAction::ShiftSelectTabRange { locator });
+        } else {
+            ctx.dispatch_typed_action(WorkspaceAction::FocusPane(locator));
+        }
     })
     .on_hover(move |is_hovered, ctx, app, position| {
         let show_details_on_hover = *TabSettings::as_ref(app)
@@ -719,6 +732,8 @@ struct PaneProps<'a> {
     is_focused: bool,
     typed: TypedPane<'a>,
     is_being_dragged: bool,
+    /// True when this row's tab is part of the active range selection.
+    is_range_selected: bool,
     pane_color: Option<ThemeFill>,
     badge_mouse_states: PaneRowBadgeMouseStates,
     detail_hover_state: VerticalTabsDetailHoverState,
@@ -1085,6 +1100,7 @@ impl VerticalTabsPanelState {
                                 pane_id,
                                 tab.pane_group.id(),
                                 *tab_index == active_tab_index,
+                                false,
                                 PaneRowState {
                                     mouse_state: ms,
                                     title_mouse_state: None,
@@ -1652,6 +1668,7 @@ fn render_groups(
                                     pane_id,
                                     tab.pane_group.id(),
                                     tab_index == workspace.active_tab_index,
+                                    false,
                                     PaneRowState {
                                         mouse_state: ms,
                                         title_mouse_state: None,
@@ -1679,6 +1696,7 @@ fn render_groups(
                                 pane_id,
                                 tab.pane_group.id(),
                                 tab_index == workspace.active_tab_index,
+                                false,
                                 PaneRowState {
                                     mouse_state,
                                     title_mouse_state: None,
@@ -1935,6 +1953,8 @@ fn render_tab_group_internal(
     let is_first_tab = tab_index == 0;
     let is_last_tab = tab_index + 1 == workspace.tabs.len();
     let is_this_tab_dragging = tab.draggable_state.is_dragging();
+    // Ensure panes inherit range selection status from the tab they belong to.
+    let is_range_selected = tab.in_range_selected;
     let color_mode = compute_tab_group_color_mode(tab, pane_group, &visible_pane_ids, theme, app);
     let per_pane_colors = color_mode.into_per_pane_colors(&visible_pane_ids);
     let is_being_renamed = is_active && workspace.current_workspace_state.is_tab_being_renamed();
@@ -1982,6 +2002,7 @@ fn render_tab_group_internal(
                     *pane_id,
                     pane_group_id,
                     is_active,
+                    is_range_selected,
                     PaneRowState {
                         mouse_state: row_mouse_state.clone(),
                         title_mouse_state: None,
@@ -2035,6 +2056,7 @@ fn render_tab_group_internal(
                     *pane_id,
                     pane_group_id,
                     is_active,
+                    is_range_selected,
                     PaneRowState {
                         mouse_state: row_mouse_state.clone(),
                         title_mouse_state: title_mouse_states.get(pane_id).cloned(),
@@ -3335,6 +3357,7 @@ impl<'a> PaneProps<'a> {
         pane_id: PaneId,
         pane_group_id: EntityId,
         is_active_tab: bool,
+        is_range_selected: bool,
         pane_row_state: PaneRowState,
         detail_hover_state: VerticalTabsDetailHoverState,
         display_granularity: VerticalTabsDisplayGranularity,
@@ -3385,6 +3408,7 @@ impl<'a> PaneProps<'a> {
             is_focused: pane_group.focused_pane_id(app) == pane_id,
             typed,
             is_being_dragged: pane.is_pane_being_dragged(app),
+            is_range_selected,
             pane_color: pane_row_state.pane_color,
             badge_mouse_states: pane_row_state.badge_mouse_states,
             detail_hover_state,
@@ -6143,6 +6167,7 @@ fn detail_pane_props<'a>(
         pane_group,
         pane_id,
         pane_group_id,
+        false,
         false,
         PaneRowState {
             mouse_state: MouseStateHandle::default(),

--- a/crates/warpui_core/src/elements/hoverable.rs
+++ b/crates/warpui_core/src/elements/hoverable.rs
@@ -7,7 +7,7 @@ use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
 
 use super::{Point, SelectableElement, Selection, SelectionFragment, ZIndex};
-use crate::event::DispatchedEvent;
+use crate::event::{DispatchedEvent, ModifiersState};
 use crate::platform::Cursor;
 use crate::text::word_boundaries::WordBoundariesPolicy;
 use crate::text::{IsRect, SelectionDirection, SelectionType};
@@ -16,6 +16,11 @@ use crate::{AfterLayoutContext, AppContext, Element, Event, EventContext, PaintC
 /// First arg is is_hovered. True when hovering in, false when hovering out.
 type HoverHandler = Box<dyn FnMut(bool, &mut EventContext, &AppContext, Vector2F)>;
 type ClickHandler = Box<dyn FnMut(&mut EventContext, &AppContext, Vector2F)>;
+/// Click handler that additionally receives the keyboard modifiers held at
+/// click time, captured from the `LeftMouseUp` event. Used by callers that
+/// need to distinguish plain clicks from shift/cmd/ctrl/alt-clicks.
+type ClickWithModifiersHandler =
+    Box<dyn FnMut(&mut EventContext, &AppContext, Vector2F, ModifiersState)>;
 
 pub struct Hoverable {
     child: Box<dyn Element>,
@@ -25,6 +30,9 @@ pub struct Hoverable {
     // A click is comprised of a mouse down and a mouse up,
     // both within the hoverable.
     click_handler: Option<ClickHandler>,
+    // Fires on the same mouse-down-then-mouse-up sequence as `click_handler`,
+    // but the callback also receives the keyboard modifiers held at click time.
+    click_with_modifiers_handler: Option<ClickWithModifiersHandler>,
     mouse_down_handler: Option<ClickHandler>,
     double_click_handler: Option<ClickHandler>,
     middle_click_handler: Option<ClickHandler>,
@@ -191,6 +199,7 @@ impl Hoverable {
             origin: None,
             hover_handler: None,
             click_handler: None,
+            click_with_modifiers_handler: None,
             mouse_down_handler: None,
             double_click_handler: None,
             middle_click_handler: None,
@@ -242,6 +251,18 @@ impl Hoverable {
         F: 'static + FnMut(&mut EventContext, &AppContext, Vector2F),
     {
         self.click_handler = Some(Box::new(callback));
+        self
+    }
+
+    /// Fires when the mouse is released within the hoverable after it was pressed
+    /// within the hoverable. The callback also receives the keyboard modifiers
+    /// (e.g. `shift`, `cmd`) held at click time, so callers can branch on
+    /// modifier-clicks.
+    pub fn on_click_with_modifiers<F>(mut self, callback: F) -> Self
+    where
+        F: 'static + FnMut(&mut EventContext, &AppContext, Vector2F, ModifiersState),
+    {
+        self.click_with_modifiers_handler = Some(Box::new(callback));
         self
     }
 
@@ -635,13 +656,17 @@ impl Element for Hoverable {
 
                 // We mark this as handled if we have a handler waiting to take action on the mouse-up event.
                 if self.click_handler.is_some()
+                    || self.click_with_modifiers_handler.is_some()
                     || (*click_count == 2 && self.double_click_handler.is_some())
                 {
                     ctx.notify();
                     return true;
                 }
             }
-            Event::LeftMouseUp { position, .. } => {
+            Event::LeftMouseUp {
+                position,
+                modifiers,
+            } => {
                 // Mouse-up should always reset clicked and double-clicked to false.
                 let click_count = self.state().click_count.take();
 
@@ -667,6 +692,14 @@ impl Element for Hoverable {
                 } else if click_count.is_some() && self.click_handler.is_some() {
                     let handler = self.click_handler.as_mut().expect("handler should exist");
                     handler(ctx, app, *position);
+                    ctx.notify();
+                    return true;
+                } else if click_count.is_some() && self.click_with_modifiers_handler.is_some() {
+                    let handler = self
+                        .click_with_modifiers_handler
+                        .as_mut()
+                        .expect("handler should exist");
+                    handler(ctx, app, *position, *modifiers);
                     ctx.notify();
                     return true;
                 }


### PR DESCRIPTION
## Description
Adds shift-click range selection and cmd-click multi tab select to the vertical tabs sidebar. Clicking a tab while holding shift **selects** every tab between the currently active tab and the clicked tab, and renders an accent highlight on the selected range. Clicking a tab while holding command, individual **selects** this tab and renders an accent highlight. Clicking a tab without shift (or starting a drag, switching panes, etc.) clears the selection.

Further actions that allow creating groups from these selected tabs, moving/removing these tabs to/from a group will be supported in a follow up PR.

NOTE: UI is not polished here, and is going to be updated in a follow up PR.

## How it works

Added a new `ClickWithModifiersHandler` handler to differentiate regular click from shift clicks and command clicks (would love some eyes on this). In the vertical tabs pane, when an element is shift clicked, we dispatch a new `on_click_with_modifiers` action rather than setting focus to this tab/pane via a regular click. This sets a new flag on all tabs and panes within the given range (from current active tab to new element that is shift-clicked) to identify that this tab/pane is now selected as part of a range. A similar situation occurs for a command click, but marks the clicked tab as **selected** individually. This is cleared on next click, or drag action. If there is a group within the range, it is automatically expanded.

Rendering logic is updated so that tabs/panes are highlighted when they are part of a multi select (with an edge case for panes so that there is differentiation between hover and selected). Helper functions are added to `app/src/workspace/view/tab_grouping.rs` to support range selection actions, this is where all existing tab grouping logic is going to be ported to. Shift click is gated behind a feature flag so that behavior remains unchanged when it is off.


## Linked Issue

https://linear.app/warpdotdev/issue/APP-4642/shift-click-range-group-selection

## Testing
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo video](https://www.loom.com/share/17c6cc1be36342a59555455e64d66600)

This video displays shift clicking a range of tabs, in both tab and pane view. It is cleared when another tab is selected or a drag begins. Also shows groups auto expanding when they are within a shift click range.

It also displays command clicking individual tabs to show they are also marked as selected.