### PR TITLE
Disable git ops button on remote

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -6522,6 +6522,24 @@ impl CodeReviewView {
     /// Updates the primary git operations button, chevron visibility, and
     /// related state to match the current [`PrimaryGitActionMode`].
     fn update_git_operations_ui(&mut self, ctx: &mut ViewContext<Self>) {
+        // Disable the button for remote sessions.
+        if self.repo_path().is_some_and(LocalOrRemotePath::is_remote) {
+            const REMOTE_TOOLTIP: &str = "Git operations aren't available in remote sessions";
+            self.git_primary_action_button.update(ctx, |button, ctx| {
+                button.set_label("Commit", ctx);
+                button.set_icon(Some(Icon::GitCommit), ctx);
+                button.set_disabled(true, ctx);
+                button.set_tooltip(Some(REMOTE_TOOLTIP), ctx);
+                button.set_adjoined_side(AdjoinedSide::Right, ctx);
+            });
+            self.git_operations_chevron.update(ctx, |button, ctx| {
+                button.set_disabled(true, ctx);
+                button.set_tooltip(Some(REMOTE_TOOLTIP), ctx);
+            });
+            ctx.notify();
+            return;
+        }
+
         let mode = self.primary_git_action_mode(ctx);
 
         match mode {


### PR DESCRIPTION
## Description
* Quick stop gap before adding support for git operations on remote sessions
* For remote paths, we disable the primary git button with a tooltip explaining why
  * Prefer this over removing the button entirely so there's less ui difference between local and remote sessions

## Testing
<img width="363" height="126" alt="Screenshot 2026-06-04 at 12 01 07 PM" src="https://github.com/user-attachments/assets/5fd1d69a-8398-45ec-83b0-e584d1bf4edb" />

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode