### PR TITLE
Improve terminal server teardown behavior.

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -368,6 +368,7 @@ signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"] }
 nix = { workspace = true, features = [
     "fs",
     "hostname",
+    "poll",
     "resource",
     "signal",
     "socket",

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2139,12 +2139,12 @@ pub(crate) fn app_callbacks(is_integration_test: bool) -> warpui::platform::AppC
             // after terminating the persistence writer, so we don't keep track
             // of the fact that the shell sessions terminated.
             #[cfg(feature = "local_tty")]
+            terminal::local_tty::shutdown_all_pty_event_loops(ctx);
+
+            #[cfg(feature = "local_tty")]
             terminal::local_tty::spawner::PtySpawner::handle(ctx).update(ctx, |pty_spawner, _| {
                 pty_spawner.prepare_for_app_termination();
             });
-
-            #[cfg(all(feature = "local_tty", windows))]
-            terminal::local_tty::shutdown_all_pty_event_loops(ctx);
 
             // Tear down app services before spawning the new process, to
             // ensure that the new process doesn't find the old process while

--- a/app/src/terminal/local_tty/mod.rs
+++ b/app/src/terminal/local_tty/mod.rs
@@ -28,7 +28,6 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use shell::ShellStarter;
 
-#[cfg(windows)]
 pub use self::terminal_manager::shutdown_all_pty_event_loops;
 pub use self::terminal_manager::{get_shell_starter, TerminalManager};
 #[cfg(unix)]

--- a/app/src/terminal/local_tty/server/api.rs
+++ b/app/src/terminal/local_tty/server/api.rs
@@ -44,6 +44,12 @@ pub(super) enum Message {
     /// an error that occurred during the operation, if any.  Should only be
     /// sent from server -> client.
     KillChildResponse { error_msg: Option<String> },
+    /// A message sent from client -> server requesting that the server clean
+    /// up all hosted shell processes before shutting itself down.
+    ShutdownRequest,
+    /// The response for a `ShutdownRequest`, sent once hosted shell cleanup
+    /// has completed. Should only be sent from server -> client.
+    ShutdownResponse,
     /// A message sent from server -> client requesting that a log message be
     /// written to the host application's log.  This has no matching response
     /// message - these requests are fire-and-forget from the server to the

--- a/app/src/terminal/local_tty/server/client.rs
+++ b/app/src/terminal/local_tty/server/client.rs
@@ -1,8 +1,10 @@
 use std::collections::HashSet;
 use std::os::unix::prelude::*;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Result};
+use nix::poll::{poll, PollFd, PollFlags};
 use parking_lot::Mutex;
 
 use super::{api, protocol};
@@ -105,6 +107,44 @@ impl TerminalServerClient {
             }
             None => {
                 bail!("Received error reading message back from terminal server");
+            }
+        }
+    }
+
+    /// Asks the server to clean up all hosted shells and shut itself down.
+    pub fn shutdown(&self, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        let Some(fd) = self
+            .socket_fd
+            .try_lock_for(deadline.saturating_duration_since(Instant::now()))
+        else {
+            bail!("Timed out waiting for terminal server protocol socket during shutdown");
+        };
+
+        protocol::send_message(
+            fd.as_fd(),
+            api::Message::ShutdownRequest,
+            Option::<RawFd>::None,
+        )?;
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            bail!("Timed out waiting for terminal server to shut down");
+        }
+        let timeout_ms: i32 = remaining.as_millis().max(1).try_into().unwrap_or(i32::MAX);
+        let mut poll_fds = [PollFd::new(fd.as_raw_fd(), PollFlags::POLLIN)];
+        let poll_result = poll(&mut poll_fds, timeout_ms)?;
+        if poll_result == 0 {
+            bail!("Timed out waiting for terminal server to shut down");
+        }
+
+        match protocol::receive_message(fd.as_fd())? {
+            Some(api::Message::ShutdownResponse) => Ok(()),
+            Some(_) => {
+                bail!("Got response message other than ShutdownResponse after sending a ShutdownRequest message!");
+            }
+            None => {
+                bail!("Received error reading shutdown response from terminal server");
             }
         }
     }

--- a/app/src/terminal/local_tty/server/event_loop.rs
+++ b/app/src/terminal/local_tty/server/event_loop.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 use std::os::unix::prelude::*;
 use std::process::Child;
 use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
 
+use anyhow::Result;
 use itertools::Itertools;
 use mio::Interest;
 use parking_lot::Mutex;
@@ -16,6 +19,8 @@ use crate::terminal::platform;
 
 const RECV_SOCKET_TOKEN: mio::Token = mio::Token(0);
 const SIGNALS_TOKEN: mio::Token = mio::Token(1);
+const CHILD_TERMINATION_GRACE_PERIOD: Duration = Duration::from_millis(500);
+const CHILD_TERMINATION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// A helper structure for holding onto child processes and ensuring that
 /// all children are killed when the structure is dropped.
@@ -54,23 +59,105 @@ impl Children {
         }
         terminated_children
     }
+
+    /// Sends a signal to all processes in one hosted PTY process group.
+    ///
+    /// The group may already have exited before cleanup observes it, which is
+    /// equivalent to successful termination.
+    fn signal_process_group(pgid: u32, signal: nix::sys::signal::Signal) -> Result<()> {
+        let process_group = nix::unistd::Pid::from_raw(pgid as i32);
+        match nix::sys::signal::killpg(process_group, signal) {
+            Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Returns whether any process still exists in one hosted PTY process group.
+    fn process_group_exists(pgid: u32) -> bool {
+        let process_group = nix::unistd::Pid::from_raw(pgid as i32);
+        match nix::sys::signal::killpg(process_group, None) {
+            Ok(()) | Err(nix::errno::Errno::EPERM) => true,
+            Err(nix::errno::Errno::ESRCH) => false,
+            Err(err) => {
+                log::warn!("Failed to inspect PTY process group {pgid}: {err:#}");
+                true
+            }
+        }
+    }
+
+    /// Terminates one hosted PTY process group within a bounded period.
+    ///
+    /// PTY shell processes are process-group leaders, so their process IDs are
+    /// also their process-group IDs. The direct child may exit from `SIGHUP`
+    /// while descendants remain in that group, so this keeps checking group
+    /// liveness throughout a grace period and sends `SIGKILL` to survivors.
+    fn terminate_child(&mut self, pid: u32) -> Result<()> {
+        if !self.0.contains_key(&pid) {
+            log::info!(
+                "Did not find child shell process with pid {pid}; assuming it has already terminated."
+            );
+            return Ok(());
+        }
+        let pgid = pid;
+        Self::signal_process_group(pgid, nix::sys::signal::SIGHUP)?;
+        let deadline = Instant::now() + CHILD_TERMINATION_GRACE_PERIOD;
+        while Instant::now() < deadline {
+            if let Some(child) = self.0.get_mut(&pid) {
+                let _ = child.try_wait()?;
+            }
+            if !Self::process_group_exists(pgid) {
+                if let Some(mut child) = self.remove(&pid) {
+                    child.wait()?;
+                }
+                return Ok(());
+            }
+            thread::sleep(CHILD_TERMINATION_POLL_INTERVAL);
+        }
+        if Self::process_group_exists(pgid) {
+            Self::signal_process_group(pgid, nix::sys::signal::SIGKILL)?;
+        }
+        if let Some(mut child) = self.remove(&pid) {
+            child.wait()?;
+        }
+        Ok(())
+    }
+
+    /// Terminates all hosted PTY process groups during server shutdown.
+    fn terminate_all(&mut self) {
+        let pgids = self.0.keys().cloned().collect_vec();
+        for pgid in &pgids {
+            if let Err(err) = Self::signal_process_group(*pgid, nix::sys::signal::SIGHUP) {
+                log::warn!("Failed to send SIGHUP to PTY process group {pgid}: {err:#}");
+            }
+        }
+
+        let deadline = Instant::now() + CHILD_TERMINATION_GRACE_PERIOD;
+        while Instant::now() < deadline {
+            for child in self.0.values_mut() {
+                let _ = child.try_wait();
+            }
+            if pgids.iter().all(|pgid| !Self::process_group_exists(*pgid)) {
+                break;
+            }
+            thread::sleep(CHILD_TERMINATION_POLL_INTERVAL);
+        }
+        for pgid in pgids {
+            if Self::process_group_exists(pgid) {
+                if let Err(err) = Self::signal_process_group(pgid, nix::sys::signal::SIGKILL) {
+                    log::warn!("Failed to send SIGKILL to PTY process group {pgid}: {err:#}");
+                }
+            }
+        }
+        for child in self.0.values_mut() {
+            let _ = child.wait();
+        }
+        self.0.clear();
+    }
 }
 
 impl std::ops::Drop for Children {
     fn drop(&mut self) {
-        // Explicitly kill all children on drop.
-        for child in self.0.values_mut() {
-            // Send SIGHUP instead of SIGKILL (which is what `child.kill()`
-            // sends) so that the shell process can properly clean up
-            // foreground jobs.  SIGKILL cannot be ignored or caught, and kills
-            // the receiving process immediately.
-            let pid = nix::unistd::Pid::from_raw(child.id() as i32);
-            let _ = nix::sys::signal::kill(pid, nix::sys::signal::SIGHUP);
-            // Ensure we consume the child's exit code to avoid it becoming
-            // a zombie.
-            // See: https://doc.rust-lang.org/std/process/struct.Child.html#warning
-            let _ = child.wait();
-        }
+        self.terminate_all();
     }
 }
 
@@ -287,14 +374,9 @@ impl EventLoop {
                     }
                 }
                 api::Message::KillChildRequest { pid } => {
-                    let result = match self.children.remove(&pid) {
-                        Some(mut child) => child.kill().and_then(|_| child.wait()),
-                        None => {
-                            log::info!("Did not find child shell process with pid {pid}; assuming it has already terminated.");
-                            Ok(std::process::ExitStatus::default())
-                        }
-                    };
-                    let error_msg = result.err().map(|err| err.to_string());
+                    let error_msg = self.children.terminate_child(pid).err().map(|err| {
+                        format!("Failed to terminate child shell process {pid}: {err:#}")
+                    });
                     if let Err(err) = protocol::send_message(
                         RECV_SOCKET_FILENO,
                         api::Message::KillChildResponse { error_msg },
@@ -305,11 +387,25 @@ impl EventLoop {
                         return None;
                     };
                 }
+                api::Message::ShutdownRequest => {
+                    self.children.terminate_all();
+                    if let Err(err) = protocol::send_message(
+                        RECV_SOCKET_FILENO,
+                        api::Message::ShutdownResponse,
+                        Option::<RawFd>::None,
+                    ) {
+                        log::error!("Encountered unexpected error sending terminal server shutdown response: {err:#}.");
+                    }
+                    return None;
+                }
                 api::Message::SpawnShellResponse { .. } => {
                     log::error!("Terminal server received unexpected SpawnShellResponse message!");
                 }
                 api::Message::KillChildResponse { .. } => {
                     log::error!("Terminal server received unexpected KillChildResponse message!");
+                }
+                api::Message::ShutdownResponse => {
+                    log::error!("Terminal server received unexpected ShutdownResponse message!");
                 }
                 api::Message::WriteLogRequest { .. } => {
                     log::error!("Terminal server received unexpected WriteLogRequest message!");
@@ -323,3 +419,7 @@ impl EventLoop {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "event_loop_tests.rs"]
+mod tests;

--- a/app/src/terminal/local_tty/server/event_loop_tests.rs
+++ b/app/src/terminal/local_tty/server/event_loop_tests.rs
@@ -1,0 +1,113 @@
+use std::io::{BufRead as _, BufReader};
+use std::os::unix::process::CommandExt as _;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::*;
+
+struct ProcessGroupGuard(u32);
+
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        let _ = Children::signal_process_group(self.0, nix::sys::signal::SIGKILL);
+    }
+}
+
+fn spawn_shell_process_group(script: &str) -> (Child, u32, ProcessGroupGuard) {
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg(script).stdout(Stdio::piped());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = command.spawn().expect("shell process group should spawn");
+    let group_guard = ProcessGroupGuard(child.id());
+    let mut descendant_pid = String::new();
+    BufReader::new(
+        child
+            .stdout
+            .take()
+            .expect("shell process should expose stdout"),
+    )
+    .read_line(&mut descendant_pid)
+    .expect("shell should report descendant pid");
+
+    (
+        child,
+        descendant_pid
+            .trim()
+            .parse()
+            .expect("reported descendant pid should be numeric"),
+        group_guard,
+    )
+}
+
+fn assert_process_exits(pid: u32) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        let result = unsafe { libc::kill(pid as i32, 0) };
+        if result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("process {pid} did not exit before the deadline");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn terminate_child_signals_the_entire_pty_process_group() {
+    let (child, descendant_pid, _group_guard) =
+        spawn_shell_process_group("sleep 30 & printf '%s\n' \"$!\"; wait");
+    let leader_pid = child.id();
+    let mut children = Children::new();
+    children.insert(child);
+
+    children
+        .terminate_child(leader_pid)
+        .expect("PTY process group should terminate");
+
+    assert_eq!(children.0.len(), 0);
+    assert_process_exits(descendant_pid);
+}
+
+#[test]
+fn terminate_child_escalates_when_a_descendant_ignores_sighup_after_the_shell_exits() {
+    let (child, descendant_pid, _group_guard) = spawn_shell_process_group(
+        "/bin/sh -c 'trap \"\" HUP; printf \"%s\\n\" \"$$\"; sleep 30' & wait",
+    );
+    let leader_pid = child.id();
+    let mut children = Children::new();
+    children.insert(child);
+    let started_at = Instant::now();
+
+    children
+        .terminate_child(leader_pid)
+        .expect("PTY process group should terminate after escalation");
+
+    assert!(started_at.elapsed() >= CHILD_TERMINATION_GRACE_PERIOD);
+    assert_eq!(children.0.len(), 0);
+    assert_process_exits(descendant_pid);
+}
+
+#[test]
+fn terminate_all_escalates_when_a_pty_process_group_ignores_sighup() {
+    let (child, descendant_pid, _group_guard) =
+        spawn_shell_process_group("trap '' HUP; sleep 30 & printf '%s\n' \"$!\"; wait");
+    let mut children = Children::new();
+    children.insert(child);
+    let started_at = Instant::now();
+
+    children.terminate_all();
+
+    assert!(started_at.elapsed() >= CHILD_TERMINATION_GRACE_PERIOD);
+    assert_eq!(children.0.len(), 0);
+    assert_process_exits(descendant_pid);
+}

--- a/app/src/terminal/local_tty/server/mod.rs
+++ b/app/src/terminal/local_tty/server/mod.rs
@@ -26,7 +26,9 @@ mod protocol;
 
 use std::collections::HashSet;
 use std::os::unix::prelude::*;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use command::blocking::Command;
@@ -50,6 +52,9 @@ const RECV_SOCKET_FILENO: RawFd = libc::STDERR_FILENO + 1;
 /// The file descriptor of the Unix domain socket where the terminal server will
 /// send requests to the host application.
 const SEND_SOCKET_FILENO: RawFd = RECV_SOCKET_FILENO + 1;
+/// How long the host waits for terminal-server shell cleanup before using its
+/// final force-termination fallback.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Runs the terminal server event loop.
 ///
@@ -66,7 +71,11 @@ pub fn run_terminal_server(args: &warp_cli::TerminalServerArgs) {
 }
 
 /// Spawns a thread to handle fire-and-forget messages sent back from the server.
-fn spawn_message_receiver_thread(socket_fd: RawFd, terminated_children: Arc<Mutex<HashSet<u32>>>) {
+fn spawn_message_receiver_thread(
+    socket_fd: RawFd,
+    terminated_children: Arc<Mutex<HashSet<u32>>>,
+    shutdown_initiated: Arc<AtomicBool>,
+) {
     std::thread::spawn(move || {
         loop {
             match protocol::receive_message(socket_fd).expect("should not fail to receive") {
@@ -94,7 +103,12 @@ fn spawn_message_receiver_thread(socket_fd: RawFd, terminated_children: Arc<Mute
                     );
                 }
                 None => {
-                    // The server process exited, so we can just let this thread terminate.
+                    // The server process exited, so we can just let this thread
+                    // terminate. This is expected after the host initiates
+                    // terminal-server shutdown.
+                    if !shutdown_initiated.load(Ordering::Relaxed) {
+                        log::warn!("Received unexpected EOF on terminal server socket.");
+                    }
                     break;
                 }
             }
@@ -119,6 +133,10 @@ pub(super) struct TerminalServer {
 
     /// A client for communicating with the terminal server process.
     client: Arc<TerminalServerClient>,
+
+    /// Indicates whether the host application has initiated graceful shutdown
+    /// of the terminal server.
+    shutdown_initiated: Arc<AtomicBool>,
 }
 
 impl TerminalServer {
@@ -150,9 +168,14 @@ impl TerminalServer {
         // children that the terminal server has notified us about but
         // the pty event loops haven't yet processed.
         let terminated_children = Arc::new(Mutex::new(HashSet::new()));
+        let shutdown_initiated = Arc::new(AtomicBool::new(false));
 
         // Spawn the message receiver background thread.
-        spawn_message_receiver_thread(client_recv_fd, terminated_children.clone());
+        spawn_message_receiver_thread(
+            client_recv_fd,
+            terminated_children.clone(),
+            shutdown_initiated.clone(),
+        );
 
         unsafe {
             // Make sure the client file descriptor is closed when the server process
@@ -198,7 +221,11 @@ impl TerminalServer {
                 terminated_children,
             ));
 
-            Ok(Self { server, client })
+            Ok(Self {
+                server,
+                client,
+                shutdown_initiated,
+            })
         }
     }
 
@@ -210,7 +237,12 @@ impl TerminalServer {
 
 impl Drop for TerminalServer {
     fn drop(&mut self) {
-        // Kill the server child process and wait for it to terminate.
+        // Ask the server to clean up hosted PTYs before terminating it. If the
+        // server is unresponsive, force-killing it remains a bounded fallback.
+        self.shutdown_initiated.store(true, Ordering::Relaxed);
+        if let Err(err) = self.client.shutdown(SHUTDOWN_TIMEOUT) {
+            log::warn!("Failed to gracefully shut down terminal server: {err:#}");
+        }
         let _ = self.server.kill();
         let _ = self.server.wait();
     }

--- a/app/src/terminal/local_tty/server/protocol.rs
+++ b/app/src/terminal/local_tty/server/protocol.rs
@@ -238,7 +238,6 @@ fn receive_message_header(socket_fd: &impl AsRawFd) -> Result<ReceiveMessageHead
     if msg.bytes == 0 {
         // The other side of the connection has been closed, so we should
         // quit.
-        log::info!("Received empty message; assuming the connection has been closed.");
         return Ok(ReceiveMessageHeaderResult::SocketClosed);
     }
 

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -184,18 +184,16 @@ impl TerminalManager {
     /// Sends a shutdown message to the PTY event loop and waits for it to
     /// process that event.
     fn shutdown_event_loop(&mut self) {
+        let Some(join_handle) = self.event_loop_handle.take() else {
+            return;
+        };
         let shutdown_res = self.event_loop_tx.lock().send(Message::Shutdown);
         // Happens normally if the event loop has already been terminated (so the channel is now gone).
         if let Err(e) = shutdown_res {
             log::info!("Failed to send Shutdown {e:?}");
         }
-
-        if let Some(join_handle) = self.event_loop_handle.take() {
-            if let Err(e) = join_handle.join() {
-                log::error!("Failed to join event loop handle {e:?}");
-            }
-        } else {
-            log::error!("No event loop handle to join when dropping terminal manager.")
+        if let Err(e) = join_handle.join() {
+            log::error!("Failed to join event loop handle {e:?}");
         }
 
         self.inactive_pty_reads_rx.close();
@@ -2645,11 +2643,10 @@ fn get_shell_starter_internal(
     }
 }
 
-/// Send a Shutdown event to each PTY's event loop and waits for the
-/// event loop to terminate.
-/// This is needed on Windows to ensure all OpenConsole processes are
-/// cleaned up before the main thread exits.
-#[cfg(windows)]
+/// Sends a Shutdown event to each PTY's event loop and waits for each event
+/// loop to terminate.
+/// This is needed to ensure all PTY processes are cleaned up before the
+/// terminal server or main thread exits.
 pub fn shutdown_all_pty_event_loops(ctx: &mut AppContext) {
     let terminal_managers: Vec<ModelHandle<Box<dyn crate::terminal::TerminalManager>>> =
         ctx.models_of_type();


### PR DESCRIPTION
## Description
Fix terminal-server teardown so Warp does not leave server-owned PTY shell process groups running after application shutdown.

This adds an explicit terminal-server shutdown request/response, terminates PTY process groups with `SIGHUP` followed by a bounded `SIGKILL` fallback, and reuses the same group-aware cleanup when terminating individual children. It also stops pane PTY event loops before tearing down the terminal server so normal shutdown does not produce redundant socket writes or misleading EOF logs.

> [!NOTE]
> note from dstern: i was seeing (terminal session) shell processes leaking, and impacting performance of my system.  i asked agent mode to do a little investigation, it pointed out that we don't have a terribly robust teardown strategy for the terminal server.  while i'm not entirely sure whether this will fix the cause, improving this can't hurt.

## Linked Issue
N/A

## Testing
- [x] Ran `cargo fmt --manifest-path /Users/david/src/warp/Cargo.toml --package warp`
- [x] Ran `cargo nextest run --manifest-path /Users/david/src/warp/Cargo.toml -p warp -E 'test(terminate_child_signals_the_entire_pty_process_group) | test(terminate_child_escalates_when_a_descendant_ignores_sighup_after_the_shell_exits) | test(terminate_all_escalates_when_a_pty_process_group_ignores_sighup)'`
- [x] Ran `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp --lib`
- [x] Ran `git diff --check`
- [x] Manually tested application startup and shutdown twice with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/08d6a0a1-30ed-43e3-8815-9ebbcc2dbd07
- Plan: https://staging.warp.dev/drive/notebook/Z5D0BZbzLmCW5CHlgp87XQ

CHANGELOG-BUG-FIX: Prevent terminal shell processes from being left running after Warp shuts down.

Co-Authored-By: Oz <oz-agent@warp.dev>
