### PR TITLE
Do not eagerly expand subtrees on lazy loaded repo update

### DIFF
--- a/crates/repo_metadata/src/file_tree_update_tests.rs
+++ b/crates/repo_metadata/src/file_tree_update_tests.rs
@@ -218,7 +218,7 @@ fn apply_mutations_generates_update_for_add_empty_directory() {
 
     let initial = dir("/repo", vec![dir("/repo/src", vec![])]);
     let mut tree = build_tree_from_entry(initial);
-    let mutations = vec![FileTreeMutation::AddEmptyDirectory {
+    let mutations = vec![FileTreeMutation::AddUnloadedDirectory {
         path: mutation_path("/repo/src/empty"),
         is_ignored: true,
     }];
@@ -250,7 +250,7 @@ fn apply_mutations_generates_update_for_mixed_mutations() {
             is_ignored: false,
             extension: Some("rs".to_string()),
         },
-        FileTreeMutation::AddEmptyDirectory {
+        FileTreeMutation::AddUnloadedDirectory {
             path: mutation_path("/repo/new_dir"),
             is_ignored: false,
         },

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -276,7 +276,9 @@ pub(crate) enum FileTreeMutation {
     },
     /// Add a directory with its fully-built subtree.
     AddDirectorySubtree { dir_path: PathBuf, subtree: Entry },
-    /// Fallback: add a bare (unloaded) directory entry when `build_tree` fails.
+    /// Add a bare (unloaded) directory placeholder, materialized on demand when
+    /// the user expands it. Used for newly created directories under lazy roots
+    /// and as a fallback when `build_tree` fails.
     AddEmptyDirectory { path: PathBuf, is_ignored: bool },
 }
 
@@ -595,6 +597,7 @@ impl LocalRepoMetadataModel {
                                 &gitignores_clone,
                                 &force_included_paths,
                                 &standing_query_definitions,
+                                lazy_load,
                             )
                             .await;
                         (
@@ -608,38 +611,6 @@ impl LocalRepoMetadataModel {
                     |model,
                      (mutations, discovered_results, removed_roots, repo_path, lazy_load),
                      ctx| {
-                        // Only a non-recursive root (lazy non-git roots on
-                        // Linux) needs to watch newly added directories: nothing
-                        // under such a root is covered by a recursive watch, so
-                        // each new dir needs its own watch. Collect them before
-                        // the mutations are consumed.
-                        //
-                        // Recursive roots don't need this: non-ignored new dirs
-                        // are auto-followed by the recursive backend, and
-                        // gitignored new dirs are added as lazy placeholders that
-                        // get watched only when the user expands them (see
-                        // `load_directory`).
-                        let new_dirs: Vec<StandardizedPath> = if matches!(
-                            model.repo_watches.get(&repo_path).map(|w| w.root_mode),
-                            Some(RootWatchMode::NonRecursive)
-                        ) {
-                            mutations
-                                .iter()
-                                .filter_map(|mutation| {
-                                    let path = match mutation {
-                                        FileTreeMutation::AddDirectorySubtree {
-                                            dir_path, ..
-                                        } => dir_path,
-                                        FileTreeMutation::AddEmptyDirectory { path, .. } => path,
-                                        _ => return None,
-                                    };
-                                    StandardizedPath::try_from_local(path).ok()
-                                })
-                                .collect()
-                        } else {
-                            Vec::new()
-                        };
-
                         if let Some(IndexedRepoState::Indexed(state)) =
                             model.repositories.get_mut(&repo_path)
                         {
@@ -681,13 +652,6 @@ impl LocalRepoMetadataModel {
                         // directory is later recreated at the same path.
                         for removed in &removed_roots {
                             model.unwatch_removed_subtree(&repo_path, removed, ctx);
-                        }
-
-                        // Watch any newly added directories under a non-recursive
-                        // root. `new_dirs` is empty for recursive roots, so this
-                        // is a no-op there.
-                        for dir in new_dirs {
-                            model.watch_subdir(&repo_path, &dir, ctx);
                         }
                     },
                 );
@@ -1167,11 +1131,17 @@ impl LocalRepoMetadataModel {
     /// Performs all filesystem I/O (`exists()`, `is_dir()`, `build_tree()`,
     /// gitignore checks) and returns a lightweight list of mutations that can
     /// be applied to the tree on the main thread without cloning it.
+    ///
+    /// When `lazy_load` is true (lazy non-git roots), newly added directories
+    /// are emitted as unloaded placeholders rather than fully-materialized
+    /// subtrees, matching the lazy tree model; the directory is materialized
+    /// (and watched) on demand when the user expands it via `load_directory`.
     async fn compute_file_tree_mutations(
         update: &RepoUpdate,
         gitignores: &[Gitignore],
         force_included_paths: &[PathBuf],
         standing_query_definitions: &StandingQueryDefinitions,
+        lazy_load: bool,
     ) -> (
         Vec<FileTreeMutation>,
         StandingQueryResults,
@@ -1204,6 +1174,18 @@ impl LocalRepoMetadataModel {
             let is_ignored = Self::path_is_ignored(path_to_add, gitignores);
 
             if path_to_add.is_dir() {
+                if lazy_load {
+                    // Lazy (non-git) roots are not materialized when a directory
+                    // is created; insert it as an unloaded placeholder and build
+                    // the subtree on demand when the user expands it (see
+                    // `load_directory`).
+                    mutations.push(FileTreeMutation::AddEmptyDirectory {
+                        path: path_to_add.clone(),
+                        is_ignored,
+                    });
+                    continue;
+                }
+
                 let mut files = Vec::new();
                 let mut gitignores = gitignores.to_owned();
                 let mut file_limit = MAX_FILES_PER_REPO;

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -279,7 +279,7 @@ pub(crate) enum FileTreeMutation {
     /// Add a bare (unloaded) directory placeholder, materialized on demand when
     /// the user expands it. Used for newly created directories under lazy roots
     /// and as a fallback when `build_tree` fails.
-    AddEmptyDirectory { path: PathBuf, is_ignored: bool },
+    AddUnloadedDirectory { path: PathBuf, is_ignored: bool },
 }
 
 /// A filter function for filtering repo contents during traversal.
@@ -1179,7 +1179,7 @@ impl LocalRepoMetadataModel {
                     // is created; insert it as an unloaded placeholder and build
                     // the subtree on demand when the user expands it (see
                     // `load_directory`).
-                    mutations.push(FileTreeMutation::AddEmptyDirectory {
+                    mutations.push(FileTreeMutation::AddUnloadedDirectory {
                         path: path_to_add.clone(),
                         is_ignored,
                     });
@@ -1225,7 +1225,7 @@ impl LocalRepoMetadataModel {
                     }
                     Err(e) => {
                         log::warn!("Failed to build subtree for directory {path_to_add:?}: {e:?}");
-                        mutations.push(FileTreeMutation::AddEmptyDirectory {
+                        mutations.push(FileTreeMutation::AddUnloadedDirectory {
                             path: path_to_add.clone(),
                             is_ignored,
                         });
@@ -1355,7 +1355,7 @@ impl LocalRepoMetadataModel {
                         }
                     }
                 }
-                FileTreeMutation::AddEmptyDirectory {
+                FileTreeMutation::AddUnloadedDirectory {
                     ref path,
                     is_ignored,
                 } => {

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -931,6 +931,7 @@ fn test_update_file_tree_entry_respects_gitignore() {
             &gitignores,
             &[],
             &standing_query_definitions,
+            false,
         ));
         LocalRepoMetadataModel::apply_file_tree_mutations(&mut root, mutations, false, false);
 
@@ -1404,9 +1405,14 @@ fn added_symlinked_skill_directory_refreshes_provider_without_canonical_tree_mut
             added: vec![linked_skill.clone()],
             ..Default::default()
         };
-        let (mutations, discovered, removed_roots) = block_on(
-            LocalRepoMetadataModel::compute_file_tree_mutations(&update, &[], &[], &definitions),
-        );
+        let (mutations, discovered, removed_roots) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &[],
+                &[],
+                &definitions,
+                false,
+            ));
 
         assert!(mutations.is_empty());
         assert!(removed_roots.is_empty());
@@ -1447,6 +1453,7 @@ fn unrelated_skill_support_file_does_not_refresh_project_skills() {
             &[],
             &[],
             &definitions,
+            false,
         ));
 
         assert!(discovered.project_skills().next().is_none());
@@ -1470,6 +1477,7 @@ fn removed_direct_skill_child_refreshes_provider_for_possible_symlink_removal() 
             &[],
             &[],
             &definitions,
+            false,
         ));
 
         assert!(discovered.project_skills().any(|content| {
@@ -2475,5 +2483,91 @@ fn deleted_subdir_drops_its_tracked_watch() {
                 assert!(!repo_watch.extra_dirs.contains(&inner));
             });
         });
+    });
+}
+
+/// On a lazy root, a newly created directory is inserted as an unloaded
+/// placeholder rather than having its whole subtree materialized eagerly; the
+/// contents are loaded on demand when the user expands it. On an eager root the
+/// same directory is fully materialized.
+#[test]
+fn lazy_root_created_directory_inserted_as_placeholder() {
+    VirtualFS::test("lazy_created_dir_placeholder", |dirs, mut vfs| {
+        let repo_path = dirs.tests();
+        vfs.mkdir("newdir/sub")
+            .with_files(vec![Stub::FileWithContent("newdir/sub/file.txt", "x")]);
+
+        let new_dir = repo_path.join("newdir");
+        let nested = repo_path.join("newdir/sub");
+        let new_dir_std = StandardizedPath::try_from_local(&new_dir).unwrap();
+        let nested_std = StandardizedPath::try_from_local(&nested).unwrap();
+
+        let make_root = || {
+            FileTreeEntry::from(Entry::Directory(DirectoryEntry {
+                path: StandardizedPath::try_from_local(repo_path).unwrap(),
+                children: Vec::new(),
+                ignored: false,
+                loaded: true,
+            }))
+        };
+        let update = RepoUpdate {
+            added: vec![new_dir.clone()],
+            ..Default::default()
+        };
+        let definitions = StandingQueryDefinitions::default();
+
+        // Lazy root: the new directory is an unloaded placeholder and its
+        // subtree is not materialized.
+        let mut lazy_root = make_root();
+        let (lazy_mutations, _, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+            &update,
+            &[],
+            &[],
+            &definitions,
+            true,
+        ));
+        LocalRepoMetadataModel::apply_file_tree_mutations(
+            &mut lazy_root,
+            lazy_mutations,
+            true,
+            false,
+        );
+
+        let placeholder = lazy_root
+            .get(&new_dir_std)
+            .expect("new directory should be present");
+        assert!(
+            !placeholder.loaded(),
+            "lazy root should add the directory as an unloaded placeholder"
+        );
+        assert!(
+            lazy_root.get(&nested_std).is_none(),
+            "lazy root should not materialize the subtree"
+        );
+
+        // Eager root: the same directory is fully materialized.
+        let mut eager_root = make_root();
+        let (eager_mutations, _, _) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &[],
+                &[],
+                &definitions,
+                false,
+            ));
+        LocalRepoMetadataModel::apply_file_tree_mutations(
+            &mut eager_root,
+            eager_mutations,
+            false,
+            false,
+        );
+        assert!(
+            eager_root.get(&new_dir_std).is_some_and(|e| e.loaded()),
+            "eager root should materialize the directory"
+        );
+        assert!(
+            eager_root.get(&nested_std).is_some(),
+            "eager root should materialize the subtree"
+        );
     });
 }


### PR DESCRIPTION
## Description
For lazy-loaded (non-git) roots, the file watcher previously **eagerly materialized the full subtree** of any newly-created directory, even though lazy roots only materialize what the user has actually expanded. This PR inserts a newly-created directory as an **unloaded placeholder** instead; its subtree is built on demand when the user expands it via `load_directory`.

Concretely, in `compute_file_tree_mutations`, when `lazy_load` is set, a created directory now emits an `AddEmptyDirectory` placeholder mutation and skips the eager `build_tree` traversal entirely. Eager (git/recursive) roots are unchanged and still build the full subtree.

This also removes the now-unnecessary watch-on-create (`new_dirs`) logic: because lazy roots no longer eagerly load descendants, there are no loaded-but-unwatched directories. On Linux (non-recursive watching) this closes a gap where a bulk-created nested directory tree could leave descendant directories loaded but unwatched — they are now placeholders, watched only when expanded (which already registers a watch via `watch_subdir`).

Net effect in `local_model.rs` is a reduction in code.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
This is internal repo-metadata logic with no UI surface, covered by unit tests:
- Added `lazy_root_created_directory_inserted_as_placeholder`: asserts a lazy root inserts the created directory as an unloaded placeholder with its subtree **not** materialized, while an eager root fully materializes it.
- Existing `compute_file_tree_mutations` call sites updated for the new `lazy_load` argument.
- `cargo nextest run -p repo_metadata --features local_fs` passes (100 tests), with `cargo clippy` and `./script/format` clean.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — no user-visible/UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Warp conversation: https://staging.warp.dev/conversation/652230d5-e5fb-41bf-af9d-b478310176cf

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.
-->
CHANGELOG-NONE
