### PR TITLE
Avoid cloning whole file tree on view update & flatten entries

### DIFF
--- a/crates/repo_metadata/src/file_tree_store.rs
+++ b/crates/repo_metadata/src/file_tree_store.rs
@@ -11,7 +11,11 @@ use crate::{BuildTreeError, Entry, FileId, FileMetadata, Repository};
 
 #[derive(Debug, Clone)]
 pub struct FileTreeEntry {
-    state_map: FileTreeMapStore,
+    // Wrapped in an `Arc` so cloning a `FileTreeEntry` is O(1) (a refcount
+    // bump) instead of deep-copying the whole tree. Mutations go through
+    // `Arc::make_mut`, which copies-on-write only when the store is actually
+    // shared with another holder (e.g. the model and a view).
+    state_map: Arc<FileTreeMapStore>,
     root_path: Arc<StandardizedPath>,
 }
 
@@ -40,7 +44,7 @@ impl FileTreeEntry {
     }
 
     pub fn rename_path(&mut self, path: &StandardizedPath, new_path: &StandardizedPath) -> bool {
-        self.state_map.rename_path(path, new_path)
+        Arc::make_mut(&mut self.state_map).rename_path(path, new_path)
     }
 
     pub fn load_at_path(
@@ -48,11 +52,11 @@ impl FileTreeEntry {
         path: &StandardizedPath,
         gitignores: &mut Vec<Gitignore>,
     ) -> Result<(), BuildTreeError> {
-        self.state_map.load_at_path(path, gitignores)
+        Arc::make_mut(&mut self.state_map).load_at_path(path, gitignores)
     }
 
     pub fn insert_entry_at_path(&mut self, path: Arc<StandardizedPath>, entry: Entry) {
-        self.state_map.insert_entry_at_path(path, entry);
+        Arc::make_mut(&mut self.state_map).insert_entry_at_path(path, entry);
     }
 
     pub fn child_paths(
@@ -63,16 +67,16 @@ impl FileTreeEntry {
     }
 
     pub fn get_mut(&mut self, path: &StandardizedPath) -> Option<&mut FileTreeEntryState> {
-        self.state_map.get_mut(path)
+        Arc::make_mut(&mut self.state_map).get_mut(path)
     }
 
     pub fn remove(&mut self, path: &StandardizedPath) {
-        self.state_map.remove(path);
+        Arc::make_mut(&mut self.state_map).remove(path);
     }
 
     pub fn new_for_directory(root_path: Arc<StandardizedPath>) -> Self {
         Self {
-            state_map: FileTreeMapStore::new_for_directory(root_path.clone()),
+            state_map: Arc::new(FileTreeMapStore::new_for_directory(root_path.clone())),
             root_path,
         }
     }
@@ -84,8 +88,10 @@ impl FileTreeEntry {
         parent_path: &StandardizedPath,
         target_path: &StandardizedPath,
     ) -> Option<&mut FileTreeEntryState> {
+        // `contains_child` is a read, so check it before `make_mut` to avoid
+        // a copy-on-write when the child already exists.
         if self.state_map.contains_child(parent_path, target_path) {
-            return self.state_map.get_mut(target_path);
+            return Arc::make_mut(&mut self.state_map).get_mut(target_path);
         }
 
         // Child not found, create new directory entry
@@ -95,9 +101,9 @@ impl FileTreeEntry {
             loaded: false,
         });
 
-        self.state_map
-            .insert_child(Arc::new(parent_path.clone()), new_entry);
-        self.state_map.get_mut(target_path)
+        let store = Arc::make_mut(&mut self.state_map);
+        store.insert_child(Arc::new(parent_path.clone()), new_entry);
+        store.get_mut(target_path)
     }
 
     pub fn find_parent_directory(&self, path: &StandardizedPath) -> Option<Arc<StandardizedPath>> {
@@ -132,8 +138,7 @@ impl FileTreeEntry {
             return None;
         };
 
-        self.state_map
-            .insert_child(Arc::new(parent_path.clone()), new_entry)
+        Arc::make_mut(&mut self.state_map).insert_child(Arc::new(parent_path.clone()), new_entry)
     }
 
     pub fn insert_child_state(
@@ -141,8 +146,7 @@ impl FileTreeEntry {
         parent_path: &StandardizedPath,
         child_state: FileTreeEntryState,
     ) -> Option<Arc<StandardizedPath>> {
-        self.state_map
-            .insert_child(Arc::new(parent_path.clone()), child_state)
+        Arc::make_mut(&mut self.state_map).insert_child(Arc::new(parent_path.clone()), child_state)
     }
 
     /// Ensures all ancestor directories between root and `target_parent`
@@ -341,7 +345,7 @@ pub struct FileTreeDirectoryEntryState {
 impl From<Entry> for FileTreeEntry {
     fn from(value: Entry) -> Self {
         let root_path = Arc::new(value.path().clone());
-        let state_map = FileTreeMapStore::from(value);
+        let state_map = Arc::new(FileTreeMapStore::from(value));
 
         FileTreeEntry {
             state_map,

--- a/crates/repo_metadata/src/file_tree_store/file_tree_state.rs
+++ b/crates/repo_metadata/src/file_tree_store/file_tree_state.rs
@@ -203,9 +203,14 @@ impl FileTreeMapStore {
 
     pub fn insert_entry_at_path(&mut self, path: Arc<StandardizedPath>, entry: Entry) {
         let child_entry_map = FileTreeEntry::from(entry);
-        self.state_map.extend(child_entry_map.state_map.state_map);
+        // The child was just constructed, so its `Arc` is unique and
+        // `try_unwrap` avoids a clone; fall back to cloning only if it is
+        // somehow shared.
+        let child_store =
+            Arc::try_unwrap(child_entry_map.state_map).unwrap_or_else(|arc| (*arc).clone());
+        self.state_map.extend(child_store.state_map);
         self.parent_to_child_map
-            .extend(child_entry_map.state_map.parent_to_child_map);
+            .extend(child_store.parent_to_child_map);
 
         // ATODO test this
         if let Some(parent) = self.parent_directory(&path) {


### PR DESCRIPTION
## Description

Switching tabs could beachball the app for users with large file trees. A `sample` of a hung client showed the main thread spending ~100% of its time under `FileTreeView::set_root_directories` → `update_directory_contents` → `rebuild_flatten_items_impl`, dominated by deep-cloning and dropping the entire file-tree map (`FileTreeEntry`, which wraps two large `HashMap`s). On a ~13 GB-footprint client these O(total-entries) clones cost seconds.

`FileTreeEntry` is cloned in two hot spots per displayed root on a tab switch:
1. The model→view sync (`root_dir.entry = state.entry.clone()`), which happens at ~8 sites in the view.
2. The flatten pass (`let entry_state = root_dir.entry.clone()`), cloned only to dodge a borrow conflict.

This PR wraps the inner store (`FileTreeMapStore`) in an `Arc` inside `FileTreeEntry` and mutates it via `Arc::make_mut` (copy-on-write). Cloning a `FileTreeEntry` is now an O(1) refcount bump; the full copy only happens when a holder actually mutates a shared store, and at most once per mutation batch. This makes both clone sites cheap and reduces tab-switch work to the O(visible-items) flatten.

### Why `Arc` instead of removing `Clone` from `FileTreeEntry`

The biggest reason is that **the file-tree view holds its own snapshot of the model's tree**: each `RootDirectory.entry` is an owned `FileTreeEntry` that the view copies from the model on every sync (`root_dir.entry = state.entry.clone()`). That snapshot is load-bearing — it lets the view read a stable tree during flatten, decide when to adopt new model state, and deliberately keep the old entry during a Pending re-index so the tree doesn't flash to a loading state.

The model itself never deep-clones the entry (it mutates in place), so `Clone` exists almost entirely to serve the view's snapshot. Removing `Clone` would force the view to stop owning a snapshot and instead rebuild the local sync around incremental updates (the remote model's `apply_repo_metadata_update` pattern) — a much larger rearchitecture: the local model would have to emit snapshots/deltas, the several `FullReplace` sync points would need converting, and the Pending/no-flicker handling preserved.

Wrapping the inner store in `Arc` keeps the existing snapshot semantics exactly (every holder still behaves as if it owns an independent copy) while making the copy O(1) until someone writes — a contained change that fixes the hot path without renegotiating the model/view contract. (It also keeps `Clone`, which `Arc::make_mut` requires, so the model can keep mutating its own entry in place via copy-on-write.)

### Why `Arc::make_mut` (copy-on-write) instead of interior mutability

The requirement here is **cheap snapshots with isolation**, not coordinated shared mutation — so interior mutability (`Arc<RwLock<…>>`, `RefCell`) would solve a problem we don't have while adding cost:

- **Snapshot semantics.** With a shared cell, the model and view would point at the same mutable store, so a model mutation would be observed by the view mid-read (out from under `flatten_entry_for_root`) and would break the intentional "keep old entry during Pending re-index" flicker handling. COW preserves value semantics: each holder behaves as if it owns an independent copy.
- **Reads are the hot path, and they're aliasing-shaped, not lock-shaped.** Flattening walks many nodes calling `get`/`child_paths` while mutating `item_states` (a different field). COW reads are plain `&` derefs with zero synchronization; a lock would add atomic traffic per node, and holding a read guard across the recursion risks re-entrancy/deadlock (`RefCell` would outright panic).
- **The mutation pattern is "owner mutates, readers snapshot,"** not concurrent shared writes — textbook COW. `make_mut` keeps the common in-place mutation O(1) when the entry is unshared and only forks when it's actually shared.
- **Thread-safety fit.** `make_mut` needs only `Clone`; `RefCell` is single-threaded and `RwLock`/`Mutex` buy coordination we don't need.

### Tradeoff

COW relocates rather than eliminates the steady-state clone: the view already re-clones its entry on every `FileTreeEntryUpdated` event, so after this change that clone is O(1) but the model's next mutation pays the copy via `make_mut`. Net per fs-update batch is unchanged for a single view and better when a repo is shown in multiple panes (1 copy instead of N), while the tab-switch path goes from two full clones to ~0. Peak memory is unchanged (a copy still transiently holds 2x the store).

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo test -p repo_metadata` — 91 passed, 0 failed (COW semantics preserved across insert/remove/rename/apply-update).
- `cargo check -p warp --features local_fs` — compiles cleanly.
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: {{text goes here...}}
-->
CHANGELOG-BUG-FIX: Fixed the app hanging when switching tabs in very large repositories.
