### PR TITLE
Fix limiting get_repo_contents result failing file search

### DIFF
--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -149,19 +149,13 @@ impl FileSearchModel {
             Some(LocalOrRemotePath::Remote(ref remote_path)) => {
                 let id = RepositoryIdentifier::Remote(remote_path.clone());
                 let repo_metadata = RepoMetadataModel::as_ref(app);
+                // Truncated results (capped at the repo metadata budget) are
+                // intentionally used as-is to return partial matches rather
+                // than nothing.
                 let contents =
                     match repo_metadata.get_repo_contents(&id, GetContentsArgs::default(), app) {
-                        Ok(contents) => contents,
-                        Err(
-                            repo_metadata::RepoMetadataError::RepositoryNotIndexed
-                            | repo_metadata::RepoMetadataError::RepositoryIndexingPending
-                            | repo_metadata::RepoMetadataError::RepositoryIndexingFailed,
-                        ) => {
-                            return Vec::new();
-                        }
-                        Err(_) => {
-                            return Vec::new();
-                        }
+                        Ok(repo_contents) => repo_contents.contents,
+                        Err(_) => return Vec::new(),
                     };
                 let root_std_path = &remote_path.path;
                 contents
@@ -263,19 +257,13 @@ impl FileSearchModel {
                 let Some(id) = RepositoryIdentifier::try_local(local_path) else {
                     return Vec::new();
                 };
+                // Truncated results (capped at the repo metadata budget) are
+                // intentionally used as-is to return partial matches rather
+                // than nothing.
                 let contents =
                     match repo_metadata.get_repo_contents(&id, GetContentsArgs::default(), app) {
-                        Ok(contents) => contents,
-                        Err(
-                            repo_metadata::RepoMetadataError::RepositoryNotIndexed
-                            | repo_metadata::RepoMetadataError::RepositoryIndexingPending
-                            | repo_metadata::RepoMetadataError::RepositoryIndexingFailed,
-                        ) => {
-                            return Vec::new();
-                        }
-                        Err(_) => {
-                            return Vec::new();
-                        }
+                        Ok(repo_contents) => repo_contents.contents,
+                        Err(_) => return Vec::new(),
                     };
                 contents
                     .iter()
@@ -313,19 +301,13 @@ impl FileSearchModel {
             }
             LocalOrRemotePath::Remote(remote_path) => {
                 let id = RepositoryIdentifier::Remote(remote_path.clone());
+                // Truncated results (capped at the repo metadata budget) are
+                // intentionally used as-is to return partial matches rather
+                // than nothing.
                 let contents =
                     match repo_metadata.get_repo_contents(&id, GetContentsArgs::default(), app) {
-                        Ok(contents) => contents,
-                        Err(
-                            repo_metadata::RepoMetadataError::RepositoryNotIndexed
-                            | repo_metadata::RepoMetadataError::RepositoryIndexingPending
-                            | repo_metadata::RepoMetadataError::RepositoryIndexingFailed,
-                        ) => {
-                            return Vec::new();
-                        }
-                        Err(_) => {
-                            return Vec::new();
-                        }
+                        Ok(repo_contents) => repo_contents.contents,
+                        Err(_) => return Vec::new(),
                     };
                 let root_std_path = &remote_path.path;
                 contents

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -25,8 +25,6 @@ pub enum RepoMetadataError {
     BuildTree(BuildTreeError),
     #[error("Failed to start watcher: {0}")]
     WatcherError(#[from] anyhow::Error),
-    #[error("Result size exceeded maximum limit of {0}")]
-    ExceededMaxResultSize(usize),
     #[error("Repository not indexed")]
     RepositoryNotIndexed,
     #[error("Repository indexing in progress")]
@@ -74,7 +72,7 @@ pub fn is_in_repo(_path: &str, _app: &warpui_core::AppContext) -> bool {
 }
 pub use file_tree_store::FileTreeEntry;
 pub use file_tree_update::{MetadataUpdateType, RepoMetadataUpdate};
-pub use local_model::{LocalRepoMetadataModel, RepoContent};
+pub use local_model::{LocalRepoMetadataModel, RepoContent, RepoContents};
 pub use remote_model::RemoteRepoMetadataModel;
 pub use repository_identifier::{RemoteRepositoryIdentifier, RepositoryIdentifier};
 pub use standing_queries::{

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -22,6 +22,20 @@ pub enum RepoContent<'a> {
     Directory(&'a FileTreeDirectoryEntryState),
 }
 
+/// The result of [`LocalRepoMetadataModel::get_repo_contents`].
+///
+/// The number of returned entries is capped at [`MAX_REPO_CONTENTS_RESULTS`].
+/// When the repository contains more matching entries than that cap, the
+/// returned `contents` are a partial prefix and `truncated` is `true`.
+#[derive(Debug, Default)]
+pub struct RepoContents<'a> {
+    /// The collected repository contents, capped at [`MAX_REPO_CONTENTS_RESULTS`].
+    pub contents: Vec<RepoContent<'a>>,
+    /// `true` if traversal stopped early because the maximum result size was
+    /// reached, meaning more matching entries exist than were returned.
+    pub truncated: bool,
+}
+
 use warp_util::standardized_path::StandardizedPath;
 
 use crate::entry::{
@@ -1333,13 +1347,16 @@ impl LocalRepoMetadataModel {
 
     /// Returns repository contents (files and optionally directories) in a given repository.
     ///
-    /// Returns an error if the number of results exceeds MAX_REPO_CONTENTS_RESULTS.
+    /// At most [`MAX_REPO_CONTENTS_RESULTS`] entries are returned. When the
+    /// repository contains more matching entries, the result is truncated to
+    /// that cap and [`RepoContents::truncated`] is set to `true`.
+    ///
     /// Returns an error if the repository is not indexed, indexing is pending, or indexing failed.
     pub fn get_repo_contents(
         &self,
         repo_path: &StandardizedPath,
         args: GetContentsArgs,
-    ) -> Result<Vec<RepoContent<'_>>, RepoMetadataError> {
+    ) -> Result<RepoContents<'_>, RepoMetadataError> {
         let state = match self.repositories.get(repo_path) {
             Some(IndexedRepoState::Indexed(state)) => state,
             Some(IndexedRepoState::Pending(_)) => {
@@ -1353,13 +1370,16 @@ impl LocalRepoMetadataModel {
             }
         };
         let mut contents = Vec::new();
-        collect_contents_recursive(
+        let truncated = collect_contents_recursive(
             &state.entry,
             state.entry.root_directory(),
             &mut contents,
             &args,
-        )?;
-        Ok(contents)
+        );
+        Ok(RepoContents {
+            contents,
+            truncated,
+        })
     }
 
     /// Change the indexing state of `repo_path` to `state`.
@@ -1421,26 +1441,28 @@ impl warpui_core::Entity for LocalRepoMetadataModel {
 }
 
 /// Helper function to recursively collect contents (files and optionally directories) from an Entry tree.
-/// Returns an error if the number of results exceeds MAX_REPO_CONTENTS_RESULTS.
+///
+/// Collects at most [`MAX_REPO_CONTENTS_RESULTS`] entries into `contents`.
+/// Returns `true` if traversal stopped early because that cap was reached,
+/// indicating the collected `contents` are truncated and more matching entries
+/// exist.
 pub(crate) fn collect_contents_recursive<'a>(
     entry: &'a FileTreeEntry,
     current_path: &'a StandardizedPath,
     contents: &mut Vec<RepoContent<'a>>,
     args: &GetContentsArgs,
-) -> Result<(), RepoMetadataError> {
+) -> bool {
     if !args.include_ignored && entry.ignored(current_path) {
-        return Ok(());
+        return false;
     }
 
     match entry.get(current_path) {
         Some(FileTreeEntryState::File(metadata)) => {
             let content = RepoContent::File(metadata);
             if args.filter.as_ref().is_none_or(|f| f(&content)) {
-                // Check limit before adding
+                // Stop before exceeding the cap, reporting that results are truncated.
                 if contents.len() >= MAX_REPO_CONTENTS_RESULTS {
-                    return Err(RepoMetadataError::ExceededMaxResultSize(
-                        MAX_REPO_CONTENTS_RESULTS,
-                    ));
+                    return true;
                 }
                 contents.push(content);
             }
@@ -1449,23 +1471,23 @@ pub(crate) fn collect_contents_recursive<'a>(
             if args.include_folders {
                 let content = RepoContent::Directory(dir);
                 if args.filter.as_ref().is_none_or(|f| f(&content)) {
-                    // Check limit before adding
+                    // Stop before exceeding the cap, reporting that results are truncated.
                     if contents.len() >= MAX_REPO_CONTENTS_RESULTS {
-                        return Err(RepoMetadataError::ExceededMaxResultSize(
-                            MAX_REPO_CONTENTS_RESULTS,
-                        ));
+                        return true;
                     }
                     contents.push(content);
                 }
             }
 
             for child in entry.child_paths(current_path) {
-                collect_contents_recursive(entry, child, contents, args)?;
+                if collect_contents_recursive(entry, child, contents, args) {
+                    return true;
+                }
             }
         }
         None => {}
     }
-    Ok(())
+    false
 }
 
 // Test helpers

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -312,17 +312,14 @@ fn test_get_repo_contents() {
 
 #[test]
 fn test_get_repo_contents_truncates_to_max_results() {
-    let repo_path = StandardizedPath::try_new("/trunc_repo").unwrap();
+    // Use an absolute base path so file metadata is valid on all platforms.
+    let base = std::env::temp_dir().join("trunc_repo");
+    let repo_path = StandardizedPath::try_from_local(&base).unwrap();
 
     // Build a flat repo with more files than the result cap so traversal stops early.
     let file_count = crate::local_model::MAX_REPO_CONTENTS_RESULTS + 50;
     let children: Vec<Entry> = (0..file_count)
-        .map(|i| {
-            Entry::File(FileMetadata::new(
-                PathBuf::from(format!("/trunc_repo/file{i}.txt")),
-                false,
-            ))
-        })
+        .map(|i| Entry::File(FileMetadata::new(base.join(format!("file{i}.txt")), false)))
         .collect();
     let root = Entry::Directory(DirectoryEntry {
         path: repo_path.clone(),

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -282,7 +282,7 @@ fn test_get_repo_contents() {
                     include_ignored: false,
                     filter: None,
                 };
-                let files = model
+                let result = model
                     .get_repo_contents(
                         &StandardizedPath::from_local_canonicalized(&test_repo).unwrap(),
                         args,
@@ -290,7 +290,8 @@ fn test_get_repo_contents() {
                     .unwrap();
 
                 // Should have 4 files total (file1.txt, file2.rs, file3.py, file4.md)
-                assert_eq!(files.len(), 4);
+                assert_eq!(result.contents.len(), 4);
+                assert!(!result.truncated);
 
                 // Test with non-existent repository
                 let non_existent = StandardizedPath::try_new("/non_existent_repo").unwrap();
@@ -307,6 +308,52 @@ fn test_get_repo_contents() {
             });
         });
     });
+}
+
+#[test]
+fn test_get_repo_contents_truncates_to_max_results() {
+    let repo_path = StandardizedPath::try_new("/trunc_repo").unwrap();
+
+    // Build a flat repo with more files than the result cap so traversal stops early.
+    let file_count = crate::local_model::MAX_REPO_CONTENTS_RESULTS + 50;
+    let children: Vec<Entry> = (0..file_count)
+        .map(|i| {
+            Entry::File(FileMetadata::new(
+                PathBuf::from(format!("/trunc_repo/file{i}.txt")),
+                false,
+            ))
+        })
+        .collect();
+    let root = Entry::Directory(DirectoryEntry {
+        path: repo_path.clone(),
+        children,
+        ignored: false,
+        loaded: true,
+    });
+    let state = FileTreeState::new(root, Vec::new(), None);
+
+    let mut model = LocalRepoMetadataModel::new_for_test();
+    model
+        .repositories
+        .insert(repo_path.clone(), IndexedRepoState::Indexed(state));
+
+    let result = model
+        .get_repo_contents(
+            &repo_path,
+            GetContentsArgs {
+                include_folders: false,
+                include_ignored: false,
+                filter: None,
+            },
+        )
+        .unwrap();
+
+    // The result is capped and flagged as truncated rather than erroring.
+    assert_eq!(
+        result.contents.len(),
+        crate::local_model::MAX_REPO_CONTENTS_RESULTS
+    );
+    assert!(result.truncated);
 }
 
 #[cfg(feature = "local_fs")]
@@ -606,7 +653,8 @@ fn test_get_repo_contents_include_ignored() {
                         &StandardizedPath::from_local_canonicalized(&test_repo).unwrap(),
                         args,
                     )
-                    .unwrap();
+                    .unwrap()
+                    .contents;
 
                 let paths: Vec<PathBuf> = contents
                     .iter()
@@ -639,7 +687,8 @@ fn test_get_repo_contents_include_ignored() {
                         &StandardizedPath::from_local_canonicalized(&test_repo).unwrap(),
                         args,
                     )
-                    .unwrap();
+                    .unwrap()
+                    .contents;
 
                 let paths: Vec<PathBuf> = contents
                     .iter()

--- a/crates/repo_metadata/src/remote_model.rs
+++ b/crates/repo_metadata/src/remote_model.rs
@@ -14,7 +14,7 @@ use warpui_core::ModelContext;
 use super::local_model::collect_contents_recursive;
 use crate::file_tree_store::{FileTreeEntry, FileTreeState};
 use crate::file_tree_update::{MetadataUpdateType, RepoMetadataUpdate};
-use crate::local_model::{GetContentsArgs, IndexedRepoState, RepoContent};
+use crate::local_model::{GetContentsArgs, IndexedRepoState, RepoContents};
 use crate::repository_identifier::RemoteRepositoryIdentifier;
 use crate::standing_queries::{StandingQueryResults, StandingQueryResultsDelta};
 use crate::RepoMetadataError;
@@ -107,13 +107,16 @@ impl RemoteRepoMetadataModel {
 
     /// Returns repository contents for the specified remote repository.
     ///
-    /// Returns an error if the number of results exceeds MAX_REPO_CONTENTS_RESULTS.
+    /// The number of returned entries is capped; when the repository contains
+    /// more matching entries, the result is truncated and
+    /// [`RepoContents::truncated`] is set to `true`.
+    ///
     /// Returns an error if the repository is not indexed, indexing is pending, or indexing failed.
     pub fn get_repo_contents(
         &self,
         id: &RemoteRepositoryIdentifier,
         args: GetContentsArgs,
-    ) -> Result<Vec<RepoContent<'_>>, RepoMetadataError> {
+    ) -> Result<RepoContents<'_>, RepoMetadataError> {
         let state = match self.repositories.get(id) {
             Some(IndexedRepoState::Indexed(state)) => state,
             Some(IndexedRepoState::Pending(_)) => {
@@ -127,13 +130,16 @@ impl RemoteRepoMetadataModel {
             }
         };
         let mut contents = Vec::new();
-        collect_contents_recursive(
+        let truncated = collect_contents_recursive(
             &state.entry,
             state.entry.root_directory(),
             &mut contents,
             &args,
-        )?;
-        Ok(contents)
+        );
+        Ok(RepoContents {
+            contents,
+            truncated,
+        })
     }
 
     /// Returns all tracked remote repository identifiers, including those in

--- a/crates/repo_metadata/src/wrapper_model.rs
+++ b/crates/repo_metadata/src/wrapper_model.rs
@@ -15,7 +15,8 @@ use warpui_core::{AppContext, ModelContext, ModelHandle, SingletonEntity};
 use crate::file_tree_store::FileTreeState;
 use crate::file_tree_update::{MetadataUpdateType, RepoMetadataUpdate};
 use crate::local_model::{
-    GetContentsArgs, IndexedRepoState, LocalRepoMetadataModel, RepoContent, RepositoryMetadataEvent,
+    GetContentsArgs, IndexedRepoState, LocalRepoMetadataModel, RepoContents,
+    RepositoryMetadataEvent,
 };
 use crate::remote_model::{RemoteRepoMetadataModel, RemoteRepositoryMetadataEvent};
 use crate::repository_identifier::{RemoteRepositoryIdentifier, RepositoryIdentifier};
@@ -267,14 +268,17 @@ impl RepoMetadataModel {
 
     /// Returns repository contents for the specified repository.
     ///
-    /// Returns an error if the number of results exceeds MAX_REPO_CONTENTS_RESULTS.
+    /// The number of returned entries is capped; when the repository contains
+    /// more matching entries, the result is truncated and
+    /// [`RepoContents::truncated`] is set to `true`.
+    ///
     /// Returns an error if the repository is not indexed, indexing is pending, or indexing failed.
     pub fn get_repo_contents<'a>(
         &self,
         id: &RepositoryIdentifier,
         args: GetContentsArgs,
         ctx: &'a AppContext,
-    ) -> Result<Vec<RepoContent<'a>>, RepoMetadataError> {
+    ) -> Result<RepoContents<'a>, RepoMetadataError> {
         match id {
             RepositoryIdentifier::Local(path) => {
                 self.local.as_ref(ctx).get_repo_contents(path, args)


### PR DESCRIPTION
## Description
Instead of outright failing, we should return a truncated result so features like `file_search` don't surface no results on large query results

## Testing
Tested manually