### PR TITLE
Support multi select grouping actions for vertical tabs

### DIFF
--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -153,6 +153,13 @@ pub enum WorkspaceAction {
         tab_index: usize,
         anchor: TabContextMenuAnchor,
     },
+    /// Toggles the multi-tab selection right-click menu.
+    /// Dispatched by the UI when the right-clicked tab is part of a multi-tab
+    /// selection (cmd-click or shift-click).
+    ToggleTabSelectionRightClickMenu {
+        tab_index: usize,
+        anchor: TabContextMenuAnchor,
+    },
     ToggleVerticalTabsPaneContextMenu {
         tab_index: usize,
         target: VerticalTabsPaneContextMenuTarget,
@@ -195,6 +202,17 @@ pub enum WorkspaceAction {
     ToggleTabMultiSelection {
         locator: PaneViewLocator,
     },
+    /// Clears the tab multi-selection. Dispatched from the UI when the user takes
+    /// an action that should cancel any active selections.
+    ClearTabMultiSelection,
+    /// Creates a new tab group from the current tab multi-selection.
+    NewTabGroupFromSelectedTabs,
+    /// Moves every selected tab into `group_id`.
+    MoveSelectedTabsToGroup {
+        group_id: TabGroupId,
+    },
+    /// Removes every selected tab from its group (requires a single shared group).
+    RemoveSelectedTabsFromGroup,
     ToggleTabGroupRightClickMenu {
         group_id: TabGroupId,
         anchor: TabContextMenuAnchor,
@@ -841,6 +859,9 @@ impl WorkspaceAction {
             | NewTabGroupFromTab(_)
             | MoveTabToGroup { .. }
             | RemoveTabFromGroup(_)
+            | NewTabGroupFromSelectedTabs
+            | MoveSelectedTabsToGroup { .. }
+            | RemoveSelectedTabsFromGroup
             | UngroupTabs(_)
             | NewTabInGroup(_)
             | MoveTabGroupUp(_)
@@ -907,6 +928,7 @@ impl WorkspaceAction {
             | ToggleSyntaxHighlighting
             | OpenLaunchConfigSaveModal
             | ToggleTabRightClickMenu { .. }
+            | ToggleTabSelectionRightClickMenu { .. }
             | ToggleTabGroupRightClickMenu { .. }
             | ToggleVerticalTabsPaneContextMenu { .. }
             | OpenNewSessionMenu { .. }
@@ -1023,6 +1045,7 @@ impl WorkspaceAction {
             | FocusPane(..)
             | ShiftSelectTabRange { .. }
             | ToggleTabMultiSelection { .. }
+            | ClearTabMultiSelection
             | StartNewConversation { .. }
             | UndoRevertInCodeReviewPane { .. }
             | JumpToLatestToast

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -988,6 +988,8 @@ pub struct Workspace {
     show_tab_right_click_menu: Option<(usize, TabContextMenuAnchor)>,
     /// Open tab group more-options menu; reuses the `tab_right_click_menu` view.
     show_tab_group_right_click_menu: Option<(TabGroupId, TabContextMenuAnchor)>,
+    /// Open multi-tab selection menu (right-click on any tab in a multi-tab selection).
+    show_tab_selection_right_click_menu: Option<(usize, TabContextMenuAnchor)>,
     // TODO(CORE-2300): this used to be add_tab_dropdown_menu.
     // Because we are rolling out the change behind a feature flag,
     // keep this comment here until the feature flag is removed.
@@ -3245,6 +3247,7 @@ impl Workspace {
             tab_right_click_menu,
             show_tab_right_click_menu: None,
             show_tab_group_right_click_menu: None,
+            show_tab_selection_right_click_menu: None,
             new_session_dropdown_menu,
             show_new_session_dropdown_menu: None,
             changelog_model,
@@ -9341,6 +9344,7 @@ impl Workspace {
             MenuEvent::Close { via_select_item: _ } => {
                 self.show_tab_right_click_menu = None;
                 self.show_tab_group_right_click_menu = None;
+                self.show_tab_selection_right_click_menu = None;
                 self.hide_move_to_group_sidecar(ctx);
                 ctx.notify();
             }
@@ -9458,53 +9462,15 @@ impl Workspace {
         menu_items
     }
 
-    /// Builds the sidecar rows: every group except the tab's current one,
-    /// ordered by first member's tab index to match the tabs panel.
-    fn build_move_to_group_sidecar_items(
-        &self,
-        tab_index: usize,
-    ) -> Vec<MenuItem<WorkspaceAction>> {
-        let Some(tab) = self.tabs.get(tab_index) else {
-            return vec![];
-        };
-        let current_group_id = tab.group_id;
-
-        // Other groups paired with their first member's tab index, sorted so the menu
-        // matches panel order.
-        let sorted_other_groups = self
-            .tab_groups
-            .keys()
-            .copied()
-            .filter(|gid| Some(*gid) != current_group_id)
-            .filter_map(|gid| {
-                group_member_indices(&self.tabs, gid)
-                    .next()
-                    .map(|idx| (gid, idx))
-            })
-            .sorted_by_key(|(_, idx)| *idx);
-
-        sorted_other_groups
-            .map(|(group_id, _)| {
-                let label = self
-                    .tab_groups
-                    .get(&group_id)
-                    .and_then(|g| g.name.clone())
-                    .unwrap_or_else(|| "Untitled group".to_string());
-                MenuItemFields::new(label)
-                    .with_on_select_action(WorkspaceAction::MoveTabToGroup {
-                        tab_index,
-                        group_id,
-                    })
-                    .into_item()
-            })
-            .collect()
-    }
-
     /// Opens the sidecar when "Move to group" is hovered, hides it otherwise.
+    /// Handles both the single-tab pane menu and the multi-tab selection menu.
     fn update_move_to_group_sidecar(&mut self, ctx: &mut ViewContext<Self>) {
-        let Some((tab_index, _)) = self.show_tab_right_click_menu else {
+        // If neither menu is open, nothing to update.
+        if self.show_tab_right_click_menu.is_none()
+            && self.show_tab_selection_right_click_menu.is_none()
+        {
             return;
-        };
+        }
         // No hovered index = cursor left the menu (possibly onto the sidecar);
         // no label = hovered a non-label row (e.g. separator).
         let hovered = self.tab_right_click_menu.read(ctx, |menu, _| {
@@ -9528,7 +9494,13 @@ impl Workspace {
         };
 
         if label == MOVE_TO_GROUP_LABEL {
-            let items = self.build_move_to_group_sidecar_items(tab_index);
+            // Single-tab pane menu carries a `tab_index`; the multi-tab
+            // selection menu has no single source tab so we pass `None` and
+            // the sidecar builder infers the multi-tab selection.
+            let source_tab_index = self
+                .show_tab_right_click_menu
+                .map(|(tab_index, _)| tab_index);
+            let items = self.build_move_to_group_sidecar_items(source_tab_index);
             if items.is_empty() {
                 self.hide_move_to_group_sidecar(ctx);
                 return;
@@ -9565,6 +9537,48 @@ impl Workspace {
         ctx.notify();
     }
 
+    /// Shared between the single-tab pane menu and the multi-tab selection
+    /// menu render paths so the two parent menus can't drift apart in how
+    /// they position the "move to group" sidecar.
+    fn add_move_to_group_sidecar_overlay(&self, stack: &mut Stack, app: &AppContext) {
+        if !self.show_move_to_group_sidecar {
+            return;
+        }
+        let sidecar_element = SavePosition::new(
+            ChildView::new(&self.move_to_group_sidecar_menu).finish(),
+            MOVE_TO_GROUP_SIDECAR_POSITION_ID,
+        )
+        .finish();
+
+        // Flip the anchor side when the sidecar would overflow the window.
+        let render_left =
+            self.should_render_sidecar_left(MOVE_TO_GROUP_LABEL, MOVE_TO_GROUP_SIDECAR_WIDTH, app);
+        let (offset, parent_anchor, child_anchor) = if render_left {
+            (
+                vec2f(-4., 0.),
+                PositionedElementAnchor::TopLeft,
+                ChildAnchor::TopRight,
+            )
+        } else {
+            (
+                vec2f(4., 0.),
+                PositionedElementAnchor::TopRight,
+                ChildAnchor::TopLeft,
+            )
+        };
+
+        stack.add_positioned_overlay_child(
+            sidecar_element,
+            OffsetPositioning::offset_from_save_position_element(
+                MOVE_TO_GROUP_LABEL,
+                offset,
+                PositionedElementOffsetBounds::WindowByPosition,
+                parent_anchor,
+                child_anchor,
+            ),
+        );
+    }
+
     fn handle_move_to_group_sidecar_event(
         &mut self,
         event: &MenuEvent,
@@ -9572,10 +9586,11 @@ impl Workspace {
     ) {
         match event {
             MenuEvent::Close { via_select_item } => {
-                // Item dispatch fires `MoveTabToGroup` itself; we just tear
-                // down the parent menu on a real pick.
+                // Item dispatch fires the move action itself; we just tear down
+                // the parent menu (single-tab or multi-tab selection) on a pick.
                 if *via_select_item {
                     self.show_tab_right_click_menu = None;
+                    self.show_tab_selection_right_click_menu = None;
                 }
                 self.show_move_to_group_sidecar = false;
                 self.tab_right_click_menu.update(ctx, |menu, _| {
@@ -22646,6 +22661,9 @@ impl TypedActionView for Workspace {
             ToggleTabRightClickMenu { tab_index, anchor } => {
                 self.toggle_tab_right_click_menu(*tab_index, *anchor, ctx)
             }
+            ToggleTabSelectionRightClickMenu { tab_index, anchor } => {
+                self.toggle_tab_selection_right_click_menu(*tab_index, *anchor, ctx)
+            }
             ToggleVerticalTabsPaneContextMenu {
                 tab_index,
                 target,
@@ -22675,6 +22693,12 @@ impl TypedActionView for Workspace {
             RemoveTabFromGroup(tab_index) => self.remove_tab_from_group(*tab_index, ctx),
             ShiftSelectTabRange { locator } => self.shift_select_tab_range(*locator, ctx),
             ToggleTabMultiSelection { locator } => self.toggle_tab_multi_selection(*locator, ctx),
+            ClearTabMultiSelection => self.clear_tab_multi_selection(ctx),
+            NewTabGroupFromSelectedTabs => self.new_tab_group_from_selected_tabs(ctx),
+            MoveSelectedTabsToGroup { group_id } => {
+                self.move_selected_tabs_to_group(*group_id, ctx)
+            }
+            RemoveSelectedTabsFromGroup => self.remove_selected_tabs_from_group(ctx),
             ToggleTabGroupRightClickMenu { group_id, anchor } => {
                 self.toggle_tab_group_right_click_menu(*group_id, *anchor, ctx)
             }
@@ -25267,45 +25291,32 @@ impl View for Workspace {
                     );
                 }
 
-                // Sidecar menu for the "Move to group" submenu parent. Mirrors
-                // the new-session sidecar's overflow-aware left/right anchoring.
-                if self.show_move_to_group_sidecar {
-                    let sidecar_element = SavePosition::new(
-                        ChildView::new(&self.move_to_group_sidecar_menu).finish(),
-                        MOVE_TO_GROUP_SIDECAR_POSITION_ID,
-                    )
-                    .finish();
+                self.add_move_to_group_sidecar_overlay(&mut stack, app);
+            }
+        }
 
-                    let render_left = self.should_render_sidecar_left(
-                        MOVE_TO_GROUP_LABEL,
-                        MOVE_TO_GROUP_SIDECAR_WIDTH,
-                        app,
-                    );
-                    let (offset, parent_anchor, child_anchor) = if render_left {
-                        (
-                            vec2f(-4., 0.),
-                            PositionedElementAnchor::TopLeft,
-                            ChildAnchor::TopRight,
-                        )
-                    } else {
-                        (
-                            vec2f(4., 0.),
-                            PositionedElementAnchor::TopRight,
-                            ChildAnchor::TopLeft,
-                        )
-                    };
+        // Multi-tab selection menu (reuses the `tab_right_click_menu` view).
+        if let Some((_tab_idx, anchor)) = self.show_tab_selection_right_click_menu {
+            let is_vertical = FeatureFlag::VerticalTabs.is_enabled()
+                && *TabSettings::as_ref(app).use_vertical_tabs
+                && self.vertical_tabs_panel_open;
+            if is_vertical {
+                let position = match anchor {
+                    TabContextMenuAnchor::Pointer(position) => position,
+                    // The selection menu is never opened via the kebab button.
+                    TabContextMenuAnchor::VerticalTabsKebab => Vector2F::zero(),
+                };
+                stack.add_positioned_overlay_child(
+                    ChildView::new(&self.tab_right_click_menu).finish(),
+                    OffsetPositioning::offset_from_parent(
+                        position,
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::TopLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                );
 
-                    stack.add_positioned_overlay_child(
-                        sidecar_element,
-                        OffsetPositioning::offset_from_save_position_element(
-                            MOVE_TO_GROUP_LABEL,
-                            offset,
-                            PositionedElementOffsetBounds::WindowByPosition,
-                            parent_anchor,
-                            child_anchor,
-                        ),
-                    );
-                }
+                self.add_move_to_group_sidecar_overlay(&mut stack, app);
             }
         }
 

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -1,10 +1,14 @@
 use std::collections::HashSet;
 
+use itertools::{Either, Itertools};
 use warp_core::features::FeatureFlag;
-use warpui::ViewContext;
+use warpui::{EntityId, UpdateView, ViewContext};
 
-use super::Workspace;
-use crate::workspace::tab_group::TabGroupId;
+use super::{group_member_indices, Workspace};
+use crate::menu::{MenuItem, MenuItemFields};
+use crate::tab::MOVE_TO_GROUP_LABEL;
+use crate::workspace::action::{TabContextMenuAnchor, WorkspaceAction};
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::util::PaneViewLocator;
 
 // TODO(johnturcoo) move tab grouping helpers here from workspace/view.rs.
@@ -96,5 +100,380 @@ impl Workspace {
             tab.in_multi_selection = !tab.in_multi_selection;
             ctx.notify();
         }
+    }
+
+    /// Returns all tabs that are part of the multi tab selection.
+    /// The active tab index is always included if any other tab is marked
+    /// as selected. This is to handle the edge case where we only mark other
+    /// tabs as selected via command click.
+    fn selected_tab_indices(&self) -> Vec<usize> {
+        let any_flagged = self.tabs.iter().any(|tab| tab.in_multi_selection);
+        // If no tab is part of the multi selection, return empty list.
+        if !any_flagged {
+            return Vec::new();
+        }
+        // Otherwise, the active tab must always be part of the multi tab selection.
+        self.tabs
+            .iter()
+            .enumerate()
+            .filter(|(index, tab)| tab.in_multi_selection || *index == self.active_tab_index)
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// Drives right-click menu dispatch: when a selected tab is right-clicked
+    /// and the selection covers multiple tabs, show the multi-tab menu;
+    /// otherwise fall through to the normal single-pane menu.
+    pub(super) fn is_tab_in_multi_tab_selection(&self, tab_index: usize) -> bool {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return false;
+        }
+        let indices = self.selected_tab_indices();
+        indices.len() > 1 && indices.contains(&tab_index)
+    }
+
+    /// Gates the "Remove from group" menu item. All selected tabs
+    /// must be in the same group in order to display this option.
+    fn selection_shared_group(&self) -> Option<TabGroupId> {
+        let indices = self.selected_tab_indices();
+        let mut group_ids = indices
+            .iter()
+            .filter_map(|index| self.tabs.get(*index))
+            .map(|tab| tab.group_id);
+        let first = group_ids.next()??;
+        group_ids.all(|gid| gid == Some(first)).then_some(first)
+    }
+
+    /// Re-seats `active_tab_index` so the previously-active pane group stays
+    /// visually active across a tab reorder. Pass the pane group id captured
+    /// before the reorder; no-op if it can't be found.
+    fn restore_active_tab_index(&mut self, pane_group_id: Option<EntityId>) {
+        if let Some(active_id) = pane_group_id {
+            if let Some(new_index) = self
+                .tabs
+                .iter()
+                .position(|tab| tab.pane_group.id() == active_id)
+            {
+                self.active_tab_index = new_index;
+            }
+        }
+    }
+
+    /// "Create group from tabs" menu action. Group membership requires
+    /// tabs to be contiguous in the bar, so we relocate the selected tabs
+    /// to the top as a single block before binding them to the new group.
+    pub(super) fn new_tab_group_from_selected_tabs(&mut self, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        let selected_indices = self.selected_tab_indices();
+
+        // Should be unreachable: the multi-tab menu only opens when 2+ tabs
+        // are selected. 
+        if selected_indices.len() < 2 {
+            log::warn!(
+                "new_tab_group_from_selected_tabs called with {} selected tab(s); expected at least 2",
+                selected_indices.len()
+            );
+            return;
+        }
+
+        // Remember the groups the selected tabs are leaving so we can prune
+        // any that become empty after the move.
+        let previous_group_ids: HashSet<TabGroupId> = selected_indices
+            .iter()
+            .filter_map(|index| self.tabs[*index].group_id)
+            .collect();
+
+        let group = TabGroup::new();
+        let group_id = group.id;
+        self.tab_groups.insert(group_id, group);
+
+        // Store the active tab (pane group).
+        let active_pane_group_id = self
+            .tabs
+            .get(self.active_tab_index)
+            .map(|tab| tab.pane_group.id());
+
+        // Assign membership and clear flags for every selected tab.
+        for &index in &selected_indices {
+            let tab = &mut self.tabs[index];
+            tab.group_id = Some(group_id);
+            tab.in_multi_selection = false;
+        }
+
+        // Split tabs into the new group's members and all other tabs.
+        let (selected_tabs, other_tabs): (Vec<_>, Vec<_>) = self
+            .tabs
+            .drain(..)
+            .partition(|tab| tab.group_id == Some(group_id));
+        // Place the group block at the top, with the rest of the tabs after.
+        self.tabs = selected_tabs.into_iter().chain(other_tabs).collect();
+
+        self.restore_active_tab_index(active_pane_group_id);
+
+        // Prune any groups that are now empty.
+        for previous_group_id in previous_group_ids {
+            self.prune_empty_tab_group(previous_group_id, ctx);
+        }
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+
+        ctx.dispatch_typed_action_deferred(WorkspaceAction::RenameTabGroup(group_id));
+    }
+
+    /// "Move to group" menu action. The destination group's first-member
+    /// position is preserved so the group doesn't visually jump while the
+    /// selected tabs are folded in.
+    pub(super) fn move_selected_tabs_to_group(
+        &mut self,
+        group_id: TabGroupId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !FeatureFlag::GroupedTabs.is_enabled() || !self.tab_groups.contains_key(&group_id) {
+            return;
+        }
+        let selected_indices = self.selected_tab_indices();
+
+        // Should be unreachable: the multi-tab menu only opens when 2+ tabs
+        // are selected. 
+        if selected_indices.len() < 2 {
+            log::warn!(
+                "move_selected_tabs_to_group called with {} selected tab(s); expected at least 2",
+                selected_indices.len()
+            );
+            return;
+        }
+
+        // Store all groups that tabs previously belonged to, excluding the 
+        // group that we are moving tabs to. In order to prune these groups later.
+        let previous_group_ids: HashSet<TabGroupId> = selected_indices
+            .iter()
+            .filter_map(|index| self.tabs[*index].group_id)
+            .filter(|gid| *gid != group_id)
+            .collect();
+
+        // Anchor the block at the existing first member so the group doesn't jump.
+        let first_existing_member = self
+            .tabs
+            .iter()
+            .position(|tab| tab.group_id == Some(group_id));
+
+        // Store the active tab (pane group).
+        let active_pane_group_id = self
+            .tabs
+            .get(self.active_tab_index)
+            .map(|tab| tab.pane_group.id());
+
+        // Assign membership and clear flags for every selected tab.
+        for &index in &selected_indices {
+            let tab = &mut self.tabs[index];
+            tab.group_id = Some(group_id);
+            tab.in_multi_selection = false;
+        }
+
+        // Anchor the group block at its original first-member position, shifted
+        // left by the count of newly-added members from before that position.
+        let insert_at = first_existing_member.map_or(0, |first| {
+            first - selected_indices.iter().filter(|&&i| i < first).count()
+        });
+        // Split tabs into the destination group's members (existing + newly
+        // added) and the rest.
+        let (members, mut rest): (Vec<_>, Vec<_>) = self
+            .tabs
+            .drain(..)
+            .partition(|tab| tab.group_id == Some(group_id));
+        // Drop the group block into rest at the anchored position.
+        rest.splice(insert_at..insert_at, members);
+        self.tabs = rest;
+
+        self.restore_active_tab_index(active_pane_group_id);
+
+        // Prune any groups that are now empty.
+        for previous_group_id in previous_group_ids {
+            self.prune_empty_tab_group(previous_group_id, ctx);
+        }
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// "Remove from group" menu action. Removed tabs land just below the
+    /// group's remaining members so the user can still see where they came
+    /// from; if the group ends up empty it's pruned and the removed block
+    /// anchors at the original position instead.
+    pub(super) fn remove_selected_tabs_from_group(&mut self, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        let Some(group_id) = self.selection_shared_group() else {
+            // Only a single-group selection has an unambiguous group to leave.
+            self.clear_tab_multi_selection(ctx);
+            return;
+        };
+
+        // Capture the group's first index before clearing membership so we can
+        // anchor the removed block if the group ends up empty.
+        let group_first_index = self
+            .tabs
+            .iter()
+            .position(|tab| tab.group_id == Some(group_id))
+            .unwrap_or(0);
+        // Store the active tab (pane group).
+        let active_pane_group_id = self
+            .tabs
+            .get(self.active_tab_index)
+            .map(|tab| tab.pane_group.id());
+        let selected_indices = self.selected_tab_indices();
+        let selected_set: HashSet<usize> = selected_indices.iter().copied().collect();
+
+        // Clear the group that all selected tabs belonged to.
+        for &index in &selected_indices {
+            self.tabs[index].group_id = None;
+        }
+
+        // Non-selected tabs originally before the group's first member; if the
+        // group ends up empty we fall back to inserting at this position.
+        let kept_before_group = group_first_index
+            - selected_indices
+                .iter()
+                .filter(|&&i| i < group_first_index)
+                .count();
+
+        // Split tabs by index into the removed (selected) block and the rest.
+        let (removed, mut rest): (Vec<_>, Vec<_>) =
+            self.tabs.drain(..).enumerate().partition_map(|(index, tab)| {
+                if selected_set.contains(&index) {
+                    Either::Left(tab)
+                } else {
+                    Either::Right(tab)
+                }
+            });
+        // Anchor the removed block just after the group's remaining members;
+        // if none remain, fall back to the pre-computed prefix position.
+        let insert_at = match rest.iter().rposition(|tab| tab.group_id == Some(group_id)) {
+            Some(last) => last + 1,
+            None => kept_before_group,
+        };
+        rest.splice(insert_at..insert_at, removed);
+        self.tabs = rest;
+
+        self.clear_tab_multi_selection(ctx);
+        self.restore_active_tab_index(active_pane_group_id);
+        self.prune_empty_tab_group(group_id, ctx);
+
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Items shown in the multi-tab right-click menu. Composition depends on
+    /// the selection: "Create group from tabs" is always there; "Remove from
+    /// group" only when the selection has an unambiguous group; "Move to
+    /// group" only when there's a destination group worth offering.
+    fn tab_selection_menu_items(&self) -> Vec<MenuItem<WorkspaceAction>> {
+        let shared_group = self.selection_shared_group();
+        let mut menu_items = vec![MenuItemFields::new("Create group from tabs")
+            .with_on_select_action(WorkspaceAction::NewTabGroupFromSelectedTabs)
+            .into_item()];
+
+        // Only single-group selections have an unambiguous group to leave.
+        if shared_group.is_some() {
+            menu_items.push(
+                MenuItemFields::new("Remove from group")
+                    .with_on_select_action(WorkspaceAction::RemoveSelectedTabsFromGroup)
+                    .into_item(),
+            );
+        }
+
+        // Offer "Move to group" only when another group is available.
+        let has_destination_group = self
+            .tab_groups
+            .keys()
+            .any(|group_id| Some(*group_id) != shared_group);
+        if has_destination_group {
+            menu_items.push(MenuItemFields::new_submenu(MOVE_TO_GROUP_LABEL).into_item());
+        }
+        menu_items
+    }
+
+    /// Opens (or closes) the multi-tab right-click menu. Reuses the shared
+    /// `tab_right_click_menu` view — the menu rendering pipeline doesn't need
+    /// to know which item set is loaded, only which `show_*` flag is set.
+    pub fn toggle_tab_selection_right_click_menu(
+        &mut self,
+        tab_index: usize,
+        anchor: TabContextMenuAnchor,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.show_tab_selection_right_click_menu.is_some() {
+            self.show_tab_selection_right_click_menu = None;
+            self.hide_move_to_group_sidecar(ctx);
+            ctx.notify();
+            return;
+        }
+
+        let menu_items = self.tab_selection_menu_items();
+        ctx.update_view(&self.tab_right_click_menu, |context_menu, view_ctx| {
+            context_menu.set_items(menu_items, view_ctx);
+        });
+        self.show_tab_right_click_menu = None;
+        self.show_tab_group_right_click_menu = None;
+        self.hide_move_to_group_sidecar(ctx);
+        self.show_tab_selection_right_click_menu = Some((tab_index, anchor));
+        ctx.focus(&self.tab_right_click_menu);
+        ctx.notify();
+    }
+
+    /// Builds the "Move to group" submenu. One builder serves both parent
+    /// menus: `Some(tab_index)` for the single-tab pane menu, `None` for the
+    /// multi-tab selection menu. Destination groups exclude the source's own
+    /// group (no useful move) and follow panel order so the submenu visually
+    /// matches what the user sees in the tabs sidebar.
+    pub(super) fn build_move_to_group_sidecar_items(
+        &self,
+        tab_index: Option<usize>,
+    ) -> Vec<MenuItem<WorkspaceAction>> {
+        // Exclude the source's current group (if any) — there's nowhere to
+        // move it to. For a mixed selection (no shared group) every
+        // destination stays available.
+        let excluded_group = match tab_index {
+            Some(idx) => self.tabs.get(idx).and_then(|tab| tab.group_id),
+            None => self.selection_shared_group(),
+        };
+
+        let mut groups_with_first_index: Vec<(TabGroupId, usize)> = self
+            .tab_groups
+            .keys()
+            .copied()
+            .filter(|gid| Some(*gid) != excluded_group)
+            .filter_map(|gid| {
+                group_member_indices(&self.tabs, gid)
+                    .next()
+                    .map(|idx| (gid, idx))
+            })
+            .collect();
+        groups_with_first_index.sort_by_key(|(_, idx)| *idx);
+
+        groups_with_first_index
+            .into_iter()
+            .map(|(group_id, _)| {
+                let label = self
+                    .tab_groups
+                    .get(&group_id)
+                    .and_then(|g| g.name.clone())
+                    .unwrap_or_else(|| "Untitled group".to_string());
+                let action = match tab_index {
+                    Some(tab_index) => WorkspaceAction::MoveTabToGroup {
+                        tab_index,
+                        group_id,
+                    },
+                    None => WorkspaceAction::MoveSelectedTabsToGroup { group_id },
+                };
+                MenuItemFields::new(label)
+                    .with_on_select_action(action)
+                    .into_item()
+            })
+            .collect()
     }
 }

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -169,7 +169,7 @@ impl Workspace {
         let selected_indices = self.selected_tab_indices();
 
         // Should be unreachable: the multi-tab menu only opens when 2+ tabs
-        // are selected. 
+        // are selected.
         if selected_indices.len() < 2 {
             log::warn!(
                 "new_tab_group_from_selected_tabs called with {} selected tab(s); expected at least 2",
@@ -237,7 +237,7 @@ impl Workspace {
         let selected_indices = self.selected_tab_indices();
 
         // Should be unreachable: the multi-tab menu only opens when 2+ tabs
-        // are selected. 
+        // are selected.
         if selected_indices.len() < 2 {
             log::warn!(
                 "move_selected_tabs_to_group called with {} selected tab(s); expected at least 2",
@@ -246,7 +246,7 @@ impl Workspace {
             return;
         }
 
-        // Store all groups that tabs previously belonged to, excluding the 
+        // Store all groups that tabs previously belonged to, excluding the
         // group that we are moving tabs to. In order to prune these groups later.
         let previous_group_ids: HashSet<TabGroupId> = selected_indices
             .iter()
@@ -343,13 +343,16 @@ impl Workspace {
 
         // Split tabs by index into the removed (selected) block and the rest.
         let (removed, mut rest): (Vec<_>, Vec<_>) =
-            self.tabs.drain(..).enumerate().partition_map(|(index, tab)| {
-                if selected_set.contains(&index) {
-                    Either::Left(tab)
-                } else {
-                    Either::Right(tab)
-                }
-            });
+            self.tabs
+                .drain(..)
+                .enumerate()
+                .partition_map(|(index, tab)| {
+                    if selected_set.contains(&index) {
+                        Either::Left(tab)
+                    } else {
+                        Either::Right(tab)
+                    }
+                });
         // Anchor the removed block just after the group's remaining members;
         // if none remain, fall back to the pre-computed prefix position.
         let insert_at = match rest.iter().rposition(|tab| tab.group_id == Some(group_id)) {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -358,6 +358,7 @@ fn render_pane_row_element(
         typed: _,
         is_being_dragged,
         is_in_multi_selection,
+        is_in_multi_tab_selection,
         pane_color,
         badge_mouse_states: _,
         detail_hover_state,
@@ -480,11 +481,21 @@ fn render_pane_row_element(
     }
     if let Some(tab_index) = pane_context_menu_tab_index {
         row = row.on_right_click(move |ctx, _, position| {
-            ctx.dispatch_typed_action(WorkspaceAction::ToggleVerticalTabsPaneContextMenu {
-                tab_index,
-                target: VerticalTabsPaneContextMenuTarget::ClickedPane(pane_locator),
-                position,
-            });
+            let anchor = TabContextMenuAnchor::Pointer(position);
+            if is_in_multi_tab_selection {
+                ctx.dispatch_typed_action(WorkspaceAction::ToggleTabSelectionRightClickMenu {
+                    tab_index,
+                    anchor,
+                });
+            } else {
+                // Right-clicking outside the multi-selection cancels it.
+                ctx.dispatch_typed_action(WorkspaceAction::ClearTabMultiSelection);
+                ctx.dispatch_typed_action(WorkspaceAction::ToggleVerticalTabsPaneContextMenu {
+                    tab_index,
+                    target: VerticalTabsPaneContextMenuTarget::ClickedPane(pane_locator),
+                    position,
+                });
+            }
         });
     }
 
@@ -738,6 +749,10 @@ struct PaneProps<'a> {
     /// True when this row's tab is part of the active multi-selection
     /// (shift-click range or cmd-click toggle).
     is_in_multi_selection: bool,
+    /// True when the row's tab is part of a multi-tab (count > 1) selection.
+    /// The right-click handler dispatches the selection menu when set,
+    /// otherwise the single-pane menu.
+    is_in_multi_tab_selection: bool,
     pane_color: Option<ThemeFill>,
     badge_mouse_states: PaneRowBadgeMouseStates,
     detail_hover_state: VerticalTabsDetailHoverState,
@@ -1104,6 +1119,7 @@ impl VerticalTabsPanelState {
                                 pane_id,
                                 tab.pane_group.id(),
                                 *tab_index == active_tab_index,
+                                false,
                                 false,
                                 PaneRowState {
                                     mouse_state: ms,
@@ -1673,6 +1689,7 @@ fn render_groups(
                                     tab.pane_group.id(),
                                     tab_index == workspace.active_tab_index,
                                     false,
+                                    false,
                                     PaneRowState {
                                         mouse_state: ms,
                                         title_mouse_state: None,
@@ -1700,6 +1717,7 @@ fn render_groups(
                                 pane_id,
                                 tab.pane_group.id(),
                                 tab_index == workspace.active_tab_index,
+                                false,
                                 false,
                                 PaneRowState {
                                     mouse_state,
@@ -1959,6 +1977,9 @@ fn render_tab_group_internal(
     let is_this_tab_dragging = tab.draggable_state.is_dragging();
     // Panes inherit multi-selection status from the tab they belong to.
     let is_in_multi_selection = tab.in_multi_selection;
+    // Captured into row/group right-click closures so they can pick between
+    // the single-pane menu and the multi-tab selection menu.
+    let is_in_multi_tab_selection = workspace.is_tab_in_multi_tab_selection(tab_index);
     let color_mode = compute_tab_group_color_mode(tab, pane_group, &visible_pane_ids, theme, app);
     let per_pane_colors = color_mode.into_per_pane_colors(&visible_pane_ids);
     let is_being_renamed = is_active && workspace.current_workspace_state.is_tab_being_renamed();
@@ -2007,6 +2028,7 @@ fn render_tab_group_internal(
                     pane_group_id,
                     is_active,
                     is_in_multi_selection,
+                    is_in_multi_tab_selection,
                     PaneRowState {
                         mouse_state: row_mouse_state.clone(),
                         title_mouse_state: None,
@@ -2061,6 +2083,7 @@ fn render_tab_group_internal(
                     pane_group_id,
                     is_active,
                     is_in_multi_selection,
+                    is_in_multi_tab_selection,
                     PaneRowState {
                         mouse_state: row_mouse_state.clone(),
                         title_mouse_state: title_mouse_states.get(pane_id).cloned(),
@@ -2241,11 +2264,23 @@ fn render_tab_group_internal(
         stack.finish()
     })
     .on_right_click(move |ctx, _, position| {
-        ctx.dispatch_typed_action(WorkspaceAction::ToggleVerticalTabsPaneContextMenu {
-            tab_index,
-            target: VerticalTabsPaneContextMenuTarget::ActivePane(active_pane_context_menu_target),
-            position,
-        });
+        let anchor = TabContextMenuAnchor::Pointer(position);
+        if is_in_multi_tab_selection {
+            ctx.dispatch_typed_action(WorkspaceAction::ToggleTabSelectionRightClickMenu {
+                tab_index,
+                anchor,
+            });
+        } else {
+            // Right-clicking outside the multi-selection cancels it.
+            ctx.dispatch_typed_action(WorkspaceAction::ClearTabMultiSelection);
+            ctx.dispatch_typed_action(WorkspaceAction::ToggleVerticalTabsPaneContextMenu {
+                tab_index,
+                target: VerticalTabsPaneContextMenuTarget::ActivePane(
+                    active_pane_context_menu_target,
+                ),
+                position,
+            });
+        }
     });
 
     // Mirror the horizontal-tab behavior: middle-click closes the tab, except when it would
@@ -3362,6 +3397,7 @@ impl<'a> PaneProps<'a> {
         pane_group_id: EntityId,
         is_active_tab: bool,
         is_in_multi_selection: bool,
+        is_in_multi_tab_selection: bool,
         pane_row_state: PaneRowState,
         detail_hover_state: VerticalTabsDetailHoverState,
         display_granularity: VerticalTabsDisplayGranularity,
@@ -3413,6 +3449,7 @@ impl<'a> PaneProps<'a> {
             typed,
             is_being_dragged: pane.is_pane_being_dragged(app),
             is_in_multi_selection,
+            is_in_multi_tab_selection,
             pane_color: pane_row_state.pane_color,
             badge_mouse_states: pane_row_state.badge_mouse_states,
             detail_hover_state,
@@ -6171,6 +6208,7 @@ fn detail_pane_props<'a>(
         pane_group,
         pane_id,
         pane_group_id,
+        false,
         false,
         false,
         PaneRowState {


### PR DESCRIPTION
## Description
Adds group operations to the vertical tabs multi-selection from [the previous PR](https://github.com/warpdotdev/warp/pull/12200). When the user has multiple tabs selected (via shift-click or cmd-click), right-clicking any selected tab opens a new multi-tab menu with three actions: Create group from tabs, Move to group, and Remove from group. 

Create group from tabs turns the selection into a new tab group at the top of the tab list. Move to group folds the selection into an existing group, anchored at the group's first member so the group doesn't visually move. Remove from group is available only when every selected tab shares the same group; the removed tabs land just below the group's remaining members, or in the same position if no remaining members existing.

NOTE: UI is not polished here and is going to be updated in a follow up PR.

## How it works

Added new workspace actions for creating group, moving to group and removing from group when several tabs are selected. Helper functions containing the logic can be found in  `app/src/workspace/view/tab_grouping.rs`. Important note:
- Moving to group is possible if there is another group available for at least one of the selected tabs (ie Group 1 contains members A,B,C, tab list contains A,B,C,D. Selecting all 4 tabs allows move to group 1, since tab D can be moved to group 1). 
All other behavior for these actions should be as expected. Empty groups are deleted after any of these actions.

Added two new actions for clearing all selected tabs, and for toggling the multi-tab selection right click menu, which displays the "Move to group", "Remove from group" and "Create group from tabs" options. This menu is displayed on right click of a `selected` tab, otherwise the regular single-tab menu appears. Right click on a tab or pane branches on `is_in_multi_tab_selection` to determine which menu to display.

The "move to group" sidecar menu is now used for both the single-tab menu as well as the multi-tab selection menu, rendering is extracted into a shared function `add_move_to_group_sidecar_overlay`. 

The only other thing to note here: Since we support cmd + click to select any individual tab, the active tab is always assumed to be selected when any other member is selected, but is only marked as selected for a range selection. This is important when determining which menu to display when right clicking the active tab, without needing to do additional bookkeeping on every cmd + click that toggles selected tabs.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4661/group-creation-from-multi-select-for-vertical-tabs

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

[Demo video](https://www.loom.com/share/adbfa7c9fd794863995655316c4cdc4b)

This demo video shows a mix of shift + click range selection, cmd + click individual tab selection and a mix of different actions from the multi tab selection menu