### PR TITLE
Hide gutter icons for embedded code review comments

### DIFF
--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -586,6 +586,10 @@ impl<V: EditorView> EditorWrapper<V> {
         line_number_config.active_cursor_is_visible
     }
 
+    fn should_render_gutter_action_icons() -> bool {
+        !FeatureFlag::EmbeddedCodeReviewComments.is_enabled()
+    }
+
     /// Returning **no** gutter means the gutter shouldn't be rendered at all.
     /// Returning an **empty** gutter means the gutter should be rendered with no contents.
     fn gutter_elements(&self, app: &AppContext) -> Option<Vec<GutterElement>> {
@@ -1186,16 +1190,24 @@ impl<V: EditorView> EditorWrapper<V> {
             .with_width(GUTTER_WIDTH)
             .finish();
 
-        let show_add_as_context_button = self.add_hunk_as_context_button.is_some();
-        let show_revert_diff_hunk =
-            FeatureFlag::RevertDiffHunk.is_enabled() && self.revert_hunk_button.is_some();
+        let render_icons = Self::should_render_gutter_action_icons();
+
+        let show_add_as_context_button = render_icons && self.add_hunk_as_context_button.is_some();
+        let show_revert_diff_hunk = render_icons
+            && FeatureFlag::RevertDiffHunk.is_enabled()
+            && self.revert_hunk_button.is_some();
 
         // Show comment button independently of diff hunk state when requested
-        let show_comment_button = FeatureFlag::InlineCodeReview.is_enabled()
+        let show_comment_button = render_icons
+            && FeatureFlag::InlineCodeReview.is_enabled()
             && self.comment_button.is_some()
             && (should_show_comment_button || is_active_comment_on_current_line);
 
-        if should_show_diff_hunk_icons || is_active_comment_on_current_line || show_comment_button {
+        // When embedded comments are on, suppress the diff-hunk icons as well
+        let effective_show_diff_hunk_icons = render_icons && should_show_diff_hunk_icons;
+        let effective_active_comment = render_icons && is_active_comment_on_current_line;
+
+        if effective_show_diff_hunk_icons || effective_active_comment || show_comment_button {
             let mut buttons = Flex::row().with_main_axis_size(MainAxisSize::Min);
             if let Some(comment_button) =
                 self.comment_button.as_ref().filter(|_| show_comment_button)
@@ -1209,7 +1221,7 @@ impl<V: EditorView> EditorWrapper<V> {
                 ));
             }
 
-            if should_show_diff_hunk_icons {
+            if effective_show_diff_hunk_icons {
                 if let Some(revert_hunk_button) = self
                     .revert_hunk_button
                     .as_ref()

--- a/app/src/code/editor/element_tests.rs
+++ b/app/src/code/editor/element_tests.rs
@@ -69,3 +69,17 @@ fn relative_line_numbers_use_starting_line_number_for_active_line_only() {
     assert_eq!(config.display_line_number(LineCount::from(4)), 14);
     assert_eq!(config.display_line_number(LineCount::from(1)), 3);
 }
+
+#[test]
+fn gutter_action_icons_are_hidden_for_embedded_code_review_comments() {
+    let _embedded_comments = FeatureFlag::EmbeddedCodeReviewComments.override_enabled(true);
+
+    assert!(!EditorWrapper::<crate::code::editor::view::CodeEditorView>::should_render_gutter_action_icons());
+}
+
+#[test]
+fn gutter_action_icons_render_without_embedded_code_review_comments() {
+    let _embedded_comments = FeatureFlag::EmbeddedCodeReviewComments.override_enabled(false);
+
+    assert!(EditorWrapper::<crate::code::editor::view::CodeEditorView>::should_render_gutter_action_icons());
+}


### PR DESCRIPTION
Summary:
- Suppress per-line code review gutter action icons when `EmbeddedCodeReviewComments` is enabled.
- Keep the gutter itself intact so line numbers and diff sliver/background rendering still work.
- Add regression coverage for the embedded-comments enabled and disabled states.

Validation:
- `cargo test --manifest-path /workspace/warp/Cargo.toml -p warp gutter_action_icons --features test-util`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- `RUSTFLAGS='--cfg feature="inline_code_review" --cfg feature="embedded_code_review_comments" --cfg feature="revert_diff_hunk"' cargo check --manifest-path /workspace/warp/Cargo.toml -p warp`
- Computer-use visual validation: created a local git diff, opened Code Review with embedded comments enabled, and observed line numbers plus red/green diff slivers in the changed-line gutter with no per-line comment/revert/paperclip/plus icons before hover, on hover, or after clicks.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/cb9d8370-72ea-40d7-9e88-0d9f46ef1909_
_Run: https://oz.staging.warp.dev/runs/019e94ce-664f-7a32-8bfe-c382fce20fb7_
_This PR was generated with [Oz](https://warp.dev/oz)._
