### PR TITLE
Honor force-included paths in lazy repo metadata

### DIFF
--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -119,7 +119,8 @@ impl Entry {
     }
 
     /// Builds a tree of entries from a given path, handling gitignored files and directories.
-    /// After max_depth is reached, all children are lazy-loaded to prevent deeply nested trees.
+    /// After max_depth is reached, children outside force-included paths are lazy-loaded to
+    /// prevent deeply nested trees.
     /// IgnoredPathStrategy determines what happens when ignored files are encountered.
     /// `budget_exceeded_behavior` controls what happens once the file budget is
     /// exhausted (see [`BudgetExceededBehavior`]).
@@ -580,8 +581,11 @@ fn evaluate_entry(
             false, /* check_ancestors */
         );
 
-    // If we've reached the max depth, force lazy-loading even of non-ignored folders.
-    let mut lazy = current_depth >= options.max_depth;
+    let force_included = matches_force_included_path(curr_path, options.force_included_paths);
+
+    // If we've reached the max depth, force lazy-loading even of non-ignored folders unless the
+    // folder is on the path to a force-included subtree.
+    let mut lazy = current_depth >= options.max_depth && !force_included;
 
     if path_is_ignored {
         match options.ignored_path_strategy {
@@ -594,7 +598,7 @@ fn evaluate_entry(
                 }
             }
             IgnoredPathStrategy::IncludeLazy => {
-                lazy = !matches_force_included_path(curr_path, options.force_included_paths);
+                lazy = !force_included;
             }
             IgnoredPathStrategy::Include => {}
         }
@@ -638,7 +642,8 @@ fn push_child(nodes: &mut [Option<NodeBuilder>], parent: usize, child: usize) {
 }
 
 /// Recursively assembles the nested [`Entry`] tree from the build arena.
-/// Recursion depth is bounded by `BuildTreeOptions::max_depth`.
+/// Recursion depth is normally bounded by `BuildTreeOptions::max_depth`, except for force-included
+/// subtrees.
 fn assemble_node(nodes: &mut [Option<NodeBuilder>], index: usize) -> Entry {
     match nodes[index]
         .take()

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -511,6 +511,67 @@ fn standing_queries_do_not_report_rules_below_an_unloaded_shallow_directory() {
 }
 
 #[test]
+fn shallow_tree_expands_force_included_skill_branch_only() {
+    virtual_fs::VirtualFS::test("shallow_tree_force_included_skills", |dirs, mut vfs| {
+        vfs.mkdir("workspace/.agents/skills/review")
+            .mkdir("workspace/src/deep")
+            .with_files(vec![
+                virtual_fs::Stub::FileWithContent(
+                    "workspace/.agents/skills/review/SKILL.md",
+                    "name: review",
+                ),
+                virtual_fs::Stub::FileWithContent("workspace/src/deep/WARP.md", "project rules"),
+            ]);
+        let workspace = dirs.tests().join("workspace");
+        let skill_path = workspace.join(".agents/skills/review/SKILL.md");
+        let rule_path = workspace.join("src/deep/WARP.md");
+
+        let mut files = Vec::new();
+        let mut gitignores = Vec::new();
+        let mut results = StandingQueryResults::default();
+        let mut definitions = StandingQueryDefinitions::default();
+        definitions.set_project_skill_provider_paths([std::path::PathBuf::from(".agents/skills")]);
+        let tree = Entry::build_tree_with_standing_queries(
+            &workspace,
+            &mut files,
+            &mut gitignores,
+            None,
+            super::BuildTreeOptions {
+                max_depth: 1,
+                current_depth: 0,
+                ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
+                force_included_paths: &[std::path::PathBuf::from(".agents/skills")],
+                budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
+            },
+            &mut results,
+            &definitions,
+        )
+        .unwrap();
+
+        let agents = find_entry(&tree, &workspace.join(".agents"))
+            .expect("force-included ancestor should be represented");
+        assert!(agents.loaded());
+        assert!(find_entry(&tree, &skill_path).is_some());
+
+        let src = find_entry(&tree, &workspace.join("src"))
+            .expect("unrelated shallow directory should be represented");
+        assert!(!src.loaded());
+        assert!(find_entry(&tree, &rule_path).is_none());
+
+        let skill_path =
+            warp_util::standardized_path::StandardizedPath::try_from_local(&skill_path).unwrap();
+        let rule_path =
+            warp_util::standardized_path::StandardizedPath::try_from_local(&rule_path).unwrap();
+        assert!(results
+            .project_skills()
+            .any(|content| content.path == skill_path && !content.is_directory));
+        assert!(!results
+            .project_rules()
+            .any(|content| content.path == rule_path));
+    });
+}
+
+#[test]
 fn ignored_directory_stays_lazy() {
     virtual_fs::VirtualFS::test("ignored_dir_lazy", |dirs, mut vfs| {
         vfs.mkdir("repo/target/debug")

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -14,7 +14,7 @@ use virtual_fs::{Stub, VirtualFS};
 use warp_util::standardized_path::StandardizedPath;
 use warpui_core::r#async::FutureExt as _;
 use warpui_core::App;
-#[cfg(all(unix, feature = "local_fs"))]
+#[cfg(feature = "local_fs")]
 use watcher::BulkFilesystemWatcherEvent;
 
 use crate::entry::{DirectoryEntry, Entry, FileMetadata};
@@ -448,6 +448,101 @@ fn test_lazy_loaded_path_does_not_build_standing_rule_results_below_shallow_tree
     });
 }
 
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_lazy_loaded_path_discovers_force_included_skills_and_emits_watcher_delta() {
+    VirtualFS::test("lazy_loaded_path_force_included_skills", |dirs, mut vfs| {
+        vfs.mkdir("workspace/.agents/skills/review")
+            .mkdir("workspace/src/deep")
+            .with_files(vec![
+                Stub::FileWithContent("workspace/.agents/skills/review/SKILL.md", "name: review"),
+                Stub::FileWithContent("workspace/src/deep/WARP.md", "project rules"),
+            ]);
+
+        let workspace = dirs.tests().join("workspace");
+        let skill_path = workspace.join(".agents/skills/review/SKILL.md");
+        let src_path = workspace.join("src");
+        let rule_path = workspace.join("src/deep/WARP.md");
+        App::test((), |mut app| async move {
+            let model_handle = app.add_model(|_| {
+                let mut model = LocalRepoMetadataModel::new_for_test();
+                model.register_force_included_paths([PathBuf::from(".agents/skills")]);
+                model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+                model
+            });
+            let workspace_path = StandardizedPath::from_local_canonicalized(&workspace).unwrap();
+            let skill_path = StandardizedPath::try_from_local(&skill_path).unwrap();
+            let src_path = StandardizedPath::try_from_local(&src_path).unwrap();
+            let rule_path = StandardizedPath::try_from_local(&rule_path).unwrap();
+
+            model_handle.update(&mut app, |model, ctx| {
+                model.index_lazy_loaded_path(&workspace_path, ctx).unwrap();
+            });
+
+            model_handle.read(&app, |model, _ctx| {
+                let Some(IndexedRepoState::Indexed(state)) =
+                    model.repository_state(&workspace_path)
+                else {
+                    panic!("expected indexed lazy-loaded path");
+                };
+                assert!(state.entry.contains(&skill_path));
+                assert!(
+                    matches!(state.entry.get(&src_path), Some(FileTreeEntryState::Directory(dir)) if !dir.loaded)
+                );
+                assert!(!state.entry.contains(&rule_path));
+
+                let results = model
+                    .standing_query_results(&workspace_path)
+                    .expect("lazy indexed paths should retain standing results");
+                assert!(results
+                    .project_skills()
+                    .any(|content| content.path == skill_path && !content.is_directory));
+                assert!(!results
+                    .project_rules()
+                    .any(|content| content.path == rule_path));
+            });
+
+            let (tx, rx) = oneshot::channel();
+            let received_delta = Rc::new(RefCell::new(Some(tx)));
+            let received_delta_for_event = received_delta.clone();
+            let workspace_path_for_event = workspace_path.clone();
+            let skill_path_for_event = skill_path.clone();
+            app.update(|ctx| {
+                ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
+                    if let RepositoryMetadataEvent::StandingQueryResultsUpdated { path, delta } =
+                        event
+                    {
+                        if path == &workspace_path_for_event
+                            && delta.upserted_project_skills.iter().any(|content| {
+                                content.path == skill_path_for_event && !content.is_directory
+                            })
+                        {
+                            if let Some(tx) = received_delta_for_event.borrow_mut().take() {
+                                let _ = tx.send(());
+                            }
+                        }
+                    }
+                });
+            });
+
+            let skill_path = skill_path.to_local_path().unwrap();
+            std::fs::write(&skill_path, "name: updated review").unwrap();
+            model_handle.update(&mut app, |model, ctx| {
+                model.handle_watcher_event(
+                    &BulkFilesystemWatcherEvent {
+                        modified: std::collections::HashSet::from([skill_path]),
+                        ..Default::default()
+                    },
+                    ctx,
+                );
+            });
+            rx.with_timeout(Duration::from_secs(5))
+                .await
+                .expect("timed out waiting for standing project-skill update")
+                .expect("standing project-skill update sender dropped");
+        });
+    });
+}
 #[cfg(feature = "local_fs")]
 #[test]
 fn test_index_directory_upgrades_lazy_loaded_path_to_repo() {


### PR DESCRIPTION
## Description
- Make force-included paths override the shallow tree depth limit.
- Preserve lazy loading for unrelated branches while discovering initial project skills.
- Verify existing watcher updates emit standing-query skill deltas.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- `./script/format`
- `./script/format --check`
- `cargo nextest run -p repo_metadata --features local_fs` (100 passed, 2 skipped)
- `cargo clippy -p repo_metadata --all-targets --tests --features local_fs -- -D warnings`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
<img width="682" height="622" alt="Screenshot 2026-06-04 at 5 34 43 PM" src="https://github.com/user-attachments/assets/3a198aac-83b7-46d1-ba08-2702c0bdf226" />

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Discover project skills under force-included paths when repo metadata is lazily loaded.

Co-Authored-By: Oz <oz-agent@warp.dev>