### PR TITLE
Make long-running command box resizable

### DIFF
--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -99,7 +99,6 @@ use crate::{send_telemetry_from_ctx, BlocklistAIHistoryModel, ToastStack};
 const MENU_WIDTH: f32 = 200.0;
 const MAX_HEIGHT: f32 = 320.0;
 const MIN_RESIZABLE_WIDTH: f32 = 360.0;
-const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
 const MIN_RESIZABLE_HEIGHT: f32 = 40.0;
 const MIN_REMAINING_WINDOW_WIDTH: f32 = 200.0;
 const MIN_REMAINING_WINDOW_HEIGHT: f32 = 100.0;
@@ -477,7 +476,7 @@ impl CLISubagentView {
             always_allow_read_files_checked,
             is_input_dismissed: false,
             input_dismiss_timer_handle: None,
-            resizable_width: resizable_state_handle(DEFAULT_RESIZABLE_WIDTH),
+            resizable_width: resizable_state_handle(MIN_RESIZABLE_WIDTH),
             resizable_height: resizable_state_handle(MAX_HEIGHT),
             current_working_directory,
             shell_launch_data,

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -971,8 +971,8 @@ impl View for CLISubagentView {
         let resizable_height = self
             .resizable_height
             .lock()
-            .expect("Resizable state should be accessible")
-            .size();
+            .map(|g| g.size())
+            .unwrap_or(DEFAULT_RESIZABLE_HEIGHT);
 
         let mut result = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -100,8 +100,6 @@ const MENU_WIDTH: f32 = 200.0;
 const MAX_HEIGHT: f32 = 320.0;
 const MIN_RESIZABLE_WIDTH: f32 = 280.0;
 const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
-// Small enough to stay under the layout constraint even for short blocks (2–3 rows),
-// while still keeping at least a couple of lines of text visible.
 const MIN_RESIZABLE_HEIGHT: f32 = 40.0;
 const AVATAR_RIGHT_MARGIN: f32 = 8.;
 const CONTENT_PADDING: f32 = 12.;

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -102,7 +102,6 @@ const MIN_RESIZABLE_WIDTH: f32 = 280.0;
 const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
 const MAX_RESIZABLE_WIDTH_RATIO: f32 = 0.75;
 const MIN_RESIZABLE_HEIGHT: f32 = 160.0;
-const DEFAULT_RESIZABLE_HEIGHT: f32 = MAX_HEIGHT;
 const MAX_RESIZABLE_HEIGHT_RATIO: f32 = 0.75;
 const AVATAR_RIGHT_MARGIN: f32 = 8.;
 const CONTENT_PADDING: f32 = 12.;
@@ -479,7 +478,7 @@ impl CLISubagentView {
             is_input_dismissed: false,
             input_dismiss_timer_handle: None,
             resizable_width: resizable_state_handle(DEFAULT_RESIZABLE_WIDTH),
-            resizable_height: resizable_state_handle(DEFAULT_RESIZABLE_HEIGHT),
+            resizable_height: resizable_state_handle(MAX_HEIGHT),
             current_working_directory,
             shell_launch_data,
             selected_text: Arc::new(RwLock::new(None)),
@@ -972,7 +971,7 @@ impl View for CLISubagentView {
             .resizable_height
             .lock()
             .map(|g| g.size())
-            .unwrap_or(DEFAULT_RESIZABLE_HEIGHT);
+            .unwrap_or(MAX_HEIGHT);
 
         let mut result = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -100,9 +100,7 @@ const MENU_WIDTH: f32 = 200.0;
 const MAX_HEIGHT: f32 = 320.0;
 const MIN_RESIZABLE_WIDTH: f32 = 280.0;
 const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
-const MAX_RESIZABLE_WIDTH_RATIO: f32 = 0.75;
 const MIN_RESIZABLE_HEIGHT: f32 = 160.0;
-const MAX_RESIZABLE_HEIGHT_RATIO: f32 = 0.75;
 const AVATAR_RIGHT_MARGIN: f32 = 8.;
 const CONTENT_PADDING: f32 = 12.;
 const ALLOW_ACTION_POSITION_ID: &str = "allow-action-position-id";
@@ -1400,21 +1398,13 @@ impl View for CLISubagentView {
         let width_resizable = Resizable::new(self.resizable_width.clone(), content)
             .with_dragbar_side(DragBarSide::Left)
             .on_resize(|ctx, _| ctx.notify())
-            .with_bounds_callback(Box::new(|window_size| {
-                let max_width =
-                    (window_size.x() * MAX_RESIZABLE_WIDTH_RATIO).max(MIN_RESIZABLE_WIDTH);
-                (MIN_RESIZABLE_WIDTH, max_width)
-            }))
+            .with_bounds_callback(Box::new(|_| (MIN_RESIZABLE_WIDTH, f32::MAX)))
             .finish();
 
         Resizable::new(self.resizable_height.clone(), width_resizable)
             .with_dragbar_side(DragBarSide::Top)
             .on_resize(|ctx, _| ctx.notify())
-            .with_bounds_callback(Box::new(|window_size| {
-                let max_height =
-                    (window_size.y() * MAX_RESIZABLE_HEIGHT_RATIO).max(MIN_RESIZABLE_HEIGHT);
-                (MIN_RESIZABLE_HEIGHT, max_height)
-            }))
+            .with_bounds_callback(Box::new(|_| (MIN_RESIZABLE_HEIGHT, f32::MAX)))
             .finish()
     }
 

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -98,7 +98,7 @@ use crate::workspace::WorkspaceAction;
 use crate::{send_telemetry_from_ctx, BlocklistAIHistoryModel, ToastStack};
 const MENU_WIDTH: f32 = 200.0;
 const MAX_HEIGHT: f32 = 320.0;
-const MIN_RESIZABLE_WIDTH: f32 = 280.0;
+const MIN_RESIZABLE_WIDTH: f32 = 360.0;
 const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
 const MIN_RESIZABLE_HEIGHT: f32 = 40.0;
 const MIN_REMAINING_WINDOW_WIDTH: f32 = 200.0;

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -101,6 +101,8 @@ const MAX_HEIGHT: f32 = 320.0;
 const MIN_RESIZABLE_WIDTH: f32 = 280.0;
 const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
 const MIN_RESIZABLE_HEIGHT: f32 = 40.0;
+const MIN_REMAINING_WINDOW_WIDTH: f32 = 200.0;
+const MIN_REMAINING_WINDOW_HEIGHT: f32 = 100.0;
 const AVATAR_RIGHT_MARGIN: f32 = 8.;
 const CONTENT_PADDING: f32 = 12.;
 const ALLOW_ACTION_POSITION_ID: &str = "allow-action-position-id";
@@ -1398,13 +1400,19 @@ impl View for CLISubagentView {
         let width_resizable = Resizable::new(self.resizable_width.clone(), content)
             .with_dragbar_side(DragBarSide::Left)
             .on_resize(|ctx, _| ctx.notify())
-            .with_bounds_callback(Box::new(|_| (MIN_RESIZABLE_WIDTH, f32::MAX)))
+            .with_bounds_callback(Box::new(|window_size| {
+                let max = (window_size.x() - MIN_REMAINING_WINDOW_WIDTH).max(MIN_RESIZABLE_WIDTH);
+                (MIN_RESIZABLE_WIDTH, max)
+            }))
             .finish();
 
         Resizable::new(self.resizable_height.clone(), width_resizable)
             .with_dragbar_side(DragBarSide::Top)
             .on_resize(|ctx, _| ctx.notify())
-            .with_bounds_callback(Box::new(|_| (MIN_RESIZABLE_HEIGHT, f32::MAX)))
+            .with_bounds_callback(Box::new(|window_size| {
+                let max = (window_size.y() - MIN_REMAINING_WINDOW_HEIGHT).max(MIN_RESIZABLE_HEIGHT);
+                (MIN_RESIZABLE_HEIGHT, max)
+            }))
             .finish()
     }
 

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -100,7 +100,9 @@ const MENU_WIDTH: f32 = 200.0;
 const MAX_HEIGHT: f32 = 320.0;
 const MIN_RESIZABLE_WIDTH: f32 = 280.0;
 const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
-const MIN_RESIZABLE_HEIGHT: f32 = 160.0;
+// Small enough to stay under the layout constraint even for short blocks (2–3 rows),
+// while still keeping at least a couple of lines of text visible.
+const MIN_RESIZABLE_HEIGHT: f32 = 40.0;
 const AVATAR_RIGHT_MARGIN: f32 = 8.;
 const CONTENT_PADDING: f32 = 12.;
 const ALLOW_ACTION_POSITION_ID: &str = "allow-action-position-id";

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -20,12 +20,13 @@ use warp_editor::render::element::VerticalExpansionBehavior;
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::new_scrollable::SingleAxisConfig;
 use warpui::elements::{
-    Border, ChildAnchor, ChildView, ClippedScrollStateHandle, ConstrainedBox, Container,
-    CornerRadius, CrossAxisAlignment, DropShadow, Empty, Expanded, Fill, Flex,
-    FormattedTextElement, Highlight, HighlightedHyperlink, Hoverable, MainAxisAlignment,
-    MainAxisSize, MouseStateHandle, NewScrollable, OffsetPositioning, ParentElement,
-    PositionedElementAnchor, PositionedElementOffsetBounds, Radius, SavePosition, SelectableArea,
-    SelectionHandle, Shrinkable, SizeConstraintCondition, SizeConstraintSwitch, Stack, Text,
+    resizable_state_handle, Border, ChildAnchor, ChildView, ClippedScrollStateHandle,
+    ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, DragBarSide, DropShadow, Empty,
+    Expanded, Fill, Flex, FormattedTextElement, Highlight, HighlightedHyperlink, Hoverable,
+    MainAxisAlignment, MainAxisSize, MouseStateHandle, NewScrollable, OffsetPositioning,
+    ParentElement, PositionedElementAnchor, PositionedElementOffsetBounds, Radius, Resizable,
+    ResizableStateHandle, SavePosition, SelectableArea, SelectionHandle, Shrinkable,
+    SizeConstraintCondition, SizeConstraintSwitch, Stack, Text,
 };
 use warpui::fonts::{Properties, Style, Weight};
 use warpui::keymap::{EditableBinding, Keystroke};
@@ -97,6 +98,12 @@ use crate::workspace::WorkspaceAction;
 use crate::{send_telemetry_from_ctx, BlocklistAIHistoryModel, ToastStack};
 const MENU_WIDTH: f32 = 200.0;
 const MAX_HEIGHT: f32 = 320.0;
+const MIN_RESIZABLE_WIDTH: f32 = 280.0;
+const DEFAULT_RESIZABLE_WIDTH: f32 = 480.0;
+const MAX_RESIZABLE_WIDTH_RATIO: f32 = 0.75;
+const MIN_RESIZABLE_HEIGHT: f32 = 160.0;
+const DEFAULT_RESIZABLE_HEIGHT: f32 = MAX_HEIGHT;
+const MAX_RESIZABLE_HEIGHT_RATIO: f32 = 0.75;
 const AVATAR_RIGHT_MARGIN: f32 = 8.;
 const CONTENT_PADDING: f32 = 12.;
 const ALLOW_ACTION_POSITION_ID: &str = "allow-action-position-id";
@@ -215,6 +222,8 @@ pub struct CLISubagentView {
 
     is_input_dismissed: bool,
     input_dismiss_timer_handle: Option<SpawnedFutureHandle>,
+    resizable_width: ResizableStateHandle,
+    resizable_height: ResizableStateHandle,
 
     current_working_directory: Option<String>,
     shell_launch_data: Option<ShellLaunchData>,
@@ -469,6 +478,8 @@ impl CLISubagentView {
             always_allow_read_files_checked,
             is_input_dismissed: false,
             input_dismiss_timer_handle: None,
+            resizable_width: resizable_state_handle(DEFAULT_RESIZABLE_WIDTH),
+            resizable_height: resizable_state_handle(DEFAULT_RESIZABLE_HEIGHT),
             current_working_directory,
             shell_launch_data,
             selected_text: Arc::new(RwLock::new(None)),
@@ -957,6 +968,11 @@ impl View for CLISubagentView {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
         let semantic_selection = SemanticSelection::handle(app).as_ref(app);
+        let resizable_height = self
+            .resizable_height
+            .lock()
+            .expect("Resizable state should be accessible")
+            .size();
 
         let mut result = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
@@ -1015,6 +1031,7 @@ impl View for CLISubagentView {
                         child: selectable_text.finish(),
                         background_color: internal_colors::accent_bg(theme).into(),
                         border: Some(Border::all(1.).with_border_fill(theme.accent())),
+                        max_height: resizable_height,
                     },
                     app,
                 )
@@ -1128,6 +1145,7 @@ impl View for CLISubagentView {
                                             border: Some(Border::all(1.).with_border_fill(
                                                 internal_colors::neutral_3(theme),
                                             )),
+                                            max_height: resizable_height,
                                         },
                                         app,
                                     )
@@ -1155,6 +1173,7 @@ impl View for CLISubagentView {
                                                 internal_colors::neutral_3(theme),
                                             ),
                                         ),
+                                        max_height: resizable_height,
                                     },
                                     app,
                                 )
@@ -1257,6 +1276,7 @@ impl View for CLISubagentView {
                         child: output.finish(),
                         background_color: internal_colors::neutral_2(appearance.theme()),
                         border: Some(output_border),
+                        max_height: resizable_height,
                     },
                     app,
                 )
@@ -1276,6 +1296,7 @@ impl View for CLISubagentView {
                                 input: input.clone(),
                                 mode,
                                 scroll_state: self.state_handles.input_scroll_state.clone(),
+                                max_height: resizable_height,
                             },
                             app,
                         )),
@@ -1376,7 +1397,26 @@ impl View for CLISubagentView {
             );
         }
 
-        result.finish()
+        let content = result.finish();
+        let width_resizable = Resizable::new(self.resizable_width.clone(), content)
+            .with_dragbar_side(DragBarSide::Left)
+            .on_resize(|ctx, _| ctx.notify())
+            .with_bounds_callback(Box::new(|window_size| {
+                let max_width =
+                    (window_size.x() * MAX_RESIZABLE_WIDTH_RATIO).max(MIN_RESIZABLE_WIDTH);
+                (MIN_RESIZABLE_WIDTH, max_width)
+            }))
+            .finish();
+
+        Resizable::new(self.resizable_height.clone(), width_resizable)
+            .with_dragbar_side(DragBarSide::Top)
+            .on_resize(|ctx, _| ctx.notify())
+            .with_bounds_callback(Box::new(|window_size| {
+                let max_height =
+                    (window_size.y() * MAX_RESIZABLE_HEIGHT_RATIO).max(MIN_RESIZABLE_HEIGHT);
+                (MIN_RESIZABLE_HEIGHT, max_height)
+            }))
+            .finish()
     }
 
     fn keymap_context(&self, app: &AppContext) -> warpui::keymap::Context {
@@ -1688,6 +1728,7 @@ struct ScrollableContainerProps {
     child: Box<dyn Element>,
     background_color: ColorU,
     border: Option<Border>,
+    max_height: f32,
 }
 
 fn render_scrollable_container(props: ScrollableContainerProps, _app: &AppContext) -> Container {
@@ -1696,6 +1737,7 @@ fn render_scrollable_container(props: ScrollableContainerProps, _app: &AppContex
         child,
         background_color,
         border,
+        max_height,
     } = props;
 
     let scrollable = NewScrollable::vertical(
@@ -1711,7 +1753,7 @@ fn render_scrollable_container(props: ScrollableContainerProps, _app: &AppContex
     .finish();
 
     let clipped = ConstrainedBox::new(scrollable)
-        .with_max_height(MAX_HEIGHT)
+        .with_max_height(max_height)
         .finish();
 
     let mut container = Container::new(clipped)
@@ -1895,6 +1937,7 @@ struct WriteToPtyInputProps {
     input: bytes::Bytes,
     mode: AIAgentPtyWriteMode,
     scroll_state: ClippedScrollStateHandle,
+    max_height: f32,
 }
 
 fn render_write_to_pty_input(props: WriteToPtyInputProps, app: &AppContext) -> Box<dyn Element> {
@@ -1902,6 +1945,7 @@ fn render_write_to_pty_input(props: WriteToPtyInputProps, app: &AppContext) -> B
         input,
         mode,
         scroll_state,
+        max_height,
     } = props;
 
     let appearance = Appearance::as_ref(app);
@@ -1947,7 +1991,7 @@ fn render_write_to_pty_input(props: WriteToPtyInputProps, app: &AppContext) -> B
     .finish();
 
     let clipped = ConstrainedBox::new(scrollable)
-        .with_max_height(MAX_HEIGHT)
+        .with_max_height(max_height)
         .finish();
 
     Container::new(clipped)

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -186,6 +186,8 @@ const SPACE_BETWEEN_SELECTED_BLOCK_AVATARS: f32 = 2.;
 
 const CLI_SUBAGENT_HORIZONTAL_MARGIN: f32 = 8.;
 const CLI_SUBAGENT_VERTICAL_MARGIN: f32 = 8.;
+const CLI_SUBAGENT_MAX_WIDTH_RATIO: f32 = 0.75;
+const CLI_SUBAGENT_MAX_HEIGHT_RATIO: f32 = 0.75;
 
 pub type LabelBuilderFn = dyn Fn(
     Vec<BlockIndex>,
@@ -3360,14 +3362,16 @@ impl Element for BlockListElement {
                                 self.cli_subagent_views.get_mut(block.id())
                             {
                                 let block_height = (height.as_f64() as f32) * cell_size.y();
+                                let max_width = (constraint.max.x() * CLI_SUBAGENT_MAX_WIDTH_RATIO
+                                    - CLI_SUBAGENT_HORIZONTAL_MARGIN)
+                                    .max(0.);
+                                let max_height = (block_height - CLI_SUBAGENT_VERTICAL_MARGIN * 2.)
+                                    .min(constraint.max.y() * CLI_SUBAGENT_MAX_HEIGHT_RATIO)
+                                    .max(0.);
                                 cli_subagent_view.layout(
                                     SizeConstraint {
                                         min: vec2f(0., 0.),
-                                        max: vec2f(
-                                            constraint.max.x() * 0.4
-                                                - CLI_SUBAGENT_HORIZONTAL_MARGIN,
-                                            block_height - CLI_SUBAGENT_VERTICAL_MARGIN * 2.,
-                                        ),
+                                        max: vec2f(max_width, max_height),
                                     },
                                     ctx,
                                     app,

--- a/crates/warpui_core/src/elements/resizable.rs
+++ b/crates/warpui_core/src/elements/resizable.rs
@@ -331,6 +331,15 @@ impl Element for Resizable {
         // Use the window size to set bounds on the width/height
         if let Some(bounds_callback) = self.bounds_callback.as_mut() {
             let mut new_bounds = bounds_callback(ctx.window_size);
+            // Also clamp the max bound to the parent layout constraint so the stored
+            // size never exceeds what can actually be rendered. Without this, on narrow
+            // panes the stored size can sit above the constraint max, creating a dead
+            // zone where dragging the handle produces no visual change.
+            let constraint_max = match self.direction {
+                ResizeDirection::Horizontal => constraint.max.x(),
+                ResizeDirection::Vertical => constraint.max.y(),
+            };
+            new_bounds.1 = new_bounds.1.min(constraint_max);
             if new_bounds.0 > new_bounds.1 {
                 log::error!("Resizable: min bound is greater than max bound");
                 new_bounds = (new_bounds.0, new_bounds.0);

--- a/crates/warpui_core/src/elements/resizable.rs
+++ b/crates/warpui_core/src/elements/resizable.rs
@@ -331,15 +331,6 @@ impl Element for Resizable {
         // Use the window size to set bounds on the width/height
         if let Some(bounds_callback) = self.bounds_callback.as_mut() {
             let mut new_bounds = bounds_callback(ctx.window_size);
-            // Also clamp the max bound to the parent layout constraint so the stored
-            // size never exceeds what can actually be rendered. Without this, on narrow
-            // panes the stored size can sit above the constraint max, creating a dead
-            // zone where dragging the handle produces no visual change.
-            let constraint_max = match self.direction {
-                ResizeDirection::Horizontal => constraint.max.x(),
-                ResizeDirection::Vertical => constraint.max.y(),
-            };
-            new_bounds.1 = new_bounds.1.min(constraint_max);
             if new_bounds.0 > new_bounds.1 {
                 log::error!("Resizable: min bound is greater than max bound");
                 new_bounds = (new_bounds.0, new_bounds.0);


### PR DESCRIPTION
## Description
Adds bounded resizing to the long-running command CLI subagent box that appears over the bottom-right of a running command block.

Users can now:
- Drag the left edge to resize the box width.
- Drag the top edge to resize the box height.

The resize bounds keep the box from taking over the whole pane, and the scrollable content areas use the resized height so expanded vertical space is useful.

## Testing
Loom: https://www.loom.com/share/046c6471b45a4f109b645ac6f5173bfd
I didn't speak in the Loom since I was in a public area.

### Screenshots / Videos
N/A - please see the Loom above.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Long-running command agent boxes can now be resized by dragging their top or left edge.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/7040184b-b262-42de-aac7-273e3ad155e8_
_Run: https://oz.staging.warp.dev/runs/019e94fe-aefc-7920-8c1c-ce81bb9984aa_
_This PR was generated with [Oz](https://warp.dev/oz)._
