### PR TITLE
Clean up LRC state logs for shared sessions

### DIFF
--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -2178,10 +2178,6 @@ impl TerminalManager {
                     if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
-                        log::info!(
-                            "[sharer] UniversalDeveloperInputContextUpdated: \
-                             applying LRC interaction_state={interaction_state:?}"
-                        );
                         terminal_view.update(ctx, |view, ctx| {
                             view.apply_long_running_command_agent_interaction_state(
                                 interaction_state,

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -731,6 +731,10 @@ impl Network {
             }
         }
 
+        sharer_info!(
+            self,
+            "sending universal developer input context update: {update:?}"
+        );
         self.apply_context_update_to_cache(update.clone());
         self.send_message_to_server(UpstreamMessage::UpdateUniversalDeveloperInputContext(
             update,

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -988,10 +988,6 @@ impl TerminalManager {
                     if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
-                        log::info!(
-                            "[viewer] UniversalDeveloperInputContextUpdated: \
-                             applying LRC interaction_state={interaction_state:?}"
-                        );
                         if let Some(view) = weak_view_handle.upgrade(ctx) {
                             view.update(ctx, |view, ctx| {
                                 view.apply_long_running_command_agent_interaction_state(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8008,11 +8008,21 @@ impl TerminalView {
         agent_has_control: bool,
         ctx: &mut ViewContext<Self>,
     ) {
-        let mut state = self.current_long_running_command_agent_interaction_state();
-        if agent_has_control {
-            log::warn!("emit_long_running_command_agent_interaction_state_changed called with agent_has_control=true, but current state is {state:?}. Overriding with InControl.");
-            state = LongRunningCommandAgentInteractionState::InControl;
-        }
+        let state = if agent_has_control {
+            LongRunningCommandAgentInteractionState::InControl
+        } else {
+            let is_tagged_in = self
+                .model
+                .lock()
+                .block_list()
+                .active_block()
+                .is_agent_tagged_in();
+            if is_tagged_in {
+                LongRunningCommandAgentInteractionState::TaggedIn
+            } else {
+                LongRunningCommandAgentInteractionState::NotInteracting
+            }
+        };
         ctx.emit(Event::LongRunningCommandAgentInteractionStateChanged { state });
     }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7989,30 +7989,30 @@ impl TerminalView {
         ctx.notify();
     }
 
+    fn current_long_running_command_agent_interaction_state(
+        &self,
+    ) -> LongRunningCommandAgentInteractionState {
+        let model = self.model.lock();
+        let active_block = model.block_list().active_block();
+        if active_block.is_agent_in_control() {
+            LongRunningCommandAgentInteractionState::InControl
+        } else if active_block.is_agent_tagged_in() {
+            LongRunningCommandAgentInteractionState::TaggedIn
+        } else {
+            LongRunningCommandAgentInteractionState::NotInteracting
+        }
+    }
+
     fn emit_long_running_command_agent_interaction_state_changed(
         &self,
         agent_has_control: bool,
         ctx: &mut ViewContext<Self>,
     ) {
-        let state = if agent_has_control {
-            LongRunningCommandAgentInteractionState::InControl
-        } else {
-            let is_tagged_in = self
-                .model
-                .lock()
-                .block_list()
-                .active_block()
-                .is_agent_tagged_in();
-            if is_tagged_in {
-                LongRunningCommandAgentInteractionState::TaggedIn
-            } else {
-                LongRunningCommandAgentInteractionState::NotInteracting
-            }
-        };
-        log::info!(
-            "emit_long_running_command_agent_interaction_state_changed: \
-             agent_has_control={agent_has_control}, emitting state={state:?}"
-        );
+        let mut state = self.current_long_running_command_agent_interaction_state();
+        if agent_has_control {
+            log::warn!("emit_long_running_command_agent_interaction_state_changed called with agent_has_control=true, but current state is {state:?}. Overriding with InControl.");
+            state = LongRunningCommandAgentInteractionState::InControl;
+        }
         ctx.emit(Event::LongRunningCommandAgentInteractionStateChanged { state });
     }
 
@@ -8022,6 +8022,10 @@ impl TerminalView {
         state: LongRunningCommandAgentInteractionState,
         ctx: &mut ViewContext<Self>,
     ) {
+        if self.current_long_running_command_agent_interaction_state() == state {
+            return;
+        }
+        log::info!("Applying shared-session LRC interaction_state={state:?}");
         match state {
             LongRunningCommandAgentInteractionState::InControl => {
                 self.cli_subagent_controller.update(ctx, |controller, ctx| {


### PR DESCRIPTION
## Description

The `emit_long_running_command_agent_interaction_state_changed` log was emitted even if we never actually sent an event over the shared session network. The network caches the previous state and avoids sending if nothing changed.

The `UniversalDeveloperInputContextUpdated: applying LRC interaction_state` log was emitted followed by an error log if we tried to apply a state that already matched our current state.

Clean up the log so only emitted when something changes, since it misled me when debugging some runs