### PR TITLE
Preserve wide-character invariants during no-reflow clear resize

### DIFF
--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2243,6 +2243,39 @@ fn test_full_grid_clear_resize_then_scroll_does_not_panic_on_row_iteration() {
 }
 
 #[test]
+fn test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary() {
+    let old_cols = 155;
+    let new_cols = 117;
+    let num_rows = 3;
+
+    let mut grid =
+        GridHandler::new_for_test_with_scroll_limit(num_rows, old_cols, MAX_SCROLL_LIMIT);
+    grid.enable_full_grid_clear_behavior();
+
+    for col in 0..116 {
+        grid.grid_storage_mut()[VisibleRow(0)][col].c = char::from(b'a' + (col as u8 % 26));
+    }
+    grid.grid_storage_mut()[VisibleRow(0)][116].c = '\u{4e2d}';
+    grid.grid_storage_mut()[VisibleRow(0)][116]
+        .flags
+        .insert(Flags::WIDE_CHAR);
+    grid.grid_storage_mut()[VisibleRow(0)][117]
+        .flags
+        .insert(Flags::WIDE_CHAR_SPACER);
+    grid.grid_storage_mut()[VisibleRow(0)].occ = old_cols;
+
+    grid.resize(SizeInfo::new_without_font_metrics(num_rows, new_cols));
+
+    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+
+    let row = grid.grid_storage()[VisibleRow(0)].clone();
+    grid.flat_storage.push_rows_without_truncation([&row]);
+    let rows = grid.flat_storage.pop_rows(1);
+
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
 fn test_full_grid_clear_resize_narrower_then_scroll_does_not_panic() {
     // Same scenario but resizing to a narrower width.
     let old_cols = 20;

--- a/app/src/terminal/model/grid/grid_storage/resize.rs
+++ b/app/src/terminal/model/grid/grid_storage/resize.rs
@@ -340,7 +340,20 @@ impl GridStorage {
 
             loop {
                 // Remove all cells which require reflowing.
-                let mut wrapped = match row.shrink(columns) {
+                let shrunk = row.shrink(columns);
+                if !reflow
+                    && columns > 0
+                    && row[columns - 1].flags().contains(Flags::WIDE_CHAR)
+                    && shrunk.as_ref().is_some_and(|wrapped| {
+                        wrapped
+                            .first()
+                            .is_some_and(|cell| cell.flags().contains(Flags::WIDE_CHAR_SPACER))
+                    })
+                {
+                    row[columns - 1].flags_mut().remove(Flags::WIDE_CHAR);
+                }
+
+                let mut wrapped = match shrunk {
                     Some(wrapped) if reflow => wrapped,
                     _ => {
                         let cursor_buffer_line =


### PR DESCRIPTION
## Description

Fixes a `RowIterator::next` crash that can occur after `FullGridClearBehavior::Clear` resizes the active grid without reflow.

In that path, `GridStorage::shrink_cols(reflow=false)` can truncate a valid wide-character pair between the `WIDE_CHAR` cell and its `WIDE_CHAR_SPACER`, leaving an orphaned final-column `WIDE_CHAR`. If that row later enters flat storage, materialization can attempt to write the missing spacer beyond the end of the row and panic.

This PR fixes the producer side of the issue: after no-reflow shrink, if the new final cell is `WIDE_CHAR` and the first discarded cell was its matching `WIDE_CHAR_SPACER`, the final cell is no longer marked as double-width. This preserves the row invariant after truncation and prevents `FlatStorage::pop_rows` / `RowIterator::next` from materializing an impossible spacer.

Scope note: this is intentionally a source-side fix for the confirmed `FullGridClearBehavior::Clear` + `shrink_cols(reflow=false)` producer. It does not claim to be a general hardening layer for every possible malformed flat-storage row.

## Linked Issue

Fixes #12243

- [ ] The linked issue is labeled `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Note: this is a non-visual crash fix. The linked issue includes sanitized crash-report and Warp-log excerpts plus the deterministic regression shape. The issue has already received automated triage labels `triaged` and `repro:high`, but it has not yet received `ready-to-implement`; please apply readiness during triage if appropriate.

## Testing

Automated regression coverage:

```text
cargo test -p warp -- test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary -- --nocapture
# 1 passed; 0 failed

cargo test -p warp -- test_full_grid_clear_resize -- --nocapture
# 3 passed; 0 failed

./script/format --check
# passed
```

`./script/presubmit` status:

```text
./script/presubmit
# Summary [1038.785s] 7227 tests run: 7220 passed (4 slow, 1 leaky), 6 failed, 1 timed out, 85 skipped
```

Observed presubmit failures:

```text
FAIL integration::integration shell_integration_tests::test_legacy_ssh_into_bash
FAIL integration::integration shell_integration_tests::test_legacy_ssh_into_zsh
FAIL integration::integration shell_integration_tests::test_ssh_into_ash
FAIL integration::integration shell_integration_tests::test_ssh_into_sh
FAIL integration::integration ui_tests::test_ssh_with_shell_override
FAIL warp ai::agent_sdk::driver::harness::codex::tests::resolve_openai_api_key_returns_value_from_resolved_map
TIMEOUT warp editor::view::model::buffer::tests::test_random_concurrent_operations
```

None of the observed failures are in the modified grid storage / row invariant tests. The focused regression tests for this PR pass, but the full presubmit run did not complete green in this local environment.

Regression red/green proof:

```text
# Before the fix, at commit 6dd1dcf4:
cargo test -p warp -- test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary -- --nocapture

running 1 test
test terminal::model::grid::grid_handler::tests::test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary ... FAILED

thread 'terminal::model::grid::grid_handler::tests::test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary' panicked at app/src/terminal/model/grid/grid_handler_tests.rs:1518:13:
Orphaned WIDE_CHAR at column 116: next cell is not a WIDE_CHAR_SPACER.

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4829 filtered out
```

The new regression test exercises the relevant producer path:

- Creates a 155-column `GridHandler`.
- Enables `FullGridClearBehavior::Clear`.
- Builds a valid wide-character pair at the shrink boundary: `WIDE_CHAR@116`, `WIDE_CHAR_SPACER@117`.
- Resizes through the real `grid.resize(...)` API to 117 columns.
- Asserts the row has no orphaned wide-character flags.
- Pushes/pops the row through flat storage to verify materialization no longer panics.

Manual testing:

- [x] I have manually tested my changes locally with `./script/run`

Manual testing note: `./script/run` built, bundled, signed, and launched `WarpOss.app` locally. The original user-visible crash depends on a narrow timing/layout condition involving command enter, clear hook handling, resize, and a wide-character boundary, so the deterministic `GridHandler` regression test is the primary proof for the confirmed producer-side corruption path.

### Screenshots / Videos

This is a non-visual crash fix. A screenshot is not meaningful for the code change itself. If maintainers request manual evidence, I can attach a short local smoke-test recording showing Warp running through resize/clear activity without crashing.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a crash that could occur after resizing CLI-agent terminal output containing wide characters.

Co-Authored-By: Warp <agent@warp.dev>
