### PR TITLE
Add setting to hide the title bar search bar in vertical tab layout

### DIFF
--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -90,9 +90,10 @@ use crate::window_settings::{
 };
 use crate::workspace::header_toolbar_editor::HeaderToolbarInlineEditor;
 use crate::workspace::tab_settings::{
-    DirectoryTabColor, PreserveActiveTabColor, ShowCodeReviewButton, ShowIndicatorsButton,
-    ShowVerticalTabPanelInRestoredWindows, TabCloseButtonPosition, TabSettings,
-    TabSettingsChangedEvent, UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
+    DirectoryTabColor, HideTitleBarSearchBarInVerticalTabs, PreserveActiveTabColor,
+    ShowCodeReviewButton, ShowIndicatorsButton, ShowVerticalTabPanelInRestoredWindows,
+    TabCloseButtonPosition, TabSettings, TabSettingsChangedEvent,
+    UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
     WorkspaceDecorationVisibility,
 };
 use crate::workspace::WorkspaceAction;
@@ -518,6 +519,7 @@ pub enum AppearancePageAction {
     TogglePreserveActiveTabColor,
     ToggleVerticalTabs,
     ToggleShowVerticalTabPanelInRestoredWindows,
+    ToggleHideTitleBarSearchBarInVerticalTabs,
     ToggleUseLatestUserPromptAsConversationTitleInTabNames,
     ToggleLigatureRendering,
     ToggleBlurTexture,
@@ -659,6 +661,9 @@ impl TypedActionView for AppearanceSettingsPageView {
             ToggleVerticalTabs => self.toggle_vertical_tabs(ctx),
             ToggleShowVerticalTabPanelInRestoredWindows => {
                 self.toggle_show_vertical_tab_panel_in_restored_windows(ctx)
+            }
+            ToggleHideTitleBarSearchBarInVerticalTabs => {
+                self.toggle_hide_title_bar_search_bar_in_vertical_tabs(ctx)
             }
             ToggleUseLatestUserPromptAsConversationTitleInTabNames => {
                 self.toggle_use_latest_user_prompt_as_conversation_title_in_tab_names(ctx)
@@ -1460,6 +1465,9 @@ impl AppearanceSettingsPageView {
             tab_settings_widgets.push(Box::new(VerticalTabsWidget::default()));
             tab_settings_widgets.push(Box::new(
                 ShowVerticalTabPanelInRestoredWindowsWidget::default(),
+            ));
+            tab_settings_widgets.push(Box::new(
+                HideTitleBarSearchBarInVerticalTabsWidget::default(),
             ));
             tab_settings_widgets.push(Box::new(
                 UseLatestUserPromptAsConversationTitleInTabNamesWidget::default(),
@@ -2395,6 +2403,14 @@ impl AppearanceSettingsPageView {
         TabSettings::handle(ctx).update(ctx, |settings, ctx| {
             report_if_error!(settings
                 .show_vertical_tab_panel_in_restored_windows
+                .toggle_and_save_value(ctx));
+        });
+    }
+
+    fn toggle_hide_title_bar_search_bar_in_vertical_tabs(&mut self, ctx: &mut ViewContext<Self>) {
+        TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+            report_if_error!(settings
+                .hide_title_bar_search_bar_in_vertical_tabs
                 .toggle_and_save_value(ctx));
         });
     }
@@ -4718,6 +4734,56 @@ impl SettingsWidget for ShowVerticalTabPanelInRestoredWindowsWidget {
                 .finish(),
             Some(
                 "When enabled, reopening or restoring a window opens the vertical tabs panel even if it was closed when the window was last saved."
+                    .to_string(),
+            ),
+        )
+    }
+}
+
+#[derive(Default)]
+struct HideTitleBarSearchBarInVerticalTabsWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for HideTitleBarSearchBarInVerticalTabsWidget {
+    type View = AppearanceSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "hide title bar search bar vertical tabs chrome minimal"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let tab_settings = TabSettings::as_ref(app);
+
+        render_body_item::<AppearancePageAction>(
+            "Hide search bar in vertical tab layout".into(),
+            None,
+            LocalOnlyIconState::for_setting(
+                HideTitleBarSearchBarInVerticalTabs::storage_key(),
+                HideTitleBarSearchBarInVerticalTabs::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .switch(self.switch_state.clone())
+                .check(*tab_settings.hide_title_bar_search_bar_in_vertical_tabs)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(
+                        AppearancePageAction::ToggleHideTitleBarSearchBarInVerticalTabs,
+                    );
+                })
+                .finish(),
+            Some(
+                "When using the vertical tab layout, hide the search bar in the title bar. Search stays available via the command palette and keyboard shortcuts."
                     .to_string(),
             ),
         )

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -496,6 +496,15 @@ define_settings_group!(TabSettings, settings: [
         toml_path: "appearance.vertical_tabs.show_panel_in_restored_windows",
         description: "When restoring a window, open the vertical tabs panel even if it was closed when the session was saved.",
     },
+    hide_title_bar_search_bar_in_vertical_tabs: HideTitleBarSearchBarInVerticalTabs {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "appearance.vertical_tabs.hide_title_bar_search_bar",
+        description: "When using the vertical tab layout, hide the search bar in the title bar. Search stays available via the command palette and keyboard shortcuts.",
+    },
     use_latest_user_prompt_as_conversation_title_in_tab_names: UseLatestUserPromptAsConversationTitleInTabNames {
         type: bool,
         default: false,

--- a/app/src/workspace/tab_settings_tests.rs
+++ b/app/src/workspace/tab_settings_tests.rs
@@ -60,6 +60,33 @@ fn show_vertical_tab_panel_in_restored_windows_uses_vertical_tabs_path() {
 }
 
 #[test]
+fn hide_title_bar_search_bar_in_vertical_tabs_defaults_to_false() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        TabSettings::handle(&app).read(&app, |settings, _ctx| {
+            assert!(!*settings.hide_title_bar_search_bar_in_vertical_tabs);
+        });
+    });
+}
+
+#[test]
+fn hide_title_bar_search_bar_in_vertical_tabs_uses_vertical_tabs_path() {
+    assert_eq!(
+        HideTitleBarSearchBarInVerticalTabs::toml_path(),
+        Some("appearance.vertical_tabs.hide_title_bar_search_bar")
+    );
+    assert_eq!(
+        HideTitleBarSearchBarInVerticalTabs::hierarchy(),
+        Some("appearance.vertical_tabs")
+    );
+    assert_eq!(
+        HideTitleBarSearchBarInVerticalTabs::toml_key(),
+        "hide_title_bar_search_bar"
+    );
+}
+
+#[test]
 fn header_toolbar_chip_selection_default_contains_code_review() {
     let config = HeaderToolbarChipSelection::Default;
     assert!(config.contains_item(&HeaderToolbarItemKind::CodeReview));

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3644,7 +3644,8 @@ impl Workspace {
                 ..
             }
             | TabSettingsChangedEvent::VerticalTabsShowPrLink { .. }
-            | TabSettingsChangedEvent::VerticalTabsShowDiffStats { .. } => {
+            | TabSettingsChangedEvent::VerticalTabsShowDiffStats { .. }
+            | TabSettingsChangedEvent::HideTitleBarSearchBarInVerticalTabs { .. } => {
                 ctx.notify();
             }
             TabSettingsChangedEvent::VerticalTabsShowDetailsOnHover { .. } => {
@@ -19381,25 +19382,33 @@ impl Workspace {
 
             let left_padding = self.compute_tab_bar_left_padding(ctx);
 
-            let tab_bar = Flex::row()
-                .with_main_axis_size(MainAxisSize::Max)
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(tab_bar.finish())
-                .with_child(
-                    Shrinkable::new(
-                        1.,
-                        Clipped::new(
-                            Container::new(
-                                Align::new(self.render_title_bar_search_bar(appearance)).finish(),
-                            )
-                            .with_padding_left(TITLE_BAR_SEARCH_BAR_SLOT_PADDING)
-                            .with_padding_right(TITLE_BAR_SEARCH_BAR_SLOT_PADDING)
-                            .finish(),
+            // The title bar search bar can be hidden via a user setting; when hidden,
+            // an empty flexible slot keeps the right-side controls aligned to the right.
+            let hide_search_bar =
+                *TabSettings::as_ref(ctx).hide_title_bar_search_bar_in_vertical_tabs;
+            let search_bar_slot = if hide_search_bar {
+                Expanded::new(1., Empty::new().finish()).finish()
+            } else {
+                Shrinkable::new(
+                    1.,
+                    Clipped::new(
+                        Container::new(
+                            Align::new(self.render_title_bar_search_bar(appearance)).finish(),
                         )
+                        .with_padding_left(TITLE_BAR_SEARCH_BAR_SLOT_PADDING)
+                        .with_padding_right(TITLE_BAR_SEARCH_BAR_SLOT_PADDING)
                         .finish(),
                     )
                     .finish(),
                 )
+                .finish()
+            };
+
+            let tab_bar = Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(tab_bar.finish())
+                .with_child(search_bar_slot)
                 .with_child(right_controls.finish())
                 .finish();
 


### PR DESCRIPTION
## Description

Adds a user setting that hides the search bar in the title bar when the vertical tab layout is active, per #12218. Users on vertical tabs who prefer minimal top chrome can remove the search bar from the title bar; search remains reachable through the command palette and keyboard shortcuts.

The new setting is `appearance.vertical_tabs.hide_title_bar_search_bar` (boolean, default off). When vertical tabs are active and the setting is on, the title-bar search bar is replaced by an empty flexible slot, so the right-side controls stay right-aligned. The change lives entirely inside the vertical-tabs render path, so **horizontal tab layouts are unaffected**.

The toggle appears under **Settings → Appearance → Tabs** ("Hide search bar in vertical tab layout"), shown only when the vertical tabs feature is enabled — mirroring the existing vertical-tabs toggles.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

Fixes #12218

## Testing
- [x] `cargo fmt -- --check`
- [x] `cargo check -p warp`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [x] `cargo nextest run -p warp hide_title_bar_search_bar` — 2/2 passing (new: defaults-to-false + toml-path)
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos


https://github.com/user-attachments/assets/2f7f8e04-e2b7-44c7-b1a7-fc655609a8a7

_Toggling **Settings → Appearance → Tabs → “Hide search bar in vertical tab layout”** while in vertical tab mode: the title-bar search bar is hidden when the setting is **ON** (right-side controls stay right-aligned) and restored when **OFF**. Horizontal tab layouts are unaffected._

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NEW-FEATURE: Add a setting to hide the title bar search bar in vertical tab layouts (Settings → Appearance → Tabs).
-->

