### PR TITLE
Support multi tab selection actions for horizontal tabs

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -772,6 +772,12 @@ pub struct TabComponent<'a> {
     grouped_member: bool,
     /// Set when this member is the sole tab in its group.
     sole_grouped_member: bool,
+    /// Locator pointing at this tab's focused pane.
+    locator: PaneViewLocator,
+    /// True when this tab is part of a multi-tab (count > 1) selection. Drives
+    /// both the in-selection highlight and the right-click menu dispatch
+    /// (multi-tab menu vs single-tab menu).
+    is_in_multi_tab_selection: bool,
 }
 
 /// Structure that holds TabComponent styles.
@@ -914,6 +920,12 @@ impl<'a> TabComponent<'a> {
             .background_opacity
             .effective_opacity(window_id, ctx)
             .clamp(20, 100);
+        let pane_group_id = tab.pane_group.id();
+        let pane_id = tab.pane_group.as_ref(ctx).focused_pane_id(ctx);
+        let locator = PaneViewLocator {
+            pane_group_id,
+            pane_id,
+        };
         Self {
             tab: tab.clone(),
             tab_bar,
@@ -934,6 +946,8 @@ impl<'a> TabComponent<'a> {
             for_drag_ghost: false,
             grouped_member: false,
             sole_grouped_member: false,
+            locator,
+            is_in_multi_tab_selection: false,
         }
     }
 
@@ -951,6 +965,14 @@ impl<'a> TabComponent<'a> {
     pub fn for_grouped_member(mut self, is_sole_member: bool) -> Self {
         self.grouped_member = true;
         self.sole_grouped_member = is_sole_member;
+        self
+    }
+
+    /// Marks this tab as part of a multi-tab selection (count > 1). When set,
+    /// the tab renders with the in-selection highlight and right-clicks
+    /// dispatch the multi-tab selection menu instead of the single-tab menu.
+    pub fn with_multi_tab_selection(mut self, is_in_multi_tab_selection: bool) -> Self {
+        self.is_in_multi_tab_selection = is_in_multi_tab_selection;
         self
     }
 
@@ -1390,11 +1412,12 @@ impl<'a> TabComponent<'a> {
     ) -> Box<dyn Element> {
         let theme = self.appearance.theme();
         let is_active = self.is_active_tab();
+        let is_in_multi_tab_selection = self.is_in_multi_tab_selection;
 
         let (background_color, border_fill) = if FeatureFlag::NewTabStyling.is_enabled() {
             // If there is a custom tab background, we overlay it with varying opacities.
             let bg = if let Some(custom_background) = self.styles.background {
-                let base_opacity = if is_active {
+                let base_opacity = if is_active || is_in_multi_tab_selection {
                     60
                 } else if is_hovered {
                     40
@@ -1413,7 +1436,11 @@ impl<'a> TabComponent<'a> {
                 }
             } else if is_active {
                 internal_colors::fg_overlay_2(theme).into()
-            } else if is_hovered {
+            } else if is_in_multi_tab_selection && is_hovered {
+                // Hovering a multi-selected tab steps one shade darker so the
+                // hover stays distinguishable from the in-selection highlight.
+                internal_colors::fg_overlay_2(theme).into()
+            } else if is_in_multi_tab_selection || is_hovered {
                 internal_colors::fg_overlay_1(theme).into()
             } else {
                 Fill::None
@@ -1695,6 +1722,8 @@ impl UiComponent for TabComponent<'_> {
         // Capture before `self` is moved into the Hoverable closure below.
         let for_drag_ghost = self.for_drag_ghost;
         let sole_grouped_member = self.sole_grouped_member;
+        let locator = self.locator;
+        let is_in_multi_tab_selection = self.is_in_multi_tab_selection;
 
         // Extract values before moving self into closure
         let tooltip_text = self.tooltip_message.clone();
@@ -1832,17 +1861,25 @@ impl UiComponent for TabComponent<'_> {
             .with_hover_in_delay(Duration::from_millis(500));
         }
 
-        // Copy the values so they can be passed within the on_click and on_right_click handlers
-
         // We only want the on_click action to take effect on the tab, if it's not being renamed at a moment.
         // Note that clicking on other tabs is still ok.
         if !is_tab_being_renamed {
-            tab = tab.on_mouse_down(move |ctx, _app, _| {
-                let is_hovered = mouse_close_state
+            // Modifier-aware mouse-down: shift extends the selection range,
+            // cmd toggles a tab in/out of the selection, plain press
+            // activates.
+            tab = tab.on_mouse_down_with_modifiers(move |ctx, _, _, modifiers| {
+                let close_hovered = mouse_close_state
                     .lock()
                     .expect("lock acquired")
                     .is_hovered();
-                if !is_hovered {
+                if close_hovered {
+                    return;
+                }
+                if modifiers.shift && FeatureFlag::GroupedTabs.is_enabled() {
+                    ctx.dispatch_typed_action(WorkspaceAction::ShiftSelectTabRange { locator });
+                } else if modifiers.cmd && FeatureFlag::GroupedTabs.is_enabled() {
+                    ctx.dispatch_typed_action(WorkspaceAction::ToggleTabMultiSelection { locator });
+                } else {
                     ctx.dispatch_typed_action(WorkspaceAction::ActivateTab(tab_index));
                 }
             });
@@ -1853,12 +1890,23 @@ impl UiComponent for TabComponent<'_> {
         }
 
         tab = tab.on_right_click(move |ctx, _app, position| {
-            ctx.dispatch_typed_action(WorkspaceAction::ToggleTabRightClickMenu {
-                tab_index,
-                anchor: TabContextMenuAnchor::Pointer(position),
-            });
+            let anchor = TabContextMenuAnchor::Pointer(position);
+            if is_in_multi_tab_selection {
+                ctx.dispatch_typed_action(WorkspaceAction::ToggleTabSelectionRightClickMenu {
+                    tab_index,
+                    anchor,
+                });
+            } else {
+                // Right-clicking outside the multi-selection cancels it.
+                if FeatureFlag::GroupedTabs.is_enabled() {
+                    ctx.dispatch_typed_action(WorkspaceAction::ClearTabMultiSelection);
+                }
+                ctx.dispatch_typed_action(WorkspaceAction::ToggleTabRightClickMenu {
+                    tab_index,
+                    anchor,
+                });
+            }
         });
-
         if ContextFlag::CloseWindow.is_enabled() || !is_last_tab {
             tab = tab.on_middle_click(move |ctx, _app, _position| {
                 ctx.dispatch_typed_action(WorkspaceAction::CloseTab(tab_index));

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -18852,6 +18852,7 @@ impl Workspace {
             is_drag_target,
             ctx,
         )
+        .with_multi_tab_selection(self.is_tab_in_multi_tab_selection(tab_index))
         .build()
         .finish()
     }
@@ -18915,6 +18916,7 @@ impl Workspace {
                     ctx,
                 )
                 .for_grouped_member(is_sole_member)
+                .with_multi_tab_selection(self.is_tab_in_multi_tab_selection(idx))
                 .build()
                 .finish();
                 row.add_child(member);
@@ -25296,21 +25298,30 @@ impl View for Workspace {
         }
 
         // Multi-tab selection menu (reuses the `tab_right_click_menu` view).
+        // Rendered for both the horizontal tab bar and the vertical tabs panel
+        // — the right-click handlers on both surfaces dispatch the same action.
         if let Some((_tab_idx, anchor)) = self.show_tab_selection_right_click_menu {
             let is_vertical = FeatureFlag::VerticalTabs.is_enabled()
                 && *TabSettings::as_ref(app).use_vertical_tabs
                 && self.vertical_tabs_panel_open;
-            if is_vertical {
+            if tab_bar_mode.has_tab_bar() || is_vertical {
                 let position = match anchor {
                     TabContextMenuAnchor::Pointer(position) => position,
                     // The selection menu is never opened via the kebab button.
                     TabContextMenuAnchor::VerticalTabsKebab => Vector2F::zero(),
                 };
+                // Vertical-tabs anchors against the window; the horizontal tab
+                // bar uses unbounded positioning to match the single-tab menu.
+                let bounds = if is_vertical {
+                    ParentOffsetBounds::WindowByPosition
+                } else {
+                    ParentOffsetBounds::Unbounded
+                };
                 stack.add_positioned_overlay_child(
                     ChildView::new(&self.tab_right_click_menu).finish(),
                     OffsetPositioning::offset_from_parent(
                         position,
-                        ParentOffsetBounds::WindowByPosition,
+                        bounds,
                         ParentAnchor::TopLeft,
                         ChildAnchor::TopLeft,
                     ),

--- a/crates/warpui_core/src/elements/hoverable.rs
+++ b/crates/warpui_core/src/elements/hoverable.rs
@@ -22,6 +22,11 @@ type ClickHandler = Box<dyn FnMut(&mut EventContext, &AppContext, Vector2F)>;
 type ClickWithModifiersHandler =
     Box<dyn FnMut(&mut EventContext, &AppContext, Vector2F, ModifiersState)>;
 
+/// Mouse-down handler that additionally receives the keyboard modifiers held
+/// at press time, captured from the `LeftMouseDown` event. 
+type MouseDownWithModifiersHandler =
+    Box<dyn FnMut(&mut EventContext, &AppContext, Vector2F, ModifiersState)>;
+
 pub struct Hoverable {
     child: Box<dyn Element>,
     state: MouseStateHandle,
@@ -34,6 +39,9 @@ pub struct Hoverable {
     // but the callback also receives the keyboard modifiers held at click time.
     click_with_modifiers_handler: Option<ClickWithModifiersHandler>,
     mouse_down_handler: Option<ClickHandler>,
+    // Fires on `LeftMouseDown` and additionally receives the keyboard modifiers
+    // held at press time.
+    mouse_down_with_modifiers_handler: Option<MouseDownWithModifiersHandler>,
     double_click_handler: Option<ClickHandler>,
     middle_click_handler: Option<ClickHandler>,
     right_click_handler: Option<ClickHandler>,
@@ -201,6 +209,7 @@ impl Hoverable {
             click_handler: None,
             click_with_modifiers_handler: None,
             mouse_down_handler: None,
+            mouse_down_with_modifiers_handler: None,
             double_click_handler: None,
             middle_click_handler: None,
             right_click_handler: None,
@@ -273,6 +282,18 @@ impl Hoverable {
         F: 'static + FnMut(&mut EventContext, &AppContext, Vector2F),
     {
         self.mouse_down_handler = Some(Box::new(callback));
+        self
+    }
+
+    /// Fires on `LeftMouseDown`, with the keyboard modifiers held at press time.
+    /// Use this when you need both press-based timing (snappy activation,
+    /// drag-implies-activate) and modifier-aware branching (e.g. shift/cmd-click
+    /// extending a selection).
+    pub fn on_mouse_down_with_modifiers<F>(mut self, callback: F) -> Self
+    where
+        F: 'static + FnMut(&mut EventContext, &AppContext, Vector2F, ModifiersState),
+    {
+        self.mouse_down_with_modifiers_handler = Some(Box::new(callback));
         self
     }
 
@@ -642,10 +663,18 @@ impl Element for Hoverable {
             Event::LeftMouseDown {
                 click_count,
                 position,
+                modifiers,
                 ..
             } => {
                 // Mouse-down sets the mouse state handle accordingly.
                 self.state().click_count = Some(*click_count);
+
+                // Fire the mouse-down-with-modifiers handler immediately if set.
+                if let Some(handler) = self.mouse_down_with_modifiers_handler.as_mut() {
+                    handler(ctx, app, *position, *modifiers);
+                    ctx.notify();
+                    return true;
+                }
 
                 // Fire the mouse-down handler immediately if one is set.
                 if let Some(handler) = self.mouse_down_handler.as_mut() {

--- a/crates/warpui_core/src/elements/hoverable.rs
+++ b/crates/warpui_core/src/elements/hoverable.rs
@@ -23,7 +23,7 @@ type ClickWithModifiersHandler =
     Box<dyn FnMut(&mut EventContext, &AppContext, Vector2F, ModifiersState)>;
 
 /// Mouse-down handler that additionally receives the keyboard modifiers held
-/// at press time, captured from the `LeftMouseDown` event. 
+/// at press time, captured from the `LeftMouseDown` event.
 type MouseDownWithModifiersHandler =
     Box<dyn FnMut(&mut EventContext, &AppContext, Vector2F, ModifiersState)>;
 


### PR DESCRIPTION
## Description
Adds shift-click range selection, cmd-click multi tab select, and the multi-tab right-click menu (create group from tabs, move to group, remove from group) to the horizontal tab bar. Clicking a tab while holding shift selects every tab between the currently active tab and the clicked tab, and renders an accent highlight on the selected range. Clicking a tab while holding command individually selects that tab and renders the same highlight. Right-clicking a tab that's part of a multi-tab selection opens the multi-tab menu. Plain clicks (or drags) clear the selection.

Follow up to [this PR](https://github.com/warpdotdev/warp/pull/12229)

This brings the horizontal tab bar to feature parity with the multi-select + group actions already available on the vertical tabs panel. Everything is gated behind the tab grouping feature flag, so behavior remains unchanged when it is off.

## How it works

This PR reuses all the existing multi tab selection logic from vertical tabs. Most of the changes are rendering and variable plumbing: threads `is_in_multi_tab_selection` through TabComponent, branches the existing right-click handler on it (chooses to display multi-tab menu vs single-tab menu), and extends the shared multi-tab selection menu render block in view.rs to fire for the horizontal tab bar too. 

One thing worth flagging: I added a new `MouseDownWithModifiersHandler` to Hoverable. Horizontal tabs originally used `on_mouse_down` rather than `on_click` (where the existing modifier handler lives) for dispatching click actions on tabs. I chose to reimplement this for mouse down rather than switching to this to an `on_click` to preserve existing behavior and UX. For example, currently a tab is set as active on mouse down, so starting a tab drag makes it active. If we changed this to `on_click` rather than using `on_mouse_down` this would change the UX which I believe is a regression. 


## Linked Issue

https://linear.app/warpdotdev/issue/APP-4654/group-creation-from-multi-select-for-horizontal-tabs

## Testing
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

[Demo video](https://www.loom.com/share/fa9909a4866842a6a12f767c609b27f1)

This demo video shows several different multi tab selection scenarios via shift-click and cmd-click, as well as different combinations of actions from the multi tab selection menu.