### PR TITLE
Show context-available slash commands in CLI agent rich input

### DIFF
--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -342,12 +342,6 @@ impl SlashCommandDataSource {
         if command.name == commands::HOST.name && !context.has_default_host {
             return false;
         }
-        // When CLI agent input is open, restrict to the explicit allowlist.
-        if context.is_cli_agent_input
-            && !Self::CLI_AGENT_INPUT_ALLOWED_COMMANDS.contains(&command.name)
-        {
-            return false;
-        }
 
         true
     }


### PR DESCRIPTION
When a CLI agent's rich input is open, Warp gates its slash-command menu to a hardcoded allowlist (`/prompts`, `/skills`). Remove that gate so all of Warp's normally context-available commands are offered while composing a prompt for a running CLI agent (Claude Code, Codex, etc.), the same set shown in the regular input.

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
When you try to type /commands into the CLI rich input, you are restricted to /skills and /prompts. Eliminating this check, gives us /commands back.

Closes issue #12263

## Linked Issue
https://github.com/warpdotdev/warp/issues/12263
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Before:
<img width="3840" height="2117" alt="WarpCurrent" src="https://github.com/user-attachments/assets/f305bcae-df7c-4a7a-b4de-77e8f3da9e15" />
After:
<img width="3840" height="2117" alt="WarpGateRemoved" src="https://github.com/user-attachments/assets/3e96407f-0c4b-4dba-b644-a2c6499e03d3" />


<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
