### PR TITLE
Release Gemini integration to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -650,6 +650,7 @@ default = [
     "hoa_onboarding_flow",
     "hoa_remote_control",
     "codex_notifications",
+    "gemini_notifications",
     "trim_trailing_blank_lines",
     "open_warp_new_settings_modes",
     "skip_firebase_anonymous_user",
@@ -989,6 +990,7 @@ hoa_onboarding_flow = []
 git_operations_in_code_review = []
 hoa_remote_control = []
 codex_notifications = []
+gemini_notifications = []
 codex_plugin = []
 cloud_mode_setup_v2 = ["cloud_mode"]
 cloud_mode_input_v2 = ["cloud_mode"]

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -479,6 +479,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::HOARemoteControl,
         #[cfg(feature = "codex_notifications")]
         FeatureFlag::CodexNotifications,
+        #[cfg(feature = "gemini_notifications")]
+        FeatureFlag::GeminiNotifications,
         #[cfg(feature = "codex_plugin")]
         FeatureFlag::CodexPlugin,
         #[cfg(feature = "trim_trailing_blank_lines")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -932,7 +932,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::CodeReviewScrollPreservation,
     FeatureFlag::RememberFastForwardState,
     FeatureFlag::CodexPlugin,
-    FeatureFlag::GeminiNotifications,
     FeatureFlag::LocalDockerSandbox,
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,


### PR DESCRIPTION
## Summary
- Promote the Gemini CLI notification integration from dogfood-only to stable/prod.
- Add the `gemini_notifications` Cargo feature and enable it in the default feature set.
- Bridge `gemini_notifications` to `FeatureFlag::GeminiNotifications` and remove the dogfood rollout entry.

## Validation
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all --check`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/577a3da4-f226-4319-8ccf-531a901a3c47_
_Run: https://oz.staging.warp.dev/runs/019e9943-cefe-7a25-8d05-391f8091d647_

_This PR was generated with [Oz](https://warp.dev/oz)._
