### PR TITLE
feat: make repo pulling by agents done in parallel

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1424,22 +1424,25 @@ impl AgentDriver {
         foreground: &ModelSpawner<Self>,
         global_skill_repos: &[GithubRepo],
     ) -> Result<(), AgentDriverError> {
-        for repo in global_skill_repos {
-            let repo = repo.clone();
-            let repo_for_log = repo.clone();
-            let clone_future = foreground
-                .spawn(move |me, ctx| {
-                    let working_dir = me.working_dir.clone();
-                    me.terminal_driver.update(ctx, |_, ctx| {
-                        let spawner = ctx.spawner();
-                        async move { environment::clone_repo(&repo, &working_dir, &spawner).await }
-                    })
-                })
-                .await?;
+        if global_skill_repos.is_empty() {
+            return Ok(());
+        }
 
-            if let Err(err) = clone_future.await {
-                log::warn!("Failed to clone global-skill repo {repo_for_log}: {err}");
-            }
+        let global_skill_repos = global_skill_repos.to_vec();
+        let clone_future = foreground
+            .spawn(move |me, ctx| {
+                let working_dir = me.working_dir.clone();
+                me.terminal_driver.update(ctx, |_, ctx| {
+                    let spawner = ctx.spawner();
+                    async move {
+                        environment::clone_repos(&global_skill_repos, &working_dir, &spawner).await
+                    }
+                })
+            })
+            .await?;
+
+        if let Err(err) = clone_future.await {
+            log::warn!("Failed to clone one or more global-skill repos: {err}");
         }
 
         Ok(())

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -269,6 +269,11 @@ fn build_parallel_clone_command(repos: &[GithubRepo], shell_type: ShellType) -> 
         r#"set +e
 failed=0
 pids=""
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/warp-clone-logs.XXXXXX")"
+cleanup_clone_logs() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup_clone_logs EXIT
 clone_repo() {
   repo_name="$1"
   repo_url="$2"
@@ -283,16 +288,27 @@ clone_repo() {
 "#,
     );
 
-    for repo in repos {
+    let mut log_outputs = String::new();
+    for (index, repo) in repos.iter().enumerate() {
         let repo_name = format!("{}/{}", repo.owner, repo.repo);
         let repo_url = format!("https://github.com/{repo_name}.git");
         let escaped_repo_name = shell_escape_single_quotes(&repo_name, ShellType::Bash);
         let escaped_repo_url = shell_escape_single_quotes(&repo_url, ShellType::Bash);
         let escaped_target = shell_escape_single_quotes(&repo.repo, ShellType::Bash);
+        let log_var = format!("log_file_{index}");
         script.push_str(&format!(
-            "clone_repo '{escaped_repo_name}' '{escaped_repo_url}' '{escaped_target}' &\n"
+            "{log_var}=\"$tmp_dir/repo-{index}.log\"\n\
+             clone_repo '{escaped_repo_name}' '{escaped_repo_url}' '{escaped_target}' >\"${log_var}\" 2>&1 &\n"
         ));
         script.push_str("pids=\"$pids $!\"\n");
+        log_outputs.push_str(&format!(
+            "printf '%s\\n' '===== {escaped_repo_name} ====='\n\
+             if [ -s \"${log_var}\" ]; then\n\
+             \tcat \"${log_var}\"\n\
+             else\n\
+             \tprintf '%s\\n' '(no output)'\n\
+             fi\n"
+        ));
     }
 
     script.push_str(
@@ -301,6 +317,11 @@ clone_repo() {
     failed=1
   fi
 done
+"#,
+    );
+    script.push_str(&log_outputs);
+    script.push_str(
+        r#"
 exit "$failed"
 "#,
     );

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -130,8 +130,9 @@ async fn prepare_environment_impl(
     if !github_repos.is_empty() {
         setup_events
             .record_result(SetupStep::EnvironmentRepoClone, async {
+                clone_repos(github_repos, working_dir, spawner).await?;
                 for repo in github_repos {
-                    ensure_repo_cloned(repo, working_dir, is_sandbox, spawner).await?;
+                    register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
                     if !is_sandbox && should_index_codebase {
                         let receiver = index_repo_codebase(
                             &repo.repo,
@@ -263,6 +264,97 @@ fn record_codebase_indexing(
     });
 }
 
+fn build_parallel_clone_command(repos: &[GithubRepo], shell_type: ShellType) -> String {
+    let mut script = String::from(
+        r#"set +e
+failed=0
+pids=""
+clone_repo() {
+  repo_name="$1"
+  repo_url="$2"
+  target="$3"
+  if [ -d "$target" ]; then
+    printf '%s\n' "Repository directory $target already exists, skipping clone..."
+    return 0
+  fi
+  printf '%s\n' "Cloning repository $repo_name..."
+  git clone --filter=tree:0 "$repo_url" "$target"
+}
+"#,
+    );
+
+    for repo in repos {
+        let repo_name = format!("{}/{}", repo.owner, repo.repo);
+        let repo_url = format!("https://github.com/{repo_name}.git");
+        let escaped_repo_name = shell_escape_single_quotes(&repo_name, ShellType::Bash);
+        let escaped_repo_url = shell_escape_single_quotes(&repo_url, ShellType::Bash);
+        let escaped_target = shell_escape_single_quotes(&repo.repo, ShellType::Bash);
+        script.push_str(&format!(
+            "clone_repo '{escaped_repo_name}' '{escaped_repo_url}' '{escaped_target}' &\n"
+        ));
+        script.push_str("pids=\"$pids $!\"\n");
+    }
+
+    script.push_str(
+        r#"for pid in $pids; do
+  if ! wait "$pid"; then
+    failed=1
+  fi
+done
+exit "$failed"
+"#,
+    );
+
+    let escaped_script = shell_escape_single_quotes(&script, shell_type);
+    format!("sh -c '{escaped_script}'")
+}
+
+/// Clone all GitHub repositories to `{working_dir}/{repo.repo}` if they do not already exist.
+/// Multiple repositories are cloned in parallel to reduce environment setup time.
+pub(super) async fn clone_repos(
+    repos: &[GithubRepo],
+    working_dir: &Path,
+    spawner: &ModelSpawner<TerminalDriver>,
+) -> Result<(), PrepareEnvironmentError> {
+    match repos {
+        [] => Ok(()),
+        [repo] => clone_repo(repo, working_dir, spawner).await,
+        repos => {
+            let shell_type = spawner
+                .spawn(|driver, ctx| {
+                    driver
+                        .active_session_shell_type(ctx)
+                        .unwrap_or(ShellType::Bash)
+                })
+                .await
+                .unwrap_or(ShellType::Bash);
+
+            let repo_names = repos
+                .iter()
+                .map(|repo| format!("{}/{}", repo.owner, repo.repo))
+                .collect::<Vec<_>>();
+            safe_info!(
+                safe: ("Cloning repositories via terminal"),
+                full: ("Cloning repositories via terminal: {}", repo_names.join(", "))
+            );
+
+            let command = build_parallel_clone_command(repos, shell_type);
+            let exit_code = execute_command(command, spawner).await?;
+            if exit_code != 0.into() {
+                return Err(PrepareEnvironmentError::CloneRepo {
+                    repo_name: repo_names.join(", "),
+                });
+            }
+
+            safe_info!(
+                safe: ("Successfully cloned repositories"),
+                full: ("Successfully cloned repositories: {}", repo_names.join(", "))
+            );
+            Ok(())
+        }
+    }
+}
+
 /// Clone a GitHub repository to `{working_dir}/{repo.repo}` if it does not already exist.
 /// This only performs the clone -- it does NOT register the repo with `DetectedRepositories`.
 pub(super) async fn clone_repo(
@@ -323,16 +415,14 @@ pub(super) async fn clone_repo(
     Ok(())
 }
 
-/// Clone a GitHub repository and register it with `DetectedRepositories` so that
-/// the skill watcher and other repo-aware subsystems can discover it.
-pub(super) async fn ensure_repo_cloned(
+/// Register a cloned GitHub repository with `DetectedRepositories` so that the
+/// skill watcher and other repo-aware subsystems can discover it.
+pub(super) async fn register_cloned_repo(
     repo: &GithubRepo,
     working_dir: &Path,
     is_sandbox: bool,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<(), PrepareEnvironmentError> {
-    clone_repo(repo, working_dir, spawner).await?;
-
     let repo_dir = working_dir.join(&repo.repo);
 
     // Register the repo with DetectedRepositories so that the skill watcher

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -1,5 +1,6 @@
-use super::single_repo_name;
+use super::{build_parallel_clone_command, single_repo_name};
 use crate::ai::cloud_environments::GithubRepo;
+use crate::terminal::shell::ShellType;
 
 #[test]
 fn single_repo_name_returns_repo_when_exactly_one_repo() {
@@ -21,4 +22,25 @@ fn single_repo_name_returns_none_for_zero_or_many_repos() {
         GithubRepo::new("warpdotdev".to_string(), "warp-server".to_string()),
     ];
     assert_eq!(single_repo_name(&two_repos), None);
+}
+
+#[test]
+fn parallel_clone_command_runs_repos_in_background_and_waits() {
+    let repos = vec![
+        GithubRepo::new("warpdotdev".to_string(), "warp".to_string()),
+        GithubRepo::new("warpdotdev".to_string(), "warp-server".to_string()),
+    ];
+
+    let command = build_parallel_clone_command(&repos, ShellType::Bash);
+
+    assert!(command.starts_with("sh -c '"));
+    assert!(command.contains("warpdotdev/warp"));
+    assert!(command.contains("https://github.com/warpdotdev/warp.git"));
+    assert!(command.contains("warpdotdev/warp-server"));
+    assert!(command.contains("https://github.com/warpdotdev/warp-server.git"));
+    assert_eq!(command.matches("clone_repo").count(), 3);
+    assert_eq!(command.matches("&").count(), 2);
+    assert!(command.contains("pids=\"$pids $!\""));
+    assert!(command.contains("wait \"$pid\""));
+    assert!(command.contains("exit \"$failed\""));
 }

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -39,8 +39,19 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
     assert!(command.contains("warpdotdev/warp-server"));
     assert!(command.contains("https://github.com/warpdotdev/warp-server.git"));
     assert_eq!(command.matches("clone_repo").count(), 3);
-    assert_eq!(command.matches("&").count(), 2);
+    assert_eq!(command.matches("2>&1 &").count(), 2);
+    assert!(command.contains("mktemp -d"));
+    assert!(command.contains("warp-clone-logs"));
+    assert!(command.contains("trap cleanup_clone_logs EXIT"));
+    assert!(command.contains("repo-0.log"));
+    assert!(command.contains("repo-1.log"));
+    assert!(command.contains(">\"$log_file_0\" 2>&1 &"));
+    assert!(command.contains(">\"$log_file_1\" 2>&1 &"));
     assert!(command.contains("pids=\"$pids $!\""));
     assert!(command.contains("wait \"$pid\""));
+    assert!(command.contains("===== warpdotdev/warp ====="));
+    assert!(command.contains("cat \"$log_file_0\""));
+    assert!(command.contains("===== warpdotdev/warp-server ====="));
+    assert!(command.contains("cat \"$log_file_1\""));
     assert!(command.contains("exit \"$failed\""));
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR makes repo pulling in agent mode done in parallel rather than done sequentially. Oz environments with many repos can take a long time currently to start up, and much of that time is due to pulling in multiple large repos one after another. 
## Linked Issue
https://linear.app/warpdotdev/issue/REMOTE-1867/parallelize-environment-repo-cloning-to-speed-up-startup

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->
Before:
<img width="489" height="600" alt="image" src="https://github.com/user-attachments/assets/9b9ebae5-cd02-4819-8887-c1bb0bd22615" />


After:
<img width="489" height="600" alt="image" src="https://github.com/user-attachments/assets/95052d3e-09bd-4420-9653-18295f600901" />

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
