### PR TITLE
[QUALITY-814] Update child agent input placeholder

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -143,7 +143,7 @@ use super::view::{
 };
 use super::warpify::SubshellSource;
 use super::{prompt, History, HistoryEntry, SizeInfo, TerminalModel, UpArrowHistoryConfig};
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 use crate::ai::agent::{AIAgentContext, AIAgentExchangeId, CancellationReason, EntrypointType};
 use crate::ai::agent_conversations_model::{
     AgentConversationNavigationSubject, AgentConversationsModel,
@@ -452,6 +452,22 @@ const AGENT_MODE_AI_ENABLED_STEER_HINT_TEXT_CLASSIC: &str =
 const AGENT_MODE_AI_ENABLED_FOLLOW_UP_HINT_TEXT_UDI: &str = "Ask a follow up";
 const AGENT_MODE_AI_ENABLED_FOLLOW_UP_HINT_TEXT_CLASSIC: &str =
     "Ask a follow up, or backspace to exit";
+
+/// Returns the child-agent placeholder text, including the child agent's display name.
+fn child_agent_hint_text(conversation: &AIConversation) -> Option<Cow<'static, str>> {
+    if !conversation.is_child_agent_conversation() {
+        return None;
+    }
+
+    let agent_name = conversation.agent_name().unwrap_or("child");
+    if conversation.status().is_in_progress() {
+        Some(Cow::Owned(format!("Steer the {agent_name} agent")))
+    } else {
+        Some(Cow::Owned(format!(
+            "Ask the {agent_name} agent a follow up"
+        )))
+    }
+}
 
 /// Action name for setting input mode to agent mode
 pub const SET_INPUT_MODE_AGENT_ACTION_NAME: &str = "input:set_mode_agent";
@@ -5983,7 +5999,7 @@ impl Input {
     // Returns the appropriate hint/placeholder text to render in an empty input when Agent Mode is
     // enabled (the feature flag, not the specific AI input mode). This method ensures that hint text
     // is cached when needed for new conversations.
-    fn agent_mode_hint_text(&mut self, app: &AppContext) -> &str {
+    fn agent_mode_hint_text(&mut self, app: &AppContext) -> Cow<'static, str> {
         let input_model = self.ai_input_model.as_ref(app);
         let is_udi_enabled = InputSettings::as_ref(app).is_universal_developer_input_enabled(app);
 
@@ -5991,12 +6007,24 @@ impl Input {
             input_model.input_type(),
             input_model.should_run_input_autodetection(app),
         ) {
-            (InputType::Shell, false) => AGENT_MODE_AI_DISABLED_AUTODETECTION_DISABLED_HINT_TEXT,
+            (InputType::Shell, false) => {
+                Cow::Borrowed(AGENT_MODE_AI_DISABLED_AUTODETECTION_DISABLED_HINT_TEXT)
+            }
             (InputType::Shell, true) => {
                 // Ensure hint text is cached for new conversations
-                get_stable_agent_mode_hint_text(&mut self.cached_agent_mode_hint_text)
+                Cow::Borrowed(get_stable_agent_mode_hint_text(
+                    &mut self.cached_agent_mode_hint_text,
+                ))
             }
             (InputType::AI, _) => {
+                if let Some(hint) = self
+                    .ai_context_model
+                    .as_ref(app)
+                    .selected_conversation(app)
+                    .and_then(child_agent_hint_text)
+                {
+                    return hint;
+                }
                 // Follow the `agent_indicator` pattern (see `app/src/tab.rs`):
                 //  * `None` (no conversation, empty, passive, or untitled) => new conversation => "Warp anything"
                 //  * `InProgress`                                           => agent running    => "Steer"
@@ -6008,21 +6036,23 @@ impl Input {
                 {
                     Some(status) if status.is_in_progress() => {
                         if is_udi_enabled {
-                            AGENT_MODE_AI_ENABLED_STEER_HINT_TEXT_UDI
+                            Cow::Borrowed(AGENT_MODE_AI_ENABLED_STEER_HINT_TEXT_UDI)
                         } else {
-                            AGENT_MODE_AI_ENABLED_STEER_HINT_TEXT_CLASSIC
+                            Cow::Borrowed(AGENT_MODE_AI_ENABLED_STEER_HINT_TEXT_CLASSIC)
                         }
                     }
                     Some(_) => {
                         if is_udi_enabled {
-                            AGENT_MODE_AI_ENABLED_FOLLOW_UP_HINT_TEXT_UDI
+                            Cow::Borrowed(AGENT_MODE_AI_ENABLED_FOLLOW_UP_HINT_TEXT_UDI)
                         } else {
-                            AGENT_MODE_AI_ENABLED_FOLLOW_UP_HINT_TEXT_CLASSIC
+                            Cow::Borrowed(AGENT_MODE_AI_ENABLED_FOLLOW_UP_HINT_TEXT_CLASSIC)
                         }
                     }
                     None => {
                         // Ensure hint text is cached for new conversations
-                        get_stable_agent_mode_hint_text(&mut self.cached_agent_mode_hint_text)
+                        Cow::Borrowed(get_stable_agent_mode_hint_text(
+                            &mut self.cached_agent_mode_hint_text,
+                        ))
                     }
                 }
             }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -6484,6 +6484,88 @@ fn cli_session_status_updates_single_child_conversation_without_agent_view() {
     })
 }
 
+/// Regression test for child-agent input placeholder text.
+#[test]
+fn child_agent_input_placeholder_mentions_child_agent_name() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let _agent_view = FeatureFlag::AgentView.override_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        let child_conversation_id = terminal.update(&mut app, |view, ctx| {
+            let parent_conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    history_model.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+            let child_conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    history_model.start_new_child_conversation(
+                        view.view_id,
+                        "Planner".to_string(),
+                        parent_conversation_id,
+                        None,
+                        ctx,
+                    )
+                });
+
+            view.enter_agent_view(
+                None,
+                Some(child_conversation_id),
+                AgentViewEntryOrigin::ChildAgent,
+                ctx,
+            );
+            view.input.update(ctx, |input, ctx| {
+                input.ai_input_model().update(ctx, |ai_input, ctx| {
+                    ai_input.set_input_config(
+                        InputConfig {
+                            input_type: InputType::AI,
+                            is_locked: true,
+                        },
+                        true,
+                        None,
+                        ctx,
+                    );
+                });
+                input.set_zero_state_hint_text(ctx);
+            });
+
+            child_conversation_id
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let placeholder_text = view
+                .input
+                .as_ref(ctx)
+                .editor()
+                .as_ref(ctx)
+                .placeholder_text("");
+            assert_eq!(placeholder_text, Some("Steer the Planner agent"));
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                let conversation = history
+                    .conversation_mut(&child_conversation_id)
+                    .expect("child conversation should exist");
+                conversation.update_status(ConversationStatus::Success, view.view_id, ctx);
+            });
+            view.input
+                .update(ctx, |input, ctx| input.set_zero_state_hint_text(ctx));
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let placeholder_text = view
+                .input
+                .as_ref(ctx)
+                .editor()
+                .as_ref(ctx)
+                .placeholder_text("");
+            assert_eq!(placeholder_text, Some("Ask the Planner agent a follow up"));
+        });
+    })
+}
+
 #[test]
 fn manual_dismiss_disables_auto_toggle_for_session() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

Updates the Agent Mode input placeholder for child-agent conversations so the empty input clearly targets the child agent instead of the orchestrator:

- In-progress child agents show: `Steer the <agent name> agent`
- Non-in-progress child agents show: `Ask the <agent name> agent a follow up`
- Parent/non-child agent conversations keep the existing generic placeholder behavior.

## Linked Issue

QUALITY-814

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all`
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml --all --check`
- `cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --tests`
- Added regression coverage in `app/src/terminal/view_tests.rs` for in-progress and completed child-agent placeholders.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not included; compile-only validation was used for this change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/86a117cf-0e93-409f-92b5-02adf206f679_
_Run: https://oz.staging.warp.dev/runs/019e996b-3c90-7f41-9ba2-612b0523624b_
_This PR was generated with [Oz](https://warp.dev/oz)._
