### PR TITLE
Enable IME on X11.

### DIFF
--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -1416,6 +1416,18 @@ fn create_window(
         .create_window(window_attributes)
         .map_err(Into::into);
 
+    #[cfg(target_os = "linux")]
+    if let Ok(window) = created_window.as_ref() {
+        use wgpu::rwh::RawDisplayHandle;
+        let is_x11 = matches!(
+            window_target.display_handle().map(|dh| dh.as_raw()),
+            Ok(RawDisplayHandle::Xlib(_)) | Ok(RawDisplayHandle::Xcb(_))
+        );
+        if is_x11 {
+            window.set_ime_allowed(true);
+        }
+    }
+
     #[cfg(windows)]
     {
         use super::windows::WindowExt;


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fixes https://github.com/warpdotdev/warp/issues/11543 by enabling the IME for X11 only. There is an issue with for KDE/Wayland users where some sort of infinite loop occurs. While someone (me or community member) investigates that, we can enable it for a large chunk of users.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

I tested that the IME is not enabled with Wayland.

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

