### PR TITLE
Preserve environment secrets through CLI and desktop-form updates (REMOTE-1880)

### DIFF
--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -3,7 +3,8 @@
 #[cfg_attr(target_family = "wasm", expect(unused_imports))]
 pub use cloud_object_models::{
     AmbientAgentEnvironment, AwsProviderConfig, BaseImage, CloudAmbientAgentEnvironment,
-    CloudAmbientAgentEnvironmentModel, GcpProviderConfig, GithubRepo, ProvidersConfig,
+    CloudAmbientAgentEnvironmentModel, EnvironmentSecretRef, GcpProviderConfig, GithubRepo,
+    ProvidersConfig,
 };
 use cloud_objects::cloud_object::Owner;
 use warpui::{AppContext, SingletonEntity as _};

--- a/app/src/settings_view/environments_page.rs
+++ b/app/src/settings_view/environments_page.rs
@@ -272,6 +272,9 @@ impl EnvironmentsPageView {
                         selected_repos: model.github_repos.clone(),
                         docker_image: model.base_image.to_string(),
                         setup_commands: model.setup_commands.clone(),
+                        // Carry the existing secrets opaquely so a desktop-form
+                        // save does not wipe a secrets list set via the web UI.
+                        secrets: model.secrets.clone(),
                     }
                 });
 

--- a/app/src/settings_view/update_environment_form.rs
+++ b/app/src/settings_view/update_environment_form.rs
@@ -31,7 +31,7 @@ use super::settings_page::{render_input_list, InputListItem};
 use crate::ai::ambient_agents::github_auth_notifier::{GitHubAuthEvent, GitHubAuthNotifier};
 use crate::ai::ambient_agents::github_auth_url::{self, AuthSource, GithubAuthRedirectTarget};
 use crate::ai::ambient_agents::telemetry::CloudAgentTelemetryEvent;
-use crate::ai::cloud_environments::{AmbientAgentEnvironment, GithubRepo};
+use crate::ai::cloud_environments::{AmbientAgentEnvironment, EnvironmentSecretRef, GithubRepo};
 use crate::appearance::Appearance;
 use crate::editor::{
     EditorOptions, EditorView, PropagateAndNoOpNavigationKeys, SingleLineEditorOptions, TextOptions,
@@ -91,6 +91,14 @@ pub struct EnvironmentFormValues {
     pub selected_repos: Vec<GithubRepo>,
     pub docker_image: String,
     pub setup_commands: Vec<String>,
+    /// Secrets from the existing environment, preserved opaquely through the
+    /// edit flow so that a save via the desktop form does not inadvertently
+    /// clear a secrets list that was configured via the web UI.
+    ///
+    /// The desktop environment form does not expose a secrets editor yet, so
+    /// this field is never modified — it is only carried through from the
+    /// initial environment model and written back unchanged on submit.
+    pub secrets: Option<Vec<EnvironmentSecretRef>>,
 }
 
 impl EnvironmentFormValues {
@@ -113,13 +121,15 @@ impl EnvironmentFormValues {
             }
         };
 
-        AmbientAgentEnvironment::new(
+        let mut env = AmbientAgentEnvironment::new(
             self.name.trim().to_string(),
             description,
             self.selected_repos.clone(),
             self.docker_image.trim().to_string(),
             setup_commands,
-        )
+        );
+        env.secrets = self.secrets.clone();
+        env
     }
 
     /// Validates the form values.

--- a/app/src/settings_view/update_environment_form_tests.rs
+++ b/app/src/settings_view/update_environment_form_tests.rs
@@ -287,6 +287,7 @@ fn test_environment_form_values_default() {
     assert!(form_state.docker_image.is_empty());
     assert!(form_state.setup_commands.is_empty());
     assert!(form_state.selected_repos.is_empty());
+    assert!(form_state.secrets.is_none());
 }
 
 #[test]
@@ -309,6 +310,7 @@ fn test_edit_mode_initializes_form_state_from_initial_values() {
                     "pip install -r requirements.txt".to_string(),
                     "pytest".to_string(),
                 ],
+                secrets: None,
             };
 
             let view_handle = ctx.add_typed_action_view(window_id, |ctx| {
@@ -682,6 +684,7 @@ fn test_can_suggest_image_for_edit_requires_repos_modified() {
             )],
             docker_image: "ubuntu:latest".to_string(),
             setup_commands: vec![],
+            secrets: None,
         };
 
         app.update(|ctx| {
@@ -784,6 +787,7 @@ fn test_render_docker_image_field_shows_suggest_image_button_on_edit() {
                 selected_repos: vec![],
                 docker_image: "ubuntu:latest".to_string(),
                 setup_commands: vec![],
+                secrets: None,
             };
 
             let view_handle = ctx.add_typed_action_view(window_id, |ctx| {

--- a/crates/cloud_object_models/src/cloud_environment.rs
+++ b/crates/cloud_object_models/src/cloud_environment.rs
@@ -72,6 +72,13 @@ impl ProvidersConfig {
     }
 }
 
+/// A reference to a managed secret by name.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnvironmentSecretRef {
+    /// The managed secret name.
+    pub name: String,
+}
+
 /// An AmbientAgentEnvironment represents an environment that we would run a Warp agent in.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AmbientAgentEnvironment {
@@ -93,6 +100,19 @@ pub struct AmbientAgentEnvironment {
     /// Optional cloud provider configurations for automatic auth.
     #[serde(default, skip_serializing_if = "ProvidersConfig::is_empty")]
     pub providers: ProvidersConfig,
+    /// Default secrets for runs using this environment.
+    ///
+    /// Semantics mirror the server-side model:
+    /// - `None` (field absent in JSON): no environment-level secret scoping; the run
+    ///   falls back to injecting all accessible secrets (legacy behaviour).
+    /// - `Some([])`: no secrets are injected by default.
+    /// - `Some([…])`: only the named secrets are injected.
+    ///
+    /// This field must be round-tripped faithfully so that a CLI update (which only
+    /// modifies name/repos/etc.) does not accidentally clear a secrets list that was
+    /// configured via the UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<Vec<EnvironmentSecretRef>>,
 }
 
 impl AmbientAgentEnvironment {
@@ -110,6 +130,7 @@ impl AmbientAgentEnvironment {
             base_image: BaseImage::DockerImage(docker_image),
             setup_commands,
             providers: ProvidersConfig::default(),
+            secrets: None,
         }
     }
 }

--- a/crates/cloud_object_models/src/cloud_environment_tests.rs
+++ b/crates/cloud_object_models/src/cloud_environment_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AmbientAgentEnvironment, AwsProviderConfig, BaseImage, GcpProviderConfig, GithubRepo,
-    ProvidersConfig,
+    AmbientAgentEnvironment, AwsProviderConfig, BaseImage, EnvironmentSecretRef, GcpProviderConfig,
+    GithubRepo, ProvidersConfig,
 };
 
 #[test]
@@ -176,4 +176,125 @@ fn roundtrip_serde_with_providers() {
     let serialized = serde_json::to_string(&env).unwrap();
     let deserialized: AmbientAgentEnvironment = serde_json::from_str(&serialized).unwrap();
     assert_eq!(env, deserialized);
+}
+
+// --- Secrets field tests ---
+
+#[test]
+fn secrets_none_omits_field_in_serialization() {
+    // Environments created via new() should have secrets=None, which must be
+    // omitted from the serialized JSON so the server interprets it as
+    // "no environment-level scoping" (legacy all-secrets behaviour).
+    let env = AmbientAgentEnvironment::new(
+        "env".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+    let json = serde_json::to_value(&env).unwrap();
+    assert!(!json.as_object().unwrap().contains_key("secrets"));
+}
+
+#[test]
+fn secrets_empty_vec_serializes_as_empty_array() {
+    // An environment with an empty secrets list must serialize as `"secrets": []`
+    // so the server stores "no secrets" rather than omitting the field.
+    let mut env = AmbientAgentEnvironment::new(
+        "env".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+    env.secrets = Some(vec![]);
+    let json = serde_json::to_value(&env).unwrap();
+    let secrets = json.get("secrets").expect("secrets field must be present");
+    assert_eq!(secrets, &serde_json::json!([]));
+}
+
+#[test]
+fn secrets_specific_list_serializes_correctly() {
+    let mut env = AmbientAgentEnvironment::new(
+        "env".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+    env.secrets = Some(vec![
+        EnvironmentSecretRef { name: "API_KEY".into() },
+        EnvironmentSecretRef { name: "DB_PASS".into() },
+    ]);
+    let json = serde_json::to_value(&env).unwrap();
+    let secrets = json.get("secrets").expect("secrets field must be present");
+    assert_eq!(
+        secrets,
+        &serde_json::json!([{"name": "API_KEY"}, {"name": "DB_PASS"}])
+    );
+}
+
+#[test]
+fn deserialize_environment_with_secrets_list() {
+    // When the server returns an environment with specific secrets, the client
+    // must deserialize and round-trip them correctly so a CLI update does not
+    // accidentally wipe the secrets (regression test for REMOTE-1880).
+    let json = serde_json::json!({
+        "name": "secret-env",
+        "github_repos": [],
+        "docker_image": "ubuntu:latest",
+        "secrets": [{"name": "MY_SECRET"}, {"name": "OTHER_SECRET"}]
+    });
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+    let secrets = env.secrets.expect("secrets must be Some");
+    assert_eq!(secrets.len(), 2);
+    assert_eq!(secrets[0].name, "MY_SECRET");
+    assert_eq!(secrets[1].name, "OTHER_SECRET");
+}
+
+#[test]
+fn deserialize_environment_with_empty_secrets_list() {
+    let json = serde_json::json!({
+        "name": "no-secret-env",
+        "github_repos": [],
+        "docker_image": "ubuntu:latest",
+        "secrets": []
+    });
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+    assert_eq!(env.secrets, Some(vec![]));
+}
+
+#[test]
+fn deserialize_environment_without_secrets_field_gives_none() {
+    // Legacy environments without a secrets field must deserialize with secrets=None,
+    // preserving the "all secrets" behaviour.
+    let json = serde_json::json!({
+        "name": "legacy-env",
+        "github_repos": [],
+        "docker_image": "ubuntu:latest"
+    });
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+    assert_eq!(env.secrets, None);
+}
+
+#[test]
+fn roundtrip_preserves_secrets() {
+    // Core regression test: serializing an environment that has secrets and
+    // deserializing the result must produce the same secrets list.  This
+    // simulates what happens during a CLI update: the existing environment is
+    // read, modified (e.g. name changed), and written back.
+    let mut env = AmbientAgentEnvironment::new(
+        "env-with-secrets".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+    env.secrets = Some(vec![
+        EnvironmentSecretRef { name: "SECRET_A".into() },
+    ]);
+
+    let serialized = serde_json::to_string(&env).unwrap();
+    let deserialized: AmbientAgentEnvironment = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(env.secrets, deserialized.secrets);
 }


### PR DESCRIPTION
## Description

Preserve environment secrets through CLI and desktop-form updates.

When a user updates an environment via the Warp CLI (`oz environment update`) or via the desktop Settings form, any secrets configured on the environment were silently cleared. Updating via the web UI (Oz web app) was unaffected.

**Root cause:** `AmbientAgentEnvironment` — the Rust model used by both the CLI and the desktop Settings form — did not include a `secrets` field. The update path serializes the full model to JSON and sends it to the server via `updateGenericStringObject`. Because `secrets` was absent from the struct, the resulting JSON had no `secrets` field, and the server replaced the stored model with the new one, wiping the existing secrets.

**Fix:**

- Add `EnvironmentSecretRef` struct to `cloud_object_models` (mirrors the server-side `types.EnvironmentSecretRef`).
- Add `secrets: Option<Vec<EnvironmentSecretRef>>` to `AmbientAgentEnvironment` with `skip_serializing_if = "Option::is_none"` so that `None` (the legacy "all secrets" / no scoping semantics) is omitted from JSON, maintaining backward compatibility.
- Add `secrets` to `EnvironmentFormValues` (desktop settings form) and populate it from the existing environment model when entering Edit mode, so that saving via the desktop form also preserves the secrets list.
- Add comprehensive serde round-trip tests.

**Semantics (unchanged on server side):**
- `None` / field absent in JSON → no environment-level secret scoping (legacy all-secrets behaviour)
- `Some([])` → no secrets injected by default
- `Some([...])` → only the listed secrets are injected

## Linked Issue

- Linear: REMOTE-1880

## Testing

- Added unit tests covering all secrets serialization/deserialization cases in `cloud_environment_tests.rs` — all pass.
- `cargo check --workspace` passes.

<!-- CHANGELOG-BUG-FIX: Fixed CLI `environment update` and desktop Settings form silently clearing environment secrets configured via the web UI. -->

---

_Conversation: https://staging.warp.dev/conversation/b9871fd3-d8b7-4397-9e87-2745f24287fc_
_Run: https://oz.staging.warp.dev/runs/019e999a-4d71-7044-a696-680ab82ff9fa_
_This PR was generated with [Oz](https://warp.dev/oz)._
