### PR TITLE
fix: add secrets field to AmbientAgentEnvironment to prevent CLI updates from resetting secrets [REMOTE-1880]

### DIFF
--- a/crates/cloud_object_models/src/cloud_environment.rs
+++ b/crates/cloud_object_models/src/cloud_environment.rs
@@ -72,6 +72,12 @@ impl ProvidersConfig {
     }
 }
 
+/// Identifies a managed secret configured on an environment.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnvironmentSecretRef {
+    pub name: String,
+}
+
 /// An AmbientAgentEnvironment represents an environment that we would run a Warp agent in.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AmbientAgentEnvironment {
@@ -93,6 +99,12 @@ pub struct AmbientAgentEnvironment {
     /// Optional cloud provider configurations for automatic auth.
     #[serde(default, skip_serializing_if = "ProvidersConfig::is_empty")]
     pub providers: ProvidersConfig,
+    /// Default set of managed secrets for runs using this environment.
+    ///   - `None`: no environment-level secret scoping (all secrets / defer to run config)
+    ///   - `Some([])`: no secrets by default
+    ///   - `Some([...])`: these specific secrets are the default
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<Vec<EnvironmentSecretRef>>,
 }
 
 impl AmbientAgentEnvironment {
@@ -110,6 +122,7 @@ impl AmbientAgentEnvironment {
             base_image: BaseImage::DockerImage(docker_image),
             setup_commands,
             providers: ProvidersConfig::default(),
+            secrets: None,
         }
     }
 }

--- a/crates/cloud_object_models/src/cloud_environment_tests.rs
+++ b/crates/cloud_object_models/src/cloud_environment_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AmbientAgentEnvironment, AwsProviderConfig, BaseImage, GcpProviderConfig, GithubRepo,
-    ProvidersConfig,
+    AmbientAgentEnvironment, AwsProviderConfig, BaseImage, EnvironmentSecretRef, GcpProviderConfig,
+    GithubRepo, ProvidersConfig,
 };
 
 #[test]
@@ -172,6 +172,103 @@ fn roundtrip_serde_with_providers() {
             role_arn: "arn:aws:iam::1:role/r".into(),
         }),
     };
+
+    let serialized = serde_json::to_string(&env).unwrap();
+    let deserialized: AmbientAgentEnvironment = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(env, deserialized);
+}
+
+#[test]
+fn deserialize_legacy_environment_without_secrets() {
+    let json = serde_json::json!({
+        "name": "no-secrets-env",
+        "github_repos": [],
+        "docker_image": "ubuntu:latest"
+    });
+
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+    assert_eq!(env.secrets, None);
+}
+
+#[test]
+fn deserialize_with_empty_secrets() {
+    let json = serde_json::json!({
+        "name": "empty-secrets-env",
+        "github_repos": [],
+        "docker_image": "ubuntu:latest",
+        "secrets": []
+    });
+
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+    assert_eq!(env.secrets, Some(vec![]));
+}
+
+#[test]
+fn deserialize_with_specific_secrets() {
+    let json = serde_json::json!({
+        "name": "secrets-env",
+        "github_repos": [],
+        "docker_image": "ubuntu:latest",
+        "secrets": [
+            {"name": "GH_TOKEN"},
+            {"name": "NPM_TOKEN"}
+        ]
+    });
+
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+    let secrets = env.secrets.unwrap();
+    assert_eq!(secrets.len(), 2);
+    assert_eq!(secrets[0].name, "GH_TOKEN");
+    assert_eq!(secrets[1].name, "NPM_TOKEN");
+}
+
+#[test]
+fn serialize_with_secrets_none_omits_field() {
+    let env = AmbientAgentEnvironment::new(
+        "test-env".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+
+    let json = serde_json::to_value(&env).unwrap();
+    assert!(!json.as_object().unwrap().contains_key("secrets"));
+}
+
+#[test]
+fn serialize_with_empty_secrets_includes_field() {
+    let mut env = AmbientAgentEnvironment::new(
+        "test-env".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+    env.secrets = Some(vec![]);
+
+    let json = serde_json::to_value(&env).unwrap();
+    let secrets = json.get("secrets").unwrap();
+    assert!(secrets.as_array().unwrap().is_empty());
+}
+
+#[test]
+fn roundtrip_serde_with_secrets() {
+    let mut env = AmbientAgentEnvironment::new(
+        "secrets-rt".into(),
+        None,
+        vec![],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+    env.secrets = Some(vec![
+        EnvironmentSecretRef {
+            name: "MY_SECRET".into(),
+        },
+        EnvironmentSecretRef {
+            name: "OTHER_SECRET".into(),
+        },
+    ]);
 
     let serialized = serde_json::to_string(&env).unwrap();
     let deserialized: AmbientAgentEnvironment = serde_json::from_str(&serialized).unwrap();


### PR DESCRIPTION
## Description

Add a `secrets` field to the Rust `AmbientAgentEnvironment` struct to match the server-side `CloudEnvironmentConfig` Go model. Without this field, CLI environment updates via Warp Drive sync would serialize JSON without a `secrets` key, causing the server to interpret the missing field as `nil` (= "all secrets" / no scoping), effectively clearing any previously configured secret selection.

### Root Cause

The `AmbientAgentEnvironment` struct in `crates/cloud_object_models/src/cloud_environment.rs` was missing a `secrets` field that the server-side `CloudEnvironmentConfig` has (`Secrets *[]EnvironmentSecretRef`). When the CLI's `oz environment update` command updated an environment:

1. It cloned the existing `AmbientAgentEnvironment` model (no secrets field)
2. Updated the requested fields (name, docker image, etc.)
3. Serialized and sent the model via Warp Drive sync
4. The server received JSON without a `secrets` key → Go deserialized it as `nil` → "all secrets"

The web UI was unaffected because it goes through the `upsertCloudEnvironment` GraphQL mutation, which properly includes secrets from the current environment data.

### Fix

- Added `EnvironmentSecretRef` struct and `secrets: Option<Vec<EnvironmentSecretRef>>` to `AmbientAgentEnvironment`
- Uses `#[serde(default, skip_serializing_if = "Option::is_none")]` for backward compatibility
- Existing serialized environments without secrets still deserialize correctly as `None`

## Linked Issue

- [REMOTE-1880](https://linear.app/warpdotdev/issue/REMOTE-1880)
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Added 7 new unit tests covering secrets serialization/deserialization:
  - Legacy environments without secrets deserialize correctly (`None`)
  - Empty secrets array round-trips as `Some([])`
  - Specific secrets round-trip correctly
  - `None` secrets are omitted from serialized JSON
  - `Some([])` secrets are included in serialized JSON
- All 14 tests in `cloud_environment::tests` pass
- `cargo check -p warp` succeeds with no errors

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed CLI environment updates resetting secret selection to "All Secrets".
-->

_Conversation: https://staging.warp.dev/conversation/cfdf3038-1c57-4a8c-9d3c-4e7df3f85332_
_Run: https://oz.staging.warp.dev/runs/019e99cd-9dc8-72eb-a7e4-c20662f3239c_
_This PR was generated with [Oz](https://warp.dev/oz)._
