### PR TITLE
feat: add base_url to Anthropic API Key for custom Claude Code endpoints

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -3280,8 +3280,14 @@ fn typed_secret_env_names(secrets: &HashMap<String, ManagedSecretValue>) -> Hash
 fn typed_secret_entries(secret: &ManagedSecretValue) -> Vec<(&'static str, &str)> {
     match secret {
         ManagedSecretValue::RawValue { .. } => vec![],
-        ManagedSecretValue::AnthropicApiKey { api_key } => {
-            vec![("ANTHROPIC_API_KEY", api_key.as_str())]
+        ManagedSecretValue::AnthropicApiKey { api_key, base_url } => {
+            let mut entries = vec![("ANTHROPIC_API_KEY", api_key.as_str())];
+            if let Some(url) = base_url.as_deref() {
+                if !url.trim().is_empty() {
+                    entries.push(("ANTHROPIC_BASE_URL", url));
+                }
+            }
+            entries
         }
         ManagedSecretValue::AnthropicBedrockApiKey {
             aws_bearer_token_bedrock,

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -474,7 +474,7 @@ fn anthropic_api_key_writes_anthropic_env_var() {
     std::env::remove_var("ANTHROPIC_API_KEY");
     let secrets = HashMap::from([(
         "my-custom-name".to_string(),
-        ManagedSecretValue::anthropic_api_key("sk-ant-test-key"),
+        ManagedSecretValue::anthropic_api_key("sk-ant-test-key", None),
     )]);
     let env_vars = build_secret_env_vars(&secrets);
     assert_eq!(
@@ -492,7 +492,7 @@ fn typed_secret_overrides_raw_value_with_same_env_name() {
     let secrets = HashMap::from([
         (
             "my-auth".to_string(),
-            ManagedSecretValue::anthropic_api_key(typed_key),
+            ManagedSecretValue::anthropic_api_key(typed_key, None),
         ),
         (
             "ANTHROPIC_API_KEY".to_string(),
@@ -603,7 +603,7 @@ fn worker_injected_env_wins_over_typed_secret() {
     std::env::set_var("ANTHROPIC_API_KEY", "worker-key");
     let secrets = HashMap::from([(
         "my-auth".to_string(),
-        ManagedSecretValue::anthropic_api_key("managed-key"),
+        ManagedSecretValue::anthropic_api_key("managed-key", None),
     )]);
     let env_vars = build_secret_env_vars(&secrets);
     // The typed secret should be skipped entirely; the child inherits

--- a/app/src/ai/agent_sdk/secret.rs
+++ b/app/src/ai/agent_sdk/secret.rs
@@ -566,7 +566,7 @@ fn read_simple_secret_value(args: &ValueArgs) -> Result<Option<String>> {
 fn make_simple_secret_value(secret_type: SecretType, raw: &str) -> ManagedSecretValue {
     match secret_type {
         SecretType::RawValue => ManagedSecretValue::raw_value(raw),
-        SecretType::AnthropicApiKey => ManagedSecretValue::anthropic_api_key(raw),
+        SecretType::AnthropicApiKey => ManagedSecretValue::anthropic_api_key(raw, None),
         SecretType::AnthropicBedrockApiKey => {
             // Bedrock secrets are multi-field and handled via SecretInput::Bedrock.
             unreachable!("Bedrock secrets should not go through make_simple_secret_value")
@@ -589,7 +589,7 @@ fn make_secret_value_from_gql_type(
         ManagedSecretType::RawValue | ManagedSecretType::Dotenvx => {
             Ok(ManagedSecretValue::raw_value(raw))
         }
-        ManagedSecretType::AnthropicApiKey => Ok(ManagedSecretValue::anthropic_api_key(raw)),
+        ManagedSecretType::AnthropicApiKey => Ok(ManagedSecretValue::anthropic_api_key(raw, None)),
         ManagedSecretType::AnthropicBedrockAccessKey => {
             // Bedrock access key secrets cannot be updated through the generic raw-string path.
             Err(anyhow::anyhow!(

--- a/app/src/ai/auth_secret_types.rs
+++ b/app/src/ai/auth_secret_types.rs
@@ -59,9 +59,16 @@ pub fn build_managed_secret_value(
         }
     }
     match info.secret_type {
-        ManagedSecretType::AnthropicApiKey => Ok(ManagedSecretValue::anthropic_api_key(
-            field_values[0].clone(),
-        )),
+        ManagedSecretType::AnthropicApiKey => {
+            let base_url = field_values
+                .get(1)
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty());
+            Ok(ManagedSecretValue::anthropic_api_key(
+                field_values[0].clone(),
+                base_url,
+            ))
+        }
         ManagedSecretType::AnthropicBedrockApiKey => {
             Ok(ManagedSecretValue::anthropic_bedrock_api_key(
                 field_values[0].clone(),
@@ -123,12 +130,20 @@ static CLAUDE_AUTH_SECRET_TYPES: [AuthSecretTypeInfo; 3] = [
         display_name: "Anthropic API Key",
         secret_type: ManagedSecretType::AnthropicApiKey,
         learn_more_url: CLAUDE_LEARN_MORE_URL,
-        fields: &[AuthSecretTypeField {
-            label: "ANTHROPIC_API_KEY",
-            placeholder: Some("sk-ant-..."),
-            optional: false,
-            sensitive: true,
-        }],
+        fields: &[
+            AuthSecretTypeField {
+                label: "ANTHROPIC_API_KEY",
+                placeholder: Some("sk-ant-..."),
+                optional: false,
+                sensitive: true,
+            },
+            AuthSecretTypeField {
+                label: "BASE_URL",
+                placeholder: Some("https://your-gateway.example.com/v1"),
+                optional: true,
+                sensitive: false,
+            },
+        ],
     },
     AuthSecretTypeInfo {
         display_name: "Bedrock API Key",

--- a/crates/graphql/src/api/queries/task_secrets.rs
+++ b/crates/graphql/src/api/queries/task_secrets.rs
@@ -67,6 +67,8 @@ pub struct ManagedSecretRawValue {
 #[derive(cynic::QueryFragment, Debug)]
 pub struct ManagedSecretAnthropicApiKeyValue {
     pub api_key: String,
+    /// Optional base URL for custom AI gateway endpoints.
+    pub base_url: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/crates/managed_secrets/src/manager.rs
+++ b/crates/managed_secrets/src/manager.rs
@@ -178,7 +178,7 @@ impl ManagedSecretManager {
                         ManagedSecretValue::raw_value(raw.value)
                     }
                     GqlManagedSecretValue::ManagedSecretAnthropicApiKeyValue(v) => {
-                        ManagedSecretValue::anthropic_api_key(v.api_key)
+                        ManagedSecretValue::anthropic_api_key(v.api_key, v.base_url)
                     }
                     GqlManagedSecretValue::ManagedSecretAnthropicBedrockAccessKeyValue(v) => {
                         ManagedSecretValue::anthropic_bedrock_access_key(

--- a/crates/managed_secrets/src/secret_value.rs
+++ b/crates/managed_secrets/src/secret_value.rs
@@ -11,6 +11,10 @@ pub enum ManagedSecretValue {
     },
     AnthropicApiKey {
         api_key: String,
+        /// Optional base URL for the Anthropic API (e.g. custom AI gateway endpoints).
+        /// When absent, the harness uses the provider's default endpoint.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
     },
     AnthropicBedrockAccessKey {
         aws_access_key_id: String,
@@ -40,8 +44,12 @@ impl ManagedSecretValue {
         Self::RawValue { value: s.into() }
     }
 
-    pub fn anthropic_api_key(s: impl Into<String>) -> Self {
-        Self::AnthropicApiKey { api_key: s.into() }
+    /// Construct an Anthropic API key secret value with an optional base URL.
+    pub fn anthropic_api_key(api_key: impl Into<String>, base_url: Option<String>) -> Self {
+        Self::AnthropicApiKey {
+            api_key: api_key.into(),
+            base_url,
+        }
     }
 
     /// Construct an Anthropic Bedrock access key secret from IAM credentials and AWS region.

--- a/crates/managed_secrets/src/secret_value_tests.rs
+++ b/crates/managed_secrets/src/secret_value_tests.rs
@@ -28,6 +28,7 @@ fn test_debug_representation_no_secrets() {
 fn test_serialize_anthropic_api_key() {
     let secret = ManagedSecretValue::AnthropicApiKey {
         api_key: "sk-ant-test-key".to_string(),
+        base_url: None,
     };
     let serialized = serde_json::to_string(&secret).expect("failed to serialize");
     assert_eq!(serialized, "{\"api_key\":\"sk-ant-test-key\"}");
@@ -38,6 +39,7 @@ fn test_serialize_anthropic_api_key() {
 fn test_debug_representation_no_secrets_anthropic_api_key() {
     let secret = ManagedSecretValue::AnthropicApiKey {
         api_key: "sk-ant-secret-key".to_string(),
+        base_url: None,
     };
     let debug_representation = format!("{:?}", secret);
     assert!(

--- a/crates/managed_secrets_wasm/src/lib.rs
+++ b/crates/managed_secrets_wasm/src/lib.rs
@@ -45,12 +45,13 @@ pub fn encrypt_anthropic_api_key_secret(
     actor_uid: &str,
     secret_name: &str,
     api_key: &str,
+    base_url: Option<String>,
 ) -> Result<String, JsValue> {
     do_encrypt(
         public_key_base64,
         actor_uid,
         secret_name,
-        &ManagedSecretValue::anthropic_api_key(api_key),
+        &ManagedSecretValue::anthropic_api_key(api_key, base_url),
     )
 }
 

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -2173,6 +2173,12 @@ type ManagedSecret {
 """A managed secret value representing an Anthropic API key."""
 type ManagedSecretAnthropicApiKeyValue {
   apiKey: String!
+
+  """
+  Optional base URL for the Anthropic API. When set, the harness uses this
+  instead of the provider default (e.g. for custom AI gateway or proxy endpoints).
+  """
+  baseUrl: String
 }
 
 """


### PR DESCRIPTION
## Summary

Add an optional `base_url` field to the `AnthropicApiKey` managed secret type, allowing customers to route Claude Code inference through their own AI Gateway (e.g., a custom proxy endpoint) instead of using the Anthropic API directly.

This mirrors the existing `base_url` support already available for the OpenAI/Codex harness via the `OpenaiApiKey` secret type.

## Changes

### Managed Secrets Crate
- Added `base_url: Option<String>` to `ManagedSecretValue::AnthropicApiKey` variant
- Updated `anthropic_api_key()` constructor to accept `base_url: Option<String>`
- Updated serialization tests

### GraphQL
- Added `base_url: Option<String>` to `ManagedSecretAnthropicApiKeyValue` query fragment
- Added `baseUrl: String` to `ManagedSecretAnthropicApiKeyValue` in client schema

### Agent Driver
- Updated `typed_secret_entries` to emit `ANTHROPIC_BASE_URL` env var when `base_url` is set
- Updated `build_secret_env_vars` tests

### Auth Secret UI
- Added `BASE_URL` field to Claude Code's Anthropic API Key auth secret type

### WASM
- Updated `encrypt_anthropic_api_key_secret` to accept optional `base_url` parameter

### GQL → ManagedSecretValue Conversion
- Updated `manager.rs` to thread `base_url` through from GQL response

## Companion PR
- warp-server: https://github.com/warpdotdev/warp-server/pull/11726

## Linear
REMOTE-1882

_Conversation: https://staging.warp.dev/conversation/34a0b3f8-6279-4d55-9803-c7114cfd8187_
_Run: https://oz.staging.warp.dev/runs/019e9a08-1143-78c7-9f1e-5b1a3c17b132_
_Plans:_
- _[REMOTE-1882: Add base_url to Anthropic API Key for Custom Claude Code Endpoints](https://staging.warp.dev/drive/notebook/WAPS9YMsM60tVVsCmtuqaW)_

_This PR was generated with [Oz](https://warp.dev/oz)._
