### PR TITLE
remove unneeded focus_ai_block_if_self_focused

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5123,10 +5123,6 @@ impl TerminalView {
 
             let mut finish_reason: Option<FinishReason> = None;
             if let Some(active_ai_block) = self.active_ai_block(ctx) {
-                // Focus the block so that the user can interact
-                // with any blocking actions (if any).
-                self.focus_ai_block_if_self_focused(active_ai_block, ctx);
-
                 // A new exchange is already active, so callbacks for the
                 // just-finished exchange will be skipped. Clear any pending
                 // user query now to prevent its callback from firing when


### PR DESCRIPTION
## Description
https://github.com/warpdotdev/warp/commit/edf83549f51788b3cea634fc38020f06443ff551 changed it so that we avoid resetting focus whenever any AI block is stolen. But this means we'd have instances where we want focus to be stolen back to the input editor that weren't triggering. 

Here's a video of the issue 
https://github.com/user-attachments/assets/d8d528cc-d117-4155-a71b-3fce14626ce7

This PR removes the unnecessary focus attempt so `redetermine_terminal_focus` can continue distinguishing intentional AI-block focus from elsewhere without preserving an async accidental steal.

## Linked Issue
N/A

## Testing
Manually tested
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
https://www.loom.com/share/e23ae73a05dc42609abd2a888772047e

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
