### PR TITLE
Add remote project skills RPC plumbing

### DIFF
--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -453,6 +453,7 @@ impl RemoteCodebaseIndexModel {
             | RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::BufferUpdated { .. }
             | RemoteServerManagerEvent::BufferConflictDetected { .. }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -10,6 +10,7 @@ use ::ai::index::full_source_code_embedding::manager::{
 use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
+use async_fs::{metadata, read_to_string};
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
@@ -41,17 +42,19 @@ use super::proto::{
     CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, CodebaseResyncMode, DeleteFile,
     DeleteFileResponse, DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse,
     DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
-    FileContextProto, FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
+    FileContextProto, FileOperationError, FindProjectSkillFiles, FindProjectSkillFilesResponse,
+    FragmentMetadata as ProtoFragmentMetadata,
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
     FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
     GetFragmentMetadataFromHashSuccess, IndexCodebase, Initialize, InitializeResponse,
     MissingFragmentMetadata, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
-    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
-    ResolveConflictSuccess, ResyncCodebase, RunCommandError, RunCommandErrorCode,
-    RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
-    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, UploadHandoffSnapshot,
-    WriteFile, WriteFileResponse, WriteFileSuccess,
+    OpenBufferResponse, ProjectSkillFileProto, ProjectSkillFilesUpdatedPush,
+    ReadFileContextResponse, ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess,
+    ResyncCodebase, RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse,
+    RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage,
+    SessionBootstrapped, TextEdit, UploadHandoffSnapshot, WriteFile, WriteFileResponse,
+    WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
@@ -65,6 +68,10 @@ pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 
 /// Prevents a client from forcing the daemon to enumerate an arbitrarily
 /// large ref list.
 const MAX_BRANCH_COUNT_CAP: usize = 500;
+/// Default per-file cap for project skill files returned by the daemon.
+const DEFAULT_PROJECT_SKILL_FILE_BYTES: usize = 1_000_000;
+/// Default total cap for project skill file content returned by the daemon.
+const DEFAULT_PROJECT_SKILL_TOTAL_BYTES: usize = 8_000_000;
 
 /// Unique identifier for a connected proxy session in daemon mode.
 pub type ConnectionId = uuid::Uuid;
@@ -359,12 +366,28 @@ impl ServerModel {
                         }
                     }
                 }
+                RepoMetadataEvent::ProjectSkillFilesUpdated {
+                    id: RepositoryIdentifier::Local(path),
+                } => {
+                    me.send_server_message(
+                        None,
+                        None,
+                        server_message::Message::ProjectSkillFilesUpdated(
+                            ProjectSkillFilesUpdatedPush {
+                                repo_path: path.to_string(),
+                            },
+                        ),
+                    );
+                }
                 RepoMetadataEvent::RepositoryRemoved { .. }
                 | RepoMetadataEvent::FileTreeUpdated { .. }
                 | RepoMetadataEvent::FileTreeEntryUpdated { .. }
                 | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                 | RepoMetadataEvent::RepositoryUpdated {
+                    id: RepositoryIdentifier::Remote(_),
+                }
+                | RepoMetadataEvent::ProjectSkillFilesUpdated {
                     id: RepositoryIdentifier::Remote(_),
                 } => {}
             });
@@ -715,6 +738,9 @@ impl ServerModel {
                     }
                     Some(host_scoped_request::Message::ReadFileContext(m)) => {
                         self.handle_read_file_context(m, &request_id, conn_id, ctx)
+                    }
+                    Some(host_scoped_request::Message::FindProjectSkillFiles(m)) => {
+                        self.handle_find_project_skill_files(m, &request_id, conn_id, ctx)
                     }
                     Some(host_scoped_request::Message::SaveBuffer(m)) => {
                         self.handle_save_buffer(m, &request_id, conn_id, ctx)
@@ -2149,6 +2175,75 @@ impl ServerModel {
         HandlerOutcome::Async(Some(handle))
     }
 
+    /// Handles `FindProjectSkillFiles` by reading the paths discovered by repo
+    /// metadata's dedicated project-skills sidecar. Reads are UTF-8 only and
+    /// bounded by per-file and total byte budgets.
+    fn handle_find_project_skill_files(
+        &mut self,
+        msg: FindProjectSkillFiles,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling FindProjectSkillFiles repo={} (request_id={request_id})",
+            msg.repo_path
+        );
+
+        let repo_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path))
+        {
+            Ok(path) => path,
+            Err(error) => {
+                return HandlerOutcome::Sync(
+                    server_message::Message::FindProjectSkillFilesResponse(
+                        FindProjectSkillFilesResponse {
+                            files: vec![],
+                            failed_files: vec![failed_file_read(
+                                msg.repo_path,
+                                format!("Invalid repo_path: {error}"),
+                            )],
+                        },
+                    ),
+                );
+            }
+        };
+        let id = RepositoryIdentifier::local(repo_path);
+        let paths = RepoMetadataModel::handle(ctx)
+            .as_ref(ctx)
+            .get_project_skills(&id, ctx)
+            .map(|skills| {
+                skills
+                    .iter()
+                    .map(|skill| skill.path.to_local_path_lossy())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let max_file_bytes = msg
+            .max_file_bytes
+            .map(|bytes| bytes as usize)
+            .unwrap_or(DEFAULT_PROJECT_SKILL_FILE_BYTES);
+        let max_total_bytes = msg
+            .max_total_bytes
+            .map(|bytes| bytes as usize)
+            .unwrap_or(DEFAULT_PROJECT_SKILL_TOTAL_BYTES);
+        let request_id_for_response = request_id.clone();
+
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            read_project_skill_file_contents(paths, max_file_bytes, max_total_bytes),
+            move |me, response, _ctx| {
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::FindProjectSkillFilesResponse(response),
+                );
+            },
+            ctx,
+        );
+
+        HandlerOutcome::Async(Some(handle))
+    }
+
     /// Handles `OpenBuffer` by opening the file via `GlobalBufferModel`.
     /// The response is sent asynchronously when `BufferLoaded` fires.
     ///
@@ -2858,6 +2953,89 @@ fn canonicalize_index_repo_path(repo_path: &str) -> Result<PathBuf, String> {
     Ok(standardized_path
         .to_local_path()
         .unwrap_or_else(|| standardized_path.to_local_path_lossy()))
+}
+
+fn failed_file_read(path: String, message: String) -> FailedFileRead {
+    FailedFileRead {
+        path,
+        error: Some(FileOperationError { message }),
+    }
+}
+
+async fn read_project_skill_file_contents(
+    paths: Vec<PathBuf>,
+    max_file_bytes: usize,
+    max_total_bytes: usize,
+) -> FindProjectSkillFilesResponse {
+    let mut files = Vec::new();
+    let mut failed_files = Vec::new();
+    let mut remaining_total_bytes = max_total_bytes;
+
+    for path in paths {
+        let path_string = path.to_string_lossy().to_string();
+        let file_size = match metadata(&path).await {
+            Ok(metadata) => metadata.len() as usize,
+            Err(error) => {
+                failed_files.push(failed_file_read(
+                    path_string,
+                    format!("Failed to stat file: {error}"),
+                ));
+                continue;
+            }
+        };
+        if file_size > max_file_bytes {
+            failed_files.push(failed_file_read(
+                path_string,
+                format!("File exceeds per-file byte limit of {max_file_bytes} bytes"),
+            ));
+            continue;
+        }
+        if file_size > remaining_total_bytes {
+            failed_files.push(failed_file_read(
+                path_string,
+                format!("File exceeds remaining total byte limit of {remaining_total_bytes} bytes"),
+            ));
+            continue;
+        }
+
+        match read_to_string(&path).await {
+            Ok(content) => {
+                let content_bytes = content.len();
+                if content_bytes > max_file_bytes {
+                    failed_files.push(failed_file_read(
+                        path_string,
+                        format!("File exceeds per-file byte limit of {max_file_bytes} bytes"),
+                    ));
+                    continue;
+                }
+                if content_bytes > remaining_total_bytes {
+                    failed_files.push(failed_file_read(
+                        path_string,
+                        format!(
+                            "File exceeds remaining total byte limit of {remaining_total_bytes} bytes"
+                        ),
+                    ));
+                    continue;
+                }
+                remaining_total_bytes -= content_bytes;
+                files.push(ProjectSkillFileProto {
+                    path: path_string,
+                    content,
+                });
+            }
+            Err(error) => {
+                failed_files.push(failed_file_read(
+                    path_string,
+                    format!("Failed to read UTF-8 file: {error}"),
+                ));
+            }
+        }
+    }
+
+    FindProjectSkillFilesResponse {
+        files,
+        failed_files,
+    }
 }
 
 fn missing_fragment_metadata(content_hash: String, message: String) -> MissingFragmentMetadata {

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::fs;
 use std::sync::Arc;
 
+use tempfile::TempDir;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
@@ -11,7 +13,10 @@ use super::super::proto::{
 };
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{ConnectionId, PendingFileOps, ServerModel};
+use super::{
+    read_project_skill_file_contents, ConnectionId, PendingFileOps, ServerModel,
+    DEFAULT_PROJECT_SKILL_FILE_BYTES, DEFAULT_PROJECT_SKILL_TOTAL_BYTES,
+};
 use crate::auth::auth_state::AuthState;
 use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
@@ -39,6 +44,61 @@ fn test_key(repo: &str, mode: DiffMode) -> DiffModelKey {
         repo_path: StandardizedPath::try_new(repo).unwrap(),
         mode,
     }
+}
+
+#[test]
+fn project_skill_file_defaults_are_bounded() {
+    assert_eq!(DEFAULT_PROJECT_SKILL_FILE_BYTES, 1_000_000);
+    assert_eq!(DEFAULT_PROJECT_SKILL_TOTAL_BYTES, 8_000_000);
+}
+
+#[tokio::test]
+async fn project_skill_file_reads_return_successes_and_per_file_failures() {
+    let temp_dir = TempDir::new().unwrap();
+    let good = temp_dir.path().join("good.md");
+    let too_large = temp_dir.path().join("too-large.md");
+    let invalid_utf8 = temp_dir.path().join("invalid-utf8.md");
+    let missing = temp_dir.path().join("missing.md");
+    fs::write(&good, "skill").unwrap();
+    fs::write(&too_large, "skills").unwrap();
+    fs::write(&invalid_utf8, [0xff, 0xfe]).unwrap();
+
+    let response =
+        read_project_skill_file_contents(vec![good, too_large, invalid_utf8, missing], 5, 8).await;
+
+    assert_eq!(response.files.len(), 1);
+    assert_eq!(response.files[0].content, "skill");
+    assert_eq!(response.failed_files.len(), 3);
+    assert!(response.failed_files.iter().any(|failed| failed
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("per-file byte limit"))));
+    assert!(response.failed_files.iter().any(|failed| failed
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("UTF-8"))));
+    assert!(response.failed_files.iter().any(|failed| failed
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("stat"))));
+}
+
+#[tokio::test]
+async fn project_skill_file_reads_enforce_total_byte_budget() {
+    let temp_dir = TempDir::new().unwrap();
+    let first = temp_dir.path().join("first.md");
+    let second = temp_dir.path().join("second.md");
+    fs::write(&first, "12345").unwrap();
+    fs::write(&second, "6789").unwrap();
+
+    let response = read_project_skill_file_contents(vec![first, second], 10, 5).await;
+
+    assert_eq!(response.files.len(), 1);
+    assert_eq!(response.failed_files.len(), 1);
+    assert!(response.failed_files[0]
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("remaining total byte limit")));
 }
 
 #[test]

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -172,6 +172,7 @@ impl Sessions {
                 | RemoteServerManagerEvent::NavigatedToDirectory { .. }
                 | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                 | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+                | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
                 | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4659,6 +4659,7 @@ impl TerminalView {
                     | RemoteServerManagerEvent::HostConnected { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+                    | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -141,6 +141,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::NavigatedToDirectory { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -43,6 +43,7 @@ message HostScopedRequest {
     GetBranches get_branches = 12;
     ResyncCodebase resync_codebase = 13;
     UploadHandoffSnapshot upload_handoff_snapshot = 14;
+    FindProjectSkillFiles find_project_skill_files = 15;
   }
 }
 
@@ -106,6 +107,8 @@ message ServerMessage {
     GetFragmentMetadataFromHashResponse get_fragment_metadata_from_hash_response = 24;
     GetBranchesResponse get_branches_response = 25;
     UploadHandoffSnapshotResponse upload_handoff_snapshot_response = 26;
+    FindProjectSkillFilesResponse find_project_skill_files_response = 27;
+    ProjectSkillFilesUpdatedPush project_skill_files_updated = 28;
   }
 }
 
@@ -391,6 +394,29 @@ message FileContextProto {
   uint32 line_count = 7;
 }
 
+// ── Project skill files ───────────────────────────────────────────
+
+// Client → server: read the contents of project skill files discovered by
+// repo metadata's dedicated project-skills sidecar.
+message FindProjectSkillFiles {
+  string repo_path = 1;
+  // Per-file byte limit. Absent = use server default.
+  optional uint32 max_file_bytes = 2;
+  // Cumulative byte budget across all files. Absent = use server default.
+  optional uint32 max_total_bytes = 3;
+}
+
+// Server → client: readable project skill files and any per-file failures.
+message FindProjectSkillFilesResponse {
+  repeated ProjectSkillFileProto files = 1;
+  repeated FailedFileRead failed_files = 2;
+}
+
+message ProjectSkillFileProto {
+  string path = 1;
+  string content = 2;
+}
+
 // ── Remote codebase indexing status ───────────────────────────────
 
 message IndexCodebase {
@@ -503,6 +529,12 @@ message RepoMetadataUpdatePush {
   repeated string remove_entries = 2;
   repeated RepoMetadataEntryUpdate update_entries = 3;
   StandingQueryResultsDelta standing_results_delta = 4;
+}
+
+// Project skill sidecar contents changed for a repository. Clients should
+// re-fetch them with FindProjectSkillFiles.
+message ProjectSkillFilesUpdatedPush {
+  string repo_path = 1;
 }
 
 // ── Buffer syncing ────────────────────────────────────────────────

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -75,6 +75,8 @@ pub enum ClientEvent {
     RepoMetadataUpdated {
         update: repo_metadata::RepoMetadataUpdate,
     },
+    /// Project skill files changed for a repository on the remote host.
+    ProjectSkillFilesUpdated { repo_path: StandardizedPath },
     /// A full remote codebase-index status snapshot was pushed by the server.
     CodebaseIndexStatusesSnapshotReceived {
         statuses: Vec<RemoteCodebaseIndexStatus>,
@@ -563,6 +565,16 @@ impl RemoteServerClient {
             server_message::Message::RepoMetadataUpdate(push) => {
                 let update = proto_to_repo_metadata_update(&push)?;
                 Some(ClientEvent::RepoMetadataUpdated { update })
+            }
+            server_message::Message::ProjectSkillFilesUpdated(push) => {
+                let Some(repo_path) = StandardizedPath::try_new(&push.repo_path).ok() else {
+                    log::warn!(
+                        "ProjectSkillFilesUpdatedPush: invalid repo_path: {}",
+                        push.repo_path
+                    );
+                    return None;
+                };
+                Some(ClientEvent::ProjectSkillFilesUpdated { repo_path })
             }
             server_message::Message::CodebaseIndexStatusesSnapshot(snapshot) => {
                 let statuses = proto_to_codebase_index_statuses_snapshot(&snapshot);

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -8,8 +8,8 @@ use crate::proto::{
     client_message, host_scoped_request, notification, run_command_response, server_message,
     session_scoped_request, ClientMessage, CodebaseIndexStatus, CodebaseIndexStatusState,
     CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, ErrorCode, GetDiffStateResponse,
-    InitializeResponse, OpenBufferResponse, RunCommandResponse, RunCommandSuccess, ServerMessage,
-    WriteFile,
+    InitializeResponse, OpenBufferResponse, ProjectSkillFilesUpdatedPush, RunCommandResponse,
+    RunCommandSuccess, ServerMessage, WriteFile,
 };
 use crate::protocol;
 
@@ -18,6 +18,41 @@ fn unwrap_session_scoped(msg: &ClientMessage) -> &session_scoped_request::Messag
     match &msg.message {
         Some(client_message::Message::SessionScoped(w)) => w.message.as_ref().unwrap(),
         other => panic!("Expected SessionScoped, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn project_skill_files_updated_push_becomes_client_event() {
+    let (client_stream, server_stream) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    drop(server_read);
+
+    let executor = executor::Background::default();
+    let (_client, event_rx, _failure_rx, _host_rx) =
+        RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
+    let mut writer = server_write.compat_write();
+
+    protocol::write_server_message(
+        &mut writer,
+        &ServerMessage {
+            request_id: String::new(),
+            message: Some(server_message::Message::ProjectSkillFilesUpdated(
+                ProjectSkillFilesUpdatedPush {
+                    repo_path: "/repo".to_string(),
+                },
+            )),
+        },
+    )
+    .await
+    .unwrap();
+    writer.flush().await.unwrap();
+
+    match event_rx.recv().await.unwrap() {
+        ClientEvent::ProjectSkillFilesUpdated { repo_path } => {
+            assert_eq!(repo_path.to_string(), "/repo");
+        }
+        other => panic!("Expected ProjectSkillFilesUpdated, got {other:?}"),
     }
 }
 

--- a/crates/remote_server/src/host_response_tests.rs
+++ b/crates/remote_server/src/host_response_tests.rs
@@ -154,6 +154,7 @@ fn every_host_scoped_request_has_a_response_disposition() {
             M::DiscardFiles(_) => "host_response::discard_files_result",
             // Richer responses parsed at the manager call site.
             M::ReadFileContext(_) => "manager::read_file_context",
+            M::FindProjectSkillFiles(_) => "manager::find_project_skill_files",
             M::GetFragmentMetadataFromHash(_) => "manager::get_fragment_metadata_from_hash",
             M::UploadHandoffSnapshot(_) => "manager::upload_handoff_snapshot",
             M::GetBranches(_) => "manager::get_branches",

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -135,6 +135,7 @@ pub enum RemoteServerOperation {
     DiscardFiles,
     GetBranches,
     UploadHandoffSnapshot,
+    FindProjectSkillFiles,
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -262,6 +263,7 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::Disconnected => "disconnected",
         ClientEvent::RepoMetadataSnapshotReceived { .. } => "repo_metadata_snapshot",
         ClientEvent::RepoMetadataUpdated { .. } => "repo_metadata_updated",
+        ClientEvent::ProjectSkillFilesUpdated { .. } => "project_skill_files_updated",
         ClientEvent::CodebaseIndexStatusesSnapshotReceived { .. } => {
             "codebase_index_statuses_snapshot"
         }
@@ -468,6 +470,8 @@ pub enum RemoteServerManagerEvent {
         host_id: HostId,
         update: RepoMetadataUpdate,
     },
+    /// Project skill files changed on the remote host and should be re-fetched.
+    ProjectSkillFilesUpdated { remote_path: RemotePath },
     /// A `LoadRepoMetadataDirectory` response was received from the server.
     RepoMetadataDirectoryLoaded {
         host_id: HostId,
@@ -616,6 +620,7 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::HostDisconnected { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
@@ -833,6 +838,36 @@ impl HostRequestHandle {
             Some(crate::proto::server_message::Message::ReadFileContextResponse(resp)) => Ok(resp),
             other => {
                 log::error!("Unexpected response variant for ReadFileContext: {other:?}");
+                Err(HostRequestError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Finds project skill files on the remote host and returns their UTF-8
+    /// contents. Per-file failures are returned in the response.
+    pub async fn find_project_skill_files(
+        &self,
+        repo_path: String,
+        max_file_bytes: Option<u32>,
+        max_total_bytes: Option<u32>,
+    ) -> Result<crate::proto::FindProjectSkillFilesResponse, HostRequestError> {
+        let msg = self
+            .send(
+                crate::proto::host_scoped_request::Message::FindProjectSkillFiles(
+                    crate::proto::FindProjectSkillFiles {
+                        repo_path,
+                        max_file_bytes,
+                        max_total_bytes,
+                    },
+                ),
+            )
+            .await?;
+        match msg.message {
+            Some(crate::proto::server_message::Message::FindProjectSkillFilesResponse(resp)) => {
+                Ok(resp)
+            }
+            other => {
+                log::error!("Unexpected response variant for FindProjectSkillFiles: {other:?}");
                 Err(HostRequestError::UnexpectedResponse)
             }
         }
@@ -2803,6 +2838,11 @@ impl RemoteServerManager {
             }
             ClientEvent::RepoMetadataUpdated { update } => {
                 ctx.emit(RemoteServerManagerEvent::RepoMetadataUpdated { host_id, update });
+            }
+            ClientEvent::ProjectSkillFilesUpdated { repo_path } => {
+                ctx.emit(RemoteServerManagerEvent::ProjectSkillFilesUpdated {
+                    remote_path: RemotePath::new(host_id, repo_path),
+                });
             }
             ClientEvent::CodebaseIndexStatusesSnapshotReceived { statuses } => {
                 let statuses = statuses


### PR DESCRIPTION
## Summary
- add a host-scoped `FindProjectSkillFiles` request/response and project-skill update push
- route the request through `HostRequestHandle`, client events, manager events, telemetry, and daemon dispatch
- read sidecar-discovered UTF-8 skill files with per-file/total budgets and separate failed-read entries

## Validation
- `cargo test -p remote_server` (88 passed)
- `cargo check -p warp --lib` (expected failure only because the sidecar branch has not yet supplied `RepoMetadataEvent::ProjectSkillFilesUpdated` and `RepoMetadataModel::get_project_skills`)
- `git diff --check`

_Conversation: https://staging.warp.dev/conversation/967cc6e5-a49e-4b9c-85ab-0536eb783515_
_Run: https://oz.staging.warp.dev/runs/019e9af0-6fe3-76e4-82f1-034d876506e0_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
