### PR TITLE
Fix streaming NDJSON output not emitting incrementally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16737,11 +16737,13 @@ name = "wsh"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.9.4",
  "crossterm",
  "env_logger",
  "libc",
  "log",
  "nix 0.26.4",
+ "vte",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15457,6 +15457,7 @@ dependencies = [
 name = "warpui_tui"
 version = "0.1.0"
 dependencies = [
+ "crossterm",
  "warpui_core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16733,6 +16733,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wsh"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossterm",
+ "env_logger",
+ "libc",
+ "log",
+ "nix 0.26.4",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15454,6 +15454,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "warpui_tui"
+version = "0.1.0"
+dependencies = [
+ "warpui_core",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15458,6 +15458,8 @@ name = "warpui_tui"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
  "warpui_core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16743,6 +16743,8 @@ dependencies = [
  "libc",
  "log",
  "nix 0.26.4",
+ "serde",
+ "serde_json",
  "vte",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ clap = { version = "4.5", features = ["derive"] }
 cocoa = "=0.26.0"
 ctrlc = "3.4.7"
 crc = "3.4.0"
+crossterm = "0.29.0"
 cynic = { version = "3" }
 cynic-codegen = { version = "3", features = ["rkyv"] }
 dashmap = "6.1.0"

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1883,6 +1883,7 @@ fn create_exchange_from_messages(
             is_fallback: model.is_fallback,
         }),
         request_cost: None,
+        revision: 0,
     };
 
     // There is a special case where an exchange consists of only ActionResults with no outputs

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -4115,6 +4115,7 @@ impl AIAgentExchange {
                         telemetry_events: vec![],
                         model_info: None,
                         request_cost: None,
+                        revision: 0,
                     }));
                 }
                 Ok(())

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -395,6 +395,13 @@ pub struct AIAgentOutput {
 
     /// The number of requests that the request cost.
     pub request_cost: Option<RequestCost>,
+
+    /// Monotonically increasing counter bumped on every mutation to
+    /// `messages`. Used by the streaming NDJSON driver to detect
+    /// in-place message updates (e.g. `AppendToMessageContent`) that
+    /// do not change the message count.
+    #[derivative(PartialEq = "ignore")]
+    pub(crate) revision: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/app/src/ai/agent/task.rs
+++ b/app/src/ai/agent/task.rs
@@ -970,7 +970,9 @@ impl Task {
                     }
                 })
                 .collect();
-        output.get_mut().messages.extend(output_messages?);
+        let mut out = output.get_mut();
+        out.messages.extend(output_messages?);
+        out.revision += 1;
         Ok(())
     }
 }
@@ -1014,7 +1016,7 @@ impl AIAgentExchange {
                 .clone()
                 .to_client_output_message(conversion_params)?
             {
-                MaybeAIAgentOutputMessage::Message(m) => {
+            MaybeAIAgentOutputMessage::Message(m) => {
                     // Extract citations from the message and add to the output citations
                     output.extend_citations(m.citations.clone());
                     // Upsert behavior: update the message if it exists, otherwise add it to the end of the list.
@@ -1023,6 +1025,7 @@ impl AIAgentExchange {
                     } else {
                         output.messages.push(m);
                     }
+                    output.revision += 1;
                 }
                 MaybeAIAgentOutputMessage::NoClientRepresentation => {
                     log::warn!(

--- a/app/src/ai/agent/task_store_tests.rs
+++ b/app/src/ai/agent/task_store_tests.rs
@@ -66,6 +66,7 @@ fn create_exchange_with_subagent_call(subtask_id: &TaskId) -> AIAgentExchange {
         telemetry_events: vec![],
         model_info: None,
         request_cost: None,
+        revision: 0,
     };
 
     AIAgentExchange {

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2539,6 +2539,7 @@ impl AgentDriver {
         let history_model_handle = BlocklistAIHistoryModel::handle(ctx);
         let terminal_id = self.terminal_driver.as_ref(ctx).terminal_view().id();
         let mut written_conversation_id = false;
+        let mut streaming_ndjson_emitted: usize = 0;
 
         // Create shared storage for the conversation ID
         let conversation_id_cell = Arc::new(Mutex::new(Option::<String>::None));
@@ -2623,6 +2624,9 @@ impl AgentDriver {
                     // This handles the case where a follow-up query creates new exchanges after
                     // the conversation has finished and an idle timer was set.
                     run_exit.cancel_idle_timeout();
+
+                    // New exchange starts fresh streaming output.
+                    streaming_ndjson_emitted = 0;
                 }
                 BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id,
@@ -2664,11 +2668,53 @@ impl AgentDriver {
                         }
                     }
 
-                    // Once the outputs are fully streamed from the server, write them to stdout.
+                    // Emit new output messages incrementally when streaming
+                    // NDJSON is enabled, so callers see tokens as they arrive.
+                    let is_streaming_ndjson =
+                        FeatureFlag::StreamingNdjsonOutput.is_enabled()
+                            && matches!(me.output_format, OutputFormat::Ndjson);
+
+                    if is_streaming_ndjson {
+                        if let Some(shared) = exchange.output_status.output() {
+                            let output = shared.get();
+                            let total = output.messages.len();
+                            if total > streaming_ndjson_emitted {
+                                let new_messages =
+                                    &output.messages[streaming_ndjson_emitted..];
+                                report_if_error!(output::with_stdout_buffered(|buf| {
+                                    for msg in new_messages {
+                                        output::json::format_output_message(msg, buf)?;
+                                    }
+                                    Ok(())
+                                })
+                                .context("Failed to write streaming NDJSON output"));
+                                streaming_ndjson_emitted = total;
+                            }
+                        }
+                    }
+
                     if exchange.output_status.is_finished() {
-                        report_if_error!(me
-                            .write_exchange_output(exchange)
-                            .context("Failed to write exchange output"));
+                        if is_streaming_ndjson {
+                            // Emit any messages that arrived between the last
+                            // streaming tick and the finished snapshot.
+                            if let Some(shared) = exchange.output_status.output() {
+                                let output = shared.get();
+                                if output.messages.len() > streaming_ndjson_emitted {
+                                    report_if_error!(output::with_stdout_buffered(|buf| {
+                                        for msg in &output.messages[streaming_ndjson_emitted..] {
+                                            output::json::format_output_message(msg, buf)?;
+                                        }
+                                        Ok(())
+                                    })
+                                    .context("Failed to write remaining NDJSON output"));
+                                }
+                            }
+                            streaming_ndjson_emitted = 0;
+                        } else {
+                            report_if_error!(me
+                                .write_exchange_output(exchange)
+                                .context("Failed to write exchange output"));
+                        }
                     }
 
                     // Perform task update after all immutable borrows end

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2540,6 +2540,7 @@ impl AgentDriver {
         let terminal_id = self.terminal_driver.as_ref(ctx).terminal_view().id();
         let mut written_conversation_id = false;
         let mut streaming_ndjson_emitted: usize = 0;
+        let mut streaming_ndjson_revision: u64 = 0;
 
         // Create shared storage for the conversation ID
         let conversation_id_cell = Arc::new(Mutex::new(Option::<String>::None));
@@ -2627,6 +2628,7 @@ impl AgentDriver {
 
                     // New exchange starts fresh streaming output.
                     streaming_ndjson_emitted = 0;
+                    streaming_ndjson_revision = 0;
                 }
                 BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id,
@@ -2678,7 +2680,9 @@ impl AgentDriver {
                         if let Some(shared) = exchange.output_status.output() {
                             let output = shared.get();
                             let total = output.messages.len();
+                            let rev = output.revision;
                             if total > streaming_ndjson_emitted {
+                                // New messages were added — emit them.
                                 let new_messages =
                                     &output.messages[streaming_ndjson_emitted..];
                                 report_if_error!(output::with_stdout_buffered(|buf| {
@@ -2689,17 +2693,35 @@ impl AgentDriver {
                                 })
                                 .context("Failed to write streaming NDJSON output"));
                                 streaming_ndjson_emitted = total;
+                            } else if rev != streaming_ndjson_revision
+                                && streaming_ndjson_emitted > 0
+                            {
+                                // Same message count but content changed (e.g.
+                                // AppendToMessageContent updated a message in
+                                // place). Re-emit the last message so callers
+                                // see the latest content.
+                                let last_idx = streaming_ndjson_emitted - 1;
+                                report_if_error!(output::with_stdout_buffered(|buf| {
+                                    output::json::format_output_message(
+                                        &output.messages[last_idx],
+                                        buf,
+                                    )
+                                })
+                                .context("Failed to write streaming NDJSON update"));
                             }
+                            streaming_ndjson_revision = rev;
                         }
                     }
 
                     if exchange.output_status.is_finished() {
                         if is_streaming_ndjson {
-                            // Emit any messages that arrived between the last
-                            // streaming tick and the finished snapshot.
+                            // Emit any new messages or final in-place updates
+                            // that arrived between the last streaming tick and
+                            // the finished snapshot.
                             if let Some(shared) = exchange.output_status.output() {
                                 let output = shared.get();
-                                if output.messages.len() > streaming_ndjson_emitted {
+                                let total = output.messages.len();
+                                if total > streaming_ndjson_emitted {
                                     report_if_error!(output::with_stdout_buffered(|buf| {
                                         for msg in &output.messages[streaming_ndjson_emitted..] {
                                             output::json::format_output_message(msg, buf)?;
@@ -2707,9 +2729,22 @@ impl AgentDriver {
                                         Ok(())
                                     })
                                     .context("Failed to write remaining NDJSON output"));
+                                } else if output.revision != streaming_ndjson_revision
+                                    && streaming_ndjson_emitted > 0
+                                {
+                                    // Re-emit the last message with its final content.
+                                    let last_idx = streaming_ndjson_emitted - 1;
+                                    report_if_error!(output::with_stdout_buffered(|buf| {
+                                        output::json::format_output_message(
+                                            &output.messages[last_idx],
+                                            buf,
+                                        )
+                                    })
+                                    .context("Failed to write final NDJSON update"));
                                 }
                             }
                             streaming_ndjson_emitted = 0;
+                            streaming_ndjson_revision = 0;
                         } else {
                             report_if_error!(me
                                 .write_exchange_output(exchange)

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -1261,6 +1261,16 @@ pub mod json {
         Ok(())
     }
 
+    pub fn format_output_message<W: Write>(
+        message: &AIAgentOutputMessage,
+        w: &mut W,
+    ) -> io::Result<()> {
+        if let Some(json) = JsonMessage::from_output_message(message) {
+            write_message(&json, w)?;
+        }
+        Ok(())
+    }
+
     pub fn format_input<W: Write>(input: &AIAgentInput, w: &mut W) -> io::Result<()> {
         match JsonMessage::from_input(input) {
             Some(message) => write_message(&message, w),

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -874,6 +874,11 @@ pub enum FeatureFlag {
 
     /// Gates the Grouped Tabs feature.
     GroupedTabs,
+
+    /// When enabled, the SDK driver emits NDJSON output messages
+    /// incrementally as they stream in instead of buffering the
+    /// entire exchange before writing.
+    StreamingNdjsonOutput,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -941,6 +946,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::AsyncFind,
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
+    FeatureFlag::StreamingNdjsonOutput,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -23,7 +23,7 @@ use rustc_hash::FxHashMap;
 use super::{
     autotracking, ActionCallback, BlurContext, FocusContext, GlobalActionCallback, GlobalShortcut,
     InvalidationCallback, Observation, PendingUnsubscribes, RefCounts, Subscription, TaskCallback,
-    TypedActionCallback, ViewType,
+    TuiWindow, TypedActionCallback, ViewType,
 };
 use crate::accessibility::{AccessibilityVerbosity, ActionAccessibilityContent};
 use crate::actions::StandardAction;
@@ -58,9 +58,10 @@ use crate::{
     assets, rendering, AccessibilityData, Action, AddSingletonModel, AddWindowOptions, AnyModel,
     AnyModelHandle, AnyView, ApplicationBundleInfo, Clipboard, CursorInfo, Effect, Element, Entity,
     EntityId, Event, GetSingletonModelHandle, ModelAsRef, ModelContext, ModelHandle,
-    NextNewWindowsHasThisWindowsBoundsUponClose, Presenter, ReadModel, ReadView, Scene,
-    SingletonEntity, SpawnedFuture, TaskId, TypedActionView, UpdateModel, UpdateView, View,
-    ViewAsRef, ViewContext, ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
+    NextNewWindowsHasThisWindowsBoundsUponClose, Presenter, ReadModel, ReadTuiView, ReadView,
+    Scene, SingletonEntity, SpawnedFuture, TaskId, TuiView, TuiViewAsRef, TuiViewContext,
+    TuiViewHandle, TypedActionView, UpdateModel, UpdateTuiView, UpdateView, View, ViewAsRef,
+    ViewContext, ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
 };
 
 lazy_static! {
@@ -380,6 +381,22 @@ impl App {
         handle
     }
 
+    pub fn add_tui_window<T, F>(&mut self, build_root_view: F) -> (WindowId, TuiViewHandle<T>)
+    where
+        T: TuiView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        self.0.borrow_mut().add_tui_window(build_root_view)
+    }
+
+    pub fn add_tui_view<T, F>(&mut self, window_id: WindowId, build_view: F) -> TuiViewHandle<T>
+    where
+        T: TuiView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        self.0.borrow_mut().add_tui_view(window_id, build_view)
+    }
+
     pub fn read<T, F: FnOnce(&AppContext) -> T>(&self, callback: F) -> T {
         callback(&self.0.borrow())
     }
@@ -466,6 +483,16 @@ impl UpdateView for App {
     }
 }
 
+impl UpdateTuiView for App {
+    fn update_tui_view<T, F, S>(&mut self, handle: &TuiViewHandle<T>, update: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S,
+    {
+        self.as_mut().update_tui_view(handle, update)
+    }
+}
+
 impl ReadView for App {
     fn read_view<T, F, S>(&self, handle: &ViewHandle<T>, read: F) -> S
     where
@@ -474,6 +501,17 @@ impl ReadView for App {
     {
         let state = self.0.borrow();
         state.read_view(handle, read)
+    }
+}
+
+impl ReadTuiView for App {
+    fn read_tui_view<T, F, S>(&self, handle: &TuiViewHandle<T>, read: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        let state = self.0.borrow();
+        state.read_tui_view(handle, read)
     }
 }
 
@@ -492,6 +530,12 @@ impl ViewAsRef for App {
 
     fn try_view<T: View>(&self, _handle: &ViewHandle<T>) -> Option<&T> {
         unimplemented!("Read from [`App::read_view`] instead");
+    }
+}
+
+impl TuiViewAsRef for App {
+    fn tui_view<T: TuiView>(&self, _handle: &TuiViewHandle<T>) -> &T {
+        unimplemented!("Read from [`App::read_tui_view`] instead");
     }
 }
 
@@ -580,6 +624,7 @@ pub struct AppContext {
     singleton_models: FxHashMap<TypeId, AnyModelHandle>,
     last_frame_position_cache: HashMap<WindowId, crate::presenter::PositionCache>,
     pub(super) windows: HashMap<WindowId, Window>,
+    pub(super) tui_windows: HashMap<WindowId, TuiWindow>,
     pub(super) ref_counts: Arc<Mutex<RefCounts>>,
     pub(super) platform_delegate: Box<dyn platform::Delegate>,
 
@@ -731,6 +776,10 @@ impl AppContext {
         self.windows.contains_key(&window_id)
     }
 
+    pub fn is_tui_window_open(&self, window_id: WindowId) -> bool {
+        self.tui_windows.contains_key(&window_id)
+    }
+
     /// Sets or clears the window for which focus changes should be suppressed.
     /// When set, all `ctx.focus()` calls targeting this window will be ignored.
     pub fn set_suppress_focus_for_window(&mut self, window_id: Option<WindowId>) {
@@ -750,6 +799,7 @@ impl AppContext {
             models: Default::default(),
             singleton_models: Default::default(),
             windows: Default::default(),
+            tui_windows: Default::default(),
             ref_counts: Arc::new(Mutex::new(RefCounts::default())),
             last_frame_position_cache: Default::default(),
             platform_delegate,
@@ -2818,6 +2868,51 @@ impl AppContext {
         handle
     }
 
+    pub fn add_tui_window<T, F>(&mut self, build_root_view: F) -> (WindowId, TuiViewHandle<T>)
+    where
+        T: TuiView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        let window_id = WindowId::new();
+        self.tui_windows.insert(window_id, TuiWindow::default());
+        let root_handle = self.add_tui_view(window_id, build_root_view);
+        let root_view_id = root_handle.id();
+        self.tui_windows
+            .get_mut(&window_id)
+            .expect("this TUI window was just inserted and should still exist")
+            .root_view = Some(root_handle.clone().into());
+        self.focus(window_id, root_view_id);
+        (window_id, root_handle)
+    }
+
+    pub fn add_tui_view<T, F>(&mut self, window_id: WindowId, build_view: F) -> TuiViewHandle<T>
+    where
+        T: TuiView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        self.pending_flushes += 1;
+
+        let view_id = EntityId::new();
+        let mut ctx = TuiViewContext::new(self, window_id, view_id);
+        let view = build_view(&mut ctx);
+        let window = self
+            .tui_windows
+            .get_mut(&window_id)
+            .expect("TUI window does not exist");
+        window.views.insert(view_id, Box::new(view));
+
+        self.view_to_window.insert(view_id, window_id);
+        self.window_invalidations
+            .entry(window_id)
+            .or_default()
+            .updated
+            .insert(view_id);
+
+        let handle = TuiViewHandle::new(window_id, view_id, &self.ref_counts);
+        self.flush_effects();
+        handle
+    }
+
     /// Add a view that implements the `TypedAction` trait, including the default parent view
     ///
     /// This will create the view as normal as well as register it's `handle_action` method in the
@@ -3104,6 +3199,25 @@ impl AppContext {
                         .or_default()
                         .removed
                         .insert(view_id);
+                    window.views.remove(&view_id);
+                }
+
+                if let Some(window) = self.tui_windows.get_mut(&current_window_id) {
+                    self.window_invalidations
+                        .entry(current_window_id)
+                        .or_default()
+                        .removed
+                        .insert(view_id);
+                    if window.focused_view == Some(view_id) {
+                        window.focused_view = window.root_view.as_ref().map(|root| root.id());
+                    }
+                    if window
+                        .root_view
+                        .as_ref()
+                        .is_some_and(|root| root.id() == view_id)
+                    {
+                        window.root_view = None;
+                    }
                     window.views.remove(&view_id);
                 }
 
@@ -3671,7 +3785,28 @@ impl AppContext {
                                 false
                             }
                         } else {
-                            false
+                            if let Some(mut view) = self
+                                .tui_windows
+                                .get_mut(&current_window_id)
+                                .and_then(|window| window.views.remove(view_id))
+                            {
+                                callback(
+                                    view.as_any_mut(),
+                                    payload.as_ref(),
+                                    self,
+                                    current_window_id,
+                                    *view_id,
+                                );
+
+                                if let Some(window) = self.tui_windows.get_mut(&current_window_id) {
+                                    window.views.insert(*view_id, view);
+                                    true
+                                } else {
+                                    false
+                                }
+                            } else {
+                                false
+                            }
                         }
                     }
                     Subscription::FromApp { callback } => {
@@ -3751,7 +3886,27 @@ impl AppContext {
                                 }
                                 true
                             } else {
-                                false
+                                if let Some(mut view) = self
+                                    .tui_windows
+                                    .get_mut(&current_window_id)
+                                    .and_then(|w| w.views.remove(view_id))
+                                {
+                                    callback(
+                                        view.as_any_mut(),
+                                        observed_id,
+                                        self,
+                                        current_window_id,
+                                        *view_id,
+                                    );
+                                    if let Some(window) =
+                                        self.tui_windows.get_mut(&current_window_id)
+                                    {
+                                        window.views.insert(*view_id, view);
+                                    }
+                                    true
+                                } else {
+                                    false
+                                }
                             }
                         }
                         Observation::FromApp { callback } => {
@@ -3780,6 +3935,21 @@ impl AppContext {
     }
 
     fn focus(&mut self, window_id: WindowId, focused_id: EntityId) {
+        if let Some(window) = self.tui_windows.get_mut(&window_id) {
+            if window.focused_view == Some(focused_id) {
+                return;
+            }
+            if self.suppress_focus_for_window == Some(window_id) {
+                return;
+            }
+            window.focused_view = Some(focused_id);
+            self.window_invalidations
+                .entry(window_id)
+                .or_default()
+                .updated
+                .insert(focused_id);
+            return;
+        }
         if self.windows.get(&window_id).and_then(|w| w.focused_view) == Some(focused_id) {
             return;
         }
@@ -4345,6 +4515,44 @@ impl UpdateView for AppContext {
     }
 }
 
+impl UpdateTuiView for AppContext {
+    fn update_tui_view<T, F, S>(&mut self, handle: &TuiViewHandle<T>, update: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S,
+    {
+        self.pending_flushes += 1;
+        let window_id = handle.window_id(self);
+        let mut view = if let Some(window) = self.tui_windows.get_mut(&window_id) {
+            if let Some(view) = window.views.remove(&handle.id()) {
+                view
+            } else {
+                panic!("Circular TUI view update");
+            }
+        } else {
+            panic!("TUI window does not exist");
+        };
+
+        let mut ctx = TuiViewContext::new(self, window_id, handle.id());
+        let result = update(
+            view.as_any_mut()
+                .downcast_mut()
+                .expect("Downcast is type safe"),
+            &mut ctx,
+        );
+        if let Some(window) = self.tui_windows.get_mut(&window_id) {
+            window.views.insert(handle.id(), view);
+        }
+        self.window_invalidations
+            .entry(window_id)
+            .or_default()
+            .updated
+            .insert(handle.id());
+        self.flush_effects();
+        result
+    }
+}
+
 impl AddSingletonModel for AppContext {
     fn add_singleton_model<T, F>(&mut self, build_model: F) -> ModelHandle<T>
     where
@@ -4377,14 +4585,33 @@ impl AppContext {
             .and_then(|window| window.root_view.as_ref().map(|v| v.id()))
     }
 
+    pub fn root_tui_view_id(&self, window_id: WindowId) -> Option<EntityId> {
+        self.tui_windows
+            .get(&window_id)
+            .and_then(|window| window.root_view.as_ref().map(|v| v.id()))
+    }
+
     pub fn focused_view_id(&self, window_id: WindowId) -> Option<EntityId> {
         self.windows
             .get(&window_id)
             .and_then(|window| window.focused_view)
     }
 
+    pub fn focused_tui_view_id(&self, window_id: WindowId) -> Option<EntityId> {
+        self.tui_windows
+            .get(&window_id)
+            .and_then(|window| window.focused_view)
+    }
+
     pub fn view_name(&self, window_id: WindowId, view_id: EntityId) -> Option<&str> {
         self.windows
+            .get(&window_id)
+            .and_then(|window| window.views.get(&view_id))
+            .map(|view| view.ui_name())
+    }
+
+    pub fn tui_view_name(&self, window_id: WindowId, view_id: EntityId) -> Option<&str> {
+        self.tui_windows
             .get(&window_id)
             .and_then(|window| window.views.get(&view_id))
             .map(|view| view.ui_name())
@@ -4416,6 +4643,43 @@ impl AppContext {
                 .get(&entity_id)
                 .filter(|view| (*view).as_any().type_id() == TypeId::of::<T>())
                 .map(|_| ViewHandle::new(window_id, entity_id, ref_counts))
+        })
+    }
+
+    pub fn root_tui_view<T: TuiView>(&self, window_id: WindowId) -> Option<TuiViewHandle<T>> {
+        self.tui_windows
+            .get(&window_id)
+            .and_then(|window| window.root_view.as_ref())
+            .and_then(|root_view| root_view.clone().downcast::<T>())
+    }
+
+    pub fn tui_views_of_type<T: TuiView>(
+        &self,
+        window_id: WindowId,
+    ) -> Option<Vec<TuiViewHandle<T>>> {
+        let ref_counts = &self.ref_counts;
+        self.tui_windows.get(&window_id).map(|window| {
+            window
+                .views
+                .iter()
+                .filter(|(_, view)| (*view).as_any().type_id() == TypeId::of::<T>())
+                .map(|(view_id, _)| TuiViewHandle::new(window_id, *view_id, ref_counts))
+                .collect::<Vec<TuiViewHandle<T>>>()
+        })
+    }
+
+    pub fn tui_view_with_id<T: TuiView>(
+        &self,
+        window_id: WindowId,
+        entity_id: EntityId,
+    ) -> Option<TuiViewHandle<T>> {
+        let ref_counts = &self.ref_counts;
+        self.tui_windows.get(&window_id).and_then(|window| {
+            window
+                .views
+                .get(&entity_id)
+                .filter(|view| (*view).as_any().type_id() == TypeId::of::<T>())
+                .map(|_| TuiViewHandle::new(window_id, entity_id, ref_counts))
         })
     }
 
@@ -4460,6 +4724,13 @@ impl AppContext {
             .unwrap_or_default()
     }
 
+    pub fn tui_view_ids_for_window(&self, window_id: WindowId) -> Vec<EntityId> {
+        self.tui_windows
+            .get(&window_id)
+            .map(|window| window.views.keys().copied().collect())
+            .unwrap_or_default()
+    }
+
     pub fn render_view(&self, window_id: WindowId, view_id: EntityId) -> Result<Box<dyn Element>> {
         // surfacing the error of a missing window earlier
         let window = self
@@ -4483,6 +4754,18 @@ impl AppContext {
                     .collect::<HashMap<_, _>>()
             })
             .ok_or_else(|| anyhow!("window not found"))
+    }
+
+    pub fn render_tui_view(&self, window_id: WindowId, view_id: EntityId) -> Result<Box<dyn Any>> {
+        let window = self
+            .tui_windows
+            .get(&window_id)
+            .ok_or_else(|| anyhow!("TUI window not found"))?;
+        window
+            .views
+            .get(&view_id)
+            .map(|view| view.render_tui(self))
+            .ok_or_else(|| anyhow!("TUI view not found"))
     }
 
     /// Returns the cached element position from the last rendered frame, if there is one.
@@ -4571,6 +4854,36 @@ impl ReadView for AppContext {
         F: FnOnce(&T, &AppContext) -> S,
     {
         read(self.view(handle), self)
+    }
+}
+
+impl TuiViewAsRef for AppContext {
+    fn tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> &T {
+        let window_id = handle.window_id(self);
+        if let Some(window) = self.tui_windows.get(&window_id) {
+            if let Some(view) = window.views.get(&handle.id()) {
+                view.as_any()
+                    .downcast_ref()
+                    .expect("downcast should be type safe")
+            } else {
+                panic!(
+                    "circular TUI view reference for view type {}",
+                    std::any::type_name::<T>()
+                );
+            }
+        } else {
+            panic!("TUI window does not exist");
+        }
+    }
+}
+
+impl ReadTuiView for AppContext {
+    fn read_tui_view<T, F, S>(&self, handle: &TuiViewHandle<T>, read: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        read(self.tui_view(handle), self)
     }
 }
 

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -23,7 +23,7 @@ use rustc_hash::FxHashMap;
 use super::{
     autotracking, ActionCallback, BlurContext, FocusContext, GlobalActionCallback, GlobalShortcut,
     InvalidationCallback, Observation, PendingUnsubscribes, RefCounts, Subscription, TaskCallback,
-    TuiWindow, TypedActionCallback, ViewType,
+    TuiTypedActionCallback, TuiWindow, TypedActionCallback, ViewType,
 };
 use crate::accessibility::{AccessibilityVerbosity, ActionAccessibilityContent};
 use crate::actions::StandardAction;
@@ -56,12 +56,12 @@ use crate::util::post_inc;
 use crate::windowing::{self, WindowCallbacks, WindowManager};
 use crate::{
     assets, rendering, AccessibilityData, Action, AddSingletonModel, AddWindowOptions, AnyModel,
-    AnyModelHandle, AnyView, ApplicationBundleInfo, Clipboard, CursorInfo, Effect, Element, Entity,
-    EntityId, Event, GetSingletonModelHandle, ModelAsRef, ModelContext, ModelHandle,
+    AnyModelHandle, AnyTuiView, AnyView, ApplicationBundleInfo, Clipboard, CursorInfo, Effect,
+    Element, Entity, EntityId, Event, GetSingletonModelHandle, ModelAsRef, ModelContext, ModelHandle,
     NextNewWindowsHasThisWindowsBoundsUponClose, Presenter, ReadModel, ReadTuiView, ReadView,
-    Scene, SingletonEntity, SpawnedFuture, TaskId, TuiView, TuiViewAsRef, TuiViewContext,
-    TuiViewHandle, TypedActionView, UpdateModel, UpdateTuiView, UpdateView, View, ViewAsRef,
-    ViewContext, ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
+    Scene, SingletonEntity, SpawnedFuture, TaskId, TuiTypedActionView, TuiView, TuiViewAsRef,
+    TuiViewContext, TuiViewHandle, TypedActionView, UpdateModel, UpdateTuiView, UpdateView, View,
+    ViewAsRef, ViewContext, ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
 };
 
 lazy_static! {
@@ -223,6 +223,20 @@ impl App {
         );
     }
 
+    pub fn dispatch_tui_typed_action(
+        &self,
+        window_id: WindowId,
+        responder_chain: &[EntityId],
+        action: &dyn Action,
+    ) -> bool {
+        self.0.borrow_mut().dispatch_tui_typed_action(
+            window_id,
+            responder_chain,
+            action,
+            log::Level::Info,
+        )
+    }
+
     pub fn last_active_timestamp() -> i64 {
         LAST_USER_ACTION_UNIX_TIMESTAMP.load(Ordering::SeqCst)
     }
@@ -268,6 +282,21 @@ impl App {
     ) -> Result<bool> {
         let mut state = self.0.borrow_mut();
         state.dispatch_keystroke(window_id, responder_chain, keystroke, is_composing)
+    }
+
+    pub fn dispatch_tui_keystroke(
+        &self,
+        window_id: WindowId,
+        responder_chain: &[EntityId],
+        keystroke: &Keystroke,
+    ) -> Result<bool> {
+        self.0
+            .borrow_mut()
+            .dispatch_tui_keystroke(window_id, responder_chain, keystroke)
+    }
+
+    pub fn focus_tui_view(&mut self, window_id: WindowId, view_id: EntityId) {
+        self.update(|ctx| ctx.focus(window_id, view_id));
     }
 
     pub fn add_model<T, F>(&mut self, build_model: F) -> ModelHandle<T>
@@ -395,12 +424,39 @@ impl App {
         self.0.borrow_mut().add_tui_window(build_root_view)
     }
 
+    pub fn add_tui_typed_action_window<T, F>(
+        &mut self,
+        build_root_view: F,
+    ) -> (WindowId, TuiViewHandle<T>)
+    where
+        T: TuiView + TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        self.0
+            .borrow_mut()
+            .add_tui_typed_action_window(build_root_view)
+    }
+
     pub fn add_tui_view<T, F>(&mut self, window_id: WindowId, build_view: F) -> TuiViewHandle<T>
     where
         T: TuiView,
         F: FnOnce(&mut TuiViewContext<T>) -> T,
     {
         self.0.borrow_mut().add_tui_view(window_id, build_view)
+    }
+
+    pub fn add_tui_typed_action_view<T, F>(
+        &mut self,
+        window_id: WindowId,
+        build_view: F,
+    ) -> TuiViewHandle<T>
+    where
+        T: TuiView + TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        self.0
+            .borrow_mut()
+            .add_tui_typed_action_view(window_id, build_view)
     }
 
     pub fn read<T, F: FnOnce(&AppContext) -> T>(&self, callback: F) -> T {
@@ -646,6 +702,7 @@ pub struct AppContext {
     /// Safety Note: The `TypedActionCallback` must only be called with parameters that match the
     /// type keys, as it requires the values to appropriately downcast.
     typed_actions: HashMap<ActionType, HashMap<ViewType, Box<TypedActionCallback>>>,
+    tui_typed_actions: HashMap<ActionType, HashMap<ViewType, Box<TuiTypedActionCallback>>>,
     presenters: HashMap<WindowId, Rc<RefCell<Presenter>>>,
     /// Configuration options related to rendering of the application.
     rendering_config: rendering::Config,
@@ -812,6 +869,7 @@ impl AppContext {
             // AppContext fields
             actions: Default::default(),
             typed_actions: Default::default(),
+            tui_typed_actions: Default::default(),
             global_actions: Default::default(),
             presenters: Default::default(),
             rendering_config: Default::default(),
@@ -1299,6 +1357,35 @@ impl AppContext {
             .or_insert(handler);
     }
 
+    fn add_tui_typed_action<V>(&mut self)
+    where
+        V: TuiTypedActionView + TuiView,
+    {
+        let handler = Box::new(
+            |view: &mut dyn AnyTuiView,
+             action: &dyn Any,
+             app: &mut AppContext,
+             window_id: WindowId,
+             view_id: EntityId| {
+                let action = action
+                    .downcast_ref()
+                    .expect("Handlers are hashed by action type");
+                let view = view
+                    .as_any_mut()
+                    .downcast_mut()
+                    .expect("Handlers are hashed by view type");
+                let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                V::handle_action(view, action, &mut ctx);
+            },
+        );
+
+        self.tui_typed_actions
+            .entry(ActionType::of::<V::Action>())
+            .or_default()
+            .entry(ViewType::of::<V>())
+            .or_insert(handler);
+    }
+
     pub fn add_action<S, V, T, F>(&mut self, name: S, mut handler: F)
     where
         S: Into<String>,
@@ -1566,6 +1653,62 @@ impl AppContext {
 
         if !handled {
             log::warn!("Action {action:?} was dispatched, but no view handled it");
+        }
+
+        self.flush_effects();
+        handled
+    }
+
+    pub fn dispatch_tui_typed_action(
+        &mut self,
+        window_id: WindowId,
+        responder_chain: &[EntityId],
+        action: &dyn Action,
+        log_level: log::Level,
+    ) -> bool {
+        log::log!(
+            log_level,
+            "dispatching TUI typed action: {}::{action:?}",
+            action.type_name()
+        );
+
+        let action_type: ActionType = action.into();
+        let Some(mut handlers) = self.tui_typed_actions.remove(&action_type) else {
+            log::warn!("Dispatched TUI action has no handlers: {:?}", &action);
+            return false;
+        };
+
+        self.pending_flushes += 1;
+        let handled = responder_chain.iter().rev().any(|view_id| {
+            let mut view = match self
+                .tui_windows
+                .get_mut(&window_id)
+                .and_then(|window| window.views.remove(view_id))
+            {
+                Some(view) => view,
+                None => return false,
+            };
+
+            let view_type = ViewType(view.as_any().type_id());
+            let found = match handlers.get_mut(&view_type) {
+                Some(handler) => {
+                    handler(view.as_mut(), action.as_any(), self, window_id, *view_id);
+                    true
+                }
+                None => false,
+            };
+
+            if let Some(window) = self.tui_windows.get_mut(&window_id) {
+                window.views.insert(*view_id, view);
+            }
+
+            found
+        });
+
+        self.tui_typed_actions.insert(action_type, handlers);
+
+        if !handled {
+            log::warn!("TUI action {action:?} was dispatched, but no view handled it");
         }
 
         self.flush_effects();
@@ -1899,6 +2042,29 @@ impl AppContext {
         Ok(context_chain)
     }
 
+    fn contexts_from_tui_responder_chain(
+        &self,
+        window_id: WindowId,
+        responder_chain: &[EntityId],
+    ) -> Result<Vec<Context>> {
+        let mut context_chain = Vec::new();
+        for view_id in responder_chain {
+            if let Some(view) = self
+                .tui_windows
+                .get(&window_id)
+                .and_then(|window| window.views.get(view_id))
+            {
+                context_chain.push(view.keymap_context(self));
+            } else {
+                return Err(anyhow!(
+                    "TUI view {} in responder chain does not exist",
+                    view_id
+                ));
+            }
+        }
+        Ok(context_chain)
+    }
+
     fn dispatch_standard_action(
         &mut self,
         action: StandardAction,
@@ -2062,6 +2228,41 @@ impl AppContext {
                     false
                 }
                 MatchResult::Action(action) => self.dispatch_typed_action(
+                    window_id,
+                    &responder_chain[0..=i],
+                    action.as_ref(),
+                    log::Level::Info,
+                ),
+            };
+
+            if handled {
+                return Ok(true);
+            }
+        }
+        Ok(pending)
+    }
+
+    pub fn dispatch_tui_keystroke(
+        &mut self,
+        window_id: WindowId,
+        responder_chain: &[EntityId],
+        keystroke: &Keystroke,
+    ) -> Result<bool> {
+        let mut context_chain =
+            self.contexts_from_tui_responder_chain(window_id, responder_chain)?;
+        let mut pending = false;
+        for (i, ctx) in context_chain.iter_mut().enumerate().rev() {
+            let handled = match self.keystroke_matcher.push_keystroke(
+                keystroke.clone(),
+                responder_chain[i],
+                ctx,
+            ) {
+                MatchResult::None => false,
+                MatchResult::Pending => {
+                    pending = true;
+                    false
+                }
+                MatchResult::Action(action) => self.dispatch_tui_typed_action(
                     window_id,
                     &responder_chain[0..=i],
                     action.as_ref(),
@@ -2450,7 +2651,10 @@ impl AppContext {
                                         presenter.clone(),
                                     );
                                 }
-                            }
+                                true
+                            } else {
+                                false
+                            };
                         }
                     }
                     // Update the last mouse moved event on mouse up with the new position.
@@ -2916,6 +3120,40 @@ impl AppContext {
 
         let handle = TuiViewHandle::new(window_id, view_id, &self.ref_counts);
         self.flush_effects();
+        handle
+    }
+
+    pub fn add_tui_typed_action_window<T, F>(
+        &mut self,
+        build_root_view: F,
+    ) -> (WindowId, TuiViewHandle<T>)
+    where
+        T: TuiView + TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        let window_id = WindowId::new();
+        self.tui_windows.insert(window_id, TuiWindow::default());
+        let root_handle = self.add_tui_typed_action_view(window_id, build_root_view);
+        let root_view_id = root_handle.id();
+        self.tui_windows
+            .get_mut(&window_id)
+            .expect("this TUI window was just inserted and should still exist")
+            .root_view = Some(root_handle.clone().into());
+        self.focus(window_id, root_view_id);
+        (window_id, root_handle)
+    }
+
+    pub fn add_tui_typed_action_view<T, F>(
+        &mut self,
+        window_id: WindowId,
+        build_view: F,
+    ) -> TuiViewHandle<T>
+    where
+        T: TuiView + TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        let handle = self.add_tui_view(window_id, build_view);
+        self.add_tui_typed_action::<T>();
         handle
     }
 
@@ -3790,29 +4028,27 @@ impl AppContext {
                             } else {
                                 false
                             }
-                        } else {
-                            if let Some(mut view) = self
-                                .tui_windows
-                                .get_mut(&current_window_id)
-                                .and_then(|window| window.views.remove(view_id))
-                            {
-                                callback(
-                                    view.as_any_mut(),
-                                    payload.as_ref(),
-                                    self,
-                                    current_window_id,
-                                    *view_id,
-                                );
+                        } else if let Some(mut view) = self
+                            .tui_windows
+                            .get_mut(&current_window_id)
+                            .and_then(|window| window.views.remove(view_id))
+                        {
+                            callback(
+                                view.as_any_mut(),
+                                payload.as_ref(),
+                                self,
+                                current_window_id,
+                                *view_id,
+                            );
 
-                                if let Some(window) = self.tui_windows.get_mut(&current_window_id) {
-                                    window.views.insert(*view_id, view);
-                                    true
-                                } else {
-                                    false
-                                }
+                            if let Some(window) = self.tui_windows.get_mut(&current_window_id) {
+                                window.views.insert(*view_id, view);
+                                true
                             } else {
                                 false
                             }
+                        } else {
+                            false
                         }
                     }
                     Subscription::FromApp { callback } => {
@@ -3891,28 +4127,26 @@ impl AppContext {
                                     window.views.insert(*view_id, view);
                                 }
                                 true
-                            } else {
-                                if let Some(mut view) = self
-                                    .tui_windows
-                                    .get_mut(&current_window_id)
-                                    .and_then(|w| w.views.remove(view_id))
+                            } else if let Some(mut view) = self
+                                .tui_windows
+                                .get_mut(&current_window_id)
+                                .and_then(|w| w.views.remove(view_id))
+                            {
+                                callback(
+                                    view.as_any_mut(),
+                                    observed_id,
+                                    self,
+                                    current_window_id,
+                                    *view_id,
+                                );
+                                if let Some(window) =
+                                    self.tui_windows.get_mut(&current_window_id)
                                 {
-                                    callback(
-                                        view.as_any_mut(),
-                                        observed_id,
-                                        self,
-                                        current_window_id,
-                                        *view_id,
-                                    );
-                                    if let Some(window) =
-                                        self.tui_windows.get_mut(&current_window_id)
-                                    {
-                                        window.views.insert(*view_id, view);
-                                    }
-                                    true
-                                } else {
-                                    false
+                                    window.views.insert(*view_id, view);
                                 }
+                                true
+                            } else {
+                                false
                             }
                         }
                         Observation::FromApp { callback } => {

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -123,6 +123,12 @@ impl App {
         self.0.borrow().has_window_invalidations(window_id)
     }
 
+    pub fn take_window_invalidations(&self, window_id: WindowId) -> WindowInvalidation {
+        self.0
+            .borrow_mut()
+            .take_all_invalidations_for_window(window_id)
+    }
+
     pub fn window_bounds(&self, window_id: &WindowId) -> Option<RectF> {
         self.0.borrow().window_bounds(window_id)
     }

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -3,6 +3,8 @@ mod app;
 mod autotracking;
 mod entity;
 mod model;
+mod tui_view;
+mod tui_window;
 mod view;
 mod window;
 
@@ -26,6 +28,8 @@ use futures_util::future::BoxFuture;
 pub use model::*;
 use pathfinder_geometry::rect::RectF;
 use serde::{Deserialize, Serialize};
+pub use tui_view::*;
+pub(in crate::core) use tui_window::*;
 pub use view::*;
 pub use window::*;
 
@@ -387,6 +391,7 @@ pub trait Handle<T> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum EntityLocation {
     Model(EntityId),
+    TuiView(WindowId, EntityId),
     View(WindowId, EntityId),
 }
 

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -140,6 +140,8 @@ type ActionCallback =
 
 type TypedActionCallback =
     dyn FnMut(&mut dyn AnyView, &dyn Any, &mut AppContext, WindowId, EntityId);
+type TuiTypedActionCallback =
+    dyn FnMut(&mut dyn AnyTuiView, &dyn Any, &mut AppContext, WindowId, EntityId);
 
 type GlobalActionCallback =
     dyn FnMut(&dyn Any, &'static std::panic::Location<'static>, &mut AppContext);

--- a/crates/warpui_core/src/core/tui_view/context.rs
+++ b/crates/warpui_core/src/core/tui_view/context.rs
@@ -1,0 +1,127 @@
+use std::marker::PhantomData;
+
+use crate::core::{Observation, Subscription};
+use crate::{
+    AppContext, Effect, Entity, EntityId, ModelContext, ModelHandle, TuiView, TuiViewHandle,
+    WeakTuiViewHandle, WindowId,
+};
+
+pub struct TuiViewContext<'a, T: ?Sized> {
+    app: &'a mut AppContext,
+    window_id: WindowId,
+    view_id: EntityId,
+    view_type: PhantomData<T>,
+}
+
+impl<'a, T: TuiView> TuiViewContext<'a, T> {
+    pub(in crate::core) fn new(
+        app: &'a mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    ) -> Self {
+        Self {
+            app,
+            window_id,
+            view_id,
+            view_type: PhantomData,
+        }
+    }
+
+    pub fn handle(&self) -> WeakTuiViewHandle<T> {
+        WeakTuiViewHandle::new(self.view_id)
+    }
+
+    pub fn window_id(&self) -> WindowId {
+        self.window_id
+    }
+
+    pub fn view_id(&self) -> EntityId {
+        self.view_id
+    }
+
+    pub fn add_model<S, F>(&mut self, build_model: F) -> ModelHandle<S>
+    where
+        S: Entity,
+        F: FnOnce(&mut ModelContext<S>) -> S,
+    {
+        self.app.add_model(build_model)
+    }
+
+    pub fn subscribe_to_model<S: Entity, F>(&mut self, handle: &ModelHandle<S>, mut callback: F)
+    where
+        S::Event: 'static,
+        F: 'static + FnMut(&mut T, ModelHandle<S>, &S::Event, &mut TuiViewContext<T>),
+    {
+        let emitter_handle = handle.downgrade();
+        self.app
+            .subscriptions
+            .entry(handle.id())
+            .or_default()
+            .push(Subscription::FromView {
+                window_id: self.window_id,
+                view_id: self.view_id,
+                callback: Box::new(move |view, payload, app, window_id, view_id| {
+                    if let Some(emitter_handle) = emitter_handle.upgrade(app) {
+                        let view = view.downcast_mut().expect("downcast is type safe");
+                        let payload = payload.downcast_ref().expect("downcast is type safe");
+                        let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                        callback(view, emitter_handle, payload, &mut ctx);
+                    }
+                }),
+            });
+    }
+
+    pub fn observe<S, F>(&mut self, handle: &ModelHandle<S>, mut callback: F)
+    where
+        S: Entity,
+        F: 'static + FnMut(&mut T, ModelHandle<S>, &mut TuiViewContext<T>),
+    {
+        self.app
+            .observations
+            .entry(handle.id())
+            .or_default()
+            .push(Observation::FromView {
+                window_id: self.window_id,
+                view_id: self.view_id,
+                callback: Box::new(move |view, observed_id, app, window_id, view_id| {
+                    let view = view.downcast_mut().expect("downcast is type safe");
+                    let observed = ModelHandle::new(observed_id, &app.ref_counts);
+                    let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                    callback(view, observed, &mut ctx);
+                }),
+            });
+    }
+
+    pub fn emit(&mut self, payload: T::Event)
+    where
+        T::Event: 'static,
+    {
+        self.app.pending_effects.push_back(Effect::Event {
+            entity_id: self.view_id,
+            payload: Box::new(payload),
+        });
+    }
+
+    pub fn notify(&mut self) {
+        self.app
+            .pending_effects
+            .push_back(Effect::ViewNotification {
+                window_id: self.window_id,
+                view_id: self.view_id,
+            });
+    }
+
+    pub fn focus_self(&mut self) {
+        self.app.pending_effects.push_back(Effect::Focus {
+            window_id: self.window_id,
+            view_id: self.view_id,
+        });
+    }
+
+    pub fn focus<S: TuiView>(&mut self, handle: &TuiViewHandle<S>) {
+        self.app.pending_effects.push_back(Effect::Focus {
+            window_id: handle.window_id(self.app),
+            view_id: handle.id(),
+        });
+    }
+}

--- a/crates/warpui_core/src/core/tui_view/context.rs
+++ b/crates/warpui_core/src/core/tui_view/context.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use super::TuiTypedActionView;
 use crate::core::{Observation, Subscription};
 use crate::{
     AppContext, Effect, Entity, EntityId, ModelContext, ModelHandle, TuiView, TuiViewHandle,
@@ -45,6 +46,22 @@ impl<'a, T: TuiView> TuiViewContext<'a, T> {
         F: FnOnce(&mut ModelContext<S>) -> S,
     {
         self.app.add_model(build_model)
+    }
+    pub fn add_tui_view<S, F>(&mut self, build_view: F) -> TuiViewHandle<S>
+    where
+        S: TuiView,
+        F: FnOnce(&mut TuiViewContext<S>) -> S,
+    {
+        self.app.add_tui_view(self.window_id, build_view)
+    }
+
+    pub fn add_tui_typed_action_view<S, F>(&mut self, build_view: F) -> TuiViewHandle<S>
+    where
+        S: TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<S>) -> S,
+    {
+        self.app
+            .add_tui_typed_action_view(self.window_id, build_view)
     }
 
     pub fn subscribe_to_model<S: Entity, F>(&mut self, handle: &ModelHandle<S>, mut callback: F)

--- a/crates/warpui_core/src/core/tui_view/handle.rs
+++ b/crates/warpui_core/src/core/tui_view/handle.rs
@@ -1,0 +1,262 @@
+use std::any::TypeId;
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+use std::sync::{Arc, Weak};
+
+use parking_lot::Mutex;
+
+use super::context::TuiViewContext;
+use super::{AnyTuiViewHandle, TuiView};
+use crate::core::RefCounts;
+use crate::{AppContext, EntityId, EntityLocation, Handle, WindowId};
+
+pub struct TuiViewHandle<T> {
+    window_id: WindowId,
+    view_id: EntityId,
+    view_type: PhantomData<T>,
+    ref_counts: Weak<Mutex<RefCounts>>,
+}
+
+impl<T: TuiView> TuiViewHandle<T> {
+    pub(in crate::core) fn new(
+        window_id: WindowId,
+        view_id: EntityId,
+        ref_counts: &Arc<Mutex<RefCounts>>,
+    ) -> Self {
+        ref_counts.lock().inc_entity(view_id);
+        Self {
+            window_id,
+            view_id,
+            view_type: PhantomData,
+            ref_counts: Arc::downgrade(ref_counts),
+        }
+    }
+
+    pub fn downgrade(&self) -> WeakTuiViewHandle<T> {
+        WeakTuiViewHandle::new(self.view_id)
+    }
+
+    pub fn window_id(&self, app: &AppContext) -> WindowId {
+        app.view_to_window
+            .get(&self.view_id)
+            .copied()
+            .unwrap_or(self.window_id)
+    }
+
+    pub fn id(&self) -> EntityId {
+        self.view_id
+    }
+
+    pub fn as_ref<'a, A: TuiViewAsRef>(&self, app: &'a A) -> &'a T {
+        app.tui_view(self)
+    }
+
+    pub fn read<A, F, S>(&self, app: &A, read: F) -> S
+    where
+        A: ReadTuiView,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        app.read_tui_view(self, read)
+    }
+
+    pub fn update<A, F, S>(&self, app: &mut A, update: F) -> S
+    where
+        A: UpdateTuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S,
+    {
+        app.update_tui_view(self, update)
+    }
+}
+
+impl<T> Clone for TuiViewHandle<T> {
+    fn clone(&self) -> Self {
+        if let Some(ref_counts) = self.ref_counts.upgrade() {
+            ref_counts.lock().inc_entity(self.view_id);
+        }
+
+        Self {
+            window_id: self.window_id,
+            view_id: self.view_id,
+            view_type: PhantomData,
+            ref_counts: self.ref_counts.clone(),
+        }
+    }
+}
+
+impl<T> PartialEq for TuiViewHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.window_id == other.window_id && self.view_id == other.view_id
+    }
+}
+
+impl<T> Eq for TuiViewHandle<T> {}
+
+impl<T> Debug for TuiViewHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(&format!("TuiViewHandle<{}>", core::any::type_name::<T>()))
+            .field("window_id", &self.window_id)
+            .field("view_id", &self.view_id)
+            .finish()
+    }
+}
+
+impl<T> Drop for TuiViewHandle<T> {
+    fn drop(&mut self) {
+        if let Some(ref_counts) = self.ref_counts.upgrade() {
+            ref_counts.lock().dec_view(self.window_id, self.view_id);
+        }
+    }
+}
+
+unsafe impl<T> Send for TuiViewHandle<T> {}
+unsafe impl<T> Sync for TuiViewHandle<T> {}
+
+impl<T> Handle<T> for TuiViewHandle<T> {
+    fn id(&self) -> EntityId {
+        self.view_id
+    }
+
+    fn location(&self) -> EntityLocation {
+        EntityLocation::TuiView(self.window_id, self.view_id)
+    }
+}
+
+impl AnyTuiViewHandle {
+    pub fn id(&self) -> EntityId {
+        self.view_id
+    }
+
+    pub fn is<T: 'static>(&self) -> bool {
+        TypeId::of::<T>() == self.view_type
+    }
+
+    pub fn downcast<T: TuiView>(self) -> Option<TuiViewHandle<T>> {
+        if self.is::<T>() {
+            if let Some(ref_counts) = self.ref_counts.upgrade() {
+                return Some(TuiViewHandle::new(
+                    self.window_id,
+                    self.view_id,
+                    &ref_counts,
+                ));
+            }
+        }
+        None
+    }
+}
+
+impl Clone for AnyTuiViewHandle {
+    fn clone(&self) -> Self {
+        if let Some(ref_counts) = self.ref_counts.upgrade() {
+            ref_counts.lock().inc_entity(self.view_id);
+        }
+
+        Self {
+            view_id: self.view_id,
+            window_id: self.window_id,
+            view_type: self.view_type,
+            ref_counts: self.ref_counts.clone(),
+        }
+    }
+}
+
+impl<T: TuiView> From<&TuiViewHandle<T>> for AnyTuiViewHandle {
+    fn from(handle: &TuiViewHandle<T>) -> Self {
+        if let Some(ref_counts) = handle.ref_counts.upgrade() {
+            ref_counts.lock().inc_entity(handle.view_id);
+        }
+        AnyTuiViewHandle {
+            window_id: handle.window_id,
+            view_id: handle.view_id,
+            view_type: TypeId::of::<T>(),
+            ref_counts: handle.ref_counts.clone(),
+        }
+    }
+}
+
+impl<T: TuiView> From<TuiViewHandle<T>> for AnyTuiViewHandle {
+    fn from(handle: TuiViewHandle<T>) -> Self {
+        (&handle).into()
+    }
+}
+
+impl Drop for AnyTuiViewHandle {
+    fn drop(&mut self) {
+        if let Some(ref_counts) = self.ref_counts.upgrade() {
+            ref_counts.lock().dec_view(self.window_id, self.view_id);
+        }
+    }
+}
+
+pub struct WeakTuiViewHandle<T> {
+    view_id: EntityId,
+    view_type: PhantomData<T>,
+}
+
+impl<T: TuiView> WeakTuiViewHandle<T> {
+    pub(super) fn new(view_id: EntityId) -> Self {
+        Self {
+            view_id,
+            view_type: PhantomData,
+        }
+    }
+
+    pub fn upgrade(&self, app: &AppContext) -> Option<TuiViewHandle<T>> {
+        let window_id = app.view_to_window.get(&self.view_id).copied()?;
+
+        if app
+            .tui_windows
+            .get(&window_id)
+            .and_then(|w| w.views.get(&self.view_id))
+            .is_some()
+        {
+            Some(TuiViewHandle::new(window_id, self.view_id, &app.ref_counts))
+        } else {
+            None
+        }
+    }
+
+    pub fn id(&self) -> EntityId {
+        self.view_id
+    }
+}
+
+impl<T> Clone for WeakTuiViewHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            view_id: self.view_id,
+            view_type: PhantomData,
+        }
+    }
+}
+
+impl<T> Debug for WeakTuiViewHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(&format!(
+            "WeakTuiViewHandle<{}>",
+            core::any::type_name::<T>()
+        ))
+        .field("view_id", &self.view_id)
+        .finish()
+    }
+}
+
+unsafe impl<T> Send for WeakTuiViewHandle<T> {}
+unsafe impl<T> Sync for WeakTuiViewHandle<T> {}
+
+pub trait TuiViewAsRef {
+    fn tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> &T;
+}
+
+pub trait ReadTuiView: TuiViewAsRef {
+    fn read_tui_view<T, F, S>(&self, handle: &TuiViewHandle<T>, read: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&T, &AppContext) -> S;
+}
+
+pub trait UpdateTuiView: ReadTuiView {
+    fn update_tui_view<T, F, S>(&mut self, handle: &TuiViewHandle<T>, update: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S;
+}

--- a/crates/warpui_core/src/core/tui_view/mod.rs
+++ b/crates/warpui_core/src/core/tui_view/mod.rs
@@ -6,7 +6,7 @@ use std::any::Any;
 pub use context::TuiViewContext;
 pub use handle::{ReadTuiView, TuiViewAsRef, TuiViewHandle, UpdateTuiView, WeakTuiViewHandle};
 
-use crate::{keymap, AppContext, Entity, EntityId, WindowId};
+use crate::{keymap, Action, AppContext, Entity, EntityId, WindowId};
 
 pub trait TuiView: Entity {
     type RenderOutput: Any;
@@ -20,6 +20,12 @@ pub trait TuiView: Entity {
         ctx.set.insert(Self::ui_name());
         ctx
     }
+}
+
+pub trait TuiTypedActionView: TuiView {
+    type Action: Action;
+
+    fn handle_action(&mut self, _action: &Self::Action, _ctx: &mut TuiViewContext<Self>) {}
 }
 
 pub trait AnyTuiView {

--- a/crates/warpui_core/src/core/tui_view/mod.rs
+++ b/crates/warpui_core/src/core/tui_view/mod.rs
@@ -1,0 +1,63 @@
+mod context;
+mod handle;
+
+use std::any::Any;
+
+pub use context::TuiViewContext;
+pub use handle::{ReadTuiView, TuiViewAsRef, TuiViewHandle, UpdateTuiView, WeakTuiViewHandle};
+
+use crate::{keymap, AppContext, Entity, EntityId, WindowId};
+
+pub trait TuiView: Entity {
+    type RenderOutput: Any;
+
+    fn ui_name() -> &'static str;
+
+    fn render_tui(&self, app: &AppContext) -> Self::RenderOutput;
+
+    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
+        let mut ctx = keymap::Context::default();
+        ctx.set.insert(Self::ui_name());
+        ctx
+    }
+}
+
+pub trait AnyTuiView {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn ui_name(&self) -> &'static str;
+    fn render_tui(&self, app: &AppContext) -> Box<dyn Any>;
+    fn keymap_context(&self, app: &AppContext) -> keymap::Context;
+}
+
+impl<T> AnyTuiView for T
+where
+    T: TuiView,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn ui_name(&self) -> &'static str {
+        T::ui_name()
+    }
+
+    fn render_tui(&self, app: &AppContext) -> Box<dyn Any> {
+        Box::new(TuiView::render_tui(self, app))
+    }
+
+    fn keymap_context(&self, app: &AppContext) -> keymap::Context {
+        TuiView::keymap_context(self, app)
+    }
+}
+
+pub(in crate::core) struct AnyTuiViewHandle {
+    pub(super) window_id: WindowId,
+    pub(super) view_id: EntityId,
+    pub(super) view_type: std::any::TypeId,
+    pub(super) ref_counts: std::sync::Weak<parking_lot::Mutex<crate::core::RefCounts>>,
+}

--- a/crates/warpui_core/src/core/tui_window.rs
+++ b/crates/warpui_core/src/core/tui_window.rs
@@ -1,0 +1,11 @@
+use std::collections::HashMap;
+
+use crate::core::tui_view::AnyTuiViewHandle;
+use crate::{AnyTuiView, EntityId};
+
+#[derive(Default)]
+pub(in crate::core) struct TuiWindow {
+    pub views: HashMap<EntityId, Box<dyn AnyTuiView>>,
+    pub root_view: Option<AnyTuiViewHandle>,
+    pub focused_view: Option<EntityId>,
+}

--- a/crates/warpui_tui/Cargo.toml
+++ b/crates/warpui_tui/Cargo.toml
@@ -7,4 +7,5 @@ publish.workspace = true
 license = "MIT"
 
 [dependencies]
+crossterm.workspace = true
 warpui_core.workspace = true

--- a/crates/warpui_tui/Cargo.toml
+++ b/crates/warpui_tui/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "warpui_tui"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+publish.workspace = true
+license = "MIT"
+
+[dependencies]
+warpui_core.workspace = true

--- a/crates/warpui_tui/Cargo.toml
+++ b/crates/warpui_tui/Cargo.toml
@@ -8,4 +8,6 @@ license = "MIT"
 
 [dependencies]
 crossterm.workspace = true
+unicode-segmentation = "1.11.0"
+unicode-width.workspace = true
 warpui_core.workspace = true

--- a/crates/warpui_tui/examples/basic/main.rs
+++ b/crates/warpui_tui/examples/basic/main.rs
@@ -1,0 +1,233 @@
+use std::io::{self, stdout, Stdout, Write};
+use std::time::Duration;
+
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture};
+use crossterm::style::Print;
+use crossterm::terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::{execute, queue};
+use warpui_core::{App, AppContext, Entity, ModelHandle};
+use warpui_tui::elements::{TuiColumn, TuiContainer, TuiElement, TuiEventHandler, TuiText};
+use warpui_tui::{
+    crossterm_event_to_warp_event, TuiDispatchEventResult, TuiFrame, TuiPresenter, TuiSize,
+    TuiView,
+};
+
+struct TodoItem {
+    label: String,
+    done: bool,
+}
+
+struct TodoModel {
+    title: String,
+    items: Vec<TodoItem>,
+    selected_index: usize,
+    should_quit: bool,
+}
+
+impl TodoModel {
+    fn select_next(&mut self) {
+        if !self.items.is_empty() {
+            self.selected_index = (self.selected_index + 1) % self.items.len();
+        }
+    }
+
+    fn select_previous(&mut self) {
+        if !self.items.is_empty() {
+            self.selected_index = (self.selected_index + self.items.len() - 1) % self.items.len();
+        }
+    }
+
+    fn toggle_selected(&mut self) {
+        if let Some(item) = self.items.get_mut(self.selected_index) {
+            item.done = !item.done;
+        }
+    }
+
+    fn quit(&mut self) {
+        self.should_quit = true;
+    }
+}
+
+impl Entity for TodoModel {
+    type Event = ();
+}
+
+struct TodoView {
+    model: ModelHandle<TodoModel>,
+}
+
+impl Entity for TodoView {
+    type Event = ();
+}
+
+impl TuiView for TodoView {
+    type RenderOutput = Box<dyn TuiElement>;
+
+    fn ui_name() -> &'static str {
+        "InteractiveTodoView"
+    }
+
+    fn render_tui(&self, app: &AppContext) -> Self::RenderOutput {
+        let lines = self.model.read(app, |model, _| {
+            let mut lines = vec![model.title.clone(), String::new()];
+            lines.extend(model.items.iter().enumerate().map(|(index, item)| {
+                let marker = if index == model.selected_index {
+                    ">"
+                } else {
+                    " "
+                };
+                let checkbox = if item.done { "[x]" } else { "[ ]" };
+                format!("{marker} {checkbox} {}", item.label)
+            }));
+            lines.push(String::new());
+            lines.push("↑/↓ or j/k: move   space: toggle   q/esc: quit".to_owned());
+            lines
+        });
+
+        let children = lines
+            .into_iter()
+            .map(|line| Box::new(TuiText::new(line)) as Box<dyn TuiElement>);
+        let model = self.model.clone();
+
+        Box::new(
+            TuiEventHandler::new(TuiContainer::new(TuiColumn::new(children)).with_border())
+                .on_key_down(move |ctx, _, keystroke| {
+                    let model = model.clone();
+                    match keystroke.key.as_str() {
+                        "up" | "k" if keystroke.is_unmodified() => {
+                            ctx.dispatch_app_update(move |app| {
+                                model.update(app, |model, ctx| {
+                                    model.select_previous();
+                                    ctx.notify();
+                                });
+                            });
+                            TuiDispatchEventResult::StopPropagation
+                        }
+                        "down" | "j" if keystroke.is_unmodified() => {
+                            ctx.dispatch_app_update(move |app| {
+                                model.update(app, |model, ctx| {
+                                    model.select_next();
+                                    ctx.notify();
+                                });
+                            });
+                            TuiDispatchEventResult::StopPropagation
+                        }
+                        " " | "enter" if keystroke.is_unmodified() => {
+                            ctx.dispatch_app_update(move |app| {
+                                model.update(app, |model, ctx| {
+                                    model.toggle_selected();
+                                    ctx.notify();
+                                });
+                            });
+                            TuiDispatchEventResult::StopPropagation
+                        }
+                        "escape" | "q" if keystroke.is_unmodified() => {
+                            ctx.dispatch_app_update(move |app| {
+                                model.update(app, |model, _| {
+                                    model.quit();
+                                });
+                            });
+                            TuiDispatchEventResult::StopPropagation
+                        }
+                        _ => TuiDispatchEventResult::PropagateToParent,
+                    }
+                }),
+        )
+    }
+}
+
+struct TerminalSession {
+    stdout: Stdout,
+}
+
+impl TerminalSession {
+    fn enter() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+
+        let mut stdout = stdout();
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture, Hide) {
+            let _ = terminal::disable_raw_mode();
+            return Err(error);
+        }
+
+        Ok(Self { stdout })
+    }
+
+    fn size(&self) -> io::Result<TuiSize> {
+        let (width, height) = terminal::size()?;
+        Ok(TuiSize::new(width.max(1), height.max(1)))
+    }
+
+    fn draw(&mut self, frame: &TuiFrame) -> io::Result<()> {
+        queue!(self.stdout, MoveTo(0, 0), Clear(ClearType::All))?;
+
+        for (row, line) in frame.buffer.lines().into_iter().enumerate() {
+            let Ok(row) = u16::try_from(row) else {
+                break;
+            };
+            queue!(self.stdout, MoveTo(0, row), Print(line))?;
+        }
+
+        self.stdout.flush()
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        let _ = execute!(self.stdout, Show, DisableMouseCapture, LeaveAlternateScreen);
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+fn main() -> io::Result<()> {
+    let terminal = TerminalSession::enter()?;
+
+    App::test((), |mut app| async move {
+        let mut terminal = terminal;
+        let mut presenter = TuiPresenter::new();
+        let model = app.add_model(|_| TodoModel {
+            title: "warpui_tui interactive example".to_owned(),
+            items: vec![
+                TodoItem {
+                    label: "reuse warpui_core models".to_owned(),
+                    done: true,
+                },
+                TodoItem {
+                    label: "render through a TuiView".to_owned(),
+                    done: false,
+                },
+                TodoItem {
+                    label: "paint into a terminal buffer".to_owned(),
+                    done: false,
+                },
+            ],
+            selected_index: 1,
+            should_quit: false,
+        });
+
+        let (_, root_view) = app.add_tui_window(|_| TodoView {
+            model: model.clone(),
+        });
+
+        loop {
+            let size = terminal.size()?;
+            let frame = app.read(|ctx| {
+                root_view.read(ctx, |view, ctx| presenter.render_view(view, ctx, size))
+            });
+            terminal.draw(&frame)?;
+
+            if event::poll(Duration::from_millis(250))? {
+                if let Some(event) = crossterm_event_to_warp_event(event::read()?) {
+                    presenter.dispatch_event(&event, &mut app);
+                }
+            }
+
+            if model.read(&app, |model, _| model.should_quit) {
+                break;
+            }
+        }
+
+        Ok(())
+    })
+}

--- a/crates/warpui_tui/examples/basic/main.rs
+++ b/crates/warpui_tui/examples/basic/main.rs
@@ -1,46 +1,126 @@
-use std::io::{self, stdout, Stdout, Write};
-use std::time::Duration;
-
-use crossterm::cursor::{Hide, MoveTo, Show};
-use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture};
-use crossterm::style::Print;
-use crossterm::terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen};
-use crossterm::{execute, queue};
-use warpui_core::{App, AppContext, Entity, ModelHandle};
-use warpui_tui::elements::{TuiColumn, TuiContainer, TuiElement, TuiEventHandler, TuiText};
+use crossterm::style::Color;
+use std::io;
+use warpui_core::geometry::vector::Vector2F;
+use warpui_core::keymap::Keystroke;
+use warpui_core::{App, AppContext, Entity, Event, ModelHandle};
+use warpui_tui::elements::TuiElement;
 use warpui_tui::{
-    crossterm_event_to_warp_event, TuiDispatchEventResult, TuiFrame, TuiPresenter, TuiSize,
-    TuiView,
+    vertical_scroll_lines, TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiRuntime, TuiSize,
+    TuiStyle, TuiView,
 };
 
-struct TodoItem {
-    label: String,
-    done: bool,
+#[derive(Clone)]
+enum ChatRole {
+    User,
+    Assistant,
 }
 
-struct TodoModel {
-    title: String,
-    items: Vec<TodoItem>,
-    selected_index: usize,
+impl ChatRole {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::User => "You",
+            Self::Assistant => "warp_tui",
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ChatMessage {
+    role: ChatRole,
+    text: String,
+    has_toggled_color: bool,
+}
+
+impl ChatMessage {
+    fn user(text: impl Into<String>) -> Self {
+        Self {
+            role: ChatRole::User,
+            text: text.into(),
+            has_toggled_color: false,
+        }
+    }
+
+    fn assistant(text: impl Into<String>) -> Self {
+        Self {
+            role: ChatRole::Assistant,
+            text: text.into(),
+            has_toggled_color: false,
+        }
+    }
+
+    fn style(&self) -> TuiStyle {
+        if matches!(self.role, ChatRole::Assistant) && self.has_toggled_color {
+            TuiStyle::default().with_foreground_color(Color::Yellow)
+        } else {
+            TuiStyle::default()
+        }
+    }
+}
+
+struct ChatModel {
+    messages: Vec<ChatMessage>,
+    input: String,
+    transcript_scroll_offset: usize,
+    pressed_assistant_message_index: Option<usize>,
     should_quit: bool,
 }
 
-impl TodoModel {
-    fn select_next(&mut self) {
-        if !self.items.is_empty() {
-            self.selected_index = (self.selected_index + 1) % self.items.len();
-        }
+impl ChatModel {
+    fn insert_text(&mut self, text: &str) {
+        self.input.push_str(text);
     }
 
-    fn select_previous(&mut self) {
-        if !self.items.is_empty() {
-            self.selected_index = (self.selected_index + self.items.len() - 1) % self.items.len();
-        }
+    fn delete_backward(&mut self) {
+        self.input.pop();
     }
 
-    fn toggle_selected(&mut self) {
-        if let Some(item) = self.items.get_mut(self.selected_index) {
-            item.done = !item.done;
+    fn submit_input(&mut self) {
+        let input = self.input.trim().to_owned();
+        self.input.clear();
+
+        if input.is_empty() {
+            return;
+        }
+
+        self.messages.push(ChatMessage::user(input.clone()));
+        self.messages.push(ChatMessage::assistant(format!(
+            "Echoing from the example app: {input}"
+        )));
+        self.transcript_scroll_offset = 0;
+    }
+
+    fn scroll_transcript_up(&mut self, lines: usize, max_scroll_offset: usize) {
+        self.transcript_scroll_offset = self
+            .transcript_scroll_offset
+            .saturating_add(lines)
+            .min(max_scroll_offset);
+    }
+
+    fn scroll_transcript_down(&mut self, lines: usize, max_scroll_offset: usize) {
+        self.transcript_scroll_offset = self
+            .transcript_scroll_offset
+            .min(max_scroll_offset)
+            .saturating_sub(lines);
+    }
+
+    fn begin_assistant_message_click(&mut self, message_index: usize) {
+        self.pressed_assistant_message_index = Some(message_index);
+    }
+
+    fn end_assistant_message_click(&mut self, released_message_index: Option<usize>) {
+        let pressed_message_index = self.pressed_assistant_message_index.take();
+        if pressed_message_index != released_message_index {
+            return;
+        }
+
+        let Some(message_index) = released_message_index else {
+            return;
+        };
+        let Some(message) = self.messages.get_mut(message_index) else {
+            return;
+        };
+        if matches!(message.role, ChatRole::Assistant) {
+            message.has_toggled_color = !message.has_toggled_color;
         }
     }
 
@@ -49,184 +129,441 @@ impl TodoModel {
     }
 }
 
-impl Entity for TodoModel {
+impl Entity for ChatModel {
     type Event = ();
 }
 
-struct TodoView {
-    model: ModelHandle<TodoModel>,
+struct ChatView {
+    model: ModelHandle<ChatModel>,
 }
 
-impl Entity for TodoView {
+impl Entity for ChatView {
     type Event = ();
 }
 
-impl TuiView for TodoView {
+impl TuiView for ChatView {
     type RenderOutput = Box<dyn TuiElement>;
 
     fn ui_name() -> &'static str {
-        "InteractiveTodoView"
+        "ChatView"
     }
 
     fn render_tui(&self, app: &AppContext) -> Self::RenderOutput {
-        let lines = self.model.read(app, |model, _| {
-            let mut lines = vec![model.title.clone(), String::new()];
-            lines.extend(model.items.iter().enumerate().map(|(index, item)| {
-                let marker = if index == model.selected_index {
-                    ">"
-                } else {
-                    " "
-                };
-                let checkbox = if item.done { "[x]" } else { "[ ]" };
-                format!("{marker} {checkbox} {}", item.label)
-            }));
-            lines.push(String::new());
-            lines.push("↑/↓ or j/k: move   space: toggle   q/esc: quit".to_owned());
-            lines
-        });
+        let (messages, input, transcript_scroll_offset, pressed_assistant_message_index) =
+            self.model.read(app, |model, _| {
+                (
+                    model.messages.clone(),
+                    model.input.clone(),
+                    model.transcript_scroll_offset,
+                    model.pressed_assistant_message_index,
+                )
+            });
+        Box::new(ChatElement::new(
+            self.model.clone(),
+            messages,
+            input,
+            transcript_scroll_offset,
+            pressed_assistant_message_index,
+        ))
+    }
+}
 
-        let children = lines
-            .into_iter()
-            .map(|line| Box::new(TuiText::new(line)) as Box<dyn TuiElement>);
-        let model = self.model.clone();
+fn is_text_input(keystroke: &Keystroke, chars: &str) -> bool {
+    !chars.is_empty() && !keystroke.ctrl && !keystroke.alt && !keystroke.cmd && !keystroke.meta
+}
 
-        Box::new(
-            TuiEventHandler::new(TuiContainer::new(TuiColumn::new(children)).with_border())
-                .on_key_down(move |ctx, _, keystroke| {
-                    let model = model.clone();
-                    match keystroke.key.as_str() {
-                        "up" | "k" if keystroke.is_unmodified() => {
-                            ctx.dispatch_app_update(move |app| {
-                                model.update(app, |model, ctx| {
-                                    model.select_previous();
-                                    ctx.notify();
-                                });
-                            });
-                            TuiDispatchEventResult::StopPropagation
-                        }
-                        "down" | "j" if keystroke.is_unmodified() => {
-                            ctx.dispatch_app_update(move |app| {
-                                model.update(app, |model, ctx| {
-                                    model.select_next();
-                                    ctx.notify();
-                                });
-                            });
-                            TuiDispatchEventResult::StopPropagation
-                        }
-                        " " | "enter" if keystroke.is_unmodified() => {
-                            ctx.dispatch_app_update(move |app| {
-                                model.update(app, |model, ctx| {
-                                    model.toggle_selected();
-                                    ctx.notify();
-                                });
-                            });
-                            TuiDispatchEventResult::StopPropagation
-                        }
-                        "escape" | "q" if keystroke.is_unmodified() => {
-                            ctx.dispatch_app_update(move |app| {
-                                model.update(app, |model, _| {
-                                    model.quit();
-                                });
-                            });
-                            TuiDispatchEventResult::StopPropagation
-                        }
-                        _ => TuiDispatchEventResult::PropagateToParent,
-                    }
+struct ChatElement {
+    model: ModelHandle<ChatModel>,
+    messages: Vec<ChatMessage>,
+    input: String,
+    transcript_scroll_offset: usize,
+    pressed_assistant_message_index: Option<usize>,
+    size: TuiSize,
+}
+
+#[derive(Clone)]
+struct TranscriptLine {
+    text: String,
+    message_index: Option<usize>,
+    style: TuiStyle,
+}
+
+impl TranscriptLine {
+    fn spacer() -> Self {
+        Self {
+            text: String::new(),
+            message_index: None,
+            style: TuiStyle::default(),
+        }
+    }
+}
+
+impl ChatElement {
+    fn new(
+        model: ModelHandle<ChatModel>,
+        messages: Vec<ChatMessage>,
+        input: String,
+        transcript_scroll_offset: usize,
+        pressed_assistant_message_index: Option<usize>,
+    ) -> Self {
+        Self {
+            model,
+            messages,
+            input,
+            transcript_scroll_offset,
+            pressed_assistant_message_index,
+            size: TuiSize::default(),
+        }
+    }
+
+    fn transcript_lines(&self, width: u16) -> Vec<TranscriptLine> {
+        let mut lines = Vec::new();
+        for (message_index, message) in self.messages.iter().enumerate() {
+            let style = message.style();
+            lines.extend(
+                wrapped_lines(
+                    &format!("{}: {}", message.role.label(), message.text),
+                    width,
+                )
+                .into_iter()
+                .map(|text| TranscriptLine {
+                    text,
+                    message_index: Some(message_index),
+                    style,
                 }),
+            );
+            lines.push(TranscriptLine::spacer());
+        }
+        lines.pop();
+        lines
+    }
+
+    fn input_line(&self, width: u16) -> (String, usize) {
+        let width = usize::from(width);
+        if width == 0 {
+            return (String::new(), 0);
+        }
+
+        let prompt = "› ";
+        let prompt_width = prompt.chars().count().min(width);
+        let available_input_width = width.saturating_sub(prompt_width);
+        let input_chars = self.input.chars().collect::<Vec<_>>();
+        let start_index = input_chars.len().saturating_sub(available_input_width);
+        let visible_input = input_chars[start_index..].iter().collect::<String>();
+
+        (
+            format!("{prompt}{visible_input}"),
+            prompt_width.saturating_add(visible_input.chars().count()),
         )
     }
-}
 
-struct TerminalSession {
-    stdout: Stdout,
-}
+    fn input_y(&self, area: TuiRect) -> u16 {
+        area.bottom().saturating_sub(1)
+    }
 
-impl TerminalSession {
-    fn enter() -> io::Result<Self> {
-        terminal::enable_raw_mode()?;
+    fn header_height(&self, area: TuiRect) -> u16 {
+        match area.height {
+            0..=3 => 0,
+            4 => 1,
+            _ => 2,
+        }
+    }
 
-        let mut stdout = stdout();
-        if let Err(error) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture, Hide) {
-            let _ = terminal::disable_raw_mode();
-            return Err(error);
+    fn transcript_area(&self, area: TuiRect) -> TuiRect {
+        let input_height = area.height.min(2);
+        let input_top = area.bottom().saturating_sub(input_height);
+        let transcript_top = area.y.saturating_add(self.header_height(area));
+        TuiRect::new(
+            area.x,
+            transcript_top,
+            area.width,
+            input_top.saturating_sub(transcript_top),
+        )
+    }
+
+    fn max_transcript_scroll_offset(&self) -> usize {
+        let area = TuiRect::new(0, 0, self.size.width, self.size.height);
+        let transcript_area = self.transcript_area(area);
+        self.transcript_lines(transcript_area.width)
+            .len()
+            .saturating_sub(usize::from(transcript_area.height))
+    }
+
+    fn visible_transcript_lines(&self, area: TuiRect) -> Vec<TranscriptLine> {
+        let transcript_lines = self.transcript_lines(area.width);
+        let visible_transcript_height = usize::from(area.height);
+        let max_scroll_offset = transcript_lines
+            .len()
+            .saturating_sub(visible_transcript_height);
+        let scroll_offset = self.transcript_scroll_offset.min(max_scroll_offset);
+        let end_index = transcript_lines.len().saturating_sub(scroll_offset);
+        let start_index = end_index.saturating_sub(visible_transcript_height);
+        transcript_lines[start_index..end_index].to_vec()
+    }
+
+    fn assistant_message_index_at_position(
+        &self,
+        area: TuiRect,
+        position: Vector2F,
+    ) -> Option<usize> {
+        let transcript_area = self.transcript_area(area);
+        if !transcript_area.contains_position(position) {
+            return None;
         }
 
-        Ok(Self { stdout })
-    }
-
-    fn size(&self) -> io::Result<TuiSize> {
-        let (width, height) = terminal::size()?;
-        Ok(TuiSize::new(width.max(1), height.max(1)))
-    }
-
-    fn draw(&mut self, frame: &TuiFrame) -> io::Result<()> {
-        queue!(self.stdout, MoveTo(0, 0), Clear(ClearType::All))?;
-
-        for (row, line) in frame.buffer.lines().into_iter().enumerate() {
-            let Ok(row) = u16::try_from(row) else {
-                break;
-            };
-            queue!(self.stdout, MoveTo(0, row), Print(line))?;
-        }
-
-        self.stdout.flush()
+        let row = (position.y() as u16).saturating_sub(transcript_area.y);
+        let message_index = self
+            .visible_transcript_lines(transcript_area)
+            .get(usize::from(row))?
+            .message_index?;
+        let message = self.messages.get(message_index)?;
+        matches!(message.role, ChatRole::Assistant).then_some(message_index)
     }
 }
 
-impl Drop for TerminalSession {
-    fn drop(&mut self) {
-        let _ = execute!(self.stdout, Show, DisableMouseCapture, LeaveAlternateScreen);
-        let _ = terminal::disable_raw_mode();
+impl TuiElement for ChatElement {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.size = constraint.max;
+        self.size
     }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        if area.is_empty() {
+            return;
+        }
+
+        let header_height = self.header_height(area);
+        if header_height >= 1 {
+            buffer.write_str(area.x, area.y, area.width, "warpui_tui chat example");
+        }
+        if header_height >= 2 {
+            buffer.write_str(
+                area.x,
+                area.y.saturating_add(1),
+                area.width,
+                "Enter: submit · PageUp/PageDown or scroll: transcript · Esc/Ctrl-C: quit",
+            );
+        }
+
+        let transcript_area = self.transcript_area(area);
+        let visible_transcript_height = usize::from(transcript_area.height);
+        if visible_transcript_height > 0 {
+            for (row, line) in self
+                .visible_transcript_lines(transcript_area)
+                .iter()
+                .enumerate()
+            {
+                let Ok(row) = u16::try_from(row) else {
+                    break;
+                };
+                buffer.write_str_with_style(
+                    transcript_area.x,
+                    transcript_area.y.saturating_add(row),
+                    transcript_area.width,
+                    &line.text,
+                    line.style,
+                );
+            }
+        }
+
+        let input_height = area.height.min(2);
+        let input_top = area.bottom().saturating_sub(input_height);
+        if input_height == 2 {
+            for x in area.x..area.right() {
+                buffer.set_symbol(x, input_top, '─');
+            }
+        }
+
+        let input_y = self.input_y(area);
+        let (input_line, _) = self.input_line(area.width);
+        buffer.write_str(area.x, input_y, area.width, &input_line);
+    }
+
+    fn desired_height(&self, _: u16) -> u16 {
+        self.size.height
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        if area.is_empty() {
+            return None;
+        }
+
+        let (_, cursor_offset) = self.input_line(area.width);
+        let cursor_x = area
+            .x
+            .saturating_add(u16::try_from(cursor_offset).unwrap_or(u16::MAX))
+            .min(area.right().saturating_sub(1));
+        Some((cursor_x, self.input_y(area)))
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        area: TuiRect,
+        ctx: &mut TuiEventContext,
+        _: &AppContext,
+    ) -> bool {
+        let model = self.model.clone();
+        match event {
+            Event::LeftMouseDown { position, .. } => {
+                let Some(message_index) = self.assistant_message_index_at_position(area, *position)
+                else {
+                    return false;
+                };
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        model.begin_assistant_message_click(message_index);
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            Event::LeftMouseUp { position, .. }
+                if self.pressed_assistant_message_index.is_some() =>
+            {
+                let released_message_index =
+                    self.assistant_message_index_at_position(area, *position);
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        model.end_assistant_message_click(released_message_index);
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            Event::KeyDown {
+                keystroke, chars, ..
+            } if is_text_input(keystroke, chars) => {
+                let chars = chars.clone();
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        model.insert_text(&chars);
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            Event::KeyDown { keystroke, .. } if keystroke.is_unmodified_enter() => {
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        model.submit_input();
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            Event::KeyDown { keystroke, .. } if keystroke.is_unmodified_key("backspace") => {
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        model.delete_backward();
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            Event::KeyDown { keystroke, .. } if keystroke.is_unmodified_key("pageup") => {
+                let max_scroll_offset = self.max_transcript_scroll_offset();
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        model.scroll_transcript_up(8, max_scroll_offset);
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            Event::KeyDown { keystroke, .. } if keystroke.is_unmodified_key("pagedown") => {
+                let max_scroll_offset = self.max_transcript_scroll_offset();
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        model.scroll_transcript_down(8, max_scroll_offset);
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            Event::KeyDown { keystroke, .. }
+                if keystroke.is_unmodified_key("escape")
+                    || (keystroke.ctrl && keystroke.key == "c") =>
+            {
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, _| {
+                        model.quit();
+                    });
+                });
+                true
+            }
+            Event::ScrollWheel { delta, .. } => {
+                let lines = vertical_scroll_lines(*delta);
+                if lines == 0 {
+                    return false;
+                }
+
+                let max_scroll_offset = self.max_transcript_scroll_offset();
+                ctx.dispatch_app_update(move |app| {
+                    model.update(app, |model, ctx| {
+                        if lines > 0 {
+                            model.scroll_transcript_up(
+                                lines.unsigned_abs().into(),
+                                max_scroll_offset,
+                            );
+                        } else {
+                            model.scroll_transcript_down(
+                                lines.unsigned_abs().into(),
+                                max_scroll_offset,
+                            );
+                        }
+                        ctx.notify();
+                    });
+                });
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+fn wrapped_lines(text: &str, width: u16) -> Vec<String> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let width = usize::from(width);
+    text.split('\n')
+        .flat_map(|line| {
+            if line.is_empty() {
+                return vec![String::new()];
+            }
+
+            line.chars()
+                .collect::<Vec<_>>()
+                .chunks(width)
+                .map(|chunk| chunk.iter().collect::<String>())
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 fn main() -> io::Result<()> {
-    let terminal = TerminalSession::enter()?;
-
     App::test((), |mut app| async move {
-        let mut terminal = terminal;
-        let mut presenter = TuiPresenter::new();
-        let model = app.add_model(|_| TodoModel {
-            title: "warpui_tui interactive example".to_owned(),
-            items: vec![
-                TodoItem {
-                    label: "reuse warpui_core models".to_owned(),
-                    done: true,
-                },
-                TodoItem {
-                    label: "render through a TuiView".to_owned(),
-                    done: false,
-                },
-                TodoItem {
-                    label: "paint into a terminal buffer".to_owned(),
-                    done: false,
-                },
+        let model = app.add_model(|_| ChatModel {
+            messages: vec![
+                ChatMessage::assistant("This is a tiny chat shell rendered through warpui_tui."),
+                ChatMessage::assistant(
+                    "Type a message below and press Enter to append it to the transcript.",
+                ),
             ],
-            selected_index: 1,
+            input: String::new(),
+            transcript_scroll_offset: 0,
+            pressed_assistant_message_index: None,
             should_quit: false,
         });
-
-        let (_, root_view) = app.add_tui_window(|_| TodoView {
+        let (window_id, root_view) = app.add_tui_window(|_| ChatView {
             model: model.clone(),
         });
-
-        loop {
-            let size = terminal.size()?;
-            let frame = app.read(|ctx| {
-                root_view.read(ctx, |view, ctx| presenter.render_view(view, ctx, size))
-            });
-            terminal.draw(&frame)?;
-
-            if event::poll(Duration::from_millis(250))? {
-                if let Some(event) = crossterm_event_to_warp_event(event::read()?) {
-                    presenter.dispatch_event(&event, &mut app);
-                }
-            }
-
-            if model.read(&app, |model, _| model.should_quit) {
-                break;
-            }
-        }
+        let mut runtime = TuiRuntime::enter(&app, window_id, root_view)?;
+        runtime.run_until(&mut app, |app| {
+            model.read(app, |model, _| model.should_quit)
+        })?;
 
         Ok(())
     })

--- a/crates/warpui_tui/src/buffer.rs
+++ b/crates/warpui_tui/src/buffer.rs
@@ -1,0 +1,65 @@
+use crate::TuiRect;
+use crate::TuiSize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Cell {
+    pub symbol: char,
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self { symbol: ' ' }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TuiBuffer {
+    size: TuiSize,
+    cells: Vec<Cell>,
+}
+
+impl TuiBuffer {
+    pub fn new(size: TuiSize) -> Self {
+        Self {
+            size,
+            cells: vec![Cell::default(); usize::from(size.width) * usize::from(size.height)],
+        }
+    }
+
+    pub fn size(&self) -> TuiSize {
+        self.size
+    }
+
+    pub fn set_symbol(&mut self, x: u16, y: u16, symbol: char) {
+        if x >= self.size.width || y >= self.size.height {
+            return;
+        }
+
+        let index = usize::from(y) * usize::from(self.size.width) + usize::from(x);
+        self.cells[index].symbol = symbol;
+    }
+
+    pub fn write_str(&mut self, x: u16, y: u16, max_width: u16, text: &str) {
+        for (offset, ch) in text.chars().take(usize::from(max_width)).enumerate() {
+            let Ok(offset) = u16::try_from(offset) else {
+                break;
+            };
+            self.set_symbol(x.saturating_add(offset), y, ch);
+        }
+    }
+
+    pub fn fill_rect(&mut self, rect: TuiRect, symbol: char) {
+        for y in rect.y..rect.bottom().min(self.size.height) {
+            for x in rect.x..rect.right().min(self.size.width) {
+                self.set_symbol(x, y, symbol);
+            }
+        }
+    }
+
+    pub fn lines(&self) -> Vec<String> {
+        self.cells
+            .chunks(usize::from(self.size.width))
+            .map(|row| row.iter().map(|cell| cell.symbol).collect())
+            .collect()
+    }
+}

--- a/crates/warpui_tui/src/buffer.rs
+++ b/crates/warpui_tui/src/buffer.rs
@@ -1,14 +1,65 @@
+use crossterm::style::Color;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
 use crate::TuiRect;
 use crate::TuiSize;
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TuiStyle {
+    foreground_color: Option<Color>,
+}
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+impl TuiStyle {
+    pub fn foreground_color(self) -> Option<Color> {
+        self.foreground_color
+    }
+
+    pub fn with_foreground_color(mut self, color: Color) -> Self {
+        self.foreground_color = Some(color);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Cell {
-    pub symbol: char,
+    symbol: String,
+    continuation: bool,
+    style: TuiStyle,
+}
+
+impl Cell {
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+
+    pub fn is_continuation(&self) -> bool {
+        self.continuation
+    }
+
+    pub fn style(&self) -> TuiStyle {
+        self.style
+    }
+
+    fn blank() -> Self {
+        Self {
+            symbol: " ".to_owned(),
+            continuation: false,
+            style: TuiStyle::default(),
+        }
+    }
+
+    fn continuation(style: TuiStyle) -> Self {
+        Self {
+            symbol: String::new(),
+            continuation: true,
+            style,
+        }
+    }
 }
 
 impl Default for Cell {
     fn default() -> Self {
-        Self { symbol: ' ' }
+        Self::blank()
     }
 }
 
@@ -30,22 +81,56 @@ impl TuiBuffer {
         self.size
     }
 
-    pub fn set_symbol(&mut self, x: u16, y: u16, symbol: char) {
-        if x >= self.size.width || y >= self.size.height {
-            return;
-        }
+    pub fn cell(&self, x: u16, y: u16) -> Option<&Cell> {
+        self.cell_index(x, y).map(|index| &self.cells[index])
+    }
 
-        let index = usize::from(y) * usize::from(self.size.width) + usize::from(x);
-        self.cells[index].symbol = symbol;
+    pub fn set_symbol(&mut self, x: u16, y: u16, symbol: char) {
+        self.write_grapheme(x, y, &symbol.to_string(), TuiStyle::default());
+    }
+
+    pub fn set_symbol_with_style(&mut self, x: u16, y: u16, symbol: char, style: TuiStyle) {
+        self.write_grapheme(x, y, &symbol.to_string(), style);
     }
 
     pub fn write_str(&mut self, x: u16, y: u16, max_width: u16, text: &str) {
-        for (offset, ch) in text.chars().take(usize::from(max_width)).enumerate() {
-            let Ok(offset) = u16::try_from(offset) else {
-                break;
-            };
-            self.set_symbol(x.saturating_add(offset), y, ch);
+        self.write_str_with_style(x, y, max_width, text, TuiStyle::default());
+    }
+
+    pub fn write_str_with_style(
+        &mut self,
+        x: u16,
+        y: u16,
+        max_width: u16,
+        text: &str,
+        style: TuiStyle,
+    ) {
+        if x >= self.size.width || y >= self.size.height {
+            return;
         }
+        let max_right = x.saturating_add(max_width).min(self.size.width);
+        let mut column = x;
+        for grapheme in text.graphemes(true) {
+            let width = grapheme_width(grapheme);
+            if column.saturating_add(width) > max_right {
+                break;
+            }
+            self.write_grapheme(column, y, grapheme, style);
+            column = column.saturating_add(width);
+        }
+    }
+
+    pub(crate) fn display_string_for_range(&self, y: u16, start_x: u16, end_x: u16) -> String {
+        let mut line = String::new();
+        for x in start_x..end_x.min(self.size.width) {
+            let Some(cell) = self.cell(x, y) else {
+                continue;
+            };
+            if !cell.is_continuation() {
+                line.push_str(cell.symbol());
+            }
+        }
+        line
     }
 
     pub fn fill_rect(&mut self, rect: TuiRect, symbol: char) {
@@ -57,9 +142,171 @@ impl TuiBuffer {
     }
 
     pub fn lines(&self) -> Vec<String> {
-        self.cells
-            .chunks(usize::from(self.size.width))
-            .map(|row| row.iter().map(|cell| cell.symbol).collect())
+        (0..self.size.height)
+            .map(|y| self.display_string_for_range(y, 0, self.size.width))
             .collect()
+    }
+
+    fn write_grapheme(&mut self, x: u16, y: u16, grapheme: &str, style: TuiStyle) {
+        if x >= self.size.width || y >= self.size.height {
+            return;
+        }
+
+        let width = grapheme_width(grapheme);
+        if x.saturating_add(width) > self.size.width {
+            return;
+        }
+
+        self.clear_grapheme_at(x, y);
+        for continuation_x in x.saturating_add(1)..x.saturating_add(width) {
+            self.clear_grapheme_at(continuation_x, y);
+        }
+
+        if let Some(index) = self.cell_index(x, y) {
+            self.cells[index] = Cell {
+                symbol: grapheme.to_owned(),
+                continuation: false,
+                style,
+            };
+        }
+
+        for continuation_x in x.saturating_add(1)..x.saturating_add(width) {
+            if let Some(index) = self.cell_index(continuation_x, y) {
+                self.cells[index] = Cell::continuation(style);
+            }
+        }
+    }
+
+    fn clear_grapheme_at(&mut self, x: u16, y: u16) {
+        let Some(index) = self.cell_index(x, y) else {
+            return;
+        };
+
+        if self.cells[index].is_continuation() {
+            let mut start_x = x;
+            while start_x > 0 {
+                let previous_x = start_x.saturating_sub(1);
+                let Some(previous_index) = self.cell_index(previous_x, y) else {
+                    break;
+                };
+                start_x = previous_x;
+                if !self.cells[previous_index].is_continuation() {
+                    break;
+                }
+            }
+            self.clear_grapheme_at(start_x, y);
+            return;
+        }
+
+        self.cells[index] = Cell::blank();
+        let mut continuation_x = x.saturating_add(1);
+        while continuation_x < self.size.width {
+            let Some(continuation_index) = self.cell_index(continuation_x, y) else {
+                break;
+            };
+            if !self.cells[continuation_index].is_continuation() {
+                break;
+            }
+            self.cells[continuation_index] = Cell::blank();
+            continuation_x = continuation_x.saturating_add(1);
+        }
+    }
+
+    fn cell_index(&self, x: u16, y: u16) -> Option<usize> {
+        if x >= self.size.width || y >= self.size.height {
+            return None;
+        }
+        Some(usize::from(y) * usize::from(self.size.width) + usize::from(x))
+    }
+}
+
+fn grapheme_width(grapheme: &str) -> u16 {
+    UnicodeWidthStr::width(grapheme)
+        .max(1)
+        .try_into()
+        .unwrap_or(u16::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_ascii_text() {
+        let mut buffer = TuiBuffer::new(TuiSize::new(5, 1));
+
+        buffer.write_str(0, 0, 5, "abc");
+
+        assert_eq!(buffer.lines(), vec!["abc  "]);
+    }
+
+    #[test]
+    fn writes_combining_graphemes_into_one_cell() {
+        let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
+
+        buffer.write_str(0, 0, 4, "e\u{301}x");
+
+        assert_eq!(buffer.lines(), vec!["e\u{301}x  "]);
+        assert_eq!(buffer.cell(0, 0).unwrap().symbol(), "e\u{301}");
+        assert!(!buffer.cell(0, 0).unwrap().is_continuation());
+        assert_eq!(buffer.cell(1, 0).unwrap().symbol(), "x");
+    }
+
+    #[test]
+    fn writes_wide_graphemes_into_two_columns() {
+        let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
+
+        buffer.write_str(0, 0, 4, "界a");
+
+        assert_eq!(buffer.lines(), vec!["界a "]);
+        assert_eq!(buffer.cell(0, 0).unwrap().symbol(), "界");
+        assert!(buffer.cell(1, 0).unwrap().is_continuation());
+        assert_eq!(buffer.cell(2, 0).unwrap().symbol(), "a");
+    }
+
+    #[test]
+    fn truncates_before_graphemes_that_would_cross_the_right_edge() {
+        let mut buffer = TuiBuffer::new(TuiSize::new(3, 1));
+
+        buffer.write_str(0, 0, 3, "ab界");
+
+        assert_eq!(buffer.lines(), vec!["ab "]);
+    }
+
+    #[test]
+    fn replacing_wide_graphemes_clears_continuation_cells() {
+        let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
+        buffer.write_str(0, 0, 4, "界a");
+
+        buffer.write_str(0, 0, 1, "b");
+
+        assert_eq!(buffer.lines(), vec!["b a "]);
+        assert_eq!(buffer.cell(0, 0).unwrap().symbol(), "b");
+        assert!(!buffer.cell(1, 0).unwrap().is_continuation());
+        assert_eq!(buffer.cell(1, 0).unwrap().symbol(), " ");
+    }
+
+    #[test]
+    fn writes_text_with_style() {
+        let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
+        let style = TuiStyle::default().with_foreground_color(Color::Yellow);
+
+        buffer.write_str_with_style(0, 0, 4, "ab", style);
+
+        assert_eq!(buffer.lines(), vec!["ab  "]);
+        assert_eq!(buffer.cell(0, 0).unwrap().style(), style);
+        assert_eq!(buffer.cell(1, 0).unwrap().style(), style);
+        assert_eq!(buffer.cell(2, 0).unwrap().style(), TuiStyle::default());
+    }
+
+    #[test]
+    fn writes_wide_grapheme_continuations_with_style() {
+        let mut buffer = TuiBuffer::new(TuiSize::new(3, 1));
+        let style = TuiStyle::default().with_foreground_color(Color::Blue);
+
+        buffer.write_str_with_style(0, 0, 3, "界", style);
+
+        assert_eq!(buffer.cell(0, 0).unwrap().style(), style);
+        assert_eq!(buffer.cell(1, 0).unwrap().style(), style);
     }
 }

--- a/crates/warpui_tui/src/elements/child_view.rs
+++ b/crates/warpui_tui/src/elements/child_view.rs
@@ -1,0 +1,58 @@
+use warpui_core::{AppContext, EntityId, Event, TuiView, TuiViewHandle};
+
+use crate::elements::{TuiElement, TuiPresentationContext};
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
+
+pub struct TuiChildView {
+    view_id: EntityId,
+    child: Box<dyn TuiElement>,
+}
+
+impl TuiChildView {
+    pub fn new<V>(handle: &TuiViewHandle<V>, app: &AppContext) -> Self
+    where
+        V: TuiView<RenderOutput = Box<dyn TuiElement>>,
+    {
+        Self {
+            view_id: handle.id(),
+            child: handle.read(app, |view, ctx| view.render_tui(ctx)),
+        }
+    }
+}
+
+impl TuiElement for TuiChildView {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.child.layout(constraint)
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        self.child.render(area, buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.child.desired_height(width)
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        self.child.cursor_position(area)
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        ctx.enter_child(self.view_id);
+        self.child.present(ctx);
+        ctx.exit_child();
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        area: TuiRect,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        let previous_origin = ctx.set_origin_view(Some(self.view_id));
+        let handled = self.child.dispatch_event(event, area, ctx, app);
+        ctx.set_origin_view(previous_origin);
+        handled
+    }
+}

--- a/crates/warpui_tui/src/elements/column.rs
+++ b/crates/warpui_tui/src/elements/column.rs
@@ -1,5 +1,7 @@
+use warpui_core::{AppContext, Event};
+
 use crate::elements::TuiElement;
-use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
 
 pub struct TuiColumn {
     children: Vec<Box<dyn TuiElement>>,
@@ -72,5 +74,17 @@ impl TuiElement for TuiColumn {
             y = y.saturating_add(child_height);
         }
         None
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        self.children
+            .iter_mut()
+            .rev()
+            .any(|child| child.dispatch_event(event, ctx, app))
     }
 }

--- a/crates/warpui_tui/src/elements/column.rs
+++ b/crates/warpui_tui/src/elements/column.rs
@@ -1,6 +1,6 @@
 use warpui_core::{AppContext, Event};
 
-use crate::elements::TuiElement;
+use crate::elements::{TuiElement, TuiPresentationContext};
 use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
 
 pub struct TuiColumn {
@@ -74,6 +74,12 @@ impl TuiElement for TuiColumn {
             y = y.saturating_add(child_height);
         }
         None
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        for child in &mut self.children {
+            child.present(ctx);
+        }
     }
 
     fn dispatch_event(

--- a/crates/warpui_tui/src/elements/column.rs
+++ b/crates/warpui_tui/src/elements/column.rs
@@ -1,0 +1,76 @@
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+
+pub struct TuiColumn {
+    children: Vec<Box<dyn TuiElement>>,
+    size: TuiSize,
+}
+
+impl TuiColumn {
+    pub fn new(children: impl IntoIterator<Item = Box<dyn TuiElement>>) -> Self {
+        Self {
+            children: children.into_iter().collect(),
+            size: TuiSize::default(),
+        }
+    }
+
+    pub fn push(&mut self, child: impl TuiElement + 'static) {
+        self.children.push(Box::new(child));
+    }
+}
+
+impl TuiElement for TuiColumn {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let mut remaining_height = constraint.max.height;
+        let mut total_height: u16 = 0;
+        for child in &mut self.children {
+            let child_size = child.layout(TuiConstraint::new(
+                TuiSize::new(constraint.min.width, 0),
+                TuiSize::new(constraint.max.width, remaining_height),
+            ));
+            remaining_height = remaining_height.saturating_sub(child_size.height);
+            total_height = total_height.saturating_add(child_size.height);
+        }
+
+        self.size = TuiSize::new(
+            constraint.max.width,
+            total_height.max(constraint.min.height),
+        );
+        self.size
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        let mut y = area.y;
+        for child in &self.children {
+            if y >= area.bottom() {
+                break;
+            }
+
+            let child_height = child
+                .desired_height(area.width)
+                .min(area.bottom().saturating_sub(y));
+            child.render(TuiRect::new(area.x, y, area.width, child_height), buffer);
+            y = y.saturating_add(child_height);
+        }
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.children
+            .iter()
+            .map(|child| child.desired_height(width))
+            .sum()
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        let mut y = area.y;
+        for child in &self.children {
+            let child_height = child.desired_height(area.width);
+            let child_area = TuiRect::new(area.x, y, area.width, child_height);
+            if let Some(position) = child.cursor_position(child_area) {
+                return Some(position);
+            }
+            y = y.saturating_add(child_height);
+        }
+        None
+    }
+}

--- a/crates/warpui_tui/src/elements/column.rs
+++ b/crates/warpui_tui/src/elements/column.rs
@@ -79,12 +79,28 @@ impl TuiElement for TuiColumn {
     fn dispatch_event(
         &mut self,
         event: &Event,
+        area: TuiRect,
         ctx: &mut TuiEventContext,
         app: &AppContext,
     ) -> bool {
+        let mut child_areas = Vec::with_capacity(self.children.len());
+        let mut y = area.y;
+        for child in &self.children {
+            if y >= area.bottom() {
+                break;
+            }
+
+            let child_height = child
+                .desired_height(area.width)
+                .min(area.bottom().saturating_sub(y));
+            child_areas.push(TuiRect::new(area.x, y, area.width, child_height));
+            y = y.saturating_add(child_height);
+        }
+
         self.children
             .iter_mut()
+            .zip(child_areas)
             .rev()
-            .any(|child| child.dispatch_event(event, ctx, app))
+            .any(|(child, child_area)| child.dispatch_event(event, child_area, ctx, app))
     }
 }

--- a/crates/warpui_tui/src/elements/container.rs
+++ b/crates/warpui_tui/src/elements/container.rs
@@ -1,5 +1,7 @@
+use warpui_core::{AppContext, Event};
+
 use crate::elements::TuiElement;
-use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
 
 pub struct TuiContainer {
     child: Box<dyn TuiElement>,
@@ -90,5 +92,14 @@ impl TuiElement for TuiContainer {
 
     fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
         self.child.cursor_position(self.child_area(area))
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        self.child.dispatch_event(event, ctx, app)
     }
 }

--- a/crates/warpui_tui/src/elements/container.rs
+++ b/crates/warpui_tui/src/elements/container.rs
@@ -1,0 +1,94 @@
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+
+pub struct TuiContainer {
+    child: Box<dyn TuiElement>,
+    border: bool,
+    size: TuiSize,
+}
+
+impl TuiContainer {
+    pub fn new(child: impl TuiElement + 'static) -> Self {
+        Self {
+            child: Box::new(child),
+            border: false,
+            size: TuiSize::default(),
+        }
+    }
+
+    pub fn with_border(mut self) -> Self {
+        self.border = true;
+        self
+    }
+
+    fn child_area(&self, area: TuiRect) -> TuiRect {
+        if self.border {
+            area.inset(1)
+        } else {
+            area
+        }
+    }
+
+    fn border_size(&self) -> u16 {
+        if self.border {
+            2
+        } else {
+            0
+        }
+    }
+}
+
+impl TuiElement for TuiContainer {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let border_size = self.border_size();
+        let child_size = self.child.layout(TuiConstraint::new(
+            TuiSize::new(
+                constraint.min.width.saturating_sub(border_size),
+                constraint.min.height.saturating_sub(border_size),
+            ),
+            TuiSize::new(
+                constraint.max.width.saturating_sub(border_size),
+                constraint.max.height.saturating_sub(border_size),
+            ),
+        ));
+        self.size = TuiSize::new(
+            child_size.width.saturating_add(border_size),
+            child_size.height.saturating_add(border_size),
+        );
+        self.size
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        if self.border && area.width >= 2 && area.height >= 2 {
+            for x in area.x..area.right() {
+                buffer.set_symbol(x, area.y, '─');
+                buffer.set_symbol(x, area.bottom().saturating_sub(1), '─');
+            }
+            for y in area.y..area.bottom() {
+                buffer.set_symbol(area.x, y, '│');
+                buffer.set_symbol(area.right().saturating_sub(1), y, '│');
+            }
+            buffer.set_symbol(area.x, area.y, '┌');
+            buffer.set_symbol(area.right().saturating_sub(1), area.y, '┐');
+            buffer.set_symbol(area.x, area.bottom().saturating_sub(1), '└');
+            buffer.set_symbol(
+                area.right().saturating_sub(1),
+                area.bottom().saturating_sub(1),
+                '┘',
+            );
+        }
+
+        self.child.render(self.child_area(area), buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        let border_size = self.border_size();
+        self.child
+            .desired_height(width.saturating_sub(border_size))
+            .saturating_add(border_size)
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        self.child.cursor_position(self.child_area(area))
+    }
+}

--- a/crates/warpui_tui/src/elements/container.rs
+++ b/crates/warpui_tui/src/elements/container.rs
@@ -1,6 +1,6 @@
 use warpui_core::{AppContext, Event};
 
-use crate::elements::TuiElement;
+use crate::elements::{TuiElement, TuiPresentationContext};
 use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
 
 pub struct TuiContainer {
@@ -92,6 +92,10 @@ impl TuiElement for TuiContainer {
 
     fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
         self.child.cursor_position(self.child_area(area))
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        self.child.present(ctx);
     }
 
     fn dispatch_event(

--- a/crates/warpui_tui/src/elements/container.rs
+++ b/crates/warpui_tui/src/elements/container.rs
@@ -97,9 +97,11 @@ impl TuiElement for TuiContainer {
     fn dispatch_event(
         &mut self,
         event: &Event,
+        area: TuiRect,
         ctx: &mut TuiEventContext,
         app: &AppContext,
     ) -> bool {
-        self.child.dispatch_event(event, ctx, app)
+        self.child
+            .dispatch_event(event, self.child_area(area), ctx, app)
     }
 }

--- a/crates/warpui_tui/src/elements/event_handler.rs
+++ b/crates/warpui_tui/src/elements/event_handler.rs
@@ -1,0 +1,93 @@
+use warpui_core::keymap::Keystroke;
+use warpui_core::{AppContext, Event};
+
+use crate::elements::TuiElement;
+use crate::{
+    TuiBuffer, TuiConstraint, TuiDispatchEventResult, TuiEventContext, TuiRect, TuiSize,
+};
+
+type TuiEventCallback =
+    dyn FnMut(&mut TuiEventContext, &AppContext, &Event) -> TuiDispatchEventResult;
+type TuiKeyCallback =
+    dyn FnMut(&mut TuiEventContext, &AppContext, &Keystroke) -> TuiDispatchEventResult;
+
+pub struct TuiEventHandler {
+    child: Box<dyn TuiElement>,
+    event: Option<Box<TuiEventCallback>>,
+    key_down: Option<Box<TuiKeyCallback>>,
+}
+
+impl TuiEventHandler {
+    pub fn new(child: impl TuiElement + 'static) -> Self {
+        Self {
+            child: Box::new(child),
+            event: None,
+            key_down: None,
+        }
+    }
+
+    pub fn on_event<F>(mut self, callback: F) -> Self
+    where
+        F: 'static + FnMut(&mut TuiEventContext, &AppContext, &Event) -> TuiDispatchEventResult,
+    {
+        self.event = Some(Box::new(callback));
+        self
+    }
+
+    pub fn on_key_down<F>(mut self, callback: F) -> Self
+    where
+        F: 'static + FnMut(&mut TuiEventContext, &AppContext, &Keystroke) -> TuiDispatchEventResult,
+    {
+        self.key_down = Some(Box::new(callback));
+        self
+    }
+}
+
+impl TuiElement for TuiEventHandler {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.child.layout(constraint)
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        self.child.render(area, buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.child.desired_height(width)
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        self.child.cursor_position(area)
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        if self.child.dispatch_event(event, ctx, app) {
+            return true;
+        }
+
+        if let Event::KeyDown { keystroke, .. } = event {
+            if let Some(callback) = self.key_down.as_mut() {
+                if matches!(
+                    callback(ctx, app, keystroke),
+                    TuiDispatchEventResult::StopPropagation
+                ) {
+                    return true;
+                }
+            }
+        }
+
+        if let Some(callback) = self.event.as_mut() {
+            return matches!(
+                callback(ctx, app, event),
+                TuiDispatchEventResult::StopPropagation
+            );
+        }
+
+        false
+    }
+}

--- a/crates/warpui_tui/src/elements/event_handler.rs
+++ b/crates/warpui_tui/src/elements/event_handler.rs
@@ -1,7 +1,7 @@
 use warpui_core::keymap::Keystroke;
 use warpui_core::{AppContext, Event};
 
-use crate::elements::TuiElement;
+use crate::elements::{TuiElement, TuiPresentationContext};
 use crate::{TuiBuffer, TuiConstraint, TuiDispatchEventResult, TuiEventContext, TuiRect, TuiSize};
 
 type TuiEventCallback =
@@ -56,6 +56,10 @@ impl TuiElement for TuiEventHandler {
 
     fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
         self.child.cursor_position(area)
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        self.child.present(ctx);
     }
 
     fn dispatch_event(

--- a/crates/warpui_tui/src/elements/event_handler.rs
+++ b/crates/warpui_tui/src/elements/event_handler.rs
@@ -2,9 +2,7 @@ use warpui_core::keymap::Keystroke;
 use warpui_core::{AppContext, Event};
 
 use crate::elements::TuiElement;
-use crate::{
-    TuiBuffer, TuiConstraint, TuiDispatchEventResult, TuiEventContext, TuiRect, TuiSize,
-};
+use crate::{TuiBuffer, TuiConstraint, TuiDispatchEventResult, TuiEventContext, TuiRect, TuiSize};
 
 type TuiEventCallback =
     dyn FnMut(&mut TuiEventContext, &AppContext, &Event) -> TuiDispatchEventResult;
@@ -63,10 +61,11 @@ impl TuiElement for TuiEventHandler {
     fn dispatch_event(
         &mut self,
         event: &Event,
+        area: TuiRect,
         ctx: &mut TuiEventContext,
         app: &AppContext,
     ) -> bool {
-        if self.child.dispatch_event(event, ctx, app) {
+        if self.child.dispatch_event(event, area, ctx, app) {
             return true;
         }
 

--- a/crates/warpui_tui/src/elements/mod.rs
+++ b/crates/warpui_tui/src/elements/mod.rs
@@ -1,14 +1,15 @@
 mod column;
 mod container;
+mod event_handler;
 mod text;
 
 pub use column::TuiColumn;
 pub use container::TuiContainer;
+pub use event_handler::TuiEventHandler;
 pub use text::TuiText;
+use warpui_core::{AppContext, Event};
 
-use warpui_core::Event;
-
-use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
 
 pub trait TuiElement {
     fn layout(&mut self, constraint: TuiConstraint) -> TuiSize;
@@ -21,7 +22,12 @@ pub trait TuiElement {
         None
     }
 
-    fn dispatch_event(&mut self, _event: &Event) -> bool {
+    fn dispatch_event(
+        &mut self,
+        _event: &Event,
+        _ctx: &mut TuiEventContext,
+        _app: &AppContext,
+    ) -> bool {
         false
     }
 }

--- a/crates/warpui_tui/src/elements/mod.rs
+++ b/crates/warpui_tui/src/elements/mod.rs
@@ -1,9 +1,15 @@
+use std::collections::HashMap;
+
+use warpui_core::EntityId;
+
+mod child_view;
 mod column;
 mod container;
 mod event_handler;
 mod mouse_area;
 mod text;
 
+pub use child_view::TuiChildView;
 pub use column::TuiColumn;
 pub use container::TuiContainer;
 pub use event_handler::TuiEventHandler;
@@ -12,6 +18,38 @@ pub use text::TuiText;
 use warpui_core::{AppContext, Event};
 
 use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
+pub struct TuiPresentationContext<'a> {
+    parent_by_child: &'a mut HashMap<EntityId, EntityId>,
+    view_stack: Vec<EntityId>,
+}
+
+impl<'a> TuiPresentationContext<'a> {
+    pub(crate) fn new(
+        root_view_id: EntityId,
+        parent_by_child: &'a mut HashMap<EntityId, EntityId>,
+    ) -> Self {
+        Self {
+            parent_by_child,
+            view_stack: vec![root_view_id],
+        }
+    }
+
+    pub(crate) fn enter_child(&mut self, child_view_id: EntityId) {
+        let parent_view_id = *self
+            .view_stack
+            .last()
+            .expect("the TUI presentation stack contains a root view");
+        self.parent_by_child
+            .insert(child_view_id, parent_view_id);
+        self.view_stack.push(child_view_id);
+    }
+
+    pub(crate) fn exit_child(&mut self) {
+        self.view_stack
+            .pop()
+            .expect("a child view is entered before it is exited");
+    }
+}
 
 pub trait TuiElement {
     fn layout(&mut self, constraint: TuiConstraint) -> TuiSize;
@@ -23,6 +61,7 @@ pub trait TuiElement {
     fn cursor_position(&self, _area: TuiRect) -> Option<(u16, u16)> {
         None
     }
+    fn present(&mut self, _ctx: &mut TuiPresentationContext<'_>) {}
 
     fn dispatch_event(
         &mut self,

--- a/crates/warpui_tui/src/elements/mod.rs
+++ b/crates/warpui_tui/src/elements/mod.rs
@@ -1,0 +1,39 @@
+mod column;
+mod container;
+mod text;
+
+pub use column::TuiColumn;
+pub use container::TuiContainer;
+pub use text::TuiText;
+
+use warpui_core::Event;
+
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+
+pub trait TuiElement {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize;
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer);
+
+    fn desired_height(&self, width: u16) -> u16;
+
+    fn cursor_position(&self, _area: TuiRect) -> Option<(u16, u16)> {
+        None
+    }
+
+    fn dispatch_event(&mut self, _event: &Event) -> bool {
+        false
+    }
+}
+
+impl TuiElement for () {
+    fn layout(&mut self, _: TuiConstraint) -> TuiSize {
+        TuiSize::default()
+    }
+
+    fn render(&self, _: TuiRect, _: &mut TuiBuffer) {}
+
+    fn desired_height(&self, _: u16) -> u16 {
+        0
+    }
+}

--- a/crates/warpui_tui/src/elements/mod.rs
+++ b/crates/warpui_tui/src/elements/mod.rs
@@ -1,11 +1,13 @@
 mod column;
 mod container;
 mod event_handler;
+mod mouse_area;
 mod text;
 
 pub use column::TuiColumn;
 pub use container::TuiContainer;
 pub use event_handler::TuiEventHandler;
+pub use mouse_area::{TuiMouseArea, TuiMouseState, TuiMouseStateHandle};
 pub use text::TuiText;
 use warpui_core::{AppContext, Event};
 
@@ -25,6 +27,7 @@ pub trait TuiElement {
     fn dispatch_event(
         &mut self,
         _event: &Event,
+        _area: TuiRect,
         _ctx: &mut TuiEventContext,
         _app: &AppContext,
     ) -> bool {

--- a/crates/warpui_tui/src/elements/mouse_area.rs
+++ b/crates/warpui_tui/src/elements/mouse_area.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use warpui_core::geometry::vector::Vector2F;
 use warpui_core::{AppContext, Event};
 
-use crate::elements::TuiElement;
+use crate::elements::{TuiElement, TuiPresentationContext};
 use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
 
 type TuiMouseHandler = dyn FnMut(&mut TuiEventContext, &AppContext, Vector2F);
@@ -136,6 +136,10 @@ impl TuiElement for TuiMouseArea {
 
     fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
         self.child.cursor_position(area)
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        self.child.present(ctx);
     }
 
     fn dispatch_event(

--- a/crates/warpui_tui/src/elements/mouse_area.rs
+++ b/crates/warpui_tui/src/elements/mouse_area.rs
@@ -1,0 +1,168 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use warpui_core::geometry::vector::Vector2F;
+use warpui_core::{AppContext, Event};
+
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
+
+type TuiMouseHandler = dyn FnMut(&mut TuiEventContext, &AppContext, Vector2F);
+
+#[derive(Clone, Debug, Default)]
+pub struct TuiMouseState {
+    click_count: Option<u32>,
+}
+
+impl TuiMouseState {
+    pub fn is_clicked(&self) -> bool {
+        self.click_count.is_some()
+    }
+
+    pub fn click_count(&self) -> Option<u32> {
+        self.click_count
+    }
+
+    fn set_clicked(&mut self, click_count: u32) {
+        self.click_count = Some(click_count);
+    }
+
+    fn clear_clicked(&mut self) {
+        self.click_count = None;
+    }
+}
+
+pub type TuiMouseStateHandle = Rc<RefCell<TuiMouseState>>;
+
+pub struct TuiMouseArea {
+    child: Box<dyn TuiElement>,
+    state: TuiMouseStateHandle,
+    click_handler: Option<Box<TuiMouseHandler>>,
+    mouse_down_handler: Option<Box<TuiMouseHandler>>,
+    disabled: bool,
+}
+
+impl TuiMouseArea {
+    pub fn new<F>(state: TuiMouseStateHandle, build_child: F) -> Self
+    where
+        F: FnOnce(&TuiMouseState) -> Box<dyn TuiElement>,
+    {
+        let child = build_child(&state.borrow());
+        Self {
+            child,
+            state,
+            click_handler: None,
+            mouse_down_handler: None,
+            disabled: false,
+        }
+    }
+
+    pub fn on_click<F>(mut self, callback: F) -> Self
+    where
+        F: 'static + FnMut(&mut TuiEventContext, &AppContext, Vector2F),
+    {
+        self.click_handler = Some(Box::new(callback));
+        self
+    }
+
+    pub fn on_mouse_down<F>(mut self, callback: F) -> Self
+    where
+        F: 'static + FnMut(&mut TuiEventContext, &AppContext, Vector2F),
+    {
+        self.mouse_down_handler = Some(Box::new(callback));
+        self
+    }
+
+    pub fn disable(mut self) -> Self {
+        self.disabled = true;
+        self
+    }
+
+    fn handle_left_mouse_down(
+        &mut self,
+        area: TuiRect,
+        position: Vector2F,
+        click_count: u32,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        if !area.contains_position(position)
+            || (self.click_handler.is_none() && self.mouse_down_handler.is_none())
+        {
+            return false;
+        }
+
+        self.state.borrow_mut().set_clicked(click_count);
+        if let Some(handler) = self.mouse_down_handler.as_mut() {
+            handler(ctx, app, position);
+        }
+        true
+    }
+
+    fn handle_left_mouse_up(
+        &mut self,
+        area: TuiRect,
+        position: Vector2F,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        let was_clicked = self.state.borrow().is_clicked();
+        self.state.borrow_mut().clear_clicked();
+        if !was_clicked || !area.contains_position(position) {
+            return false;
+        }
+
+        if let Some(handler) = self.click_handler.as_mut() {
+            handler(ctx, app, position);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl TuiElement for TuiMouseArea {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.child.layout(constraint)
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        self.child.render(area, buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.child.desired_height(width)
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        self.child.cursor_position(area)
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        area: TuiRect,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        if self.child.dispatch_event(event, area, ctx, app) {
+            return true;
+        }
+
+        if self.disabled {
+            return false;
+        }
+
+        match event {
+            Event::LeftMouseDown {
+                position,
+                click_count,
+                ..
+            } => self.handle_left_mouse_down(area, *position, *click_count, ctx, app),
+            Event::LeftMouseUp { position, .. } => {
+                self.handle_left_mouse_up(area, *position, ctx, app)
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/warpui_tui/src/elements/text.rs
+++ b/crates/warpui_tui/src/elements/text.rs
@@ -1,0 +1,70 @@
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+
+pub struct TuiText {
+    text: String,
+    size: TuiSize,
+}
+
+impl TuiText {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            size: TuiSize::default(),
+        }
+    }
+
+    fn wrapped_lines(&self, width: u16) -> Vec<String> {
+        if width == 0 {
+            return Vec::new();
+        }
+
+        let width = usize::from(width);
+        self.text
+            .split('\n')
+            .flat_map(|line| {
+                if line.is_empty() {
+                    return vec![String::new()];
+                }
+
+                line.chars()
+                    .collect::<Vec<_>>()
+                    .chunks(width)
+                    .map(|chunk| chunk.iter().collect::<String>())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+}
+
+impl TuiElement for TuiText {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let width = constraint.max.width.max(constraint.min.width);
+        let height = self
+            .desired_height(width)
+            .clamp(constraint.min.height, constraint.max.height);
+        self.size = TuiSize::new(width, height);
+        self.size
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        for (row, line) in self
+            .wrapped_lines(area.width)
+            .into_iter()
+            .take(usize::from(area.height))
+            .enumerate()
+        {
+            let Ok(row) = u16::try_from(row) else {
+                break;
+            };
+            buffer.write_str(area.x, area.y.saturating_add(row), area.width, &line);
+        }
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.wrapped_lines(width)
+            .len()
+            .try_into()
+            .unwrap_or(u16::MAX)
+    }
+}

--- a/crates/warpui_tui/src/event.rs
+++ b/crates/warpui_tui/src/event.rs
@@ -1,0 +1,194 @@
+use crossterm::event::{
+    Event as CrosstermEvent, KeyCode as CrosstermKeyCode, KeyEvent, KeyEventKind, KeyModifiers,
+    MouseButton, MouseEvent, MouseEventKind,
+};
+use warpui_core::event::{KeyEventDetails, ModifiersState};
+use warpui_core::geometry::vector::{vec2f, Vector2F};
+use warpui_core::keymap::Keystroke;
+use warpui_core::{App, Event};
+
+pub enum TuiDispatchEventResult {
+    PropagateToParent,
+    StopPropagation,
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub struct TuiEventDispatchResult {
+    pub handled: bool,
+}
+
+#[derive(Default)]
+pub struct TuiEventContext {
+    updates: Vec<Box<dyn FnOnce(&mut App)>>,
+}
+
+impl TuiEventContext {
+    pub fn dispatch_app_update<F>(&mut self, update: F)
+    where
+        F: 'static + FnOnce(&mut App),
+    {
+        self.updates.push(Box::new(update));
+    }
+
+    pub(crate) fn take_updates(&mut self) -> Vec<Box<dyn FnOnce(&mut App)>> {
+        std::mem::take(&mut self.updates)
+    }
+}
+
+pub fn crossterm_event_to_warp_event(event: CrosstermEvent) -> Option<Event> {
+    match event {
+        CrosstermEvent::Key(event) => key_event_to_warp_event(event),
+        CrosstermEvent::Mouse(event) => mouse_event_to_warp_event(event),
+        CrosstermEvent::FocusGained
+        | CrosstermEvent::FocusLost
+        | CrosstermEvent::Paste(_)
+        | CrosstermEvent::Resize(_, _) => None,
+    }
+}
+
+fn key_event_to_warp_event(event: KeyEvent) -> Option<Event> {
+    if event.kind != KeyEventKind::Press {
+        return None;
+    }
+
+    let key = key_name(event.code, event.modifiers)?;
+    let chars = match event.code {
+        CrosstermKeyCode::Char(char) => char.to_string(),
+        _ => String::new(),
+    };
+
+    Some(Event::KeyDown {
+        keystroke: Keystroke {
+            ctrl: event.modifiers.contains(KeyModifiers::CONTROL),
+            alt: event.modifiers.contains(KeyModifiers::ALT),
+            shift: event.modifiers.contains(KeyModifiers::SHIFT),
+            cmd: event.modifiers.contains(KeyModifiers::SUPER),
+            meta: event.modifiers.contains(KeyModifiers::META),
+            key,
+        },
+        chars,
+        details: KeyEventDetails {
+            key_without_modifiers: key_without_modifiers(event.code),
+            ..Default::default()
+        },
+        is_composing: false,
+    })
+}
+
+fn key_name(code: CrosstermKeyCode, modifiers: KeyModifiers) -> Option<String> {
+    match code {
+        CrosstermKeyCode::Backspace => Some("backspace".to_owned()),
+        CrosstermKeyCode::Enter => Some("enter".to_owned()),
+        CrosstermKeyCode::Left => Some("left".to_owned()),
+        CrosstermKeyCode::Right => Some("right".to_owned()),
+        CrosstermKeyCode::Up => Some("up".to_owned()),
+        CrosstermKeyCode::Down => Some("down".to_owned()),
+        CrosstermKeyCode::Home => Some("home".to_owned()),
+        CrosstermKeyCode::End => Some("end".to_owned()),
+        CrosstermKeyCode::PageUp => Some("pageup".to_owned()),
+        CrosstermKeyCode::PageDown => Some("pagedown".to_owned()),
+        CrosstermKeyCode::Tab => Some("\t".to_owned()),
+        CrosstermKeyCode::BackTab => Some("\t".to_owned()),
+        CrosstermKeyCode::Delete => Some("delete".to_owned()),
+        CrosstermKeyCode::Insert => Some("insert".to_owned()),
+        CrosstermKeyCode::F(key) if key <= 20 => Some(format!("f{key}")),
+        CrosstermKeyCode::Char(' ') => Some(" ".to_owned()),
+        CrosstermKeyCode::Char(char) if modifiers.contains(KeyModifiers::SHIFT) => {
+            Some(char.to_string())
+        }
+        CrosstermKeyCode::Char(char) => Some(char.to_lowercase().to_string()),
+        CrosstermKeyCode::Esc => Some("escape".to_owned()),
+        CrosstermKeyCode::Null
+        | CrosstermKeyCode::CapsLock
+        | CrosstermKeyCode::ScrollLock
+        | CrosstermKeyCode::NumLock
+        | CrosstermKeyCode::PrintScreen
+        | CrosstermKeyCode::Pause
+        | CrosstermKeyCode::Menu
+        | CrosstermKeyCode::KeypadBegin
+        | CrosstermKeyCode::Media(_)
+        | CrosstermKeyCode::Modifier(_)
+        | CrosstermKeyCode::F(_) => None,
+    }
+}
+
+fn key_without_modifiers(code: CrosstermKeyCode) -> Option<String> {
+    match code {
+        CrosstermKeyCode::Char(char) => Some(char.to_lowercase().to_string()),
+        _ => None,
+    }
+}
+
+fn mouse_event_to_warp_event(event: MouseEvent) -> Option<Event> {
+    let position = mouse_position(event.column, event.row);
+    let modifiers = modifiers_state(event.modifiers);
+    match event.kind {
+        MouseEventKind::Down(MouseButton::Left) => Some(Event::LeftMouseDown {
+            position,
+            modifiers,
+            click_count: 1,
+            is_first_mouse: false,
+        }),
+        MouseEventKind::Up(MouseButton::Left) => Some(Event::LeftMouseUp {
+            position,
+            modifiers,
+        }),
+        MouseEventKind::Drag(MouseButton::Left) => Some(Event::LeftMouseDragged {
+            position,
+            modifiers,
+        }),
+        MouseEventKind::Down(MouseButton::Middle) => Some(Event::MiddleMouseDown {
+            position,
+            cmd: modifiers.cmd,
+            shift: modifiers.shift,
+            click_count: 1,
+        }),
+        MouseEventKind::Down(MouseButton::Right) => Some(Event::RightMouseDown {
+            position,
+            cmd: modifiers.cmd,
+            shift: modifiers.shift,
+            click_count: 1,
+        }),
+        MouseEventKind::Moved => Some(Event::MouseMoved {
+            position,
+            cmd: modifiers.cmd,
+            shift: modifiers.shift,
+            is_synthetic: false,
+        }),
+        MouseEventKind::ScrollUp => Some(scroll_wheel_event(position, modifiers, vec2f(0.0, 1.0))),
+        MouseEventKind::ScrollDown => {
+            Some(scroll_wheel_event(position, modifiers, vec2f(0.0, -1.0)))
+        }
+        MouseEventKind::ScrollLeft => {
+            Some(scroll_wheel_event(position, modifiers, vec2f(-1.0, 0.0)))
+        }
+        MouseEventKind::ScrollRight => {
+            Some(scroll_wheel_event(position, modifiers, vec2f(1.0, 0.0)))
+        }
+        MouseEventKind::Up(MouseButton::Middle | MouseButton::Right)
+        | MouseEventKind::Drag(MouseButton::Middle | MouseButton::Right) => None,
+    }
+}
+
+fn mouse_position(column: u16, row: u16) -> Vector2F {
+    vec2f(f32::from(column), f32::from(row))
+}
+
+fn scroll_wheel_event(position: Vector2F, modifiers: ModifiersState, delta: Vector2F) -> Event {
+    Event::ScrollWheel {
+        position,
+        delta,
+        precise: false,
+        modifiers,
+    }
+}
+
+fn modifiers_state(modifiers: KeyModifiers) -> ModifiersState {
+    ModifiersState {
+        alt: modifiers.contains(KeyModifiers::ALT),
+        cmd: modifiers.contains(KeyModifiers::SUPER),
+        shift: modifiers.contains(KeyModifiers::SHIFT),
+        ctrl: modifiers.contains(KeyModifiers::CONTROL),
+        func: false,
+    }
+}

--- a/crates/warpui_tui/src/event.rs
+++ b/crates/warpui_tui/src/event.rs
@@ -5,7 +5,7 @@ use crossterm::event::{
 use warpui_core::event::{KeyEventDetails, ModifiersState};
 use warpui_core::geometry::vector::{vec2f, Vector2F};
 use warpui_core::keymap::Keystroke;
-use warpui_core::{App, Event};
+use warpui_core::{Action, App, EntityId, Event};
 
 pub enum TuiDispatchEventResult {
     PropagateToParent,
@@ -16,6 +16,7 @@ pub enum TuiDispatchEventResult {
 pub struct TuiEventDispatchResult {
     pub handled: bool,
 }
+type TuiAppUpdate = Box<dyn FnOnce(&mut App)>;
 
 pub fn vertical_scroll_lines(delta: Vector2F) -> i16 {
     let y = delta.y();
@@ -33,7 +34,14 @@ pub fn vertical_scroll_lines(delta: Vector2F) -> i16 {
 
 #[derive(Default)]
 pub struct TuiEventContext {
-    updates: Vec<Box<dyn FnOnce(&mut App)>>,
+    updates: Vec<TuiAppUpdate>,
+    typed_actions: Vec<TuiDispatchedAction>,
+    origin_view_id: Option<EntityId>,
+}
+
+pub(crate) struct TuiDispatchedAction {
+    pub(crate) origin_view_id: EntityId,
+    pub(crate) action: Box<dyn Action>,
 }
 
 impl TuiEventContext {
@@ -43,9 +51,26 @@ impl TuiEventContext {
     {
         self.updates.push(Box::new(update));
     }
+    pub fn dispatch_typed_action(&mut self, action: impl Action) {
+        let origin_view_id = self
+            .origin_view_id
+            .expect("typed actions can only be dispatched while processing a rendered TUI view");
+        self.typed_actions.push(TuiDispatchedAction {
+            origin_view_id,
+            action: Box::new(action),
+        });
+    }
 
-    pub(crate) fn take_updates(&mut self) -> Vec<Box<dyn FnOnce(&mut App)>> {
+    pub(crate) fn take_updates(&mut self) -> Vec<TuiAppUpdate> {
         std::mem::take(&mut self.updates)
+    }
+
+    pub(crate) fn take_typed_actions(&mut self) -> Vec<TuiDispatchedAction> {
+        std::mem::take(&mut self.typed_actions)
+    }
+
+    pub(crate) fn set_origin_view(&mut self, view_id: Option<EntityId>) -> Option<EntityId> {
+        std::mem::replace(&mut self.origin_view_id, view_id)
     }
 }
 

--- a/crates/warpui_tui/src/event.rs
+++ b/crates/warpui_tui/src/event.rs
@@ -17,6 +17,20 @@ pub struct TuiEventDispatchResult {
     pub handled: bool,
 }
 
+pub fn vertical_scroll_lines(delta: Vector2F) -> i16 {
+    let y = delta.y();
+    if y == 0.0 || !y.is_finite() {
+        return 0;
+    }
+
+    let lines = y.abs().ceil().min(f32::from(i16::MAX)) as i16;
+    if y.is_sign_positive() {
+        lines
+    } else {
+        -lines
+    }
+}
+
 #[derive(Default)]
 pub struct TuiEventContext {
     updates: Vec<Box<dyn FnOnce(&mut App)>>,
@@ -190,5 +204,39 @@ fn modifiers_state(modifiers: KeyModifiers) -> ModifiersState {
         shift: modifiers.contains(KeyModifiers::SHIFT),
         ctrl: modifiers.contains(KeyModifiers::CONTROL),
         func: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+
+    use super::*;
+
+    #[test]
+    fn mouse_wheel_ticks_are_normalized_to_single_line_deltas() {
+        let event = mouse_event_to_warp_event(MouseEvent {
+            kind: MouseEventKind::ScrollUp,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        });
+
+        let Some(Event::ScrollWheel { delta, .. }) = event else {
+            panic!("expected scroll wheel event");
+        };
+        assert_eq!(vertical_scroll_lines(delta), 1);
+
+        let event = mouse_event_to_warp_event(MouseEvent {
+            kind: MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        });
+
+        let Some(Event::ScrollWheel { delta, .. }) = event else {
+            panic!("expected scroll wheel event");
+        };
+        assert_eq!(vertical_scroll_lines(delta), -1);
     }
 }

--- a/crates/warpui_tui/src/geometry.rs
+++ b/crates/warpui_tui/src/geometry.rs
@@ -1,0 +1,71 @@
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TuiSize {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl TuiSize {
+    pub const fn new(width: u16, height: u16) -> Self {
+        Self { width, height }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TuiRect {
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl TuiRect {
+    pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub fn right(self) -> u16 {
+        self.x.saturating_add(self.width)
+    }
+
+    pub fn bottom(self) -> u16 {
+        self.y.saturating_add(self.height)
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.width == 0 || self.height == 0
+    }
+
+    pub fn inset(self, inset: u16) -> Self {
+        let inset_width = inset.saturating_mul(2);
+        Self {
+            x: self.x.saturating_add(inset),
+            y: self.y.saturating_add(inset),
+            width: self.width.saturating_sub(inset_width),
+            height: self.height.saturating_sub(inset_width),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TuiConstraint {
+    pub min: TuiSize,
+    pub max: TuiSize,
+}
+
+impl TuiConstraint {
+    pub const fn new(min: TuiSize, max: TuiSize) -> Self {
+        Self { min, max }
+    }
+
+    pub const fn tight(size: TuiSize) -> Self {
+        Self {
+            min: size,
+            max: size,
+        }
+    }
+}

--- a/crates/warpui_tui/src/geometry.rs
+++ b/crates/warpui_tui/src/geometry.rs
@@ -1,3 +1,5 @@
+use warpui_core::geometry::vector::Vector2F;
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TuiSize {
     pub width: u16,
@@ -48,6 +50,13 @@ impl TuiRect {
             width: self.width.saturating_sub(inset_width),
             height: self.height.saturating_sub(inset_width),
         }
+    }
+
+    pub fn contains_position(self, position: Vector2F) -> bool {
+        position.x() >= f32::from(self.x)
+            && position.x() < f32::from(self.right())
+            && position.y() >= f32::from(self.y)
+            && position.y() < f32::from(self.bottom())
     }
 }
 

--- a/crates/warpui_tui/src/lib.rs
+++ b/crates/warpui_tui/src/lib.rs
@@ -1,9 +1,14 @@
 mod buffer;
+mod event;
 pub mod elements;
 mod geometry;
 mod presenter;
 
 pub use buffer::{Cell, TuiBuffer};
+pub use event::{
+    crossterm_event_to_warp_event, TuiDispatchEventResult, TuiEventContext,
+    TuiEventDispatchResult,
+};
 pub use geometry::{TuiConstraint, TuiRect, TuiSize};
 pub use presenter::{TuiFrame, TuiPresenter};
 pub use warpui_core::TuiView;

--- a/crates/warpui_tui/src/lib.rs
+++ b/crates/warpui_tui/src/lib.rs
@@ -1,0 +1,9 @@
+mod buffer;
+pub mod elements;
+mod geometry;
+mod presenter;
+
+pub use buffer::{Cell, TuiBuffer};
+pub use geometry::{TuiConstraint, TuiRect, TuiSize};
+pub use presenter::{TuiFrame, TuiPresenter};
+pub use warpui_core::TuiView;

--- a/crates/warpui_tui/src/lib.rs
+++ b/crates/warpui_tui/src/lib.rs
@@ -1,14 +1,18 @@
 mod buffer;
-mod event;
 pub mod elements;
+mod event;
 mod geometry;
 mod presenter;
+mod renderer;
+mod runtime;
 
-pub use buffer::{Cell, TuiBuffer};
+pub use buffer::{Cell, TuiBuffer, TuiStyle};
 pub use event::{
-    crossterm_event_to_warp_event, TuiDispatchEventResult, TuiEventContext,
+    crossterm_event_to_warp_event, vertical_scroll_lines, TuiDispatchEventResult, TuiEventContext,
     TuiEventDispatchResult,
 };
 pub use geometry::{TuiConstraint, TuiRect, TuiSize};
 pub use presenter::{TuiFrame, TuiPresenter};
+pub use renderer::TuiFrameRenderer;
+pub use runtime::TuiRuntime;
 pub use warpui_core::TuiView;

--- a/crates/warpui_tui/src/presenter.rs
+++ b/crates/warpui_tui/src/presenter.rs
@@ -1,7 +1,9 @@
-use warpui_core::AppContext;
+use warpui_core::{App, AppContext, Event};
 
 use crate::elements::TuiElement;
-use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize, TuiView};
+use crate::{
+    TuiBuffer, TuiConstraint, TuiEventContext, TuiEventDispatchResult, TuiRect, TuiSize, TuiView,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TuiFrame {
@@ -11,11 +13,17 @@ pub struct TuiFrame {
 
 pub struct TuiPresenter {
     frame_count: usize,
+    root: Option<Box<dyn TuiElement>>,
+    root_area: TuiRect,
 }
 
 impl TuiPresenter {
     pub fn new() -> Self {
-        Self { frame_count: 0 }
+        Self {
+            frame_count: 0,
+            root: None,
+            root_area: TuiRect::default(),
+        }
     }
 
     pub fn frame_count(&self) -> usize {
@@ -35,11 +43,29 @@ impl TuiPresenter {
         let area = TuiRect::new(0, 0, size.width, size.height);
         root.render(area, &mut buffer);
         let cursor_position = root.cursor_position(area);
+        self.root = Some(root);
+        self.root_area = area;
         self.frame_count += 1;
         TuiFrame {
             buffer,
             cursor_position,
         }
+    }
+
+    pub fn dispatch_event(&mut self, event: &Event, app: &mut App) -> TuiEventDispatchResult {
+        let Some(mut root) = self.root.take() else {
+            return TuiEventDispatchResult { handled: false };
+        };
+
+        let mut event_ctx = TuiEventContext::default();
+        let handled = app.read(|ctx| root.dispatch_event(event, &mut event_ctx, ctx));
+        self.root = Some(root);
+
+        for update in event_ctx.take_updates() {
+            update(app);
+        }
+
+        TuiEventDispatchResult { handled }
     }
 }
 
@@ -51,10 +77,13 @@ impl Default for TuiPresenter {
 
 #[cfg(test)]
 mod tests {
-    use warpui_core::{App, Entity, ModelHandle};
+    use warpui_core::event::KeyEventDetails;
+    use warpui_core::keymap::Keystroke;
+    use warpui_core::{App, Entity, Event, ModelHandle};
 
     use super::*;
-    use crate::elements::{TuiContainer, TuiText};
+    use crate::elements::{TuiContainer, TuiEventHandler, TuiText};
+    use crate::TuiDispatchEventResult;
 
     struct GreetingModel {
         greeting: String,
@@ -84,6 +113,43 @@ mod tests {
         }
     }
 
+    struct EventHandlingView {
+        model: ModelHandle<GreetingModel>,
+    }
+
+    impl Entity for EventHandlingView {
+        type Event = ();
+    }
+
+    impl TuiView for EventHandlingView {
+        type RenderOutput = Box<dyn crate::elements::TuiElement>;
+
+        fn ui_name() -> &'static str {
+            "EventHandlingView"
+        }
+
+        fn render_tui(&self, _: &AppContext) -> Box<dyn crate::elements::TuiElement> {
+            let model = self.model.clone();
+            Box::new(
+                TuiEventHandler::new(TuiText::new("press enter")).on_key_down(
+                    move |ctx, _, keystroke| {
+                        if keystroke.is_unmodified_enter() {
+                            let model = model.clone();
+                            ctx.dispatch_app_update(move |app| {
+                                model.update(app, |model, _| {
+                                    model.greeting = "event handled".to_owned();
+                                });
+                            });
+                            TuiDispatchEventResult::StopPropagation
+                        } else {
+                            TuiDispatchEventResult::PropagateToParent
+                        }
+                    },
+                ),
+            )
+        }
+    }
+
     #[test]
     fn renders_view_from_shared_model_state() {
         App::test((), |mut app| async move {
@@ -108,6 +174,43 @@ mod tests {
                 ]
             );
             assert_eq!(presenter.frame_count(), 1);
+        });
+    }
+
+    #[test]
+    fn dispatches_events_through_rendered_element_tree() {
+        App::test((), |mut app| async move {
+            let model = app.add_model(|_| GreetingModel {
+                greeting: "hello tui".to_string(),
+            });
+            let (_, view) = app.add_tui_window(|_| EventHandlingView {
+                model: model.clone(),
+            });
+
+            let mut presenter = TuiPresenter::new();
+            app.read(|ctx| {
+                view.read(ctx, |view, ctx| {
+                    presenter.render_view(view, ctx, TuiSize::new(12, 3));
+                })
+            });
+
+            let event = Event::KeyDown {
+                keystroke: Keystroke {
+                    key: "enter".to_owned(),
+                    ..Default::default()
+                },
+                chars: String::new(),
+                details: KeyEventDetails::default(),
+                is_composing: false,
+            };
+
+            let result = presenter.dispatch_event(&event, &mut app);
+
+            assert!(result.handled);
+            assert_eq!(
+                model.read(&app, |model, _| model.greeting.clone()),
+                "event handled"
+            );
         });
     }
 }

--- a/crates/warpui_tui/src/presenter.rs
+++ b/crates/warpui_tui/src/presenter.rs
@@ -1,0 +1,113 @@
+use warpui_core::AppContext;
+
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize, TuiView};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TuiFrame {
+    pub buffer: TuiBuffer,
+    pub cursor_position: Option<(u16, u16)>,
+}
+
+pub struct TuiPresenter {
+    frame_count: usize,
+}
+
+impl TuiPresenter {
+    pub fn new() -> Self {
+        Self { frame_count: 0 }
+    }
+
+    pub fn frame_count(&self) -> usize {
+        self.frame_count
+    }
+
+    pub fn render_view(
+        &mut self,
+        view: &impl TuiView<RenderOutput = Box<dyn TuiElement>>,
+        app: &AppContext,
+        size: TuiSize,
+    ) -> TuiFrame {
+        let mut root = view.render_tui(app);
+        root.layout(TuiConstraint::tight(size));
+
+        let mut buffer = TuiBuffer::new(size);
+        let area = TuiRect::new(0, 0, size.width, size.height);
+        root.render(area, &mut buffer);
+        let cursor_position = root.cursor_position(area);
+        self.frame_count += 1;
+        TuiFrame {
+            buffer,
+            cursor_position,
+        }
+    }
+}
+
+impl Default for TuiPresenter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use warpui_core::{App, Entity, ModelHandle};
+
+    use super::*;
+    use crate::elements::{TuiContainer, TuiText};
+
+    struct GreetingModel {
+        greeting: String,
+    }
+
+    impl Entity for GreetingModel {
+        type Event = ();
+    }
+
+    struct GreetingView {
+        model: ModelHandle<GreetingModel>,
+    }
+
+    impl Entity for GreetingView {
+        type Event = ();
+    }
+
+    impl TuiView for GreetingView {
+        type RenderOutput = Box<dyn crate::elements::TuiElement>;
+        fn ui_name() -> &'static str {
+            "GreetingView"
+        }
+
+        fn render_tui(&self, app: &AppContext) -> Box<dyn crate::elements::TuiElement> {
+            let greeting = self.model.read(app, |model, _| model.greeting.clone());
+            Box::new(TuiContainer::new(TuiText::new(greeting)).with_border())
+        }
+    }
+
+    #[test]
+    fn renders_view_from_shared_model_state() {
+        App::test((), |mut app| async move {
+            let model = app.add_model(|_| GreetingModel {
+                greeting: "hello tui".to_string(),
+            });
+            let (_, view) = app.add_tui_window(|_| GreetingView { model });
+
+            let mut presenter = TuiPresenter::new();
+            let frame = app.read(|ctx| {
+                view.read(ctx, |view, ctx| {
+                    presenter.render_view(view, ctx, TuiSize::new(12, 3))
+                })
+            });
+
+            assert_eq!(
+                frame.buffer.lines(),
+                vec![
+                    "┌──────────┐".to_string(),
+                    "│hello tui │".to_string(),
+                    "└──────────┘".to_string(),
+                ]
+            );
+            assert_eq!(presenter.frame_count(), 1);
+        });
+    }
+}

--- a/crates/warpui_tui/src/presenter.rs
+++ b/crates/warpui_tui/src/presenter.rs
@@ -1,6 +1,8 @@
-use warpui_core::{App, AppContext, Event};
+use std::collections::HashMap;
 
-use crate::elements::TuiElement;
+use warpui_core::{App, AppContext, EntityId, Event, WindowId};
+
+use crate::elements::{TuiElement, TuiPresentationContext};
 use crate::{
     TuiBuffer, TuiConstraint, TuiEventContext, TuiEventDispatchResult, TuiRect, TuiSize, TuiView,
 };
@@ -15,6 +17,9 @@ pub struct TuiPresenter {
     frame_count: usize,
     root: Option<Box<dyn TuiElement>>,
     root_area: TuiRect,
+    window_id: Option<WindowId>,
+    root_view_id: Option<EntityId>,
+    parent_by_child: HashMap<EntityId, EntityId>,
 }
 
 impl TuiPresenter {
@@ -23,6 +28,9 @@ impl TuiPresenter {
             frame_count: 0,
             root: None,
             root_area: TuiRect::default(),
+            window_id: None,
+            root_view_id: None,
+            parent_by_child: HashMap::new(),
         }
     }
 
@@ -36,8 +44,43 @@ impl TuiPresenter {
         app: &AppContext,
         size: TuiSize,
     ) -> TuiFrame {
-        let mut root = view.render_tui(app);
+        self.render_root(view.render_tui(app), size, None)
+    }
+
+    pub fn render_window(
+        &mut self,
+        window_id: WindowId,
+        root_view_id: EntityId,
+        view: &impl TuiView<RenderOutput = Box<dyn TuiElement>>,
+        app: &AppContext,
+        size: TuiSize,
+    ) -> TuiFrame {
+        self.render_root(
+            view.render_tui(app),
+            size,
+            Some((window_id, root_view_id)),
+        )
+    }
+
+    fn render_root(
+        &mut self,
+        mut root: Box<dyn TuiElement>,
+        size: TuiSize,
+        identity: Option<(WindowId, EntityId)>,
+    ) -> TuiFrame {
         root.layout(TuiConstraint::tight(size));
+        self.parent_by_child.clear();
+        if let Some((window_id, root_view_id)) = identity {
+            self.window_id = Some(window_id);
+            self.root_view_id = Some(root_view_id);
+            root.present(&mut TuiPresentationContext::new(
+                root_view_id,
+                &mut self.parent_by_child,
+            ));
+        } else {
+            self.window_id = None;
+            self.root_view_id = None;
+        }
 
         let mut buffer = TuiBuffer::new(size);
         let area = TuiRect::new(0, 0, size.width, size.height);
@@ -51,16 +94,80 @@ impl TuiPresenter {
             cursor_position,
         }
     }
+    pub fn responder_chain(&self, view_id: EntityId) -> Vec<EntityId> {
+        let Some(root_view_id) = self.root_view_id else {
+            return Vec::new();
+        };
+        let mut chain = vec![view_id];
+        while let Some(parent_id) = self.parent_by_child.get(chain.last().unwrap()) {
+            chain.push(*parent_id);
+        }
+        if chain.last().copied() != Some(root_view_id) {
+            return vec![root_view_id];
+        }
+        chain.reverse();
+        chain
+    }
+
+    pub fn sync_focus(&self, app: &mut App) {
+        let (Some(window_id), Some(root_view_id)) = (self.window_id, self.root_view_id) else {
+            return;
+        };
+        let focused_view_id = app.read(|ctx| ctx.focused_tui_view_id(window_id));
+        if focused_view_id.is_none_or(|view_id| {
+            view_id != root_view_id && !self.parent_by_child.contains_key(&view_id)
+        }) {
+            app.focus_tui_view(window_id, root_view_id);
+        }
+    }
 
     pub fn dispatch_event(&mut self, event: &Event, app: &mut App) -> TuiEventDispatchResult {
+        self.sync_focus(app);
+        if let (Some(window_id), Some(root_view_id)) = (self.window_id, self.root_view_id) {
+            if app.key_bindings_dispatching_enabled(window_id) {
+                if let Event::KeyDown { keystroke, .. } = event {
+                    let focused_view_id = app
+                        .read(|ctx| ctx.focused_tui_view_id(window_id))
+                        .filter(|view_id| {
+                            *view_id == root_view_id || self.parent_by_child.contains_key(view_id)
+                        })
+                        .unwrap_or(root_view_id);
+                    if app.read(|ctx| ctx.focused_tui_view_id(window_id)) != Some(focused_view_id) {
+                        app.focus_tui_view(window_id, focused_view_id);
+                    }
+                    if app
+                        .dispatch_tui_keystroke(
+                            window_id,
+                            &self.responder_chain(focused_view_id),
+                            keystroke,
+                        )
+                        .unwrap_or(false)
+                    {
+                        return TuiEventDispatchResult { handled: true };
+                    }
+                }
+            }
+        }
         let Some(mut root) = self.root.take() else {
             return TuiEventDispatchResult { handled: false };
         };
 
         let mut event_ctx = TuiEventContext::default();
-        let handled =
+        if let Some(root_view_id) = self.root_view_id {
+            event_ctx.set_origin_view(Some(root_view_id));
+        }
+        let mut handled =
             app.read(|ctx| root.dispatch_event(event, self.root_area, &mut event_ctx, ctx));
         self.root = Some(root);
+        if let Some(window_id) = self.window_id {
+            for dispatched_action in event_ctx.take_typed_actions() {
+                handled |= app.dispatch_tui_typed_action(
+                    window_id,
+                    &self.responder_chain(dispatched_action.origin_view_id),
+                    dispatched_action.action.as_ref(),
+                );
+            }
+        }
 
         for update in event_ctx.take_updates() {
             update(app);
@@ -80,12 +187,14 @@ impl Default for TuiPresenter {
 mod tests {
     use warpui_core::event::KeyEventDetails;
     use warpui_core::geometry::vector::vec2f;
-    use warpui_core::keymap::Keystroke;
-    use warpui_core::{App, Entity, Event, ModelHandle};
+    use warpui_core::keymap::{ContextPredicate, FixedBinding, Keystroke};
+    use warpui_core::{
+        App, Entity, Event, ModelHandle, TuiTypedActionView, TuiViewContext, TuiViewHandle,
+    };
 
     use super::*;
     use crate::elements::{
-        TuiContainer, TuiEventHandler, TuiMouseArea, TuiMouseStateHandle, TuiText,
+        TuiChildView, TuiContainer, TuiEventHandler, TuiMouseArea, TuiMouseStateHandle, TuiText,
     };
     use crate::TuiDispatchEventResult;
 
@@ -201,6 +310,155 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct PointerAction;
+
+    struct PointerParentView {
+        child: TuiViewHandle<PointerChildView>,
+        handled: usize,
+    }
+
+    impl Entity for PointerParentView {
+        type Event = ();
+    }
+
+    impl TuiView for PointerParentView {
+        type RenderOutput = Box<dyn crate::elements::TuiElement>;
+
+        fn ui_name() -> &'static str {
+            "PointerParentView"
+        }
+
+        fn render_tui(&self, app: &AppContext) -> Self::RenderOutput {
+            Box::new(TuiChildView::new(&self.child, app))
+        }
+    }
+
+    impl TuiTypedActionView for PointerParentView {
+        type Action = PointerAction;
+
+        fn handle_action(&mut self, _: &Self::Action, _: &mut TuiViewContext<Self>) {
+            self.handled += 1;
+        }
+    }
+
+    struct PointerChildView {
+        mouse_state: TuiMouseStateHandle,
+        handled: usize,
+    }
+
+    impl Entity for PointerChildView {
+        type Event = ();
+    }
+
+    impl TuiView for PointerChildView {
+        type RenderOutput = Box<dyn crate::elements::TuiElement>;
+
+        fn ui_name() -> &'static str {
+            "PointerChildView"
+        }
+
+        fn render_tui(&self, _: &AppContext) -> Self::RenderOutput {
+            Box::new(
+                TuiMouseArea::new(self.mouse_state.clone(), |_| Box::new(TuiText::new("child")))
+                    .on_click(|ctx, _, _| ctx.dispatch_typed_action(PointerAction)),
+            )
+        }
+    }
+
+    impl TuiTypedActionView for PointerChildView {
+        type Action = PointerAction;
+
+        fn handle_action(&mut self, _: &Self::Action, _: &mut TuiViewContext<Self>) {
+            self.handled += 1;
+        }
+    }
+
+    #[derive(Debug)]
+    struct KeyAction;
+
+    struct RawKeyModel {
+        count: usize,
+    }
+
+    impl Entity for RawKeyModel {
+        type Event = ();
+    }
+
+    struct KeyParentView {
+        child: TuiViewHandle<KeyChildView>,
+        child_visible: bool,
+    }
+
+    impl Entity for KeyParentView {
+        type Event = ();
+    }
+
+    impl TuiView for KeyParentView {
+        type RenderOutput = Box<dyn crate::elements::TuiElement>;
+
+        fn ui_name() -> &'static str {
+            "KeyParentView"
+        }
+
+        fn render_tui(&self, app: &AppContext) -> Self::RenderOutput {
+            if self.child_visible {
+                Box::new(TuiChildView::new(&self.child, app))
+            } else {
+                Box::new(TuiText::new("hidden"))
+            }
+        }
+    }
+
+    struct KeyChildView {
+        raw_keys: ModelHandle<RawKeyModel>,
+        actions: usize,
+    }
+
+    impl Entity for KeyChildView {
+        type Event = ();
+    }
+
+    impl TuiView for KeyChildView {
+        type RenderOutput = Box<dyn crate::elements::TuiElement>;
+
+        fn ui_name() -> &'static str {
+            "KeyChildView"
+        }
+
+        fn render_tui(&self, _: &AppContext) -> Self::RenderOutput {
+            let raw_keys = self.raw_keys.clone();
+            Box::new(TuiEventHandler::new(TuiText::new("keys")).on_key_down(
+                move |ctx, _, _| {
+                    let raw_keys = raw_keys.clone();
+                    ctx.dispatch_app_update(move |app| {
+                        raw_keys.update(app, |model, _| model.count += 1);
+                    });
+                    TuiDispatchEventResult::StopPropagation
+                },
+            ))
+        }
+    }
+
+    impl TuiTypedActionView for KeyChildView {
+        type Action = KeyAction;
+
+        fn handle_action(&mut self, _: &Self::Action, _: &mut TuiViewContext<Self>) {
+            self.actions += 1;
+        }
+    }
+
+    fn key_down(key: &str) -> Event {
+        Event::KeyDown {
+            keystroke: Keystroke {
+                key: key.to_owned(),
+                ..Default::default()
+            },
+            chars: key.to_owned(),
+            details: KeyEventDetails::default(),
+            is_composing: false,
+        }
+    }
     #[test]
     fn renders_view_from_shared_model_state() {
         App::test((), |mut app| async move {
@@ -297,6 +555,105 @@ mod tests {
             assert_eq!(model.read(&app, |model, _| model.click_count), 0);
             assert!(presenter.dispatch_event(&up, &mut app).handled);
             assert_eq!(model.read(&app, |model, _| model.click_count), 1);
+        });
+    }
+
+    #[test]
+    fn pointer_actions_use_the_visible_child_responder_chain() {
+        App::test((), |mut app| async move {
+            let (window_id, root) = app.add_tui_typed_action_window(|ctx| {
+                let child = ctx.add_tui_typed_action_view(|_| PointerChildView {
+                    mouse_state: TuiMouseStateHandle::default(),
+                    handled: 0,
+                });
+                PointerParentView { child, handled: 0 }
+            });
+            let child = root.read(&app, |root, _| root.child.clone());
+            let root_id = root.id();
+
+            let mut presenter = TuiPresenter::new();
+            app.read(|ctx| {
+                root.read(ctx, |root, ctx| {
+                    presenter.render_window(window_id, root_id, root, ctx, TuiSize::new(8, 1));
+                })
+            });
+
+            assert_eq!(presenter.responder_chain(child.id()), vec![root.id(), child.id()]);
+            assert!(presenter
+                .dispatch_event(
+                    &Event::LeftMouseDown {
+                        position: vec2f(2.0, 0.0),
+                        modifiers: Default::default(),
+                        click_count: 1,
+                        is_first_mouse: false,
+                    },
+                    &mut app,
+                )
+                .handled);
+            assert!(presenter
+                .dispatch_event(
+                    &Event::LeftMouseUp {
+                        position: vec2f(2.0, 0.0),
+                        modifiers: Default::default(),
+                    },
+                    &mut app,
+                )
+                .handled);
+            assert_eq!(child.read(&app, |child, _| child.handled), 1);
+            assert_eq!(root.read(&app, |root, _| root.handled), 0);
+        });
+    }
+
+    #[test]
+    fn focused_keybindings_suppress_raw_keys_and_hidden_focus_falls_back_to_root() {
+        App::test((), |mut app| async move {
+            let raw_keys = app.add_model(|_| RawKeyModel { count: 0 });
+            let (window_id, root) = app.add_tui_window(|ctx| {
+                let child = ctx.add_tui_typed_action_view(|_| KeyChildView {
+                    raw_keys: raw_keys.clone(),
+                    actions: 0,
+                });
+                KeyParentView {
+                    child,
+                    child_visible: true,
+                }
+            });
+            let child = root.read(&app, |root, _| root.child.clone());
+            let root_id = root.id();
+            app.update(|ctx| {
+                ctx.register_fixed_bindings([FixedBinding::new(
+                    "enter a",
+                    KeyAction,
+                    ContextPredicate::Identifier("KeyChildView"),
+                )]);
+            });
+            app.focus_tui_view(window_id, child.id());
+
+            let mut presenter = TuiPresenter::new();
+            app.read(|ctx| {
+                root.read(ctx, |root, ctx| {
+                    presenter.render_window(window_id, root_id, root, ctx, TuiSize::new(8, 1));
+                })
+            });
+
+            assert!(presenter.dispatch_event(&key_down("enter"), &mut app).handled);
+            assert_eq!(raw_keys.read(&app, |model, _| model.count), 0);
+            assert_eq!(child.read(&app, |child, _| child.actions), 0);
+            assert!(presenter.dispatch_event(&key_down("a"), &mut app).handled);
+            assert_eq!(raw_keys.read(&app, |model, _| model.count), 0);
+            assert_eq!(child.read(&app, |child, _| child.actions), 1);
+
+            root.update(&mut app, |root, _| root.child_visible = false);
+            app.read(|ctx| {
+                root.read(ctx, |root, ctx| {
+                    presenter.render_window(window_id, root_id, root, ctx, TuiSize::new(8, 1));
+                })
+            });
+            presenter.sync_focus(&mut app);
+            assert_eq!(
+                app.read(|ctx| ctx.focused_tui_view_id(window_id)),
+                Some(root_id)
+            );
         });
     }
 }

--- a/crates/warpui_tui/src/presenter.rs
+++ b/crates/warpui_tui/src/presenter.rs
@@ -58,7 +58,8 @@ impl TuiPresenter {
         };
 
         let mut event_ctx = TuiEventContext::default();
-        let handled = app.read(|ctx| root.dispatch_event(event, &mut event_ctx, ctx));
+        let handled =
+            app.read(|ctx| root.dispatch_event(event, self.root_area, &mut event_ctx, ctx));
         self.root = Some(root);
 
         for update in event_ctx.take_updates() {
@@ -78,11 +79,14 @@ impl Default for TuiPresenter {
 #[cfg(test)]
 mod tests {
     use warpui_core::event::KeyEventDetails;
+    use warpui_core::geometry::vector::vec2f;
     use warpui_core::keymap::Keystroke;
     use warpui_core::{App, Entity, Event, ModelHandle};
 
     use super::*;
-    use crate::elements::{TuiContainer, TuiEventHandler, TuiText};
+    use crate::elements::{
+        TuiContainer, TuiEventHandler, TuiMouseArea, TuiMouseStateHandle, TuiText,
+    };
     use crate::TuiDispatchEventResult;
 
     struct GreetingModel {
@@ -150,6 +154,53 @@ mod tests {
         }
     }
 
+    struct ClickModel {
+        click_count: usize,
+    }
+
+    impl Entity for ClickModel {
+        type Event = ();
+    }
+
+    struct ClickView {
+        model: ModelHandle<ClickModel>,
+        mouse_state: TuiMouseStateHandle,
+    }
+
+    impl Entity for ClickView {
+        type Event = ();
+    }
+
+    impl TuiView for ClickView {
+        type RenderOutput = Box<dyn crate::elements::TuiElement>;
+
+        fn ui_name() -> &'static str {
+            "ClickView"
+        }
+
+        fn render_tui(&self, _: &AppContext) -> Box<dyn crate::elements::TuiElement> {
+            let model = self.model.clone();
+            Box::new(
+                TuiMouseArea::new(self.mouse_state.clone(), |state| {
+                    let label = if state.is_clicked() {
+                        "pressed"
+                    } else {
+                        "click me"
+                    };
+                    Box::new(TuiText::new(label))
+                })
+                .on_click(move |ctx, _, _| {
+                    let model = model.clone();
+                    ctx.dispatch_app_update(move |app| {
+                        model.update(app, |model, _| {
+                            model.click_count += 1;
+                        });
+                    });
+                }),
+            )
+        }
+    }
+
     #[test]
     fn renders_view_from_shared_model_state() {
         App::test((), |mut app| async move {
@@ -211,6 +262,41 @@ mod tests {
                 model.read(&app, |model, _| model.greeting.clone()),
                 "event handled"
             );
+        });
+    }
+
+    #[test]
+    fn dispatches_clicks_to_mouse_area() {
+        App::test((), |mut app| async move {
+            let model = app.add_model(|_| ClickModel { click_count: 0 });
+            let mouse_state = TuiMouseStateHandle::default();
+            let (_, view) = app.add_tui_window(|_| ClickView {
+                model: model.clone(),
+                mouse_state,
+            });
+
+            let mut presenter = TuiPresenter::new();
+            app.read(|ctx| {
+                view.read(ctx, |view, ctx| {
+                    presenter.render_view(view, ctx, TuiSize::new(8, 1));
+                })
+            });
+
+            let down = Event::LeftMouseDown {
+                position: vec2f(2.0, 0.0),
+                modifiers: Default::default(),
+                click_count: 1,
+                is_first_mouse: false,
+            };
+            let up = Event::LeftMouseUp {
+                position: vec2f(2.0, 0.0),
+                modifiers: Default::default(),
+            };
+
+            assert!(presenter.dispatch_event(&down, &mut app).handled);
+            assert_eq!(model.read(&app, |model, _| model.click_count), 0);
+            assert!(presenter.dispatch_event(&up, &mut app).handled);
+            assert_eq!(model.read(&app, |model, _| model.click_count), 1);
         });
     }
 }

--- a/crates/warpui_tui/src/renderer.rs
+++ b/crates/warpui_tui/src/renderer.rs
@@ -1,0 +1,283 @@
+use std::io::{self, Write};
+
+use crate::{TuiBuffer, TuiFrame, TuiStyle};
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::queue;
+use crossterm::style::{Print, ResetColor, SetForegroundColor};
+use crossterm::terminal::{Clear, ClearType};
+
+pub struct TuiFrameRenderer {
+    previous_frame: Option<TuiFrame>,
+}
+
+impl TuiFrameRenderer {
+    pub fn new() -> Self {
+        Self {
+            previous_frame: None,
+        }
+    }
+
+    pub fn draw(&mut self, writer: &mut impl Write, frame: &TuiFrame) -> io::Result<()> {
+        if self.should_draw_full_frame(frame) {
+            draw_full_frame(writer, frame)?;
+        } else if let Some(previous_frame) = &self.previous_frame {
+            draw_changed_runs(writer, &previous_frame.buffer, &frame.buffer)?;
+            draw_cursor(writer, frame)?;
+        }
+
+        writer.flush()?;
+        self.previous_frame = Some(frame.clone());
+        Ok(())
+    }
+
+    fn should_draw_full_frame(&self, frame: &TuiFrame) -> bool {
+        self.previous_frame
+            .as_ref()
+            .is_none_or(|previous_frame| previous_frame.buffer.size() != frame.buffer.size())
+    }
+}
+
+impl Default for TuiFrameRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn draw_full_frame(writer: &mut impl Write, frame: &TuiFrame) -> io::Result<()> {
+    queue!(writer, MoveTo(0, 0), Clear(ClearType::All))?;
+    for row in 0..frame.buffer.size().height {
+        for run in styled_runs_for_range(&frame.buffer, row, 0, frame.buffer.size().width) {
+            draw_styled_run(writer, &run)?;
+        }
+    }
+
+    queue!(writer, ResetColor)?;
+    draw_cursor(writer, frame)
+}
+
+fn draw_changed_runs(
+    writer: &mut impl Write,
+    previous_buffer: &TuiBuffer,
+    next_buffer: &TuiBuffer,
+) -> io::Result<()> {
+    for run in changed_runs(previous_buffer, next_buffer) {
+        draw_styled_run(writer, &run)?;
+    }
+    queue!(writer, ResetColor)?;
+    Ok(())
+}
+
+fn draw_cursor(writer: &mut impl Write, frame: &TuiFrame) -> io::Result<()> {
+    if let Some((x, y)) = frame.cursor_position {
+        queue!(writer, MoveTo(x, y), Show)
+    } else {
+        queue!(writer, Hide)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ChangedRun {
+    x: u16,
+    y: u16,
+    text: String,
+    style: TuiStyle,
+}
+
+fn changed_runs(previous_buffer: &TuiBuffer, next_buffer: &TuiBuffer) -> Vec<ChangedRun> {
+    if previous_buffer.size() != next_buffer.size() {
+        return Vec::new();
+    }
+
+    let size = next_buffer.size();
+    let mut runs = Vec::new();
+
+    for y in 0..size.height {
+        let mut x = 0;
+        while x < size.width {
+            if !cell_changed(previous_buffer, next_buffer, x, y) {
+                x = x.saturating_add(1);
+                continue;
+            }
+
+            let start_x = x;
+            let style = next_buffer
+                .cell(x, y)
+                .map(|cell| cell.style())
+                .unwrap_or_default();
+            x = x.saturating_add(1);
+            while x < size.width
+                && cell_changed(previous_buffer, next_buffer, x, y)
+                && next_buffer
+                    .cell(x, y)
+                    .is_some_and(|cell| cell.is_continuation() || cell.style() == style)
+            {
+                x = x.saturating_add(1);
+            }
+            while x < size.width
+                && next_buffer
+                    .cell(x, y)
+                    .is_some_and(|cell| cell.is_continuation())
+            {
+                x = x.saturating_add(1);
+            }
+
+            let mut text = next_buffer.display_string_for_range(y, start_x, x);
+            if text.is_empty() {
+                text = " ".repeat(usize::from(x.saturating_sub(start_x)));
+            }
+            runs.push(ChangedRun {
+                x: start_x,
+                y,
+                text,
+                style,
+            });
+        }
+    }
+
+    runs
+}
+
+fn styled_runs_for_range(buffer: &TuiBuffer, y: u16, start_x: u16, end_x: u16) -> Vec<ChangedRun> {
+    let mut runs = Vec::new();
+    let mut x = start_x;
+    let end_x = end_x.min(buffer.size().width);
+    while x < end_x {
+        let Some(cell) = buffer.cell(x, y) else {
+            break;
+        };
+        let style = cell.style();
+        let run_start_x = x;
+        x = x.saturating_add(1);
+        while x < end_x
+            && buffer
+                .cell(x, y)
+                .is_some_and(|cell| cell.is_continuation() || cell.style() == style)
+        {
+            x = x.saturating_add(1);
+        }
+
+        let mut text = buffer.display_string_for_range(y, run_start_x, x);
+        if text.is_empty() {
+            text = " ".repeat(usize::from(x.saturating_sub(run_start_x)));
+        }
+        runs.push(ChangedRun {
+            x: run_start_x,
+            y,
+            text,
+            style,
+        });
+    }
+    runs
+}
+
+fn draw_styled_run(writer: &mut impl Write, run: &ChangedRun) -> io::Result<()> {
+    match run.style.foreground_color() {
+        Some(color) => queue!(writer, MoveTo(run.x, run.y), SetForegroundColor(color))?,
+        None => queue!(writer, MoveTo(run.x, run.y), ResetColor)?,
+    }
+    queue!(writer, Print(&run.text))
+}
+
+fn cell_changed(previous_buffer: &TuiBuffer, next_buffer: &TuiBuffer, x: u16, y: u16) -> bool {
+    previous_buffer.cell(x, y) != next_buffer.cell(x, y)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TuiSize;
+    use crossterm::style::Color;
+
+    fn run(x: u16, y: u16, text: &str) -> ChangedRun {
+        styled_run(x, y, text, TuiStyle::default())
+    }
+
+    fn styled_run(x: u16, y: u16, text: &str, style: TuiStyle) -> ChangedRun {
+        ChangedRun {
+            x,
+            y,
+            text: text.to_owned(),
+            style,
+        }
+    }
+
+    fn buffer(lines: &[&str], width: u16) -> TuiBuffer {
+        let mut buffer = TuiBuffer::new(TuiSize::new(width, lines.len().try_into().unwrap()));
+        for (row, line) in lines.iter().enumerate() {
+            buffer.write_str(0, row.try_into().unwrap(), width, line);
+        }
+        buffer
+    }
+
+    #[test]
+    fn unchanged_frames_emit_no_runs() {
+        let previous = buffer(&["abc"], 3);
+        let next = buffer(&["abc"], 3);
+
+        assert_eq!(changed_runs(&previous, &next), Vec::new());
+    }
+
+    #[test]
+    fn single_row_edits_are_coalesced() {
+        let previous = buffer(&["abcde"], 5);
+        let next = buffer(&["abXYe"], 5);
+
+        assert_eq!(changed_runs(&previous, &next), vec![run(2, 0, "XY")]);
+    }
+
+    #[test]
+    fn scroll_like_changes_emit_changed_rows() {
+        let previous = buffer(&["one", "two", "thr"], 3);
+        let next = buffer(&["two", "thr", "fou"], 3);
+
+        assert_eq!(
+            changed_runs(&previous, &next),
+            vec![run(0, 0, "two"), run(1, 1, "hr"), run(0, 2, "fou")]
+        );
+    }
+
+    #[test]
+    fn wide_cell_changes_include_continuation_columns() {
+        let previous = buffer(&["ab "], 3);
+        let next = buffer(&["界 "], 3);
+
+        assert_eq!(changed_runs(&previous, &next), vec![run(0, 0, "界")]);
+    }
+
+    #[test]
+    fn replacing_wide_cells_clears_leftover_columns() {
+        let previous = buffer(&["界 "], 3);
+        let next = buffer(&["ab "], 3);
+
+        assert_eq!(changed_runs(&previous, &next), vec![run(0, 0, "ab")]);
+    }
+
+    #[test]
+    fn style_changes_emit_styled_runs() {
+        let previous = buffer(&["abc"], 3);
+        let mut next = buffer(&["abc"], 3);
+        let style = TuiStyle::default().with_foreground_color(Color::Yellow);
+        next.write_str_with_style(1, 0, 1, "b", style);
+
+        assert_eq!(
+            changed_runs(&previous, &next),
+            vec![styled_run(1, 0, "b", style)]
+        );
+    }
+
+    #[test]
+    fn adjacent_style_changes_split_runs_by_style() {
+        let previous = buffer(&["abc"], 3);
+        let mut next = TuiBuffer::new(TuiSize::new(3, 1));
+        let yellow = TuiStyle::default().with_foreground_color(Color::Yellow);
+        let blue = TuiStyle::default().with_foreground_color(Color::Blue);
+        next.write_str_with_style(0, 0, 1, "a", yellow);
+        next.write_str_with_style(1, 0, 1, "b", blue);
+        next.write_str(2, 0, 1, "c");
+
+        assert_eq!(
+            changed_runs(&previous, &next),
+            vec![styled_run(0, 0, "a", yellow), styled_run(1, 0, "b", blue)]
+        );
+    }
+}

--- a/crates/warpui_tui/src/runtime.rs
+++ b/crates/warpui_tui/src/runtime.rs
@@ -56,7 +56,7 @@ where
         Ok(())
     }
 
-    fn draw_if_dirty(&mut self, app: &App) -> io::Result<()> {
+    fn draw_if_dirty(&mut self, app: &mut App) -> io::Result<()> {
         let size = self.terminal.size()?;
         if self.last_size != Some(size) {
             self.dirty.set(true);
@@ -68,9 +68,17 @@ where
 
         let _ = app.take_window_invalidations(self.window_id);
         let frame = app.read(|ctx| {
-            self.root_view
-                .read(ctx, |view, ctx| self.presenter.render_view(view, ctx, size))
+            self.root_view.read(ctx, |view, ctx| {
+                self.presenter.render_window(
+                    self.window_id,
+                    self.root_view.id(),
+                    view,
+                    ctx,
+                    size,
+                )
+            })
         });
+        self.presenter.sync_focus(app);
         self.terminal.draw(&frame)?;
         self.last_size = Some(size);
         Ok(())

--- a/crates/warpui_tui/src/runtime.rs
+++ b/crates/warpui_tui/src/runtime.rs
@@ -1,0 +1,138 @@
+use std::cell::Cell;
+use std::io::{self, stdout, Stdout};
+use std::rc::Rc;
+use std::time::Duration;
+
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent};
+use crossterm::execute;
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use warpui_core::{App, TuiViewHandle, WindowId};
+
+use crate::elements::TuiElement;
+use crate::{
+    crossterm_event_to_warp_event, TuiFrame, TuiFrameRenderer, TuiPresenter, TuiSize, TuiView,
+};
+
+pub struct TuiRuntime<T> {
+    window_id: WindowId,
+    root_view: TuiViewHandle<T>,
+    presenter: TuiPresenter,
+    terminal: TuiTerminalSession,
+    dirty: Rc<Cell<bool>>,
+    last_size: Option<TuiSize>,
+}
+
+impl<T> TuiRuntime<T>
+where
+    T: TuiView<RenderOutput = Box<dyn TuiElement>>,
+{
+    pub fn enter(app: &App, window_id: WindowId, root_view: TuiViewHandle<T>) -> io::Result<Self> {
+        let dirty = Rc::new(Cell::new(true));
+        let dirty_for_invalidation = dirty.clone();
+        app.on_window_invalidated(window_id, move |_, _| {
+            dirty_for_invalidation.set(true);
+        });
+
+        Ok(Self {
+            window_id,
+            root_view,
+            presenter: TuiPresenter::new(),
+            terminal: TuiTerminalSession::enter()?,
+            dirty,
+            last_size: None,
+        })
+    }
+
+    pub fn run_until(
+        &mut self,
+        app: &mut App,
+        mut should_quit: impl FnMut(&App) -> bool,
+    ) -> io::Result<()> {
+        while !should_quit(app) {
+            self.draw_if_dirty(app)?;
+            self.poll_and_dispatch_event(app, Duration::from_millis(250))?;
+        }
+        Ok(())
+    }
+
+    fn draw_if_dirty(&mut self, app: &App) -> io::Result<()> {
+        let size = self.terminal.size()?;
+        if self.last_size != Some(size) {
+            self.dirty.set(true);
+        }
+
+        if !self.dirty.replace(false) {
+            return Ok(());
+        }
+
+        let _ = app.take_window_invalidations(self.window_id);
+        let frame = app.read(|ctx| {
+            self.root_view
+                .read(ctx, |view, ctx| self.presenter.render_view(view, ctx, size))
+        });
+        self.terminal.draw(&frame)?;
+        self.last_size = Some(size);
+        Ok(())
+    }
+
+    fn poll_and_dispatch_event(&mut self, app: &mut App, timeout: Duration) -> io::Result<()> {
+        if !event::poll(timeout)? {
+            return Ok(());
+        }
+
+        match event::read()? {
+            CrosstermEvent::Resize(_, _) => {
+                self.dirty.set(true);
+            }
+            event => {
+                if let Some(event) = crossterm_event_to_warp_event(event) {
+                    let result = self.presenter.dispatch_event(&event, app);
+                    if result.handled {
+                        self.dirty.set(true);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct TuiTerminalSession {
+    stdout: Stdout,
+    frame_renderer: TuiFrameRenderer,
+}
+
+impl TuiTerminalSession {
+    fn enter() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+
+        let mut stdout = stdout();
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture, Hide) {
+            let _ = terminal::disable_raw_mode();
+            return Err(error);
+        }
+
+        Ok(Self {
+            stdout,
+            frame_renderer: TuiFrameRenderer::new(),
+        })
+    }
+
+    fn size(&self) -> io::Result<TuiSize> {
+        let (width, height) = terminal::size()?;
+        Ok(TuiSize::new(width.max(1), height.max(1)))
+    }
+
+    fn draw(&mut self, frame: &TuiFrame) -> io::Result<()> {
+        self.frame_renderer.draw(&mut self.stdout, frame)
+    }
+}
+
+impl Drop for TuiTerminalSession {
+    fn drop(&mut self) {
+        let _ = execute!(self.stdout, Show, DisableMouseCapture, LeaveAlternateScreen);
+        let _ = terminal::disable_raw_mode();
+    }
+}

--- a/crates/wsh/Cargo.toml
+++ b/crates/wsh/Cargo.toml
@@ -10,8 +10,10 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+bitflags.workspace = true
 crossterm.workspace = true
 libc.workspace = true
 log.workspace = true
 env_logger.workspace = true
 nix = { workspace = true, features = ["fs", "term"] }
+vte.workspace = true

--- a/crates/wsh/Cargo.toml
+++ b/crates/wsh/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "wsh"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "wsh"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+crossterm.workspace = true
+libc.workspace = true
+log.workspace = true
+env_logger.workspace = true
+nix = { workspace = true, features = ["fs", "term"] }

--- a/crates/wsh/Cargo.toml
+++ b/crates/wsh/Cargo.toml
@@ -16,4 +16,6 @@ libc.workspace = true
 log.workspace = true
 env_logger.workspace = true
 nix = { workspace = true, features = ["fs", "term"] }
+serde.workspace = true
+serde_json.workspace = true
 vte.workspace = true

--- a/crates/wsh/assets/wsh_zsh_init.sh
+++ b/crates/wsh/assets/wsh_zsh_init.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env zsh
+# wsh zsh integration — emits OSC 133 semantic prompt markers.
+# Sourced automatically by wsh; do not source manually.
+
+# Source the user's real .zshrc if it exists.
+if [[ -n "$WSH_REAL_ZDOTDIR" ]]; then
+    if [[ -f "$WSH_REAL_ZDOTDIR/.zshrc" ]]; then
+        source "$WSH_REAL_ZDOTDIR/.zshrc"
+    fi
+elif [[ -f "$HOME/.zshrc" ]]; then
+    source "$HOME/.zshrc"
+fi
+
+# --- OSC 133 hooks ---
+
+__wsh_precmd() {
+    local exit_code=$?
+    # D = command finished (with exit code from the previous command).
+    printf '\e]133;D;%d\a' "$exit_code"
+    # A = prompt start.
+    printf '\e]133;A\a'
+}
+
+__wsh_preexec() {
+    # C = command execution start.
+    printf '\e]133;C\a'
+}
+
+__wsh_install_prompt_end_marker() {
+    # Append B marker (prompt end) to PROMPT if not already present.
+    if [[ "$PROMPT" != *$'\e]133;B\a'* ]]; then
+        PROMPT="${PROMPT}%{$(printf '\e]133;B\a')%}"
+    fi
+}
+
+precmd_functions+=(__wsh_precmd __wsh_install_prompt_end_marker)
+preexec_functions+=(__wsh_preexec)

--- a/crates/wsh/src/block.rs
+++ b/crates/wsh/src/block.rs
@@ -1,0 +1,73 @@
+use crate::cell::{Cell, CellAttr, CellFlags, Color};
+
+pub struct CompletedBlock {
+    pub rows: Vec<Vec<Cell>>,
+}
+
+pub struct BlockManager {
+    completed: Vec<CompletedBlock>,
+    scroll_offset: usize,
+}
+
+impl Default for BlockManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BlockManager {
+    pub fn new() -> Self {
+        Self {
+            completed: Vec::new(),
+            scroll_offset: 0,
+        }
+    }
+
+    pub fn add_block(&mut self, rows: Vec<Vec<Cell>>) {
+        // Trim trailing blank rows.
+        let mut rows = rows;
+        while let Some(last) = rows.last() {
+            if last.iter().all(|c| c.ch == ' ' && c.attr == CellAttr::default()) {
+                rows.pop();
+            } else {
+                break;
+            }
+        }
+        if !rows.is_empty() {
+            self.completed.push(CompletedBlock { rows });
+        }
+    }
+
+    pub fn add_styled_line(&mut self, text: &str, fg: Color, flags: CellFlags, cols: usize) {
+        let attr = CellAttr {
+            fg,
+            bg: Color::Default,
+            flags,
+        };
+        let mut row: Vec<Cell> = text
+            .chars()
+            .take(cols)
+            .map(|ch| Cell::with_char(ch, attr))
+            .collect();
+        // Pad to full width.
+        while row.len() < cols {
+            row.push(Cell::default());
+        }
+        self.completed.push(CompletedBlock { rows: vec![row] });
+    }
+
+    pub fn collected_rows(&self) -> Vec<Vec<Cell>> {
+        self.completed
+            .iter()
+            .flat_map(|b| b.rows.iter().cloned())
+            .collect()
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn scroll_to_bottom(&mut self) {
+        self.scroll_offset = 0;
+    }
+}

--- a/crates/wsh/src/cell.rs
+++ b/crates/wsh/src/cell.rs
@@ -1,0 +1,58 @@
+use bitflags::bitflags;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Color {
+    Default,
+    Indexed(u8),
+    Rgb(u8, u8, u8),
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CellFlags: u8 {
+        const BOLD      = 0b0000_0001;
+        const DIM       = 0b0000_0010;
+        const ITALIC    = 0b0000_0100;
+        const UNDERLINE = 0b0000_1000;
+        const INVERSE   = 0b0001_0000;
+        const HIDDEN    = 0b0010_0000;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellAttr {
+    pub fg: Color,
+    pub bg: Color,
+    pub flags: CellFlags,
+}
+
+impl Default for CellAttr {
+    fn default() -> Self {
+        Self {
+            fg: Color::Default,
+            bg: Color::Default,
+            flags: CellFlags::empty(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Cell {
+    pub ch: char,
+    pub attr: CellAttr,
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self {
+            ch: ' ',
+            attr: CellAttr::default(),
+        }
+    }
+}
+
+impl Cell {
+    pub fn with_char(ch: char, attr: CellAttr) -> Self {
+        Self { ch, attr }
+    }
+}

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Write};
+use std::io::{self, Read};
 use std::os::unix::io::RawFd;
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -6,8 +6,11 @@ use anyhow::{Context, Result};
 use crossterm::terminal;
 use nix::unistd::{close, pipe, read, write as nix_write};
 
+use crate::block::BlockManager;
+use crate::cell::{CellFlags, Color};
+use crate::miniterm::MiniTerm;
 use crate::pty::resize_pty;
-use crate::renderer::{self, AgentBlock, BlockKind};
+use crate::screen::{self, Frame, StatusBar};
 use crate::shell_integration::{OscParser, ShellEvent};
 
 // ── SIGWINCH self-pipe ───────────────────────────────────────────────
@@ -47,20 +50,10 @@ fn install_sigwinch_handler() -> Result<RawFd> {
 
 // ── Mode state machine ──────────────────────────────────────────────
 
-enum AgentPhase {
-    WaitingForEcho,
-    Capturing,
-    WaitingForPrompt,
-}
-
 enum Mode {
     Shell,
     AgentInput { buffer: String, cursor: usize },
-    AgentRunning {
-        command: String,
-        output: Vec<u8>,
-        phase: AgentPhase,
-    },
+    AgentRunning,
 }
 
 impl Mode {
@@ -68,7 +61,7 @@ impl Mode {
         match self {
             Mode::Shell => "SHELL",
             Mode::AgentInput { .. } => "AGENT",
-            Mode::AgentRunning { .. } => "RUNNING",
+            Mode::AgentRunning => "RUNNING",
         }
     }
 
@@ -76,12 +69,12 @@ impl Mode {
         match self {
             Mode::Shell => "Ctrl-A: agent",
             Mode::AgentInput { .. } => "Enter: run | Esc: cancel",
-            Mode::AgentRunning { .. } => "Ctrl-C: cancel",
+            Mode::AgentRunning => "Ctrl-C: cancel",
         }
     }
 }
 
-// ── Interleaved OSC parser output ───────────────────────────────────
+// ── Interleaved OSC parser ──────────────────────────────────────────
 
 enum ParsedItem {
     Output(Vec<u8>),
@@ -106,59 +99,32 @@ fn feed_interleaved(parser: &mut OscParser, input: &[u8]) -> Vec<ParsedItem> {
     items
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────
-
-fn write_stdout(bytes: &[u8]) {
-    let _ = io::stdout().write_all(bytes);
-    let _ = io::stdout().flush();
-}
-
-fn update_status_bar(mode: &Mode, cols: u16, rows: u16) {
-    let mut out = Vec::new();
-    out.extend_from_slice(&renderer::save_cursor());
-    out.extend_from_slice(&renderer::move_to_status_bar_row(rows));
-    out.extend_from_slice(&renderer::clear_line());
-    out.extend_from_slice(&renderer::render_status_bar(
-        mode.label(),
-        "mock",
-        mode.hint(),
-        cols,
-    ));
-    out.extend_from_slice(&renderer::restore_cursor());
-    write_stdout(&out);
-}
-
 // ── Public entry point ──────────────────────────────────────────────
 
 pub fn run(master_fd: RawFd) -> Result<()> {
     let sigwinch_fd = install_sigwinch_handler()?;
 
     let (cols, rows) = terminal::size().context("terminal::size")?;
-    // Child PTY gets one fewer row — the bottom row is the status bar.
-    resize_pty(master_fd, cols, rows.saturating_sub(1))?;
+    let usable = rows.saturating_sub(1);
+    resize_pty(master_fd, cols, usable)?;
 
-    terminal::enable_raw_mode().context("enable_raw_mode")?;
-
-    // Set scroll region and park cursor.
-    write_stdout(&renderer::set_scroll_region(1, rows.saturating_sub(1)));
-    write_stdout(b"\x1b[1;1H");
+    screen::enter_alt_screen().context("enter_alt_screen")?;
 
     let mut state = Wsh {
         mode: Mode::Shell,
         master_fd,
         osc_parser: OscParser::new(),
+        miniterm: MiniTerm::new(cols, usable),
+        blocks: BlockManager::new(),
         cols,
         rows,
         should_exit: false,
     };
-    update_status_bar(&state.mode, state.cols, state.rows);
+    state.render_frame();
 
     let result = state.run_loop(sigwinch_fd);
 
-    // Restore terminal.
-    let _ = terminal::disable_raw_mode();
-    write_stdout(&renderer::reset_scroll_region());
-    write_stdout(b"\r\n");
+    let _ = screen::leave_alt_screen();
 
     let wfd = SIGWINCH_WRITE_FD.swap(-1, Ordering::Relaxed);
     if wfd >= 0 {
@@ -175,6 +141,8 @@ struct Wsh {
     mode: Mode,
     master_fd: RawFd,
     osc_parser: OscParser,
+    miniterm: MiniTerm,
+    blocks: BlockManager,
     cols: u16,
     rows: u16,
     should_exit: bool,
@@ -207,19 +175,26 @@ impl Wsh {
                 return Err(err).context("poll");
             }
 
+            let mut needs_render = false;
+
             if pollfds[2].revents & libc::POLLIN != 0 {
                 self.handle_resize(sigwinch_fd)?;
+                needs_render = true;
             }
 
             if pollfds[1].revents & libc::POLLIN != 0 {
                 match read(self.master_fd, &mut buf) {
                     Ok(0) | Err(_) => break,
-                    Ok(n) => self.handle_pty_output(&buf[..n]),
+                    Ok(n) => {
+                        self.handle_pty_output(&buf[..n]);
+                        needs_render = true;
+                    }
                 }
             }
 
             if pollfds[1].revents & libc::POLLHUP != 0 {
                 self.drain_pty(&mut buf);
+                self.render_frame();
                 break;
             }
 
@@ -229,13 +204,43 @@ impl Wsh {
                     break;
                 }
                 self.handle_stdin(&buf[..n])?;
+                needs_render = true;
+            }
+
+            if needs_render {
+                self.render_frame();
             }
         }
 
         Ok(())
     }
 
-    // ── Resize ──────────────────────────────────────────────────────
+    // ── Render ────────────────────────────────────────────────────────
+
+    fn render_frame(&self) {
+        let completed = self.blocks.collected_rows();
+        let frame = Frame {
+            completed_rows: &completed,
+            active_grid: self.miniterm.grid(),
+            active_cursor: self.miniterm.cursor_pos(),
+            status_bar: StatusBar {
+                mode: self.mode.label(),
+                model: "mock",
+                hint: self.mode.hint(),
+            },
+            scroll_offset: self.blocks.scroll_offset(),
+            agent_input: match &self.mode {
+                Mode::AgentInput { buffer, cursor } => Some((buffer.as_str(), *cursor)),
+                _ => None,
+            },
+            total_rows: self.rows,
+            total_cols: self.cols,
+            show_cursor: matches!(self.mode, Mode::Shell),
+        };
+        let _ = screen::render(&frame);
+    }
+
+    // ── Resize ────────────────────────────────────────────────────────
 
     fn handle_resize(&mut self, sigwinch_fd: RawFd) -> Result<()> {
         let mut drain = [0u8; 64];
@@ -245,95 +250,45 @@ impl Wsh {
         let (cols, rows) = terminal::size().context("terminal::size on resize")?;
         self.cols = cols;
         self.rows = rows;
-        resize_pty(self.master_fd, cols, rows.saturating_sub(1))?;
-        write_stdout(&renderer::set_scroll_region(1, rows.saturating_sub(1)));
-        update_status_bar(&self.mode, self.cols, self.rows);
+        let usable = rows.saturating_sub(1);
+        resize_pty(self.master_fd, cols, usable)?;
+        self.miniterm.resize(cols, usable);
         Ok(())
     }
 
-    // ── PTY output handling ─────────────────────────────────────────
+    // ── PTY output ────────────────────────────────────────────────────
 
     fn handle_pty_output(&mut self, raw: &[u8]) {
         let items = feed_interleaved(&mut self.osc_parser, raw);
         for item in items {
             match item {
-                ParsedItem::Output(bytes) => self.handle_filtered_output(&bytes),
+                ParsedItem::Output(bytes) => self.miniterm.process_bytes(&bytes),
                 ParsedItem::Event(event) => self.process_event(event),
             }
         }
     }
 
-    fn handle_filtered_output(&mut self, bytes: &[u8]) {
-        if bytes.is_empty() {
-            return;
-        }
-        match &mut self.mode {
-            Mode::Shell | Mode::AgentInput { .. } => write_stdout(bytes),
-            Mode::AgentRunning { phase, output, .. } => match phase {
-                AgentPhase::WaitingForEcho => { /* discard shell echo */ }
-                AgentPhase::Capturing => output.extend_from_slice(bytes),
-                AgentPhase::WaitingForPrompt => write_stdout(bytes),
-            },
-        }
-    }
-
     fn process_event(&mut self, event: ShellEvent) {
         match event {
-            ShellEvent::CommandStart => {
-                if let Mode::AgentRunning { phase, .. } = &mut self.mode {
-                    if matches!(phase, AgentPhase::WaitingForEcho) {
-                        *phase = AgentPhase::Capturing;
-                    }
-                }
-            }
-            ShellEvent::CommandFinished { exit_code } => {
-                if matches!(
-                    &self.mode,
-                    Mode::AgentRunning { phase: AgentPhase::Capturing, .. }
-                ) {
-                    self.render_agent_result(exit_code);
-                }
+            ShellEvent::PromptStart => {
+                self.capture_completed_block();
+                self.blocks.scroll_to_bottom();
             }
             ShellEvent::PromptEnd => {
-                if matches!(
-                    &self.mode,
-                    Mode::AgentRunning { phase: AgentPhase::WaitingForPrompt, .. }
-                ) {
+                if matches!(self.mode, Mode::AgentRunning) {
                     self.mode = Mode::Shell;
-                    update_status_bar(&self.mode, self.cols, self.rows);
                 }
             }
             _ => {}
         }
     }
 
-    fn render_agent_result(&mut self, exit_code: Option<i32>) {
-        let old = std::mem::replace(&mut self.mode, Mode::Shell);
-        if let Mode::AgentRunning { output, command, .. } = old {
-            let output_str = String::from_utf8_lossy(&output);
-            // Strip \r from PTY output — the line discipline converts \n → \r\n,
-            // and embedded \r would overwrite the left border when rendering.
-            let body = output_str.replace('\r', "");
-            let body = body.trim_end().to_string();
-            let block = AgentBlock {
-                kind: if exit_code == Some(0) || exit_code.is_none() {
-                    BlockKind::CommandOutput
-                } else {
-                    BlockKind::Error
-                },
-                header: Some(format!(
-                    "Output{}",
-                    exit_code.map_or(String::new(), |c| format!(" (exit {c})"))
-                )),
-                body,
-            };
-            write_stdout(&renderer::render_block(&block, self.cols));
-            self.mode = Mode::AgentRunning {
-                command,
-                output: Vec::new(),
-                phase: AgentPhase::WaitingForPrompt,
-            };
-        }
+    fn capture_completed_block(&mut self) {
+        let mut rows = self.miniterm.take_scrolled_out();
+        rows.extend(self.miniterm.grid().iter().cloned());
+        self.blocks.add_block(rows);
+        let usable = self.rows.saturating_sub(1);
+        self.miniterm.resize(self.cols, usable);
     }
 
     fn drain_pty(&mut self, buf: &mut [u8]) {
@@ -343,14 +298,14 @@ impl Wsh {
                 Ok(n) => {
                     let (filtered, _) = self.osc_parser.feed(&buf[..n]);
                     if !filtered.is_empty() {
-                        write_stdout(&filtered);
+                        self.miniterm.process_bytes(&filtered);
                     }
                 }
             }
         }
     }
 
-    // ── Stdin handling ──────────────────────────────────────────────
+    // ── Stdin handling ────────────────────────────────────────────────
 
     fn handle_stdin(&mut self, bytes: &[u8]) -> Result<()> {
         match &self.mode {
@@ -364,14 +319,14 @@ impl Wsh {
                         return self.handle_agent_input_bytes(&bytes[pos + 1..]);
                     }
                 } else {
+                    self.blocks.scroll_to_bottom();
                     nix_write(self.master_fd, bytes).context("write to pty")?;
                 }
             }
             Mode::AgentInput { .. } => {
                 self.handle_agent_input_bytes(bytes)?;
             }
-            Mode::AgentRunning { .. } => {
-                // Ctrl-C cancels the running agent.
+            Mode::AgentRunning => {
                 if bytes.contains(&0x03) {
                     self.cancel_agent();
                 }
@@ -380,40 +335,23 @@ impl Wsh {
         Ok(())
     }
 
-    // ── Agent input mode ────────────────────────────────────────────
+    // ── Agent input mode ──────────────────────────────────────────────
 
     fn enter_agent_mode(&mut self) {
         self.mode = Mode::AgentInput {
             buffer: String::new(),
             cursor: 0,
         };
-        write_stdout(b"\r\n");
-        self.render_input_prompt();
-        update_status_bar(&self.mode, self.cols, self.rows);
     }
 
     fn exit_agent_mode(&mut self) {
-        write_stdout(&renderer::clear_line());
         self.mode = Mode::Shell;
-        // Send newline to child to re-display the prompt.
         let _ = nix_write(self.master_fd, b"\n");
-        update_status_bar(&self.mode, self.cols, self.rows);
     }
 
     fn cancel_agent(&mut self) {
         self.mode = Mode::Shell;
-        write_stdout(b"\r\n");
-        // Forward Ctrl-C so the child shell can handle any in-flight command.
         let _ = nix_write(self.master_fd, b"\x03");
-        update_status_bar(&self.mode, self.cols, self.rows);
-    }
-
-    fn render_input_prompt(&self) {
-        if let Mode::AgentInput { buffer, cursor } = &self.mode {
-            let mut out = renderer::clear_line();
-            out.extend_from_slice(&renderer::render_agent_input_prompt(buffer, *cursor));
-            write_stdout(&out);
-        }
     }
 
     fn handle_agent_input_bytes(&mut self, bytes: &[u8]) -> Result<()> {
@@ -441,11 +379,10 @@ impl Wsh {
                 _ => {}
             }
         }
-        self.render_input_prompt();
         Ok(())
     }
 
-    // ── Mock agent ──────────────────────────────────────────────────
+    // ── Mock agent ────────────────────────────────────────────────────
 
     fn submit_agent_query(&mut self) -> Result<()> {
         let command = match &self.mode {
@@ -458,24 +395,16 @@ impl Wsh {
             return Ok(());
         }
 
-        write_stdout(&renderer::clear_line());
-
-        // Built-in commands.
         match command.trim() {
             "help" => {
-                let block = AgentBlock {
-                    kind: BlockKind::AgentText,
-                    header: Some("wsh mock agent".into()),
-                    body: "Type any shell command and I'll execute it.\n\
-                           Special commands:\n  \
-                           help  — show this message\n  \
-                           exit  — quit wsh"
-                        .into(),
-                };
-                write_stdout(&renderer::render_block(&block, self.cols));
+                self.blocks.add_styled_line(
+                    "🤖 Type any command. Special: help, exit",
+                    Color::Indexed(6),
+                    CellFlags::DIM,
+                    self.cols as usize,
+                );
                 self.mode = Mode::Shell;
                 let _ = nix_write(self.master_fd, b"\n");
-                update_status_bar(&self.mode, self.cols, self.rows);
                 return Ok(());
             }
             "exit" => {
@@ -485,25 +414,17 @@ impl Wsh {
             _ => {}
         }
 
-        // Show thinking indicator and "Running" block.
-        write_stdout(&renderer::render_thinking_indicator());
-        let run_block = AgentBlock {
-            kind: BlockKind::CommandRun,
-            header: Some(format!("Running: {command}")),
-            body: String::new(),
-        };
-        write_stdout(&renderer::render_block(&run_block, self.cols));
+        self.blocks.add_styled_line(
+            &format!("🤖 running: {command}"),
+            Color::Indexed(5),
+            CellFlags::DIM,
+            self.cols as usize,
+        );
 
-        // Write command to child PTY.
         let cmd = format!("{command}\n");
         nix_write(self.master_fd, cmd.as_bytes()).context("write command to pty")?;
 
-        self.mode = Mode::AgentRunning {
-            command,
-            output: Vec::new(),
-            phase: AgentPhase::WaitingForEcho,
-        };
-        update_status_bar(&self.mode, self.cols, self.rows);
+        self.mode = Mode::AgentRunning;
         Ok(())
     }
 }

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -117,11 +117,18 @@ struct AgentProcess {
 }
 
 impl AgentProcess {
-    #[allow(clippy::disallowed_types)] // wsh is Unix-only; no Windows terminal flash concern.
-    fn spawn(prompt: &str) -> Result<Self> {
+    #[allow(clippy::disallowed_types)]
+    fn spawn(prompt: &str, conversation_id: Option<&str>) -> Result<Self> {
         let binary = resolve_agent_binary();
+        let mut args = vec!["agent", "run", "--prompt", prompt, "--output-format", "ndjson"];
+        let conv_flag;
+        if let Some(id) = conversation_id {
+            conv_flag = id.to_string();
+            args.push("--conversation");
+            args.push(&conv_flag);
+        }
         let child = std::process::Command::new(&binary)
-            .args(["agent", "run", "--prompt", prompt, "--output-format", "ndjson"])
+            .args(&args)
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
@@ -185,7 +192,11 @@ fn parse_agent_event(line: &str, cols: usize) -> Option<(String, Color, CellFlag
     let event_type = json.get("type")?.as_str()?;
 
     match event_type {
-        "system" => None,
+        "system" => {
+            // Return conversation_id extraction as a special marker.
+            // The caller will handle it separately.
+            None
+        }
         "agent" | "agent_reasoning" => {
             let text = json.get("text")?.as_str()?;
             if text.trim().is_empty() {
@@ -298,6 +309,7 @@ pub fn run(master_fd: RawFd) -> Result<()> {
         miniterm: MiniTerm::new(cols, usable),
         blocks: BlockManager::new(),
         agent: None,
+        conversation_id: None,
         cols,
         rows,
         should_exit: false,
@@ -345,6 +357,7 @@ struct Wsh {
     miniterm: MiniTerm,
     blocks: BlockManager,
     agent: Option<AgentProcess>,
+    conversation_id: Option<String>,
     cols: u16,
     rows: u16,
     should_exit: bool,
@@ -548,8 +561,8 @@ impl Wsh {
         let cols = self.cols as usize;
 
         for line in &lines {
+            self.maybe_extract_conversation_id(line);
             if let Some((text, color, flags)) = parse_agent_event(line, cols) {
-                // Agent text output can be multi-line — add each line separately.
                 for text_line in text.lines() {
                     self.blocks.add_styled_line(text_line, color, flags, cols);
                 }
@@ -559,9 +572,9 @@ impl Wsh {
         // Check if the agent process has finished.
         if let Some(agent) = self.agent.as_mut() {
             if agent.is_finished() {
-                // Drain any remaining output.
                 let final_lines = agent.read_lines();
                 for line in &final_lines {
+                    self.maybe_extract_conversation_id(line);
                     if let Some((text, color, flags)) = parse_agent_event(line, cols) {
                         for text_line in text.lines() {
                             self.blocks.add_styled_line(text_line, color, flags, cols);
@@ -571,12 +584,24 @@ impl Wsh {
                 self.agent = None;
                 self.blocks.add_styled_line(
                     "✓ agent finished",
-                    Color::Indexed(2), // green
+                    Color::Indexed(2),
                     CellFlags::DIM,
                     cols,
                 );
-                // If no PTY command is pending, return to Shell immediately.
                 self.mode = Mode::Shell;
+            }
+        }
+    }
+
+    fn maybe_extract_conversation_id(&mut self, line: &str) {
+        if self.conversation_id.is_some() {
+            return;
+        }
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(line) {
+            if json.get("type").and_then(|t| t.as_str()) == Some("system") {
+                if let Some(id) = json.get("conversation_id").and_then(|c| c.as_str()) {
+                    self.conversation_id = Some(id.to_string());
+                }
             }
         }
     }
@@ -691,8 +716,8 @@ impl Wsh {
             self.cols as usize,
         );
 
-        // Spawn the real agent subprocess.
-        match AgentProcess::spawn(&prompt) {
+        // Spawn the real agent subprocess, continuing the conversation if one exists.
+        match AgentProcess::spawn(&prompt, self.conversation_id.as_deref()) {
             Ok(agent) => {
                 self.agent = Some(agent);
                 self.mode = Mode::AgentRunning;

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -78,36 +78,13 @@ impl Mode {
 
 // ── Agent subprocess ─────────────────────────────────────────────────
 
-#[allow(clippy::disallowed_types)]
 fn resolve_agent_binary() -> String {
     if let Ok(bin) = env::var("WSH_AGENT_BINARY") {
         return bin;
     }
 
-    // Try well-known CLI names on PATH.
-    for name in ["warp", "oz"] {
-        if std::process::Command::new(name)
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok()
-        {
-            return name.to_string();
-        }
-    }
-
-    // Fall back to macOS app bundle binaries.
-    for path in [
-        "/Applications/WarpDev.app/Contents/MacOS/dev",
-        "/Applications/Warp.app/Contents/MacOS/stable",
-    ] {
-        if std::path::Path::new(path).exists() {
-            return path.to_string();
-        }
-    }
-
-    "warp".to_string()
+    // This is a demo prototype; always use the local WarpDev build.
+    "/Applications/WarpDev.app/Contents/MacOS/dev".to_string()
 }
 
 struct AgentProcess {

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -78,6 +78,37 @@ impl Mode {
 
 // ── Agent subprocess ─────────────────────────────────────────────────
 
+fn resolve_agent_binary() -> String {
+    if let Ok(bin) = env::var("WSH_AGENT_BINARY") {
+        return bin;
+    }
+
+    // Try well-known CLI names on PATH.
+    for name in ["warp", "oz"] {
+        if std::process::Command::new(name)
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok()
+        {
+            return name.to_string();
+        }
+    }
+
+    // Fall back to macOS app bundle binaries.
+    for path in [
+        "/Applications/WarpDev.app/Contents/MacOS/dev",
+        "/Applications/Warp.app/Contents/MacOS/stable",
+    ] {
+        if std::path::Path::new(path).exists() {
+            return path.to_string();
+        }
+    }
+
+    "warp".to_string()
+}
+
 struct AgentProcess {
     child: Child,
     stdout_fd: RawFd,
@@ -87,11 +118,11 @@ struct AgentProcess {
 impl AgentProcess {
     #[allow(clippy::disallowed_types)] // wsh is Unix-only; no Windows terminal flash concern.
     fn spawn(prompt: &str) -> Result<Self> {
-        let binary = env::var("WSH_AGENT_BINARY").unwrap_or_else(|_| "warp".into());
+        let binary = resolve_agent_binary();
         let child = std::process::Command::new(&binary)
             .args(["agent", "run", "--prompt", prompt, "--output-format", "ndjson"])
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::null())
             .spawn()
             .with_context(|| format!("failed to spawn `{binary} agent run`"))?;
 
@@ -153,6 +184,24 @@ fn parse_agent_event(line: &str, cols: usize) -> Option<(String, Color, CellFlag
     let event_type = json.get("type")?.as_str()?;
 
     match event_type {
+        "system" => {
+            let sub = json.get("event_type").and_then(|e| e.as_str());
+            match sub {
+                Some("run_started") => {
+                    let url = json.get("run_url").and_then(|u| u.as_str()).unwrap_or("");
+                    if !url.is_empty() {
+                        let display = if url.len() > cols {
+                            format!("{}…", &url[..cols.saturating_sub(1)])
+                        } else {
+                            url.to_string()
+                        };
+                        return Some((display, Color::Indexed(8), CellFlags::DIM));
+                    }
+                    None
+                }
+                _ => None,
+            }
+        }
         "agent" | "agent_reasoning" => {
             let text = json.get("text")?.as_str()?;
             if text.trim().is_empty() {

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -9,7 +9,7 @@ use crossterm::terminal;
 use nix::unistd::{close, pipe, read, write as nix_write};
 
 use crate::block::BlockManager;
-use crate::cell::{CellFlags, Color};
+use crate::cell::{Cell, CellAttr, CellFlags, Color};
 use crate::miniterm::MiniTerm;
 use crate::pty::resize_pty;
 use crate::screen::{self, Frame, StatusBar};
@@ -314,6 +314,8 @@ pub fn run(master_fd: RawFd) -> Result<()> {
         rows,
         should_exit: false,
         spinner_tick: 0,
+        streaming_lines: Vec::new(),
+        streaming_col: 0,
     };
     state.render_frame();
 
@@ -362,6 +364,8 @@ struct Wsh {
     rows: u16,
     should_exit: bool,
     spinner_tick: usize,
+    streaming_lines: Vec<Vec<Cell>>,
+    streaming_col: usize,
 }
 
 impl Wsh {
@@ -457,6 +461,7 @@ impl Wsh {
         let completed = self.blocks.collected_rows();
         let frame = Frame {
             completed_rows: &completed,
+            streaming_rows: &self.streaming_lines,
             active_grid: self.miniterm.grid(),
             active_cursor: self.miniterm.cursor_pos(),
             status_bar: StatusBar {
@@ -562,11 +567,7 @@ impl Wsh {
 
         for line in &lines {
             self.maybe_extract_conversation_id(line);
-            if let Some((text, color, flags)) = parse_agent_event(line, cols) {
-                for text_line in text.lines() {
-                    self.blocks.add_styled_line(text_line, color, flags, cols);
-                }
-            }
+            self.process_agent_line(line, cols);
         }
 
         // Check if the agent process has finished.
@@ -575,12 +576,9 @@ impl Wsh {
                 let final_lines = agent.read_lines();
                 for line in &final_lines {
                     self.maybe_extract_conversation_id(line);
-                    if let Some((text, color, flags)) = parse_agent_event(line, cols) {
-                        for text_line in text.lines() {
-                            self.blocks.add_styled_line(text_line, color, flags, cols);
-                        }
-                    }
+                    self.process_agent_line(line, cols);
                 }
+                self.flush_streaming_lines();
                 self.agent = None;
                 self.blocks.add_styled_line(
                     "✓ agent finished",
@@ -589,6 +587,43 @@ impl Wsh {
                     cols,
                 );
                 self.mode = Mode::Shell;
+            }
+        }
+    }
+
+    fn process_agent_line(&mut self, line: &str, cols: usize) {
+        let json: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let event_type = match json.get("type").and_then(|t| t.as_str()) {
+            Some(t) => t,
+            None => return,
+        };
+
+        match event_type {
+            "agent" | "agent_reasoning" => {
+                let text = match json.get("text").and_then(|t| t.as_str()) {
+                    Some(t) if !t.trim().is_empty() => t,
+                    _ => return,
+                };
+                let color = if event_type == "agent_reasoning" {
+                    Color::Indexed(8)
+                } else {
+                    Color::Default
+                };
+                let flags = CellFlags::empty();
+                self.append_streaming_text(text, color, flags);
+            }
+            "system" => {}
+            _ => {
+                // Non-text events: flush streaming text first, then add as permanent scrollback.
+                self.flush_streaming_lines();
+                if let Some((text, color, flags)) = parse_agent_event(line, cols) {
+                    for text_line in text.lines() {
+                        self.blocks.add_styled_line(text_line, color, flags, cols);
+                    }
+                }
             }
         }
     }
@@ -654,6 +689,7 @@ impl Wsh {
         if let Some(mut agent) = self.agent.take() {
             agent.kill();
         }
+        self.flush_streaming_lines();
         self.mode = Mode::Shell;
         self.blocks.add_styled_line(
             "✗ agent canceled",
@@ -661,6 +697,37 @@ impl Wsh {
             CellFlags::DIM,
             self.cols as usize,
         );
+    }
+
+    fn append_streaming_text(&mut self, text: &str, color: Color, flags: CellFlags) {
+        let cols = self.cols as usize;
+        let attr = CellAttr { fg: color, bg: Color::Default, flags };
+        for ch in text.chars() {
+            if ch == '\n' || self.streaming_col >= cols {
+                self.streaming_lines.push(vec![Cell::default(); cols]);
+                self.streaming_col = 0;
+                if ch == '\n' {
+                    continue;
+                }
+            }
+            if self.streaming_lines.is_empty() {
+                self.streaming_lines.push(vec![Cell::default(); cols]);
+            }
+            let last = self.streaming_lines.last_mut().unwrap();
+            if self.streaming_col < cols {
+                last[self.streaming_col] = Cell::with_char(ch, attr);
+                self.streaming_col += 1;
+            }
+        }
+    }
+
+    fn flush_streaming_lines(&mut self) {
+        if self.streaming_lines.is_empty() {
+            return;
+        }
+        let rows = std::mem::take(&mut self.streaming_lines);
+        self.streaming_col = 0;
+        self.blocks.add_block(rows);
     }
 
     fn handle_agent_input_bytes(&mut self, bytes: &[u8]) -> Result<()> {

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -291,8 +291,7 @@ impl Wsh {
         let mut rows = self.miniterm.take_scrolled_out();
         rows.extend(self.miniterm.grid().iter().cloned());
         self.blocks.add_block(rows);
-        let usable = self.rows.saturating_sub(1);
-        self.miniterm.resize(self.cols, usable);
+        self.miniterm.reset();
     }
 
     fn drain_pty(&mut self, buf: &mut [u8]) {

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -6,9 +6,12 @@ use anyhow::{Context, Result};
 use crossterm::terminal;
 use nix::unistd::{close, pipe, read, write as nix_write};
 
-use crate::pty::sync_pty_size;
+use crate::pty::resize_pty;
+use crate::renderer::{self, AgentBlock, BlockKind};
+use crate::shell_integration::{OscParser, ShellEvent};
 
-/// Write-end of the SIGWINCH self-pipe. Set by `install_sigwinch_handler`.
+// ── SIGWINCH self-pipe ───────────────────────────────────────────────
+
 static SIGWINCH_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
 
 extern "C" fn sigwinch_handler(_sig: libc::c_int) {
@@ -22,132 +25,485 @@ extern "C" fn sigwinch_handler(_sig: libc::c_int) {
 
 fn install_sigwinch_handler() -> Result<RawFd> {
     let (read_fd, write_fd) = pipe().context("pipe for SIGWINCH")?;
-
-    // Make both ends non-blocking so the signal handler never blocks.
     for fd in [read_fd, write_fd] {
         let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
         unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
     }
-
     SIGWINCH_WRITE_FD.store(write_fd, Ordering::Relaxed);
-
     unsafe {
         let mut sa: libc::sigaction = std::mem::zeroed();
         sa.sa_sigaction = sigwinch_handler as usize;
         sa.sa_flags = libc::SA_RESTART;
         libc::sigemptyset(&mut sa.sa_mask);
         if libc::sigaction(libc::SIGWINCH, &sa, std::ptr::null_mut()) < 0 {
-            return Err(anyhow::anyhow!("sigaction SIGWINCH: {}", io::Error::last_os_error()));
+            return Err(anyhow::anyhow!(
+                "sigaction SIGWINCH: {}",
+                io::Error::last_os_error()
+            ));
+        }
+    }
+    Ok(read_fd)
+}
+
+// ── Mode state machine ──────────────────────────────────────────────
+
+enum AgentPhase {
+    WaitingForEcho,
+    Capturing,
+    WaitingForPrompt,
+}
+
+enum Mode {
+    Shell,
+    AgentInput { buffer: String, cursor: usize },
+    AgentRunning {
+        command: String,
+        output: Vec<u8>,
+        phase: AgentPhase,
+    },
+}
+
+impl Mode {
+    fn label(&self) -> &'static str {
+        match self {
+            Mode::Shell => "SHELL",
+            Mode::AgentInput { .. } => "AGENT",
+            Mode::AgentRunning { .. } => "RUNNING",
         }
     }
 
-    Ok(read_fd)
+    fn hint(&self) -> &'static str {
+        match self {
+            Mode::Shell => "Ctrl-A: agent",
+            Mode::AgentInput { .. } => "Enter: run | Esc: cancel",
+            Mode::AgentRunning { .. } => "Ctrl-C: cancel",
+        }
+    }
 }
+
+// ── Interleaved OSC parser output ───────────────────────────────────
+
+enum ParsedItem {
+    Output(Vec<u8>),
+    Event(ShellEvent),
+}
+
+fn feed_interleaved(parser: &mut OscParser, input: &[u8]) -> Vec<ParsedItem> {
+    let mut items = Vec::new();
+    for &byte in input {
+        let (out, events) = parser.feed(&[byte]);
+        if !out.is_empty() {
+            if let Some(ParsedItem::Output(ref mut prev)) = items.last_mut() {
+                prev.extend_from_slice(&out);
+            } else {
+                items.push(ParsedItem::Output(out));
+            }
+        }
+        for event in events {
+            items.push(ParsedItem::Event(event));
+        }
+    }
+    items
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn write_stdout(bytes: &[u8]) {
+    let _ = io::stdout().write_all(bytes);
+    let _ = io::stdout().flush();
+}
+
+fn update_status_bar(mode: &Mode, cols: u16, rows: u16) {
+    let mut out = Vec::new();
+    out.extend_from_slice(&renderer::save_cursor());
+    out.extend_from_slice(&renderer::move_to_status_bar_row(rows));
+    out.extend_from_slice(&renderer::clear_line());
+    out.extend_from_slice(&renderer::render_status_bar(
+        mode.label(),
+        "mock",
+        mode.hint(),
+        cols,
+    ));
+    out.extend_from_slice(&renderer::restore_cursor());
+    write_stdout(&out);
+}
+
+// ── Public entry point ──────────────────────────────────────────────
 
 pub fn run(master_fd: RawFd) -> Result<()> {
     let sigwinch_fd = install_sigwinch_handler()?;
 
-    // Sync terminal size before entering the loop.
-    sync_pty_size(master_fd)?;
+    let (cols, rows) = terminal::size().context("terminal::size")?;
+    // Child PTY gets one fewer row — the bottom row is the status bar.
+    resize_pty(master_fd, cols, rows.saturating_sub(1))?;
 
     terminal::enable_raw_mode().context("enable_raw_mode")?;
 
-    let result = run_inner(master_fd, sigwinch_fd);
+    // Set scroll region and park cursor.
+    write_stdout(&renderer::set_scroll_region(1, rows.saturating_sub(1)));
+    write_stdout(b"\x1b[1;1H");
 
-    // Always restore terminal state.
+    let mut state = Wsh {
+        mode: Mode::Shell,
+        master_fd,
+        osc_parser: OscParser::new(),
+        cols,
+        rows,
+        should_exit: false,
+    };
+    update_status_bar(&state.mode, state.cols, state.rows);
+
+    let result = state.run_loop(sigwinch_fd);
+
+    // Restore terminal.
     let _ = terminal::disable_raw_mode();
+    write_stdout(&renderer::reset_scroll_region());
+    write_stdout(b"\r\n");
 
-    // Clean up the self-pipe.
-    let write_fd = SIGWINCH_WRITE_FD.swap(-1, Ordering::Relaxed);
-    if write_fd >= 0 {
-        let _ = close(write_fd);
+    let wfd = SIGWINCH_WRITE_FD.swap(-1, Ordering::Relaxed);
+    if wfd >= 0 {
+        let _ = close(wfd);
     }
     let _ = close(sigwinch_fd);
 
     result
 }
 
-fn run_inner(master_fd: RawFd, sigwinch_fd: RawFd) -> Result<()> {
-    let stdin_fd: RawFd = libc::STDIN_FILENO;
-    let mut buf = [0u8; 4096];
+// ── Core state ──────────────────────────────────────────────────────
 
-    loop {
-        let mut pollfds = [
-            libc::pollfd {
-                fd: stdin_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: master_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: sigwinch_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-        ];
+struct Wsh {
+    mode: Mode,
+    master_fd: RawFd,
+    osc_parser: OscParser,
+    cols: u16,
+    rows: u16,
+    should_exit: bool,
+}
 
-        let ret = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, -1) };
-        if ret < 0 {
-            let err = io::Error::last_os_error();
-            if err.kind() == io::ErrorKind::Interrupted {
-                continue;
+impl Wsh {
+    fn run_loop(&mut self, sigwinch_fd: RawFd) -> Result<()> {
+        let stdin_fd: RawFd = libc::STDIN_FILENO;
+        let mut buf = [0u8; 4096];
+
+        loop {
+            if self.should_exit {
+                break;
             }
-            return Err(err).context("poll");
-        }
 
-        // SIGWINCH — propagate terminal resize.
-        if pollfds[2].revents & libc::POLLIN != 0 {
-            // Drain the self-pipe.
-            let mut drain = [0u8; 64];
-            while let Ok(n) = read(sigwinch_fd, &mut drain) {
+            let mut pollfds = [
+                libc::pollfd { fd: stdin_fd, events: libc::POLLIN, revents: 0 },
+                libc::pollfd { fd: self.master_fd, events: libc::POLLIN, revents: 0 },
+                libc::pollfd { fd: sigwinch_fd, events: libc::POLLIN, revents: 0 },
+            ];
+
+            let ret = unsafe {
+                libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, -1)
+            };
+            if ret < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err).context("poll");
+            }
+
+            if pollfds[2].revents & libc::POLLIN != 0 {
+                self.handle_resize(sigwinch_fd)?;
+            }
+
+            if pollfds[1].revents & libc::POLLIN != 0 {
+                match read(self.master_fd, &mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => self.handle_pty_output(&buf[..n]),
+                }
+            }
+
+            if pollfds[1].revents & libc::POLLHUP != 0 {
+                self.drain_pty(&mut buf);
+                break;
+            }
+
+            if pollfds[0].revents & libc::POLLIN != 0 {
+                let n = io::stdin().read(&mut buf).context("read stdin")?;
                 if n == 0 {
                     break;
                 }
-            }
-            if let Err(e) = sync_pty_size(master_fd) {
-                log::warn!("resize_pty: {e}");
+                self.handle_stdin(&buf[..n])?;
             }
         }
 
-        // PTY master → stdout (shell output).
-        if pollfds[1].revents & libc::POLLIN != 0 {
-            match read(master_fd, &mut buf) {
-                Ok(0) | Err(_) => break,
-                Ok(n) => {
-                    io::stdout().write_all(&buf[..n]).context("write stdout")?;
-                    io::stdout().flush().context("flush stdout")?;
-                }
-            }
-        }
+        Ok(())
+    }
 
-        // Child exited.
-        if pollfds[1].revents & libc::POLLHUP != 0 {
-            // Drain any remaining output.
-            loop {
-                match read(master_fd, &mut buf) {
-                    Ok(0) | Err(_) => break,
-                    Ok(n) => {
-                        let _ = io::stdout().write_all(&buf[..n]);
-                    }
-                }
-            }
-            let _ = io::stdout().flush();
-            break;
-        }
+    // ── Resize ──────────────────────────────────────────────────────
 
-        // stdin → PTY master (user input).
-        if pollfds[0].revents & libc::POLLIN != 0 {
-            let n = io::stdin().read(&mut buf).context("read stdin")?;
-            if n == 0 {
-                break;
+    fn handle_resize(&mut self, sigwinch_fd: RawFd) -> Result<()> {
+        let mut drain = [0u8; 64];
+        while let Ok(n) = read(sigwinch_fd, &mut drain) {
+            if n == 0 { break; }
+        }
+        let (cols, rows) = terminal::size().context("terminal::size on resize")?;
+        self.cols = cols;
+        self.rows = rows;
+        resize_pty(self.master_fd, cols, rows.saturating_sub(1))?;
+        write_stdout(&renderer::set_scroll_region(1, rows.saturating_sub(1)));
+        update_status_bar(&self.mode, self.cols, self.rows);
+        Ok(())
+    }
+
+    // ── PTY output handling ─────────────────────────────────────────
+
+    fn handle_pty_output(&mut self, raw: &[u8]) {
+        let items = feed_interleaved(&mut self.osc_parser, raw);
+        for item in items {
+            match item {
+                ParsedItem::Output(bytes) => self.handle_filtered_output(&bytes),
+                ParsedItem::Event(event) => self.process_event(event),
             }
-            nix_write(master_fd, &buf[..n]).context("write to pty")?;
         }
     }
 
-    Ok(())
+    fn handle_filtered_output(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        match &mut self.mode {
+            Mode::Shell | Mode::AgentInput { .. } => write_stdout(bytes),
+            Mode::AgentRunning { phase, output, .. } => match phase {
+                AgentPhase::WaitingForEcho => { /* discard shell echo */ }
+                AgentPhase::Capturing => output.extend_from_slice(bytes),
+                AgentPhase::WaitingForPrompt => write_stdout(bytes),
+            },
+        }
+    }
+
+    fn process_event(&mut self, event: ShellEvent) {
+        match event {
+            ShellEvent::CommandStart => {
+                if let Mode::AgentRunning { phase, .. } = &mut self.mode {
+                    if matches!(phase, AgentPhase::WaitingForEcho) {
+                        *phase = AgentPhase::Capturing;
+                    }
+                }
+            }
+            ShellEvent::CommandFinished { exit_code } => {
+                if matches!(
+                    &self.mode,
+                    Mode::AgentRunning { phase: AgentPhase::Capturing, .. }
+                ) {
+                    self.render_agent_result(exit_code);
+                }
+            }
+            ShellEvent::PromptEnd => {
+                if matches!(
+                    &self.mode,
+                    Mode::AgentRunning { phase: AgentPhase::WaitingForPrompt, .. }
+                ) {
+                    self.mode = Mode::Shell;
+                    update_status_bar(&self.mode, self.cols, self.rows);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn render_agent_result(&mut self, exit_code: Option<i32>) {
+        let old = std::mem::replace(&mut self.mode, Mode::Shell);
+        if let Mode::AgentRunning { output, command, .. } = old {
+            let output_str = String::from_utf8_lossy(&output);
+            // Strip \r from PTY output — the line discipline converts \n → \r\n,
+            // and embedded \r would overwrite the left border when rendering.
+            let body = output_str.replace('\r', "");
+            let body = body.trim_end().to_string();
+            let block = AgentBlock {
+                kind: if exit_code == Some(0) || exit_code.is_none() {
+                    BlockKind::CommandOutput
+                } else {
+                    BlockKind::Error
+                },
+                header: Some(format!(
+                    "Output{}",
+                    exit_code.map_or(String::new(), |c| format!(" (exit {c})"))
+                )),
+                body,
+            };
+            write_stdout(&renderer::render_block(&block, self.cols));
+            self.mode = Mode::AgentRunning {
+                command,
+                output: Vec::new(),
+                phase: AgentPhase::WaitingForPrompt,
+            };
+        }
+    }
+
+    fn drain_pty(&mut self, buf: &mut [u8]) {
+        loop {
+            match read(self.master_fd, buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let (filtered, _) = self.osc_parser.feed(&buf[..n]);
+                    if !filtered.is_empty() {
+                        write_stdout(&filtered);
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Stdin handling ──────────────────────────────────────────────
+
+    fn handle_stdin(&mut self, bytes: &[u8]) -> Result<()> {
+        match &self.mode {
+            Mode::Shell => {
+                if let Some(pos) = bytes.iter().position(|&b| b == 0x01) {
+                    if pos > 0 {
+                        nix_write(self.master_fd, &bytes[..pos]).context("write to pty")?;
+                    }
+                    self.enter_agent_mode();
+                    if pos + 1 < bytes.len() {
+                        return self.handle_agent_input_bytes(&bytes[pos + 1..]);
+                    }
+                } else {
+                    nix_write(self.master_fd, bytes).context("write to pty")?;
+                }
+            }
+            Mode::AgentInput { .. } => {
+                self.handle_agent_input_bytes(bytes)?;
+            }
+            Mode::AgentRunning { .. } => {
+                // Ctrl-C cancels the running agent.
+                if bytes.contains(&0x03) {
+                    self.cancel_agent();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // ── Agent input mode ────────────────────────────────────────────
+
+    fn enter_agent_mode(&mut self) {
+        self.mode = Mode::AgentInput {
+            buffer: String::new(),
+            cursor: 0,
+        };
+        write_stdout(b"\r\n");
+        self.render_input_prompt();
+        update_status_bar(&self.mode, self.cols, self.rows);
+    }
+
+    fn exit_agent_mode(&mut self) {
+        write_stdout(&renderer::clear_line());
+        self.mode = Mode::Shell;
+        // Send newline to child to re-display the prompt.
+        let _ = nix_write(self.master_fd, b"\n");
+        update_status_bar(&self.mode, self.cols, self.rows);
+    }
+
+    fn cancel_agent(&mut self) {
+        self.mode = Mode::Shell;
+        write_stdout(b"\r\n");
+        // Forward Ctrl-C so the child shell can handle any in-flight command.
+        let _ = nix_write(self.master_fd, b"\x03");
+        update_status_bar(&self.mode, self.cols, self.rows);
+    }
+
+    fn render_input_prompt(&self) {
+        if let Mode::AgentInput { buffer, cursor } = &self.mode {
+            let mut out = renderer::clear_line();
+            out.extend_from_slice(&renderer::render_agent_input_prompt(buffer, *cursor));
+            write_stdout(&out);
+        }
+    }
+
+    fn handle_agent_input_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        for &b in bytes {
+            match b {
+                0x0d | 0x0a => return self.submit_agent_query(),
+                0x1b | 0x03 => {
+                    self.exit_agent_mode();
+                    return Ok(());
+                }
+                0x7f | 0x08 => {
+                    if let Mode::AgentInput { buffer, cursor } = &mut self.mode {
+                        if *cursor > 0 {
+                            *cursor -= 1;
+                            buffer.remove(*cursor);
+                        }
+                    }
+                }
+                b if (0x20..0x7f).contains(&b) => {
+                    if let Mode::AgentInput { buffer, cursor } = &mut self.mode {
+                        buffer.insert(*cursor, b as char);
+                        *cursor += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        self.render_input_prompt();
+        Ok(())
+    }
+
+    // ── Mock agent ──────────────────────────────────────────────────
+
+    fn submit_agent_query(&mut self) -> Result<()> {
+        let command = match &self.mode {
+            Mode::AgentInput { buffer, .. } => buffer.clone(),
+            _ => return Ok(()),
+        };
+
+        if command.trim().is_empty() {
+            self.exit_agent_mode();
+            return Ok(());
+        }
+
+        write_stdout(&renderer::clear_line());
+
+        // Built-in commands.
+        match command.trim() {
+            "help" => {
+                let block = AgentBlock {
+                    kind: BlockKind::AgentText,
+                    header: Some("wsh mock agent".into()),
+                    body: "Type any shell command and I'll execute it.\n\
+                           Special commands:\n  \
+                           help  — show this message\n  \
+                           exit  — quit wsh"
+                        .into(),
+                };
+                write_stdout(&renderer::render_block(&block, self.cols));
+                self.mode = Mode::Shell;
+                let _ = nix_write(self.master_fd, b"\n");
+                update_status_bar(&self.mode, self.cols, self.rows);
+                return Ok(());
+            }
+            "exit" => {
+                self.should_exit = true;
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        // Show thinking indicator and "Running" block.
+        write_stdout(&renderer::render_thinking_indicator());
+        let run_block = AgentBlock {
+            kind: BlockKind::CommandRun,
+            header: Some(format!("Running: {command}")),
+            body: String::new(),
+        };
+        write_stdout(&renderer::render_block(&run_block, self.cols));
+
+        // Write command to child PTY.
+        let cmd = format!("{command}\n");
+        nix_write(self.master_fd, cmd.as_bytes()).context("write command to pty")?;
+
+        self.mode = Mode::AgentRunning {
+            command,
+            output: Vec::new(),
+            phase: AgentPhase::WaitingForEcho,
+        };
+        update_status_bar(&self.mode, self.cols, self.rows);
+        Ok(())
+    }
 }

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -120,7 +120,7 @@ impl AgentProcess {
     #[allow(clippy::disallowed_types)]
     fn spawn(prompt: &str, conversation_id: Option<&str>) -> Result<Self> {
         let binary = resolve_agent_binary();
-        let mut args = vec!["agent", "run", "--prompt", prompt, "--output-format", "ndjson"];
+        let mut args = vec!["agent", "run", "--prompt", prompt, "--output-format", "ndjson", "--model", "kimi-k26-fireworks"];
         let conv_flag;
         if let Some(id) = conversation_id {
             conv_flag = id.to_string();

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -1,0 +1,153 @@
+use std::io::{self, Read, Write};
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use anyhow::{Context, Result};
+use crossterm::terminal;
+use nix::unistd::{close, pipe, read, write as nix_write};
+
+use crate::pty::sync_pty_size;
+
+/// Write-end of the SIGWINCH self-pipe. Set by `install_sigwinch_handler`.
+static SIGWINCH_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
+
+extern "C" fn sigwinch_handler(_sig: libc::c_int) {
+    let fd = SIGWINCH_WRITE_FD.load(Ordering::Relaxed);
+    if fd >= 0 {
+        unsafe {
+            libc::write(fd, b"W".as_ptr() as *const libc::c_void, 1);
+        }
+    }
+}
+
+fn install_sigwinch_handler() -> Result<RawFd> {
+    let (read_fd, write_fd) = pipe().context("pipe for SIGWINCH")?;
+
+    // Make both ends non-blocking so the signal handler never blocks.
+    for fd in [read_fd, write_fd] {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    }
+
+    SIGWINCH_WRITE_FD.store(write_fd, Ordering::Relaxed);
+
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = sigwinch_handler as usize;
+        sa.sa_flags = libc::SA_RESTART;
+        libc::sigemptyset(&mut sa.sa_mask);
+        if libc::sigaction(libc::SIGWINCH, &sa, std::ptr::null_mut()) < 0 {
+            return Err(anyhow::anyhow!("sigaction SIGWINCH: {}", io::Error::last_os_error()));
+        }
+    }
+
+    Ok(read_fd)
+}
+
+pub fn run(master_fd: RawFd) -> Result<()> {
+    let sigwinch_fd = install_sigwinch_handler()?;
+
+    // Sync terminal size before entering the loop.
+    sync_pty_size(master_fd)?;
+
+    terminal::enable_raw_mode().context("enable_raw_mode")?;
+
+    let result = run_inner(master_fd, sigwinch_fd);
+
+    // Always restore terminal state.
+    let _ = terminal::disable_raw_mode();
+
+    // Clean up the self-pipe.
+    let write_fd = SIGWINCH_WRITE_FD.swap(-1, Ordering::Relaxed);
+    if write_fd >= 0 {
+        let _ = close(write_fd);
+    }
+    let _ = close(sigwinch_fd);
+
+    result
+}
+
+fn run_inner(master_fd: RawFd, sigwinch_fd: RawFd) -> Result<()> {
+    let stdin_fd: RawFd = libc::STDIN_FILENO;
+    let mut buf = [0u8; 4096];
+
+    loop {
+        let mut pollfds = [
+            libc::pollfd {
+                fd: stdin_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: master_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: sigwinch_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+
+        let ret = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, -1) };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err).context("poll");
+        }
+
+        // SIGWINCH — propagate terminal resize.
+        if pollfds[2].revents & libc::POLLIN != 0 {
+            // Drain the self-pipe.
+            let mut drain = [0u8; 64];
+            while let Ok(n) = read(sigwinch_fd, &mut drain) {
+                if n == 0 {
+                    break;
+                }
+            }
+            if let Err(e) = sync_pty_size(master_fd) {
+                log::warn!("resize_pty: {e}");
+            }
+        }
+
+        // PTY master → stdout (shell output).
+        if pollfds[1].revents & libc::POLLIN != 0 {
+            match read(master_fd, &mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    io::stdout().write_all(&buf[..n]).context("write stdout")?;
+                    io::stdout().flush().context("flush stdout")?;
+                }
+            }
+        }
+
+        // Child exited.
+        if pollfds[1].revents & libc::POLLHUP != 0 {
+            // Drain any remaining output.
+            loop {
+                match read(master_fd, &mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let _ = io::stdout().write_all(&buf[..n]);
+                    }
+                }
+            }
+            let _ = io::stdout().flush();
+            break;
+        }
+
+        // stdin → PTY master (user input).
+        if pollfds[0].revents & libc::POLLIN != 0 {
+            let n = io::stdin().read(&mut buf).context("read stdin")?;
+            if n == 0 {
+                break;
+            }
+            nix_write(master_fd, &buf[..n]).context("write to pty")?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -185,24 +185,7 @@ fn parse_agent_event(line: &str, cols: usize) -> Option<(String, Color, CellFlag
     let event_type = json.get("type")?.as_str()?;
 
     match event_type {
-        "system" => {
-            let sub = json.get("event_type").and_then(|e| e.as_str());
-            match sub {
-                Some("run_started") => {
-                    let url = json.get("run_url").and_then(|u| u.as_str()).unwrap_or("");
-                    if !url.is_empty() {
-                        let display = if url.len() > cols {
-                            format!("{}…", &url[..cols.saturating_sub(1)])
-                        } else {
-                            url.to_string()
-                        };
-                        return Some((display, Color::Indexed(8), CellFlags::DIM));
-                    }
-                    None
-                }
-                _ => None,
-            }
-        }
+        "system" => None,
         "agent" | "agent_reasoning" => {
             let text = json.get("text")?.as_str()?;
             if text.trim().is_empty() {
@@ -318,6 +301,7 @@ pub fn run(master_fd: RawFd) -> Result<()> {
         cols,
         rows,
         should_exit: false,
+        spinner_tick: 0,
     };
     state.render_frame();
 
@@ -341,6 +325,19 @@ pub fn run(master_fd: RawFd) -> Result<()> {
 
 // ── Core state ──────────────────────────────────────────────────────
 
+const SPINNER: &[&str] = &[
+    "⠋ agent working...",
+    "⠙ agent working...",
+    "⠹ agent working...",
+    "⠸ agent working...",
+    "⠼ agent working...",
+    "⠴ agent working...",
+    "⠦ agent working...",
+    "⠧ agent working...",
+    "⠇ agent working...",
+    "⠏ agent working...",
+];
+
 struct Wsh {
     mode: Mode,
     master_fd: RawFd,
@@ -351,6 +348,7 @@ struct Wsh {
     cols: u16,
     rows: u16,
     should_exit: bool,
+    spinner_tick: usize,
 }
 
 impl Wsh {
@@ -427,6 +425,9 @@ impl Wsh {
             }
 
             if needs_render {
+                if matches!(self.mode, Mode::AgentRunning) {
+                    self.spinner_tick = self.spinner_tick.wrapping_add(1);
+                }
                 self.render_frame();
             }
         }
@@ -453,7 +454,7 @@ impl Wsh {
                 _ => None,
             },
             agent_status: match &self.mode {
-                Mode::AgentRunning => Some("⠋ agent working..."),
+                Mode::AgentRunning => Some(SPINNER[self.spinner_tick % SPINNER.len()]),
                 _ => None,
             },
             total_rows: self.rows,

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -510,8 +510,11 @@ impl Wsh {
         let mut rows = self.miniterm.take_scrolled_out();
         rows.extend(self.miniterm.grid().iter().cloned());
         self.blocks.add_block(rows);
-        let usable = self.rows.saturating_sub(1);
-        self.miniterm.resize(self.cols, usable);
+        // Reset rather than resize: resize preserves content, which causes
+        // the same grid to be re-captured on every subsequent PromptStart
+        // (duplicate blocks) and keeps a stale cursor position that inflates
+        // active_height, starving the scrollback region of display rows.
+        self.miniterm.reset();
     }
 
     fn drain_pty(&mut self, buf: &mut [u8]) {

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -78,6 +78,7 @@ impl Mode {
 
 // ── Agent subprocess ─────────────────────────────────────────────────
 
+#[allow(clippy::disallowed_types)]
 fn resolve_agent_binary() -> String {
     if let Ok(bin) = env::var("WSH_AGENT_BINARY") {
         return bin;

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -371,8 +371,10 @@ impl Wsh {
             ];
             let nfds = if agent_fd >= 0 { 4 } else { 3 };
 
+            // Use a short timeout when the agent is running so the spinner animates.
+            let timeout_ms = if matches!(self.mode, Mode::AgentRunning) { 120 } else { -1 };
             let ret = unsafe {
-                libc::poll(pollfds.as_mut_ptr(), nfds as libc::nfds_t, -1)
+                libc::poll(pollfds.as_mut_ptr(), nfds as libc::nfds_t, timeout_ms)
             };
             if ret < 0 {
                 let err = io::Error::last_os_error();
@@ -382,7 +384,8 @@ impl Wsh {
                 return Err(err).context("poll");
             }
 
-            let mut needs_render = false;
+            // Timeout with no events — still need to re-render for spinner.
+            let mut needs_render = ret == 0 && matches!(self.mode, Mode::AgentRunning);
 
             // SIGWINCH
             if pollfds[2].revents & libc::POLLIN != 0 {

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -1,5 +1,7 @@
+use std::env;
 use std::io::{self, Read};
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::process::{Child, Stdio};
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use anyhow::{Context, Result};
@@ -74,6 +76,152 @@ impl Mode {
     }
 }
 
+// ── Agent subprocess ─────────────────────────────────────────────────
+
+struct AgentProcess {
+    child: Child,
+    stdout_fd: RawFd,
+    line_buffer: Vec<u8>,
+}
+
+impl AgentProcess {
+    #[allow(clippy::disallowed_types)] // wsh is Unix-only; no Windows terminal flash concern.
+    fn spawn(prompt: &str) -> Result<Self> {
+        let binary = env::var("WSH_AGENT_BINARY").unwrap_or_else(|_| "warp".into());
+        let child = std::process::Command::new(&binary)
+            .args(["agent", "run", "--prompt", prompt, "--output-format", "ndjson"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn `{binary} agent run`"))?;
+
+        let stdout = child.stdout.as_ref().expect("piped stdout");
+        let stdout_fd = stdout.as_raw_fd();
+
+        // Make stdout non-blocking for polling.
+        let flags = unsafe { libc::fcntl(stdout_fd, libc::F_GETFL) };
+        unsafe { libc::fcntl(stdout_fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+
+        Ok(Self {
+            child,
+            stdout_fd,
+            line_buffer: Vec::new(),
+        })
+    }
+
+    fn read_lines(&mut self) -> Vec<String> {
+        let mut buf = [0u8; 4096];
+        let mut lines = Vec::new();
+
+        loop {
+            let n = match read(self.stdout_fd, &mut buf) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            self.line_buffer.extend_from_slice(&buf[..n]);
+        }
+
+        // Extract complete lines from the buffer.
+        while let Some(pos) = self.line_buffer.iter().position(|&b| b == b'\n') {
+            let line = self.line_buffer.drain(..=pos).collect::<Vec<_>>();
+            if let Ok(s) = String::from_utf8(line) {
+                let trimmed = s.trim().to_string();
+                if !trimmed.is_empty() {
+                    lines.push(trimmed);
+                }
+            }
+        }
+
+        lines
+    }
+
+    fn is_finished(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(Some(_)))
+    }
+
+    fn kill(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+// ── NDJSON event parsing ─────────────────────────────────────────────
+
+fn parse_agent_event(line: &str, cols: usize) -> Option<(String, Color, CellFlags)> {
+    let json: serde_json::Value = serde_json::from_str(line).ok()?;
+    let event_type = json.get("type")?.as_str()?;
+
+    match event_type {
+        "agent" | "agent_reasoning" => {
+            let text = json.get("text")?.as_str()?;
+            if text.trim().is_empty() {
+                return None;
+            }
+            let color = if event_type == "agent_reasoning" {
+                Color::Indexed(8) // dim gray for reasoning
+            } else {
+                Color::Default
+            };
+            Some((text.to_string(), color, CellFlags::empty()))
+        }
+        "tool_call" => {
+            let tool = json.get("tool").and_then(|t| t.as_str()).unwrap_or("tool");
+            let summary = json
+                .get("summary")
+                .and_then(|s| s.as_str())
+                .or_else(|| json.get("command").and_then(|c| c.as_str()))
+                .unwrap_or("");
+            let display = if summary.is_empty() {
+                format!("⚡ {tool}")
+            } else {
+                let max = cols.saturating_sub(4);
+                let s = if summary.len() > max {
+                    format!("{}…", &summary[..max.saturating_sub(1)])
+                } else {
+                    summary.to_string()
+                };
+                format!("⚡ {tool}: {s}")
+            };
+            Some((display, Color::Indexed(3), CellFlags::DIM)) // yellow
+        }
+        "tool_result" => {
+            // Show a condensed result — just the first meaningful line.
+            let output = json
+                .get("output")
+                .and_then(|o| o.as_str())
+                .unwrap_or("");
+            let first_line = output.lines().next().unwrap_or("(done)");
+            let max = cols.saturating_sub(4);
+            let display = if first_line.len() > max {
+                format!("  ↪ {}…", &first_line[..max.saturating_sub(3)])
+            } else {
+                format!("  ↪ {first_line}")
+            };
+            Some((display, Color::Indexed(8), CellFlags::DIM)) // dim gray
+        }
+        "tool_error" => {
+            let error = json
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or("unknown error");
+            Some((format!("✗ {error}"), Color::Indexed(1), CellFlags::empty())) // red
+        }
+        "tool_canceled" => {
+            Some(("✗ canceled".to_string(), Color::Indexed(3), CellFlags::DIM))
+        }
+        _ => {
+            // Unknown event type — show raw for debugging.
+            let preview = if line.len() > cols {
+                format!("{}…", &line[..cols.saturating_sub(1)])
+            } else {
+                line.to_string()
+            };
+            Some((preview, Color::Indexed(8), CellFlags::DIM))
+        }
+    }
+}
+
 // ── Interleaved OSC parser ──────────────────────────────────────────
 
 enum ParsedItem {
@@ -116,6 +264,7 @@ pub fn run(master_fd: RawFd) -> Result<()> {
         osc_parser: OscParser::new(),
         miniterm: MiniTerm::new(cols, usable),
         blocks: BlockManager::new(),
+        agent: None,
         cols,
         rows,
         should_exit: false,
@@ -123,6 +272,11 @@ pub fn run(master_fd: RawFd) -> Result<()> {
     state.render_frame();
 
     let result = state.run_loop(sigwinch_fd);
+
+    // Clean up agent subprocess if still running.
+    if let Some(mut agent) = state.agent.take() {
+        agent.kill();
+    }
 
     let _ = screen::leave_alt_screen();
 
@@ -143,6 +297,7 @@ struct Wsh {
     osc_parser: OscParser,
     miniterm: MiniTerm,
     blocks: BlockManager,
+    agent: Option<AgentProcess>,
     cols: u16,
     rows: u16,
     should_exit: bool,
@@ -158,14 +313,18 @@ impl Wsh {
                 break;
             }
 
+            // Build poll fds: stdin, master, sigwinch, and optionally agent stdout.
+            let agent_fd = self.agent.as_ref().map(|a| a.stdout_fd).unwrap_or(-1);
             let mut pollfds = [
                 libc::pollfd { fd: stdin_fd, events: libc::POLLIN, revents: 0 },
                 libc::pollfd { fd: self.master_fd, events: libc::POLLIN, revents: 0 },
                 libc::pollfd { fd: sigwinch_fd, events: libc::POLLIN, revents: 0 },
+                libc::pollfd { fd: agent_fd, events: libc::POLLIN, revents: 0 },
             ];
+            let nfds = if agent_fd >= 0 { 4 } else { 3 };
 
             let ret = unsafe {
-                libc::poll(pollfds.as_mut_ptr(), pollfds.len() as libc::nfds_t, -1)
+                libc::poll(pollfds.as_mut_ptr(), nfds as libc::nfds_t, -1)
             };
             if ret < 0 {
                 let err = io::Error::last_os_error();
@@ -177,11 +336,13 @@ impl Wsh {
 
             let mut needs_render = false;
 
+            // SIGWINCH
             if pollfds[2].revents & libc::POLLIN != 0 {
                 self.handle_resize(sigwinch_fd)?;
                 needs_render = true;
             }
 
+            // PTY output
             if pollfds[1].revents & libc::POLLIN != 0 {
                 match read(self.master_fd, &mut buf) {
                     Ok(0) | Err(_) => break,
@@ -192,12 +353,20 @@ impl Wsh {
                 }
             }
 
+            // Child shell exited
             if pollfds[1].revents & libc::POLLHUP != 0 {
                 self.drain_pty(&mut buf);
                 self.render_frame();
                 break;
             }
 
+            // Agent subprocess output
+            if nfds == 4 && pollfds[3].revents & (libc::POLLIN | libc::POLLHUP) != 0 {
+                self.handle_agent_output();
+                needs_render = true;
+            }
+
+            // stdin
             if pollfds[0].revents & libc::POLLIN != 0 {
                 let n = io::stdin().read(&mut buf).context("read stdin")?;
                 if n == 0 {
@@ -225,7 +394,7 @@ impl Wsh {
             active_cursor: self.miniterm.cursor_pos(),
             status_bar: StatusBar {
                 mode: self.mode.label(),
-                model: "mock",
+                model: "warp",
                 hint: self.mode.hint(),
             },
             scroll_offset: self.blocks.scroll_offset(),
@@ -234,7 +403,7 @@ impl Wsh {
                 _ => None,
             },
             agent_status: match &self.mode {
-                Mode::AgentRunning => Some("⠋ thinking..."),
+                Mode::AgentRunning => Some("⠋ agent working..."),
                 _ => None,
             },
             total_rows: self.rows,
@@ -279,7 +448,8 @@ impl Wsh {
                 self.blocks.scroll_to_bottom();
             }
             ShellEvent::PromptEnd => {
-                if matches!(self.mode, Mode::AgentRunning) {
+                // If agent finished and shell prompt returned, go back to Shell.
+                if matches!(self.mode, Mode::AgentRunning) && self.agent.is_none() {
                     self.mode = Mode::Shell;
                 }
             }
@@ -291,7 +461,8 @@ impl Wsh {
         let mut rows = self.miniterm.take_scrolled_out();
         rows.extend(self.miniterm.grid().iter().cloned());
         self.blocks.add_block(rows);
-        self.miniterm.reset();
+        let usable = self.rows.saturating_sub(1);
+        self.miniterm.resize(self.cols, usable);
     }
 
     fn drain_pty(&mut self, buf: &mut [u8]) {
@@ -304,6 +475,51 @@ impl Wsh {
                         self.miniterm.process_bytes(&filtered);
                     }
                 }
+            }
+        }
+    }
+
+    // ── Agent subprocess output ───────────────────────────────────────
+
+    fn handle_agent_output(&mut self) {
+        let agent = match self.agent.as_mut() {
+            Some(a) => a,
+            None => return,
+        };
+
+        let lines = agent.read_lines();
+        let cols = self.cols as usize;
+
+        for line in &lines {
+            if let Some((text, color, flags)) = parse_agent_event(line, cols) {
+                // Agent text output can be multi-line — add each line separately.
+                for text_line in text.lines() {
+                    self.blocks.add_styled_line(text_line, color, flags, cols);
+                }
+            }
+        }
+
+        // Check if the agent process has finished.
+        if let Some(agent) = self.agent.as_mut() {
+            if agent.is_finished() {
+                // Drain any remaining output.
+                let final_lines = agent.read_lines();
+                for line in &final_lines {
+                    if let Some((text, color, flags)) = parse_agent_event(line, cols) {
+                        for text_line in text.lines() {
+                            self.blocks.add_styled_line(text_line, color, flags, cols);
+                        }
+                    }
+                }
+                self.agent = None;
+                self.blocks.add_styled_line(
+                    "✓ agent finished",
+                    Color::Indexed(2), // green
+                    CellFlags::DIM,
+                    cols,
+                );
+                // If no PTY command is pending, return to Shell immediately.
+                self.mode = Mode::Shell;
             }
         }
     }
@@ -353,8 +569,16 @@ impl Wsh {
     }
 
     fn cancel_agent(&mut self) {
+        if let Some(mut agent) = self.agent.take() {
+            agent.kill();
+        }
         self.mode = Mode::Shell;
-        let _ = nix_write(self.master_fd, b"\x03");
+        self.blocks.add_styled_line(
+            "✗ agent canceled",
+            Color::Indexed(3),
+            CellFlags::DIM,
+            self.cols as usize,
+        );
     }
 
     fn handle_agent_input_bytes(&mut self, bytes: &[u8]) -> Result<()> {
@@ -385,49 +609,49 @@ impl Wsh {
         Ok(())
     }
 
-    // ── Mock agent ────────────────────────────────────────────────────
+    // ── Agent submission ──────────────────────────────────────────────
 
     fn submit_agent_query(&mut self) -> Result<()> {
-        let command = match &self.mode {
+        let prompt = match &self.mode {
             Mode::AgentInput { buffer, .. } => buffer.clone(),
             _ => return Ok(()),
         };
 
-        if command.trim().is_empty() {
+        if prompt.trim().is_empty() {
             self.exit_agent_mode();
             return Ok(());
         }
 
-        match command.trim() {
-            "help" => {
+        if prompt.trim() == "exit" {
+            self.should_exit = true;
+            return Ok(());
+        }
+
+        self.blocks.add_styled_line(
+            &format!("🤖 {prompt}"),
+            Color::Indexed(5),
+            CellFlags::empty(),
+            self.cols as usize,
+        );
+
+        // Spawn the real agent subprocess.
+        match AgentProcess::spawn(&prompt) {
+            Ok(agent) => {
+                self.agent = Some(agent);
+                self.mode = Mode::AgentRunning;
+            }
+            Err(e) => {
                 self.blocks.add_styled_line(
-                    "🤖 Type any command. Special: help, exit",
-                    Color::Indexed(6),
-                    CellFlags::DIM,
+                    &format!("✗ failed to start agent: {e}"),
+                    Color::Indexed(1),
+                    CellFlags::empty(),
                     self.cols as usize,
                 );
                 self.mode = Mode::Shell;
                 let _ = nix_write(self.master_fd, b"\n");
-                return Ok(());
             }
-            "exit" => {
-                self.should_exit = true;
-                return Ok(());
-            }
-            _ => {}
         }
 
-        self.blocks.add_styled_line(
-            &format!("🤖 running: {command}"),
-            Color::Indexed(5),
-            CellFlags::DIM,
-            self.cols as usize,
-        );
-
-        let cmd = format!("{command}\n");
-        nix_write(self.master_fd, cmd.as_bytes()).context("write command to pty")?;
-
-        self.mode = Mode::AgentRunning;
         Ok(())
     }
 }

--- a/crates/wsh/src/event_loop.rs
+++ b/crates/wsh/src/event_loop.rs
@@ -233,6 +233,10 @@ impl Wsh {
                 Mode::AgentInput { buffer, cursor } => Some((buffer.as_str(), *cursor)),
                 _ => None,
             },
+            agent_status: match &self.mode {
+                Mode::AgentRunning => Some("⠋ thinking..."),
+                _ => None,
+            },
             total_rows: self.rows,
             total_cols: self.cols,
             show_cursor: matches!(self.mode, Mode::Shell),

--- a/crates/wsh/src/lib.rs
+++ b/crates/wsh/src/lib.rs
@@ -1,5 +1,8 @@
+pub mod block;
 pub mod cell;
 pub mod event_loop;
+pub mod miniterm;
 pub mod pty;
 pub mod renderer;
+pub mod screen;
 pub mod shell_integration;

--- a/crates/wsh/src/lib.rs
+++ b/crates/wsh/src/lib.rs
@@ -1,2 +1,5 @@
+pub mod cell;
 pub mod event_loop;
 pub mod pty;
+pub mod renderer;
+pub mod shell_integration;

--- a/crates/wsh/src/lib.rs
+++ b/crates/wsh/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod event_loop;
+pub mod pty;

--- a/crates/wsh/src/main.rs
+++ b/crates/wsh/src/main.rs
@@ -1,8 +1,43 @@
-use anyhow::Result;
+use std::env;
+use std::fs;
+use std::io::Write;
+
+use anyhow::{Context, Result};
+
+const ZSH_INIT_SCRIPT: &str = include_str!("../assets/wsh_zsh_init.sh");
+
+fn setup_shell_integration() -> Result<std::path::PathBuf> {
+    let tmp_dir = env::temp_dir().join(format!("wsh-{}", std::process::id()));
+    fs::create_dir_all(&tmp_dir).context("create temp ZDOTDIR")?;
+
+    // Determine the user's real ZDOTDIR (or HOME as fallback).
+    let real_zdotdir = env::var("ZDOTDIR")
+        .unwrap_or_else(|_| env::var("HOME").unwrap_or_else(|_| "/".to_string()));
+
+    // Write a .zshenv that sources the user's real one.
+    let zshenv_content = format!(
+        "if [[ -f \"{real_zdotdir}/.zshenv\" ]]; then\n  source \"{real_zdotdir}/.zshenv\"\nfi\n"
+    );
+    fs::write(tmp_dir.join(".zshenv"), zshenv_content).context("write .zshenv")?;
+
+    // Write our init script as .zshrc (it sources the user's real .zshrc internally).
+    let mut f = fs::File::create(tmp_dir.join(".zshrc")).context("create .zshrc")?;
+    f.write_all(ZSH_INIT_SCRIPT.as_bytes())
+        .context("write .zshrc")?;
+
+    env::set_var("WSH_REAL_ZDOTDIR", &real_zdotdir);
+    env::set_var("ZDOTDIR", &tmp_dir);
+
+    Ok(tmp_dir)
+}
 
 fn main() -> Result<()> {
     env_logger::init();
 
+    let tmp_dir = setup_shell_integration()?;
     let pair = wsh::pty::spawn_shell()?;
-    wsh::event_loop::run(pair.master_fd)
+    let result = wsh::event_loop::run(pair.master_fd);
+
+    let _ = fs::remove_dir_all(&tmp_dir);
+    result
 }

--- a/crates/wsh/src/main.rs
+++ b/crates/wsh/src/main.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let pair = wsh::pty::spawn_shell()?;
+    wsh::event_loop::run(pair.master_fd)
+}

--- a/crates/wsh/src/miniterm.rs
+++ b/crates/wsh/src/miniterm.rs
@@ -1,0 +1,877 @@
+use vte::{Params, Perform};
+
+use crate::cell::{Cell, CellAttr, CellFlags, Color};
+
+pub struct MiniTerm {
+    grid: Vec<Vec<Cell>>,
+    cursor_row: usize,
+    cursor_col: usize,
+    cols: usize,
+    rows: usize,
+    current_attr: CellAttr,
+    saved_cursor: Option<(usize, usize)>,
+    scroll_top: usize,
+    scroll_bottom: usize,
+    scrolled_out: Vec<Vec<Cell>>,
+    alt_grid: Option<Vec<Vec<Cell>>>,
+    parser: Option<vte::Parser>,
+}
+
+impl MiniTerm {
+    pub fn new(cols: u16, rows: u16) -> Self {
+        let cols = cols as usize;
+        let rows = rows as usize;
+        Self {
+            grid: blank_grid(cols, rows),
+            cursor_row: 0,
+            cursor_col: 0,
+            cols,
+            rows,
+            current_attr: CellAttr::default(),
+            saved_cursor: None,
+            scroll_top: 0,
+            scroll_bottom: rows,
+            scrolled_out: Vec::new(),
+            alt_grid: None,
+            parser: Some(vte::Parser::new()),
+        }
+    }
+
+    pub fn process_bytes(&mut self, bytes: &[u8]) {
+        let mut parser = self.parser.take().unwrap_or_else(vte::Parser::new);
+        for &byte in bytes {
+            parser.advance(self, byte);
+        }
+        self.parser = Some(parser);
+    }
+
+    pub fn resize(&mut self, cols: u16, rows: u16) {
+        let new_cols = cols as usize;
+        let new_rows = rows as usize;
+        let mut new_grid = blank_grid(new_cols, new_rows);
+        for (r, row) in self.grid.iter().enumerate() {
+            if r >= new_rows {
+                break;
+            }
+            for (c, cell) in row.iter().enumerate() {
+                if c >= new_cols {
+                    break;
+                }
+                new_grid[r][c] = *cell;
+            }
+        }
+        self.grid = new_grid;
+        self.cols = new_cols;
+        self.rows = new_rows;
+        self.cursor_row = self.cursor_row.min(new_rows.saturating_sub(1));
+        self.cursor_col = self.cursor_col.min(new_cols.saturating_sub(1));
+        self.scroll_top = 0;
+        self.scroll_bottom = new_rows;
+    }
+
+    pub fn grid(&self) -> &[Vec<Cell>] {
+        &self.grid
+    }
+
+    pub fn cursor_pos(&self) -> (usize, usize) {
+        (self.cursor_row, self.cursor_col)
+    }
+
+    pub fn take_scrolled_out(&mut self) -> Vec<Vec<Cell>> {
+        std::mem::take(&mut self.scrolled_out)
+    }
+
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    // -- scroll helpers --
+
+    fn scroll_up(&mut self, n: usize) {
+        let top = self.scroll_top;
+        let bot = self.scroll_bottom;
+        let n = n.min(bot - top);
+        if n == 0 {
+            return;
+        }
+        if top == 0 {
+            self.scrolled_out
+                .extend(self.grid[..n].iter().cloned());
+        }
+        for i in top..bot - n {
+            self.grid[i] = self.grid[i + n].clone();
+        }
+        for i in bot - n..bot {
+            self.grid[i] = blank_row(self.cols);
+        }
+    }
+
+    fn scroll_down(&mut self, n: usize) {
+        let top = self.scroll_top;
+        let bot = self.scroll_bottom;
+        let n = n.min(bot - top);
+        if n == 0 {
+            return;
+        }
+        for i in (top + n..bot).rev() {
+            self.grid[i] = self.grid[i - n].clone();
+        }
+        for i in top..top + n {
+            self.grid[i] = blank_row(self.cols);
+        }
+    }
+
+    fn advance_cursor_down(&mut self) {
+        if self.cursor_row == self.scroll_bottom - 1 {
+            self.scroll_up(1);
+        } else if self.cursor_row < self.rows - 1 {
+            self.cursor_row += 1;
+        }
+    }
+}
+
+fn blank_row(cols: usize) -> Vec<Cell> {
+    vec![Cell::default(); cols]
+}
+
+fn blank_grid(cols: usize, rows: usize) -> Vec<Vec<Cell>> {
+    vec![blank_row(cols); rows]
+}
+
+// -- SGR helpers --
+
+fn parse_sgr(params: &Params, attr: &mut CellAttr) {
+    let collected: Vec<&[u16]> = params.iter().collect();
+    if collected.is_empty() {
+        attr.reset();
+        return;
+    }
+    let mut i = 0;
+    while i < collected.len() {
+        let p = collected[i][0];
+        match p {
+            0 => *attr = CellAttr::default(),
+            1 => attr.flags |= CellFlags::BOLD,
+            2 => attr.flags |= CellFlags::DIM,
+            3 => attr.flags |= CellFlags::ITALIC,
+            4 => attr.flags |= CellFlags::UNDERLINE,
+            7 => attr.flags |= CellFlags::INVERSE,
+            8 => attr.flags |= CellFlags::HIDDEN,
+            22 => attr.flags &= !(CellFlags::BOLD | CellFlags::DIM),
+            23 => attr.flags &= !CellFlags::ITALIC,
+            24 => attr.flags &= !CellFlags::UNDERLINE,
+            27 => attr.flags &= !CellFlags::INVERSE,
+            28 => attr.flags &= !CellFlags::HIDDEN,
+            30..=37 => attr.fg = Color::Indexed((p - 30) as u8),
+            38 => {
+                i += 1;
+                parse_extended_color(&collected, &mut i, &mut attr.fg);
+                continue;
+            }
+            39 => attr.fg = Color::Default,
+            40..=47 => attr.bg = Color::Indexed((p - 40) as u8),
+            48 => {
+                i += 1;
+                parse_extended_color(&collected, &mut i, &mut attr.bg);
+                continue;
+            }
+            49 => attr.bg = Color::Default,
+            90..=97 => attr.fg = Color::Indexed((p - 90 + 8) as u8),
+            100..=107 => attr.bg = Color::Indexed((p - 100 + 8) as u8),
+            _ => {}
+        }
+        i += 1;
+    }
+}
+
+fn parse_extended_color(params: &[&[u16]], i: &mut usize, color: &mut Color) {
+    if *i >= params.len() {
+        return;
+    }
+    let kind = params[*i][0];
+    match kind {
+        5 => {
+            *i += 1;
+            if *i < params.len() {
+                *color = Color::Indexed(params[*i][0] as u8);
+                *i += 1;
+            }
+        }
+        2 => {
+            if *i + 3 < params.len() {
+                let r = params[*i + 1][0] as u8;
+                let g = params[*i + 2][0] as u8;
+                let b = params[*i + 3][0] as u8;
+                *color = Color::Rgb(r, g, b);
+                *i += 4;
+            } else {
+                *i += 1;
+            }
+        }
+        _ => {
+            *i += 1;
+        }
+    }
+}
+
+impl CellAttr {
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+// -- vte::Perform --
+
+impl Perform for MiniTerm {
+    fn print(&mut self, ch: char) {
+        // Deferred wrap: only wrap when a new character needs to be placed.
+        if self.cursor_col >= self.cols {
+            self.cursor_col = 0;
+            self.advance_cursor_down();
+        }
+        self.grid[self.cursor_row][self.cursor_col] = Cell::with_char(ch, self.current_attr);
+        self.cursor_col += 1;
+    }
+
+    fn execute(&mut self, byte: u8) {
+        match byte {
+            0x0d => self.cursor_col = 0,
+            0x0a => self.advance_cursor_down(),
+            0x08 => {
+                if self.cursor_col > 0 {
+                    self.cursor_col -= 1;
+                }
+            }
+            0x09 => {
+                self.cursor_col = ((self.cursor_col / 8) + 1) * 8;
+                if self.cursor_col >= self.cols {
+                    self.cursor_col = self.cols.saturating_sub(1);
+                }
+            }
+            0x07 => {} // BEL
+            _ => {}
+        }
+    }
+
+    fn csi_dispatch(
+        &mut self,
+        params: &Params,
+        intermediates: &[u8],
+        _has_ignored_intermediates: bool,
+        action: char,
+    ) {
+        let mut params_iter = params.iter();
+        let mut next_param_or = |default: u16| -> u16 {
+            params_iter
+                .next()
+                .map(|p| p[0])
+                .filter(|&p| p != 0)
+                .unwrap_or(default)
+        };
+
+        match (action, intermediates.first()) {
+            ('m', None) => parse_sgr(params, &mut self.current_attr),
+
+            ('H', None) | ('f', None) => {
+                let row = next_param_or(1) as usize;
+                let col = next_param_or(1) as usize;
+                self.cursor_row = row.saturating_sub(1).min(self.rows.saturating_sub(1));
+                self.cursor_col = col.saturating_sub(1).min(self.cols.saturating_sub(1));
+            }
+
+            ('A', None) => {
+                let n = next_param_or(1) as usize;
+                self.cursor_row = self.cursor_row.saturating_sub(n).max(self.scroll_top);
+            }
+            ('B', None) => {
+                let n = next_param_or(1) as usize;
+                self.cursor_row = (self.cursor_row + n).min(self.scroll_bottom - 1);
+            }
+            ('C', None) => {
+                let n = next_param_or(1) as usize;
+                self.cursor_col = (self.cursor_col + n).min(self.cols.saturating_sub(1));
+            }
+            ('D', None) => {
+                let n = next_param_or(1) as usize;
+                self.cursor_col = self.cursor_col.saturating_sub(n);
+            }
+            ('G', None) => {
+                let n = next_param_or(1) as usize;
+                self.cursor_col = n.saturating_sub(1).min(self.cols.saturating_sub(1));
+            }
+            ('d', None) => {
+                let n = next_param_or(1) as usize;
+                self.cursor_row = n.saturating_sub(1).min(self.rows.saturating_sub(1));
+            }
+
+            ('J', None) => {
+                let mode = next_param_or(0);
+                match mode {
+                    0 => {
+                        // Erase from cursor to end of screen.
+                        for c in self.cursor_col..self.cols {
+                            self.grid[self.cursor_row][c] = Cell::default();
+                        }
+                        for r in self.cursor_row + 1..self.rows {
+                            self.grid[r] = blank_row(self.cols);
+                        }
+                    }
+                    1 => {
+                        // Erase from start of screen to cursor.
+                        for r in 0..self.cursor_row {
+                            self.grid[r] = blank_row(self.cols);
+                        }
+                        for c in 0..=self.cursor_col.min(self.cols.saturating_sub(1)) {
+                            self.grid[self.cursor_row][c] = Cell::default();
+                        }
+                    }
+                    2 | 3 => {
+                        for r in 0..self.rows {
+                            self.grid[r] = blank_row(self.cols);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            ('K', None) => {
+                let mode = next_param_or(0);
+                match mode {
+                    0 => {
+                        for c in self.cursor_col..self.cols {
+                            self.grid[self.cursor_row][c] = Cell::default();
+                        }
+                    }
+                    1 => {
+                        for c in 0..=self.cursor_col.min(self.cols.saturating_sub(1)) {
+                            self.grid[self.cursor_row][c] = Cell::default();
+                        }
+                    }
+                    2 => {
+                        self.grid[self.cursor_row] = blank_row(self.cols);
+                    }
+                    _ => {}
+                }
+            }
+
+            ('r', None) => {
+                let top = next_param_or(1) as usize;
+                let bot = params_iter
+                    .next()
+                    .map(|p| p[0] as usize)
+                    .filter(|&p| p != 0)
+                    .unwrap_or(self.rows);
+                self.scroll_top = top.saturating_sub(1).min(self.rows.saturating_sub(1));
+                self.scroll_bottom = bot.min(self.rows);
+                if self.scroll_top >= self.scroll_bottom {
+                    self.scroll_top = 0;
+                    self.scroll_bottom = self.rows;
+                }
+                self.cursor_row = self.scroll_top;
+                self.cursor_col = 0;
+            }
+
+            ('L', None) => {
+                let n = next_param_or(1) as usize;
+                let bot = self.scroll_bottom;
+                let row = self.cursor_row;
+                if row < bot {
+                    let n = n.min(bot - row);
+                    for i in (row + n..bot).rev() {
+                        self.grid[i] = self.grid[i - n].clone();
+                    }
+                    for i in row..row + n {
+                        self.grid[i] = blank_row(self.cols);
+                    }
+                }
+            }
+            ('M', None) => {
+                let n = next_param_or(1) as usize;
+                let bot = self.scroll_bottom;
+                let row = self.cursor_row;
+                if row < bot {
+                    let n = n.min(bot - row);
+                    for i in row..bot - n {
+                        self.grid[i] = self.grid[i + n].clone();
+                    }
+                    for i in bot - n..bot {
+                        self.grid[i] = blank_row(self.cols);
+                    }
+                }
+            }
+            ('S', None) => {
+                let n = next_param_or(1) as usize;
+                self.scroll_up(n);
+            }
+            ('T', None) => {
+                let n = next_param_or(1) as usize;
+                self.scroll_down(n);
+            }
+
+            ('@', None) => {
+                let n = next_param_or(1) as usize;
+                let row = self.cursor_row;
+                let col = self.cursor_col;
+                let end = self.cols;
+                if col < end {
+                    let n = n.min(end - col);
+                    for i in (col + n..end).rev() {
+                        self.grid[row][i] = self.grid[row][i - n];
+                    }
+                    for i in col..col + n {
+                        self.grid[row][i] = Cell::default();
+                    }
+                }
+            }
+            ('P', None) => {
+                let n = next_param_or(1) as usize;
+                let row = self.cursor_row;
+                let col = self.cursor_col;
+                let end = self.cols;
+                if col < end {
+                    let n = n.min(end - col);
+                    for i in col..end - n {
+                        self.grid[row][i] = self.grid[row][i + n];
+                    }
+                    for i in end - n..end {
+                        self.grid[row][i] = Cell::default();
+                    }
+                }
+            }
+            ('X', None) => {
+                let n = next_param_or(1) as usize;
+                let row = self.cursor_row;
+                let end = (self.cursor_col + n).min(self.cols);
+                for c in self.cursor_col..end {
+                    self.grid[row][c] = Cell::default();
+                }
+            }
+
+            ('h', Some(b'?')) => {
+                for param in params_iter.map(|p| p[0]) {
+                    if param == 1049 {
+                        // Switch to alt screen.
+                        self.saved_cursor = Some((self.cursor_row, self.cursor_col));
+                        let alt = blank_grid(self.cols, self.rows);
+                        self.alt_grid = Some(std::mem::replace(&mut self.grid, alt));
+                        self.cursor_row = 0;
+                        self.cursor_col = 0;
+                    }
+                }
+            }
+            ('l', Some(b'?')) => {
+                for param in params_iter.map(|p| p[0]) {
+                    if param == 1049 {
+                        // Switch back from alt screen.
+                        if let Some(main) = self.alt_grid.take() {
+                            self.grid = main;
+                        }
+                        if let Some((r, c)) = self.saved_cursor.take() {
+                            self.cursor_row = r;
+                            self.cursor_col = c;
+                        }
+                    }
+                }
+            }
+
+            ('n', None) => {} // DSR — ignored
+
+            _ => {}
+        }
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], _ignore: bool, byte: u8) {
+        match (byte, intermediates) {
+            (b'7', []) => {
+                self.saved_cursor = Some((self.cursor_row, self.cursor_col));
+            }
+            (b'8', []) => {
+                if let Some((r, c)) = self.saved_cursor {
+                    self.cursor_row = r;
+                    self.cursor_col = c;
+                }
+            }
+            (b'M', []) => {
+                // Reverse Index — move cursor up, scroll down if at top of region.
+                if self.cursor_row == self.scroll_top {
+                    self.scroll_down(1);
+                } else if self.cursor_row > 0 {
+                    self.cursor_row -= 1;
+                }
+            }
+            (b'D', []) => {
+                // Index — move cursor down, scroll up if at bottom of region.
+                self.advance_cursor_down();
+            }
+            _ => {}
+        }
+    }
+
+    fn osc_dispatch(&mut self, _params: &[&[u8]], _bell_terminated: bool) {}
+    fn hook(&mut self, _params: &Params, _intermediates: &[u8], _ignore: bool, _c: char) {}
+    fn put(&mut self, _byte: u8) {}
+    fn unhook(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid_text(term: &MiniTerm) -> Vec<String> {
+        term.grid()
+            .iter()
+            .map(|row| row.iter().map(|c| c.ch).collect::<String>())
+            .collect()
+    }
+
+    fn row_text(term: &MiniTerm, row: usize) -> String {
+        term.grid()[row].iter().map(|c| c.ch).collect()
+    }
+
+    #[test]
+    fn print_writes_chars_and_advances_cursor() {
+        let mut t = MiniTerm::new(10, 5);
+        t.process_bytes(b"Hi");
+        assert_eq!(t.grid()[0][0].ch, 'H');
+        assert_eq!(t.grid()[0][1].ch, 'i');
+        assert_eq!(t.cursor_pos(), (0, 2));
+    }
+
+    #[test]
+    fn line_wrapping() {
+        let mut t = MiniTerm::new(4, 3);
+        t.process_bytes(b"abcde");
+        assert_eq!(row_text(&t, 0), "abcd");
+        // 'e' wraps to the next row.
+        assert_eq!(t.grid()[1][0].ch, 'e');
+        assert_eq!(t.cursor_pos(), (1, 1));
+    }
+
+    #[test]
+    fn lf_scrolls_at_bottom() {
+        let mut t = MiniTerm::new(5, 3);
+        // Fill all three rows.
+        t.process_bytes(b"aaaa\r\nbbb\r\nccc");
+        assert_eq!(t.cursor_pos(), (2, 3));
+        // One more LF while on last row should scroll.
+        t.process_bytes(b"\n");
+        assert_eq!(row_text(&t, 0).trim_end(), "bbb");
+        assert_eq!(row_text(&t, 1).trim_end(), "ccc");
+        assert_eq!(row_text(&t, 2).trim(), "");
+    }
+
+    #[test]
+    fn cr_moves_to_col_0() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"hello\r");
+        assert_eq!(t.cursor_pos(), (0, 0));
+    }
+
+    #[test]
+    fn sgr_sets_colors_and_flags() {
+        let mut t = MiniTerm::new(10, 3);
+        // ESC[1;31m = bold + fg red(1)
+        t.process_bytes(b"\x1b[1;31mX");
+        let cell = t.grid()[0][0];
+        assert!(cell.attr.flags.contains(CellFlags::BOLD));
+        assert_eq!(cell.attr.fg, Color::Indexed(1));
+    }
+
+    #[test]
+    fn sgr_extended_256_color() {
+        let mut t = MiniTerm::new(10, 3);
+        // ESC[38;5;200m = fg indexed 200
+        t.process_bytes(b"\x1b[38;5;200mA");
+        assert_eq!(t.grid()[0][0].attr.fg, Color::Indexed(200));
+    }
+
+    #[test]
+    fn sgr_extended_rgb_color() {
+        let mut t = MiniTerm::new(10, 3);
+        // ESC[48;2;10;20;30m = bg rgb(10,20,30)
+        t.process_bytes(b"\x1b[48;2;10;20;30mB");
+        assert_eq!(t.grid()[0][0].attr.bg, Color::Rgb(10, 20, 30));
+    }
+
+    #[test]
+    fn cup_moves_cursor() {
+        let mut t = MiniTerm::new(10, 10);
+        // ESC[3;5H = move to row 3, col 5 (1-based)
+        t.process_bytes(b"\x1b[3;5H");
+        assert_eq!(t.cursor_pos(), (2, 4));
+    }
+
+    #[test]
+    fn cup_defaults_to_1_1() {
+        let mut t = MiniTerm::new(10, 10);
+        t.process_bytes(b"\x1b[5;5H"); // move away
+        t.process_bytes(b"\x1b[H"); // defaults to 1;1
+        assert_eq!(t.cursor_pos(), (0, 0));
+    }
+
+    #[test]
+    fn ed_erase_entire_screen() {
+        let mut t = MiniTerm::new(5, 3);
+        t.process_bytes(b"hello\r\nworld");
+        // ESC[2J = erase entire screen
+        t.process_bytes(b"\x1b[2J");
+        for row in grid_text(&t) {
+            assert_eq!(row, "     ");
+        }
+    }
+
+    #[test]
+    fn ed_erase_below() {
+        let mut t = MiniTerm::new(5, 3);
+        t.process_bytes(b"aaaaa\r\nbbbbb\r\nccccc");
+        // Move to row 1, col 2 and erase below.
+        t.process_bytes(b"\x1b[2;3H\x1b[0J");
+        assert_eq!(row_text(&t, 0), "aaaaa");
+        // Row 1 from col 2 onward should be cleared.
+        assert_eq!(row_text(&t, 1), "bb   ");
+        assert_eq!(row_text(&t, 2), "     ");
+    }
+
+    #[test]
+    fn el_erase_to_end_of_line() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"0123456789");
+        // Move to col 5 and erase to end of line.
+        t.process_bytes(b"\x1b[1;6H\x1b[0K");
+        assert_eq!(row_text(&t, 0), "01234     ");
+    }
+
+    #[test]
+    fn el_erase_from_start_of_line() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"0123456789");
+        // Move to col 3 and erase from start.
+        t.process_bytes(b"\x1b[1;4H\x1b[1K");
+        assert_eq!(row_text(&t, 0), "    456789");
+    }
+
+    #[test]
+    fn el_erase_entire_line() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"0123456789");
+        t.process_bytes(b"\x1b[1;4H\x1b[2K");
+        assert_eq!(row_text(&t, 0), "          ");
+    }
+
+    #[test]
+    fn scroll_region_limits_scrolling() {
+        let mut t = MiniTerm::new(5, 5);
+        // Fill rows.
+        t.process_bytes(b"row0\r\n");
+        t.process_bytes(b"row1\r\n");
+        t.process_bytes(b"row2\r\n");
+        t.process_bytes(b"row3\r\n");
+        t.process_bytes(b"row4");
+        // Set scroll region to rows 2-4 (1-indexed: 2;4).
+        t.process_bytes(b"\x1b[2;4r");
+        // Cursor should move to scroll_top.
+        assert_eq!(t.cursor_pos(), (1, 0));
+        // Move cursor to the bottom of the region and LF to scroll within it.
+        t.process_bytes(b"\x1b[4;1H");
+        t.process_bytes(b"\n");
+        // row0 should be untouched (outside scroll region).
+        assert_eq!(row_text(&t, 0).trim_end(), "row0");
+        // row4 should also be untouched.
+        assert_eq!(row_text(&t, 4).trim_end(), "row4");
+        // Within the region, rows should have shifted up.
+        assert_eq!(row_text(&t, 1).trim_end(), "row2");
+        assert_eq!(row_text(&t, 2).trim_end(), "row3");
+        assert_eq!(row_text(&t, 3).trim_end(), "");
+    }
+
+    #[test]
+    fn take_scrolled_out_returns_and_drains() {
+        let mut t = MiniTerm::new(5, 2);
+        t.process_bytes(b"AAA\r\nBBB\r\nCCC");
+        // AAA should have scrolled out.
+        let scrolled = t.take_scrolled_out();
+        assert_eq!(scrolled.len(), 1);
+        assert_eq!(
+            scrolled[0].iter().map(|c| c.ch).collect::<String>().trim_end(),
+            "AAA"
+        );
+        // Calling again should return empty.
+        assert!(t.take_scrolled_out().is_empty());
+    }
+
+    #[test]
+    fn alt_screen_preserves_main() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"main text");
+        // Enter alt screen: ESC[?1049h
+        t.process_bytes(b"\x1b[?1049h");
+        // Alt screen should be blank.
+        assert_eq!(row_text(&t, 0).trim(), "");
+        t.process_bytes(b"alt!");
+        assert_eq!(row_text(&t, 0).trim_end(), "alt!");
+        // Leave alt screen: ESC[?1049l
+        t.process_bytes(b"\x1b[?1049l");
+        assert_eq!(row_text(&t, 0).trim_end(), "main text");
+    }
+
+    #[test]
+    fn cursor_movement_csi_abcd() {
+        let mut t = MiniTerm::new(10, 10);
+        t.process_bytes(b"\x1b[5;5H"); // row 4, col 4
+        t.process_bytes(b"\x1b[2A"); // up 2
+        assert_eq!(t.cursor_pos(), (2, 4));
+        t.process_bytes(b"\x1b[3B"); // down 3
+        assert_eq!(t.cursor_pos(), (5, 4));
+        t.process_bytes(b"\x1b[2C"); // right 2
+        assert_eq!(t.cursor_pos(), (5, 6));
+        t.process_bytes(b"\x1b[4D"); // left 4
+        assert_eq!(t.cursor_pos(), (5, 2));
+    }
+
+    #[test]
+    fn save_and_restore_cursor_via_esc() {
+        let mut t = MiniTerm::new(10, 10);
+        t.process_bytes(b"\x1b[3;7H"); // row 2, col 6
+        t.process_bytes(b"\x1b7"); // save
+        t.process_bytes(b"\x1b[1;1H"); // home
+        assert_eq!(t.cursor_pos(), (0, 0));
+        t.process_bytes(b"\x1b8"); // restore
+        assert_eq!(t.cursor_pos(), (2, 6));
+    }
+
+    #[test]
+    fn backspace() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"abc");
+        assert_eq!(t.cursor_pos(), (0, 3));
+        t.process_bytes(b"\x08");
+        assert_eq!(t.cursor_pos(), (0, 2));
+        // Can't go below 0.
+        t.process_bytes(b"\x08\x08\x08\x08");
+        assert_eq!(t.cursor_pos(), (0, 0));
+    }
+
+    #[test]
+    fn tab_advances_to_next_multiple_of_8() {
+        let mut t = MiniTerm::new(20, 3);
+        t.process_bytes(b"ab\t");
+        assert_eq!(t.cursor_pos(), (0, 8));
+        t.process_bytes(b"\t");
+        assert_eq!(t.cursor_pos(), (0, 16));
+    }
+
+    #[test]
+    fn resize_preserves_content_and_clamps_cursor() {
+        let mut t = MiniTerm::new(10, 5);
+        t.process_bytes(b"hello");
+        t.process_bytes(b"\x1b[5;10H"); // cursor at (4, 9)
+        t.resize(6, 3);
+        assert_eq!(row_text(&t, 0), "hello ");
+        // Cursor clamped to new bounds.
+        assert_eq!(t.cursor_pos(), (2, 5));
+    }
+
+    #[test]
+    fn insert_and_delete_lines() {
+        let mut t = MiniTerm::new(5, 4);
+        t.process_bytes(b"AAA\r\nBBB\r\nCCC\r\nDDD");
+        // Move to row 1 and insert 1 line.
+        t.process_bytes(b"\x1b[2;1H\x1b[1L");
+        assert_eq!(row_text(&t, 0).trim_end(), "AAA");
+        assert_eq!(row_text(&t, 1).trim(), "");
+        assert_eq!(row_text(&t, 2).trim_end(), "BBB");
+        assert_eq!(row_text(&t, 3).trim_end(), "CCC");
+        // DDD got pushed off.
+    }
+
+    #[test]
+    fn delete_characters() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"0123456789");
+        // Move to col 2, delete 3 chars.
+        t.process_bytes(b"\x1b[1;3H\x1b[3P");
+        assert_eq!(row_text(&t, 0), "0156789   ");
+    }
+
+    #[test]
+    fn insert_characters() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"0123456789");
+        // Move to col 2, insert 2 blanks.
+        t.process_bytes(b"\x1b[1;3H\x1b[2@");
+        assert_eq!(row_text(&t, 0), "01  234567");
+    }
+
+    #[test]
+    fn erase_characters() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"0123456789");
+        // Move to col 3, erase 4 chars.
+        t.process_bytes(b"\x1b[1;4H\x1b[4X");
+        assert_eq!(row_text(&t, 0), "012    789");
+        // Cursor should not have moved.
+        assert_eq!(t.cursor_pos(), (0, 3));
+    }
+
+    #[test]
+    fn reverse_index_scrolls_down_at_top() {
+        let mut t = MiniTerm::new(5, 3);
+        t.process_bytes(b"AAA\r\nBBB\r\nCCC");
+        // Move to row 0 and reverse index.
+        t.process_bytes(b"\x1b[1;1H\x1bM");
+        assert_eq!(row_text(&t, 0).trim(), "");
+        assert_eq!(row_text(&t, 1).trim_end(), "AAA");
+        assert_eq!(row_text(&t, 2).trim_end(), "BBB");
+    }
+
+    #[test]
+    fn bright_fg_and_bg_colors() {
+        let mut t = MiniTerm::new(10, 3);
+        // ESC[93m = bright yellow fg (index 11)
+        // ESC[104m = bright blue bg (index 12)
+        t.process_bytes(b"\x1b[93;104mZ");
+        let cell = t.grid()[0][0];
+        assert_eq!(cell.attr.fg, Color::Indexed(11));
+        assert_eq!(cell.attr.bg, Color::Indexed(12));
+    }
+
+    #[test]
+    fn sgr_reset_clears_attributes() {
+        let mut t = MiniTerm::new(10, 3);
+        t.process_bytes(b"\x1b[1;3;31mX\x1b[0mY");
+        let x = t.grid()[0][0];
+        assert!(x.attr.flags.contains(CellFlags::BOLD));
+        assert!(x.attr.flags.contains(CellFlags::ITALIC));
+        let y = t.grid()[0][1];
+        assert_eq!(y.attr.flags, CellFlags::empty());
+        assert_eq!(y.attr.fg, Color::Default);
+    }
+
+    #[test]
+    fn cha_and_vpa() {
+        let mut t = MiniTerm::new(10, 10);
+        // CHA: ESC[5G = set cursor col to 4 (0-indexed).
+        t.process_bytes(b"\x1b[5G");
+        assert_eq!(t.cursor_pos(), (0, 4));
+        // VPA: ESC[3d = set cursor row to 2 (0-indexed).
+        t.process_bytes(b"\x1b[3d");
+        assert_eq!(t.cursor_pos(), (2, 4));
+    }
+
+    #[test]
+    fn scroll_up_and_down_csi() {
+        let mut t = MiniTerm::new(5, 4);
+        t.process_bytes(b"AAA\r\nBBB\r\nCCC\r\nDDD");
+        // Scroll up 1: ESC[1S
+        t.process_bytes(b"\x1b[1S");
+        assert_eq!(row_text(&t, 0).trim_end(), "BBB");
+        assert_eq!(row_text(&t, 3).trim(), "");
+        // Scroll down 1: ESC[1T
+        t.process_bytes(b"\x1b[1T");
+        assert_eq!(row_text(&t, 0).trim(), "");
+        assert_eq!(row_text(&t, 1).trim_end(), "BBB");
+    }
+}

--- a/crates/wsh/src/miniterm.rs
+++ b/crates/wsh/src/miniterm.rs
@@ -38,7 +38,7 @@ impl MiniTerm {
     }
 
     pub fn process_bytes(&mut self, bytes: &[u8]) {
-        let mut parser = self.parser.take().unwrap_or_else(vte::Parser::new);
+        let mut parser = self.parser.take().unwrap_or_default();
         for &byte in bytes {
             parser.advance(self, byte);
         }

--- a/crates/wsh/src/miniterm.rs
+++ b/crates/wsh/src/miniterm.rs
@@ -89,6 +89,17 @@ impl MiniTerm {
         self.cols
     }
 
+    pub fn reset(&mut self) {
+        self.grid = blank_grid(self.cols, self.rows);
+        self.cursor_row = 0;
+        self.cursor_col = 0;
+        self.current_attr = CellAttr::default();
+        self.saved_cursor = None;
+        self.scroll_top = 0;
+        self.scroll_bottom = self.rows;
+        self.scrolled_out.clear();
+    }
+
     // -- scroll helpers --
 
     fn scroll_up(&mut self, n: usize) {

--- a/crates/wsh/src/pty.rs
+++ b/crates/wsh/src/pty.rs
@@ -1,0 +1,87 @@
+use std::env;
+use std::ffi::CString;
+use std::os::unix::io::RawFd;
+
+use anyhow::{Context, Result};
+use nix::fcntl::{fcntl, FcntlArg, FdFlag};
+use nix::pty::openpty;
+use nix::unistd::{close, dup2, execvp, fork, setsid, ForkResult, Pid};
+
+pub struct PtyPair {
+    pub master_fd: RawFd,
+    pub child_pid: Pid,
+}
+
+pub fn spawn_shell() -> Result<PtyPair> {
+    let pty = openpty(None, None).context("openpty failed")?;
+    let master_fd = pty.master;
+    let slave_fd = pty.slave;
+
+    // Set FD_CLOEXEC on the master so it isn't leaked to child processes.
+    let flags = fcntl(master_fd, FcntlArg::F_GETFD).context("F_GETFD")?;
+    let mut fd_flags = FdFlag::from_bits_truncate(flags);
+    fd_flags.insert(FdFlag::FD_CLOEXEC);
+    fcntl(master_fd, FcntlArg::F_SETFD(fd_flags)).context("F_SETFD")?;
+
+    let shell = env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+
+    match unsafe { fork().context("fork failed")? } {
+        ForkResult::Child => {
+            // Close master in child — it's only needed by the parent.
+            let _ = close(master_fd);
+
+            // Create a new session and set the slave as the controlling terminal.
+            setsid().context("setsid")?;
+            unsafe {
+                if libc::ioctl(slave_fd, libc::TIOCSCTTY.into(), 0) < 0 {
+                    return Err(anyhow::anyhow!("TIOCSCTTY failed"));
+                }
+            }
+
+            // Redirect stdio to the slave PTY.
+            dup2(slave_fd, libc::STDIN_FILENO).context("dup2 stdin")?;
+            dup2(slave_fd, libc::STDOUT_FILENO).context("dup2 stdout")?;
+            dup2(slave_fd, libc::STDERR_FILENO).context("dup2 stderr")?;
+            if slave_fd > libc::STDERR_FILENO {
+                let _ = close(slave_fd);
+            }
+
+            let shell_c = CString::new(shell.as_str()).context("CString")?;
+            execvp(&shell_c, &[&shell_c]).context("execvp")?;
+
+            // execvp only returns on error — unreachable on success.
+            unreachable!();
+        }
+        ForkResult::Parent { child } => {
+            // Close slave in parent — it's only needed by the child.
+            let _ = close(slave_fd);
+
+            Ok(PtyPair {
+                master_fd,
+                child_pid: child,
+            })
+        }
+    }
+}
+
+pub fn resize_pty(master_fd: RawFd, cols: u16, rows: u16) -> Result<()> {
+    let ws = libc::winsize {
+        ws_row: rows,
+        ws_col: cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let ret = unsafe { libc::ioctl(master_fd, libc::TIOCSWINSZ, &ws) };
+    if ret < 0 {
+        Err(anyhow::anyhow!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error()))
+    } else {
+        Ok(())
+    }
+}
+
+/// Copy the current host terminal size to the PTY master.
+pub fn sync_pty_size(master_fd: RawFd) -> Result<(u16, u16)> {
+    let (cols, rows) = crossterm::terminal::size().context("terminal::size")?;
+    resize_pty(master_fd, cols, rows)?;
+    Ok((cols, rows))
+}

--- a/crates/wsh/src/renderer.rs
+++ b/crates/wsh/src/renderer.rs
@@ -1,0 +1,413 @@
+use std::fmt::Write as _;
+
+const CSI: &str = "\x1b[";
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const REVERSE: &str = "\x1b[7m";
+
+const DIM_CYAN: &str = "\x1b[2;36m";
+const DIM_YELLOW: &str = "\x1b[2;33m";
+const DIM_RED: &str = "\x1b[2;31m";
+const DIM_MAGENTA: &str = "\x1b[2;35m";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockKind {
+    AgentText,
+    CommandRun,
+    CommandOutput,
+    Thinking,
+    Error,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentBlock {
+    pub kind: BlockKind,
+    pub header: Option<String>,
+    pub body: String,
+}
+
+impl BlockKind {
+    fn color_code(self) -> &'static str {
+        match self {
+            BlockKind::AgentText => DIM_CYAN,
+            BlockKind::CommandRun => DIM_YELLOW,
+            BlockKind::CommandOutput => "",
+            BlockKind::Thinking => DIM_MAGENTA,
+            BlockKind::Error => DIM_RED,
+        }
+    }
+}
+
+pub fn render_block(block: &AgentBlock, width: u16) -> Vec<u8> {
+    let w = width as usize;
+    if w < 6 {
+        return Vec::new();
+    }
+    let color = block.kind.color_code();
+    let inner = w - 4; // │ + space + content + space + │
+    let mut out = String::new();
+
+    // Top border
+    let _ = write!(out, "{color}╭─");
+    if let Some(header) = &block.header {
+        let max_header = inner.saturating_sub(2);
+        let truncated: String = header.chars().take(max_header).collect();
+        let _ = write!(out, " {truncated} ");
+        let used = truncated.chars().count() + 2; // space + header + space
+        let remaining = (w - 4).saturating_sub(used);
+        for _ in 0..remaining {
+            out.push('─');
+        }
+    } else {
+        for _ in 0..(w - 4) {
+            out.push('─');
+        }
+    }
+    let _ = writeln!(out, "─╮{RESET}");
+
+    // Body lines
+    let lines = wrap_text(&block.body, inner);
+    let body_lines = if lines.is_empty() { vec![String::new()] } else { lines };
+    for line in &body_lines {
+        let visible_len = line.chars().count();
+        let padding = inner.saturating_sub(visible_len);
+        let _ = write!(out, "{color}│{RESET} {line}");
+        for _ in 0..padding {
+            out.push(' ');
+        }
+        let _ = writeln!(out, " {color}│{RESET}");
+    }
+
+    // Bottom border
+    let _ = write!(out, "{color}╰");
+    for _ in 0..(w - 2) {
+        out.push('─');
+    }
+    let _ = writeln!(out, "╯{RESET}");
+
+    out.into_bytes()
+}
+
+pub fn render_thinking_indicator() -> Vec<u8> {
+    format!("{DIM_MAGENTA}⠋ thinking...{RESET}\n").into_bytes()
+}
+
+pub fn render_agent_input_prompt(input: &str, cursor_pos: usize) -> Vec<u8> {
+    // Show: 🤖 > {input_before_cursor}█{input_after_cursor}
+    // Use bold for the prompt prefix.
+    let before: String = input.chars().take(cursor_pos).collect();
+    let after: String = input.chars().skip(cursor_pos).collect();
+
+    let mut out = String::new();
+    let _ = write!(out, "{BOLD}🤖 > {RESET}{before}");
+    // Reverse-video block cursor on the char at cursor_pos, or a space if at end.
+    let cursor_char = input.chars().nth(cursor_pos).unwrap_or(' ');
+    let _ = write!(out, "{REVERSE}{cursor_char}{RESET}");
+    if !after.is_empty() {
+        // after starts with cursor_char which we already rendered
+        let rest: String = after.chars().skip(1).collect();
+        let _ = write!(out, "{rest}");
+    }
+    out.into_bytes()
+}
+
+pub fn render_status_bar(mode: &str, model: &str, hint: &str, width: u16) -> Vec<u8> {
+    let w = width as usize;
+    let left = format!(" {mode} │ {model}");
+    let right = format!("{hint} ");
+
+    let left_len = left.chars().count();
+    let right_len = right.chars().count();
+    let gap = w.saturating_sub(left_len + right_len);
+
+    let mut bar = String::with_capacity(w + 32);
+    let _ = write!(bar, "{REVERSE}");
+    bar.push_str(&left);
+    for _ in 0..gap {
+        bar.push(' ');
+    }
+    bar.push_str(&right);
+    // If content was shorter than width, we already padded. If longer, truncation
+    // happened implicitly (we just don't pad).
+    let _ = write!(bar, "{RESET}");
+    bar.into_bytes()
+}
+
+pub fn clear_line() -> Vec<u8> {
+    b"\x1b[2K\r".to_vec()
+}
+
+pub fn move_to_status_bar_row(rows: u16) -> Vec<u8> {
+    format!("{CSI}{rows};1H").into_bytes()
+}
+
+pub fn save_cursor() -> Vec<u8> {
+    b"\x1b[s".to_vec()
+}
+
+pub fn restore_cursor() -> Vec<u8> {
+    b"\x1b[u".to_vec()
+}
+
+pub fn set_scroll_region(top: u16, bottom: u16) -> Vec<u8> {
+    format!("{CSI}{top};{bottom}r").into_bytes()
+}
+
+pub fn reset_scroll_region() -> Vec<u8> {
+    b"\x1b[r".to_vec()
+}
+
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![text.to_string()];
+    }
+    let mut result = Vec::new();
+    for raw_line in text.split('\n') {
+        if raw_line.is_empty() {
+            result.push(String::new());
+            continue;
+        }
+        let mut current = String::new();
+        let mut col = 0usize;
+        for word in raw_line.split_inclusive(' ') {
+            let wlen = word.chars().count();
+            if col > 0 && col + wlen > width {
+                result.push(current);
+                current = String::new();
+                col = 0;
+            }
+            // Hard-break words longer than width
+            if wlen > width && col == 0 {
+                for ch in word.chars() {
+                    if col >= width {
+                        result.push(current);
+                        current = String::new();
+                        col = 0;
+                    }
+                    current.push(ch);
+                    col += 1;
+                }
+            } else {
+                current.push_str(word);
+                col += wlen;
+            }
+        }
+        if !current.is_empty() || col == 0 {
+            result.push(current);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_block_contains_box_drawing() {
+        let block = AgentBlock {
+            kind: BlockKind::AgentText,
+            header: Some("test header".into()),
+            body: "hello world".into(),
+        };
+        let out = render_block(&block, 40);
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains('╭'));
+        assert!(s.contains('╮'));
+        assert!(s.contains('╰'));
+        assert!(s.contains('╯'));
+        assert!(s.contains('│'));
+        assert!(s.contains("test header"));
+        assert!(s.contains("hello world"));
+    }
+
+    #[test]
+    fn render_block_empty_body() {
+        let block = AgentBlock {
+            kind: BlockKind::Error,
+            header: None,
+            body: String::new(),
+        };
+        let out = render_block(&block, 20);
+        let s = String::from_utf8(out).unwrap();
+        // Should still produce a box with an empty content line
+        assert!(s.contains('╭'));
+        assert!(s.contains('╯'));
+        let line_count = s.lines().count();
+        assert!(line_count >= 3, "expected at least 3 lines (top, body, bottom), got {line_count}");
+    }
+
+    #[test]
+    fn render_block_multiline_body() {
+        let block = AgentBlock {
+            kind: BlockKind::CommandOutput,
+            header: None,
+            body: "line one\nline two\nline three".into(),
+        };
+        let out = render_block(&block, 30);
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("line one"));
+        assert!(s.contains("line two"));
+        assert!(s.contains("line three"));
+    }
+
+    #[test]
+    fn render_block_wraps_long_lines() {
+        let block = AgentBlock {
+            kind: BlockKind::AgentText,
+            header: None,
+            body: "a ".repeat(50), // 100 chars of "a a a ..."
+        };
+        let out = render_block(&block, 20);
+        let s = String::from_utf8(out).unwrap();
+        // With width=20, inner=16, so the long body must wrap across multiple lines
+        let body_lines: Vec<&str> = s.lines().filter(|l| l.contains('│') && !l.contains('╭') && !l.contains('╰')).collect();
+        assert!(body_lines.len() > 1, "expected wrapping, got {} body lines", body_lines.len());
+    }
+
+    #[test]
+    fn render_block_too_narrow_returns_empty() {
+        let block = AgentBlock {
+            kind: BlockKind::AgentText,
+            header: None,
+            body: "hi".into(),
+        };
+        let out = render_block(&block, 5);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn status_bar_visible_width() {
+        let out = render_status_bar("AGENT", "gpt-4", "Ctrl+C to cancel", 60);
+        let s = String::from_utf8(out).unwrap();
+        // Strip ANSI escapes and measure visible chars
+        let visible: String = strip_ansi(&s);
+        assert_eq!(
+            visible.chars().count(),
+            60,
+            "expected 60 visible chars, got {}: {:?}",
+            visible.chars().count(),
+            visible
+        );
+    }
+
+    #[test]
+    fn status_bar_wide() {
+        let out = render_status_bar("SHELL", "claude", "q: quit", 120);
+        let s = String::from_utf8(out).unwrap();
+        let visible = strip_ansi(&s);
+        assert_eq!(visible.chars().count(), 120);
+    }
+
+    #[test]
+    fn wrap_text_basic() {
+        let lines = wrap_text("hello world foo bar", 10);
+        for line in &lines {
+            assert!(line.chars().count() <= 10, "line too long: {line:?}");
+        }
+        let joined = lines.join(" ");
+        assert!(joined.contains("hello"));
+        assert!(joined.contains("bar"));
+    }
+
+    #[test]
+    fn wrap_text_hard_break() {
+        let long = "abcdefghijklmnop"; // 16 chars, no spaces
+        let lines = wrap_text(long, 5);
+        for line in &lines {
+            assert!(line.chars().count() <= 5, "line too long: {line:?}");
+        }
+        let reassembled: String = lines.concat();
+        assert_eq!(reassembled, long);
+    }
+
+    #[test]
+    fn wrap_text_preserves_newlines() {
+        let lines = wrap_text("a\nb\nc", 80);
+        assert_eq!(lines, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn wrap_text_empty() {
+        let lines = wrap_text("", 10);
+        assert_eq!(lines, vec![""]);
+    }
+
+    #[test]
+    fn clear_line_bytes() {
+        assert_eq!(clear_line(), b"\x1b[2K\r");
+    }
+
+    #[test]
+    fn save_restore_cursor() {
+        assert_eq!(save_cursor(), b"\x1b[s");
+        assert_eq!(restore_cursor(), b"\x1b[u");
+    }
+
+    #[test]
+    fn scroll_region_sequences() {
+        assert_eq!(set_scroll_region(1, 24), b"\x1b[1;24r");
+        assert_eq!(reset_scroll_region(), b"\x1b[r");
+    }
+
+    #[test]
+    fn move_to_row() {
+        assert_eq!(move_to_status_bar_row(25), b"\x1b[25;1H");
+    }
+
+    #[test]
+    fn thinking_indicator_contains_text() {
+        let out = render_thinking_indicator();
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("thinking..."));
+        assert!(s.contains("⠋"));
+    }
+
+    #[test]
+    fn agent_input_prompt_basic() {
+        let out = render_agent_input_prompt("hello", 3);
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("🤖 > "));
+        assert!(s.contains("hel"));
+    }
+
+    #[test]
+    fn agent_input_prompt_cursor_at_end() {
+        let out = render_agent_input_prompt("abc", 3);
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("🤖 > "));
+        assert!(s.contains("abc"));
+    }
+
+    #[test]
+    fn render_block_command_run_has_yellow() {
+        let block = AgentBlock {
+            kind: BlockKind::CommandRun,
+            header: Some("Running: ls".into()),
+            body: "output".into(),
+        };
+        let out = render_block(&block, 40);
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("\x1b[2;33m"), "expected dim yellow ANSI code");
+    }
+
+    /// Strip ANSI escape sequences for visible-width assertions.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' {
+                // Skip until a letter (the terminator of the escape sequence)
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(ch);
+            }
+        }
+        out
+    }
+}

--- a/crates/wsh/src/renderer.rs
+++ b/crates/wsh/src/renderer.rs
@@ -47,8 +47,8 @@ pub fn render_block(block: &AgentBlock, width: u16) -> Vec<u8> {
     let inner = w - 4; // │ + space + content + space + │
     let mut out = String::new();
 
-    // Top border
-    let _ = write!(out, "{color}╭─");
+    // Top border — \r ensures cursor starts at column 1 in raw mode.
+    let _ = write!(out, "\r{color}╭─");
     if let Some(header) = &block.header {
         let max_header = inner.saturating_sub(2);
         let truncated: String = header.chars().take(max_header).collect();
@@ -63,7 +63,7 @@ pub fn render_block(block: &AgentBlock, width: u16) -> Vec<u8> {
             out.push('─');
         }
     }
-    let _ = writeln!(out, "─╮{RESET}");
+    let _ = write!(out, "─╮{RESET}\r\n");
 
     // Body lines
     let lines = wrap_text(&block.body, inner);
@@ -71,25 +71,25 @@ pub fn render_block(block: &AgentBlock, width: u16) -> Vec<u8> {
     for line in &body_lines {
         let visible_len = line.chars().count();
         let padding = inner.saturating_sub(visible_len);
-        let _ = write!(out, "{color}│{RESET} {line}");
+        let _ = write!(out, "\r{color}│{RESET} {line}");
         for _ in 0..padding {
             out.push(' ');
         }
-        let _ = writeln!(out, " {color}│{RESET}");
+        let _ = write!(out, " {color}│{RESET}\r\n");
     }
 
     // Bottom border
-    let _ = write!(out, "{color}╰");
+    let _ = write!(out, "\r{color}╰");
     for _ in 0..(w - 2) {
         out.push('─');
     }
-    let _ = writeln!(out, "╯{RESET}");
+    let _ = write!(out, "╯{RESET}\r\n");
 
     out.into_bytes()
 }
 
 pub fn render_thinking_indicator() -> Vec<u8> {
-    format!("{DIM_MAGENTA}⠋ thinking...{RESET}\n").into_bytes()
+    format!("{DIM_MAGENTA}⠋ thinking...{RESET}\r\n").into_bytes()
 }
 
 pub fn render_agent_input_prompt(input: &str, cursor_pos: usize) -> Vec<u8> {
@@ -389,6 +389,33 @@ mod tests {
         let out = render_block(&block, 40);
         let s = String::from_utf8(out).unwrap();
         assert!(s.contains("\x1b[2;33m"), "expected dim yellow ANSI code");
+    }
+
+    #[test]
+    fn render_block_uses_crlf() {
+        let block = AgentBlock {
+            kind: BlockKind::AgentText,
+            header: Some("test".into()),
+            body: "body".into(),
+        };
+        let out = render_block(&block, 30);
+        // Every line ending must be \r\n for raw-mode terminals.
+        assert!(!out.windows(1).any(|w| w == b"\n") || out.windows(2).filter(|w| w == b"\r\n").count() > 0,
+            "render_block must use \\r\\n line endings");
+        // More specific: count bare \n (not preceded by \r)
+        let bare_lf = out.windows(2).enumerate().filter(|(_i, w)| {
+            w[1] == b'\n' && w[0] != b'\r'
+        }).count();
+        // Also check the first byte isn't a bare \n
+        let first_is_bare_lf = out.first() == Some(&b'\n');
+        assert!(!first_is_bare_lf && bare_lf == 0,
+            "found {bare_lf} bare LF(s) without preceding CR");
+    }
+
+    #[test]
+    fn thinking_indicator_uses_crlf() {
+        let out = render_thinking_indicator();
+        assert!(out.ends_with(b"\r\n"), "thinking indicator must end with \\r\\n");
     }
 
     /// Strip ANSI escape sequences for visible-width assertions.

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -1,0 +1,535 @@
+use std::io::{self, Write};
+
+use crossterm::cursor;
+use crossterm::execute;
+use crossterm::queue;
+use crossterm::style::{
+    Attribute, Color as CtColor, Print, SetAttribute, SetBackgroundColor, SetForegroundColor,
+};
+use crossterm::terminal::{self, ClearType};
+
+use crate::cell::{Cell, CellAttr, CellFlags, Color};
+
+pub struct StatusBar<'a> {
+    pub mode: &'a str,
+    pub model: &'a str,
+    pub hint: &'a str,
+}
+
+pub struct Frame<'a> {
+    pub completed_rows: &'a [Vec<Cell>],
+    pub active_grid: &'a [Vec<Cell>],
+    pub active_cursor: (usize, usize),
+    pub status_bar: StatusBar<'a>,
+    pub scroll_offset: usize,
+    pub agent_input: Option<(&'a str, usize)>,
+    pub total_rows: u16,
+    pub total_cols: u16,
+    pub show_cursor: bool,
+}
+
+pub fn enter_alt_screen() -> anyhow::Result<()> {
+    let mut stdout = io::stdout();
+    execute!(
+        stdout,
+        terminal::EnterAlternateScreen,
+        cursor::Hide,
+    )?;
+    terminal::enable_raw_mode()?;
+    Ok(())
+}
+
+pub fn leave_alt_screen() -> anyhow::Result<()> {
+    let mut stdout = io::stdout();
+    terminal::disable_raw_mode()?;
+    execute!(
+        stdout,
+        cursor::Show,
+        terminal::LeaveAlternateScreen,
+    )?;
+    Ok(())
+}
+
+struct Layout {
+    scrollback_height: usize,
+    active_height: usize,
+    agent_input_row: Option<u16>,
+    status_bar_row: u16,
+}
+
+fn compute_layout(frame: &Frame) -> Layout {
+    let total = frame.total_rows as usize;
+    let has_input = frame.agent_input.is_some();
+    let reserved = 1 + if has_input { 1 } else { 0 };
+    let usable = total.saturating_sub(reserved);
+
+    let active_height = frame.active_grid.len().min(usable);
+    let scrollback_height = usable.saturating_sub(active_height);
+
+    let agent_input_row = if has_input {
+        Some((total - 2) as u16)
+    } else {
+        None
+    };
+    let status_bar_row = (total - 1) as u16;
+
+    Layout {
+        scrollback_height,
+        active_height,
+        agent_input_row,
+        status_bar_row,
+    }
+}
+
+pub fn render(frame: &Frame) -> anyhow::Result<()> {
+    let mut stdout = io::stdout();
+    let layout = compute_layout(frame);
+    let cols = frame.total_cols as usize;
+
+    queue!(stdout, terminal::Clear(ClearType::All))?;
+
+    // --- Scrollback region ---
+    if layout.scrollback_height > 0 && !frame.completed_rows.is_empty() {
+        let total_completed = frame.completed_rows.len();
+        let end = total_completed.saturating_sub(frame.scroll_offset);
+        let start = end.saturating_sub(layout.scrollback_height);
+        let visible = &frame.completed_rows[start..end];
+
+        for (i, row) in visible.iter().enumerate() {
+            queue!(stdout, cursor::MoveTo(0, i as u16))?;
+            render_cell_row(&mut stdout, row, cols)?;
+        }
+
+        // Blank any remaining scrollback lines
+        let rendered = visible.len();
+        for i in rendered..layout.scrollback_height {
+            queue!(stdout, cursor::MoveTo(0, i as u16))?;
+            render_blank_row(&mut stdout, cols)?;
+        }
+    } else {
+        for i in 0..layout.scrollback_height {
+            queue!(stdout, cursor::MoveTo(0, i as u16))?;
+            render_blank_row(&mut stdout, cols)?;
+        }
+    }
+
+    // --- Active block region ---
+    let active_start_row = layout.scrollback_height as u16;
+    let grid_offset = frame
+        .active_grid
+        .len()
+        .saturating_sub(layout.active_height);
+    for i in 0..layout.active_height {
+        let screen_row = active_start_row + i as u16;
+        queue!(stdout, cursor::MoveTo(0, screen_row))?;
+        let grid_row_idx = grid_offset + i;
+        if grid_row_idx < frame.active_grid.len() {
+            render_cell_row(&mut stdout, &frame.active_grid[grid_row_idx], cols)?;
+        } else {
+            render_blank_row(&mut stdout, cols)?;
+        }
+    }
+
+    // --- Agent input line ---
+    if let (Some(input_row), Some((buf, cursor_pos))) =
+        (layout.agent_input_row, frame.agent_input)
+    {
+        queue!(stdout, cursor::MoveTo(0, input_row))?;
+        render_agent_input(&mut stdout, buf, cursor_pos, cols)?;
+    }
+
+    // --- Status bar ---
+    queue!(stdout, cursor::MoveTo(0, layout.status_bar_row))?;
+    render_status_bar_row(&mut stdout, &frame.status_bar, cols)?;
+
+    // --- Cursor ---
+    if frame.show_cursor {
+        let (cursor_grid_row, cursor_col) = frame.active_cursor;
+        let screen_cursor_row =
+            active_start_row + cursor_grid_row.saturating_sub(grid_offset) as u16;
+        queue!(
+            stdout,
+            cursor::MoveTo(cursor_col as u16, screen_cursor_row),
+            cursor::Show,
+        )?;
+    } else {
+        queue!(stdout, cursor::Hide)?;
+    }
+
+    // Reset style at the end to avoid bleeding
+    queue!(
+        stdout,
+        SetAttribute(Attribute::Reset),
+    )?;
+
+    stdout.flush()?;
+    Ok(())
+}
+
+fn cell_fg(color: Color) -> CtColor {
+    match color {
+        Color::Default => CtColor::Reset,
+        Color::Indexed(i) => CtColor::AnsiValue(i),
+        Color::Rgb(r, g, b) => CtColor::Rgb { r, g, b },
+    }
+}
+
+fn cell_bg(color: Color) -> CtColor {
+    match color {
+        Color::Default => CtColor::Reset,
+        Color::Indexed(i) => CtColor::AnsiValue(i),
+        Color::Rgb(r, g, b) => CtColor::Rgb { r, g, b },
+    }
+}
+
+fn render_cell_row(stdout: &mut io::Stdout, row: &[Cell], cols: usize) -> anyhow::Result<()> {
+    let mut prev_attr: Option<CellAttr> = None;
+
+    for (i, cell) in row.iter().enumerate().take(cols) {
+        if prev_attr != Some(cell.attr) {
+            apply_cell_attr(stdout, &cell.attr)?;
+            prev_attr = Some(cell.attr);
+        }
+        if i == 0 && prev_attr.is_none() {
+            apply_cell_attr(stdout, &cell.attr)?;
+            prev_attr = Some(cell.attr);
+        }
+        queue!(stdout, Print(cell.ch))?;
+    }
+
+    // Fill remaining columns with spaces
+    let rendered = row.len().min(cols);
+    if rendered < cols {
+        queue!(
+            stdout,
+            SetAttribute(Attribute::Reset),
+            SetForegroundColor(CtColor::Reset),
+            SetBackgroundColor(CtColor::Reset),
+        )?;
+        for _ in rendered..cols {
+            queue!(stdout, Print(' '))?;
+        }
+        prev_attr = None;
+    }
+
+    if prev_attr.is_some() {
+        queue!(stdout, SetAttribute(Attribute::Reset))?;
+    }
+
+    Ok(())
+}
+
+fn apply_cell_attr(stdout: &mut io::Stdout, attr: &CellAttr) -> anyhow::Result<()> {
+    queue!(stdout, SetAttribute(Attribute::Reset))?;
+
+    let (fg, bg) = if attr.flags.contains(CellFlags::INVERSE) {
+        (attr.bg, attr.fg)
+    } else {
+        (attr.fg, attr.bg)
+    };
+
+    queue!(
+        stdout,
+        SetForegroundColor(cell_fg(fg)),
+        SetBackgroundColor(cell_bg(bg)),
+    )?;
+
+    if attr.flags.contains(CellFlags::BOLD) {
+        queue!(stdout, SetAttribute(Attribute::Bold))?;
+    }
+    if attr.flags.contains(CellFlags::DIM) {
+        queue!(stdout, SetAttribute(Attribute::Dim))?;
+    }
+    if attr.flags.contains(CellFlags::ITALIC) {
+        queue!(stdout, SetAttribute(Attribute::Italic))?;
+    }
+    if attr.flags.contains(CellFlags::UNDERLINE) {
+        queue!(stdout, SetAttribute(Attribute::Underlined))?;
+    }
+    if attr.flags.contains(CellFlags::HIDDEN) {
+        queue!(stdout, SetAttribute(Attribute::Hidden))?;
+    }
+
+    Ok(())
+}
+
+fn render_blank_row(stdout: &mut io::Stdout, cols: usize) -> anyhow::Result<()> {
+    queue!(
+        stdout,
+        SetAttribute(Attribute::Reset),
+        SetForegroundColor(CtColor::Reset),
+        SetBackgroundColor(CtColor::Reset),
+    )?;
+    for _ in 0..cols {
+        queue!(stdout, Print(' '))?;
+    }
+    Ok(())
+}
+
+fn render_agent_input(
+    stdout: &mut io::Stdout,
+    buf: &str,
+    cursor_pos: usize,
+    cols: usize,
+) -> anyhow::Result<()> {
+    queue!(stdout, SetAttribute(Attribute::Reset))?;
+
+    let prefix = "🤖 > ";
+    let prefix_display_width = 5; // emoji(2) + space + > + space
+
+    queue!(stdout, SetAttribute(Attribute::Bold), Print(prefix), SetAttribute(Attribute::Reset))?;
+
+    let before: String = buf.chars().take(cursor_pos).collect();
+    queue!(stdout, Print(&before))?;
+
+    let cursor_char = buf.chars().nth(cursor_pos).unwrap_or(' ');
+    queue!(
+        stdout,
+        SetAttribute(Attribute::Reverse),
+        Print(cursor_char),
+        SetAttribute(Attribute::Reset),
+    )?;
+
+    let after: String = buf.chars().skip(cursor_pos + 1).collect();
+    if !after.is_empty() {
+        queue!(stdout, Print(&after))?;
+    }
+
+    // Pad to fill width
+    let used = prefix_display_width + buf.chars().count().max(cursor_pos + 1);
+    if used < cols {
+        for _ in used..cols {
+            queue!(stdout, Print(' '))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn format_status_bar_content(mode: &str, model: &str, hint: &str, width: usize) -> String {
+    let left = format!(" {mode} │ {model}");
+    let right = format!("{hint} ");
+
+    let left_len = left.chars().count();
+    let right_len = right.chars().count();
+    let gap = width.saturating_sub(left_len + right_len);
+
+    let mut bar = String::with_capacity(width);
+    bar.push_str(&left);
+    for _ in 0..gap {
+        bar.push(' ');
+    }
+    bar.push_str(&right);
+    bar
+}
+
+fn render_status_bar_row(
+    stdout: &mut io::Stdout,
+    sb: &StatusBar<'_>,
+    cols: usize,
+) -> anyhow::Result<()> {
+    let content = format_status_bar_content(sb.mode, sb.model, sb.hint, cols);
+    queue!(
+        stdout,
+        SetAttribute(Attribute::Reset),
+        SetAttribute(Attribute::Reverse),
+        Print(&content),
+        SetAttribute(Attribute::Reset),
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(ch: char) -> Cell {
+        Cell::with_char(ch, CellAttr::default())
+    }
+
+    fn make_row(s: &str) -> Vec<Cell> {
+        s.chars().map(|c| cell(c)).collect()
+    }
+
+    // -- Layout tests --
+
+    #[test]
+    fn layout_basic_no_agent_input() {
+        let active_grid: Vec<Vec<Cell>> = vec![make_row("hello"); 5];
+        let completed: Vec<Vec<Cell>> = vec![make_row("done"); 10];
+        let frame = Frame {
+            completed_rows: &completed,
+            active_grid: &active_grid,
+            active_cursor: (0, 0),
+            status_bar: StatusBar {
+                mode: "SHELL",
+                model: "",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: None,
+            total_rows: 24,
+            total_cols: 80,
+            show_cursor: true,
+        };
+        let layout = compute_layout(&frame);
+        // usable = 24 - 1 = 23, active = min(5, 23) = 5, scrollback = 18
+        assert_eq!(layout.active_height, 5);
+        assert_eq!(layout.scrollback_height, 18);
+        assert_eq!(layout.status_bar_row, 23);
+        assert!(layout.agent_input_row.is_none());
+    }
+
+    #[test]
+    fn layout_with_agent_input() {
+        let active_grid: Vec<Vec<Cell>> = vec![make_row("x"); 3];
+        let frame = Frame {
+            completed_rows: &[],
+            active_grid: &active_grid,
+            active_cursor: (0, 0),
+            status_bar: StatusBar {
+                mode: "AGENT",
+                model: "gpt-4",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: Some(("hello", 5)),
+            total_rows: 24,
+            total_cols: 80,
+            show_cursor: true,
+        };
+        let layout = compute_layout(&frame);
+        // usable = 24 - 1 - 1 = 22, active = min(3, 22) = 3, scrollback = 19
+        assert_eq!(layout.active_height, 3);
+        assert_eq!(layout.scrollback_height, 19);
+        assert_eq!(layout.agent_input_row, Some(22));
+        assert_eq!(layout.status_bar_row, 23);
+    }
+
+    #[test]
+    fn layout_active_grid_larger_than_usable() {
+        let active_grid: Vec<Vec<Cell>> = vec![make_row("y"); 100];
+        let frame = Frame {
+            completed_rows: &[],
+            active_grid: &active_grid,
+            active_cursor: (0, 0),
+            status_bar: StatusBar {
+                mode: "SHELL",
+                model: "",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: None,
+            total_rows: 10,
+            total_cols: 80,
+            show_cursor: true,
+        };
+        let layout = compute_layout(&frame);
+        // usable = 9, active = min(100, 9) = 9, scrollback = 0
+        assert_eq!(layout.active_height, 9);
+        assert_eq!(layout.scrollback_height, 0);
+    }
+
+    #[test]
+    fn layout_empty_everything() {
+        let frame = Frame {
+            completed_rows: &[],
+            active_grid: &[],
+            active_cursor: (0, 0),
+            status_bar: StatusBar {
+                mode: "",
+                model: "",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: None,
+            total_rows: 24,
+            total_cols: 80,
+            show_cursor: false,
+        };
+        let layout = compute_layout(&frame);
+        assert_eq!(layout.active_height, 0);
+        assert_eq!(layout.scrollback_height, 23);
+    }
+
+    #[test]
+    fn layout_tiny_terminal() {
+        let active_grid: Vec<Vec<Cell>> = vec![make_row("a"); 2];
+        let frame = Frame {
+            completed_rows: &[],
+            active_grid: &active_grid,
+            active_cursor: (0, 0),
+            status_bar: StatusBar {
+                mode: "S",
+                model: "",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: Some(("", 0)),
+            total_rows: 3,
+            total_cols: 40,
+            show_cursor: true,
+        };
+        let layout = compute_layout(&frame);
+        // usable = 3 - 1 - 1 = 1, active = min(2, 1) = 1
+        assert_eq!(layout.active_height, 1);
+        assert_eq!(layout.scrollback_height, 0);
+    }
+
+    // -- Color conversion tests --
+
+    #[test]
+    fn color_default_maps_to_reset() {
+        assert_eq!(cell_fg(Color::Default), CtColor::Reset);
+        assert_eq!(cell_bg(Color::Default), CtColor::Reset);
+    }
+
+    #[test]
+    fn color_indexed_maps_to_ansi_value() {
+        assert_eq!(cell_fg(Color::Indexed(196)), CtColor::AnsiValue(196));
+    }
+
+    #[test]
+    fn color_rgb_maps_correctly() {
+        assert_eq!(
+            cell_fg(Color::Rgb(10, 20, 30)),
+            CtColor::Rgb {
+                r: 10,
+                g: 20,
+                b: 30
+            }
+        );
+    }
+
+    // -- Status bar formatting tests --
+
+    #[test]
+    fn status_bar_format_basic() {
+        let content = format_status_bar_content("AGENT", "gpt-4", "Ctrl+C cancel", 60);
+        assert_eq!(content.chars().count(), 60);
+        assert!(content.starts_with(" AGENT │ gpt-4"));
+        assert!(content.ends_with("Ctrl+C cancel "));
+    }
+
+    #[test]
+    fn status_bar_format_narrow() {
+        let content = format_status_bar_content("S", "m", "h", 10);
+        // left = " S │ m" (6), right = "h " (2), gap = 2
+        assert_eq!(content.chars().count(), 10);
+    }
+
+    #[test]
+    fn status_bar_format_overflow() {
+        let content = format_status_bar_content("AGENT", "some-long-model-name", "hint", 10);
+        // When content overflows, gap saturates to 0, total exceeds width
+        // (no truncation in prototype)
+        assert!(content.contains("AGENT"));
+        assert!(content.contains("some-long-model-name"));
+    }
+
+    #[test]
+    fn status_bar_format_wide() {
+        let content = format_status_bar_content("SHELL", "claude", "q: quit", 120);
+        assert_eq!(content.chars().count(), 120);
+    }
+}

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -18,6 +18,7 @@ pub struct StatusBar<'a> {
 
 pub struct Frame<'a> {
     pub completed_rows: &'a [Vec<Cell>],
+    pub streaming_rows: &'a [Vec<Cell>],
     pub active_grid: &'a [Vec<Cell>],
     pub active_cursor: (usize, usize),
     pub status_bar: StatusBar<'a>,
@@ -105,7 +106,17 @@ pub fn render(frame: &Frame) -> anyhow::Result<()> {
         }
     }
 
-    // --- Active block region (immediately after scrollback) ---
+    // --- Streaming rows (ephemeral agent text, after scrollback) ---
+    for streaming_row in frame.streaming_rows {
+        if next_row >= layout.status_bar_row {
+            break;
+        }
+        queue!(stdout, cursor::MoveTo(0, next_row))?;
+        render_cell_row(&mut stdout, streaming_row, cols)?;
+        next_row += 1;
+    }
+
+    // --- Active block region (immediately after streaming) ---
     let active_start_row = next_row;
     let grid_offset = (frame.active_cursor.0 + 1).saturating_sub(layout.active_height);
     for i in 0..layout.active_height {
@@ -384,6 +395,7 @@ mod tests {
         let completed: Vec<Vec<Cell>> = vec![make_row("done"); 10];
         let frame = Frame {
             completed_rows: &completed,
+            streaming_rows: &[],
             active_grid: &active_grid,
             active_cursor: (0, 0),
             status_bar: StatusBar {
@@ -409,6 +421,7 @@ mod tests {
         let active_grid: Vec<Vec<Cell>> = vec![make_row("x"); 3];
         let frame = Frame {
             completed_rows: &[],
+            streaming_rows: &[],
             active_grid: &active_grid,
             active_cursor: (0, 0),
             status_bar: StatusBar {
@@ -434,6 +447,7 @@ mod tests {
         let active_grid: Vec<Vec<Cell>> = vec![make_row("y"); 100];
         let frame = Frame {
             completed_rows: &[],
+            streaming_rows: &[],
             active_grid: &active_grid,
             active_cursor: (0, 0),
             status_bar: StatusBar {
@@ -457,6 +471,7 @@ mod tests {
     fn layout_empty_everything() {
         let frame = Frame {
             completed_rows: &[],
+            streaming_rows: &[],
             active_grid: &[],
             active_cursor: (0, 0),
             status_bar: StatusBar {
@@ -481,6 +496,7 @@ mod tests {
         let active_grid: Vec<Vec<Cell>> = vec![make_row("a"); 2];
         let frame = Frame {
             completed_rows: &[],
+            streaming_rows: &[],
             active_grid: &active_grid,
             active_cursor: (0, 0),
             status_bar: StatusBar {
@@ -504,6 +520,7 @@ mod tests {
     fn layout_with_agent_status() {
         let frame = Frame {
             completed_rows: &[],
+            streaming_rows: &[],
             active_grid: &[],
             active_cursor: (0, 0),
             status_bar: StatusBar {

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -134,10 +134,7 @@ pub fn render(frame: &Frame) -> anyhow::Result<()> {
 
     // --- Active block region ---
     let active_start_row = layout.scrollback_height as u16;
-    let grid_offset = frame
-        .active_grid
-        .len()
-        .saturating_sub(layout.active_height);
+    let grid_offset = (frame.active_cursor.0 + 1).saturating_sub(layout.active_height);
     for i in 0..layout.active_height {
         let screen_row = active_start_row + i as u16;
         queue!(stdout, cursor::MoveTo(0, screen_row))?;

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -68,7 +68,10 @@ fn compute_layout(frame: &Frame) -> Layout {
         + if has_status { 1 } else { 0 };
     let usable = total.saturating_sub(reserved);
 
-    let active_height = frame.active_grid.len().min(usable);
+    // Dynamic active block height: show rows up to cursor + 1 (minimum 1 row for
+    // the prompt), not the full grid. This leaves room for scrollback.
+    let content_height = (frame.active_cursor.0 + 1).max(1);
+    let active_height = content_height.min(usable);
     let scrollback_height = usable.saturating_sub(active_height);
 
     // Layout from bottom: status_bar, then agent_input, then agent_status,
@@ -419,9 +422,9 @@ mod tests {
             show_cursor: true,
         };
         let layout = compute_layout(&frame);
-        // usable = 24 - 1 = 23, active = min(5, 23) = 5, scrollback = 18
-        assert_eq!(layout.active_height, 5);
-        assert_eq!(layout.scrollback_height, 18);
+        // cursor at (0,0) → content_height = 1, usable = 23
+        assert_eq!(layout.active_height, 1);
+        assert_eq!(layout.scrollback_height, 22);
         assert_eq!(layout.status_bar_row, 23);
         assert!(layout.agent_input_row.is_none());
     }
@@ -445,9 +448,9 @@ mod tests {
             show_cursor: true,
         };
         let layout = compute_layout(&frame);
-        // usable = 24 - 1 - 1 = 22, active = min(3, 22) = 3, scrollback = 19
-        assert_eq!(layout.active_height, 3);
-        assert_eq!(layout.scrollback_height, 19);
+        // cursor at (0,0) → content_height = 1, usable = 22
+        assert_eq!(layout.active_height, 1);
+        assert_eq!(layout.scrollback_height, 21);
         assert_eq!(layout.agent_input_row, Some(22));
         assert_eq!(layout.status_bar_row, 23);
     }
@@ -471,9 +474,9 @@ mod tests {
             show_cursor: true,
         };
         let layout = compute_layout(&frame);
-        // usable = 9, active = min(100, 9) = 9, scrollback = 0
-        assert_eq!(layout.active_height, 9);
-        assert_eq!(layout.scrollback_height, 0);
+        // cursor at (0,0) → content_height = 1, usable = 9
+        assert_eq!(layout.active_height, 1);
+        assert_eq!(layout.scrollback_height, 8);
     }
 
     #[test]
@@ -494,8 +497,9 @@ mod tests {
             show_cursor: false,
         };
         let layout = compute_layout(&frame);
-        assert_eq!(layout.active_height, 0);
-        assert_eq!(layout.scrollback_height, 23);
+        // cursor at (0,0) → content_height = 1, usable = 23
+        assert_eq!(layout.active_height, 1);
+        assert_eq!(layout.scrollback_height, 22);
     }
 
     #[test]

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 
 use crossterm::cursor;
 use crossterm::execute;
@@ -6,7 +6,7 @@ use crossterm::queue;
 use crossterm::style::{
     Attribute, Color as CtColor, Print, SetAttribute, SetBackgroundColor, SetForegroundColor,
 };
-use crossterm::terminal::{self, ClearType};
+use crossterm::terminal;
 
 use crate::cell::{Cell, CellAttr, CellFlags, Color};
 
@@ -86,11 +86,9 @@ fn compute_layout(frame: &Frame) -> Layout {
 }
 
 pub fn render(frame: &Frame) -> anyhow::Result<()> {
-    let mut stdout = io::stdout();
+    let mut stdout = BufWriter::with_capacity(65536, io::stdout().lock());
     let layout = compute_layout(frame);
     let cols = frame.total_cols as usize;
-
-    queue!(stdout, terminal::Clear(ClearType::All))?;
 
     // --- Scrollback region (pinned to top) ---
     let mut next_row: u16 = 0;
@@ -133,6 +131,14 @@ pub fn render(frame: &Frame) -> anyhow::Result<()> {
     if let Some((buf, cursor_pos)) = frame.agent_input {
         queue!(stdout, cursor::MoveTo(0, next_row))?;
         render_agent_input(&mut stdout, buf, cursor_pos, cols)?;
+        next_row += 1;
+    }
+
+    // --- Blank stale rows between content and status bar ---
+    while next_row < layout.status_bar_row {
+        queue!(stdout, cursor::MoveTo(0, next_row))?;
+        render_blank_row(&mut stdout, cols)?;
+        next_row += 1;
     }
 
     // --- Status bar ---
@@ -179,7 +185,7 @@ fn cell_bg(color: Color) -> CtColor {
     }
 }
 
-fn render_cell_row(stdout: &mut io::Stdout, row: &[Cell], cols: usize) -> anyhow::Result<()> {
+fn render_cell_row(stdout: &mut impl Write, row: &[Cell], cols: usize) -> anyhow::Result<()> {
     let mut prev_attr: Option<CellAttr> = None;
 
     for (i, cell) in row.iter().enumerate().take(cols) {
@@ -216,7 +222,7 @@ fn render_cell_row(stdout: &mut io::Stdout, row: &[Cell], cols: usize) -> anyhow
     Ok(())
 }
 
-fn apply_cell_attr(stdout: &mut io::Stdout, attr: &CellAttr) -> anyhow::Result<()> {
+fn apply_cell_attr(stdout: &mut impl Write, attr: &CellAttr) -> anyhow::Result<()> {
     queue!(stdout, SetAttribute(Attribute::Reset))?;
 
     let (fg, bg) = if attr.flags.contains(CellFlags::INVERSE) {
@@ -250,7 +256,7 @@ fn apply_cell_attr(stdout: &mut io::Stdout, attr: &CellAttr) -> anyhow::Result<(
     Ok(())
 }
 
-fn render_blank_row(stdout: &mut io::Stdout, cols: usize) -> anyhow::Result<()> {
+fn render_blank_row(stdout: &mut impl Write, cols: usize) -> anyhow::Result<()> {
     queue!(
         stdout,
         SetAttribute(Attribute::Reset),
@@ -264,7 +270,7 @@ fn render_blank_row(stdout: &mut io::Stdout, cols: usize) -> anyhow::Result<()> 
 }
 
 fn render_agent_status(
-    stdout: &mut io::Stdout,
+    stdout: &mut impl Write,
     text: &str,
     cols: usize,
 ) -> anyhow::Result<()> {
@@ -286,7 +292,7 @@ fn render_agent_status(
 }
 
 fn render_agent_input(
-    stdout: &mut io::Stdout,
+    stdout: &mut impl Write,
     buf: &str,
     cursor_pos: usize,
     cols: usize,
@@ -343,7 +349,7 @@ fn format_status_bar_content(mode: &str, model: &str, hint: &str, width: usize) 
 }
 
 fn render_status_bar_row(
-    stdout: &mut io::Stdout,
+    stdout: &mut impl Write,
     sb: &StatusBar<'_>,
     cols: usize,
 ) -> anyhow::Result<()> {

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -63,30 +63,33 @@ fn compute_layout(frame: &Frame) -> Layout {
     let total = frame.total_rows as usize;
     let has_input = frame.agent_input.is_some();
     let has_status = frame.agent_status.is_some();
+    let hide_active = has_input || has_status;
+
     let reserved = 1
         + if has_input { 1 } else { 0 }
         + if has_status { 1 } else { 0 };
     let usable = total.saturating_sub(reserved);
 
-    // Dynamic active block height: show rows up to cursor + 1 (minimum 1 row for
-    // the prompt), not the full grid. This leaves room for scrollback.
-    let content_height = (frame.active_cursor.0 + 1).max(1);
-    let active_height = content_height.min(usable);
+    let active_height = if hide_active {
+        0
+    } else {
+        let content_height = (frame.active_cursor.0 + 1).max(1);
+        content_height.min(usable)
+    };
     let scrollback_height = usable.saturating_sub(active_height);
 
-    // Layout from bottom: status_bar, then agent_input, then agent_status,
-    // then active block, then scrollback.
     let status_bar_row = (total - 1) as u16;
-    let mut next_row = total - 2;
-    let agent_input_row = if has_input {
-        let row = next_row as u16;
-        next_row = next_row.saturating_sub(1);
-        Some(row)
+
+    // Agent status/input render inline, immediately after scrollback.
+    let after_content = scrollback_height + active_height;
+    let agent_status_row = if has_status {
+        Some(after_content as u16)
     } else {
         None
     };
-    let agent_status_row = if has_status {
-        Some(next_row as u16)
+    let agent_input_row = if has_input {
+        let row = after_content + if has_status { 1 } else { 0 };
+        Some(row as u16)
     } else {
         None
     };
@@ -432,12 +435,13 @@ mod tests {
             agent_input: Some(("hello", 5)), agent_status: None,
             total_rows: 24,
             total_cols: 80,
-            show_cursor: true,
+            show_cursor: false,
         };
         let layout = compute_layout(&frame);
-        // cursor at (0,0) → content_height = 1, usable = 22
-        assert_eq!(layout.active_height, 1);
-        assert_eq!(layout.scrollback_height, 21);
+        // active hidden when agent_input present; usable = 22, all scrollback
+        assert_eq!(layout.active_height, 0);
+        assert_eq!(layout.scrollback_height, 22);
+        // agent_input inline right after scrollback
         assert_eq!(layout.agent_input_row, Some(22));
         assert_eq!(layout.status_bar_row, 23);
     }
@@ -505,12 +509,40 @@ mod tests {
             agent_input: Some(("", 0)), agent_status: None,
             total_rows: 3,
             total_cols: 40,
-            show_cursor: true,
+            show_cursor: false,
         };
         let layout = compute_layout(&frame);
-        // usable = 3 - 1 - 1 = 1, active = min(2, 1) = 1
-        assert_eq!(layout.active_height, 1);
-        assert_eq!(layout.scrollback_height, 0);
+        // usable = 3 - 1(status) - 1(input) = 1, active hidden
+        assert_eq!(layout.active_height, 0);
+        assert_eq!(layout.scrollback_height, 1);
+        assert_eq!(layout.agent_input_row, Some(1));
+    }
+
+    #[test]
+    fn layout_with_agent_status() {
+        let frame = Frame {
+            completed_rows: &[],
+            active_grid: &[],
+            active_cursor: (0, 0),
+            status_bar: StatusBar {
+                mode: "AGENT",
+                model: "warp",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: None,
+            agent_status: Some("⠋ working..."),
+            total_rows: 24,
+            total_cols: 80,
+            show_cursor: false,
+        };
+        let layout = compute_layout(&frame);
+        // active hidden; usable = 22, all scrollback
+        assert_eq!(layout.active_height, 0);
+        assert_eq!(layout.scrollback_height, 22);
+        assert_eq!(layout.agent_status_row, Some(22));
+        assert!(layout.agent_input_row.is_none());
+        assert_eq!(layout.status_bar_row, 23);
     }
 
     // -- Color conversion tests --

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -107,33 +107,23 @@ pub fn render(frame: &Frame) -> anyhow::Result<()> {
 
     queue!(stdout, terminal::Clear(ClearType::All))?;
 
-    // --- Scrollback region ---
+    // --- Scrollback region (pinned to top) ---
+    let mut next_row: u16 = 0;
     if layout.scrollback_height > 0 && !frame.completed_rows.is_empty() {
         let total_completed = frame.completed_rows.len();
         let end = total_completed.saturating_sub(frame.scroll_offset);
         let start = end.saturating_sub(layout.scrollback_height);
         let visible = &frame.completed_rows[start..end];
 
-        for (i, row) in visible.iter().enumerate() {
-            queue!(stdout, cursor::MoveTo(0, i as u16))?;
+        for row in visible {
+            queue!(stdout, cursor::MoveTo(0, next_row))?;
             render_cell_row(&mut stdout, row, cols)?;
-        }
-
-        // Blank any remaining scrollback lines
-        let rendered = visible.len();
-        for i in rendered..layout.scrollback_height {
-            queue!(stdout, cursor::MoveTo(0, i as u16))?;
-            render_blank_row(&mut stdout, cols)?;
-        }
-    } else {
-        for i in 0..layout.scrollback_height {
-            queue!(stdout, cursor::MoveTo(0, i as u16))?;
-            render_blank_row(&mut stdout, cols)?;
+            next_row += 1;
         }
     }
 
-    // --- Active block region ---
-    let active_start_row = layout.scrollback_height as u16;
+    // --- Active block region (immediately after scrollback) ---
+    let active_start_row = next_row;
     let grid_offset = (frame.active_cursor.0 + 1).saturating_sub(layout.active_height);
     for i in 0..layout.active_height {
         let screen_row = active_start_row + i as u16;

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -23,6 +23,7 @@ pub struct Frame<'a> {
     pub status_bar: StatusBar<'a>,
     pub scroll_offset: usize,
     pub agent_input: Option<(&'a str, usize)>,
+    pub agent_status: Option<&'a str>,
     pub total_rows: u16,
     pub total_cols: u16,
     pub show_cursor: bool,
@@ -54,29 +55,44 @@ struct Layout {
     scrollback_height: usize,
     active_height: usize,
     agent_input_row: Option<u16>,
+    agent_status_row: Option<u16>,
     status_bar_row: u16,
 }
 
 fn compute_layout(frame: &Frame) -> Layout {
     let total = frame.total_rows as usize;
     let has_input = frame.agent_input.is_some();
-    let reserved = 1 + if has_input { 1 } else { 0 };
+    let has_status = frame.agent_status.is_some();
+    let reserved = 1
+        + if has_input { 1 } else { 0 }
+        + if has_status { 1 } else { 0 };
     let usable = total.saturating_sub(reserved);
 
     let active_height = frame.active_grid.len().min(usable);
     let scrollback_height = usable.saturating_sub(active_height);
 
+    // Layout from bottom: status_bar, then agent_input, then agent_status,
+    // then active block, then scrollback.
+    let status_bar_row = (total - 1) as u16;
+    let mut next_row = total - 2;
     let agent_input_row = if has_input {
-        Some((total - 2) as u16)
+        let row = next_row as u16;
+        next_row = next_row.saturating_sub(1);
+        Some(row)
     } else {
         None
     };
-    let status_bar_row = (total - 1) as u16;
+    let agent_status_row = if has_status {
+        Some(next_row as u16)
+    } else {
+        None
+    };
 
     Layout {
         scrollback_height,
         active_height,
         agent_input_row,
+        agent_status_row,
         status_bar_row,
     }
 }
@@ -128,6 +144,14 @@ pub fn render(frame: &Frame) -> anyhow::Result<()> {
         } else {
             render_blank_row(&mut stdout, cols)?;
         }
+    }
+
+    // --- Agent status (ephemeral) ---
+    if let (Some(status_row), Some(status_text)) =
+        (layout.agent_status_row, frame.agent_status)
+    {
+        queue!(stdout, cursor::MoveTo(0, status_row))?;
+        render_agent_status(&mut stdout, status_text, cols)?;
     }
 
     // --- Agent input line ---
@@ -266,6 +290,28 @@ fn render_blank_row(stdout: &mut io::Stdout, cols: usize) -> anyhow::Result<()> 
     Ok(())
 }
 
+fn render_agent_status(
+    stdout: &mut io::Stdout,
+    text: &str,
+    cols: usize,
+) -> anyhow::Result<()> {
+    queue!(
+        stdout,
+        SetAttribute(Attribute::Reset),
+        SetAttribute(Attribute::Dim),
+        SetForegroundColor(CtColor::AnsiValue(5)), // magenta
+        Print(text),
+    )?;
+    let used = text.chars().count();
+    if used < cols {
+        for _ in used..cols {
+            queue!(stdout, Print(' '))?;
+        }
+    }
+    queue!(stdout, SetAttribute(Attribute::Reset))?;
+    Ok(())
+}
+
 fn render_agent_input(
     stdout: &mut io::Stdout,
     buf: &str,
@@ -367,7 +413,7 @@ mod tests {
                 hint: "",
             },
             scroll_offset: 0,
-            agent_input: None,
+            agent_input: None, agent_status: None,
             total_rows: 24,
             total_cols: 80,
             show_cursor: true,
@@ -393,7 +439,7 @@ mod tests {
                 hint: "",
             },
             scroll_offset: 0,
-            agent_input: Some(("hello", 5)),
+            agent_input: Some(("hello", 5)), agent_status: None,
             total_rows: 24,
             total_cols: 80,
             show_cursor: true,
@@ -419,7 +465,7 @@ mod tests {
                 hint: "",
             },
             scroll_offset: 0,
-            agent_input: None,
+            agent_input: None, agent_status: None,
             total_rows: 10,
             total_cols: 80,
             show_cursor: true,
@@ -442,7 +488,7 @@ mod tests {
                 hint: "",
             },
             scroll_offset: 0,
-            agent_input: None,
+            agent_input: None, agent_status: None,
             total_rows: 24,
             total_cols: 80,
             show_cursor: false,
@@ -465,7 +511,7 @@ mod tests {
                 hint: "",
             },
             scroll_offset: 0,
-            agent_input: Some(("", 0)),
+            agent_input: Some(("", 0)), agent_status: None,
             total_rows: 3,
             total_cols: 40,
             show_cursor: true,

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -54,8 +54,6 @@ pub fn leave_alt_screen() -> anyhow::Result<()> {
 struct Layout {
     scrollback_height: usize,
     active_height: usize,
-    agent_input_row: Option<u16>,
-    agent_status_row: Option<u16>,
     status_bar_row: u16,
 }
 
@@ -80,25 +78,9 @@ fn compute_layout(frame: &Frame) -> Layout {
 
     let status_bar_row = (total - 1) as u16;
 
-    // Agent status/input render inline, immediately after scrollback.
-    let after_content = scrollback_height + active_height;
-    let agent_status_row = if has_status {
-        Some(after_content as u16)
-    } else {
-        None
-    };
-    let agent_input_row = if has_input {
-        let row = after_content + if has_status { 1 } else { 0 };
-        Some(row as u16)
-    } else {
-        None
-    };
-
     Layout {
         scrollback_height,
         active_height,
-        agent_input_row,
-        agent_status_row,
         status_bar_row,
     }
 }
@@ -137,21 +119,19 @@ pub fn render(frame: &Frame) -> anyhow::Result<()> {
         } else {
             render_blank_row(&mut stdout, cols)?;
         }
+        next_row += 1;
     }
 
-    // --- Agent status (ephemeral) ---
-    if let (Some(status_row), Some(status_text)) =
-        (layout.agent_status_row, frame.agent_status)
-    {
-        queue!(stdout, cursor::MoveTo(0, status_row))?;
+    // --- Agent status (ephemeral, inline after content) ---
+    if let Some(status_text) = frame.agent_status {
+        queue!(stdout, cursor::MoveTo(0, next_row))?;
         render_agent_status(&mut stdout, status_text, cols)?;
+        next_row += 1;
     }
 
-    // --- Agent input line ---
-    if let (Some(input_row), Some((buf, cursor_pos))) =
-        (layout.agent_input_row, frame.agent_input)
-    {
-        queue!(stdout, cursor::MoveTo(0, input_row))?;
+    // --- Agent input line (inline after content) ---
+    if let Some((buf, cursor_pos)) = frame.agent_input {
+        queue!(stdout, cursor::MoveTo(0, next_row))?;
         render_agent_input(&mut stdout, buf, cursor_pos, cols)?;
     }
 
@@ -416,7 +396,6 @@ mod tests {
         assert_eq!(layout.active_height, 1);
         assert_eq!(layout.scrollback_height, 22);
         assert_eq!(layout.status_bar_row, 23);
-        assert!(layout.agent_input_row.is_none());
     }
 
     #[test]
@@ -441,8 +420,6 @@ mod tests {
         // active hidden when agent_input present; usable = 22, all scrollback
         assert_eq!(layout.active_height, 0);
         assert_eq!(layout.scrollback_height, 22);
-        // agent_input inline right after scrollback
-        assert_eq!(layout.agent_input_row, Some(22));
         assert_eq!(layout.status_bar_row, 23);
     }
 
@@ -515,7 +492,6 @@ mod tests {
         // usable = 3 - 1(status) - 1(input) = 1, active hidden
         assert_eq!(layout.active_height, 0);
         assert_eq!(layout.scrollback_height, 1);
-        assert_eq!(layout.agent_input_row, Some(1));
     }
 
     #[test]
@@ -540,8 +516,6 @@ mod tests {
         // active hidden; usable = 22, all scrollback
         assert_eq!(layout.active_height, 0);
         assert_eq!(layout.scrollback_height, 22);
-        assert_eq!(layout.agent_status_row, Some(22));
-        assert!(layout.agent_input_row.is_none());
         assert_eq!(layout.status_bar_row, 23);
     }
 

--- a/crates/wsh/src/screen.rs
+++ b/crates/wsh/src/screen.rs
@@ -10,6 +10,16 @@ use crossterm::terminal;
 
 use crate::cell::{Cell, CellAttr, CellFlags, Color};
 
+fn last_non_blank_row(grid: &[Vec<Cell>]) -> Option<usize> {
+    let blank = Cell::default();
+    for (i, row) in grid.iter().enumerate().rev() {
+        if row.iter().any(|c| *c != blank) {
+            return Some(i);
+        }
+    }
+    None
+}
+
 pub struct StatusBar<'a> {
     pub mode: &'a str,
     pub model: &'a str,
@@ -72,7 +82,11 @@ fn compute_layout(frame: &Frame) -> Layout {
     let active_height = if hide_active {
         0
     } else {
-        let content_height = (frame.active_cursor.0 + 1).max(1);
+        let cursor_height = frame.active_cursor.0 + 1;
+        let grid_content_height = last_non_blank_row(frame.active_grid)
+            .map(|r| r + 1)
+            .unwrap_or(0);
+        let content_height = cursor_height.max(grid_content_height).max(1);
         content_height.min(usable)
     };
     let scrollback_height = usable.saturating_sub(active_height);
@@ -410,9 +424,9 @@ mod tests {
             show_cursor: true,
         };
         let layout = compute_layout(&frame);
-        // cursor at (0,0) → content_height = 1, usable = 23
-        assert_eq!(layout.active_height, 1);
-        assert_eq!(layout.scrollback_height, 22);
+        // cursor at (0,0) but 5 non-blank rows → content_height = 5, usable = 23
+        assert_eq!(layout.active_height, 5);
+        assert_eq!(layout.scrollback_height, 18);
         assert_eq!(layout.status_bar_row, 23);
     }
 
@@ -462,9 +476,9 @@ mod tests {
             show_cursor: true,
         };
         let layout = compute_layout(&frame);
-        // cursor at (0,0) → content_height = 1, usable = 9
-        assert_eq!(layout.active_height, 1);
-        assert_eq!(layout.scrollback_height, 8);
+        // 100 non-blank rows but usable = 9 → clamped
+        assert_eq!(layout.active_height, 9);
+        assert_eq!(layout.scrollback_height, 0);
     }
 
     #[test]
@@ -540,6 +554,61 @@ mod tests {
         assert_eq!(layout.active_height, 0);
         assert_eq!(layout.scrollback_height, 22);
         assert_eq!(layout.status_bar_row, 23);
+    }
+
+    #[test]
+    fn layout_content_below_cursor_shown() {
+        // Simulates zsh completions: cursor on row 0, content on rows 1-3
+        let mut active_grid: Vec<Vec<Cell>> = vec![vec![Cell::default(); 80]; 23];
+        active_grid[0] = make_row("$ cd ");
+        active_grid[1] = make_row("dir1/");
+        active_grid[2] = make_row("dir2/");
+        active_grid[3] = make_row("dir3/");
+        let frame = Frame {
+            completed_rows: &[],
+            streaming_rows: &[],
+            active_grid: &active_grid,
+            active_cursor: (0, 5),
+            status_bar: StatusBar {
+                mode: "SHELL",
+                model: "",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: None, agent_status: None,
+            total_rows: 24,
+            total_cols: 80,
+            show_cursor: true,
+        };
+        let layout = compute_layout(&frame);
+        // cursor at row 0, but content extends to row 3 → active_height = 4
+        assert_eq!(layout.active_height, 4);
+        assert_eq!(layout.scrollback_height, 19);
+    }
+
+    #[test]
+    fn layout_blank_grid_stays_compact() {
+        // All-blank grid with cursor at row 0 → stays compact at 1 row
+        let active_grid: Vec<Vec<Cell>> = vec![vec![Cell::default(); 80]; 23];
+        let frame = Frame {
+            completed_rows: &[],
+            streaming_rows: &[],
+            active_grid: &active_grid,
+            active_cursor: (0, 0),
+            status_bar: StatusBar {
+                mode: "SHELL",
+                model: "",
+                hint: "",
+            },
+            scroll_offset: 0,
+            agent_input: None, agent_status: None,
+            total_rows: 24,
+            total_cols: 80,
+            show_cursor: true,
+        };
+        let layout = compute_layout(&frame);
+        assert_eq!(layout.active_height, 1);
+        assert_eq!(layout.scrollback_height, 22);
     }
 
     // -- Color conversion tests --

--- a/crates/wsh/src/shell_integration.rs
+++ b/crates/wsh/src/shell_integration.rs
@@ -1,0 +1,456 @@
+use std::fmt;
+
+const ESC: u8 = 0x1b;
+const BEL: u8 = 0x07;
+const RIGHT_BRACKET: u8 = 0x5d; // ']'
+const BACKSLASH: u8 = 0x5c;     // '\'
+const SEMICOLON: u8 = 0x3b;     // ';'
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ShellEvent {
+    PromptStart,
+    PromptEnd,
+    CommandStart,
+    CommandFinished { exit_code: Option<i32> },
+}
+
+impl fmt::Display for ShellEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ShellEvent::PromptStart => write!(f, "PromptStart"),
+            ShellEvent::PromptEnd => write!(f, "PromptEnd"),
+            ShellEvent::CommandStart => write!(f, "CommandStart"),
+            ShellEvent::CommandFinished { exit_code: Some(c) } => {
+                write!(f, "CommandFinished({c})")
+            }
+            ShellEvent::CommandFinished { exit_code: None } => {
+                write!(f, "CommandFinished(?)")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum ParserState {
+    Normal,
+    Escape,
+    /// Accumulating OSC header bytes, expecting "133;"
+    OscHeader { collected: Vec<u8> },
+    /// Inside an OSC 133 body, accumulating the command payload.
+    OscBody { payload: Vec<u8>, got_esc: bool },
+    /// Inside a non-133 OSC sequence — pass through everything until the terminator.
+    OscPassthrough { buffered: Vec<u8>, got_esc: bool },
+}
+
+pub struct OscParser {
+    state: ParserState,
+}
+
+impl OscParser {
+    pub fn new() -> Self {
+        Self {
+            state: ParserState::Normal,
+        }
+    }
+
+    pub fn feed(&mut self, input: &[u8]) -> (Vec<u8>, Vec<ShellEvent>) {
+        let mut output = Vec::with_capacity(input.len());
+        let mut events = Vec::new();
+
+        for &byte in input {
+            match std::mem::replace(&mut self.state, ParserState::Normal) {
+                ParserState::Normal => {
+                    if byte == ESC {
+                        self.state = ParserState::Escape;
+                    } else {
+                        output.push(byte);
+                    }
+                }
+
+                ParserState::Escape => {
+                    if byte == RIGHT_BRACKET {
+                        self.state = ParserState::OscHeader {
+                            collected: Vec::new(),
+                        };
+                    } else {
+                        // Not an OSC — flush ESC + this byte as normal output.
+                        output.push(ESC);
+                        output.push(byte);
+                    }
+                }
+
+                ParserState::OscHeader { mut collected } => {
+                    const EXPECTED: &[u8] = b"133;";
+
+                    collected.push(byte);
+                    let len = collected.len();
+
+                    if collected[len - 1] != EXPECTED[len - 1] {
+                        // Mismatch — this is a non-133 OSC. Flush what we have
+                        // and switch to passthrough mode.
+                        let mut buffered = Vec::with_capacity(2 + collected.len());
+                        buffered.push(ESC);
+                        buffered.push(RIGHT_BRACKET);
+                        buffered.extend_from_slice(&collected);
+                        self.state = ParserState::OscPassthrough {
+                            buffered,
+                            got_esc: false,
+                        };
+                    } else if len == EXPECTED.len() {
+                        // Matched "133;" — now accumulate the body.
+                        self.state = ParserState::OscBody {
+                            payload: Vec::new(),
+                            got_esc: false,
+                        };
+                    } else {
+                        // Partial match so far, keep going.
+                        self.state = ParserState::OscHeader { collected };
+                    }
+                }
+
+                ParserState::OscBody { mut payload, got_esc } => {
+                    if got_esc {
+                        if byte == BACKSLASH {
+                            // ST terminator — sequence complete.
+                            Self::parse_osc133_payload(&payload, &mut events);
+                        } else {
+                            // ESC was not followed by '\' — it's part of the payload.
+                            payload.push(ESC);
+                            payload.push(byte);
+                            self.state = ParserState::OscBody {
+                                payload,
+                                got_esc: false,
+                            };
+                        }
+                    } else if byte == BEL {
+                        // BEL terminator — sequence complete.
+                        Self::parse_osc133_payload(&payload, &mut events);
+                    } else if byte == ESC {
+                        self.state = ParserState::OscBody {
+                            payload,
+                            got_esc: true,
+                        };
+                    } else {
+                        payload.push(byte);
+                        self.state = ParserState::OscBody {
+                            payload,
+                            got_esc: false,
+                        };
+                    }
+                }
+
+                ParserState::OscPassthrough { mut buffered, got_esc } => {
+                    if got_esc {
+                        buffered.push(ESC);
+                        if byte == BACKSLASH {
+                            // ST terminator — flush entire passthrough sequence.
+                            buffered.push(byte);
+                            output.extend_from_slice(&buffered);
+                        } else {
+                            buffered.push(byte);
+                            self.state = ParserState::OscPassthrough {
+                                buffered,
+                                got_esc: false,
+                            };
+                        }
+                    } else if byte == BEL {
+                        buffered.push(byte);
+                        output.extend_from_slice(&buffered);
+                    } else if byte == ESC {
+                        self.state = ParserState::OscPassthrough {
+                            buffered,
+                            got_esc: true,
+                        };
+                    } else {
+                        buffered.push(byte);
+                        self.state = ParserState::OscPassthrough {
+                            buffered,
+                            got_esc: false,
+                        };
+                    }
+                }
+            }
+        }
+
+        (output, events)
+    }
+
+    fn parse_osc133_payload(payload: &[u8], events: &mut Vec<ShellEvent>) {
+        if payload.is_empty() {
+            return;
+        }
+
+        let command = payload[0];
+        match command {
+            b'A' => events.push(ShellEvent::PromptStart),
+            b'B' => events.push(ShellEvent::PromptEnd),
+            b'C' => events.push(ShellEvent::CommandStart),
+            b'D' => {
+                let exit_code = if payload.len() > 1 && payload[1] == SEMICOLON {
+                    std::str::from_utf8(&payload[2..])
+                        .ok()
+                        .and_then(|s| s.parse::<i32>().ok())
+                } else {
+                    None
+                };
+                events.push(ShellEvent::CommandFinished { exit_code });
+            }
+            _ => {
+                // Unknown OSC 133 command — silently drop it.
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_prompt_start_bel() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;A\x07");
+        assert!(output.is_empty());
+        assert_eq!(events, vec![ShellEvent::PromptStart]);
+    }
+
+    #[test]
+    fn parse_prompt_start_st() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;A\x1b\\");
+        assert!(output.is_empty());
+        assert_eq!(events, vec![ShellEvent::PromptStart]);
+    }
+
+    #[test]
+    fn parse_prompt_end() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;B\x07");
+        assert!(output.is_empty());
+        assert_eq!(events, vec![ShellEvent::PromptEnd]);
+    }
+
+    #[test]
+    fn parse_command_start() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;C\x07");
+        assert!(output.is_empty());
+        assert_eq!(events, vec![ShellEvent::CommandStart]);
+    }
+
+    #[test]
+    fn parse_command_finished_with_exit_code() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;D;0\x07");
+        assert!(output.is_empty());
+        assert_eq!(
+            events,
+            vec![ShellEvent::CommandFinished {
+                exit_code: Some(0)
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_command_finished_nonzero_exit() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;D;127\x07");
+        assert!(output.is_empty());
+        assert_eq!(
+            events,
+            vec![ShellEvent::CommandFinished {
+                exit_code: Some(127)
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_command_finished_no_exit_code() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;D\x07");
+        assert!(output.is_empty());
+        assert_eq!(
+            events,
+            vec![ShellEvent::CommandFinished { exit_code: None }]
+        );
+    }
+
+    #[test]
+    fn mixed_content_stripped() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"hello\x1b]133;A\x07world");
+        assert_eq!(output, b"helloworld");
+        assert_eq!(events, vec![ShellEvent::PromptStart]);
+    }
+
+    #[test]
+    fn split_across_feeds_esc_then_rest() {
+        let mut parser = OscParser::new();
+        let (out1, ev1) = parser.feed(b"before\x1b");
+        assert_eq!(out1, b"before");
+        assert!(ev1.is_empty());
+
+        let (out2, ev2) = parser.feed(b"]133;A\x07after");
+        assert_eq!(out2, b"after");
+        assert_eq!(ev2, vec![ShellEvent::PromptStart]);
+    }
+
+    #[test]
+    fn split_across_feeds_mid_header() {
+        let mut parser = OscParser::new();
+        let (out1, ev1) = parser.feed(b"\x1b]13");
+        assert!(out1.is_empty());
+        assert!(ev1.is_empty());
+
+        let (out2, ev2) = parser.feed(b"3;B\x07");
+        assert!(out2.is_empty());
+        assert_eq!(ev2, vec![ShellEvent::PromptEnd]);
+    }
+
+    #[test]
+    fn split_across_feeds_mid_body() {
+        let mut parser = OscParser::new();
+        let (out1, ev1) = parser.feed(b"\x1b]133;D;12");
+        assert!(out1.is_empty());
+        assert!(ev1.is_empty());
+
+        let (out2, ev2) = parser.feed(b"7\x07");
+        assert!(out2.is_empty());
+        assert_eq!(
+            ev2,
+            vec![ShellEvent::CommandFinished {
+                exit_code: Some(127)
+            }]
+        );
+    }
+
+    #[test]
+    fn split_st_terminator_across_feeds() {
+        let mut parser = OscParser::new();
+        let (out1, ev1) = parser.feed(b"\x1b]133;C\x1b");
+        assert!(out1.is_empty());
+        assert!(ev1.is_empty());
+
+        let (out2, ev2) = parser.feed(b"\x5c");
+        assert!(out2.is_empty());
+        assert_eq!(ev2, vec![ShellEvent::CommandStart]);
+    }
+
+    #[test]
+    fn non_133_osc_passes_through() {
+        let mut parser = OscParser::new();
+        // OSC 0 (set window title): ESC ] 0 ; t i t l e BEL
+        let input = b"\x1b]0;my title\x07";
+        let (output, events) = parser.feed(input);
+        assert_eq!(output, input.to_vec());
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn non_133_osc_with_st_passes_through() {
+        let mut parser = OscParser::new();
+        let input = b"\x1b]0;title\x1b\\";
+        let (output, events) = parser.feed(input);
+        assert_eq!(output, input.to_vec());
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn multiple_events_in_one_feed() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(
+            b"\x1b]133;D;0\x07\x1b]133;A\x07prompt$ \x1b]133;B\x07",
+        );
+        assert_eq!(output, b"prompt$ ");
+        assert_eq!(
+            events,
+            vec![
+                ShellEvent::CommandFinished {
+                    exit_code: Some(0)
+                },
+                ShellEvent::PromptStart,
+                ShellEvent::PromptEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn bare_esc_not_followed_by_bracket_passes_through() {
+        let mut parser = OscParser::new();
+        // ESC [ is CSI, not OSC — should pass through.
+        let (output, events) = parser.feed(b"\x1b[31mred\x1b[0m");
+        assert_eq!(output, b"\x1b[31mred\x1b[0m");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn interleaved_normal_escape_sequences_and_osc133() {
+        let mut parser = OscParser::new();
+        let (output, events) =
+            parser.feed(b"\x1b[32mgreen\x1b[0m\x1b]133;A\x07$ ");
+        assert_eq!(output, b"\x1b[32mgreen\x1b[0m$ ");
+        assert_eq!(events, vec![ShellEvent::PromptStart]);
+    }
+
+    #[test]
+    fn empty_input() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"");
+        assert!(output.is_empty());
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn plain_text_no_escapes() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"just plain text\n");
+        assert_eq!(output, b"just plain text\n");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn negative_exit_code() {
+        let mut parser = OscParser::new();
+        let (output, events) = parser.feed(b"\x1b]133;D;-1\x07");
+        assert!(output.is_empty());
+        assert_eq!(
+            events,
+            vec![ShellEvent::CommandFinished {
+                exit_code: Some(-1)
+            }]
+        );
+    }
+
+    #[test]
+    fn full_prompt_cycle() {
+        let mut parser = OscParser::new();
+        // Simulate a full prompt cycle: D;0, A, prompt text, B, user types, C
+        let stream = b"\x1b]133;D;0\x07\x1b]133;A\x07user@host:~$ \x1b]133;B\x07ls -la\x1b]133;C\x07";
+        let (output, events) = parser.feed(stream);
+        assert_eq!(output, b"user@host:~$ ls -la");
+        assert_eq!(
+            events,
+            vec![
+                ShellEvent::CommandFinished { exit_code: Some(0) },
+                ShellEvent::PromptStart,
+                ShellEvent::PromptEnd,
+                ShellEvent::CommandStart,
+            ]
+        );
+    }
+
+    #[test]
+    fn byte_at_a_time() {
+        let mut parser = OscParser::new();
+        let input = b"x\x1b]133;A\x07y";
+        let mut all_output = Vec::new();
+        let mut all_events = Vec::new();
+        for &byte in input {
+            let (out, evts) = parser.feed(&[byte]);
+            all_output.extend_from_slice(&out);
+            all_events.extend(evts);
+        }
+        assert_eq!(all_output, b"xy");
+        assert_eq!(all_events, vec![ShellEvent::PromptStart]);
+    }
+}

--- a/crates/wsh/src/shell_integration.rs
+++ b/crates/wsh/src/shell_integration.rs
@@ -46,6 +46,12 @@ pub struct OscParser {
     state: ParserState,
 }
 
+impl Default for OscParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl OscParser {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
## Description
Fix streaming NDJSON output (`warp agent run --output-format ndjson`) not emitting incrementally.

### Root cause
During LLM streaming, the server sends `AppendToMessageContent` events that update a single `AIAgentOutputMessage` in-place (via `upsert_output_for_message`). The streaming NDJSON code in the SDK driver tracked only message **count** (`streaming_ndjson_emitted`) to detect new output. Since in-place updates don't change the count, the streaming code never detected them — output only appeared as a single chunk when the exchange finished.

### Fix
- Added a `revision: u64` counter to `AIAgentOutput` that is bumped on every mutation (both `extend` for new messages and `upsert` for in-place updates).
- The driver now tracks both message count AND revision. When the revision changes without a count increase, it re-emits the last message with its updated content.

## Testing
- [x] All existing tests pass (41 task tests, 16 convert_conversation tests)
- [x] Compilation verified with `cargo check -p warp` and full `cargo build -p warp`

CHANGELOG-NONE

---

_Conversation: https://staging.warp.dev/conversation/3b2a5233-c0f8-4484-ac41-2f521147b3ec_
_Run: https://oz.staging.warp.dev/runs/019e9af3-5959-7747-b9f7-fda60d01cf83_

_This PR was generated with [Oz](https://warp.dev/oz)._
