### PR TITLE
Add dedicated project skills sidecar

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -7,14 +7,13 @@ use ai::skills::{
     ParsedSkill, SkillProvider, SkillScope, SKILL_PROVIDER_DEFINITIONS,
 };
 use async_channel::Sender;
-use futures::future::BoxFuture;
-use remote_server::proto::{
-    file_context_proto, FileContextProto, ReadFileContextFile, ReadFileContextRequest,
-};
+use remote_server::proto::{FindProjectSkillFilesResponse, ProjectSkillFileProto};
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repository::{Repository, SubscriberId};
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 use watcher::{BulkFilesystemWatcherEvent, HomeDirectoryWatcher, HomeDirectoryWatcherEvent};
 
@@ -26,7 +25,7 @@ use super::utils::{
     is_home_provider_path, is_home_skill_directory, is_skill_file, read_skills_from_directories,
     read_skills_from_files,
 };
-use crate::remote_server::manager::RemoteServerManager;
+use crate::remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
 use crate::warp_managed_paths_watcher::{
     filter_repository_update_by_prefix, warp_managed_skill_dirs, WarpManagedPathsWatcher,
     WarpManagedPathsWatcherEvent,
@@ -38,10 +37,6 @@ pub enum SkillWatcherEvent {
     SkillsDeleted { paths: Vec<LocalOrRemotePath> },
 }
 
-const REMOTE_SKILL_MAX_FILE_BYTES: u32 = 1024 * 1024;
-const REMOTE_SKILL_MAX_BATCH_BYTES: u32 = 5 * 1024 * 1024;
-type ProjectSkillContentsFuture =
-    BoxFuture<'static, anyhow::Result<Vec<(LocalOrRemotePath, String)>>>;
 pub struct SkillWatcher {
     // Channel for sending repository messages from subscribers.
     repository_message_tx: Sender<SkillRepositoryMessage>,
@@ -96,7 +91,7 @@ impl SkillWatcher {
     }
 
     pub fn new(ctx: &mut ModelContext<Self>, watcher_event_tx: Sender<SkillWatcherEvent>) -> Self {
-        Self::new_internal(ctx, watcher_event_tx, dirs::home_dir())
+        Self::new_internal(ctx, watcher_event_tx, dirs::home_dir(), true)
     }
 
     /// Test-only constructor that skips home-directory watching so tests are not
@@ -106,13 +101,14 @@ impl SkillWatcher {
         ctx: &mut ModelContext<Self>,
         watcher_event_tx: Sender<SkillWatcherEvent>,
     ) -> Self {
-        Self::new_internal(ctx, watcher_event_tx, None)
+        Self::new_internal(ctx, watcher_event_tx, None, false)
     }
 
     fn new_internal(
         ctx: &mut ModelContext<Self>,
         watcher_event_tx: Sender<SkillWatcherEvent>,
         home_dir: Option<PathBuf>,
+        subscribe_to_remote_updates: bool,
     ) -> Self {
         // Create channel for receiving repository messages (scans and updates)
         let (repository_message_tx, repository_message_rx) = async_channel::unbounded();
@@ -177,21 +173,18 @@ impl SkillWatcher {
             }
         }
 
-        // RepositoryMetadataEvent::RepositoryUpdated fires after the file tree is
-        // built, so we can query it for skill files. Project skill updates use
-        // RepoMetadataModel for both local and remote repos when available, while
-        // local repos fall back to a direct project watcher only if metadata
-        // indexing fails.
+        // RepositoryUpdated fires after the local sidecar has been populated.
+        // Dedicated sidecar updates trigger subsequent refreshes; local repos
+        // fall back to a direct project watcher only if metadata indexing fails.
         ctx.subscribe_to_model(&RepoMetadataModel::handle(ctx), |me, event, ctx| {
             use repo_metadata::wrapper_model::RepoMetadataEvent;
             match event {
                 RepoMetadataEvent::RepositoryUpdated { id } => {
+                    me.stop_failed_local_project_watcher(id, ctx);
                     me.refresh_project_skills_for_repo(id, ctx);
                 }
-                RepoMetadataEvent::StandingQueryResultsUpdated { id, delta } => {
-                    if delta.project_skills_changed() {
-                        me.refresh_project_skills_for_repo(id, ctx);
-                    }
+                RepoMetadataEvent::ProjectSkillFilesUpdated { id } => {
+                    me.refresh_project_skills_for_repo(id, ctx);
                 }
                 RepoMetadataEvent::RepositoryRemoved { id } => {
                     me.remove_project_skills_for_repo(id);
@@ -202,9 +195,20 @@ impl SkillWatcher {
                 }
                 RepoMetadataEvent::FileTreeUpdated { .. }
                 | RepoMetadataEvent::FileTreeEntryUpdated { .. }
+                | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
                 | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
             }
         });
+        if subscribe_to_remote_updates {
+            ctx.subscribe_to_model(&RemoteServerManager::handle(ctx), |me, event, ctx| {
+                if let RemoteServerManagerEvent::ProjectSkillFilesUpdated { remote_path } = event {
+                    me.refresh_project_skills_for_repo(
+                        &RepositoryIdentifier::Remote(remote_path.clone()),
+                        ctx,
+                    );
+                }
+            });
+        }
 
         Self {
             repository_message_tx,
@@ -224,6 +228,10 @@ impl SkillWatcher {
         repo_id: &RepositoryIdentifier,
         ctx: &mut ModelContext<Self>,
     ) {
+        let RepositoryIdentifier::Local(_) = repo_id else {
+            self.refresh_remote_project_skills_for_repo(repo_id, ctx);
+            return;
+        };
         let refresh_generation = self.advance_project_skill_refresh_generation(repo_id);
         let current_skill_files: HashSet<LocalOrRemotePath> = {
             let repo_metadata = RepoMetadataModel::as_ref(ctx);
@@ -231,7 +239,93 @@ impl SkillWatcher {
                 .into_iter()
                 .collect()
         };
+        self.replace_project_skill_files(repo_id, current_skill_files.clone());
 
+        // Project skill counts are expected to be small, so initial discovery and
+        // skill-relevant repo metadata updates trigger a full refresh rather than
+        // attempting to maintain project-skill state incrementally.
+        self.spawn_read_project_skills_from_files(
+            repo_id.clone(),
+            refresh_generation,
+            current_skill_files.into_iter().collect(),
+            ctx,
+        );
+    }
+
+    fn refresh_remote_project_skills_for_repo(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let RepositoryIdentifier::Remote(remote_repo) = repo_id else {
+            return;
+        };
+        let refresh_generation = self.advance_project_skill_refresh_generation(repo_id);
+        let repo_id = repo_id.clone();
+        let remote_repo = remote_repo.clone();
+        let request_handle =
+            RemoteServerManager::as_ref(ctx).host_request_handle(&remote_repo.host_id);
+        let repo_path = remote_repo.path.as_str().to_string();
+        ctx.spawn(
+            async move {
+                request_handle
+                    .find_project_skill_files(repo_path, None, None)
+                    .await
+            },
+            move |me, response, ctx| match response {
+                Ok(response) => me.apply_remote_project_skill_refresh(
+                    &repo_id,
+                    &remote_repo,
+                    refresh_generation,
+                    response,
+                    ctx,
+                ),
+                Err(err) => log::warn!("Failed to refresh remote project skills: {err}"),
+            },
+        );
+    }
+
+    fn apply_remote_project_skill_refresh(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        remote_repo: &RemotePath,
+        refresh_generation: u64,
+        response: FindProjectSkillFilesResponse,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.project_skill_refresh_generations.get(repo_id) != Some(&refresh_generation) {
+            return;
+        }
+        if !response.failed_files.is_empty() {
+            log::warn!(
+                "Failed to read {} remote project skill files for {}",
+                response.failed_files.len(),
+                remote_repo.path
+            );
+        }
+
+        let current_skill_files = response
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .chain(response.failed_files.iter().map(|file| file.path.as_str()))
+            .filter_map(|path| remote_project_skill_path(remote_repo, path))
+            .collect();
+        let skill_contents = remote_project_skill_contents(remote_repo, response.files);
+        self.replace_project_skill_files(repo_id, current_skill_files);
+        self.emit_project_skills_if_current(
+            repo_id,
+            refresh_generation,
+            parse_project_skill_contents(skill_contents),
+            ctx,
+        );
+    }
+
+    fn replace_project_skill_files(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        current_skill_files: HashSet<LocalOrRemotePath>,
+    ) {
         let previous_skill_files = self
             .project_skill_files_by_repo
             .get(repo_id)
@@ -254,16 +348,6 @@ impl SkillWatcher {
                     paths: deleted_paths,
                 });
         }
-
-        // Project skill counts are expected to be small, so initial discovery and
-        // skill-relevant repo metadata updates trigger a full refresh rather than
-        // attempting to maintain project-skill state incrementally.
-        self.spawn_read_project_skills_from_files(
-            repo_id.clone(),
-            refresh_generation,
-            current_skill_files.iter().cloned().collect(),
-            ctx,
-        );
 
         self.project_skill_files_by_repo
             .insert(repo_id.clone(), current_skill_files);
@@ -361,17 +445,13 @@ impl SkillWatcher {
         if skill_paths.is_empty() {
             return;
         }
-        let Some(read_skill_contents) = read_project_skill_contents(skill_paths, ctx) else {
-            return;
-        };
 
         ctx.spawn(
-            async move { read_and_parse_project_skills(read_skill_contents).await },
-            move |me, skills, ctx| match skills {
-                Ok(skills) => {
-                    me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
-                }
-                Err(err) => log::warn!("Failed to read project skills: {err}"),
+            async move {
+                parse_project_skill_contents(read_local_project_skill_contents(skill_paths))
+            },
+            move |me, skills, ctx| {
+                me.emit_project_skills_if_current(&repo_id, refresh_generation, skills, ctx);
             },
         );
     }
@@ -406,16 +486,12 @@ impl SkillWatcher {
         if skill_paths.is_empty() {
             return;
         }
-        let Some(read_skill_contents) = read_project_skill_contents(skill_paths, ctx) else {
-            return;
-        };
 
         ctx.spawn(
-            async move { read_and_parse_project_skills(read_skill_contents).await },
-            |me, skills, ctx| match skills {
-                Ok(skills) => me.emit_project_skills(skills, ctx),
-                Err(err) => log::warn!("Failed to read fallback project skills: {err}"),
+            async move {
+                parse_project_skill_contents(read_local_project_skill_contents(skill_paths))
             },
+            |me, skills, ctx| me.emit_project_skills(skills, ctx),
         );
     }
 
@@ -1041,50 +1117,6 @@ impl SkillWatcher {
     }
 }
 
-fn read_project_skill_contents(
-    skill_paths: Vec<LocalOrRemotePath>,
-    ctx: &AppContext,
-) -> Option<ProjectSkillContentsFuture> {
-    match skill_paths.first()? {
-        LocalOrRemotePath::Local(_) => Some(Box::pin(async move {
-            Ok(read_local_project_skill_contents(skill_paths))
-        })),
-        LocalOrRemotePath::Remote(remote) => {
-            let handle = RemoteServerManager::as_ref(ctx).host_request_handle(&remote.host_id);
-            Some(Box::pin(async move {
-                let request = remote_skill_read_request(&skill_paths);
-                let response = handle.read_file_context(request).await?;
-                Ok(read_remote_project_skill_contents(
-                    skill_paths,
-                    response.file_contexts,
-                ))
-            }))
-        }
-    }
-}
-
-async fn read_and_parse_project_skills(
-    read_skill_contents: ProjectSkillContentsFuture,
-) -> anyhow::Result<Vec<ParsedSkill>> {
-    Ok(parse_project_skill_contents(read_skill_contents.await?))
-}
-fn remote_skill_read_request(skill_paths: &[LocalOrRemotePath]) -> ReadFileContextRequest {
-    ReadFileContextRequest {
-        files: skill_paths
-            .iter()
-            .filter_map(|path| match path {
-                LocalOrRemotePath::Remote(remote) => Some(ReadFileContextFile {
-                    path: remote.path.as_str().to_string(),
-                    line_ranges: Vec::new(),
-                }),
-                LocalOrRemotePath::Local(_) => None,
-            })
-            .collect(),
-        max_file_bytes: Some(REMOTE_SKILL_MAX_FILE_BYTES),
-        max_batch_bytes: Some(REMOTE_SKILL_MAX_BATCH_BYTES),
-    }
-}
-
 fn read_local_project_skill_contents(
     skill_paths: Vec<LocalOrRemotePath>,
 ) -> Vec<(LocalOrRemotePath, String)> {
@@ -1097,28 +1129,23 @@ fn read_local_project_skill_contents(
         .collect()
 }
 
-fn read_remote_project_skill_contents(
-    skill_paths: Vec<LocalOrRemotePath>,
-    file_contexts: Vec<FileContextProto>,
-) -> Vec<(LocalOrRemotePath, String)> {
-    let text_content_by_path = file_contexts
-        .into_iter()
-        .filter_map(|file_context| {
-            let file_context_proto::Content::TextContent(content) = file_context.content? else {
-                return None;
-            };
-            Some((file_context.file_name, content))
-        })
-        .collect::<HashMap<_, _>>();
+fn remote_project_skill_path(remote_repo: &RemotePath, path: &str) -> Option<LocalOrRemotePath> {
+    let path = StandardizedPath::try_new(path).ok()?;
+    Some(LocalOrRemotePath::Remote(RemotePath::new(
+        remote_repo.host_id.clone(),
+        path,
+    )))
+}
 
-    skill_paths
+fn remote_project_skill_contents(
+    remote_repo: &RemotePath,
+    files: Vec<ProjectSkillFileProto>,
+) -> Vec<(LocalOrRemotePath, String)> {
+    files
         .into_iter()
-        .filter_map(|path| {
-            let LocalOrRemotePath::Remote(remote) = &path else {
-                return None;
-            };
-            let content = text_content_by_path.get(remote.path.as_str())?.clone();
-            Some((path, content))
+        .filter_map(|file| {
+            let path = remote_project_skill_path(remote_repo, &file.path)?;
+            Some((path, file.content))
         })
         .collect()
 }

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -3,13 +3,15 @@ use std::fs;
 use std::path::PathBuf;
 
 use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
-use remote_server::proto::{file_context_proto, FileContextProto};
+use remote_server::proto::{
+    FailedFileRead, FileOperationError, FindProjectSkillFilesResponse, ProjectSkillFileProto,
+};
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{
-    DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate,
-    StandingQueryContent, StandingQueryResults, StandingQueryResultsDelta, TargetFile,
+    DirectoryWatcher, ProjectSkillFileMetadata, RepoMetadataModel, RepositoryIdentifier,
+    RepositoryUpdate, TargetFile,
 };
 use tempfile::TempDir;
 use warp_util::host_id::HostId;
@@ -19,10 +21,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
 use super::super::subscribers::SkillRepositoryMessage;
-use super::{
-    parse_project_skill_contents, read_remote_project_skill_contents, remote_skill_read_request,
-    SkillWatcher, REMOTE_SKILL_MAX_BATCH_BYTES, REMOTE_SKILL_MAX_FILE_BYTES,
-};
+use super::{parse_project_skill_contents, remote_project_skill_contents, SkillWatcher};
 use crate::ai::skills::skill_manager::SkillWatcherEvent;
 
 /// Helper function for creating a single skill file
@@ -86,20 +85,13 @@ description: {description}
     )
 }
 
-fn remote_skill_file_context(path: &LocalOrRemotePath, content: &str) -> FileContextProto {
+fn remote_project_skill_file(path: &LocalOrRemotePath, content: &str) -> ProjectSkillFileProto {
     let LocalOrRemotePath::Remote(remote) = path else {
         panic!("Expected a remote skill path");
     };
-
-    FileContextProto {
-        file_name: remote.path.as_str().to_string(),
-        content: Some(file_context_proto::Content::TextContent(
-            content.to_string(),
-        )),
-        line_range_start: None,
-        line_range_end: None,
-        last_modified_epoch_millis: None,
-        line_count: content.lines().count() as u32,
+    ProjectSkillFileProto {
+        path: remote.path.as_str().to_string(),
+        content: content.to_string(),
     }
 }
 
@@ -111,23 +103,24 @@ fn parse_project_skill_contents_matches_reordered_remote_responses_by_path() {
     let first_content = remote_skill_content("first", "First skill", "First body");
     let second_content = remote_skill_content("second", "Second skill", "Second body");
 
-    let skill_contents = read_remote_project_skill_contents(
-        vec![first_path.clone(), second_path.clone()],
+    let repo = RemotePath::new(host, StandardizedPath::try_new("/repo").unwrap());
+    let skill_contents = remote_project_skill_contents(
+        &repo,
         vec![
-            remote_skill_file_context(&second_path, &second_content),
-            remote_skill_file_context(&first_path, &first_content),
+            remote_project_skill_file(&second_path, &second_content),
+            remote_project_skill_file(&first_path, &first_content),
         ],
     );
     let skills = parse_project_skill_contents(skill_contents);
 
     assert_eq!(skills.len(), 2);
-    assert_eq!(skills[0].path, first_path);
-    assert_eq!(skills[0].name, "first");
-    assert_eq!(skills[0].content, first_content);
+    assert_eq!(skills[0].path, second_path);
+    assert_eq!(skills[0].name, "second");
+    assert_eq!(skills[0].content, second_content);
     assert_eq!(skills[0].provider, SkillProvider::Agents);
-    assert_eq!(skills[1].path, second_path);
-    assert_eq!(skills[1].name, "second");
-    assert_eq!(skills[1].content, second_content);
+    assert_eq!(skills[1].path, first_path);
+    assert_eq!(skills[1].name, "first");
+    assert_eq!(skills[1].content, first_content);
 }
 
 #[test]
@@ -146,15 +139,20 @@ fn parse_project_skill_contents_classifies_foreign_encoded_provider_path() {
 }
 
 #[test]
-fn read_remote_project_skill_contents_keeps_paths_aligned_after_missing_reads() {
+fn remote_project_skill_contents_ignores_invalid_paths() {
     let host = HostId::new("test-host".to_string());
-    let missing_path = remote_skill_path(&host, "missing");
+    let repo = RemotePath::new(host.clone(), StandardizedPath::try_new("/repo").unwrap());
     let present_path = remote_skill_path(&host, "present");
     let present_content = remote_skill_content("present", "Present skill", "Present body");
-
-    let skill_contents = read_remote_project_skill_contents(
-        vec![missing_path, present_path.clone()],
-        vec![remote_skill_file_context(&present_path, &present_content)],
+    let skill_contents = remote_project_skill_contents(
+        &repo,
+        vec![
+            ProjectSkillFileProto {
+                path: "relative/SKILL.md".to_string(),
+                content: remote_skill_content("invalid", "Invalid skill", "Invalid body"),
+            },
+            remote_project_skill_file(&present_path, &present_content),
+        ],
     );
     let skills = parse_project_skill_contents(skill_contents);
 
@@ -162,27 +160,6 @@ fn read_remote_project_skill_contents_keeps_paths_aligned_after_missing_reads() 
     assert_eq!(skills[0].path, present_path);
     assert_eq!(skills[0].name, "present");
     assert_eq!(skills[0].content, present_content);
-}
-
-#[test]
-fn remote_skill_read_request_sets_bounded_read_budget() {
-    let host = HostId::new("test-host".to_string());
-    let first_path = remote_skill_path(&host, "first");
-    let second_path = remote_skill_path(&host, "second");
-
-    let request = remote_skill_read_request(&[first_path.clone(), second_path.clone()]);
-
-    assert_eq!(request.max_file_bytes, Some(REMOTE_SKILL_MAX_FILE_BYTES));
-    assert_eq!(request.max_batch_bytes, Some(REMOTE_SKILL_MAX_BATCH_BYTES));
-    assert_eq!(request.files.len(), 2);
-    let LocalOrRemotePath::Remote(first_remote) = first_path else {
-        panic!("Expected remote path");
-    };
-    let LocalOrRemotePath::Remote(second_remote) = second_path else {
-        panic!("Expected remote path");
-    };
-    assert_eq!(request.files[0].path, first_remote.path.as_str());
-    assert_eq!(request.files[1].path, second_remote.path.as_str());
 }
 
 // ============================================================================
@@ -262,6 +239,72 @@ fn test_removing_remote_project_repo_deletes_shared_cached_skill_paths() {
 
         skill_watcher_handle.read(&app, |watcher, _| {
             assert!(!watcher.project_skill_files_by_repo.contains_key(&repo_id));
+        });
+    });
+}
+
+#[test]
+fn test_remote_project_skill_refresh_preserves_failed_reads_and_removes_missing_paths() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let host = HostId::new("test-host".to_string());
+        let remote_repo =
+            RemotePath::new(host.clone(), StandardizedPath::try_new("/repo").unwrap());
+        let repo_id = RepositoryIdentifier::Remote(remote_repo.clone());
+        let failed_path = remote_skill_path(&host, "failed");
+        let removed_path = remote_skill_path(&host, "removed");
+        let present_path = remote_skill_path(&host, "present");
+        let present_content = remote_skill_content("present", "Present skill", "Present body");
+
+        skill_watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher.project_skill_files_by_repo.insert(
+                repo_id.clone(),
+                HashSet::from([failed_path.clone(), removed_path.clone()]),
+            );
+            let generation = watcher.advance_project_skill_refresh_generation(&repo_id);
+            let LocalOrRemotePath::Remote(failed_remote) = &failed_path else {
+                panic!("Expected remote path");
+            };
+            watcher.apply_remote_project_skill_refresh(
+                &repo_id,
+                &remote_repo,
+                generation,
+                FindProjectSkillFilesResponse {
+                    files: vec![remote_project_skill_file(&present_path, &present_content)],
+                    failed_files: vec![FailedFileRead {
+                        path: failed_remote.path.as_str().to_string(),
+                        error: Some(FileOperationError {
+                            message: "temporarily unreadable".to_string(),
+                        }),
+                    }],
+                },
+                ctx,
+            );
+        });
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsDeleted {
+                paths: vec![removed_path]
+            }
+        );
+        let SkillWatcherEvent::SkillsAdded { skills } = rx.recv().await.unwrap() else {
+            panic!("Expected SkillsAdded event");
+        };
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].path, present_path.clone());
+        assert_eq!(skills[0].content, present_content);
+        skill_watcher_handle.read(&app, |watcher, _| {
+            assert_eq!(
+                watcher.project_skill_files_by_repo.get(&repo_id),
+                Some(&HashSet::from([failed_path, present_path]))
+            );
         });
     });
 }
@@ -368,14 +411,9 @@ fn test_refresh_project_skills_for_repo_loads_indexed_and_symlinked_skill_direct
         repo_metadata_handle.update(&mut app, |model, ctx| {
             model.insert_test_state(
                 repo_key.clone(),
-                project_state(&repo, Some(&indexed_skill)),
+                project_state(&repo, &[&indexed_skill, &expected_skill]),
                 ctx,
             );
-            let mut standing_results = project_standing_results(&repo, Some(&indexed_skill));
-            standing_results.insert_project_skill(StandingQueryContent::file(
-                StandardizedPath::try_from_local(&skill_local_path(&expected_skill)).unwrap(),
-            ));
-            model.insert_test_standing_results(repo_key, standing_results, ctx);
         });
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
@@ -408,12 +446,7 @@ fn test_refresh_project_skills_for_repo_uses_repo_metadata_without_fallback_watc
         let repo_key = StandardizedPath::try_from_local(&repo).unwrap();
 
         repo_metadata_handle.update(&mut app, |model, ctx| {
-            model.insert_test_state(repo_key.clone(), project_state(&repo, Some(&skill)), ctx);
-            model.insert_test_standing_results(
-                repo_key,
-                project_standing_results(&repo, Some(&skill)),
-                ctx,
-            );
+            model.insert_test_state(repo_key, project_state(&repo, &[&skill]), ctx);
         });
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);
@@ -787,8 +820,8 @@ fn test_handle_repository_update_non_skill_directory_added_does_not_emit_project
     });
 }
 
-fn project_state(repo: &std::path::Path, skill: Option<&ParsedSkill>) -> FileTreeState {
-    let children = if let Some(skill) = skill {
+fn project_state(repo: &std::path::Path, skills: &[&ParsedSkill]) -> FileTreeState {
+    let children = if let Some(skill) = skills.first() {
         let skill_path = skill_local_path(skill);
         let skill_file = Entry::File(FileMetadata::new(skill_path.clone(), false));
         let skill_dir = Entry::Directory(DirectoryEntry {
@@ -820,29 +853,13 @@ fn project_state(repo: &std::path::Path, skill: Option<&ParsedSkill>) -> FileTre
         ignored: false,
         loaded: true,
     });
-    FileTreeState::new(root, Vec::new(), None)
-}
-
-fn project_standing_results(
-    repo: &std::path::Path,
-    skill: Option<&ParsedSkill>,
-) -> StandingQueryResults {
-    let mut delta = StandingQueryResultsDelta {
-        upserted_project_skills: vec![StandingQueryContent::directory(
-            StandardizedPath::try_from_local(&repo.join(".agents/skills")).unwrap(),
-        )],
-        ..StandingQueryResultsDelta::default()
-    };
-    if let Some(skill) = skill {
-        delta
-            .upserted_project_skills
-            .push(StandingQueryContent::file(
-                StandardizedPath::try_from_local(&skill_local_path(skill)).unwrap(),
-            ));
-    }
-    let mut results = StandingQueryResults::default();
-    results.apply_delta(&delta);
-    results
+    let project_skill_files = skills
+        .iter()
+        .map(|skill| ProjectSkillFileMetadata {
+            path: StandardizedPath::try_from_local(&skill_local_path(skill)).unwrap(),
+        })
+        .collect();
+    FileTreeState::new(root, Vec::new(), None, project_skill_files)
 }
 
 #[test]
@@ -862,12 +879,7 @@ fn test_refresh_project_skills_for_repo_removes_missing_project_skill_paths() {
         let repo_key = StandardizedPath::try_from_local(&repo).unwrap();
 
         repo_metadata_handle.update(&mut app, |model, ctx| {
-            model.insert_test_state(repo_key.clone(), project_state(&repo, Some(&skill)), ctx);
-            model.insert_test_standing_results(
-                repo_key.clone(),
-                project_standing_results(&repo, Some(&skill)),
-                ctx,
-            );
+            model.insert_test_state(repo_key.clone(), project_state(&repo, &[&skill]), ctx);
         });
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);
@@ -881,12 +893,7 @@ fn test_refresh_project_skills_for_repo_removes_missing_project_skill_paths() {
         );
 
         repo_metadata_handle.update(&mut app, |model, ctx| {
-            model.insert_test_state(repo_key.clone(), project_state(&repo, None), ctx);
-            model.insert_test_standing_results(
-                repo_key,
-                project_standing_results(&repo, None),
-                ctx,
-            );
+            model.insert_test_state(repo_key, project_state(&repo, &[]), ctx);
         });
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -8,48 +8,31 @@ use anyhow::Error;
 use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
 use walkdir::{DirEntry, WalkDir};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warp_util::remote_path::RemotePath;
-use warp_util::standardized_path::StandardizedPath;
 use warpui::AppContext;
 
 use crate::warp_managed_paths_watcher::warp_managed_skill_dirs;
 
-fn local_or_remote_path_for_repo_path(
-    repo_id: &RepositoryIdentifier,
-    path: &StandardizedPath,
-) -> LocalOrRemotePath {
-    match repo_id {
-        RepositoryIdentifier::Local(_) => LocalOrRemotePath::Local(path.to_local_path_lossy()),
-        RepositoryIdentifier::Remote(remote) => {
-            LocalOrRemotePath::Remote(RemotePath::new(remote.host_id.clone(), path.clone()))
-        }
-    }
-}
-
-/// Finds project skill files from stored standing results.
+/// Finds local project skill files from the dedicated repository metadata API.
 ///
-/// Symlinked project skills are resolved while evaluating standing queries on the process that
-/// owns the repository. This consumer treats those results as authoritative for both local and
-/// remote repositories; direct filesystem discovery remains confined to metadata-failure fallback.
+/// Symlinked and ignored project skills are resolved while building the local
+/// sidecar. Remote project skills are fetched through the dedicated remote RPC.
 pub(super) fn find_project_skill_files_in_tree(
     repo_id: &RepositoryIdentifier,
     repo_metadata: &RepoMetadataModel,
     ctx: &AppContext,
 ) -> Vec<LocalOrRemotePath> {
     repo_metadata
-        .standing_query_results(repo_id, ctx)
+        .get_project_skills(repo_id, ctx)
         .into_iter()
-        .flat_map(|results| results.project_skills())
-        .filter(|content| !content.is_directory)
-        .map(|content| local_or_remote_path_for_repo_path(repo_id, &content.path))
+        .flatten()
+        .map(|content| LocalOrRemotePath::Local(content.path.to_local_path_lossy()))
         .collect()
 }
 
 /// Finds local project skill files by discovering provider directories on the filesystem.
 ///
 /// This is a local-only fallback for repositories whose repo metadata indexing fails. Successful
-/// local and remote project refreshes should use [`find_project_skill_files_in_tree`] so the
-/// normal metadata-backed path remains shared.
+/// local project refreshes should use [`find_project_skill_files_in_tree`].
 pub(super) fn find_local_project_skill_files_on_filesystem(
     scan_root: &Path,
 ) -> Vec<LocalOrRemotePath> {

--- a/app/src/ai/skills/file_watchers/utils_tests.rs
+++ b/app/src/ai/skills/file_watchers/utils_tests.rs
@@ -1,12 +1,8 @@
 use repo_metadata::entry::{DirectoryEntry, Entry, FileMetadata};
 use repo_metadata::file_tree_store::FileTreeState;
-use repo_metadata::file_tree_update::{
-    DirectoryNodeMetadata, FileNodeMetadata, FileTreeEntryUpdate, RepoNodeMetadata,
-};
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{
-    DirectoryWatcher, RepoMetadataModel, RepoMetadataUpdate, RepositoryIdentifier,
-    StandingQueryContent, StandingQueryResults, StandingQueryResultsDelta,
+    DirectoryWatcher, ProjectSkillFileMetadata, RepoMetadataModel, RepositoryIdentifier,
 };
 use virtual_fs::{Stub, VirtualFS};
 use warp_util::host_id::HostId;
@@ -19,14 +15,13 @@ use super::{
     extract_skill_parent_directory, find_project_skill_files_in_tree, is_home_provider_path,
     is_home_skill_directory, is_skill_file, read_skills_from_files,
 };
-fn project_standing_results(
+fn project_skill_sidecar(
     skill_paths: impl IntoIterator<Item = StandardizedPath>,
-) -> StandingQueryResults {
-    let mut results = StandingQueryResults::default();
-    for skill_path in skill_paths {
-        results.insert_project_skill(StandingQueryContent::file(skill_path));
-    }
-    results
+) -> Vec<ProjectSkillFileMetadata> {
+    skill_paths
+        .into_iter()
+        .map(|path| ProjectSkillFileMetadata { path })
+        .collect()
 }
 
 // ============================================================================
@@ -541,28 +536,28 @@ fn find_skill_files_in_tree_finds_root_skills() {
                 )
                 .unwrap()
             });
-            let state = FileTreeState::new(root, vec![], Some(repo_handle));
+            let state = FileTreeState::new(
+                root,
+                vec![],
+                Some(repo_handle),
+                project_skill_sidecar([
+                    StandardizedPath::try_from_local(
+                        &repo.join(".agents/skills/root-skill-1/SKILL.md"),
+                    )
+                    .unwrap(),
+                    StandardizedPath::try_from_local(
+                        &repo.join(".claude/skills/root-skill-2/SKILL.md"),
+                    )
+                    .unwrap(),
+                ]),
+            );
 
             let model_handle = app.add_singleton_model(RepoMetadataModel::new);
             model_handle.update(&mut app, |model, ctx| {
                 let key =
                     warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&repo)
                         .unwrap();
-                model.insert_test_state(key.clone(), state, ctx);
-                model.insert_test_standing_results(
-                    key,
-                    project_standing_results([
-                        StandardizedPath::try_from_local(
-                            &repo.join(".agents/skills/root-skill-1/SKILL.md"),
-                        )
-                        .unwrap(),
-                        StandardizedPath::try_from_local(
-                            &repo.join(".claude/skills/root-skill-2/SKILL.md"),
-                        )
-                        .unwrap(),
-                    ]),
-                    ctx,
-                );
+                model.insert_test_state(key, state, ctx);
             });
 
             model_handle.read(&app, |model, ctx| {
@@ -708,28 +703,28 @@ fn find_skill_files_in_tree_finds_subdirectory_skills() {
                 )
                 .unwrap()
             });
-            let state = FileTreeState::new(root, vec![], Some(repo_handle));
+            let state = FileTreeState::new(
+                root,
+                vec![],
+                Some(repo_handle),
+                project_skill_sidecar([
+                    StandardizedPath::try_from_local(
+                        &repo.join(".agents/skills/root-skill/SKILL.md"),
+                    )
+                    .unwrap(),
+                    StandardizedPath::try_from_local(
+                        &repo.join("packages/frontend/.agents/skills/frontend-skill/SKILL.md"),
+                    )
+                    .unwrap(),
+                ]),
+            );
 
             let model_handle = app.add_singleton_model(RepoMetadataModel::new);
             model_handle.update(&mut app, |model, ctx| {
                 let key =
                     warp_util::standardized_path::StandardizedPath::from_local_canonicalized(&repo)
                         .unwrap();
-                model.insert_test_state(key.clone(), state, ctx);
-                model.insert_test_standing_results(
-                    key,
-                    project_standing_results([
-                        StandardizedPath::try_from_local(
-                            &repo.join(".agents/skills/root-skill/SKILL.md"),
-                        )
-                        .unwrap(),
-                        StandardizedPath::try_from_local(
-                            &repo.join("packages/frontend/.agents/skills/frontend-skill/SKILL.md"),
-                        )
-                        .unwrap(),
-                    ]),
-                    ctx,
-                );
+                model.insert_test_state(key, state, ctx);
             });
 
             model_handle.read(&app, |model, ctx| {
@@ -758,64 +753,16 @@ fn find_skill_files_in_tree_finds_subdirectory_skills() {
 }
 
 #[test]
-fn find_skill_files_in_tree_returns_remote_skill_paths_for_remote_repos() {
-    App::test((), |mut app| async move {
+fn find_skill_files_in_tree_returns_no_remote_skills() {
+    App::test((), |app| async move {
         app.add_singleton_model(|_| DetectedRepositories::default());
         let model_handle = app.add_singleton_model(RepoMetadataModel::new);
         let host_id = HostId::new("test-host".to_string());
         let repo_path = StandardizedPath::try_new("/repo").unwrap();
-        let skill_path =
-            StandardizedPath::try_new("/repo/.agents/skills/remote-skill/SKILL.md").unwrap();
-        let repo_id =
-            RepositoryIdentifier::Remote(RemotePath::new(host_id.clone(), repo_path.clone()));
-
-        let update = RepoMetadataUpdate {
-            repo_path: repo_path.clone(),
-            remove_entries: vec![],
-            update_entries: vec![FileTreeEntryUpdate {
-                parent_path_to_replace: repo_path.clone(),
-                subtree_metadata: vec![
-                    RepoNodeMetadata::Directory(DirectoryNodeMetadata {
-                        path: StandardizedPath::try_new("/repo/.agents").unwrap(),
-                        ignored: false,
-                        loaded: true,
-                    }),
-                    RepoNodeMetadata::Directory(DirectoryNodeMetadata {
-                        path: StandardizedPath::try_new("/repo/.agents/skills").unwrap(),
-                        ignored: false,
-                        loaded: true,
-                    }),
-                    RepoNodeMetadata::Directory(DirectoryNodeMetadata {
-                        path: StandardizedPath::try_new("/repo/.agents/skills/remote-skill")
-                            .unwrap(),
-                        ignored: false,
-                        loaded: true,
-                    }),
-                    RepoNodeMetadata::File(FileNodeMetadata {
-                        path: skill_path.clone(),
-                        extension: Some("md".to_string()),
-                        ignored: false,
-                    }),
-                ],
-            }],
-            standing_results_delta: StandingQueryResultsDelta {
-                upserted_project_skills: vec![StandingQueryContent::file(skill_path.clone())],
-                ..Default::default()
-            },
-        };
-
-        model_handle.update(&mut app, |model, ctx| {
-            model.insert_remote_snapshot(host_id.clone(), &update, ctx);
-        });
+        let repo_id = RepositoryIdentifier::Remote(RemotePath::new(host_id, repo_path));
 
         model_handle.read(&app, |model, ctx| {
-            let skill_files = find_project_skill_files_in_tree(&repo_id, model, ctx);
-            assert_eq!(
-                skill_files,
-                vec![LocalOrRemotePath::Remote(RemotePath::new(
-                    host_id, skill_path
-                ))]
-            );
+            assert!(find_project_skill_files_in_tree(&repo_id, model, ctx).is_empty());
         });
     });
 }
@@ -837,17 +784,9 @@ fn find_skill_files_in_tree_does_not_rescan_local_provider_directories() {
             let linked_directory = provider.join("linked");
             std::os::unix::fs::symlink(dirs.tests().join("target"), &linked_directory).unwrap();
 
-            App::test((), |mut app| async move {
+            App::test((), |app| async move {
                 app.add_singleton_model(|_| DetectedRepositories::default());
                 let model_handle = app.add_singleton_model(RepoMetadataModel::new);
-                model_handle.update(&mut app, |model, ctx| {
-                    let key = StandardizedPath::from_local_canonicalized(&repo).unwrap();
-                    let mut results = StandingQueryResults::default();
-                    results.insert_project_skill(StandingQueryContent::directory(
-                        StandardizedPath::try_from_local(&provider).unwrap(),
-                    ));
-                    model.insert_test_standing_results(key, results, ctx);
-                });
 
                 model_handle.read(&app, |model, ctx| {
                     let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
@@ -907,20 +846,20 @@ fn find_skill_files_in_tree_includes_ignored_skill_files() {
                 )
                 .unwrap()
             });
-            let state = FileTreeState::new(root, vec![], Some(repo_handle));
+            let state = FileTreeState::new(
+                root,
+                vec![],
+                Some(repo_handle),
+                project_skill_sidecar([StandardizedPath::try_from_local(
+                    &repo.join(".agents/skills/ignored-skill/SKILL.md"),
+                )
+                .unwrap()]),
+            );
 
             let model_handle = app.add_singleton_model(RepoMetadataModel::new);
             model_handle.update(&mut app, |model, ctx| {
                 let key = StandardizedPath::from_local_canonicalized(&repo).unwrap();
-                model.insert_test_state(key.clone(), state, ctx);
-                model.insert_test_standing_results(
-                    key,
-                    project_standing_results([StandardizedPath::try_from_local(
-                        &repo.join(".agents/skills/ignored-skill/SKILL.md"),
-                    )
-                    .unwrap()]),
-                    ctx,
-                );
+                model.insert_test_state(key, state, ctx);
             });
 
             model_handle.read(&app, |model, ctx| {
@@ -966,7 +905,7 @@ fn find_skill_files_in_tree_empty_repo() {
                 )
                 .unwrap()
             });
-            let state = FileTreeState::new(root, vec![], Some(repo_handle));
+            let state = FileTreeState::new(root, vec![], Some(repo_handle), vec![]);
 
             let model_handle = app.add_singleton_model(RepoMetadataModel::new);
             model_handle.update(&mut app, |model, ctx| {

--- a/app/src/code/file_tree/view.rs
+++ b/app/src/code/file_tree/view.rs
@@ -625,6 +625,7 @@ impl FileTreeView {
             RepoMetadataEvent::FileTreeUpdated { .. }
             | RepoMetadataEvent::RepositoryRemoved { .. }
             | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
+            | RepoMetadataEvent::ProjectSkillFilesUpdated { .. }
             | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
             | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
         }

--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -91,7 +91,7 @@ fn build_repo_state(repo_root: &std::path::Path) -> FileTreeState {
         ignored: false,
         loaded: true,
     });
-    FileTreeState::new(root, vec![], None)
+    FileTreeState::new(root, vec![], None, vec![])
 }
 
 fn build_repo_state_with_unloaded_directory(repo_root: &std::path::Path) -> FileTreeState {
@@ -110,7 +110,7 @@ fn build_repo_state_with_unloaded_directory(repo_root: &std::path::Path) -> File
         ignored: false,
         loaded: true,
     });
-    FileTreeState::new(root, vec![], None)
+    FileTreeState::new(root, vec![], None, vec![])
 }
 
 fn flattened_paths(

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1546,12 +1546,6 @@ pub(crate) fn initialize_app(
             } else {
                 RepoMetadataModel::new(ctx)
             };
-            model.register_force_included_paths(
-                ::ai::skills::SKILL_PROVIDER_DEFINITIONS
-                    .iter()
-                    .map(|provider| provider.skills_path.clone()),
-                ctx,
-            );
             model.set_project_skill_provider_paths(
                 ::ai::skills::SKILL_PROVIDER_DEFINITIONS
                     .iter()

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -453,6 +453,7 @@ impl RemoteCodebaseIndexModel {
             | RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::BufferUpdated { .. }
             | RemoteServerManagerEvent::BufferConflictDetected { .. }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -10,6 +10,7 @@ use ::ai::index::full_source_code_embedding::manager::{
 use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
+use async_fs::{metadata, read_to_string};
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
@@ -41,17 +42,19 @@ use super::proto::{
     CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, CodebaseResyncMode, DeleteFile,
     DeleteFileResponse, DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse,
     DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
-    FileContextProto, FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
+    FileContextProto, FileOperationError, FindProjectSkillFiles, FindProjectSkillFilesResponse,
+    FragmentMetadata as ProtoFragmentMetadata,
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
     FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
     GetFragmentMetadataFromHashSuccess, IndexCodebase, Initialize, InitializeResponse,
     MissingFragmentMetadata, NavigatedToDirectory, NavigatedToDirectoryResponse, OpenBuffer,
-    OpenBufferResponse, ReadFileContextResponse, ResolveConflict, ResolveConflictResponse,
-    ResolveConflictSuccess, ResyncCodebase, RunCommandError, RunCommandErrorCode,
-    RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
-    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, UploadHandoffSnapshot,
-    WriteFile, WriteFileResponse, WriteFileSuccess,
+    OpenBufferResponse, ProjectSkillFileProto, ProjectSkillFilesUpdatedPush,
+    ReadFileContextResponse, ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess,
+    ResyncCodebase, RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse,
+    RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage,
+    SessionBootstrapped, TextEdit, UploadHandoffSnapshot, WriteFile, WriteFileResponse,
+    WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
@@ -65,6 +68,10 @@ pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 
 /// Prevents a client from forcing the daemon to enumerate an arbitrarily
 /// large ref list.
 const MAX_BRANCH_COUNT_CAP: usize = 500;
+/// Default per-file cap for project skill files returned by the daemon.
+const DEFAULT_PROJECT_SKILL_FILE_BYTES: usize = 1_000_000;
+/// Default total cap for project skill file content returned by the daemon.
+const DEFAULT_PROJECT_SKILL_TOTAL_BYTES: usize = 8_000_000;
 
 /// Unique identifier for a connected proxy session in daemon mode.
 pub type ConnectionId = uuid::Uuid;
@@ -359,12 +366,28 @@ impl ServerModel {
                         }
                     }
                 }
+                RepoMetadataEvent::ProjectSkillFilesUpdated {
+                    id: RepositoryIdentifier::Local(path),
+                } => {
+                    me.send_server_message(
+                        None,
+                        None,
+                        server_message::Message::ProjectSkillFilesUpdated(
+                            ProjectSkillFilesUpdatedPush {
+                                repo_path: path.to_string(),
+                            },
+                        ),
+                    );
+                }
                 RepoMetadataEvent::RepositoryRemoved { .. }
                 | RepoMetadataEvent::FileTreeUpdated { .. }
                 | RepoMetadataEvent::FileTreeEntryUpdated { .. }
                 | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                 | RepoMetadataEvent::RepositoryUpdated {
+                    id: RepositoryIdentifier::Remote(_),
+                }
+                | RepoMetadataEvent::ProjectSkillFilesUpdated {
                     id: RepositoryIdentifier::Remote(_),
                 } => {}
             });
@@ -715,6 +738,9 @@ impl ServerModel {
                     }
                     Some(host_scoped_request::Message::ReadFileContext(m)) => {
                         self.handle_read_file_context(m, &request_id, conn_id, ctx)
+                    }
+                    Some(host_scoped_request::Message::FindProjectSkillFiles(m)) => {
+                        self.handle_find_project_skill_files(m, &request_id, conn_id, ctx)
                     }
                     Some(host_scoped_request::Message::SaveBuffer(m)) => {
                         self.handle_save_buffer(m, &request_id, conn_id, ctx)
@@ -2149,6 +2175,75 @@ impl ServerModel {
         HandlerOutcome::Async(Some(handle))
     }
 
+    /// Handles `FindProjectSkillFiles` by reading the paths discovered by repo
+    /// metadata's dedicated project-skills sidecar. Reads are UTF-8 only and
+    /// bounded by per-file and total byte budgets.
+    fn handle_find_project_skill_files(
+        &mut self,
+        msg: FindProjectSkillFiles,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling FindProjectSkillFiles repo={} (request_id={request_id})",
+            msg.repo_path
+        );
+
+        let repo_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path))
+        {
+            Ok(path) => path,
+            Err(error) => {
+                return HandlerOutcome::Sync(
+                    server_message::Message::FindProjectSkillFilesResponse(
+                        FindProjectSkillFilesResponse {
+                            files: vec![],
+                            failed_files: vec![failed_file_read(
+                                msg.repo_path,
+                                format!("Invalid repo_path: {error}"),
+                            )],
+                        },
+                    ),
+                );
+            }
+        };
+        let id = RepositoryIdentifier::local(repo_path);
+        let paths = RepoMetadataModel::handle(ctx)
+            .as_ref(ctx)
+            .get_project_skills(&id, ctx)
+            .map(|skills| {
+                skills
+                    .iter()
+                    .map(|skill| skill.path.to_local_path_lossy())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let max_file_bytes = msg
+            .max_file_bytes
+            .map(|bytes| bytes as usize)
+            .unwrap_or(DEFAULT_PROJECT_SKILL_FILE_BYTES);
+        let max_total_bytes = msg
+            .max_total_bytes
+            .map(|bytes| bytes as usize)
+            .unwrap_or(DEFAULT_PROJECT_SKILL_TOTAL_BYTES);
+        let request_id_for_response = request_id.clone();
+
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            read_project_skill_file_contents(paths, max_file_bytes, max_total_bytes),
+            move |me, response, _ctx| {
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::FindProjectSkillFilesResponse(response),
+                );
+            },
+            ctx,
+        );
+
+        HandlerOutcome::Async(Some(handle))
+    }
+
     /// Handles `OpenBuffer` by opening the file via `GlobalBufferModel`.
     /// The response is sent asynchronously when `BufferLoaded` fires.
     ///
@@ -2858,6 +2953,89 @@ fn canonicalize_index_repo_path(repo_path: &str) -> Result<PathBuf, String> {
     Ok(standardized_path
         .to_local_path()
         .unwrap_or_else(|| standardized_path.to_local_path_lossy()))
+}
+
+fn failed_file_read(path: String, message: String) -> FailedFileRead {
+    FailedFileRead {
+        path,
+        error: Some(FileOperationError { message }),
+    }
+}
+
+async fn read_project_skill_file_contents(
+    paths: Vec<PathBuf>,
+    max_file_bytes: usize,
+    max_total_bytes: usize,
+) -> FindProjectSkillFilesResponse {
+    let mut files = Vec::new();
+    let mut failed_files = Vec::new();
+    let mut remaining_total_bytes = max_total_bytes;
+
+    for path in paths {
+        let path_string = path.to_string_lossy().to_string();
+        let file_size = match metadata(&path).await {
+            Ok(metadata) => metadata.len() as usize,
+            Err(error) => {
+                failed_files.push(failed_file_read(
+                    path_string,
+                    format!("Failed to stat file: {error}"),
+                ));
+                continue;
+            }
+        };
+        if file_size > max_file_bytes {
+            failed_files.push(failed_file_read(
+                path_string,
+                format!("File exceeds per-file byte limit of {max_file_bytes} bytes"),
+            ));
+            continue;
+        }
+        if file_size > remaining_total_bytes {
+            failed_files.push(failed_file_read(
+                path_string,
+                format!("File exceeds remaining total byte limit of {remaining_total_bytes} bytes"),
+            ));
+            continue;
+        }
+
+        match read_to_string(&path).await {
+            Ok(content) => {
+                let content_bytes = content.len();
+                if content_bytes > max_file_bytes {
+                    failed_files.push(failed_file_read(
+                        path_string,
+                        format!("File exceeds per-file byte limit of {max_file_bytes} bytes"),
+                    ));
+                    continue;
+                }
+                if content_bytes > remaining_total_bytes {
+                    failed_files.push(failed_file_read(
+                        path_string,
+                        format!(
+                            "File exceeds remaining total byte limit of {remaining_total_bytes} bytes"
+                        ),
+                    ));
+                    continue;
+                }
+                remaining_total_bytes -= content_bytes;
+                files.push(ProjectSkillFileProto {
+                    path: path_string,
+                    content,
+                });
+            }
+            Err(error) => {
+                failed_files.push(failed_file_read(
+                    path_string,
+                    format!("Failed to read UTF-8 file: {error}"),
+                ));
+            }
+        }
+    }
+
+    FindProjectSkillFilesResponse {
+        files,
+        failed_files,
+    }
 }
 
 fn missing_fragment_metadata(content_hash: String, message: String) -> MissingFragmentMetadata {

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::fs;
 use std::sync::Arc;
 
+use tempfile::TempDir;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
@@ -11,7 +13,10 @@ use super::super::proto::{
 };
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{ConnectionId, PendingFileOps, ServerModel};
+use super::{
+    read_project_skill_file_contents, ConnectionId, PendingFileOps, ServerModel,
+    DEFAULT_PROJECT_SKILL_FILE_BYTES, DEFAULT_PROJECT_SKILL_TOTAL_BYTES,
+};
 use crate::auth::auth_state::AuthState;
 use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
@@ -39,6 +44,61 @@ fn test_key(repo: &str, mode: DiffMode) -> DiffModelKey {
         repo_path: StandardizedPath::try_new(repo).unwrap(),
         mode,
     }
+}
+
+#[test]
+fn project_skill_file_defaults_are_bounded() {
+    assert_eq!(DEFAULT_PROJECT_SKILL_FILE_BYTES, 1_000_000);
+    assert_eq!(DEFAULT_PROJECT_SKILL_TOTAL_BYTES, 8_000_000);
+}
+
+#[tokio::test]
+async fn project_skill_file_reads_return_successes_and_per_file_failures() {
+    let temp_dir = TempDir::new().unwrap();
+    let good = temp_dir.path().join("good.md");
+    let too_large = temp_dir.path().join("too-large.md");
+    let invalid_utf8 = temp_dir.path().join("invalid-utf8.md");
+    let missing = temp_dir.path().join("missing.md");
+    fs::write(&good, "skill").unwrap();
+    fs::write(&too_large, "skills").unwrap();
+    fs::write(&invalid_utf8, [0xff, 0xfe]).unwrap();
+
+    let response =
+        read_project_skill_file_contents(vec![good, too_large, invalid_utf8, missing], 5, 8).await;
+
+    assert_eq!(response.files.len(), 1);
+    assert_eq!(response.files[0].content, "skill");
+    assert_eq!(response.failed_files.len(), 3);
+    assert!(response.failed_files.iter().any(|failed| failed
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("per-file byte limit"))));
+    assert!(response.failed_files.iter().any(|failed| failed
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("UTF-8"))));
+    assert!(response.failed_files.iter().any(|failed| failed
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("stat"))));
+}
+
+#[tokio::test]
+async fn project_skill_file_reads_enforce_total_byte_budget() {
+    let temp_dir = TempDir::new().unwrap();
+    let first = temp_dir.path().join("first.md");
+    let second = temp_dir.path().join("second.md");
+    fs::write(&first, "12345").unwrap();
+    fs::write(&second, "6789").unwrap();
+
+    let response = read_project_skill_file_contents(vec![first, second], 10, 5).await;
+
+    assert_eq!(response.files.len(), 1);
+    assert_eq!(response.failed_files.len(), 1);
+    assert!(response.failed_files[0]
+        .error
+        .as_ref()
+        .is_some_and(|error| error.message.contains("remaining total byte limit")));
 }
 
 #[test]

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -58,6 +58,7 @@ impl FileSearchModel {
                 }
                 RepoMetadataEvent::FileTreeEntryUpdated { .. }
                 | RepoMetadataEvent::StandingQueryResultsUpdated { .. }
+                | RepoMetadataEvent::ProjectSkillFilesUpdated { .. }
                 | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                 | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
             },

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -172,6 +172,7 @@ impl Sessions {
                 | RemoteServerManagerEvent::NavigatedToDirectory { .. }
                 | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                 | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+                | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
                 | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                 | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4659,6 +4659,7 @@ impl TerminalView {
                     | RemoteServerManagerEvent::HostConnected { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+                    | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
                     | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -141,6 +141,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::NavigatedToDirectory { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -132,12 +132,6 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     #[cfg(feature = "local_fs")]
     app.add_singleton_model(|ctx| {
         let model = RepoMetadataModel::new(ctx);
-        model.register_force_included_paths(
-            SKILL_PROVIDER_DEFINITIONS
-                .iter()
-                .map(|provider| provider.skills_path.clone()),
-            ctx,
-        );
         model.set_project_skill_provider_paths(
             SKILL_PROVIDER_DEFINITIONS
                 .iter()

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -299,6 +299,7 @@ impl ProjectContextModel {
                     }
                     RepoMetadataEvent::FileTreeUpdated { .. }
                     | RepoMetadataEvent::FileTreeEntryUpdated { .. }
+                    | RepoMetadataEvent::ProjectSkillFilesUpdated { .. }
                     | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                     | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
                 }

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -43,6 +43,7 @@ message HostScopedRequest {
     GetBranches get_branches = 12;
     ResyncCodebase resync_codebase = 13;
     UploadHandoffSnapshot upload_handoff_snapshot = 14;
+    FindProjectSkillFiles find_project_skill_files = 15;
   }
 }
 
@@ -106,6 +107,8 @@ message ServerMessage {
     GetFragmentMetadataFromHashResponse get_fragment_metadata_from_hash_response = 24;
     GetBranchesResponse get_branches_response = 25;
     UploadHandoffSnapshotResponse upload_handoff_snapshot_response = 26;
+    FindProjectSkillFilesResponse find_project_skill_files_response = 27;
+    ProjectSkillFilesUpdatedPush project_skill_files_updated = 28;
   }
 }
 
@@ -265,8 +268,7 @@ message StandingQueryContent {
 }
 
 message StandingQueryResultsDelta {
-  repeated StandingQueryContent upserted_project_skills = 1;
-  repeated StandingQueryContent removed_project_skills = 2;
+  reserved 1, 2;
   repeated StandingQueryContent upserted_project_rules = 3;
   repeated StandingQueryContent removed_project_rules = 4;
 }
@@ -391,6 +393,29 @@ message FileContextProto {
   uint32 line_count = 7;
 }
 
+// ── Project skill files ───────────────────────────────────────────
+
+// Client → server: read the contents of project skill files discovered by
+// repo metadata's dedicated project-skills sidecar.
+message FindProjectSkillFiles {
+  string repo_path = 1;
+  // Per-file byte limit. Absent = use server default.
+  optional uint32 max_file_bytes = 2;
+  // Cumulative byte budget across all files. Absent = use server default.
+  optional uint32 max_total_bytes = 3;
+}
+
+// Server → client: readable project skill files and any per-file failures.
+message FindProjectSkillFilesResponse {
+  repeated ProjectSkillFileProto files = 1;
+  repeated FailedFileRead failed_files = 2;
+}
+
+message ProjectSkillFileProto {
+  string path = 1;
+  string content = 2;
+}
+
 // ── Remote codebase indexing status ───────────────────────────────
 
 message IndexCodebase {
@@ -503,6 +528,12 @@ message RepoMetadataUpdatePush {
   repeated string remove_entries = 2;
   repeated RepoMetadataEntryUpdate update_entries = 3;
   StandingQueryResultsDelta standing_results_delta = 4;
+}
+
+// Project skill sidecar contents changed for a repository. Clients should
+// re-fetch them with FindProjectSkillFiles.
+message ProjectSkillFilesUpdatedPush {
+  string repo_path = 1;
 }
 
 // ── Buffer syncing ────────────────────────────────────────────────

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -75,6 +75,8 @@ pub enum ClientEvent {
     RepoMetadataUpdated {
         update: repo_metadata::RepoMetadataUpdate,
     },
+    /// Project skill files changed for a repository on the remote host.
+    ProjectSkillFilesUpdated { repo_path: StandardizedPath },
     /// A full remote codebase-index status snapshot was pushed by the server.
     CodebaseIndexStatusesSnapshotReceived {
         statuses: Vec<RemoteCodebaseIndexStatus>,
@@ -563,6 +565,16 @@ impl RemoteServerClient {
             server_message::Message::RepoMetadataUpdate(push) => {
                 let update = proto_to_repo_metadata_update(&push)?;
                 Some(ClientEvent::RepoMetadataUpdated { update })
+            }
+            server_message::Message::ProjectSkillFilesUpdated(push) => {
+                let Some(repo_path) = StandardizedPath::try_new(&push.repo_path).ok() else {
+                    log::warn!(
+                        "ProjectSkillFilesUpdatedPush: invalid repo_path: {}",
+                        push.repo_path
+                    );
+                    return None;
+                };
+                Some(ClientEvent::ProjectSkillFilesUpdated { repo_path })
             }
             server_message::Message::CodebaseIndexStatusesSnapshot(snapshot) => {
                 let statuses = proto_to_codebase_index_statuses_snapshot(&snapshot);

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -8,8 +8,8 @@ use crate::proto::{
     client_message, host_scoped_request, notification, run_command_response, server_message,
     session_scoped_request, ClientMessage, CodebaseIndexStatus, CodebaseIndexStatusState,
     CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, ErrorCode, GetDiffStateResponse,
-    InitializeResponse, OpenBufferResponse, RunCommandResponse, RunCommandSuccess, ServerMessage,
-    WriteFile,
+    InitializeResponse, OpenBufferResponse, ProjectSkillFilesUpdatedPush, RunCommandResponse,
+    RunCommandSuccess, ServerMessage, WriteFile,
 };
 use crate::protocol;
 
@@ -18,6 +18,41 @@ fn unwrap_session_scoped(msg: &ClientMessage) -> &session_scoped_request::Messag
     match &msg.message {
         Some(client_message::Message::SessionScoped(w)) => w.message.as_ref().unwrap(),
         other => panic!("Expected SessionScoped, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn project_skill_files_updated_push_becomes_client_event() {
+    let (client_stream, server_stream) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    drop(server_read);
+
+    let executor = executor::Background::default();
+    let (_client, event_rx, _failure_rx, _host_rx) =
+        RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
+    let mut writer = server_write.compat_write();
+
+    protocol::write_server_message(
+        &mut writer,
+        &ServerMessage {
+            request_id: String::new(),
+            message: Some(server_message::Message::ProjectSkillFilesUpdated(
+                ProjectSkillFilesUpdatedPush {
+                    repo_path: "/repo".to_string(),
+                },
+            )),
+        },
+    )
+    .await
+    .unwrap();
+    writer.flush().await.unwrap();
+
+    match event_rx.recv().await.unwrap() {
+        ClientEvent::ProjectSkillFilesUpdated { repo_path } => {
+            assert_eq!(repo_path.to_string(), "/repo");
+        }
+        other => panic!("Expected ProjectSkillFilesUpdated, got {other:?}"),
     }
 }
 

--- a/crates/remote_server/src/host_response_tests.rs
+++ b/crates/remote_server/src/host_response_tests.rs
@@ -154,6 +154,7 @@ fn every_host_scoped_request_has_a_response_disposition() {
             M::DiscardFiles(_) => "host_response::discard_files_result",
             // Richer responses parsed at the manager call site.
             M::ReadFileContext(_) => "manager::read_file_context",
+            M::FindProjectSkillFiles(_) => "manager::find_project_skill_files",
             M::GetFragmentMetadataFromHash(_) => "manager::get_fragment_metadata_from_hash",
             M::UploadHandoffSnapshot(_) => "manager::upload_handoff_snapshot",
             M::GetBranches(_) => "manager::get_branches",

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -135,6 +135,7 @@ pub enum RemoteServerOperation {
     DiscardFiles,
     GetBranches,
     UploadHandoffSnapshot,
+    FindProjectSkillFiles,
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -262,6 +263,7 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::Disconnected => "disconnected",
         ClientEvent::RepoMetadataSnapshotReceived { .. } => "repo_metadata_snapshot",
         ClientEvent::RepoMetadataUpdated { .. } => "repo_metadata_updated",
+        ClientEvent::ProjectSkillFilesUpdated { .. } => "project_skill_files_updated",
         ClientEvent::CodebaseIndexStatusesSnapshotReceived { .. } => {
             "codebase_index_statuses_snapshot"
         }
@@ -468,6 +470,8 @@ pub enum RemoteServerManagerEvent {
         host_id: HostId,
         update: RepoMetadataUpdate,
     },
+    /// Project skill files changed on the remote host and should be re-fetched.
+    ProjectSkillFilesUpdated { remote_path: RemotePath },
     /// A `LoadRepoMetadataDirectory` response was received from the server.
     RepoMetadataDirectoryLoaded {
         host_id: HostId,
@@ -616,6 +620,7 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::HostDisconnected { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::ProjectSkillFilesUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
             | RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
@@ -833,6 +838,36 @@ impl HostRequestHandle {
             Some(crate::proto::server_message::Message::ReadFileContextResponse(resp)) => Ok(resp),
             other => {
                 log::error!("Unexpected response variant for ReadFileContext: {other:?}");
+                Err(HostRequestError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Finds project skill files on the remote host and returns their UTF-8
+    /// contents. Per-file failures are returned in the response.
+    pub async fn find_project_skill_files(
+        &self,
+        repo_path: String,
+        max_file_bytes: Option<u32>,
+        max_total_bytes: Option<u32>,
+    ) -> Result<crate::proto::FindProjectSkillFilesResponse, HostRequestError> {
+        let msg = self
+            .send(
+                crate::proto::host_scoped_request::Message::FindProjectSkillFiles(
+                    crate::proto::FindProjectSkillFiles {
+                        repo_path,
+                        max_file_bytes,
+                        max_total_bytes,
+                    },
+                ),
+            )
+            .await?;
+        match msg.message {
+            Some(crate::proto::server_message::Message::FindProjectSkillFilesResponse(resp)) => {
+                Ok(resp)
+            }
+            other => {
+                log::error!("Unexpected response variant for FindProjectSkillFiles: {other:?}");
                 Err(HostRequestError::UnexpectedResponse)
             }
         }
@@ -2803,6 +2838,11 @@ impl RemoteServerManager {
             }
             ClientEvent::RepoMetadataUpdated { update } => {
                 ctx.emit(RemoteServerManagerEvent::RepoMetadataUpdated { host_id, update });
+            }
+            ClientEvent::ProjectSkillFilesUpdated { repo_path } => {
+                ctx.emit(RemoteServerManagerEvent::ProjectSkillFilesUpdated {
+                    remote_path: RemotePath::new(host_id, repo_path),
+                });
             }
             ClientEvent::CodebaseIndexStatusesSnapshotReceived { statuses } => {
                 let statuses = statuses

--- a/crates/remote_server/src/repo_metadata_proto.rs
+++ b/crates/remote_server/src/repo_metadata_proto.rs
@@ -50,16 +50,6 @@ impl From<&StandingQueryContent> for proto::StandingQueryContent {
 impl From<&StandingQueryResultsDelta> for proto::StandingQueryResultsDelta {
     fn from(delta: &StandingQueryResultsDelta) -> Self {
         Self {
-            upserted_project_skills: delta
-                .upserted_project_skills
-                .iter()
-                .map(proto::StandingQueryContent::from)
-                .collect(),
-            removed_project_skills: delta
-                .removed_project_skills
-                .iter()
-                .map(proto::StandingQueryContent::from)
-                .collect(),
             upserted_project_rules: delta
                 .upserted_project_rules
                 .iter()
@@ -222,16 +212,6 @@ fn proto_to_standing_results_delta(
     delta: &proto::StandingQueryResultsDelta,
 ) -> StandingQueryResultsDelta {
     StandingQueryResultsDelta {
-        upserted_project_skills: delta
-            .upserted_project_skills
-            .iter()
-            .filter_map(proto_to_standing_query_content)
-            .collect(),
-        removed_project_skills: delta
-            .removed_project_skills
-            .iter()
-            .filter_map(proto_to_standing_query_content)
-            .collect(),
         upserted_project_rules: delta
             .upserted_project_rules
             .iter()

--- a/crates/remote_server/src/repo_metadata_proto_tests.rs
+++ b/crates/remote_server/src/repo_metadata_proto_tests.rs
@@ -11,12 +11,6 @@ fn path(path: &str) -> StandardizedPath {
 
 fn standing_delta() -> StandingQueryResultsDelta {
     StandingQueryResultsDelta {
-        upserted_project_skills: vec![StandingQueryContent::file(path(
-            "/repo/.agents/skills/review/SKILL.md",
-        ))],
-        removed_project_skills: vec![StandingQueryContent::directory(path(
-            "/repo/.claude/skills",
-        ))],
         upserted_project_rules: vec![StandingQueryContent::file(path("/repo/WARP.md"))],
         removed_project_rules: vec![StandingQueryContent::file(path(
             "/repo/packages/api/AGENTS.md",

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -13,6 +13,7 @@ use notify_debouncer_full::notify::WatchFilter;
 use thiserror::Error;
 use warp_util::standardized_path::StandardizedPath;
 
+use crate::project_skills::ProjectSkillFileMetadata;
 use crate::standing_queries::{StandingQueryDefinitions, StandingQueryResults};
 
 /// Maximum file size allowed for treesitter parsing (3MB).
@@ -33,6 +34,14 @@ pub enum BuildTreeError {
     Symlink,
     #[error("Maximum directory depth exceeded")]
     MaxDepthExceeded,
+}
+fn is_project_skill_path_interest(
+    path: &Path,
+    standing_queries: &Option<&mut StandingQueryBuildState<'_>>,
+) -> bool {
+    standing_queries
+        .as_ref()
+        .is_some_and(|state| state.definitions.is_project_skill_path_interest(path))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,7 +89,33 @@ pub(crate) struct BuildTreeOptions<'a> {
 }
 struct StandingQueryBuildState<'a> {
     results: &'a mut StandingQueryResults,
+    project_skill_files: &'a mut Vec<ProjectSkillFileMetadata>,
     definitions: &'a StandingQueryDefinitions,
+}
+
+impl StandingQueryBuildState<'_> {
+    fn record_path(&mut self, path: &Path, is_directory: bool) {
+        self.results
+            .record_path(path, is_directory, self.definitions);
+        if !is_directory && self.definitions.is_project_skill_file(path) {
+            self.project_skill_files
+                .push(ProjectSkillFileMetadata::from_path(path));
+        }
+    }
+
+    fn record_followed_project_skill_directory(&mut self, path: &Path) {
+        if !self
+            .definitions
+            .is_direct_project_skill_provider_child(path)
+        {
+            return;
+        }
+        let skill_file = path.join("SKILL.md");
+        if skill_file.is_file() {
+            self.project_skill_files
+                .push(ProjectSkillFileMetadata::from_path(&skill_file));
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
@@ -151,7 +186,9 @@ impl Entry {
             None,
         )
     }
-    /// Builds the materialized tree and standing results during the same filesystem traversal.
+    /// Builds the materialized tree, generic standing results, and dedicated project-skill
+    /// sidecar during the same filesystem traversal.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build_tree_with_standing_queries(
         path: impl Into<PathBuf>,
         files: &mut Vec<FileMetadata>,
@@ -159,10 +196,12 @@ impl Entry {
         remaining_file_quota: Option<&mut usize>,
         options: BuildTreeOptions<'_>,
         standing_results: &mut StandingQueryResults,
+        project_skill_files: &mut Vec<ProjectSkillFileMetadata>,
         definitions: &StandingQueryDefinitions,
     ) -> Result<Self, BuildTreeError> {
         let mut standing_queries = StandingQueryBuildState {
             results: standing_results,
+            project_skill_files,
             definitions,
         };
         Self::build_tree_with_force_included_paths_and_ancestor(
@@ -255,9 +294,7 @@ impl Entry {
         // ignored/symlinked), a classification failure at the root propagates to
         // the caller, preserving existing error behavior.
         if let Some(state) = standing_queries.as_deref_mut() {
-            state
-                .results
-                .record_path(&root_path, root_path.is_dir(), state.definitions);
+            state.record_path(&root_path, root_path.is_dir());
         }
         match evaluate_entry(
             &root_path,
@@ -265,6 +302,7 @@ impl Entry {
             &options,
             options.current_depth,
             ancestor_is_ignored,
+            is_project_skill_path_interest(&root_path, &standing_queries),
         )? {
             EvaluatedEntry::File { ignored } => {
                 if quota == Some(0)
@@ -287,7 +325,7 @@ impl Entry {
                 let mut queue: VecDeque<DirJob> = VecDeque::new();
                 if !lazy {
                     queue.push_back(DirJob {
-                        index: 0,
+                        index: Some(0),
                         path: root_path,
                         depth: options.current_depth,
                         ignored,
@@ -311,6 +349,7 @@ impl Entry {
                                     &job.path,
                                     options.force_included_paths,
                                 )
+                                || is_project_skill_path_interest(&job.path, &standing_queries)
                         }
                     };
                     if !should_expand {
@@ -330,8 +369,10 @@ impl Entry {
                         }
                     };
 
-                    if let Some(NodeBuilder::Dir { loaded, .. }) = nodes[job.index].as_mut() {
-                        *loaded = true;
+                    if let Some(index) = job.index {
+                        if let Some(NodeBuilder::Dir { loaded, .. }) = nodes[index].as_mut() {
+                            *loaded = true;
+                        }
                     }
 
                     let child_depth = job.depth + 1;
@@ -341,16 +382,13 @@ impl Entry {
                         };
                         let entry_path = entry.path();
 
-                        // Do not materialize directory symlinks in the canonical tree. Standing
-                        // project-skill queries still follow eligible provider children locally
-                        // and retain their lexical paths in the result set.
+                        // Do not materialize directory symlinks in the canonical tree. Dedicated
+                        // project-skill discovery still follows eligible provider children locally
+                        // and retains their lexical paths in the sidecar.
                         let canonical_path = if entry_path.is_symlink() {
                             if entry_path.is_dir() {
                                 if let Some(state) = standing_queries.as_deref_mut() {
-                                    state.results.record_followed_project_skill_directory(
-                                        &entry_path,
-                                        state.definitions,
-                                    );
+                                    state.record_followed_project_skill_directory(&entry_path);
                                 }
                                 None
                             } else {
@@ -363,11 +401,7 @@ impl Entry {
                             continue;
                         };
                         if let Some(state) = standing_queries.as_deref_mut() {
-                            state.results.record_path(
-                                &child_path,
-                                child_path.is_dir(),
-                                state.definitions,
-                            );
+                            state.record_path(&child_path, child_path.is_dir());
                         }
 
                         match evaluate_entry(
@@ -376,8 +410,24 @@ impl Entry {
                             &options,
                             child_depth,
                             job.ignored,
+                            is_project_skill_path_interest(&child_path, &standing_queries),
                         ) {
                             Ok(EvaluatedEntry::File { ignored }) => {
+                                // Ignored project-skill paths are traversed so the sidecar can
+                                // retain them, but they must not leak into the canonical tree.
+                                let standing_only = ignored
+                                    && is_project_skill_path_interest(
+                                        &child_path,
+                                        &standing_queries,
+                                    )
+                                    && !matches_force_included_path(
+                                        &child_path,
+                                        options.force_included_paths,
+                                    );
+                                let Some(parent_index) = job.index.filter(|_| !standing_only)
+                                else {
+                                    continue;
+                                };
                                 if quota == Some(0)
                                     && options.budget_exceeded_behavior
                                         == BudgetExceededBehavior::FailFast
@@ -388,17 +438,29 @@ impl Entry {
                                     consume_file(&child_path, ignored, files, &mut quota);
                                 let child_index = nodes.len();
                                 nodes.push(Some(NodeBuilder::File(metadata)));
-                                push_child(&mut nodes, job.index, child_index);
+                                push_child(&mut nodes, parent_index, child_index);
                             }
                             Ok(EvaluatedEntry::Directory { ignored, lazy }) => {
-                                let child_index = nodes.len();
-                                nodes.push(Some(NodeBuilder::Dir {
-                                    path: child_path.clone(),
-                                    ignored,
-                                    loaded: false,
-                                    children: Vec::new(),
-                                }));
-                                push_child(&mut nodes, job.index, child_index);
+                                // An ignored project-skill branch is walked only for sidecar
+                                // discovery. Its descendants remain outside the canonical tree
+                                // even though project-skill interest keeps the traversal eager.
+                                let standing_only = ignored
+                                    && is_project_skill_path_interest(
+                                        &child_path,
+                                        &standing_queries,
+                                    );
+                                let child_index =
+                                    job.index.filter(|_| !standing_only).map(|parent_index| {
+                                        let child_index = nodes.len();
+                                        nodes.push(Some(NodeBuilder::Dir {
+                                            path: child_path.clone(),
+                                            ignored,
+                                            loaded: false,
+                                            children: Vec::new(),
+                                        }));
+                                        push_child(&mut nodes, parent_index, child_index);
+                                        child_index
+                                    });
                                 // Lazy directories (past max depth, or ignored
                                 // without a matching force-included path) stay
                                 // unloaded. Everything else is queued for
@@ -535,7 +597,9 @@ enum NodeBuilder {
 
 /// A directory queued for expansion during the breadth-first build.
 struct DirJob {
-    index: usize,
+    /// Arena node for materialized directories. `None` means this directory is traversed only
+    /// to update sidecar results and must remain outside the canonical tree.
+    index: Option<usize>,
     path: PathBuf,
     depth: usize,
     ignored: bool,
@@ -558,6 +622,7 @@ fn evaluate_entry(
     options: &BuildTreeOptions<'_>,
     current_depth: usize,
     ancestor_is_ignored: bool,
+    project_skill_interest: bool,
 ) -> Result<EvaluatedEntry, BuildTreeError> {
     let is_dir = curr_path.is_dir();
 
@@ -581,7 +646,8 @@ fn evaluate_entry(
             false, /* check_ancestors */
         );
 
-    let force_included = matches_force_included_path(curr_path, options.force_included_paths);
+    let force_included = matches_force_included_path(curr_path, options.force_included_paths)
+        || project_skill_interest;
 
     // If we've reached the max depth, force lazy-loading even of non-ignored folders unless the
     // folder is on the path to a force-included subtree.
@@ -691,7 +757,7 @@ pub fn is_git_internal_path(path: &Path) -> bool {
 /// `force_included_paths`. Each force-included path is a relative component
 /// sequence (e.g. `.agents/skills`) matched against the tail of `path`, so a
 /// match also holds for the ancestor prefixes leading to it.
-fn matches_force_included_path(path: &Path, force_included_paths: &[PathBuf]) -> bool {
+pub(crate) fn matches_force_included_path(path: &Path, force_included_paths: &[PathBuf]) -> bool {
     let path_components: Vec<_> = path
         .components()
         .filter_map(|component| match component {

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -3,8 +3,6 @@ use std::fs;
 use ignore::gitignore::Gitignore;
 
 use super::{matches_gitignores, Entry, IgnoredPathStrategy};
-#[cfg(unix)]
-use crate::StandingQueryContent;
 use crate::{StandingQueryDefinitions, StandingQueryResults};
 #[test]
 fn test_git_path_filtering_allowlist() {
@@ -174,6 +172,46 @@ fn test_git_path_filtering_allowlist() {
             r"C:\Users\user\project\.git\index"
         )));
     }
+}
+
+#[test]
+fn standing_queries_preserve_unrelated_generic_force_included_paths() {
+    virtual_fs::VirtualFS::test(
+        "standing_queries_preserve_generic_force_included_paths",
+        |dirs, mut vfs| {
+            vfs.mkdir("repo/.cache/data")
+                .with_files(vec![virtual_fs::Stub::FileWithContent(
+                    "repo/.cache/data/value.txt",
+                    "value",
+                )]);
+            let repo = dirs.tests().join("repo");
+            std::fs::write(repo.join(".gitignore"), ".cache/\n").unwrap();
+
+            let mut files = Vec::new();
+            let mut gitignores = Vec::new();
+            let mut results = StandingQueryResults::default();
+            let mut project_skill_files = Vec::new();
+            let tree = Entry::build_tree_with_standing_queries(
+                &repo,
+                &mut files,
+                &mut gitignores,
+                None,
+                super::BuildTreeOptions {
+                    max_depth: 200,
+                    current_depth: 0,
+                    ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
+                    force_included_paths: &[std::path::PathBuf::from(".cache/data")],
+                    budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
+                },
+                &mut results,
+                &mut project_skill_files,
+                &StandingQueryDefinitions::default(),
+            )
+            .unwrap();
+
+            assert!(find_entry(&tree, &repo.join(".cache/data/value.txt")).is_some());
+        },
+    );
 }
 
 /// Writes a `.gitignore` with `content` at `root` and returns a [`Gitignore`]
@@ -380,6 +418,7 @@ fn standing_queries_report_skills_below_an_ignored_directory() {
         let mut files = Vec::new();
         let mut gitignores = Vec::new();
         let mut results = StandingQueryResults::default();
+        let mut project_skill_files = Vec::new();
         let mut definitions = StandingQueryDefinitions::default();
         definitions.set_project_skill_provider_paths([std::path::PathBuf::from(".agents/skills")]);
         let tree = Entry::build_tree_with_standing_queries(
@@ -391,25 +430,27 @@ fn standing_queries_report_skills_below_an_ignored_directory() {
                 max_depth: 200,
                 current_depth: 0,
                 ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
-                force_included_paths: &[std::path::PathBuf::from(".agents/skills")],
+                force_included_paths: &[],
                 budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
             },
             &mut results,
+            &mut project_skill_files,
             &definitions,
         )
         .unwrap();
 
-        let agents = find_entry(&tree, &repo.join(".agents")).expect(".agents should be present");
-        assert!(agents.loaded());
-        assert!(find_entry(&tree, &repo.join(".agents/skills/test/SKILL.md")).is_some());
+        assert!(
+            find_entry(&tree, &repo.join(".agents")).is_none(),
+            "ignored standing-query paths must remain outside the canonical tree"
+        );
 
         let skill_path = warp_util::standardized_path::StandardizedPath::try_from_local(
             &repo.join(".agents/skills/test/SKILL.md"),
         )
         .unwrap();
-        assert!(results
-            .project_skills()
-            .any(|content| content.path == skill_path && !content.is_directory));
+        assert!(project_skill_files
+            .iter()
+            .any(|content| content.path == skill_path));
     });
 }
 
@@ -433,6 +474,7 @@ fn standing_queries_report_symlinked_skills_without_materializing_symlinked_dire
             let mut files = Vec::new();
             let mut gitignores = Vec::new();
             let mut results = StandingQueryResults::default();
+            let mut project_skill_files = Vec::new();
             let mut definitions = StandingQueryDefinitions::default();
             definitions
                 .set_project_skill_provider_paths([std::path::PathBuf::from(".agents/skills")]);
@@ -449,19 +491,18 @@ fn standing_queries_report_symlinked_skills_without_materializing_symlinked_dire
                     budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
                 },
                 &mut results,
+                &mut project_skill_files,
                 &definitions,
             )
             .unwrap();
 
             assert!(find_entry(&tree, &linked_directory).is_none());
-            assert!(results.project_skills().any(|content| {
-                content
-                    == &StandingQueryContent::file(
-                        warp_util::standardized_path::StandardizedPath::try_from_local(
-                            &linked_directory.join("SKILL.md"),
-                        )
-                        .unwrap(),
+            assert!(project_skill_files.iter().any(|content| {
+                content.path
+                    == warp_util::standardized_path::StandardizedPath::try_from_local(
+                        &linked_directory.join("SKILL.md"),
                     )
+                    .unwrap()
             }));
         },
     );
@@ -479,6 +520,7 @@ fn standing_queries_do_not_report_rules_below_an_unloaded_shallow_directory() {
         let mut files = Vec::new();
         let mut gitignores = Vec::new();
         let mut results = StandingQueryResults::default();
+        let mut project_skill_files = Vec::new();
         let tree = Entry::build_tree_with_standing_queries(
             &repo,
             &mut files,
@@ -492,6 +534,7 @@ fn standing_queries_do_not_report_rules_below_an_unloaded_shallow_directory() {
                 budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
             },
             &mut results,
+            &mut project_skill_files,
             &StandingQueryDefinitions::default(),
         )
         .unwrap();
@@ -529,6 +572,7 @@ fn shallow_tree_expands_force_included_skill_branch_only() {
         let mut files = Vec::new();
         let mut gitignores = Vec::new();
         let mut results = StandingQueryResults::default();
+        let mut project_skill_files = Vec::new();
         let mut definitions = StandingQueryDefinitions::default();
         definitions.set_project_skill_provider_paths([std::path::PathBuf::from(".agents/skills")]);
         let tree = Entry::build_tree_with_standing_queries(
@@ -544,6 +588,7 @@ fn shallow_tree_expands_force_included_skill_branch_only() {
                 budget_exceeded_behavior: super::BudgetExceededBehavior::StopAndLazyLoad,
             },
             &mut results,
+            &mut project_skill_files,
             &definitions,
         )
         .unwrap();
@@ -562,9 +607,9 @@ fn shallow_tree_expands_force_included_skill_branch_only() {
             warp_util::standardized_path::StandardizedPath::try_from_local(&skill_path).unwrap();
         let rule_path =
             warp_util::standardized_path::StandardizedPath::try_from_local(&rule_path).unwrap();
-        assert!(results
-            .project_skills()
-            .any(|content| content.path == skill_path && !content.is_directory));
+        assert!(project_skill_files
+            .iter()
+            .any(|content| content.path == skill_path));
         assert!(!results
             .project_rules()
             .any(|content| content.path == rule_path));

--- a/crates/repo_metadata/src/file_tree_store.rs
+++ b/crates/repo_metadata/src/file_tree_store.rs
@@ -7,7 +7,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui_core::ModelHandle;
 
 use crate::file_tree_store::file_tree_state::FileTreeMapStore;
-use crate::{BuildTreeError, Entry, FileId, FileMetadata, Repository};
+use crate::{BuildTreeError, Entry, FileId, FileMetadata, ProjectSkillFileMetadata, Repository};
 
 #[derive(Debug, Clone)]
 pub struct FileTreeEntry {
@@ -361,32 +361,46 @@ pub struct FileTreeState {
     pub entry: FileTreeEntry,
     /// Gitignore rules applicable to this repository.
     pub gitignores: Vec<Gitignore>,
+    /// Project skill files discovered during the same walk as the canonical tree.
+    project_skill_files: Vec<ProjectSkillFileMetadata>,
 
     /// Handle to the backing repository (None for lazily-loaded standalone paths).
-    #[expect(unused)]
     repository: Option<ModelHandle<Repository>>,
 }
 
 impl FileTreeState {
+    pub(crate) fn project_skill_files(&self) -> &[ProjectSkillFileMetadata] {
+        &self.project_skill_files
+    }
+
+    pub(crate) fn project_skill_files_mut(&mut self) -> &mut Vec<ProjectSkillFileMetadata> {
+        &mut self.project_skill_files
+    }
     /// Creates a new FileTreeState.
     pub fn new(
         entry: Entry,
         gitignores: Vec<Gitignore>,
         repository: Option<ModelHandle<Repository>>,
+        project_skill_files: Vec<ProjectSkillFileMetadata>,
     ) -> Self {
         Self {
             entry: entry.into(),
             gitignores,
             repository,
+            project_skill_files,
         }
     }
 
     /// Creates a new FileTreeState for a lazily-loaded standalone path.
-    pub fn new_lazy_loaded(entry: Entry) -> Self {
+    pub fn new_lazy_loaded(
+        entry: Entry,
+        project_skill_files: Vec<ProjectSkillFileMetadata>,
+    ) -> Self {
         Self {
             entry: entry.into(),
             gitignores: vec![],
             repository: None,
+            project_skill_files,
         }
     }
 
@@ -399,7 +413,12 @@ impl FileTreeState {
             entry,
             gitignores: vec![],
             repository: None,
+            project_skill_files: Vec::new(),
         }
+    }
+
+    pub(crate) fn repository(&self) -> Option<&ModelHandle<Repository>> {
+        self.repository.as_ref()
     }
 }
 

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -37,6 +37,7 @@ pub mod entry;
 pub mod file_tree_store;
 pub mod file_tree_update;
 pub mod local_model;
+pub mod project_skills;
 pub mod remote_model;
 pub mod repositories;
 pub mod repository;
@@ -73,6 +74,7 @@ pub fn is_in_repo(_path: &str, _app: &warpui_core::AppContext) -> bool {
 pub use file_tree_store::FileTreeEntry;
 pub use file_tree_update::{MetadataUpdateType, RepoMetadataUpdate};
 pub use local_model::{LocalRepoMetadataModel, RepoContent, RepoContents};
+pub use project_skills::ProjectSkillFileMetadata;
 pub use remote_model::RemoteRepoMetadataModel;
 pub use repository_identifier::{RemoteRepositoryIdentifier, RepositoryIdentifier};
 pub use standing_queries::{

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -41,6 +41,7 @@ use warp_util::standardized_path::StandardizedPath;
 use crate::entry::{
     BudgetExceededBehavior, BuildTreeError, BuildTreeOptions, Entry, FileId, IgnoredPathStrategy,
 };
+use crate::project_skills::{replace_project_skill_subtrees, ProjectSkillFileMetadata};
 use crate::repository::Repository;
 use crate::standing_queries::{
     StandingQueryDefinitions, StandingQueryResults, StandingQueryResultsDelta,
@@ -89,6 +90,17 @@ const MAX_FILES_PER_REPO: usize = 200_000;
 /// Maximum number of results to return from get_repo_contents to prevent accidentally
 /// materializing the entire repository
 const MAX_REPO_CONTENTS_RESULTS: usize = 100;
+struct RepositoryBuildOutput {
+    build_result: Result<Entry, BuildTreeError>,
+    files: Vec<crate::entry::FileMetadata>,
+    gitignores: Vec<Gitignore>,
+    repo_path_str: String,
+    repo_path: StandardizedPath,
+    repository: ModelHandle<Repository>,
+    indexed_with_limit: bool,
+    standing_results: StandingQueryResults,
+    project_skill_files: Vec<ProjectSkillFileMetadata>,
+}
 
 #[derive(Debug)]
 /// Events emitted by the LocalRepoMetadataModel.
@@ -116,6 +128,10 @@ pub enum RepositoryMetadataEvent {
     StandingQueryResultsUpdated {
         path: StandardizedPath,
         delta: StandingQueryResultsDelta,
+    },
+    /// Project skill files in the dedicated sidecar changed.
+    ProjectSkillFilesUpdated {
+        path: StandardizedPath,
     },
     UpdatingRepositoryFailed {
         path: StandardizedPath,
@@ -254,6 +270,17 @@ struct RepoUpdate {
     added: Vec<PathBuf>,
     deleted: Vec<PathBuf>,
     moved: HashMap<PathBuf, PathBuf>,
+}
+
+impl RepoUpdate {
+    fn gitignore_changed(&self) -> bool {
+        self.added
+            .iter()
+            .chain(&self.deleted)
+            .chain(self.moved.keys())
+            .chain(self.moved.values())
+            .any(|path| path.file_name().is_some_and(|name| name == ".gitignore"))
+    }
 }
 #[cfg(feature = "local_fs")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -408,10 +435,11 @@ impl LocalRepoMetadataModel {
             .set_project_skill_provider_paths(paths);
     }
 
-    /// Adds synthetic lexical repository updates for changes beneath resolved symlink targets.
+    /// Adds synthetic lexical repository updates for changes beneath resolved project-skill
+    /// symlink targets.
     ///
     /// Directory symlinks are intentionally absent from the canonical tree, so target changes
-    /// must be replayed through their lexical paths to refresh standing-query results.
+    /// must be replayed through their lexical paths to refresh the project-skill sidecar.
     #[cfg(feature = "local_fs")]
     fn add_symlink_target_updates(
         &self,
@@ -466,7 +494,10 @@ impl LocalRepoMetadataModel {
         let Some(local_repo_path) = repo_path.to_local_path() else {
             return;
         };
-        for interest in &self.force_included_paths {
+        for interest in self
+            .standing_query_definitions
+            .project_skill_provider_paths()
+        {
             let Ok(entries) = std::fs::read_dir(local_repo_path.join(interest)) else {
                 continue;
             };
@@ -574,12 +605,58 @@ impl LocalRepoMetadataModel {
                     .moved
                     .insert(to_path.to_path_buf(), from_path.to_path_buf());
             }
+            if let Some(repo_path) =
+                self.find_repository_for_path_string(from_path.to_string_lossy().as_ref())
+            {
+                let repo_update = repo_updates.entry(repo_path).or_default();
+                if !repo_update.deleted.contains(from_path) {
+                    repo_update.deleted.push(from_path.to_path_buf());
+                }
+            }
         }
 
         // Collect all paths that have been updated and emit an event.
         ctx.emit(RepositoryMetadataEvent::FileTreeUpdated {
             paths: repo_updates.keys().cloned().collect(),
         });
+
+        // A changed .gitignore can reclassify whole subtrees, including paths that are not
+        // otherwise present in this watcher batch. Rebuild real repositories from the same
+        // metadata walk so the canonical tree, standing-query results, and project-skill sidecar
+        // use fresh rules.
+        // Lazily-loaded standalone paths have no backing Repository handle and continue through
+        // the incremental path below.
+        let repositories_to_reindex = repo_updates
+            .iter()
+            .filter(|(_, update)| update.gitignore_changed())
+            .filter_map(|(repo_path, _)| {
+                let IndexedRepoState::Indexed(state) = self.repositories.get(repo_path)? else {
+                    return None;
+                };
+                Some((repo_path.clone(), state.repository()?.clone()))
+            })
+            .collect::<Vec<_>>();
+        let lazy_paths_to_reindex = repo_updates
+            .iter()
+            .filter(|(_, update)| update.gitignore_changed())
+            .filter_map(|(repo_path, _)| {
+                self.lazy_loaded_paths
+                    .contains_key(repo_path)
+                    .then_some(repo_path.clone())
+            })
+            .collect::<Vec<_>>();
+        for (repo_path, repository) in repositories_to_reindex {
+            repo_updates.remove(&repo_path);
+            if let Err(error) = self.index_directory_internal(repository, true, ctx) {
+                log::warn!("Failed to reindex repository after .gitignore change: {error}");
+            }
+        }
+        for repo_path in lazy_paths_to_reindex {
+            repo_updates.remove(&repo_path);
+            if let Err(error) = self.reindex_lazy_loaded_path(&repo_path, ctx) {
+                log::warn!("Failed to reindex lazy path after .gitignore change: {error}");
+            }
+        }
         // Apply updates to each affected repository asynchronously.
         // Phase 1 (background thread): compute lightweight mutations via filesystem I/O.
         // Phase 2 (main thread callback): apply mutations directly to the tree — no clone needed.
@@ -592,7 +669,7 @@ impl LocalRepoMetadataModel {
                 let lazy_load = self.lazy_loaded_paths.contains_key(&repo_path);
                 ctx.spawn(
                     async move {
-                        let (mutations, standing_results, removed_roots) =
+                        let (mutations, standing_results, project_skill_files, removed_roots) =
                             Self::compute_file_tree_mutations(
                                 &repo_scoped_update,
                                 &gitignores_clone,
@@ -604,13 +681,21 @@ impl LocalRepoMetadataModel {
                         (
                             mutations,
                             standing_results,
+                            project_skill_files,
                             removed_roots,
                             repo_path_clone,
                             lazy_load,
                         )
                     },
                     |model,
-                     (mutations, discovered_results, removed_roots, repo_path, lazy_load),
+                     (
+                        mutations,
+                        discovered_results,
+                        project_skill_files,
+                        removed_roots,
+                        repo_path,
+                        lazy_load,
+                    ),
                      ctx| {
                         if let Some(IndexedRepoState::Indexed(state)) =
                             model.repositories.get_mut(&repo_path)
@@ -627,7 +712,13 @@ impl LocalRepoMetadataModel {
                                 .entry(repo_path.clone())
                                 .or_default()
                                 .replace_subtrees(&removed_roots, discovered_results);
+                            let project_skills_changed = replace_project_skill_subtrees(
+                                state.project_skill_files_mut(),
+                                &removed_roots,
+                                project_skill_files,
+                            );
                             model.refresh_symlink_targets(&repo_path, ctx);
+                            model.watch_project_skill_paths_for_lazy_root(&repo_path, ctx);
                             update.standing_results_delta = standing_delta.clone();
                             ctx.emit(RepositoryMetadataEvent::FileTreeEntryUpdated {
                                 path: repo_path.clone(),
@@ -637,6 +728,11 @@ impl LocalRepoMetadataModel {
                                 ctx.emit(RepositoryMetadataEvent::StandingQueryResultsUpdated {
                                     path: repo_path.clone(),
                                     delta: standing_delta,
+                                });
+                            }
+                            if project_skills_changed {
+                                ctx.emit(RepositoryMetadataEvent::ProjectSkillFilesUpdated {
+                                    path: repo_path.clone(),
                                 });
                             }
                             if model.emit_incremental_updates {
@@ -758,7 +854,13 @@ impl LocalRepoMetadataModel {
                 // while still watching registered force-included paths (e.g.
                 // skills).
                 let gitignores = crate::gitignores_for_directory(&watch_path);
-                let force_included_paths = self.force_included_paths.clone();
+                let mut force_included_paths = self.force_included_paths.clone();
+                force_included_paths.extend(
+                    self.standing_query_definitions
+                        .project_skill_provider_paths()
+                        .iter()
+                        .cloned(),
+                );
                 let had_previous = previous.is_some();
                 let previous_extra: Vec<PathBuf> = previous
                     .map(|prev| {
@@ -788,9 +890,15 @@ impl LocalRepoMetadataModel {
         let repo_path_for_event = repo_path.clone();
         self.replace_repository_state(repo_path, IndexedRepoState::Indexed(state));
         #[cfg(feature = "local_fs")]
-        self.refresh_symlink_targets(&repo_path_for_event, ctx);
+        {
+            self.refresh_symlink_targets(&repo_path_for_event, ctx);
+            self.watch_project_skill_paths_for_lazy_root(&repo_path_for_event, ctx);
+        }
 
         ctx.emit(RepositoryMetadataEvent::RepositoryUpdated {
+            path: repo_path_for_event.clone(),
+        });
+        ctx.emit(RepositoryMetadataEvent::ProjectSkillFilesUpdated {
             path: repo_path_for_event,
         });
 
@@ -857,6 +965,14 @@ impl LocalRepoMetadataModel {
         self.standing_results.get(repo_path)
     }
 
+    pub fn get_project_skills(
+        &self,
+        repo_path: &StandardizedPath,
+    ) -> Option<&[ProjectSkillFileMetadata]> {
+        self.get_repository(repo_path)
+            .map(FileTreeState::project_skill_files)
+    }
+
     /// Returns the current [`IndexedRepoState`] for the specified repository or `None` if the
     /// repository is not being tracked.
     pub fn repository_state(&self, repo_path: &StandardizedPath) -> Option<&IndexedRepoState> {
@@ -912,11 +1028,27 @@ impl LocalRepoMetadataModel {
             ));
         }
 
+        self.reindex_lazy_loaded_path(path, ctx)?;
+        self.lazy_loaded_paths.insert(path.clone(), 1);
+        Ok(())
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn reindex_lazy_loaded_path(
+        &mut self,
+        path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<(), RepoMetadataError> {
+        let local_path = path
+            .to_local_path()
+            .ok_or_else(|| RepoMetadataError::PathEncodingMismatch(path.clone()))?;
+
         // Build first-level-only tree while collecting standing results across
         // descendants that are not materialized in the lazy file tree.
         let mut files = Vec::new();
         let mut file_limit = MAX_FILES_PER_REPO;
         let mut standing_results = StandingQueryResults::default();
+        let mut project_skill_files = Vec::new();
         let root_entry = Entry::build_tree_with_standing_queries(
             &local_path,
             &mut files,
@@ -930,11 +1062,12 @@ impl LocalRepoMetadataModel {
                 budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
             },
             &mut standing_results,
+            &mut project_skill_files,
             &self.standing_query_definitions,
         )
         .map_err(RepoMetadataError::BuildTree)?;
 
-        let state = FileTreeState::new_lazy_loaded(root_entry);
+        let state = FileTreeState::new_lazy_loaded(root_entry, project_skill_files);
         self.standing_results.insert(path.clone(), standing_results);
         // On Linux, watch lazy (non-git) roots non-recursively to avoid
         // registering an inotify watch for every directory in the subtree.
@@ -947,7 +1080,6 @@ impl LocalRepoMetadataModel {
             RootWatchMode::Recursive
         };
         self.add_repository_internal(path.clone(), state, root_mode, ctx)?;
-        self.lazy_loaded_paths.insert(path.clone(), 1);
         Ok(())
     }
 
@@ -1059,6 +1191,76 @@ impl LocalRepoMetadataModel {
         }
     }
 
+    /// Keeps the dedicated project-skill sidecar live for Linux lazy roots.
+    ///
+    /// Lazy non-git roots use non-recursive watches to avoid watching the entire
+    /// tree. Project-skill discovery still needs events from provider ancestors,
+    /// provider directories, and each direct skill directory, so register those
+    /// existing directories explicitly. Newly created ancestors and skill
+    /// directories are added after their parent watch reports them.
+    #[cfg(feature = "local_fs")]
+    fn watch_project_skill_paths_for_lazy_root(
+        &mut self,
+        repo_root: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if !matches!(
+            self.repo_watches
+                .get(repo_root)
+                .map(|watch| watch.root_mode),
+            Some(RootWatchMode::NonRecursive)
+        ) {
+            return;
+        }
+        let Some(local_root) = repo_root.to_local_path() else {
+            return;
+        };
+        let provider_paths = self
+            .standing_query_definitions
+            .project_skill_provider_paths()
+            .to_vec();
+        let mut directories = Vec::new();
+        for provider_path in provider_paths {
+            if provider_path.is_absolute()
+                || provider_path
+                    .components()
+                    .any(|component| matches!(component, std::path::Component::ParentDir))
+            {
+                continue;
+            }
+
+            let mut current = local_root.clone();
+            for component in provider_path.components() {
+                current.push(component.as_os_str());
+                if !current.is_dir() || current.is_symlink() {
+                    break;
+                }
+                if let Ok(path) = StandardizedPath::try_from_local(&current) {
+                    directories.push(path);
+                }
+            }
+
+            let provider_directory = local_root.join(&provider_path);
+            let Ok(entries) = std::fs::read_dir(provider_directory) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !path.is_dir() || path.is_symlink() {
+                    continue;
+                }
+                if let Ok(path) = StandardizedPath::try_from_local(&path) {
+                    directories.push(path);
+                }
+            }
+        }
+        directories.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        directories.dedup();
+        for directory in directories {
+            self.watch_subdir(repo_root, &directory, ctx);
+        }
+    }
+
     /// Drops any on-demand per-directory watches at or under `removed_path` when
     /// a directory is deleted or moved away. Each stale path is unregistered from
     /// the watcher and removed from `extra_dirs`. Without this, a directory
@@ -1146,10 +1348,12 @@ impl LocalRepoMetadataModel {
     ) -> (
         Vec<FileTreeMutation>,
         StandingQueryResults,
+        Vec<ProjectSkillFileMetadata>,
         Vec<StandardizedPath>,
     ) {
         let mut mutations = Vec::new();
         let mut standing_results = StandingQueryResults::default();
+        let mut project_skill_files = Vec::new();
         let mut removed_roots = Vec::new();
 
         // Removals for deleted and moved-from paths
@@ -1158,12 +1362,6 @@ impl LocalRepoMetadataModel {
             if let Ok(path) = StandardizedPath::try_from_local(path_to_remove) {
                 removed_roots.push(path);
             }
-            // A removed direct provider child may have been a symlinked skill directory,
-            // which is intentionally absent from the canonical tree and standing file matches.
-            standing_results.record_direct_project_skill_provider_child_change(
-                path_to_remove,
-                standing_query_definitions,
-            );
         }
 
         // Additions for new and moved-to paths
@@ -1173,9 +1371,16 @@ impl LocalRepoMetadataModel {
             }
 
             let is_ignored = Self::path_is_ignored(path_to_add, gitignores);
+            let project_skill_interest =
+                standing_query_definitions.is_project_skill_path_interest(path_to_add);
+            let traversal_interest = project_skill_interest
+                || crate::entry::matches_force_included_path(path_to_add, force_included_paths);
+            let standing_only = is_ignored
+                && project_skill_interest
+                && !crate::entry::matches_force_included_path(path_to_add, force_included_paths);
 
             if path_to_add.is_dir() {
-                if lazy_load {
+                if lazy_load && !traversal_interest {
                     // Lazy (non-git) roots are not materialized when a directory
                     // is created; insert it as an unloaded placeholder and build
                     // the subtree on demand when the user expands it (see
@@ -1203,37 +1408,48 @@ impl LocalRepoMetadataModel {
                         budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
                     },
                     &mut standing_results,
+                    &mut project_skill_files,
                     standing_query_definitions,
                 ) {
                     Ok(subtree) => {
-                        mutations.push(FileTreeMutation::AddDirectorySubtree {
-                            dir_path: path_to_add.clone(),
-                            subtree,
-                        });
+                        if !standing_only {
+                            mutations.push(FileTreeMutation::AddDirectorySubtree {
+                                dir_path: path_to_add.clone(),
+                                subtree,
+                            });
+                        }
                     }
                     Err(BuildTreeError::Symlink) => {
                         // Directory symlinks are intentionally absent from the canonical tree.
                         // Re-hydrate only when the changed entry itself can introduce a
                         // symlinked skill; ordinary descendants should not wake consumers.
-                        standing_results.record_direct_project_skill_provider_child_change(
-                            path_to_add,
-                            standing_query_definitions,
-                        );
-                        standing_results.record_followed_project_skill_directory(
-                            path_to_add,
-                            standing_query_definitions,
-                        );
+                        let skill_file = path_to_add.join("SKILL.md");
+                        if standing_query_definitions
+                            .is_direct_project_skill_provider_child(path_to_add)
+                            && skill_file.is_file()
+                        {
+                            project_skill_files
+                                .push(ProjectSkillFileMetadata::from_path(&skill_file));
+                        }
                     }
                     Err(e) => {
                         log::warn!("Failed to build subtree for directory {path_to_add:?}: {e:?}");
-                        mutations.push(FileTreeMutation::AddUnloadedDirectory {
-                            path: path_to_add.clone(),
-                            is_ignored,
-                        });
+                        if !standing_only {
+                            mutations.push(FileTreeMutation::AddUnloadedDirectory {
+                                path: path_to_add.clone(),
+                                is_ignored,
+                            });
+                        }
                     }
                 }
             } else {
                 standing_results.record_path(path_to_add, false, standing_query_definitions);
+                if standing_query_definitions.is_project_skill_file(path_to_add) {
+                    project_skill_files.push(ProjectSkillFileMetadata::from_path(path_to_add));
+                }
+                if standing_only {
+                    continue;
+                }
                 let extension = path_to_add
                     .extension()
                     .and_then(|ext| ext.to_str().map(|s| s.to_owned()));
@@ -1245,7 +1461,12 @@ impl LocalRepoMetadataModel {
             }
         }
 
-        (mutations, standing_results, removed_roots)
+        (
+            mutations,
+            standing_results,
+            project_skill_files,
+            removed_roots,
+        )
     }
 
     /// Phase 2: Applies pre-computed mutations to the file tree on the main thread.
@@ -1451,6 +1672,15 @@ impl LocalRepoMetadataModel {
         repository: ModelHandle<Repository>,
         ctx: &mut ModelContext<'_, Self>,
     ) -> Result<(), RepoMetadataError> {
+        self.index_directory_internal(repository, false, ctx)
+    }
+
+    fn index_directory_internal(
+        &mut self,
+        repository: ModelHandle<Repository>,
+        force_reindex: bool,
+        ctx: &mut ModelContext<'_, Self>,
+    ) -> Result<(), RepoMetadataError> {
         let std_path = repository.as_ref(ctx).root_dir().clone();
         let local_path = std_path
             .to_local_path()
@@ -1472,6 +1702,11 @@ impl LocalRepoMetadataModel {
         // Check if the repository is already indexed or currently being indexed.
         // Allow re-indexing if the existing entry was a lazily-loaded path placeholder.
         match self.repositories.get(&std_path) {
+            Some(IndexedRepoState::Indexed(_)) if force_reindex => {
+                log::info!(
+                    "Reindexing repository after metadata classification changed: {std_path}"
+                );
+            }
             Some(IndexedRepoState::Indexed(_))
                 if !self.lazy_loaded_paths.contains_key(&std_path) =>
             {
@@ -1524,6 +1759,7 @@ impl LocalRepoMetadataModel {
                 let mut files: Vec<crate::entry::FileMetadata> = Vec::new();
                 let mut gitignores_for_build = gitignores_for_build;
                 let mut standing_results = StandingQueryResults::default();
+                let mut project_skill_files = Vec::new();
 
                 // Budget for non-ignored files. When it is exhausted the builder
                 // stops descending breadth-first and leaves the remaining
@@ -1546,6 +1782,7 @@ impl LocalRepoMetadataModel {
                         budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
                     },
                     &mut standing_results,
+                    &mut project_skill_files,
                     &standing_query_definitions,
                 );
 
@@ -1554,36 +1791,37 @@ impl LocalRepoMetadataModel {
                 // but still browsable and searchable as far as it goes.
                 let indexed_with_limit = file_limit == 0;
 
-                (
+                RepositoryBuildOutput {
                     build_result,
                     files,
-                    gitignores_for_build,
-                    repo_path_str_for_log,
-                    std_path_for_completion,
-                    repository_handle_for_completion,
+                    gitignores: gitignores_for_build,
+                    repo_path_str: repo_path_str_for_log,
+                    repo_path: std_path_for_completion,
+                    repository: repository_handle_for_completion,
                     indexed_with_limit,
                     standing_results,
-                )
+                    project_skill_files,
+                }
             },
-            move |model: &mut LocalRepoMetadataModel,
-                  (
-                      build_result,
-                      files,
-                      gitignores_for_build,
-                      repo_path_str,
-                      std_repo_path,
-                      repository_handle,
-                      indexed_with_limit,
-                      standing_results,
-                  ): (Result<Entry, _>, Vec<crate::entry::FileMetadata>, _, String, StandardizedPath, ModelHandle<Repository>, bool, StandingQueryResults),
-                  ctx| {
+            move |model: &mut LocalRepoMetadataModel, output: RepositoryBuildOutput, ctx| {
+                let RepositoryBuildOutput {
+                    build_result,
+                    files,
+                    gitignores: gitignores_for_build,
+                    repo_path_str,
+                    repo_path: std_repo_path,
+                    repository: repository_handle,
+                    indexed_with_limit,
+                    standing_results,
+                    project_skill_files,
+                } = output;
                 match build_result {
                     Ok(root_entry) => {
                         model
                             .standing_results
                             .insert(std_repo_path.clone(), standing_results);
                         let state =
-                            FileTreeState::new(root_entry, gitignores_for_build, Some(repository_handle));
+                            FileTreeState::new(root_entry, gitignores_for_build, Some(repository_handle), project_skill_files);
 
                         if let Err(e) = model.add_repository_internal(
                             std_repo_path.clone(),

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -25,9 +25,7 @@ use crate::local_model::{
 };
 use crate::repositories::DetectedRepositories;
 use crate::watcher::DirectoryWatcher;
-#[cfg(all(unix, feature = "local_fs"))]
-use crate::StandingQueryResults;
-use crate::{RepoMetadataError, StandingQueryContent, StandingQueryDefinitions};
+use crate::{RepoMetadataError, StandingQueryDefinitions};
 
 impl LocalRepoMetadataModel {
     fn new_for_test() -> Self {
@@ -48,6 +46,185 @@ impl LocalRepoMetadataModel {
     }
 }
 
+#[cfg(feature = "local_fs")]
+#[test]
+fn gitignore_change_reclassifies_project_skills_without_leaking_ignored_paths_into_tree() {
+    VirtualFS::test("gitignore_reclassifies_project_skills", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills/review").with_files(vec![
+            Stub::FileWithContent("repo/.gitignore", ""),
+            Stub::FileWithContent("repo/.agents/skills/review/SKILL.md", "name: review"),
+        ]);
+
+        let repo = dirs.tests().join("repo");
+        let gitignore = repo.join(".gitignore");
+        let skill = repo.join(".agents/skills/review/SKILL.md");
+        App::test((), |mut app| async move {
+            let directory_watcher = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+            let repository = directory_watcher.update(&mut app, |watcher, ctx| {
+                watcher
+                    .add_directory(
+                        StandardizedPath::from_local_canonicalized(&repo).unwrap(),
+                        ctx,
+                    )
+                    .unwrap()
+            });
+            let model_handle = app.add_model(|_| {
+                let mut model = LocalRepoMetadataModel::new_for_test();
+                model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+                model
+            });
+            let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
+            let agents_path = StandardizedPath::try_from_local(&repo.join(".agents")).unwrap();
+            let skill_path = StandardizedPath::try_from_local(&skill).unwrap();
+
+            let indexed = model_handle.update(&mut app, |model, ctx| {
+                model.index_directory(repository.clone(), ctx).unwrap();
+                model.repository_indexed(&repo_path)
+            });
+            indexed.await;
+            model_handle.read(&app, |model, _ctx| {
+                assert!(model
+                    .get_project_skills(&repo_path)
+                    .unwrap()
+                    .iter()
+                    .any(|content| content.path == skill_path));
+            });
+
+            std::fs::write(&gitignore, ".agents/\n").unwrap();
+            let reindexed = model_handle.update(&mut app, |model, ctx| {
+                model.handle_watcher_event(
+                    &BulkFilesystemWatcherEvent {
+                        modified: std::collections::HashSet::from([gitignore.clone()]),
+                        ..Default::default()
+                    },
+                    ctx,
+                );
+                model.repository_indexed(&repo_path)
+            });
+            reindexed.await;
+            model_handle.read(&app, |model, _ctx| {
+                let state = model.get_repository(&repo_path).unwrap();
+                assert!(!state.entry.contains(&agents_path));
+                assert!(!state.entry.contains(&skill_path));
+                assert!(model
+                    .get_project_skills(&repo_path)
+                    .unwrap()
+                    .iter()
+                    .any(|content| content.path == skill_path));
+                assert!(model
+                    .get_repo_contents(
+                        &repo_path,
+                        GetContentsArgs::default()
+                            .include_ignored()
+                            .exclude_folders(),
+                    )
+                    .unwrap()
+                    .contents
+                    .iter()
+                    .all(|content| match content {
+                        crate::RepoContent::File(file) => file.path.as_ref() != &skill_path,
+                        crate::RepoContent::Directory(directory) => {
+                            directory.path.as_ref() != &skill_path
+                        }
+                    }));
+            });
+
+            std::fs::write(&gitignore, "").unwrap();
+            let reindexed = model_handle.update(&mut app, |model, ctx| {
+                model.handle_watcher_event(
+                    &BulkFilesystemWatcherEvent {
+                        modified: std::collections::HashSet::from([gitignore]),
+                        ..Default::default()
+                    },
+                    ctx,
+                );
+                model.repository_indexed(&repo_path)
+            });
+            reindexed.await;
+            model_handle.read(&app, |model, _ctx| {
+                let state = model.get_repository(&repo_path).unwrap();
+                assert!(state.entry.contains(&skill_path));
+                assert!(model
+                    .get_project_skills(&repo_path)
+                    .unwrap()
+                    .iter()
+                    .any(|content| content.path == skill_path));
+            });
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn gitignore_change_reclassifies_project_skills_for_lazy_root() {
+    VirtualFS::test(
+        "gitignore_reclassifies_lazy_project_skills",
+        |dirs, mut vfs| {
+            vfs.mkdir("workspace/.agents/skills/review")
+                .with_files(vec![
+                    Stub::FileWithContent("workspace/.gitignore", ".agents/\n"),
+                    Stub::FileWithContent(
+                        "workspace/.agents/skills/review/SKILL.md",
+                        "name: review",
+                    ),
+                ]);
+
+            let workspace = dirs.tests().join("workspace");
+            let gitignore = workspace.join(".gitignore");
+            let skill =
+                StandardizedPath::try_from_local(&workspace.join(".agents/skills/review/SKILL.md"))
+                    .unwrap();
+            App::test((), |mut app| async move {
+                let model_handle = app.add_model(|_| {
+                    let mut model = LocalRepoMetadataModel::new_for_test();
+                    model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+                    model
+                });
+                let workspace_path =
+                    StandardizedPath::from_local_canonicalized(&workspace).unwrap();
+                model_handle.update(&mut app, |model, ctx| {
+                    model.index_lazy_loaded_path(&workspace_path, ctx).unwrap();
+                });
+                model_handle.read(&app, |model, _ctx| {
+                    assert!(!model
+                        .get_repository(&workspace_path)
+                        .unwrap()
+                        .entry
+                        .contains(&skill));
+                    assert!(model
+                        .get_project_skills(&workspace_path)
+                        .unwrap()
+                        .iter()
+                        .any(|content| content.path == skill));
+                });
+
+                std::fs::write(&gitignore, "").unwrap();
+                model_handle.update(&mut app, |model, ctx| {
+                    model.handle_watcher_event(
+                        &BulkFilesystemWatcherEvent {
+                            modified: std::collections::HashSet::from([gitignore]),
+                            ..Default::default()
+                        },
+                        ctx,
+                    );
+                });
+                model_handle.read(&app, |model, _ctx| {
+                    assert!(model
+                        .get_repository(&workspace_path)
+                        .unwrap()
+                        .entry
+                        .contains(&skill));
+                    assert!(model
+                        .get_project_skills(&workspace_path)
+                        .unwrap()
+                        .iter()
+                        .any(|content| content.path == skill));
+                });
+            });
+        },
+    );
+}
+
 #[test]
 #[should_panic(expected = "force-included paths must be repository-relative")]
 fn force_included_paths_must_be_relative() {
@@ -61,7 +238,7 @@ fn empty_repo_state(repo_path: &StandardizedPath) -> FileTreeState {
         ignored: false,
         loaded: true,
     });
-    FileTreeState::new(root, Vec::new(), None)
+    FileTreeState::new(root, Vec::new(), None, Vec::new())
 }
 
 #[test]
@@ -271,7 +448,7 @@ fn test_get_repo_contents() {
                     )
                     .unwrap()
             });
-            let state = FileTreeState::new(root, vec![gitignore], Some(repo_handle));
+            let state = FileTreeState::new(root, vec![gitignore], Some(repo_handle), Vec::new());
 
             let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
 
@@ -335,7 +512,7 @@ fn test_get_repo_contents_truncates_to_max_results() {
         ignored: false,
         loaded: true,
     });
-    let state = FileTreeState::new(root, Vec::new(), None);
+    let state = FileTreeState::new(root, Vec::new(), None, Vec::new());
 
     let mut model = LocalRepoMetadataModel::new_for_test();
     model
@@ -474,7 +651,6 @@ fn test_lazy_loaded_path_discovers_force_included_skills_and_emits_watcher_delta
         App::test((), |mut app| async move {
             let model_handle = app.add_model(|_| {
                 let mut model = LocalRepoMetadataModel::new_for_test();
-                model.register_force_included_paths([PathBuf::from(".agents/skills")]);
                 model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
                 model
             });
@@ -499,12 +675,14 @@ fn test_lazy_loaded_path_discovers_force_included_skills_and_emits_watcher_delta
                 );
                 assert!(!state.entry.contains(&rule_path));
 
+                assert!(model
+                    .get_project_skills(&workspace_path)
+                    .unwrap()
+                    .iter()
+                    .any(|content| content.path == skill_path));
                 let results = model
                     .standing_query_results(&workspace_path)
                     .expect("lazy indexed paths should retain standing results");
-                assert!(results
-                    .project_skills()
-                    .any(|content| content.path == skill_path && !content.is_directory));
                 assert!(!results
                     .project_rules()
                     .any(|content| content.path == rule_path));
@@ -514,17 +692,10 @@ fn test_lazy_loaded_path_discovers_force_included_skills_and_emits_watcher_delta
             let received_delta = Rc::new(RefCell::new(Some(tx)));
             let received_delta_for_event = received_delta.clone();
             let workspace_path_for_event = workspace_path.clone();
-            let skill_path_for_event = skill_path.clone();
             app.update(|ctx| {
                 ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
-                    if let RepositoryMetadataEvent::StandingQueryResultsUpdated { path, delta } =
-                        event
-                    {
-                        if path == &workspace_path_for_event
-                            && delta.upserted_project_skills.iter().any(|content| {
-                                content.path == skill_path_for_event && !content.is_directory
-                            })
-                        {
+                    if let RepositoryMetadataEvent::ProjectSkillFilesUpdated { path } = event {
+                        if path == &workspace_path_for_event {
                             if let Some(tx) = received_delta_for_event.borrow_mut().take() {
                                 let _ = tx.send(());
                             }
@@ -719,7 +890,7 @@ fn test_get_repo_contents_include_ignored() {
                     )
                     .unwrap()
             });
-            let state = FileTreeState::new(root, vec![gitignore], Some(repo_handle));
+            let state = FileTreeState::new(root, vec![gitignore], Some(repo_handle), Vec::new());
 
             let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
 
@@ -915,7 +1086,7 @@ fn test_update_file_tree_entry_respects_gitignore() {
 
         // Compute mutations on the "background thread" then apply on the "main thread".
         let standing_query_definitions = Default::default();
-        let (mutations, _, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+        let (mutations, _, _, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
             &update,
             &gitignores,
             &[],
@@ -1394,7 +1565,7 @@ fn added_symlinked_skill_directory_refreshes_provider_without_canonical_tree_mut
             added: vec![linked_skill.clone()],
             ..Default::default()
         };
-        let (mutations, discovered, removed_roots) =
+        let (mutations, _, discovered_skills, removed_roots) =
             block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
                 &update,
                 &[],
@@ -1405,18 +1576,51 @@ fn added_symlinked_skill_directory_refreshes_provider_without_canonical_tree_mut
 
         assert!(mutations.is_empty());
         assert!(removed_roots.is_empty());
-        assert!(discovered.project_skills().any(|content| {
-            content
-                == &StandingQueryContent::directory(
-                    StandardizedPath::try_from_local(&provider).unwrap(),
-                )
-        }));
-        assert!(discovered.project_skills().any(|content| {
-            content
-                == &StandingQueryContent::file(
-                    StandardizedPath::try_from_local(&linked_skill.join("SKILL.md")).unwrap(),
-                )
-        }));
+        assert_eq!(
+            discovered_skills,
+            vec![crate::ProjectSkillFileMetadata {
+                path: StandardizedPath::try_from_local(&linked_skill.join("SKILL.md")).unwrap(),
+            }]
+        );
+    });
+}
+#[test]
+fn lazy_root_added_skill_directory_is_discovered_eagerly() {
+    VirtualFS::test("lazy_root_added_skill_directory", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills/review")
+            .with_files(vec![Stub::FileWithContent(
+                "repo/.agents/skills/review/SKILL.md",
+                "review",
+            )]);
+        let skill_directory = dirs.tests().join("repo/.agents/skills/review");
+        let skill_file = skill_directory.join("SKILL.md");
+
+        let mut definitions = StandingQueryDefinitions::default();
+        definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+        let update = RepoUpdate {
+            added: vec![skill_directory.clone()],
+            ..Default::default()
+        };
+        let (mutations, _, discovered_skills, _) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &[],
+                &[],
+                &definitions,
+                true,
+            ));
+
+        assert!(matches!(
+            mutations.as_slice(),
+            [crate::local_model::FileTreeMutation::AddDirectorySubtree { dir_path, .. }]
+                if dir_path == &skill_directory
+        ));
+        assert_eq!(
+            discovered_skills,
+            vec![crate::ProjectSkillFileMetadata {
+                path: StandardizedPath::try_from_local(&skill_file).unwrap(),
+            }]
+        );
     });
 }
 
@@ -1437,15 +1641,16 @@ fn unrelated_skill_support_file_does_not_refresh_project_skills() {
             added: vec![support_file],
             ..Default::default()
         };
-        let (_, discovered, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
-            &update,
-            &[],
-            &[],
-            &definitions,
-            false,
-        ));
+        let (_, _, discovered_skills, _) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &[],
+                &[],
+                &definitions,
+                false,
+            ));
 
-        assert!(discovered.project_skills().next().is_none());
+        assert!(discovered_skills.is_empty());
     });
 }
 
@@ -1461,20 +1666,20 @@ fn removed_direct_skill_child_refreshes_provider_for_possible_symlink_removal() 
             deleted: vec![provider.join("removed-skill")],
             ..Default::default()
         };
-        let (_, discovered, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
-            &update,
-            &[],
-            &[],
-            &definitions,
-            false,
-        ));
+        let (_, _, discovered_skills, removed_roots) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &[],
+                &[],
+                &definitions,
+                false,
+            ));
 
-        assert!(discovered.project_skills().any(|content| {
-            content
-                == &StandingQueryContent::directory(
-                    StandardizedPath::try_from_local(&provider).unwrap(),
-                )
-        }));
+        assert!(discovered_skills.is_empty());
+        assert_eq!(
+            removed_roots,
+            vec![StandardizedPath::try_from_local(&provider.join("removed-skill")).unwrap()]
+        );
     });
 }
 #[cfg(all(unix, feature = "local_fs"))]
@@ -1497,7 +1702,6 @@ fn added_external_target_skill_symlink_routes_to_lexical_repository() {
 
             App::test((), |mut app| async move {
                 let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
-                let provider_path = StandardizedPath::try_from_local(&provider).unwrap();
                 let model_handle = app.add_model(|_| {
                     let mut model = LocalRepoMetadataModel::new_for_test();
                     model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
@@ -1514,22 +1718,10 @@ fn added_external_target_skill_symlink_routes_to_lexical_repository() {
                 let received_delta = Rc::new(RefCell::new(Some(tx)));
                 let received_delta_for_event = received_delta.clone();
                 let repo_path_for_event = repo_path.clone();
-                let provider_path_for_event = provider_path.clone();
                 app.update(|ctx| {
                     ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
-                        if let RepositoryMetadataEvent::StandingQueryResultsUpdated {
-                            path,
-                            delta,
-                        } = event
-                        {
-                            if path == &repo_path_for_event
-                                && delta.upserted_project_skills.iter().any(|content| {
-                                    content
-                                        == &StandingQueryContent::directory(
-                                            provider_path_for_event.clone(),
-                                        )
-                                })
-                            {
+                        if let RepositoryMetadataEvent::ProjectSkillFilesUpdated { path } = event {
+                            if path == &repo_path_for_event {
                                 if let Some(tx) = received_delta_for_event.borrow_mut().take() {
                                     let _ = tx.send(());
                                 }
@@ -1554,11 +1746,14 @@ fn added_external_target_skill_symlink_routes_to_lexical_repository() {
 
                 model_handle.read(&app, |model, _ctx| {
                     assert!(model
-                        .standing_query_results(&repo_path)
-                        .expect("standing results should be retained for the repository")
-                        .project_skills()
-                        .any(|content| content
-                            == &StandingQueryContent::directory(provider_path.clone())));
+                        .get_project_skills(&repo_path)
+                        .expect("project skills should be retained for the repository")
+                        .iter()
+                        .any(|content| content.path
+                            == StandardizedPath::try_from_local(
+                                &provider.join("linked-skill/SKILL.md")
+                            )
+                            .unwrap()));
                 });
             });
         },
@@ -1578,7 +1773,6 @@ fn modified_external_symlink_target_upserts_lexical_project_skill() {
                 )]);
             let repo = dirs.tests().join("repo");
             let logical_skill_dir = repo.join(".agents/skills/linked-skill");
-            let logical_skill_path = logical_skill_dir.join("SKILL.md");
             let target_skill_path = dirs.tests().join("outside/linked-skill/SKILL.md");
             std::os::unix::fs::symlink(
                 dirs.tests().join("outside/linked-skill"),
@@ -1588,43 +1782,25 @@ fn modified_external_symlink_target_upserts_lexical_project_skill() {
 
             App::test((), |mut app| async move {
                 let repo_path = StandardizedPath::from_local_canonicalized(&repo).unwrap();
-                let logical_skill_path =
-                    StandardizedPath::try_from_local(&logical_skill_path).unwrap();
                 let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
                 model_handle.update(&mut app, |model, ctx| {
                     model.set_emit_incremental_updates(true);
-                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
                     model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
                     model.repositories.insert(
                         repo_path.clone(),
                         IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
                     );
-                    let mut results = StandingQueryResults::default();
-                    results.insert_project_skill(StandingQueryContent::file(
-                        logical_skill_path.clone(),
-                    ));
-                    model.standing_results.insert(repo_path.clone(), results);
                     model.refresh_symlink_targets(&repo_path, ctx);
                 });
 
                 let (tx, rx) = oneshot::channel();
                 let received_delta = Rc::new(RefCell::new(Some(tx)));
                 let received_delta_for_event = received_delta.clone();
-                let logical_skill_path_for_event = logical_skill_path.clone();
+                let repo_path_for_event = repo_path.clone();
                 app.update(|ctx| {
                     ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
-                        if let RepositoryMetadataEvent::IncrementalUpdateReady { update } = event {
-                            if update
-                                .standing_results_delta
-                                .upserted_project_skills
-                                .iter()
-                                .any(|content| {
-                                    content
-                                        == &StandingQueryContent::file(
-                                            logical_skill_path_for_event.clone(),
-                                        )
-                                })
-                            {
+                        if let RepositoryMetadataEvent::ProjectSkillFilesUpdated { path } = event {
+                            if path == &repo_path_for_event {
                                 if let Some(tx) = received_delta_for_event.borrow_mut().take() {
                                     let _ = tx.send(());
                                 }
@@ -1681,36 +1857,27 @@ fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skil
                 let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
                 model_handle.update(&mut app, |model, ctx| {
                     model.set_emit_incremental_updates(true);
-                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
                     model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
-                    model.repositories.insert(
-                        repo_path.clone(),
-                        IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
-                    );
-                    let mut results = StandingQueryResults::default();
-                    results.insert_project_skill(StandingQueryContent::file(
-                        logical_skill_path.clone(),
-                    ));
-                    model.standing_results.insert(repo_path.clone(), results);
+                    let mut state = empty_repo_state(&repo_path);
+                    state
+                        .project_skill_files_mut()
+                        .push(crate::ProjectSkillFileMetadata {
+                            path: logical_skill_path.clone(),
+                        });
+                    model
+                        .repositories
+                        .insert(repo_path.clone(), IndexedRepoState::Indexed(state));
                     model.refresh_symlink_targets(&repo_path, ctx);
                 });
 
                 let (tx, rx) = oneshot::channel();
                 let received_delta = Rc::new(RefCell::new(Some(tx)));
                 let received_delta_for_event = received_delta.clone();
-                let logical_skill_path_for_event = logical_skill_path.clone();
+                let repo_path_for_event = repo_path.clone();
                 app.update(|ctx| {
                     ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
-                        if let RepositoryMetadataEvent::StandingQueryResultsUpdated {
-                            delta, ..
-                        } = event
-                        {
-                            if delta.removed_project_skills.iter().any(|content| {
-                                content
-                                    == &StandingQueryContent::file(
-                                        logical_skill_path_for_event.clone(),
-                                    )
-                            }) {
+                        if let RepositoryMetadataEvent::ProjectSkillFilesUpdated { path } = event {
+                            if path == &repo_path_for_event {
                                 if let Some(tx) = received_delta_for_event.borrow_mut().take() {
                                     let _ = tx.send(());
                                 }
@@ -1736,29 +1903,20 @@ fn removed_then_recreated_external_symlink_target_refreshes_lexical_project_skil
                     .expect("symlink target removal sender dropped");
                 model_handle.read(&app, |model, _ctx| {
                     assert!(model
-                        .standing_query_results(&repo_path)
-                        .expect("standing results should remain tracked")
-                        .project_skills()
-                        .all(|content| content
-                            != &StandingQueryContent::file(logical_skill_path.clone())));
+                        .get_project_skills(&repo_path)
+                        .expect("project skills should remain tracked")
+                        .iter()
+                        .all(|content| content.path != logical_skill_path));
                 });
 
                 let (tx, rx) = oneshot::channel();
                 let received_delta = Rc::new(RefCell::new(Some(tx)));
                 let received_delta_for_event = received_delta.clone();
-                let logical_skill_path_for_event = logical_skill_path.clone();
+                let repo_path_for_event = repo_path.clone();
                 app.update(|ctx| {
                     ctx.subscribe_to_model(&model_handle, move |_, event, _ctx| {
-                        if let RepositoryMetadataEvent::StandingQueryResultsUpdated {
-                            delta, ..
-                        } = event
-                        {
-                            if delta.upserted_project_skills.iter().any(|content| {
-                                content
-                                    == &StandingQueryContent::file(
-                                        logical_skill_path_for_event.clone(),
-                                    )
-                            }) {
+                        if let RepositoryMetadataEvent::ProjectSkillFilesUpdated { path } = event {
+                            if path == &repo_path_for_event {
                                 if let Some(tx) = received_delta_for_event.borrow_mut().take() {
                                     let _ = tx.send(());
                                 }
@@ -1808,7 +1966,7 @@ fn symlink_targets_retain_aliases_and_clear_for_removed_or_failed_repositories()
                 let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
                 model_handle.update(&mut app, |model, ctx| {
                     model.set_emit_incremental_updates(true);
-                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
+                    model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
                     model.repositories.insert(
                         repo_path.clone(),
                         IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
@@ -1878,7 +2036,7 @@ fn removed_external_symlink_target_directory_queues_lexical_removal_and_clears_m
                 let model_handle = app.add_model(|_| LocalRepoMetadataModel::new_for_test());
                 model_handle.update(&mut app, |model, ctx| {
                     model.set_emit_incremental_updates(true);
-                    model.register_force_included_paths([PathBuf::from(".agents/skills")]);
+                    model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
                     model.repositories.insert(
                         repo_path.clone(),
                         IndexedRepoState::Indexed(empty_repo_state(&repo_path)),
@@ -2033,7 +2191,8 @@ fn test_repository_operations_with_standardized_paths() {
                         )
                         .unwrap()
                 });
-                let state = FileTreeState::new(root, vec![gitignore], Some(repo_handle));
+                let state =
+                    FileTreeState::new(root, vec![gitignore], Some(repo_handle), Vec::new());
 
                 // Test adding repository using different path representations
                 model_handle.update(&mut app, |model, ctx| {
@@ -2167,6 +2326,59 @@ fn index_lazy_loaded_path_tracks_only_root() {
     });
 }
 
+#[cfg(feature = "local_fs")]
+#[test]
+fn lazy_root_tracks_existing_project_skill_directories() {
+    VirtualFS::test("lazy_root_project_skill_tracking", |dirs, mut vfs| {
+        vfs.mkdir("workspace/.agents/skills/review")
+            .with_files(vec![Stub::FileWithContent(
+                "workspace/.agents/skills/review/SKILL.md",
+                "review",
+            )]);
+        let root =
+            StandardizedPath::from_local_canonicalized(&dirs.tests().join("workspace")).unwrap();
+        let agents =
+            StandardizedPath::from_local_canonicalized(&dirs.tests().join("workspace/.agents"))
+                .unwrap();
+        let provider = StandardizedPath::from_local_canonicalized(
+            &dirs.tests().join("workspace/.agents/skills"),
+        )
+        .unwrap();
+        let skill_directory = StandardizedPath::from_local_canonicalized(
+            &dirs.tests().join("workspace/.agents/skills/review"),
+        )
+        .unwrap();
+
+        App::test((), |mut app| async move {
+            let model_handle = app.add_model(|_| {
+                let mut model = LocalRepoMetadataModel::new_for_test();
+                model.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+                model
+            });
+            model_handle.update(&mut app, |model, ctx| {
+                model
+                    .index_lazy_loaded_path(&root, ctx)
+                    .expect("should index lazy path");
+            });
+
+            model_handle.read(&app, |model, _ctx| {
+                let repo_watch = model
+                    .repo_watches
+                    .get(&root)
+                    .expect("watch should be recorded");
+                if cfg!(target_os = "linux") {
+                    assert_eq!(repo_watch.root_mode, RootWatchMode::NonRecursive);
+                    assert!(repo_watch.extra_dirs.contains(&agents));
+                    assert!(repo_watch.extra_dirs.contains(&provider));
+                    assert!(repo_watch.extra_dirs.contains(&skill_directory));
+                } else {
+                    assert_eq!(repo_watch.root_mode, RootWatchMode::Recursive);
+                    assert!(repo_watch.extra_dirs.is_empty());
+                }
+            });
+        });
+    });
+}
 /// Expanding a subdirectory of a lazy root should add a per-directory watch for
 /// it on Linux (so its children stay fresh) while leaving non-Linux untouched.
 #[cfg(feature = "local_fs")]
@@ -2273,7 +2485,7 @@ fn load_directory_watches_expanded_gitignored_dir_for_git_repo() {
                 ignored: false,
                 loaded: true,
             });
-            let state = FileTreeState::new(root, vec![gitignore], None);
+            let state = FileTreeState::new(root, vec![gitignore], None, Vec::new());
 
             model_handle.update(&mut app, |model, ctx| {
                 model
@@ -2331,7 +2543,7 @@ fn remove_repository_clears_extra_dir_watches() {
                 ignored: false,
                 loaded: true,
             });
-            let state = FileTreeState::new(root, vec![gitignore], None);
+            let state = FileTreeState::new(root, vec![gitignore], None, Vec::new());
 
             model_handle.update(&mut app, |model, ctx| {
                 model
@@ -2508,13 +2720,14 @@ fn lazy_root_created_directory_inserted_as_placeholder() {
         // Lazy root: the new directory is an unloaded placeholder and its
         // subtree is not materialized.
         let mut lazy_root = make_root();
-        let (lazy_mutations, _, _) = block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
-            &update,
-            &[],
-            &[],
-            &definitions,
-            true,
-        ));
+        let (lazy_mutations, _, _, _) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &[],
+                &[],
+                &definitions,
+                true,
+            ));
         LocalRepoMetadataModel::apply_file_tree_mutations(
             &mut lazy_root,
             lazy_mutations,
@@ -2536,7 +2749,7 @@ fn lazy_root_created_directory_inserted_as_placeholder() {
 
         // Eager root: the same directory is fully materialized.
         let mut eager_root = make_root();
-        let (eager_mutations, _, _) =
+        let (eager_mutations, _, _, _) =
             block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
                 &update,
                 &[],

--- a/crates/repo_metadata/src/project_skills.rs
+++ b/crates/repo_metadata/src/project_skills.rs
@@ -1,0 +1,40 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use warp_util::standardized_path::StandardizedPath;
+
+/// Metadata for a project skill file discovered during repository traversal.
+///
+/// Project skills are intentionally stored outside the canonical file tree so
+/// gitignored skill files remain discoverable without becoming visible through
+/// generic repository-content APIs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProjectSkillFileMetadata {
+    pub path: StandardizedPath,
+}
+
+impl ProjectSkillFileMetadata {
+    pub(crate) fn from_path(path: &Path) -> Self {
+        Self {
+            path: StandardizedPath::from_local_absolute_unchecked(path),
+        }
+    }
+}
+
+pub(crate) fn replace_project_skill_subtrees(
+    project_skill_files: &mut Vec<ProjectSkillFileMetadata>,
+    removed_roots: &[StandardizedPath],
+    discovered: Vec<ProjectSkillFileMetadata>,
+) -> bool {
+    let previous = project_skill_files.iter().cloned().collect::<HashSet<_>>();
+    let discovered_skill = !discovered.is_empty();
+    project_skill_files.retain(|skill| {
+        !removed_roots
+            .iter()
+            .any(|root| skill.path.starts_with(root))
+    });
+    project_skill_files.extend(discovered);
+    project_skill_files.sort_by(|left, right| left.path.as_str().cmp(right.path.as_str()));
+    project_skill_files.dedup();
+    discovered_skill || previous != project_skill_files.iter().cloned().collect()
+}

--- a/crates/repo_metadata/src/remote_model_tests.rs
+++ b/crates/repo_metadata/src/remote_model_tests.rs
@@ -14,20 +14,27 @@ fn snapshot_and_incremental_update_maintain_remote_standing_results() {
         let model = app.add_model(RemoteRepoMetadataModel::new);
         let host = HostId::new("remote-host".to_string());
         let repo_path = path("/repo");
-        let skill = StandingQueryContent::file(path("/repo/.agents/skills/review/SKILL.md"));
         let rule = StandingQueryContent::file(path("/repo/WARP.md"));
+        let next_rule = StandingQueryContent::file(path("/repo/AGENTS.md"));
         let id = RemoteRepositoryIdentifier::new(host.clone(), repo_path.clone());
         let snapshot = RepoMetadataUpdate {
             repo_path: repo_path.clone(),
             remove_entries: Vec::new(),
             update_entries: Vec::new(),
             standing_results_delta: StandingQueryResultsDelta {
-                upserted_project_skills: vec![skill.clone()],
+                upserted_project_rules: vec![rule.clone()],
                 ..Default::default()
             },
         };
         model.update(&mut app, |model, ctx| {
             model.insert_from_snapshot(host.clone(), &snapshot, ctx);
+        });
+        model.read(&app, |model, _ctx| {
+            assert!(model
+                .standing_query_results(&id)
+                .unwrap()
+                .project_rules()
+                .any(|content| content == &rule));
         });
 
         let incremental = RepoMetadataUpdate {
@@ -35,8 +42,8 @@ fn snapshot_and_incremental_update_maintain_remote_standing_results() {
             remove_entries: Vec::new(),
             update_entries: Vec::new(),
             standing_results_delta: StandingQueryResultsDelta {
-                removed_project_skills: vec![skill],
-                upserted_project_rules: vec![rule.clone()],
+                removed_project_rules: vec![rule],
+                upserted_project_rules: vec![next_rule.clone()],
                 ..Default::default()
             },
         };
@@ -46,8 +53,10 @@ fn snapshot_and_incremental_update_maintain_remote_standing_results() {
 
         model.read(&app, |model, _ctx| {
             let results = model.standing_query_results(&id).unwrap();
-            assert!(results.project_skills().next().is_none());
-            assert!(results.project_rules().any(|content| content == &rule));
+            assert_eq!(
+                results.project_rules().collect::<Vec<_>>(),
+                vec![&next_rule]
+            );
         });
     });
 }

--- a/crates/repo_metadata/src/standing_queries.rs
+++ b/crates/repo_metadata/src/standing_queries.rs
@@ -33,22 +33,35 @@ impl StandingQueryDefinitions {
         &self.project_skill_provider_paths
     }
 
-    fn is_project_skill_provider_directory(&self, path: &Path) -> bool {
+    pub(crate) fn is_project_skill_provider_directory(&self, path: &Path) -> bool {
         self.project_skill_provider_paths
             .iter()
             .any(|provider_path| path.ends_with(provider_path))
     }
-
-    fn project_skill_provider_ancestor<'a>(&self, path: &'a Path) -> Option<&'a Path> {
-        path.ancestors()
-            .find(|ancestor| self.is_project_skill_provider_directory(ancestor))
+    pub(crate) fn is_project_skill_path_interest(&self, path: &Path) -> bool {
+        let path_components = path.components().collect::<Vec<_>>();
+        self.project_skill_provider_paths
+            .iter()
+            .any(|provider_path| {
+                let provider_components = provider_path.components().collect::<Vec<_>>();
+                !provider_components.is_empty()
+                    && (path_components
+                        .windows(provider_components.len())
+                        .any(|window| window == provider_components)
+                        || (1..provider_components.len()).any(|prefix_len| {
+                            path_components.len() >= prefix_len
+                                && path_components[path_components.len() - prefix_len..]
+                                    == provider_components[..prefix_len]
+                        }))
+            })
     }
-    fn is_direct_project_skill_provider_child(&self, path: &Path) -> bool {
+
+    pub(crate) fn is_direct_project_skill_provider_child(&self, path: &Path) -> bool {
         path.parent()
             .is_some_and(|parent| self.is_project_skill_provider_directory(parent))
     }
 
-    fn is_project_skill_file(&self, path: &Path) -> bool {
+    pub(crate) fn is_project_skill_file(&self, path: &Path) -> bool {
         path.file_name().and_then(|name| name.to_str()) == Some("SKILL.md")
             && path
                 .parent()
@@ -93,15 +106,10 @@ impl StandingQueryContent {
 /// Current paths matching each standing repository query.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StandingQueryResults {
-    project_skills: HashSet<StandingQueryContent>,
     project_rules: HashSet<StandingQueryContent>,
 }
 
 impl StandingQueryResults {
-    pub fn project_skills(&self) -> impl Iterator<Item = &StandingQueryContent> {
-        self.project_skills.iter()
-    }
-
     pub fn project_rules(&self) -> impl Iterator<Item = &StandingQueryContent> {
         self.project_rules.iter()
     }
@@ -114,53 +122,10 @@ impl StandingQueryResults {
         definitions: &StandingQueryDefinitions,
     ) {
         let standardized = StandardizedPath::from_local_absolute_unchecked(path);
-        if is_directory && definitions.is_project_skill_provider_directory(path) {
-            self.project_skills
-                .insert(StandingQueryContent::directory(standardized.clone()));
-        }
-        if !is_directory && definitions.is_project_skill_file(path) {
-            self.project_skills
-                .insert(StandingQueryContent::file(standardized.clone()));
-        }
         if !is_directory && definitions.is_project_rule_file(path) {
             self.project_rules
                 .insert(StandingQueryContent::file(standardized));
         }
-    }
-
-    pub(crate) fn record_direct_project_skill_provider_child_change(
-        &mut self,
-        path: &Path,
-        definitions: &StandingQueryDefinitions,
-    ) {
-        if definitions.is_direct_project_skill_provider_child(path) {
-            if let Some(provider_root) = definitions.project_skill_provider_ancestor(path) {
-                self.project_skills.insert(StandingQueryContent::directory(
-                    StandardizedPath::from_local_absolute_unchecked(provider_root),
-                ));
-            }
-        }
-    }
-
-    /// Records an eligible project skill reached through a directory symlink during standing
-    /// query evaluation. The lexical path is intentionally retained so consumers address the
-    /// skill through the provider entry rather than the symlink target.
-    pub(crate) fn record_followed_project_skill_directory(
-        &mut self,
-        path: &Path,
-        definitions: &StandingQueryDefinitions,
-    ) {
-        if !definitions.is_direct_project_skill_provider_child(path) {
-            return;
-        }
-
-        let skill_file = path.join("SKILL.md");
-        if skill_file.is_file() {
-            self.record_path(&skill_file, false, definitions);
-        }
-    }
-    pub fn insert_project_skill(&mut self, content: StandingQueryContent) {
-        self.project_skills.insert(content);
     }
 
     pub fn insert_project_rule(&mut self, content: StandingQueryContent) {
@@ -168,14 +133,9 @@ impl StandingQueryResults {
     }
 
     pub fn apply_delta(&mut self, delta: &StandingQueryResultsDelta) {
-        for removed in &delta.removed_project_skills {
-            self.project_skills.remove(removed);
-        }
         for removed in &delta.removed_project_rules {
             self.project_rules.remove(removed);
         }
-        self.project_skills
-            .extend(delta.upserted_project_skills.iter().cloned());
         self.project_rules
             .extend(delta.upserted_project_rules.iter().cloned());
     }
@@ -191,24 +151,14 @@ impl StandingQueryResults {
     ) -> StandingQueryResultsDelta {
         let mut delta = StandingQueryResultsDelta::default();
         for root in removed_roots {
-            let removed_skills = self
-                .project_skills
-                .iter()
-                .filter(|content| content.path.starts_with(root))
-                .cloned()
-                .collect::<Vec<_>>();
             let removed_rules = self
                 .project_rules
                 .iter()
                 .filter(|content| content.path.starts_with(root))
                 .cloned()
                 .collect::<Vec<_>>();
-            delta.removed_project_skills.extend(removed_skills);
             delta.removed_project_rules.extend(removed_rules);
         }
-        delta
-            .upserted_project_skills
-            .extend(discovered.project_skills);
         delta
             .upserted_project_rules
             .extend(discovered.project_rules);
@@ -218,8 +168,6 @@ impl StandingQueryResults {
 
     pub fn as_snapshot_delta(&self) -> StandingQueryResultsDelta {
         StandingQueryResultsDelta {
-            upserted_project_skills: self.project_skills.iter().cloned().collect(),
-            removed_project_skills: Vec::new(),
             upserted_project_rules: self.project_rules.iter().cloned().collect(),
             removed_project_rules: Vec::new(),
         }
@@ -229,22 +177,13 @@ impl StandingQueryResults {
 /// Changes to standing query results for one repository.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StandingQueryResultsDelta {
-    pub upserted_project_skills: Vec<StandingQueryContent>,
-    pub removed_project_skills: Vec<StandingQueryContent>,
     pub upserted_project_rules: Vec<StandingQueryContent>,
     pub removed_project_rules: Vec<StandingQueryContent>,
 }
 
 impl StandingQueryResultsDelta {
     pub fn is_empty(&self) -> bool {
-        self.upserted_project_skills.is_empty()
-            && self.removed_project_skills.is_empty()
-            && self.upserted_project_rules.is_empty()
-            && self.removed_project_rules.is_empty()
-    }
-
-    pub fn project_skills_changed(&self) -> bool {
-        !self.upserted_project_skills.is_empty() || !self.removed_project_skills.is_empty()
+        self.upserted_project_rules.is_empty() && self.removed_project_rules.is_empty()
     }
 
     pub fn project_rules_changed(&self) -> bool {

--- a/crates/repo_metadata/src/standing_queries_tests.rs
+++ b/crates/repo_metadata/src/standing_queries_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+
 fn repo_path(path: &str) -> PathBuf {
     std::env::temp_dir()
         .join("repo_metadata_standing_queries_tests")
@@ -9,74 +10,40 @@ fn standardized(path: &Path) -> StandardizedPath {
     StandardizedPath::try_from_local(path).unwrap()
 }
 
-fn definitions() -> StandingQueryDefinitions {
-    let mut definitions = StandingQueryDefinitions::default();
-    definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
-    definitions
-}
-
 #[test]
-fn records_provider_skill_files_and_project_rules() {
-    let definitions = definitions();
+fn records_project_rules_without_project_skills() {
+    let definitions = StandingQueryDefinitions::default();
     let mut results = StandingQueryResults::default();
-    let skills_provider = repo_path(".agents/skills");
     let skill_file = repo_path(".agents/skills/review/SKILL.md");
     let root_rule = repo_path("WARP.md");
     let nested_rule = repo_path("packages/api/AGENTS.md");
 
-    results.record_path(&skills_provider, true, &definitions);
     results.record_path(&skill_file, false, &definitions);
     results.record_path(&root_rule, false, &definitions);
     results.record_path(&nested_rule, false, &definitions);
 
-    assert!(
-        results
-            .project_skills()
-            .any(|content| content
-                == &StandingQueryContent::directory(standardized(&skills_provider)))
-    );
-    assert!(results
-        .project_skills()
-        .any(|content| { content == &StandingQueryContent::file(standardized(&skill_file)) }));
     assert!(results
         .project_rules()
         .any(|content| content == &StandingQueryContent::file(standardized(&root_rule))));
     assert!(results
         .project_rules()
-        .any(|content| { content == &StandingQueryContent::file(standardized(&nested_rule)) }));
+        .any(|content| content == &StandingQueryContent::file(standardized(&nested_rule))));
+    assert!(results
+        .project_rules()
+        .all(|content| content.path != standardized(&skill_file)));
 }
 
 #[test]
-fn replacing_removed_direct_skill_child_can_reupsert_provider_for_hydration() {
-    let definitions = definitions();
-    let provider_path = repo_path(".agents/skills");
-    let skill_path = repo_path(".agents/skills/review/SKILL.md");
-    let removed_skill_dir = repo_path(".agents/skills/review");
-    let provider = StandingQueryContent::directory(standardized(&provider_path));
-    let skill = StandingQueryContent::file(standardized(&skill_path));
+fn replacing_rule_subtrees_returns_rule_only_delta() {
+    let rule_path = repo_path("packages/api/AGENTS.md");
+    let removed_root = repo_path("packages/api");
+    let rule = StandingQueryContent::file(standardized(&rule_path));
     let mut results = StandingQueryResults::default();
-    results.insert_project_skill(provider.clone());
-    results.insert_project_skill(skill.clone());
+    results.insert_project_rule(rule.clone());
 
-    let mut discovered = StandingQueryResults::default();
-    discovered.record_direct_project_skill_provider_child_change(&removed_skill_dir, &definitions);
-    let delta = results.replace_subtrees(&[standardized(&removed_skill_dir)], discovered);
+    let delta = results.replace_subtrees(&[standardized(&removed_root)], Default::default());
 
-    assert_eq!(delta.removed_project_skills, vec![skill]);
-    assert_eq!(delta.upserted_project_skills, vec![provider.clone()]);
-    assert!(results.project_skills().any(|content| content == &provider));
-    assert!(!results
-        .project_skills()
-        .any(|content| content.path == standardized(&skill_path)));
-}
-
-#[test]
-fn support_file_beneath_skill_does_not_synthesize_provider_update() {
-    let definitions = definitions();
-    let mut results = StandingQueryResults::default();
-    let support_file = repo_path(".agents/skills/review/README.md");
-
-    results.record_path(&support_file, false, &definitions);
-
-    assert!(results.project_skills().next().is_none());
+    assert_eq!(delta.removed_project_rules, vec![rule]);
+    assert!(delta.upserted_project_rules.is_empty());
+    assert!(results.project_rules().next().is_none());
 }

--- a/crates/repo_metadata/src/wrapper_model.rs
+++ b/crates/repo_metadata/src/wrapper_model.rs
@@ -20,7 +20,9 @@ use crate::local_model::{
 };
 use crate::remote_model::{RemoteRepoMetadataModel, RemoteRepositoryMetadataEvent};
 use crate::repository_identifier::{RemoteRepositoryIdentifier, RepositoryIdentifier};
-use crate::{RepoMetadataError, StandingQueryResults, StandingQueryResultsDelta};
+use crate::{
+    ProjectSkillFileMetadata, RepoMetadataError, StandingQueryResults, StandingQueryResultsDelta,
+};
 
 /// Unified events emitted by the [`RepoMetadataModel`] wrapper.
 ///
@@ -46,6 +48,8 @@ pub enum RepoMetadataEvent {
         id: RepositoryIdentifier,
         delta: StandingQueryResultsDelta,
     },
+    /// Project skill files in the dedicated sidecar changed.
+    ProjectSkillFilesUpdated { id: RepositoryIdentifier },
     /// Updating a repository failed.
     UpdatingRepositoryFailed { id: RepositoryIdentifier },
     /// An incremental file tree update is ready to be sent to the remote
@@ -105,6 +109,11 @@ impl RepoMetadataModel {
         let unified = match event {
             RepositoryMetadataEvent::RepositoryUpdated { path } => {
                 RepoMetadataEvent::RepositoryUpdated {
+                    id: RepositoryIdentifier::local(path.clone()),
+                }
+            }
+            RepositoryMetadataEvent::ProjectSkillFilesUpdated { path } => {
+                RepoMetadataEvent::ProjectSkillFilesUpdated {
                     id: RepositoryIdentifier::local(path.clone()),
                 }
             }
@@ -201,6 +210,17 @@ impl RepoMetadataModel {
             RepositoryIdentifier::Remote(remote_id) => {
                 self.remote.as_ref(ctx).get_repository(remote_id)
             }
+        }
+    }
+
+    pub fn get_project_skills<'a>(
+        &self,
+        id: &RepositoryIdentifier,
+        ctx: &'a AppContext,
+    ) -> Option<&'a [ProjectSkillFileMetadata]> {
+        match id {
+            RepositoryIdentifier::Local(path) => self.local.as_ref(ctx).get_project_skills(path),
+            RepositoryIdentifier::Remote(_) => None,
         }
     }
 


### PR DESCRIPTION
## Summary
- collect project skill paths in a private same-walk repo-metadata sidecar while keeping gitignored skills out of canonical and generic metadata
- add a dedicated bounded remote project-skill RPC and update push
- migrate SkillWatcher to local sidecar updates and remote RPC refreshes, retaining failure-only local fallback behavior

## Validation
- `cargo fmt --manifest-path /workspace/warp/Cargo.toml -p repo_metadata -p remote_server -p warp -p ai`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p repo_metadata --lib -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p remote_server -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib skill_watcher_tests -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib find_skill_files_in_tree -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path /workspace/warp/Cargo.toml -p warp --lib project_skill_file_ -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path /workspace/warp/Cargo.toml -p warp --lib --message-format short`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path /workspace/warp/Cargo.toml -p repo_metadata -p remote_server -p ai -p warp --lib -- -D warnings`
- `git diff --cached --check`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/1f4df60d-12de-4a36-b5ca-3c09fc040f3f_
_Run: https://oz.staging.warp.dev/runs/019e9adc-0623-7e20-8fae-dcaf4200d40e_

_This PR was generated with [Oz](https://warp.dev/oz)._
