### PR TITLE
[ipynb] Routing, hosting pane, open flow, and file save for editable .ipynb

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -184,6 +184,7 @@ pub use pane::env_var_collection_pane::EnvVarCollectionPane;
 pub use pane::environment_management_pane::EnvironmentManagementPane;
 pub use pane::execution_profile_editor_pane::ExecutionProfileEditorPane;
 pub use pane::file_pane::FilePane;
+pub use pane::jupyter_notebook_pane::JupyterNotebookPane;
 pub use pane::network_log_pane::NetworkLogPane;
 pub use pane::notebook_pane::NotebookPane;
 pub use pane::settings_pane::SettingsPane;
@@ -1717,13 +1718,31 @@ impl PaneGroup {
                         notebook_id,
                         settings,
                     } => Box::new(NotebookPane::restore(notebook_id, &settings, ctx)?),
-                    NotebookPaneSnapshot::LocalFileNotebook { path } => Box::new(FilePane::new(
-                        path.map(LocalOrRemotePath::Local),
-                        None,
+                    NotebookPaneSnapshot::LocalFileNotebook { path } => {
+                        // Re-route `.ipynb` back to the editable Jupyter pane when
+                        // the feature is on; otherwise restore the markdown
+                        // file-notebook pane as before.
                         #[cfg(feature = "local_fs")]
-                        None,
-                        ctx,
-                    )),
+                        {
+                            let restore_as_jupyter = path
+                                .as_ref()
+                                .is_some_and(warp_util::file_type::is_jupyter_notebook_file)
+                                && FeatureFlag::JupyterNotebookEditing.is_enabled();
+                            let local_path = path.map(LocalOrRemotePath::Local);
+                            if restore_as_jupyter {
+                                Box::new(JupyterNotebookPane::new(local_path, ctx))
+                                    as Box<dyn AnyPaneContent + 'static>
+                            } else {
+                                Box::new(FilePane::new(local_path, None, None, ctx))
+                                    as Box<dyn AnyPaneContent + 'static>
+                            }
+                        }
+                        #[cfg(not(feature = "local_fs"))]
+                        {
+                            Box::new(FilePane::new(path.map(LocalOrRemotePath::Local), None, ctx))
+                                as Box<dyn AnyPaneContent + 'static>
+                        }
+                    }
                 };
 
                 let pane_id = pane.as_pane().id();

--- a/app/src/pane_group/pane/jupyter_notebook_pane.rs
+++ b/app/src/pane_group/pane/jupyter_notebook_pane.rs
@@ -1,0 +1,455 @@
+//! Hosting pane for the editable, cell-based Jupyter notebook view.
+//!
+//! Mirrors [`super::file_pane::FilePane`], but wraps the cell-based
+//! [`JupyterNotebookView`] and owns the file I/O around it: a
+//! [`JupyterFileHost`] model loads content via [`FileModel`], drives the view
+//! on (re)load, persists the view's edits on save, and surfaces save failures
+//! and on-disk conflicts. The view itself is edit-only and never touches the
+//! filesystem.
+
+use std::path::Path;
+
+#[cfg(feature = "local_fs")]
+use warp_files::{FileModel, FileModelEvent};
+#[cfg(feature = "local_fs")]
+use warp_util::content_version::ContentVersion;
+#[cfg(feature = "local_fs")]
+use warp_util::file::FileId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+#[cfg(feature = "local_fs")]
+use warp_util::remote_path::RemotePath;
+#[cfg(feature = "local_fs")]
+use warpui::ModelContext;
+use warpui::{AppContext, Entity, ModelHandle, SingletonEntity, View, ViewContext, ViewHandle};
+
+use super::view::PaneView;
+use super::{
+    DetachType, PaneConfiguration, PaneContent, PaneEvent, PaneGroup, PaneId, ShareableLink,
+    ShareableLinkError,
+};
+use crate::app_state::{LeafContents, NotebookPaneSnapshot};
+#[cfg(feature = "local_fs")]
+use crate::view_components::ToastFlavor;
+
+// INTEGRATION: the real view lives at `crate::notebooks::file::jupyter`, owned
+// by the view agent. Until both branches merge, this slice compiles against a
+// local stub with the identical published API. To integrate, delete the stub
+// file and replace these two lines with:
+//   use crate::notebooks::file::jupyter::{JupyterNotebookEvent, JupyterNotebookView};
+#[path = "jupyter_notebook_view_stub.rs"]
+mod jupyter_notebook_view_stub;
+use jupyter_notebook_view_stub::JupyterNotebookEvent;
+// Re-exported so `PaneId`'s typed constructors in `pane/mod.rs` can name the
+// hosted view type. INTEGRATION: repoint both this `use` and the one in
+// `pane/mod.rs` at `crate::notebooks::file::jupyter::JupyterNotebookView`.
+pub(super) use jupyter_notebook_view_stub::JupyterNotebookView;
+
+/// A pane that hosts an editable Jupyter notebook backed by an `.ipynb` file.
+pub struct JupyterNotebookPane {
+    view: ViewHandle<PaneView<JupyterNotebookView>>,
+    pane_configuration: ModelHandle<PaneConfiguration>,
+    /// Owns the file I/O (load / save / conflict) around the view.
+    #[cfg(feature = "local_fs")]
+    file_host: Option<ModelHandle<JupyterFileHost>>,
+}
+
+impl JupyterNotebookPane {
+    fn from_view(
+        view: ViewHandle<JupyterNotebookView>,
+        #[cfg(feature = "local_fs")] file_host: Option<ModelHandle<JupyterFileHost>>,
+        ctx: &mut AppContext,
+    ) -> Self {
+        let pane_configuration = view.as_ref(ctx).pane_configuration();
+        let pane_view = ctx.add_typed_action_view(view.window_id(ctx), |ctx| {
+            let pane_id = PaneId::from_jupyter_notebook_pane_ctx(ctx);
+            PaneView::new(pane_id, view, (), pane_configuration.clone(), ctx)
+        });
+
+        Self {
+            view: pane_view,
+            pane_configuration,
+            #[cfg(feature = "local_fs")]
+            file_host,
+        }
+    }
+
+    /// Create a new Jupyter notebook pane for `path`. The view starts empty and
+    /// is populated once the file's content loads (local or remote). If `path`
+    /// is `None`, the pane is created with an empty, unbacked notebook.
+    pub fn new<V: View>(path: Option<LocalOrRemotePath>, ctx: &mut ViewContext<V>) -> Self {
+        let view_path = path.clone();
+        let view =
+            ctx.add_typed_action_view(move |ctx| JupyterNotebookView::new("", view_path, ctx));
+
+        #[cfg(feature = "local_fs")]
+        let file_host = path.map(|path| ctx.add_model(|_ctx| JupyterFileHost::new(path)));
+
+        Self::from_view(
+            view,
+            #[cfg(feature = "local_fs")]
+            file_host,
+            ctx,
+        )
+    }
+
+    /// The hosted cell-based notebook view.
+    fn jupyter_view(&self, ctx: &AppContext) -> ViewHandle<JupyterNotebookView> {
+        self.view.as_ref(ctx).child(ctx)
+    }
+}
+
+impl PaneContent for JupyterNotebookPane {
+    fn id(&self) -> PaneId {
+        PaneId::from_jupyter_notebook_pane_view(&self.view)
+    }
+
+    fn attach(
+        &self,
+        _group: &PaneGroup,
+        focus_handle: crate::pane_group::focus_state::PaneFocusHandle,
+        ctx: &mut ViewContext<PaneGroup>,
+    ) {
+        self.view
+            .update(ctx, |view, ctx| view.set_focus_handle(focus_handle, ctx));
+
+        let pane_id = self.id();
+        let jupyter_view = self.jupyter_view(ctx);
+
+        // Forward the view's events: save requests drive the file host, the raw
+        // toggle swaps to a code pane, and pane events bubble up as usual.
+        ctx.subscribe_to_view(&jupyter_view, {
+            #[cfg(feature = "local_fs")]
+            let file_host = self.file_host.clone();
+            move |pane_group, view_handle, event, ctx| match event {
+                JupyterNotebookEvent::Pane(pane_event) => {
+                    pane_group.handle_pane_event(pane_id, pane_event, ctx);
+                }
+                JupyterNotebookEvent::Focused => {
+                    pane_group.handle_pane_event(pane_id, &PaneEvent::FocusSelf, ctx);
+                }
+                JupyterNotebookEvent::Dirtied => {
+                    #[cfg(feature = "local_fs")]
+                    if let Some(host) = &file_host {
+                        host.update(ctx, |host, _ctx| host.set_dirty());
+                    }
+                    // Persist the dirty transition into session restore state.
+                    pane_group.handle_pane_event(pane_id, &PaneEvent::AppStateChanged, ctx);
+                }
+                JupyterNotebookEvent::SaveRequested { json } => {
+                    #[cfg(feature = "local_fs")]
+                    if let Some(host) = &file_host {
+                        let json = json.clone();
+                        host.update(ctx, |host, ctx| host.save(json, ctx));
+                    }
+                    #[cfg(not(feature = "local_fs"))]
+                    let _ = json;
+                }
+                JupyterNotebookEvent::RawRequested { json } => {
+                    // Swap this pane for a raw code editor on the same file,
+                    // mirroring the markdown Rendered→Raw toggle. The in-memory
+                    // `json` (which includes unsaved edits) is carried by the
+                    // view; here we open the file so the raw view is editable.
+                    let _ = json;
+                    #[cfg(feature = "local_fs")]
+                    if let Some(path) = view_handle.as_ref(ctx).path().cloned() {
+                        pane_group.handle_pane_event(
+                            pane_id,
+                            &PaneEvent::ReplaceWithCodePane { path, source: None },
+                            ctx,
+                        );
+                    }
+                    #[cfg(not(feature = "local_fs"))]
+                    let _ = view_handle;
+                }
+            }
+        });
+
+        // Drive the view from the file host's load/save/conflict events.
+        #[cfg(feature = "local_fs")]
+        if let Some(host) = &self.file_host {
+            let view = jupyter_view.clone();
+            ctx.subscribe_to_model(host, move |_pane_group, _, event, ctx| match event {
+                JupyterFileHostEvent::Loaded { content } => {
+                    view.update(ctx, |view, ctx| view.set_content(content, ctx));
+                }
+                JupyterFileHostEvent::Saved => {
+                    view.update(ctx, |view, ctx| view.mark_saved(ctx));
+                }
+                JupyterFileHostEvent::LoadFailed => {
+                    ctx.emit(crate::pane_group::Event::ShowToast {
+                        message: "Unable to read notebook file".to_owned(),
+                        flavor: ToastFlavor::Error,
+                        pane_id: Some(pane_id),
+                    });
+                }
+                JupyterFileHostEvent::SaveFailed { message } => {
+                    ctx.emit(crate::pane_group::Event::ShowToast {
+                        message: format!("Failed to save notebook: {message}"),
+                        flavor: ToastFlavor::Error,
+                        pane_id: Some(pane_id),
+                    });
+                }
+                JupyterFileHostEvent::Conflict => {
+                    // Do not overwrite the user's unsaved edits. Inform them; they
+                    // can save to overwrite or close/reopen to take the disk copy.
+                    ctx.emit(crate::pane_group::Event::ShowToast {
+                        message: "Notebook changed on disk. Your unsaved edits are preserved; \
+                                  saving will overwrite the on-disk version."
+                            .to_owned(),
+                        flavor: ToastFlavor::Default,
+                        pane_id: Some(pane_id),
+                    });
+                }
+            });
+
+            // Start loading only after the subscriptions above are registered so
+            // the initial load event is not missed.
+            host.update(ctx, |host, ctx| host.start_if_needed(ctx));
+        }
+
+        ctx.subscribe_to_view(&self.view, move |group, _, event, ctx| {
+            group.handle_pane_view_event(pane_id, event, ctx);
+        });
+    }
+
+    fn detach(
+        &self,
+        _group: &PaneGroup,
+        _detach_type: DetachType,
+        ctx: &mut ViewContext<PaneGroup>,
+    ) {
+        let jupyter_view = self.jupyter_view(ctx);
+        ctx.unsubscribe_to_view(&jupyter_view);
+        #[cfg(feature = "local_fs")]
+        if let Some(host) = &self.file_host {
+            ctx.unsubscribe_to_model(host);
+        }
+        ctx.unsubscribe_to_view(&self.view);
+    }
+
+    fn snapshot(&self, app: &AppContext) -> LeafContents {
+        // Only local files are restorable across sessions. The path-keyed
+        // restore arm re-routes `.ipynb` back to this pane when the flag is on.
+        let path = self
+            .jupyter_view(app)
+            .as_ref(app)
+            .path()
+            .and_then(|p| p.to_local_path().map(Path::to_path_buf));
+        LeafContents::Notebook(NotebookPaneSnapshot::LocalFileNotebook { path })
+    }
+
+    fn has_application_focus(&self, ctx: &mut ViewContext<PaneGroup>) -> bool {
+        self.view.is_self_or_child_focused(ctx)
+    }
+
+    fn focus(&self, ctx: &mut ViewContext<PaneGroup>) {
+        let view = self.jupyter_view(ctx);
+        ctx.focus(&view);
+    }
+
+    fn shareable_link(
+        &self,
+        _ctx: &mut ViewContext<PaneGroup>,
+    ) -> Result<ShareableLink, ShareableLinkError> {
+        Ok(ShareableLink::Base)
+    }
+
+    fn pane_configuration(&self) -> ModelHandle<PaneConfiguration> {
+        self.pane_configuration.clone()
+    }
+
+    fn is_pane_being_dragged(&self, ctx: &AppContext) -> bool {
+        self.view.as_ref(ctx).is_being_dragged()
+    }
+}
+
+/// Events emitted by [`JupyterFileHost`] to drive the hosted view.
+#[cfg(feature = "local_fs")]
+#[derive(Debug, Clone)]
+enum JupyterFileHostEvent {
+    /// Fresh content was loaded from disk (initial load or external change while
+    /// the buffer is clean).
+    Loaded { content: String },
+    /// The file could not be read.
+    LoadFailed,
+    /// A save completed successfully.
+    Saved,
+    /// A save failed; `message` is a user-facing description.
+    SaveFailed { message: String },
+    /// The file changed on disk while the buffer had unsaved edits.
+    Conflict,
+}
+
+/// Owns the file-backing for a [`JupyterNotebookPane`]: it loads content via
+/// [`FileModel`], tracks the [`ContentVersion`] and dirty state, persists the
+/// view's edits, and detects on-disk conflicts.
+#[cfg(feature = "local_fs")]
+struct JupyterFileHost {
+    path: LocalOrRemotePath,
+    file_id: Option<FileId>,
+    /// Version of the content currently reflected on disk and in the view.
+    version: Option<ContentVersion>,
+    /// Whether the view has unsaved edits (mirrors the view's dirty state).
+    dirty: bool,
+    /// Whether [`Self::start_if_needed`] has already kicked off a load.
+    started: bool,
+}
+
+#[cfg(feature = "local_fs")]
+impl Entity for JupyterFileHost {
+    type Event = JupyterFileHostEvent;
+}
+
+#[cfg(feature = "local_fs")]
+impl JupyterFileHost {
+    fn new(path: LocalOrRemotePath) -> Self {
+        Self {
+            path,
+            file_id: None,
+            version: None,
+            dirty: false,
+            started: false,
+        }
+    }
+
+    /// Begin loading the file (idempotent). Local files are read and watched via
+    /// [`FileModel`]; remote files are fetched from the remote server and
+    /// registered with [`FileModel`] for save dispatch.
+    fn start_if_needed(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.started {
+            return;
+        }
+        self.started = true;
+
+        match self.path.clone() {
+            LocalOrRemotePath::Local(local_path) => {
+                let file_model = FileModel::handle(ctx);
+                let file_id =
+                    file_model.update(ctx, |model, ctx| model.open(&local_path, true, ctx));
+                self.file_id = Some(file_id);
+                ctx.subscribe_to_model(&file_model, move |me, event: &FileModelEvent, ctx| {
+                    if event.file_id() == file_id {
+                        me.handle_file_event(event, ctx);
+                    }
+                });
+            }
+            LocalOrRemotePath::Remote(remote_path) => {
+                let file_model = FileModel::handle(ctx);
+                let file_id = file_model.update(ctx, |model, _ctx| {
+                    model
+                        .register_remote_file(remote_path.host_id.clone(), remote_path.path.clone())
+                });
+                self.file_id = Some(file_id);
+                ctx.subscribe_to_model(&file_model, move |me, event: &FileModelEvent, ctx| {
+                    if event.file_id() == file_id {
+                        me.handle_file_event(event, ctx);
+                    }
+                });
+                self.fetch_remote(remote_path, ctx);
+            }
+        }
+    }
+
+    /// Mark the buffer dirty so a concurrent on-disk change is treated as a
+    /// conflict rather than silently overwriting the user's edits.
+    fn set_dirty(&mut self) {
+        self.dirty = true;
+    }
+
+    /// Persist `json` to the backing file, tracking a fresh [`ContentVersion`].
+    fn save(&mut self, json: String, ctx: &mut ModelContext<Self>) {
+        let Some(file_id) = self.file_id else {
+            return;
+        };
+        let version = ContentVersion::new();
+        let result = FileModel::handle(ctx)
+            .update(ctx, |model, ctx| model.save(file_id, json, version, ctx));
+        if let Err(err) = result {
+            ctx.emit(JupyterFileHostEvent::SaveFailed {
+                message: err.to_string(),
+            });
+        }
+    }
+
+    fn handle_file_event(&mut self, event: &FileModelEvent, ctx: &mut ModelContext<Self>) {
+        match event {
+            FileModelEvent::FileLoaded {
+                content, version, ..
+            } => {
+                self.version = Some(*version);
+                self.dirty = false;
+                ctx.emit(JupyterFileHostEvent::Loaded {
+                    content: content.clone(),
+                });
+            }
+            FileModelEvent::FailedToLoad { .. } => {
+                ctx.emit(JupyterFileHostEvent::LoadFailed);
+            }
+            FileModelEvent::FileUpdated {
+                content,
+                new_version,
+                ..
+            } => {
+                if self.dirty {
+                    // Unsaved edits present: never silently overwrite them.
+                    ctx.emit(JupyterFileHostEvent::Conflict);
+                } else {
+                    self.version = Some(*new_version);
+                    ctx.emit(JupyterFileHostEvent::Loaded {
+                        content: content.clone(),
+                    });
+                }
+            }
+            FileModelEvent::FileSaved { version, .. } => {
+                // Advance the tracked version so the watcher echo of our own
+                // write is not mistaken for an external conflict.
+                self.version = Some(*version);
+                self.dirty = false;
+                ctx.emit(JupyterFileHostEvent::Saved);
+            }
+            FileModelEvent::FailedToSave { error, .. } => {
+                ctx.emit(JupyterFileHostEvent::SaveFailed {
+                    message: error.to_string(),
+                });
+            }
+        }
+    }
+
+    /// Fetch the content of a remote file via the remote server.
+    fn fetch_remote(&mut self, remote_path: RemotePath, ctx: &mut ModelContext<Self>) {
+        let host_id = remote_path.host_id.clone();
+        let request = remote_server::proto::ReadFileContextRequest {
+            files: vec![remote_server::proto::ReadFileContextFile {
+                path: remote_path.path.as_str().to_string(),
+                line_ranges: vec![],
+            }],
+            max_file_bytes: None,
+            max_batch_bytes: None,
+        };
+        let handle =
+            remote_server::manager::RemoteServerManager::as_ref(ctx).host_request_handle(&host_id);
+        ctx.spawn(
+            async move { handle.read_file_context(request).await },
+            move |me, result, ctx| match result {
+                Ok(response) => {
+                    if let Some(file_ctx) = response.file_contexts.first() {
+                        let text = match &file_ctx.content {
+                            Some(
+                                remote_server::proto::file_context_proto::Content::TextContent(
+                                    text,
+                                ),
+                            ) => text.clone(),
+                            _ => String::new(),
+                        };
+                        me.version = Some(ContentVersion::new());
+                        me.dirty = false;
+                        ctx.emit(JupyterFileHostEvent::Loaded { content: text });
+                    } else {
+                        ctx.emit(JupyterFileHostEvent::LoadFailed);
+                    }
+                }
+                Err(_) => ctx.emit(JupyterFileHostEvent::LoadFailed),
+            },
+        );
+    }
+}

--- a/app/src/pane_group/pane/jupyter_notebook_view_stub.rs
+++ b/app/src/pane_group/pane/jupyter_notebook_view_stub.rs
@@ -1,0 +1,202 @@
+//! TEMPORARY STUB — replaced at integration by the view agent's real module.
+//!
+//! The editable cell-based Jupyter view is owned by a parallel agent and lives
+//! at `crate::notebooks::file::jupyter`. Until both branches merge, this slice
+//! (routing + hosting pane + open/save/conflict wiring) compiles against this
+//! local stub, which reproduces the view agent's published public API exactly:
+//!
+//! ```ignore
+//! pub fn new(content: &str, path: Option<LocalOrRemotePath>, ctx) -> Self;
+//! pub fn set_content(&mut self, content: &str, ctx);
+//! pub fn to_json(&self) -> String;
+//! pub fn is_dirty(&self) -> bool;
+//! pub fn mark_saved(&mut self, ctx);
+//! pub fn request_save(&mut self, ctx);
+//! pub fn path(&self) -> Option<&LocalOrRemotePath>;
+//! pub fn title(&self) -> String;
+//! pub fn pane_configuration(&self) -> ModelHandle<PaneConfiguration>;
+//! ```
+//!
+//! plus `JupyterNotebookEvent` and a `BackingView` impl.
+//!
+//! INTEGRATION: delete this file and, in `jupyter_notebook_pane.rs`, replace the
+//! stub import with:
+//!   `use crate::notebooks::file::jupyter::{JupyterNotebookEvent, JupyterNotebookView};`
+//! The real view's `PaneHeaderOverflowMenuAction` is `JupyterNotebookAction`;
+//! this stub uses `()` since it is never wired into the responder chain.
+
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::elements::Empty;
+use warpui::{AppContext, Element, Entity, ModelHandle, TypedActionView, View, ViewContext};
+
+use crate::menu::MenuItem;
+use crate::pane_group::focus_state::PaneFocusHandle;
+use crate::pane_group::pane::{view, BackingView, PaneConfiguration, PaneEvent};
+
+/// Events emitted by the cell-based notebook view (frozen interface — mirrors
+/// the view agent's finalized enum).
+#[derive(Debug, Clone)]
+pub enum JupyterNotebookEvent {
+    /// The notebook transitioned from clean to dirty.
+    Dirtied,
+    /// The user requested a save. `json` is the full `.ipynb` to persist.
+    SaveRequested { json: String },
+    /// The user switched to the raw view. `json` is the current notebook,
+    /// including unsaved edits, so the raw editor shows them.
+    RawRequested { json: String },
+    /// The view gained focus.
+    Focused,
+    /// Pane-level events (Close / ToggleMaximized / FocusSelf), mirroring
+    /// `FileNotebookView`.
+    Pane(PaneEvent),
+}
+
+impl From<PaneEvent> for JupyterNotebookEvent {
+    fn from(event: PaneEvent) -> Self {
+        JupyterNotebookEvent::Pane(event)
+    }
+}
+
+pub struct JupyterNotebookView {
+    content: String,
+    path: Option<LocalOrRemotePath>,
+    dirty: bool,
+    pane_configuration: ModelHandle<PaneConfiguration>,
+    focus_handle: Option<PaneFocusHandle>,
+}
+
+impl JupyterNotebookView {
+    pub fn new(
+        content: &str,
+        path: Option<LocalOrRemotePath>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let title = path
+            .as_ref()
+            .map(|p| p.display_path())
+            .unwrap_or_else(|| "Untitled".to_string());
+        let pane_configuration = ctx.add_model(|_ctx| PaneConfiguration::new(title));
+        Self {
+            content: content.to_string(),
+            path,
+            dirty: false,
+            pane_configuration,
+            focus_handle: None,
+        }
+    }
+
+    /// Replace the notebook content from an external reload. Clears the dirty flag.
+    pub fn set_content(&mut self, content: &str, ctx: &mut ViewContext<Self>) {
+        self.content = content.to_string();
+        self.dirty = false;
+        ctx.notify();
+    }
+
+    /// The current `.ipynb` JSON (edits are synced eagerly in the real view).
+    pub fn to_json(&self) -> String {
+        self.content.clone()
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Called by the host after a successful save.
+    pub fn mark_saved(&mut self, ctx: &mut ViewContext<Self>) {
+        self.dirty = false;
+        ctx.notify();
+    }
+
+    /// Emit a [`JupyterNotebookEvent::SaveRequested`] with the current JSON.
+    pub fn request_save(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(JupyterNotebookEvent::SaveRequested {
+            json: self.to_json(),
+        });
+    }
+
+    pub fn path(&self) -> Option<&LocalOrRemotePath> {
+        self.path.as_ref()
+    }
+
+    pub fn title(&self) -> String {
+        self.path
+            .as_ref()
+            .map(|p| p.display_path())
+            .unwrap_or_else(|| "Untitled".to_string())
+    }
+
+    pub fn pane_configuration(&self) -> ModelHandle<PaneConfiguration> {
+        self.pane_configuration.clone()
+    }
+}
+
+impl Entity for JupyterNotebookView {
+    type Event = JupyterNotebookEvent;
+}
+
+impl View for JupyterNotebookView {
+    fn ui_name() -> &'static str {
+        "JupyterNotebookView"
+    }
+
+    fn render(&self, _app: &AppContext) -> Box<dyn Element> {
+        Empty::new().finish()
+    }
+}
+
+impl TypedActionView for JupyterNotebookView {
+    type Action = ();
+
+    fn handle_action(&mut self, _action: &Self::Action, _ctx: &mut ViewContext<Self>) {}
+}
+
+impl BackingView for JupyterNotebookView {
+    type PaneHeaderOverflowMenuAction = ();
+    type CustomAction = ();
+    type AssociatedData = ();
+
+    fn handle_pane_header_overflow_menu_action(
+        &mut self,
+        _action: &Self::PaneHeaderOverflowMenuAction,
+        _ctx: &mut ViewContext<Self>,
+    ) {
+    }
+
+    fn close(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(JupyterNotebookEvent::Pane(PaneEvent::Close));
+    }
+
+    fn focus_contents(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(JupyterNotebookEvent::Focused);
+    }
+
+    fn pane_header_overflow_menu_items(
+        &self,
+        _ctx: &AppContext,
+    ) -> Vec<MenuItem<Self::PaneHeaderOverflowMenuAction>> {
+        vec![]
+    }
+
+    fn render_header_content(
+        &self,
+        _ctx: &view::HeaderRenderContext<'_>,
+        app: &AppContext,
+    ) -> view::HeaderContent {
+        let title = self.pane_configuration.as_ref(app).title().to_owned();
+        view::HeaderContent::Standard(view::StandardHeader {
+            title,
+            title_secondary: None,
+            title_style: None,
+            title_clip_config: warpui::text_layout::ClipConfig::start(),
+            title_max_width: None,
+            left_of_title: None,
+            right_of_title: None,
+            left_of_overflow: None,
+            options: Default::default(),
+        })
+    }
+
+    fn set_focus_handle(&mut self, focus_handle: PaneFocusHandle, _ctx: &mut ViewContext<Self>) {
+        self.focus_handle = Some(focus_handle);
+    }
+}

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -19,6 +19,7 @@ pub(super) mod execution_profile_editor_pane;
 pub(super) mod file_pane;
 pub(super) mod get_started_pane;
 pub(super) mod get_started_view;
+pub(super) mod jupyter_notebook_pane;
 #[cfg(not(target_family = "wasm"))]
 pub(super) mod local_harness_launch;
 pub(super) mod network_log_pane;
@@ -60,6 +61,7 @@ use crate::notebooks::file::FileNotebookView;
 use crate::notebooks::notebook::NotebookView;
 use crate::pane_group::focus_state::PaneFocusHandle;
 use crate::pane_group::pane::get_started_view::GetStartedView;
+use crate::pane_group::pane::jupyter_notebook_pane::JupyterNotebookView;
 use crate::server::network_log_view::NetworkLogView;
 use crate::server::telemetry::SharingDialogSource;
 use crate::settings::PaneSettings;
@@ -149,6 +151,7 @@ pub(crate) enum IPaneType {
     GetStarted,
     NetworkLog,
     Welcome,
+    JupyterNotebook,
     DeferredPlaceholder,
     /// A pane type only for tests.
     #[cfg(test)]
@@ -173,6 +176,7 @@ impl Display for IPaneType {
             IPaneType::GetStarted => write!(f, "GetStarted"),
             IPaneType::NetworkLog => write!(f, "Network Log"),
             IPaneType::Welcome => write!(f, "Welcome"),
+            IPaneType::JupyterNotebook => write!(f, "Jupyter Notebook"),
             IPaneType::DeferredPlaceholder => write!(f, "Placeholder"),
             #[cfg(test)]
             IPaneType::Dummy => write!(f, "Dummy"),
@@ -203,6 +207,13 @@ impl PaneId {
     /// Creates a [`PaneId`] from a [`ViewContext<PaneView<FileNotebookView>>`]
     pub fn from_file_pane_ctx(ctx: &ViewContext<PaneView<FileNotebookView>>) -> Self {
         Self::new_from_ctx(IPaneType::File, ctx)
+    }
+
+    /// Creates a [`PaneId`] from a [`ViewContext<PaneView<JupyterNotebookView>>`]
+    pub fn from_jupyter_notebook_pane_ctx(
+        ctx: &ViewContext<PaneView<JupyterNotebookView>>,
+    ) -> Self {
+        Self::new_from_ctx(IPaneType::JupyterNotebook, ctx)
     }
 
     /// Creates a [`PaneId`] from a [`ViewContext<PaneView<NotebookView>>`]
@@ -291,6 +302,13 @@ impl PaneId {
     /// Creates a [`PaneId`] from a [`PaneView<FileNotebookView>`] entity ID.
     pub fn from_file_pane_view(file_pane_view: &ViewHandle<PaneView<FileNotebookView>>) -> Self {
         Self::new(IPaneType::File, file_pane_view)
+    }
+
+    /// Creates a [`PaneId`] from a [`PaneView<JupyterNotebookView>`] entity ID.
+    pub fn from_jupyter_notebook_pane_view(
+        jupyter_pane_view: &ViewHandle<PaneView<JupyterNotebookView>>,
+    ) -> Self {
+        Self::new(IPaneType::JupyterNotebook, jupyter_pane_view)
     }
 
     /// Creates a [`PaneId`] from a [`PaneView<TextView>`] entity ID.
@@ -425,6 +443,10 @@ impl PaneId {
         matches!(self.0.pane_type, IPaneType::File)
     }
 
+    pub fn is_jupyter_notebook_pane(&self) -> bool {
+        matches!(self.0.pane_type, IPaneType::JupyterNotebook)
+    }
+
     pub fn is_code_diff_pane(&self) -> bool {
         matches!(self.0.pane_type, IPaneType::CodeDiff)
     }
@@ -455,6 +477,9 @@ impl PaneId {
             }
             IPaneType::File => {
                 ChildView::<PaneView<FileNotebookView>>::with_id(self.0.pane_view_id).finish()
+            }
+            IPaneType::JupyterNotebook => {
+                ChildView::<PaneView<JupyterNotebookView>>::with_id(self.0.pane_view_id).finish()
             }
             IPaneType::Code => {
                 ChildView::<PaneView<CodeView>>::with_id(self.0.pane_view_id).finish()

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -3352,6 +3352,9 @@ impl TelemetryEvent {
                     FileTarget::MarkdownViewer(layout) => {
                         ("warp_markdown_viewer", Some(*layout), None)
                     }
+                    FileTarget::JupyterNotebook(layout) => {
+                        ("warp_jupyter_notebook", Some(*layout), None)
+                    }
                     FileTarget::CodeEditor(layout) => ("warp_code_editor", Some(*layout), None),
                     FileTarget::EnvEditor => ("env_editor", None, None),
                     FileTarget::SystemDefault => ("system_default", None, None),

--- a/app/src/util/openable_file_type.rs
+++ b/app/src/util/openable_file_type.rs
@@ -3,8 +3,12 @@
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-pub use warp_util::file_type::{is_binary_file, is_file_content_binary, is_markdown_file};
+pub use warp_util::file_type::{
+    is_binary_file, is_file_content_binary, is_jupyter_notebook_file, is_markdown_file,
+};
 
+#[cfg(feature = "local_fs")]
+use crate::features::FeatureFlag;
 #[cfg(feature = "local_fs")]
 use crate::util::file::external_editor::{settings::EditorChoice, Editor, EditorSettings};
 
@@ -45,6 +49,8 @@ pub enum OpenableFileType {
 pub enum FileTarget {
     /// Open in Warp's Markdown viewer.
     MarkdownViewer(EditorLayout),
+    /// Open in Warp's editable, cell-based Jupyter notebook view.
+    JupyterNotebook(EditorLayout),
     /// Open in Warp's Code Editor.
     CodeEditor(EditorLayout),
     /// Open in an external editor (e.g. VS Code, Emacs).
@@ -170,6 +176,13 @@ pub fn resolve_file_target_to_open_in_warp(
     let is_markdown = matches!(openable_file_type, Some(OpenableFileType::Markdown));
     let layout = layout.unwrap_or(*settings.open_file_layout);
 
+    // Jupyter notebooks open in the editable, cell-based notebook view. This is
+    // the default for `.ipynb` when the feature is enabled, ahead of any
+    // "prefer markdown viewer" preference.
+    if is_jupyter_notebook_file(path) && FeatureFlag::JupyterNotebookEditing.is_enabled() {
+        return FileTarget::JupyterNotebook(layout);
+    }
+
     if is_markdown && *settings.prefer_markdown_viewer {
         return FileTarget::MarkdownViewer(layout);
     }
@@ -204,6 +217,13 @@ pub fn resolve_file_target_with_editor_choice(
     let is_markdown = matches!(is_openable_in_warp, Some(OpenableFileType::Markdown));
     let layout = layout.unwrap_or(default_layout);
     let is_openable_in_warp = is_openable_in_warp.is_some();
+
+    // 0. Jupyter notebooks open in the editable, cell-based notebook view. This
+    //    is the default for `.ipynb` when the feature is enabled, ahead of the
+    //    markdown-viewer preference and the configured editor choice.
+    if is_jupyter_notebook_file(path) && FeatureFlag::JupyterNotebookEditing.is_enabled() {
+        return FileTarget::JupyterNotebook(layout);
+    }
 
     // 1. Markdown Viewer (only if user preference specified)
     if is_markdown && prefer_markdown_viewer {

--- a/app/src/util/openable_file_type_tests.rs
+++ b/app/src/util/openable_file_type_tests.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 use settings::Setting as _;
 
 use super::*;
+#[cfg(feature = "local_fs")]
+use crate::features::FeatureFlag;
 
 #[test]
 fn test_binary_files_not_openable() {
@@ -77,6 +79,64 @@ fn test_resolve_file_target_binary_uses_env_editor() {
         None,
     );
     assert_eq!(target, FileTarget::EnvEditor);
+}
+
+#[test]
+#[cfg(feature = "local_fs")]
+fn test_resolve_file_target_jupyter_notebook_flag_on() {
+    // With the editing feature enabled, `.ipynb` opens in the cell-based
+    // notebook view regardless of editor choice or markdown preference (inv 1).
+    let _guard = FeatureFlag::JupyterNotebookEditing.override_enabled(true);
+    let target = resolve_file_target_with_editor_choice(
+        Path::new("analysis.ipynb"),
+        EditorChoice::Warp,
+        true, /* prefer_markdown_viewer */
+        EditorLayout::SplitPane,
+        None,
+    );
+    assert_eq!(target, FileTarget::JupyterNotebook(EditorLayout::SplitPane));
+}
+
+#[test]
+#[cfg(feature = "local_fs")]
+fn test_resolve_file_target_jupyter_notebook_flag_off() {
+    // With the feature disabled, `.ipynb` behaves exactly as before: a text
+    // file opened in the code editor (inv 22).
+    let _guard = FeatureFlag::JupyterNotebookEditing.override_enabled(false);
+    let target = resolve_file_target_with_editor_choice(
+        Path::new("analysis.ipynb"),
+        EditorChoice::Warp,
+        true, /* prefer_markdown_viewer */
+        EditorLayout::NewTab,
+        None,
+    );
+    assert_eq!(target, FileTarget::CodeEditor(EditorLayout::NewTab));
+}
+
+#[test]
+#[cfg(feature = "local_fs")]
+fn test_resolve_file_target_jupyter_notebook_overrides_editor_choice() {
+    // The notebook target wins even when the user configured an external
+    // editor, since it is the default treatment for `.ipynb` when enabled.
+    let _guard = FeatureFlag::JupyterNotebookEditing.override_enabled(true);
+    let target = resolve_file_target_with_editor_choice(
+        Path::new("nb.ipynb"),
+        EditorChoice::ExternalEditor(Editor::VSCode),
+        false, /* prefer_markdown_viewer */
+        EditorLayout::SplitPane,
+        None,
+    );
+    assert_eq!(target, FileTarget::JupyterNotebook(EditorLayout::SplitPane));
+}
+
+#[test]
+fn test_ipynb_classified_as_text() {
+    // `.ipynb` classification is unchanged (Text) so non-routing surfaces are
+    // unaffected; only the open-flow routing differs behind the flag.
+    assert_eq!(
+        is_file_openable_in_warp(Path::new("analysis.ipynb")),
+        Some(OpenableFileType::Text)
+    );
 }
 
 #[test]

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -270,14 +270,14 @@ use crate::notebooks::CloudNotebook;
 use crate::notification::NotificationContext;
 use crate::palette::PaletteMode;
 use crate::pane_group::pane::ActionOrigin;
-#[cfg(feature = "local_fs")]
-use crate::pane_group::FilePane;
 use crate::pane_group::{
     self, AIFactPane, AnyPaneContent, ChildAgentOrigin, CodeDiffPane, CodePane, CodeReviewPanelArg,
     Direction as PaneGroupDirection, Direction, EnvironmentManagementPane,
     ExecutionProfileEditorPane, NetworkLogPane, NewTerminalOptions, PaneGroup, PaneId, PanesLayout,
     TabBarHoverIndex, TerminalPaneId,
 };
+#[cfg(feature = "local_fs")]
+use crate::pane_group::{FilePane, JupyterNotebookPane};
 use crate::persistence::ModelEvent;
 use crate::projects::ProjectManagementModel;
 use crate::prompt::editor_modal::{
@@ -6007,6 +6007,9 @@ impl Workspace {
                     ctx,
                 );
             }
+            FileTarget::JupyterNotebook(layout) => {
+                self.open_jupyter_notebook(LocalOrRemotePath::Local(path.clone()), layout, ctx);
+            }
             FileTarget::EnvEditor => {
                 let editor_value: Option<String> = self
                     .get_active_session(ctx)
@@ -8014,6 +8017,38 @@ impl Workspace {
             Some("Settings".to_owned()),
             ctx,
         );
+    }
+
+    /// Open an `.ipynb` file as an editable, cell-based Jupyter notebook pane.
+    #[cfg(feature = "local_fs")]
+    fn open_jupyter_notebook(
+        &mut self,
+        path: LocalOrRemotePath,
+        layout: EditorLayout,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let pane = JupyterNotebookPane::new(Some(path), ctx);
+
+        match layout {
+            EditorLayout::NewTab => {
+                let new_tab_placement_setting = TabSettings::as_ref(ctx).new_tab_placement;
+                let new_idx = match new_tab_placement_setting {
+                    NewTabPlacement::AfterAllTabs => self.tab_count(),
+                    NewTabPlacement::AfterCurrentTab => self.active_tab_index + 1,
+                };
+                self.add_tab_from_existing_pane(Box::new(pane), new_idx, ctx);
+            }
+            EditorLayout::SplitPane => {
+                self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
+                    pane_group.add_pane_with_direction(
+                        Direction::Right,
+                        pane,
+                        true, /* focus_new_pane */
+                        ctx,
+                    );
+                });
+            }
+        }
     }
 
     /// Open a file from the given session as a notebook pane.

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3734,6 +3734,9 @@ impl PaneGroup {
             ),
             IPaneType::CodeDiff => TypedPane::CodeDiff,
             IPaneType::File => TypedPane::File,
+            // The editable Jupyter notebook is a file-backed editor; present it
+            // like a file in the vertical tabs.
+            IPaneType::JupyterNotebook => TypedPane::File,
             IPaneType::Notebook => {
                 let is_plan = self
                     .downcast_pane_by_id::<NotebookPane>(pane_id)

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -447,6 +447,8 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_file_tree_keyboard_navigation);
     register_test!(test_file_tree_non_openable_files);
     register_test!(test_file_tree_nested_file_opening);
+    register_test!(test_file_tree_opens_ipynb_in_jupyter_pane_when_flag_enabled);
+    register_test!(test_file_tree_opens_ipynb_in_code_editor_when_flag_disabled);
 
     // Go to Line tests
     register_test!(test_goto_line_dialog_open_close);

--- a/crates/integration/src/test/file_tree.rs
+++ b/crates/integration/src/test/file_tree.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use warp::features::FeatureFlag;
 use warp::integration_testing::step::new_step_with_default_assertions;
 use warp::integration_testing::tab::assert_pane_title;
 use warp::integration_testing::terminal::wait_until_bootstrapped_single_pane_for_tab;
@@ -9,6 +10,16 @@ use warpui_core::{async_assert, async_assert_eq, App};
 
 use super::{new_builder, Builder};
 use crate::util::write_all_rc_files_for_test;
+
+/// A minimal, valid nbformat v4 notebook used by the `.ipynb` routing tests.
+/// Valid content matters: the real cell-based view keeps a parseable notebook
+/// in the Jupyter pane, whereas an unparseable one would fall back to the code
+/// editor.
+const MINIMAL_IPYNB: &str = concat!(
+    "{\"cells\":[{\"cell_type\":\"markdown\",\"metadata\":{},",
+    "\"source\":[\"# Title\"]}],",
+    "\"metadata\":{},\"nbformat\":4,\"nbformat_minor\":5}",
+);
 
 fn open_file_tree_panel(app: &mut App) {
     let window_id = app.read(|ctx| {
@@ -255,6 +266,94 @@ pub fn test_file_tree_non_openable_files() -> Builder {
                             pane_group.pane_count(),
                             1,
                             "Binary file should not open in Warp, should stay at 1 pane"
+                        )
+                    })
+                }),
+        )
+}
+
+/// With the editing feature enabled, clicking an `.ipynb` file in the file tree
+/// opens it in the editable, cell-based Jupyter notebook pane (not a code pane).
+pub fn test_file_tree_opens_ipynb_in_jupyter_pane_when_flag_enabled() -> Builder {
+    FeatureFlag::JupyterNotebookEditing.set_enabled(true);
+    new_builder()
+        .with_setup(|utils| {
+            let test_dir = utils.test_dir();
+            let dir_string = test_dir
+                .to_str()
+                .expect("Should be able to convert test dir to str");
+            write_all_rc_files_for_test(&test_dir, format!("cd {dir_string}"));
+
+            std::fs::write(test_dir.join("analysis.ipynb"), MINIMAL_IPYNB)
+                .expect("Failed to create notebook file");
+        })
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Open file tree panel")
+                .with_action(|app, _, _| open_file_tree_panel(app)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Click on analysis.ipynb in file tree")
+                .with_click_on_saved_position("file_tree_item:analysis.ipynb")
+                .add_assertion(|app, window_id| {
+                    let pane_group = pane_group_view(app, window_id, 0);
+                    pane_group.read(app, |pane_group, _ctx| {
+                        async_assert_eq!(
+                            pane_group.pane_count(),
+                            2,
+                            "Expected 2 panes after opening the notebook (terminal + notebook)"
+                        )
+                    })
+                })
+                .add_assertion(|app, window_id| {
+                    let pane_group = pane_group_view(app, window_id, 0);
+                    pane_group.read(app, |pane_group, _ctx| {
+                        let is_jupyter = pane_group
+                            .pane_by_index(1)
+                            .map(|pane| pane.id().is_jupyter_notebook_pane())
+                            .unwrap_or(false);
+                        async_assert!(
+                            is_jupyter,
+                            "Expected `.ipynb` to open an editable Jupyter notebook pane"
+                        )
+                    })
+                }),
+        )
+}
+
+/// With the editing feature disabled, an `.ipynb` file behaves exactly as
+/// before: it opens in the code editor as plain text (no notebook pane).
+pub fn test_file_tree_opens_ipynb_in_code_editor_when_flag_disabled() -> Builder {
+    FeatureFlag::JupyterNotebookEditing.set_enabled(false);
+    new_builder()
+        .with_setup(|utils| {
+            let test_dir = utils.test_dir();
+            let dir_string = test_dir
+                .to_str()
+                .expect("Should be able to convert test dir to str");
+            write_all_rc_files_for_test(&test_dir, format!("cd {dir_string}"));
+
+            std::fs::write(test_dir.join("analysis.ipynb"), MINIMAL_IPYNB)
+                .expect("Failed to create notebook file");
+        })
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Open file tree panel")
+                .with_action(|app, _, _| open_file_tree_panel(app)),
+        )
+        .with_step(
+            new_step_with_default_assertions("Click on analysis.ipynb in file tree")
+                .with_click_on_saved_position("file_tree_item:analysis.ipynb")
+                .add_assertion(|app, window_id| {
+                    let pane_group = pane_group_view(app, window_id, 0);
+                    pane_group.read(app, |pane_group, _ctx| {
+                        let is_code = pane_group
+                            .pane_by_index(1)
+                            .map(|pane| pane.id().is_code_pane())
+                            .unwrap_or(false);
+                        async_assert!(
+                            is_code,
+                            "Expected `.ipynb` to open in the code editor when the flag is off"
                         )
                     })
                 }),

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -321,6 +321,8 @@ integration_tests! {
     test_file_tree_keyboard_navigation,
     test_file_tree_non_openable_files,
     test_file_tree_nested_file_opening,
+    test_file_tree_opens_ipynb_in_jupyter_pane_when_flag_enabled,
+    test_file_tree_opens_ipynb_in_code_editor_when_flag_disabled,
 
     // Go to Line tests
     test_goto_line_dialog_open_close,


### PR DESCRIPTION
## Description
Routing / hosting-pane / open-flow / file-save slice of the editable, cell-based Jupyter `.ipynb` feature. This wires everything **around** the cell-based `JupyterNotebookView` (built on a parallel branch) and is gated behind `FeatureFlag::JupyterNotebookEditing`. Edit-only: no kernel, no execution; saved `outputs` are carried through untouched by the model.

This branch is meant to be integrated with the `view` branch by the orchestrator (do not merge standalone).

## Main files to review
- `app/src/util/openable_file_type.rs` (+ tests): adds `FileTarget::JupyterNotebook(EditorLayout)`; both resolvers route `.ipynb` to it ahead of the markdown-viewer preference when the flag is on; `.ipynb` stays `OpenableFileType::Text`. (inv. 1, 22)
- `app/src/pane_group/pane/jupyter_notebook_pane.rs` (new): `JupyterNotebookPane` (PaneContent) wrapping `PaneView<JupyterNotebookView>`, plus a `JupyterFileHost` model owning `FileModel` load/save and conflict detection (local + remote). Save flow: `SaveRequested{json}` → `FileModel::save`; `FileSaved` → `mark_saved`; `FailedToSave` → error toast + keep dirty; `FileUpdated` → reload when clean, **non-destructive** conflict toast when dirty; `RawRequested` → swap to raw code editor. (inv. 10–13, 20)
- `app/src/workspace/view.rs`: `open_jupyter_notebook` wired into `open_file_with_target`.
- `app/src/pane_group/mod.rs`: re-export + session-restore re-routes `.ipynb` to the Jupyter pane (path-keyed; no app_state/sqlite change).
- `crates/integration/src/test/file_tree.rs` (+ registration): integration tests — `.ipynb` opens a Jupyter pane (flag on) vs a code pane (flag off).

## Minor file changes
- `app/src/server/telemetry/events.rs`, `app/src/pane_group/pane/mod.rs` (`IPaneType::JupyterNotebook`, `PaneId` ctors, `PaneId::render`, `is_jupyter_notebook_pane`), `app/src/workspace/view/vertical_tabs.rs` (exhaustive match arm).

## Integration notes (orchestrator)
- The cell-based view is owned by the `view` branch at `crate::notebooks::file::jupyter`. This branch compiles against a clearly-marked **local stub** `app/src/pane_group/pane/jupyter_notebook_view_stub.rs`. To integrate: **delete that stub file** and repoint the two imports (in `jupyter_notebook_pane.rs` and `pane/mod.rs`) to `crate::notebooks::file::jupyter::{JupyterNotebookEvent, JupyterNotebookView}`.
- Requires from the real view (confirmed with the view agent): `pub fn pane_configuration(&self) -> ModelHandle<PaneConfiguration>`, `BackingView` with `AssociatedData = ()`, and (for inv. 16) emitting `RawRequested{json}` on parse failure so the existing raw-swap path falls back to the code editor.

## Validation
- `cargo check -p warp --tests` — clean.
- `cargo test -p warp --lib openable_file_type` — 26 passed (incl. 4 new flag-on/off tests).
- `cargo check -p integration --bins --tests` — clean (integration tests + registration compile).
- `./script/format` + `cargo clippy -p warp -p integration --tests` — my code is clean; remaining clippy warnings are pre-existing dead-code in the frozen `ipynb_model.rs` foundation (unused until the `view` branch that consumes the model is integrated).

## Deferred (accepted for v1; moved to spec follow-ups)
- Writable-based save-disable (inv. 21) — needs a view `set_read_only` hook.
- Full keep-vs-reload conflict dialog (inv. 13) — current behavior is a non-destructive conflict toast that never silently overwrites edits.
- Carrying unsaved edits into Raw (inv. 19) — currently opens the on-disk copy.
- Remote-open routing from the file tree (inv. 20) — pane/host already support remote read + save.

## Changelog
CHANGELOG-NEW-FEATURE: Open and edit Jupyter `.ipynb` notebooks in a cell-based view, and save changes back to the file.

_Conversation: https://staging.warp.dev/conversation/cd916525-4fbc-4046-8462-e3bde7423608_
_Run: https://oz.staging.warp.dev/runs/019e9a20-4cd6-7513-90b6-e2e014727672_

_This PR was generated with [Oz](https://warp.dev/oz)._
