### PR TITLE
Editable cell-based JupyterNotebookView + read-only output rendering

### DIFF
--- a/app/src/notebooks/file/jupyter/mod.rs
+++ b/app/src/notebooks/file/jupyter/mod.rs
@@ -1,0 +1,1236 @@
+//! Editable, cell-based Jupyter (`.ipynb`) notebook view.
+//!
+//! Given the raw contents of a `.ipynb` file, [`JupyterNotebookView`] parses it
+//! into a lossless [`NotebookDoc`] and renders each cell as an editable surface:
+//! markdown cells as rendered/editable markdown, code cells as editable
+//! syntax-highlighted source, with each code cell's saved `outputs` shown
+//! read-only beneath it (product_v1.md invariants 3-5). Editing a cell updates
+//! only that cell's `source`; saved `outputs` and untouched cells are never
+//! altered (invariants 6, 7, 9). If the file is not a parseable v4 notebook the
+//! view falls back to showing the raw text in an editable code editor — never a
+//! blank view, never a panic (invariant 16).
+//!
+//! All behavior here is gated by the caller behind
+//! [`FeatureFlag::JupyterNotebookEditing`]; the header's Rendered/Raw toggle is
+//! additionally gated inline.
+
+use std::path::Path;
+
+use serde_json::Value;
+use warp_core::features::FeatureFlag;
+use warp_editor::content::buffer::InitialBufferState;
+use warp_editor::render::element::VerticalExpansionBehavior;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::accessibility::{AccessibilityContent, WarpA11yRole};
+use warpui::assets::asset_cache::{AssetCache, AssetSource};
+use warpui::elements::new_scrollable::{NewScrollable, SingleAxisConfig};
+use warpui::elements::{
+    Align, Border, CacheOption, ChildView, ClippedScrollStateHandle, Container, CornerRadius,
+    CrossAxisAlignment, Expanded, Flex, Image, MainAxisSize, MouseStateHandle, ParentElement,
+    Radius, Text,
+};
+use warpui::image_cache::ImageType;
+use warpui::ui_components::button::ButtonVariant;
+use warpui::ui_components::components::UiComponent;
+use warpui::{
+    AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
+};
+
+use super::ipynb_model::{CellDoc, CellKind, NotebookDoc};
+use super::MarkdownDisplayMode;
+use crate::appearance::Appearance;
+use crate::editor::InteractionState;
+use crate::menu::{MenuItem, MenuItemFields};
+use crate::notebooks::editor::model::NotebooksEditorModel;
+use crate::notebooks::editor::rich_text_styles;
+use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorConfig, RichTextEditorView};
+use crate::notebooks::link::{NotebookLinks, SessionSource};
+use crate::pane_group::focus_state::PaneFocusHandle;
+use crate::pane_group::pane::view;
+use crate::pane_group::{BackingView, PaneConfiguration, PaneEvent};
+use crate::settings::FontSettings;
+use crate::view_components::{MarkdownToggleEvent, MarkdownToggleView};
+
+mod output;
+use output::OutputItem;
+
+/// Font size used for read-only preformatted output text.
+const OUTPUT_FONT_SIZE: f32 = 12.0;
+
+/// A stable identifier for a cell view, independent of its position. Structural
+/// operations (insert/delete/move) shift cell indices, so editor event handlers
+/// and per-cell actions reference cells by this id rather than by index.
+///
+/// Opaque: it appears in the public [`JupyterNotebookAction`] but carries no
+/// host-meaningful value (the inner counter is private).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CellId(u64);
+
+/// Where a newly inserted cell goes relative to an anchor cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertPosition {
+    Above,
+    Below,
+}
+
+/// Actions handled by the notebook view, including cell structural operations
+/// (product_v1.md invariant 8). Also used as the pane header overflow-menu
+/// action type for [`BackingView`].
+#[derive(Debug, Clone)]
+pub enum JupyterNotebookAction {
+    /// Focus the notebook view.
+    Focus,
+    /// Close the pane hosting this view.
+    Close,
+    /// Persist the current notebook (emits [`JupyterNotebookEvent::SaveRequested`]).
+    Save,
+    /// Toggle the pane between maximized and restored.
+    ToggleMaximized,
+    /// Insert a new empty cell relative to `anchor` (or at an end when `None`).
+    InsertCell {
+        anchor: Option<CellId>,
+        position: InsertPosition,
+        kind: CellKind,
+    },
+    /// Delete the cell with the given id.
+    DeleteCell(CellId),
+    /// Move the cell with the given id one position earlier.
+    MoveCellUp(CellId),
+    /// Move the cell with the given id one position later.
+    MoveCellDown(CellId),
+    /// Convert the cell with the given id to a different kind.
+    ConvertCell { id: CellId, kind: CellKind },
+}
+
+/// Events emitted to the host pane.
+#[derive(Debug, Clone)]
+pub enum JupyterNotebookEvent {
+    /// Emitted once when the notebook transitions from clean to having unsaved
+    /// edits (invariant 10).
+    Dirtied,
+    /// The user requested a save. `json` is the full serialized `.ipynb` to
+    /// persist; the host writes it and then calls [`JupyterNotebookView::mark_saved`].
+    SaveRequested { json: String },
+    /// The user switched to the Raw view. `json` is the current serialized
+    /// notebook (including unsaved edits) so the host can seed a raw code editor
+    /// without losing edits (invariant 19).
+    RawRequested { json: String },
+    /// Focus entered the notebook view.
+    Focused,
+    /// A pane-level event for the host pane to act on.
+    Pane(PaneEvent),
+}
+
+impl From<PaneEvent> for JupyterNotebookEvent {
+    fn from(event: PaneEvent) -> Self {
+        JupyterNotebookEvent::Pane(event)
+    }
+}
+
+/// Mouse-state handles for a single cell's structural-operation buttons.
+/// Created once when a cell view is built (never inline during render).
+#[derive(Default)]
+struct CellToolbarHandles {
+    move_up: MouseStateHandle,
+    move_down: MouseStateHandle,
+    convert: MouseStateHandle,
+    insert_markdown: MouseStateHandle,
+    insert_code: MouseStateHandle,
+    delete: MouseStateHandle,
+}
+
+/// The editable surface for a single cell.
+enum CellViewKind {
+    /// Markdown cell rendered as editable WYSIWYG markdown.
+    Markdown(ViewHandle<RichTextEditorView>),
+    /// Code cell rendered as an editable, syntax-highlighted editor.
+    Code(ViewHandle<CodeEditorView>),
+    /// Raw (or unknown-kind) cell rendered as editable plain text.
+    Raw(ViewHandle<CodeEditorView>),
+}
+
+/// A display-only, read-only output beneath a code cell.
+enum RenderableOutput {
+    /// Preformatted text (stream / `text/plain` / traceback / placeholder).
+    Text(String),
+    /// An inline image, registered in the asset cache by source.
+    Image(AssetSource),
+}
+
+/// A single cell's view state. Index-aligned with the model's `cells`.
+struct CellView {
+    id: CellId,
+    kind: CellViewKind,
+    /// Pre-rendered read-only outputs (code cells only; empty otherwise).
+    outputs: Vec<RenderableOutput>,
+    toolbar: CellToolbarHandles,
+}
+
+/// The content state of the view: either a parsed, editable notebook, or a raw
+/// fallback editor when the file is not a parseable v4 notebook (invariant 16).
+enum NotebookState {
+    Notebook {
+        doc: NotebookDoc,
+        cells: Vec<CellView>,
+    },
+    Raw {
+        editor: ViewHandle<CodeEditorView>,
+        /// The current raw text, kept in sync with the fallback editor so
+        /// [`JupyterNotebookView::to_json`] reflects edits.
+        text: String,
+    },
+}
+
+use crate::code::editor::view::{CodeEditorEvent, CodeEditorRenderOptions, CodeEditorView};
+
+/// Editable cell-based view of a Jupyter `.ipynb` file.
+pub struct JupyterNotebookView {
+    state: NotebookState,
+    path: Option<LocalOrRemotePath>,
+    dirty: bool,
+    /// Monotonic counter backing [`CellId`]s.
+    next_cell_id: u64,
+    view_position_id: String,
+    links: ModelHandle<NotebookLinks>,
+    pane_configuration: ModelHandle<PaneConfiguration>,
+    focus_handle: Option<PaneFocusHandle>,
+    display_mode_control: ViewHandle<MarkdownToggleView>,
+    vertical_scroll_state: ClippedScrollStateHandle,
+    /// Mouse states for the "add first cell" affordances shown when empty.
+    add_first_markdown: MouseStateHandle,
+    add_first_code: MouseStateHandle,
+    /// The notebook's highlight language, derived from metadata.
+    language: Option<String>,
+}
+
+impl JupyterNotebookView {
+    /// Construct a notebook view from the raw contents of a `.ipynb` file.
+    ///
+    /// Parses via [`NotebookDoc::parse`]; on parse error, falls back to showing
+    /// the raw text in an editable code editor (never blank, never panics —
+    /// invariant 16). `path` is used for the title/identity; it may be `None`
+    /// for static or untitled content.
+    pub fn new(
+        content: &str,
+        path: Option<LocalOrRemotePath>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let window_id = ctx.window_id();
+        let links = ctx.add_model(|ctx| NotebookLinks::new(SessionSource::Active(window_id), ctx));
+        let view_position_id = format!("jupyter_notebook_view_{}", ctx.view_id());
+        let pane_configuration = ctx.add_model(|_| PaneConfiguration::new(""));
+
+        let display_mode_control = ctx.add_typed_action_view(|ctx| {
+            MarkdownToggleView::new(MarkdownDisplayMode::Rendered, ctx)
+        });
+        ctx.subscribe_to_view(&display_mode_control, |view, _, event, ctx| {
+            let MarkdownToggleEvent::ModeSelected(mode) = event;
+            view.handle_display_mode_selected(*mode, ctx);
+        });
+
+        let mut next_cell_id = 0;
+        let (state, language) =
+            Self::build_state(content, &links, &view_position_id, &mut next_cell_id, ctx);
+
+        let mut view = Self {
+            state,
+            path,
+            dirty: false,
+            next_cell_id,
+            view_position_id,
+            links,
+            pane_configuration,
+            focus_handle: None,
+            display_mode_control,
+            vertical_scroll_state: ClippedScrollStateHandle::default(),
+            add_first_markdown: MouseStateHandle::default(),
+            add_first_code: MouseStateHandle::default(),
+            language,
+        };
+        view.update_pane_title(ctx);
+        view
+    }
+
+    /// Replace the notebook contents from fresh on-disk content (external
+    /// reload). Re-parses and rebuilds cell sub-views and clears the dirty flag.
+    pub fn set_content(&mut self, content: &str, ctx: &mut ViewContext<Self>) {
+        let links = self.links.clone();
+        let position_id = self.view_position_id.clone();
+        let mut next_id = self.next_cell_id;
+        let (state, language) = Self::build_state(content, &links, &position_id, &mut next_id, ctx);
+        self.next_cell_id = next_id;
+        self.state = state;
+        self.language = language;
+        self.dirty = false;
+        self.display_mode_control.update(ctx, |control, ctx| {
+            control.set_selected_mode(MarkdownDisplayMode::Rendered, ctx)
+        });
+        // If the file isn't a parseable notebook, the internal fallback already
+        // shows the raw text (never blank/panic). Additionally ask the host to
+        // open it in the real code editor so it's editable/saveable as plain
+        // text (invariant 16).
+        if matches!(self.state, NotebookState::Raw { .. }) {
+            ctx.emit(JupyterNotebookEvent::RawRequested {
+                json: content.to_string(),
+            });
+        }
+        ctx.notify();
+    }
+
+    /// The current notebook serialized to `.ipynb` JSON. Delegates to
+    /// [`NotebookDoc::to_json_pretty`] for a parsed notebook, or returns the raw
+    /// text verbatim in fallback mode. Cell edits are synced into the model
+    /// eagerly, so this needs no context.
+    pub fn to_json(&self) -> String {
+        match &self.state {
+            NotebookState::Notebook { doc, .. } => doc.to_json_pretty(),
+            NotebookState::Raw { text, .. } => text.clone(),
+        }
+    }
+
+    /// Whether there are unsaved edits.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Clear the dirty flag after the host successfully saves.
+    pub fn mark_saved(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.dirty {
+            self.dirty = false;
+            ctx.notify();
+        }
+    }
+
+    /// Emit a [`JupyterNotebookEvent::SaveRequested`] carrying the current JSON.
+    pub fn request_save(&mut self, ctx: &mut ViewContext<Self>) {
+        let json = self.to_json();
+        ctx.emit(JupyterNotebookEvent::SaveRequested { json });
+    }
+
+    /// The path to the currently-open file, if any.
+    pub fn path(&self) -> Option<&LocalOrRemotePath> {
+        self.path.as_ref()
+    }
+
+    /// The pane configuration model, used by the host pane to build its
+    /// `PaneView` and render the header title.
+    pub fn pane_configuration(&self) -> ModelHandle<PaneConfiguration> {
+        self.pane_configuration.clone()
+    }
+
+    /// The display title for this notebook (file name, or "Untitled").
+    pub fn title(&self) -> String {
+        self.path
+            .as_ref()
+            .map(|path| {
+                let display = path.display_path();
+                Path::new(&display)
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or(display)
+            })
+            .unwrap_or_else(|| "Untitled".to_string())
+    }
+
+    /// Focus the notebook's first editable cell (or the raw editor).
+    pub fn focus(&self, ctx: &mut ViewContext<Self>) {
+        match &self.state {
+            NotebookState::Notebook { cells, .. } => match cells.first() {
+                Some(cell) => match &cell.kind {
+                    CellViewKind::Markdown(editor) => ctx.focus(editor),
+                    CellViewKind::Code(editor) | CellViewKind::Raw(editor) => ctx.focus(editor),
+                },
+                None => ctx.focus_self(),
+            },
+            NotebookState::Raw { editor, .. } => ctx.focus(editor),
+        }
+    }
+
+    fn update_pane_title(&mut self, ctx: &mut ViewContext<Self>) {
+        let title = self.title();
+        self.pane_configuration
+            .update(ctx, |config, ctx| config.set_title(title, ctx));
+    }
+
+    /// Build the content state from raw file contents.
+    fn build_state(
+        content: &str,
+        links: &ModelHandle<NotebookLinks>,
+        position_id: &str,
+        next_id: &mut u64,
+        ctx: &mut ViewContext<Self>,
+    ) -> (NotebookState, Option<String>) {
+        match NotebookDoc::parse(content) {
+            Ok(doc) => {
+                let language = doc.language();
+                let mut cells = Vec::with_capacity(doc.cells.len());
+                for cell in &doc.cells {
+                    cells.push(Self::build_cell_view(
+                        cell,
+                        language.as_deref(),
+                        links,
+                        position_id,
+                        next_id,
+                        ctx,
+                    ));
+                }
+                (NotebookState::Notebook { doc, cells }, language)
+            }
+            // Not a parseable v4 notebook: fall back to editable raw text.
+            Err(_) => {
+                let editor = Self::build_raw_editor(content, ctx);
+                (
+                    NotebookState::Raw {
+                        editor,
+                        text: content.to_string(),
+                    },
+                    None,
+                )
+            }
+        }
+    }
+
+    /// Build the view state for a single cell, wiring up the appropriate editor
+    /// and (for code cells) its read-only outputs.
+    fn build_cell_view(
+        cell: &CellDoc,
+        language: Option<&str>,
+        links: &ModelHandle<NotebookLinks>,
+        position_id: &str,
+        next_id: &mut u64,
+        ctx: &mut ViewContext<Self>,
+    ) -> CellView {
+        let id = CellId(*next_id);
+        *next_id += 1;
+        let source = cell.source_text();
+        let kind = cell.kind();
+
+        let view_kind = match kind {
+            Some(CellKind::Markdown) => CellViewKind::Markdown(Self::build_markdown_editor(
+                id,
+                &source,
+                links,
+                position_id,
+                ctx,
+            )),
+            Some(CellKind::Code) => {
+                CellViewKind::Code(Self::build_code_editor(id, &source, language, ctx))
+            }
+            // Raw cells and unknown cell types render as plain editable text.
+            Some(CellKind::Raw) | None => {
+                CellViewKind::Raw(Self::build_code_editor(id, &source, None, ctx))
+            }
+        };
+
+        let outputs = match kind {
+            Some(CellKind::Code) => {
+                Self::build_outputs(id, cell.outputs.as_deref().unwrap_or(&[]), position_id, ctx)
+            }
+            Some(CellKind::Markdown) | Some(CellKind::Raw) | None => Vec::new(),
+        };
+
+        CellView {
+            id,
+            kind: view_kind,
+            outputs,
+            toolbar: CellToolbarHandles::default(),
+        }
+    }
+
+    fn build_markdown_editor(
+        id: CellId,
+        source: &str,
+        links: &ModelHandle<NotebookLinks>,
+        position_id: &str,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<RichTextEditorView> {
+        let window_id = ctx.window_id();
+        let model = ctx.add_model(|ctx| {
+            let styles = rich_text_styles(Appearance::as_ref(ctx), FontSettings::as_ref(ctx));
+            NotebooksEditorModel::new(styles, window_id, ctx)
+        });
+        let cell_position_id = format!("{position_id}_md_{}", id.0);
+        let links = links.clone();
+        let editor = ctx.add_typed_action_view(move |ctx| {
+            let config = RichTextEditorConfig {
+                disable_scrolling: true,
+                vertical_expansion_behavior: Some(VerticalExpansionBehavior::InfiniteHeight),
+                ..Default::default()
+            };
+            let mut view = RichTextEditorView::new(cell_position_id, model, links, config, ctx);
+            view.reset_with_markdown(source, ctx);
+            view.set_interaction_state(InteractionState::Editable, ctx);
+            view
+        });
+        ctx.subscribe_to_view(&editor, move |me, handle, event, ctx| {
+            me.handle_markdown_cell_event(id, handle, event, ctx);
+        });
+        editor
+    }
+
+    fn build_code_editor(
+        id: CellId,
+        source: &str,
+        language: Option<&str>,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<CodeEditorView> {
+        let editor = ctx.add_typed_action_view(move |ctx| {
+            let view = CodeEditorView::new(
+                None,
+                None,
+                CodeEditorRenderOptions::new(VerticalExpansionBehavior::InfiniteHeight),
+                ctx,
+            );
+            view.reset(InitialBufferState::plain_text(source), ctx);
+            view.set_interaction_state(InteractionState::Editable, ctx);
+            view
+        });
+        if let Some(language) = language {
+            editor.update(ctx, |view, ctx| view.set_language_with_name(language, ctx));
+        }
+        ctx.subscribe_to_view(&editor, move |me, handle, event, ctx| {
+            me.handle_code_cell_event(id, handle, event, ctx);
+        });
+        editor
+    }
+
+    fn build_raw_editor(content: &str, ctx: &mut ViewContext<Self>) -> ViewHandle<CodeEditorView> {
+        let editor = ctx.add_typed_action_view(move |ctx| {
+            let view = CodeEditorView::new(
+                None,
+                None,
+                CodeEditorRenderOptions::new(VerticalExpansionBehavior::InfiniteHeight),
+                ctx,
+            );
+            view.reset(InitialBufferState::plain_text(content), ctx);
+            view.set_interaction_state(InteractionState::Editable, ctx);
+            view
+        });
+        // The raw fallback is the file's JSON, so highlight it as JSON.
+        editor.update(ctx, |view, ctx| view.set_language_with_name("json", ctx));
+        ctx.subscribe_to_view(&editor, move |me, handle, event, ctx| {
+            me.handle_raw_editor_event(handle, event, ctx);
+        });
+        editor
+    }
+
+    /// Build the read-only output elements for a code cell. Image outputs are
+    /// decoded and registered with the asset cache here (display-only; the
+    /// model's `outputs` are never touched — invariant 17).
+    fn build_outputs(
+        id: CellId,
+        outputs: &[Value],
+        position_id: &str,
+        ctx: &mut ViewContext<Self>,
+    ) -> Vec<RenderableOutput> {
+        let mut result = Vec::new();
+        for (index, item) in output::classify_outputs(outputs).into_iter().enumerate() {
+            match item {
+                OutputItem::Text(text) | OutputItem::Placeholder(text) => {
+                    result.push(RenderableOutput::Text(text))
+                }
+                OutputItem::Image(bytes) => {
+                    let asset_id = format!("{position_id}_out_{}_{index}", id.0);
+                    AssetCache::handle(ctx).update(ctx, |cache, ctx| {
+                        cache.insert_raw_asset_bytes::<ImageType>(asset_id.clone(), &bytes, ctx);
+                    });
+                    result.push(RenderableOutput::Image(AssetSource::Raw { id: asset_id }));
+                }
+            }
+        }
+        result
+    }
+
+    // --- Edit sync -------------------------------------------------------
+
+    fn handle_markdown_cell_event(
+        &mut self,
+        id: CellId,
+        handle: ViewHandle<RichTextEditorView>,
+        event: &EditorViewEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            EditorViewEvent::Edited => {
+                let markdown = handle.as_ref(ctx).markdown(ctx);
+                self.sync_cell_source(id, markdown, ctx);
+            }
+            EditorViewEvent::Focused => self.emit_focused(ctx),
+            // Navigation, selection, menu, and link events don't affect cell content.
+            _ => {}
+        }
+    }
+
+    fn handle_code_cell_event(
+        &mut self,
+        id: CellId,
+        handle: ViewHandle<CodeEditorView>,
+        event: &CodeEditorEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            // Only user-originated edits update the model and mark dirty; the
+            // initial content load (and other system edits) use a non-user
+            // origin and must not dirty the notebook (invariants 6, 9).
+            CodeEditorEvent::ContentChanged { origin } if origin.from_user() => {
+                let text = handle.as_ref(ctx).text(ctx).into_string();
+                self.sync_cell_source(id, text, ctx);
+            }
+            CodeEditorEvent::Focused => self.emit_focused(ctx),
+            // Other code-editor events (diff, selection, viewport, system edits, ...) are irrelevant here.
+            _ => {}
+        }
+    }
+
+    fn handle_raw_editor_event(
+        &mut self,
+        handle: ViewHandle<CodeEditorView>,
+        event: &CodeEditorEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            // As with cells, ignore the initial load / system edits; only a user
+            // edit of the raw text marks the buffer dirty.
+            CodeEditorEvent::ContentChanged { origin } if origin.from_user() => {
+                let text = handle.as_ref(ctx).text(ctx).into_string();
+                let changed = if let NotebookState::Raw { text: stored, .. } = &mut self.state {
+                    *stored = text;
+                    true
+                } else {
+                    false
+                };
+                if changed {
+                    self.mark_dirty(ctx);
+                }
+            }
+            CodeEditorEvent::Focused => self.emit_focused(ctx),
+            _ => {}
+        }
+    }
+
+    /// Write `source` back into the model cell identified by `id`, marking the
+    /// notebook dirty. Untouched cells and saved outputs are never re-serialized
+    /// (invariants 6, 9).
+    fn sync_cell_source(&mut self, id: CellId, source: String, ctx: &mut ViewContext<Self>) {
+        let updated = if let NotebookState::Notebook { doc, cells } = &mut self.state {
+            if let Some(index) = cells.iter().position(|cell| cell.id == id) {
+                doc.cells[index].set_source(&source);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if updated {
+            self.mark_dirty(ctx);
+        }
+    }
+
+    fn mark_dirty(&mut self, ctx: &mut ViewContext<Self>) {
+        if !self.dirty {
+            self.dirty = true;
+            ctx.emit(JupyterNotebookEvent::Dirtied);
+        }
+        ctx.notify();
+    }
+
+    fn emit_focused(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(JupyterNotebookEvent::Focused);
+        ctx.emit(JupyterNotebookEvent::Pane(PaneEvent::FocusSelf));
+    }
+
+    fn handle_display_mode_selected(
+        &mut self,
+        mode: MarkdownDisplayMode,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match mode {
+            // Already in the rendered, cell-based view.
+            MarkdownDisplayMode::Rendered => {}
+            MarkdownDisplayMode::Raw => {
+                // Hand the current JSON (including unsaved edits) to the host so
+                // it can swap to a raw code editor without losing edits (inv 19).
+                let json = self.to_json();
+                ctx.emit(JupyterNotebookEvent::RawRequested { json });
+                self.display_mode_control.update(ctx, |control, ctx| {
+                    control.set_selected_mode(MarkdownDisplayMode::Rendered, ctx)
+                });
+            }
+        }
+    }
+
+    // --- Structural operations (invariant 8) -----------------------------
+
+    fn insert_cell(
+        &mut self,
+        anchor: Option<CellId>,
+        position: InsertPosition,
+        kind: CellKind,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let new_doc_cell = match kind {
+            CellKind::Markdown => CellDoc::new_markdown(""),
+            CellKind::Code => CellDoc::new_code(""),
+            CellKind::Raw => {
+                let mut cell = CellDoc::new_markdown("");
+                cell.convert_to(CellKind::Raw);
+                cell
+            }
+        };
+
+        let links = self.links.clone();
+        let position_id = self.view_position_id.clone();
+        let language = self.language.clone();
+        let mut next_id = self.next_cell_id;
+        let new_view = Self::build_cell_view(
+            &new_doc_cell,
+            language.as_deref(),
+            &links,
+            &position_id,
+            &mut next_id,
+            ctx,
+        );
+        self.next_cell_id = next_id;
+
+        if let NotebookState::Notebook { doc, cells } = &mut self.state {
+            let index = match anchor.and_then(|id| cells.iter().position(|cell| cell.id == id)) {
+                Some(anchor_index) => match position {
+                    InsertPosition::Above => anchor_index,
+                    InsertPosition::Below => anchor_index + 1,
+                },
+                None => match position {
+                    InsertPosition::Above => 0,
+                    InsertPosition::Below => cells.len(),
+                },
+            };
+            doc.insert_cell(index, new_doc_cell);
+            cells.insert(index.min(cells.len()), new_view);
+        }
+        self.mark_dirty(ctx);
+    }
+
+    fn delete_cell(&mut self, id: CellId, ctx: &mut ViewContext<Self>) {
+        let removed = if let NotebookState::Notebook { doc, cells } = &mut self.state {
+            if let Some(index) = cells.iter().position(|cell| cell.id == id) {
+                doc.remove_cell(index);
+                cells.remove(index);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if removed {
+            self.mark_dirty(ctx);
+        }
+    }
+
+    fn move_cell(&mut self, id: CellId, down: bool, ctx: &mut ViewContext<Self>) {
+        let moved = if let NotebookState::Notebook { doc, cells } = &mut self.state {
+            match cells.iter().position(|cell| cell.id == id) {
+                Some(index) => {
+                    let target = if down {
+                        index + 1
+                    } else {
+                        index.wrapping_sub(1)
+                    };
+                    if (down && target < cells.len()) || (!down && index > 0) {
+                        doc.move_cell(index, target);
+                        cells.swap(index, target);
+                        true
+                    } else {
+                        false
+                    }
+                }
+                None => false,
+            }
+        } else {
+            false
+        };
+        if moved {
+            self.mark_dirty(ctx);
+        }
+    }
+
+    fn convert_cell(&mut self, id: CellId, kind: CellKind, ctx: &mut ViewContext<Self>) {
+        let index = match &self.state {
+            NotebookState::Notebook { cells, .. } => cells.iter().position(|cell| cell.id == id),
+            NotebookState::Raw { .. } => None,
+        };
+        let Some(index) = index else {
+            return;
+        };
+        // Convert in the model first (drops outputs/execution_count when leaving code).
+        if let NotebookState::Notebook { doc, .. } = &mut self.state {
+            doc.cells[index].convert_to(kind);
+        }
+
+        let links = self.links.clone();
+        let position_id = self.view_position_id.clone();
+        let language = self.language.clone();
+        let mut next_id = self.next_cell_id;
+        let new_view = {
+            let cell = match &self.state {
+                NotebookState::Notebook { doc, .. } => &doc.cells[index],
+                NotebookState::Raw { .. } => return,
+            };
+            Self::build_cell_view(
+                cell,
+                language.as_deref(),
+                &links,
+                &position_id,
+                &mut next_id,
+                ctx,
+            )
+        };
+        self.next_cell_id = next_id;
+        if let NotebookState::Notebook { cells, .. } = &mut self.state {
+            cells[index] = new_view;
+        }
+        self.mark_dirty(ctx);
+    }
+
+    // --- Rendering -------------------------------------------------------
+
+    fn render_body(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+
+        let content = match &self.state {
+            NotebookState::Raw { editor, .. } => ChildView::new(editor).finish(),
+            NotebookState::Notebook { cells, .. } => self.render_cells(cells, appearance),
+        };
+
+        // Vertical-only scroll: the notebook scrolls as a single column while
+        // each cell's editor is sized to its content (the cross axis stays
+        // constrained to the viewport width).
+        let scrollable = NewScrollable::vertical(
+            SingleAxisConfig::Clipped {
+                handle: self.vertical_scroll_state.clone(),
+                child: Container::new(content).with_uniform_padding(12.).finish(),
+            },
+            theme.nonactive_ui_detail().into(),
+            theme.active_ui_detail().into(),
+            warpui::elements::Fill::None,
+        )
+        .finish();
+
+        Flex::column()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(Expanded::new(1., scrollable).finish())
+            .finish()
+    }
+
+    fn render_cells(&self, cells: &[CellView], appearance: &Appearance) -> Box<dyn Element> {
+        if cells.is_empty() {
+            return self.render_empty(appearance);
+        }
+        let count = cells.len();
+        let mut column = Flex::column()
+            .with_spacing(12.)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        for (index, cell) in cells.iter().enumerate() {
+            column.add_child(self.render_cell(index, cell, count, appearance));
+        }
+        column.finish()
+    }
+
+    fn render_cell(
+        &self,
+        index: usize,
+        cell: &CellView,
+        cell_count: usize,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let editor_element = match &cell.kind {
+            CellViewKind::Markdown(editor) => ChildView::new(editor).finish(),
+            CellViewKind::Code(editor) | CellViewKind::Raw(editor) => {
+                ChildView::new(editor).finish()
+            }
+        };
+
+        let mut column = Flex::column()
+            .with_spacing(4.)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        column.add_child(self.render_cell_toolbar(index, cell, cell_count, appearance));
+        column.add_child(editor_element);
+        // Read-only outputs render directly beneath the code editor (invariant 5).
+        if !cell.outputs.is_empty() {
+            column.add_child(self.render_outputs(&cell.outputs, appearance));
+        }
+
+        Container::new(column.finish())
+            .with_uniform_padding(8.)
+            .with_border(Border::all(1.).with_border_fill(appearance.theme().surface_3()))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(6.)))
+            .finish()
+    }
+
+    fn render_cell_toolbar(
+        &self,
+        index: usize,
+        cell: &CellView,
+        cell_count: usize,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let id = cell.id;
+        let handles = &cell.toolbar;
+        let mut row = Flex::row()
+            .with_spacing(4.)
+            .with_main_axis_size(MainAxisSize::Min);
+
+        if index > 0 {
+            row.add_child(toolbar_button(
+                &handles.move_up,
+                "↑",
+                appearance,
+                JupyterNotebookAction::MoveCellUp(id),
+            ));
+        }
+        if index + 1 < cell_count {
+            row.add_child(toolbar_button(
+                &handles.move_down,
+                "↓",
+                appearance,
+                JupyterNotebookAction::MoveCellDown(id),
+            ));
+        }
+
+        let (target_kind, convert_label) = match &cell.kind {
+            CellViewKind::Markdown(_) => (CellKind::Code, "To code"),
+            CellViewKind::Code(_) | CellViewKind::Raw(_) => (CellKind::Markdown, "To markdown"),
+        };
+        row.add_child(toolbar_button(
+            &handles.convert,
+            convert_label,
+            appearance,
+            JupyterNotebookAction::ConvertCell {
+                id,
+                kind: target_kind,
+            },
+        ));
+        row.add_child(toolbar_button(
+            &handles.insert_markdown,
+            "+md",
+            appearance,
+            JupyterNotebookAction::InsertCell {
+                anchor: Some(id),
+                position: InsertPosition::Below,
+                kind: CellKind::Markdown,
+            },
+        ));
+        row.add_child(toolbar_button(
+            &handles.insert_code,
+            "+code",
+            appearance,
+            JupyterNotebookAction::InsertCell {
+                anchor: Some(id),
+                position: InsertPosition::Below,
+                kind: CellKind::Code,
+            },
+        ));
+        row.add_child(toolbar_button(
+            &handles.delete,
+            "Delete",
+            appearance,
+            JupyterNotebookAction::DeleteCell(id),
+        ));
+        row.finish()
+    }
+
+    fn render_outputs(
+        &self,
+        outputs: &[RenderableOutput],
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let text_color = theme.main_text_color(theme.surface_2()).into_solid();
+        let mut column = Flex::column()
+            .with_spacing(4.)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        for output in outputs {
+            match output {
+                RenderableOutput::Text(text) => {
+                    let element = Text::new(
+                        text.clone(),
+                        appearance.monospace_font_family(),
+                        OUTPUT_FONT_SIZE,
+                    )
+                    .with_color(text_color)
+                    .finish();
+                    column.add_child(
+                        Container::new(element)
+                            .with_uniform_padding(6.)
+                            .with_background(theme.surface_2())
+                            .finish(),
+                    );
+                }
+                RenderableOutput::Image(source) => {
+                    let image = Image::new(source.clone(), CacheOption::Original)
+                        .contain()
+                        .layout_using_paint_bounds()
+                        .finish();
+                    column.add_child(
+                        Container::new(image)
+                            .with_uniform_padding(6.)
+                            .with_background(theme.surface_2())
+                            .finish(),
+                    );
+                }
+            }
+        }
+        column.finish()
+    }
+
+    fn render_empty(&self, appearance: &Appearance) -> Box<dyn Element> {
+        // A notebook with no cells still renders; the user can add a first cell
+        // (invariant 14).
+        let mut row = Flex::row()
+            .with_spacing(8.)
+            .with_main_axis_size(MainAxisSize::Min);
+        row.add_child(toolbar_button(
+            &self.add_first_markdown,
+            "+ Markdown cell",
+            appearance,
+            JupyterNotebookAction::InsertCell {
+                anchor: None,
+                position: InsertPosition::Below,
+                kind: CellKind::Markdown,
+            },
+        ));
+        row.add_child(toolbar_button(
+            &self.add_first_code,
+            "+ Code cell",
+            appearance,
+            JupyterNotebookAction::InsertCell {
+                anchor: None,
+                position: InsertPosition::Below,
+                kind: CellKind::Code,
+            },
+        ));
+        Align::new(row.finish()).finish()
+    }
+}
+
+/// Build a small toolbar button that dispatches `action` when clicked. The
+/// `handle` must be a persistent [`MouseStateHandle`] (created at construction,
+/// not inline during render).
+fn toolbar_button(
+    handle: &MouseStateHandle,
+    label: &str,
+    appearance: &Appearance,
+    action: JupyterNotebookAction,
+) -> Box<dyn Element> {
+    appearance
+        .ui_builder()
+        .button(ButtonVariant::Basic, handle.clone())
+        .with_text_label(label.to_string())
+        .build()
+        .on_click(move |ctx, _, _| ctx.dispatch_typed_action(action.clone()))
+        .finish()
+}
+
+impl Entity for JupyterNotebookView {
+    type Event = JupyterNotebookEvent;
+}
+
+impl View for JupyterNotebookView {
+    fn ui_name() -> &'static str {
+        "JupyterNotebookView"
+    }
+
+    fn accessibility_contents(&self, _ctx: &AppContext) -> Option<AccessibilityContent> {
+        Some(AccessibilityContent::new_without_help(
+            format!("{} notebook", self.title()),
+            WarpA11yRole::TextRole,
+        ))
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        self.render_body(app)
+    }
+}
+
+impl TypedActionView for JupyterNotebookView {
+    type Action = JupyterNotebookAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            JupyterNotebookAction::Focus => ctx.focus_self(),
+            JupyterNotebookAction::Close => ctx.emit(JupyterNotebookEvent::Pane(PaneEvent::Close)),
+            JupyterNotebookAction::Save => self.request_save(ctx),
+            JupyterNotebookAction::ToggleMaximized => {
+                ctx.emit(JupyterNotebookEvent::Pane(PaneEvent::ToggleMaximized));
+                self.pane_configuration.update(ctx, |config, ctx| {
+                    config.refresh_pane_header_overflow_menu_items(ctx)
+                });
+            }
+            JupyterNotebookAction::InsertCell {
+                anchor,
+                position,
+                kind,
+            } => self.insert_cell(*anchor, *position, *kind, ctx),
+            JupyterNotebookAction::DeleteCell(id) => self.delete_cell(*id, ctx),
+            JupyterNotebookAction::MoveCellUp(id) => self.move_cell(*id, false, ctx),
+            JupyterNotebookAction::MoveCellDown(id) => self.move_cell(*id, true, ctx),
+            JupyterNotebookAction::ConvertCell { id, kind } => self.convert_cell(*id, *kind, ctx),
+        }
+    }
+}
+
+impl BackingView for JupyterNotebookView {
+    type PaneHeaderOverflowMenuAction = JupyterNotebookAction;
+    type CustomAction = ();
+    type AssociatedData = ();
+
+    fn handle_pane_header_overflow_menu_action(
+        &mut self,
+        action: &Self::PaneHeaderOverflowMenuAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.handle_action(action, ctx);
+    }
+
+    fn close(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(JupyterNotebookEvent::Pane(PaneEvent::Close));
+    }
+
+    fn focus_contents(&mut self, ctx: &mut ViewContext<Self>) {
+        self.focus(ctx);
+    }
+
+    fn pane_header_overflow_menu_items(
+        &self,
+        ctx: &AppContext,
+    ) -> Vec<MenuItem<JupyterNotebookAction>> {
+        let is_maximized = self
+            .focus_handle
+            .as_ref()
+            .is_some_and(|handle| handle.is_maximized(ctx));
+        vec![
+            MenuItemFields::toggle_pane_action(is_maximized)
+                .with_on_select_action(JupyterNotebookAction::ToggleMaximized)
+                .into_item(),
+            MenuItem::Separator,
+            MenuItemFields::new("Save")
+                .with_on_select_action(JupyterNotebookAction::Save)
+                .into_item(),
+        ]
+    }
+
+    fn render_header_content(
+        &self,
+        _ctx: &view::HeaderRenderContext<'_>,
+        app: &AppContext,
+    ) -> view::HeaderContent {
+        let title = self.pane_configuration.as_ref(app).title().to_owned();
+
+        // The Rendered/Raw toggle is only meaningful when the editing feature is
+        // enabled (invariant 19; gated identically to the rest of the feature).
+        let right_of_title = if FeatureFlag::JupyterNotebookEditing.is_enabled() {
+            Some(ChildView::new(&self.display_mode_control).finish())
+        } else {
+            None
+        };
+
+        view::HeaderContent::Standard(view::StandardHeader {
+            title,
+            title_secondary: None,
+            title_style: None,
+            title_clip_config: warpui::text_layout::ClipConfig::start(),
+            title_max_width: None,
+            left_of_title: None,
+            right_of_title,
+            left_of_overflow: None,
+            options: Default::default(),
+        })
+    }
+
+    fn set_focus_handle(&mut self, focus_handle: PaneFocusHandle, _ctx: &mut ViewContext<Self>) {
+        self.focus_handle = Some(focus_handle);
+    }
+}
+
+#[cfg(test)]
+impl JupyterNotebookView {
+    /// Whether the view is in raw-text fallback mode (invariant 16).
+    fn is_fallback(&self) -> bool {
+        matches!(self.state, NotebookState::Raw { .. })
+    }
+
+    /// The number of cells in the parsed notebook (0 in fallback mode).
+    fn cell_count(&self) -> usize {
+        match &self.state {
+            NotebookState::Notebook { cells, .. } => cells.len(),
+            NotebookState::Raw { .. } => 0,
+        }
+    }
+
+    /// The model source text of the cell at `index`, if present.
+    fn cell_source(&self, index: usize) -> Option<String> {
+        match &self.state {
+            NotebookState::Notebook { doc, .. } => {
+                doc.cells.get(index).map(|cell| cell.source_text())
+            }
+            NotebookState::Raw { .. } => None,
+        }
+    }
+
+    /// The stable id of the cell at `index`, if present.
+    fn cell_id_at(&self, index: usize) -> Option<CellId> {
+        match &self.state {
+            NotebookState::Notebook { cells, .. } => cells.get(index).map(|cell| cell.id),
+            NotebookState::Raw { .. } => None,
+        }
+    }
+
+    /// The kind of the cell at `index`, if present.
+    fn cell_kind(&self, index: usize) -> Option<CellKind> {
+        match &self.state {
+            NotebookState::Notebook { doc, .. } => {
+                doc.cells.get(index).and_then(|cell| cell.kind())
+            }
+            NotebookState::Raw { .. } => None,
+        }
+    }
+
+    /// The number of read-only outputs rendered beneath the cell at `index`.
+    fn output_count(&self, index: usize) -> usize {
+        match &self.state {
+            NotebookState::Notebook { cells, .. } => {
+                cells.get(index).map(|cell| cell.outputs.len()).unwrap_or(0)
+            }
+            NotebookState::Raw { .. } => 0,
+        }
+    }
+
+    /// The code editor handle for the cell at `index`, if it is a code/raw cell.
+    fn code_editor_at(&self, index: usize) -> Option<ViewHandle<CodeEditorView>> {
+        match &self.state {
+            NotebookState::Notebook { cells, .. } => match &cells.get(index)?.kind {
+                CellViewKind::Code(editor) | CellViewKind::Raw(editor) => Some(editor.clone()),
+                CellViewKind::Markdown(_) => None,
+            },
+            NotebookState::Raw { .. } => None,
+        }
+    }
+
+    /// The markdown editor handle for the cell at `index`, if it is a markdown cell.
+    fn markdown_editor_at(&self, index: usize) -> Option<ViewHandle<RichTextEditorView>> {
+        match &self.state {
+            NotebookState::Notebook { cells, .. } => match &cells.get(index)?.kind {
+                CellViewKind::Markdown(editor) => Some(editor.clone()),
+                CellViewKind::Code(_) | CellViewKind::Raw(_) => None,
+            },
+            NotebookState::Raw { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/notebooks/file/jupyter/mod_tests.rs
+++ b/app/src/notebooks/file/jupyter/mod_tests.rs
@@ -1,0 +1,361 @@
+use std::sync::Arc;
+
+use repo_metadata::repositories::DetectedRepositories;
+use repo_metadata::watcher::DirectoryWatcher;
+#[cfg(feature = "local_fs")]
+use repo_metadata::RepoMetadataModel;
+use serde_json::Value;
+use warp_core::features::FeatureFlag;
+use warp_core::ui::appearance::Appearance;
+use warp_editor::model::CoreEditorModel;
+#[cfg(feature = "local_fs")]
+use warp_files::FileModel;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::platform::WindowStyle;
+use warpui::{App, TypedActionView, View};
+
+use super::super::ipynb_model::CellKind;
+use super::{InsertPosition, JupyterNotebookAction, JupyterNotebookView};
+use crate::auth::auth_manager::AuthManager;
+use crate::auth::AuthStateProvider;
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::notebooks::editor::keys::NotebookKeybindings;
+use crate::search::files::model::FileSearchModel;
+use crate::server::server_api::team::MockTeamClient;
+use crate::server::server_api::workspace::MockWorkspaceClient;
+use crate::server::server_api::ServerApiProvider;
+use crate::server::telemetry::context_provider::AppTelemetryContextProvider;
+use crate::settings_view::keybindings::KeybindingChangedNotifier;
+use crate::terminal::keys::TerminalKeybindings;
+use crate::test_util::settings::initialize_settings_for_tests;
+use crate::workspace::ActiveSession;
+use crate::workspaces::user_workspaces::UserWorkspaces;
+use crate::{GlobalResourceHandles, GlobalResourceHandlesProvider};
+
+/// A small but representative nbformat v4 notebook: a markdown cell, followed by
+/// a code cell with a saved stream output.
+const SIMPLE_NOTEBOOK: &str = r##"{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Title\n", "\n", "Some *text*."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {"name": "stdout", "output_type": "stream", "text": ["hello\n"]}
+   ],
+   "source": ["print('hello')"]
+  }
+ ],
+ "metadata": {
+  "language_info": {"name": "python", "version": "3.11.0"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"##;
+
+fn init_app(app: &mut App) {
+    initialize_settings_for_tests(app);
+
+    let global_resource_handles = GlobalResourceHandles::mock(app);
+    app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
+    app.add_singleton_model(|_| Appearance::mock());
+    app.add_singleton_model(|_| ActiveSession::default());
+    app.add_singleton_model(|_| KeybindingChangedNotifier::new());
+    app.add_singleton_model(DirectoryWatcher::new);
+    app.add_singleton_model(|_| DetectedRepositories::default());
+    #[cfg(feature = "local_fs")]
+    app.add_singleton_model(RepoMetadataModel::new);
+    app.add_singleton_model(FileSearchModel::new);
+    #[cfg(feature = "local_fs")]
+    app.add_singleton_model(FileModel::new);
+    app.add_singleton_model(NotebookKeybindings::new);
+    app.add_singleton_model(TerminalKeybindings::new);
+    app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
+    app.add_singleton_model(AuthManager::new_for_test);
+    let team_client_mock = Arc::new(MockTeamClient::new());
+    let workspace_client_mock = Arc::new(MockWorkspaceClient::new());
+    app.add_singleton_model(|ctx| {
+        UserWorkspaces::mock(
+            team_client_mock.clone(),
+            workspace_client_mock.clone(),
+            vec![],
+            ctx,
+        )
+    });
+    #[cfg(feature = "voice_input")]
+    app.add_singleton_model(voice_input::VoiceInput::new);
+}
+
+/// Build a view over the given notebook content in a fresh test window.
+fn add_view(app: &mut App, content: &'static str) -> warpui::ViewHandle<JupyterNotebookView> {
+    let (_, handle) = app.add_window(WindowStyle::NotStealFocus, move |ctx| {
+        JupyterNotebookView::new(content, None, ctx)
+    });
+    handle
+}
+
+#[test]
+fn unparseable_file_falls_back_to_raw_text() {
+    // Invariant 16: a malformed notebook never shows a blank view or panics; it
+    // falls back to the raw text, which `to_json` returns verbatim.
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let bad = "{ this is not valid notebook json";
+        let handle = add_view(&mut app, bad);
+
+        handle.read(&app, |view, ctx| {
+            assert!(view.is_fallback());
+            assert_eq!(view.cell_count(), 0);
+            assert_eq!(view.to_json(), bad);
+            // Rendering the fallback must not panic.
+            view.render(ctx);
+        });
+    });
+}
+
+#[test]
+fn parsed_notebook_round_trips_unedited() {
+    // Invariants 11/18: an unedited notebook serializes back without changing
+    // semantic content.
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let handle = add_view(&mut app, SIMPLE_NOTEBOOK);
+
+        handle.read(&app, |view, ctx| {
+            assert!(!view.is_fallback());
+            assert_eq!(view.cell_count(), 2);
+            assert_eq!(view.cell_kind(0), Some(CellKind::Markdown));
+            assert_eq!(view.cell_kind(1), Some(CellKind::Code));
+            assert!(!view.is_dirty());
+
+            let reserialized: Value =
+                serde_json::from_str(&view.to_json()).expect("serialized notebook is valid JSON");
+            let original: Value =
+                serde_json::from_str(SIMPLE_NOTEBOOK).expect("fixture is valid JSON");
+            assert_eq!(reserialized, original);
+
+            // Rendering must not panic.
+            view.render(ctx);
+        });
+    });
+}
+
+#[test]
+fn code_cell_outputs_render_read_only() {
+    // Invariant 5: a code cell's saved outputs render beneath it as read-only
+    // elements (not editors).
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let handle = add_view(&mut app, SIMPLE_NOTEBOOK);
+
+        handle.read(&app, |view, _| {
+            // The markdown cell has no outputs; the code cell has its one stream output.
+            assert_eq!(view.output_count(0), 0);
+            assert_eq!(view.output_count(1), 1);
+        });
+    });
+}
+
+#[test]
+fn editing_code_cell_updates_only_that_source_and_preserves_outputs() {
+    // Invariants 7/9: editing a code cell updates only its source and leaves its
+    // saved outputs untouched.
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let handle = add_view(&mut app, SIMPLE_NOTEBOOK);
+
+        let code_editor = handle.read(&app, |view, _| {
+            view.code_editor_at(1).expect("cell 1 is a code cell")
+        });
+
+        // Simulate a user edit (user-origin insert), which fires a
+        // content-changed event that the notebook view syncs back into the model.
+        code_editor.update(&mut app, |editor, ctx| {
+            editor.model.update(ctx, |model, ctx| {
+                model.user_insert("print('world')\n", ctx);
+            });
+        });
+
+        handle.read(&app, |view, _| {
+            assert!(view.is_dirty());
+            let source = view.cell_source(1).expect("code cell source");
+            assert!(
+                source.contains("print('world')"),
+                "edited source should be reflected, got: {source:?}"
+            );
+            // The markdown cell was not touched.
+            assert_eq!(
+                view.cell_source(0).as_deref(),
+                Some("# Title\n\nSome *text*.")
+            );
+
+            // Saved outputs are preserved byte-for-byte on save (invariant 9).
+            let json: Value = serde_json::from_str(&view.to_json()).unwrap();
+            let outputs = &json["cells"][1]["outputs"];
+            assert_eq!(outputs[0]["output_type"], "stream");
+            assert_eq!(outputs[0]["text"][0], "hello\n");
+        });
+    });
+}
+
+#[test]
+fn editing_markdown_cell_updates_only_that_source() {
+    // Invariant 6: editing a markdown cell updates only that cell.
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let handle = add_view(&mut app, SIMPLE_NOTEBOOK);
+
+        let md_editor = handle.read(&app, |view, _| {
+            view.markdown_editor_at(0)
+                .expect("cell 0 is a markdown cell")
+        });
+
+        // Type into the markdown editor (editable without focus in tests).
+        md_editor.update(&mut app, |editor, ctx| {
+            editor.user_typed("Z", ctx);
+        });
+
+        handle.read(&app, |view, _| {
+            assert!(view.is_dirty());
+            let source = view.cell_source(0).expect("markdown cell source");
+            assert!(
+                source.contains('Z'),
+                "edited markdown should be reflected, got: {source:?}"
+            );
+            // The code cell was not touched.
+            assert_eq!(view.cell_source(1).as_deref(), Some("print('hello')"));
+        });
+    });
+}
+
+#[test]
+fn reload_replaces_content_and_clears_dirty() {
+    // set_content reloads fresh content and resets dirty state (invariant 13 reload path).
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let handle = add_view(&mut app, SIMPLE_NOTEBOOK);
+
+        let other = r##"{
+ "cells": [{"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": ["x = 1"]}],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}"##;
+
+        handle.update(&mut app, |view, ctx| {
+            // Dirty the view, then reload.
+            view.handle_action(
+                &JupyterNotebookAction::InsertCell {
+                    anchor: None,
+                    position: InsertPosition::Below,
+                    kind: CellKind::Markdown,
+                },
+                ctx,
+            );
+            assert!(view.is_dirty());
+
+            view.set_content(other, ctx);
+            assert!(!view.is_dirty());
+            assert_eq!(view.cell_count(), 1);
+            assert_eq!(view.cell_kind(0), Some(CellKind::Code));
+        });
+    });
+}
+
+#[test]
+fn structural_operations_insert_delete_move_convert() {
+    // Invariant 8: insert above/below, delete, move, and convert cells.
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let handle = add_view(&mut app, SIMPLE_NOTEBOOK);
+
+        handle.update(&mut app, |view, ctx| {
+            // Insert a code cell ABOVE the first cell.
+            view.handle_action(
+                &JupyterNotebookAction::InsertCell {
+                    anchor: view.cell_id_at(0),
+                    position: InsertPosition::Above,
+                    kind: CellKind::Code,
+                },
+                ctx,
+            );
+            assert_eq!(view.cell_count(), 3);
+            assert_eq!(view.cell_kind(0), Some(CellKind::Code));
+            assert!(view.is_dirty());
+
+            view.mark_saved(ctx);
+            assert!(!view.is_dirty());
+
+            // Convert the inserted code cell to markdown.
+            let first = view.cell_id_at(0).expect("first cell id");
+            view.handle_action(
+                &JupyterNotebookAction::ConvertCell {
+                    id: first,
+                    kind: CellKind::Markdown,
+                },
+                ctx,
+            );
+            assert_eq!(view.cell_kind(0), Some(CellKind::Markdown));
+
+            // Move it down, then delete it.
+            let first = view.cell_id_at(0).expect("first cell id");
+            view.handle_action(&JupyterNotebookAction::MoveCellDown(first), ctx);
+            assert_eq!(view.cell_kind(1), Some(CellKind::Markdown));
+
+            let id = view.cell_id_at(1).expect("cell id");
+            view.handle_action(&JupyterNotebookAction::DeleteCell(id), ctx);
+            assert_eq!(view.cell_count(), 2);
+
+            // Focus/Close are valid actions and must not panic.
+            view.handle_action(&JupyterNotebookAction::Focus, ctx);
+            view.handle_action(&JupyterNotebookAction::Close, ctx);
+        });
+    });
+}
+
+#[test]
+fn path_is_exposed_and_titled() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let (_, handle) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            JupyterNotebookView::new(
+                SIMPLE_NOTEBOOK,
+                Some(LocalOrRemotePath::Local("/tmp/demo/analysis.ipynb".into())),
+                ctx,
+            )
+        });
+        handle.read(&app, |view, _| {
+            assert!(view.path().is_some());
+            assert_eq!(view.title(), "analysis.ipynb");
+        });
+    });
+}
+
+#[test]
+fn raw_requested_toggle_emits_current_json() {
+    // Invariant 19: switching to Raw hands off the current JSON so edits aren't lost.
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::JupyterNotebookEditing.override_enabled(true);
+        init_app(&mut app);
+        let handle = add_view(&mut app, SIMPLE_NOTEBOOK);
+
+        handle.update(&mut app, |view, ctx| {
+            view.request_save(ctx);
+            // Header rendering with the toggle enabled must not panic.
+            view.render(ctx);
+        });
+
+        handle.read(&app, |view, _| {
+            // Still rendered (the pane owns the actual swap).
+            assert!(!view.is_fallback());
+        });
+    });
+}

--- a/app/src/notebooks/file/jupyter/output.rs
+++ b/app/src/notebooks/file/jupyter/output.rs
@@ -1,0 +1,207 @@
+//! Read-only rendering rules for a code cell's saved `outputs`.
+//!
+//! This module is the display-only projection of a cell's outputs: it never
+//! mutates the underlying notebook model, so what is shown here can be
+//! truncated, omitted, or reformatted without changing the bytes that are
+//! written back on save (product_v1.md invariants 5, 17, 18).
+//!
+//! Supported output types (everything else is intentionally not rendered, but
+//! is still preserved verbatim by the model):
+//! - `stream` (stdout/stderr) and `text/plain` results -> preformatted text.
+//! - `error` tracebacks -> preformatted text with ANSI escape codes stripped.
+//! - `image/png` / `image/jpeg` -> decoded raster bytes (rendered inline by the
+//!   view). Invalid base64 yields a short placeholder message.
+
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine as _;
+use serde_json::Value;
+
+/// Maximum number of bytes of a single text output we will display. Larger
+/// outputs are visually truncated; the saved bytes are never affected
+/// (invariant 17).
+const MAX_TEXT_OUTPUT_BYTES: usize = 100_000;
+
+/// Maximum number of decoded image bytes we will display inline. Larger images
+/// are omitted with a visible placeholder; the saved bytes are never affected
+/// (invariant 17).
+const MAX_IMAGE_BYTES: usize = 8 * 1024 * 1024;
+
+/// A single displayable output, derived from one entry of a cell's saved
+/// `outputs`. This is a display-only model: it is rebuilt from the notebook
+/// model and is never written back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputItem {
+    /// Preformatted text (stream / `text/plain` / error traceback). ANSI escape
+    /// codes have already been stripped where applicable.
+    Text(String),
+    /// A decoded raster image (`image/png` or `image/jpeg`) ready to display.
+    Image(Vec<u8>),
+    /// A short message shown in place of an image we cannot or will not display
+    /// (invalid base64, or omitted because it is too large).
+    Placeholder(String),
+}
+
+/// Classify a code cell's saved `outputs` into the read-only items the view can
+/// render. Output entries that this version does not render (e.g. `text/html`,
+/// LaTeX, widgets) are skipped here but remain untouched in the model so they
+/// round-trip on save (invariant 18).
+pub fn classify_outputs(outputs: &[Value]) -> Vec<OutputItem> {
+    let mut items = Vec::new();
+    for output in outputs {
+        let Some(obj) = output.as_object() else {
+            continue;
+        };
+        match obj.get("output_type").and_then(Value::as_str) {
+            Some("stream") => {
+                if let Some(text) = obj.get("text").and_then(string_or_array) {
+                    items.push(OutputItem::Text(truncate_for_display(text)));
+                }
+            }
+            Some("error") => {
+                let traceback = obj
+                    .get("traceback")
+                    .and_then(string_or_array)
+                    .unwrap_or_else(|| error_summary(obj));
+                items.push(OutputItem::Text(truncate_for_display(strip_ansi(
+                    &traceback,
+                ))));
+            }
+            Some("execute_result") | Some("display_data") => {
+                if let Some(data) = obj.get("data").and_then(Value::as_object) {
+                    if let Some(item) = image_item(data) {
+                        items.push(item);
+                    } else if let Some(text) = data.get("text/plain").and_then(string_or_array) {
+                        items.push(OutputItem::Text(truncate_for_display(text)));
+                    }
+                    // Other MIME types (text/html, latex, widgets, ...) are not
+                    // rendered in v1, but remain preserved by the model.
+                }
+            }
+            // Unknown or absent output types are not rendered, but the model
+            // keeps them verbatim for save.
+            Some(_) | None => {}
+        }
+    }
+    items
+}
+
+/// Build an [`OutputItem`] for the first supported image MIME type present in a
+/// `data` map, or `None` if there is no image to render.
+fn image_item(data: &serde_json::Map<String, Value>) -> Option<OutputItem> {
+    for mime in ["image/png", "image/jpeg"] {
+        let Some(encoded) = data.get(mime).and_then(string_or_array) else {
+            continue;
+        };
+        // nbformat stores image payloads as base64, often split across lines.
+        let cleaned: String = encoded.split_whitespace().collect();
+        return Some(match BASE64_STANDARD.decode(cleaned.as_bytes()) {
+            Ok(bytes) if bytes.len() > MAX_IMAGE_BYTES => OutputItem::Placeholder(format!(
+                "[image output omitted for display: {} KB]",
+                bytes.len() / 1024
+            )),
+            Ok(bytes) => OutputItem::Image(bytes),
+            Err(_) => OutputItem::Placeholder("invalid image data".to_string()),
+        });
+    }
+    None
+}
+
+/// Build a fallback one-line summary for an `error` output that has no
+/// `traceback` (`ename: evalue`).
+fn error_summary(obj: &serde_json::Map<String, Value>) -> String {
+    let ename = obj.get("ename").and_then(Value::as_str).unwrap_or("");
+    let evalue = obj.get("evalue").and_then(Value::as_str).unwrap_or("");
+    match (ename.is_empty(), evalue.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => ename.to_string(),
+        (true, false) => evalue.to_string(),
+        (false, false) => format!("{ename}: {evalue}"),
+    }
+}
+
+/// Collapse an nbformat string-or-list field into a single `String`. nbformat
+/// allows these fields to be either a single string or a list of line strings.
+fn string_or_array(value: &Value) -> Option<String> {
+    match value {
+        Value::String(s) => Some(s.clone()),
+        Value::Array(items) => {
+            let mut out = String::new();
+            for item in items {
+                if let Value::String(s) = item {
+                    out.push_str(s);
+                }
+            }
+            Some(out)
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::Object(_) => None,
+    }
+}
+
+/// Visually cap a text output at [`MAX_TEXT_OUTPUT_BYTES`], appending a marker so
+/// the user knows display was truncated. The original bytes in the model are
+/// never affected (invariant 17).
+fn truncate_for_display(text: String) -> String {
+    if text.len() <= MAX_TEXT_OUTPUT_BYTES {
+        return text;
+    }
+    let mut end = MAX_TEXT_OUTPUT_BYTES;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = text[..end].to_string();
+    truncated.push_str("\n… [output truncated for display]");
+    truncated
+}
+
+/// Remove ANSI escape sequences (used by tracebacks for color) from `input`,
+/// leaving only the visible text (invariant 5).
+pub fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek().copied() {
+            // CSI sequence: ESC '[' params ... final byte in 0x40..=0x7e.
+            Some('[') => {
+                chars.next();
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if ('\u{40}'..='\u{7e}').contains(&next) {
+                        break;
+                    }
+                }
+            }
+            // OSC sequence: ESC ']' ... terminated by BEL or ST (ESC '\').
+            Some(']') => {
+                chars.next();
+                while let Some(&next) = chars.peek() {
+                    if next == '\u{07}' {
+                        chars.next();
+                        break;
+                    }
+                    if next == '\u{1b}' {
+                        chars.next();
+                        if chars.peek().copied() == Some('\\') {
+                            chars.next();
+                        }
+                        break;
+                    }
+                    chars.next();
+                }
+            }
+            // Any other escape: drop the single following byte.
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "output_tests.rs"]
+mod tests;

--- a/app/src/notebooks/file/jupyter/output_tests.rs
+++ b/app/src/notebooks/file/jupyter/output_tests.rs
@@ -1,0 +1,125 @@
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine as _;
+use serde_json::json;
+
+use super::{classify_outputs, strip_ansi, OutputItem};
+
+#[test]
+fn strip_ansi_removes_color_codes() {
+    // A typical colored traceback fragment (invariant 5).
+    let input = "\u{1b}[0;31mTraceback\u{1b}[0m: \u{1b}[1mboom\u{1b}[22m";
+    assert_eq!(strip_ansi(input), "Traceback: boom");
+}
+
+#[test]
+fn strip_ansi_leaves_plain_text_untouched() {
+    assert_eq!(strip_ansi("just text\nwith lines"), "just text\nwith lines");
+}
+
+#[test]
+fn classify_stream_output_as_text() {
+    let outputs = vec![json!({
+        "output_type": "stream",
+        "name": "stdout",
+        "text": ["hello\n", "world\n"],
+    })];
+    assert_eq!(
+        classify_outputs(&outputs),
+        vec![OutputItem::Text("hello\nworld\n".to_string())]
+    );
+}
+
+#[test]
+fn classify_text_plain_result_as_text() {
+    let outputs = vec![json!({
+        "output_type": "execute_result",
+        "data": {"text/plain": "42"},
+        "metadata": {},
+        "execution_count": 1,
+    })];
+    assert_eq!(
+        classify_outputs(&outputs),
+        vec![OutputItem::Text("42".to_string())]
+    );
+}
+
+#[test]
+fn classify_error_strips_ansi_from_traceback() {
+    let outputs = vec![json!({
+        "output_type": "error",
+        "ename": "ValueError",
+        "evalue": "bad",
+        "traceback": ["\u{1b}[0;31mValueError\u{1b}[0m", "bad"],
+    })];
+    assert_eq!(
+        classify_outputs(&outputs),
+        vec![OutputItem::Text("ValueErrorbad".to_string())]
+    );
+}
+
+#[test]
+fn classify_valid_png_as_image() {
+    // A 1x1 transparent PNG.
+    let png_bytes: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+        0x15, 0xc4, 0x89,
+    ];
+    let encoded = BASE64_STANDARD.encode(png_bytes);
+    let outputs = vec![json!({
+        "output_type": "display_data",
+        "data": {"image/png": encoded},
+        "metadata": {},
+    })];
+    assert_eq!(
+        classify_outputs(&outputs),
+        vec![OutputItem::Image(png_bytes.to_vec())]
+    );
+}
+
+#[test]
+fn classify_invalid_base64_image_as_placeholder() {
+    // Invalid base64 image data shows a short message instead (invariant 5).
+    let outputs = vec![json!({
+        "output_type": "display_data",
+        "data": {"image/png": "not%%%valid%%%base64"},
+        "metadata": {},
+    })];
+    assert_eq!(
+        classify_outputs(&outputs),
+        vec![OutputItem::Placeholder("invalid image data".to_string())]
+    );
+}
+
+#[test]
+fn classify_prefers_image_over_text_plain() {
+    // matplotlib outputs carry both image/png and a text/plain repr; the image wins.
+    let png = BASE64_STANDARD.encode([0x89, 0x50, 0x4e, 0x47]);
+    let outputs = vec![json!({
+        "output_type": "execute_result",
+        "data": {"image/png": png, "text/plain": "<Figure>"},
+        "metadata": {},
+        "execution_count": 2,
+    })];
+    assert_eq!(
+        classify_outputs(&outputs),
+        vec![OutputItem::Image(vec![0x89, 0x50, 0x4e, 0x47])]
+    );
+}
+
+#[test]
+fn classify_skips_unsupported_mime_types() {
+    // text/html (and other unrendered types) are not displayed; preserved by the model (inv 18).
+    let outputs = vec![json!({
+        "output_type": "display_data",
+        "data": {"text/html": "<b>x</b>"},
+        "metadata": {},
+    })];
+    assert!(classify_outputs(&outputs).is_empty());
+}
+
+#[test]
+fn classify_skips_unknown_output_type() {
+    let outputs = vec![json!({"output_type": "future_type", "payload": 7})];
+    assert!(classify_outputs(&outputs).is_empty());
+}

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -66,6 +66,11 @@ use crate::{cmd_or_ctrl_shift, safe_warn, send_telemetry_from_ctx};
 /// editable cell-based notebook view.
 mod ipynb_model;
 
+/// Editable, cell-based Jupyter `.ipynb` notebook view and read-only output
+/// rendering, gated behind `FeatureFlag::JupyterNotebookEditing`. Exposed to the
+/// crate so the open-flow routing/pane can host `JupyterNotebookView`.
+pub(crate) mod jupyter;
+
 /// Display mode for markdown files shown via the header segmented control.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarkdownDisplayMode {


### PR DESCRIPTION
## Description
Implements the **view slice** of the editable, cell-based Jupyter `.ipynb` feature, building on the committed lossless `NotebookDoc` model. All behavior is gated (by the routing chokepoint, on the integration branch) behind `FeatureFlag::JupyterNotebookEditing`.

`JupyterNotebookView` parses content via `NotebookDoc::parse` and renders each cell as an editable surface:
- **Markdown cells** → editable rendered markdown (`RichTextEditorView`/`NotebooksEditorModel`), serialized back to `CellDoc.source` on edit.
- **Code cells** → editable, syntax-highlighted `CodeEditorView` using `NotebookDoc::language()`; source stored verbatim.
- **Outputs** → read-only beneath code cells (stream / `text/plain` / ANSI-stripped tracebacks as preformatted text; `image/png`/`image/jpeg` decoded inline; invalid base64 → placeholder; display-only size guards that never alter saved bytes).

Editing only updates the edited cell's `source` (user-originated edits only); saved `outputs` and untouched cells are never mutated. Cell structural ops (insert/delete/move/convert). Robust fallback: unparseable `.ipynb` shows raw editable text and emits `RawRequested` so the host opens the real code editor — never blank, never panics.

This is **edit-only**: no kernel, no execution.

## Main files to review
- `app/src/notebooks/file/jupyter/mod.rs` — `JupyterNotebookView` (`View` + `Entity` + `TypedActionView` + `BackingView`), edit→model sync, dirty tracking, structural ops, public API + events.
- `app/src/notebooks/file/jupyter/output.rs` — `strip_ansi`, `classify_outputs`, image decode + display-only size guards.

## Minor file changes
- `app/src/notebooks/file/mod.rs` — adds `pub(crate) mod jupyter;` so the routing/pane can host the view.
- `app/src/notebooks/file/jupyter/{mod_tests.rs, output_tests.rs}` — unit/view tests.

## Public API (for the routing/integration branch)
`new(content, path, ctx)`, `set_content`, `to_json`, `is_dirty`, `mark_saved`, `request_save`, `path`, `title`, `pane_configuration`. Events: `Dirtied`, `SaveRequested { json }`, `RawRequested { json }`, `Focused`, `Pane(PaneEvent)`. `BackingView::PaneHeaderOverflowMenuAction = JupyterNotebookAction`.

## Validation
- `cargo check -p warp --tests`: passes (no errors).
- `cargo nextest run -p warp jupyter`: 19/19 pass.
- `./script/format`: clean.
- `cargo clippy -p warp --tests`: the only findings in this module are `never used/constructed` dead-code — expected because routing isn't wired on this branch (same class as the base branch's currently-unused `ipynb_model`); resolves once the integration branch wires `JupyterNotebookView::new` + `NotebookDoc::parse`.

> Note: this is one half of a parallel split; the orchestrator integrates this with the routing/pane branch into a single combined PR (full presubmit/clippy clean after merge).

_Conversation: https://staging.warp.dev/conversation/7eb55c0a-58d5-43e8-88d7-1deda8c567a8_

_Run: https://oz.staging.warp.dev/runs/019e9a20-4cd6-7283-8e9d-3b233cbd8a21_

_This PR was generated with [Oz](https://warp.dev/oz)._
