### PR TITLE
Resolve Cargo target dir in script/macos/run instead of hardcoding ./target

### DIFF
--- a/script/macos/run
+++ b/script/macos/run
@@ -21,11 +21,19 @@ cd "${REPO_ROOT}"
 : "${WARP_CHANNEL:?WARP_CHANNEL must be set (invoke via ./script/run)}"
 : "${FEATURES:?FEATURES must be set (invoke via ./script/run)}"
 
+# Resolve Cargo's actual target directory rather than assuming ./target. This
+# honors a shared CARGO_TARGET_DIR / build.target-dir (e.g. set in
+# ~/.cargo/config.toml), which is where `cargo bundle` writes the .app bundle.
+TARGET_DIR="$(cargo metadata --no-deps --format-version 1 | jq -r .target_directory)"
+if [ -z "$TARGET_DIR" ] || [ "$TARGET_DIR" = "null" ]; then
+    TARGET_DIR="${REPO_ROOT}/target"
+fi
+
 if [ "$WARP_CHANNEL" = "local" ]; then
-    WARP_APP_PATH="target/debug/bundle/osx/WarpLocal.app"
+    WARP_APP_PATH="${TARGET_DIR}/debug/bundle/osx/WarpLocal.app"
     WARP_SCHEME_NAME="warplocal"
 else
-    WARP_APP_PATH="target/debug/bundle/osx/WarpOss.app"
+    WARP_APP_PATH="${TARGET_DIR}/debug/bundle/osx/WarpOss.app"
     WARP_SCHEME_NAME="warposs"
 fi
 DONT_OPEN=false
@@ -58,11 +66,11 @@ while (( "$#" )); do
       shift
       ;;
     --release)
-      echo "Detected release build, pointing at release bundle under target/release/bundle"
+      echo "Detected release build, pointing at release bundle under ${TARGET_DIR}/release/bundle"
       if [ "$WARP_CHANNEL" = "local" ]; then
-          WARP_APP_PATH="target/release/bundle/osx/WarpLocal.app"
+          WARP_APP_PATH="${TARGET_DIR}/release/bundle/osx/WarpLocal.app"
       else
-          WARP_APP_PATH="target/release/bundle/osx/WarpOss.app"
+          WARP_APP_PATH="${TARGET_DIR}/release/bundle/osx/WarpOss.app"
       fi
       PARAMS="$PARAMS $1"
       shift
@@ -71,9 +79,9 @@ while (( "$#" )); do
       PROFILE="$2"
       shift 2
       if [ "$WARP_CHANNEL" = "local" ]; then
-          WARP_APP_PATH="target/${PROFILE}/bundle/osx/WarpLocal.app"
+          WARP_APP_PATH="${TARGET_DIR}/${PROFILE}/bundle/osx/WarpLocal.app"
       else
-          WARP_APP_PATH="target/${PROFILE}/bundle/osx/WarpOss.app"
+          WARP_APP_PATH="${TARGET_DIR}/${PROFILE}/bundle/osx/WarpOss.app"
       fi
       PARAMS="$PARAMS --profile $PROFILE"
       ;;
@@ -134,7 +142,7 @@ codesign --force --deep --options runtime --sign "${SIGNING_CERT:--}" "$WARP_APP
 if [ "$DONT_OPEN" = false ] ; then
     if  [ "$OPEN_WITH_LAUNCHD" = true ]; then
         echo "Launching with MacOS application launcher"
-        PATH="" /usr/bin/open "./$WARP_APP_PATH"
+        PATH="" /usr/bin/open "$WARP_APP_PATH"
         if [ "$WARP_CHANNEL" = "local" ]; then
             LOG_FILE=~/Library/Logs/warp_local.log
         elif [ "$WARP_CHANNEL" = "oss" ]; then
@@ -145,7 +153,7 @@ if [ "$DONT_OPEN" = false ] ; then
         fi
         tail -F "$LOG_FILE"
     else
-        echo "Opening app at ./$WARP_APP_PATH/Contents/MacOS/$WARP_BIN_NAME"
-        "./$WARP_APP_PATH/Contents/MacOS/$WARP_BIN_NAME" "${WARP_ARGS[@]}"
+        echo "Opening app at $WARP_APP_PATH/Contents/MacOS/$WARP_BIN_NAME"
+        "$WARP_APP_PATH/Contents/MacOS/$WARP_BIN_NAME" "${WARP_ARGS[@]}"
     fi
 fi


### PR DESCRIPTION
## Problem

`script/macos/run` hardcoded `target/...` for the bundled `.app` path in six
places. When a developer points Cargo at a shared target directory — via
`CARGO_TARGET_DIR` or `build.target-dir` in `~/.cargo/config.toml` (the standard
way to avoid 100GB+ of build artifacts per checkout/worktree) — `cargo bundle`
writes to the configured directory while the rest of the script keeps looking
under `./target`. The build then fails at `install_name_tool`, which can't find
the bundled binary. Fixes #11957.

## Fix

Resolve the real target directory once via Cargo's stable metadata API:

```bash
TARGET_DIR="$(cargo metadata --no-deps --format-version 1 | jq -r .target_directory)"
```

`cargo metadata` already encodes the correct precedence (env var → `config.toml`
→ default `<workspace>/target`), so a single call covers every case. If metadata
is somehow unavailable, it falls back to `${REPO_ROOT}/target` so behavior is
never worse than before. The resolved path is absolute, so the now-incorrect
`./` prefixes are dropped from the `open`/exec lines (`.//Users/...` would
otherwise resolve relative to cwd).

`cargo metadata` + `jq` are already used by the `script/wasm/*` scripts, and
`jq` is an established build dependency.

## Testing

Ran `./script/macos/run` (OSS) end-to-end in both configurations and confirmed a
live app launch each time:

- **`target-dir` set in `~/.cargo/config.toml`** → builds, bundles, rpaths,
  codesigns, and launches from the shared dir (`~/.cargo-target/...`). Previously
  failed at `install_name_tool`.
- **Nothing configured** → resolves to the in-repo `<workspace>/target`,
  identical to the previous hardcoded behavior.

In both runs `codesign --verify` passed and the launched binary had the expected
`@executable_path/../Frameworks` rpath.

## Scope

Limited to the dev `script/macos/run` flow that the issue calls out. The release
`script/macos/bundle` and the Rust-side `app_target_dir()` (a compile-time
`<repo>/target` path, tracked separately under CORE-2805) are out of scope here.