### PR TITLE
feat(code-review): add expand/collapse all actions in header overflow menu

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -561,6 +561,7 @@ default = [
     "summarization_cancellation_confirmation",
     "ui_zoom",
     "discard_per_file_and_all_changes",
+    "collapse_expand_all_files",
     "auto_open_code_review_pane",
     "diff_set_as_context",
     "summarize_conversation_command",
@@ -904,6 +905,7 @@ api_key_authentication = []
 api_key_management = []
 diff_set_as_context = []
 discard_per_file_and_all_changes = []
+collapse_expand_all_files = []
 ui_zoom = []
 summarization_cancellation_confirmation = []
 code_review_find = []

--- a/app/src/code_review/code_review_header/mod.rs
+++ b/app/src/code_review/code_review_header/mod.rs
@@ -137,6 +137,15 @@ impl CodeReviewHeader {
             } else {
                 right_section_wide.add_child(self.render_add_diff_set_context_button(appearance));
             }
+        } else if !has_no_changes
+            && FeatureFlag::FileAndDiffSetComments.is_enabled()
+            && FeatureFlag::CollapseExpandAllFiles.is_enabled()
+        {
+            right_section_wide.add_child(self.render_header_dropdown_button(
+                &code_review_header_fields.header_dropdown_button,
+                &code_review_header_fields.header_menu,
+                code_review_header_fields.header_menu_open,
+            ));
         }
 
         if code_review_header_fields.is_in_split_pane {
@@ -219,6 +228,15 @@ impl CodeReviewHeader {
                 right_subsection_compact
                     .add_child(self.render_add_diff_set_context_button(appearance));
             }
+        } else if !has_no_changes
+            && FeatureFlag::FileAndDiffSetComments.is_enabled()
+            && FeatureFlag::CollapseExpandAllFiles.is_enabled()
+        {
+            right_subsection_compact.add_child(self.render_header_dropdown_button(
+                &code_review_header_fields.header_dropdown_button,
+                &code_review_header_fields.header_menu,
+                code_review_header_fields.header_menu_open,
+            ));
         }
 
         if code_review_header_fields.is_in_split_pane {

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -321,6 +321,8 @@ pub enum CodeReviewAction {
         line_and_column: Option<LineAndColumnArg>,
     },
     ToggleFileExpanded(String),
+    ExpandAllFiles,
+    CollapseAllFiles,
     OpenHeaderMenu,
     SetDiffMode(DiffMode),
     ToggleFileSidebar,
@@ -4134,7 +4136,8 @@ impl CodeReviewView {
     ) -> Box<dyn Element> {
         let has_menu_flags = FeatureFlag::DiscardPerFileAndAllChanges.is_enabled()
             || FeatureFlag::DiffSetAsContext.is_enabled()
-            || FeatureFlag::FileAndDiffSetComments.is_enabled();
+            || FeatureFlag::FileAndDiffSetComments.is_enabled()
+            || FeatureFlag::CollapseExpandAllFiles.is_enabled();
         let has_changes = matches!(self.state(), CodeReviewViewState::Loaded(loaded) if !loaded.to_diff_stats().has_no_changes());
         let has_header_menu_items =
             has_menu_flags && (!FeatureFlag::GitOperationsInCodeReview.is_enabled() || has_changes);
@@ -6720,6 +6723,8 @@ impl CodeReviewView {
             has_changes = !loaded.to_diff_stats().has_no_changes();
         }
 
+        Self::append_collapse_expand_menu_items(&mut items, has_changes);
+
         if FeatureFlag::DiffSetAsContext.is_enabled() && has_changes {
             items.push(
                 MenuItemFields::new("Add diff set as context")
@@ -6753,6 +6758,8 @@ impl CodeReviewView {
         let mut items = Vec::new();
 
         let has_changes = matches!(self.state(), CodeReviewViewState::Loaded(loaded) if !loaded.to_diff_stats().has_no_changes());
+
+        Self::append_collapse_expand_menu_items(&mut items, has_changes);
 
         let is_ai_enabled = AISettings::as_ref(ctx).is_any_ai_enabled(ctx);
         if is_ai_enabled && FeatureFlag::DiffSetAsContext.is_enabled() && has_changes {
@@ -6790,6 +6797,31 @@ impl CodeReviewView {
         }
 
         items
+    }
+
+    /// Appends "Expand all" and "Collapse all" items to the header overflow
+    /// menu when the feature flag is enabled and there are changes to
+    /// collapse or expand.
+    fn append_collapse_expand_menu_items(
+        items: &mut Vec<MenuItem<CodeReviewAction>>,
+        has_changes: bool,
+    ) {
+        if !FeatureFlag::CollapseExpandAllFiles.is_enabled() || !has_changes {
+            return;
+        }
+
+        items.push(
+            MenuItemFields::new("Expand all")
+                .with_icon(Icon::ExpandUpAndDown)
+                .with_on_select_action(CodeReviewAction::ExpandAllFiles)
+                .into_item(),
+        );
+        items.push(
+            MenuItemFields::new("Collapse all")
+                .with_icon(Icon::ListCollapsed)
+                .with_on_select_action(CodeReviewAction::CollapseAllFiles)
+                .into_item(),
+        );
     }
 
     fn get_unsaved_file_paths(&self, app: &AppContext) -> Vec<String> {
@@ -7150,6 +7182,61 @@ impl TypedActionView for CodeReviewView {
                 // If the file gets collapsed and had a sticky header, then we scroll to make the header in view.
                 if !now_expanded && self.viewported_list_state.is_scrolled_to_item(file_index) {
                     self.viewported_list_state.scroll_to(file_index);
+                }
+
+                if self.find_model.as_ref(ctx).is_find_bar_open()
+                    && FeatureFlag::CodeReviewFind.is_enabled()
+                {
+                    self.find_model.update(ctx, |model, model_ctx| {
+                        model.run_search(self.editor_handles(), model_ctx);
+                    });
+                }
+
+                ctx.notify();
+            }
+            CodeReviewAction::ExpandAllFiles | CodeReviewAction::CollapseAllFiles => {
+                let target_expanded = matches!(action, CodeReviewAction::ExpandAllFiles);
+
+                // Phase 1: flip every file whose state differs, collecting the chevron
+                // handles to update outside the `active_repo` borrow.
+                let updates: Vec<(usize, ViewHandle<ActionButton>)> = {
+                    let Some(repo) = self.active_repo.as_mut() else {
+                        return;
+                    };
+                    let CodeReviewViewState::Loaded(state) = &mut repo.state else {
+                        return;
+                    };
+
+                    state
+                        .file_states
+                        .iter_mut()
+                        .enumerate()
+                        .filter_map(|(index, (path, file))| {
+                            if file.is_expanded == target_expanded {
+                                return None;
+                            }
+                            file.is_expanded = target_expanded;
+                            repo.file_expanded.insert(path.clone(), target_expanded);
+                            Some((index, file.chevron_button.clone()))
+                        })
+                        .collect()
+                };
+
+                if updates.is_empty() {
+                    return;
+                }
+
+                let icon = if target_expanded {
+                    Icon::ChevronDown
+                } else {
+                    Icon::ChevronRight
+                };
+                for (index, chevron) in &updates {
+                    chevron.update(ctx, |button, ctx| {
+                        button.set_icon(Some(icon), ctx);
+                    });
+                    self.viewported_list_state
+                        .invalidate_height_for_index(*index);
                 }
 
                 if self.find_model.as_ref(ctx).is_find_bar_open()

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -293,6 +293,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::DiffSetAsContext,
         #[cfg(feature = "discard_per_file_and_all_changes")]
         FeatureFlag::DiscardPerFileAndAllChanges,
+        #[cfg(feature = "collapse_expand_all_files")]
+        FeatureFlag::CollapseExpandAllFiles,
         #[cfg(feature = "summarization_cancellation_confirmation")]
         FeatureFlag::SummarizationCancellationConfirmation,
         #[cfg(feature = "code_review_find")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -440,6 +440,9 @@ pub enum FeatureFlag {
     /// Enables discarding per-file and discarding all changes
     DiscardPerFileAndAllChanges,
 
+    /// Enables "Expand all" / "Collapse all" actions in the code review header overflow menu.
+    CollapseExpandAllFiles,
+
     /// Enables UI zoom support (scaling the entire UI by a given percentage).
     UIZoom,
 


### PR DESCRIPTION
## Summary

Adds **Expand all** and **Collapse all** actions to the Code Review panel's header overflow menu, letting users collapse every file diff in the current view with one click — useful when reviewing branches with many changed files.

Closes #9129.

## Changes

- New `CollapseExpandAllFiles` Cargo feature flag (mirrors `DiscardPerFileAndAllChanges` and the other header overflow items for staged rollout).
- Two new `CodeReviewAction` variants (`ExpandAllFiles`, `CollapseAllFiles`) and a bulk handler that generalizes the existing `ToggleFileExpanded` pattern: flips every file's `is_expanded`, updates each chevron icon, persists to the per-repo `file_expanded` map, invalidates each row's height, and re-runs find search if the bar is open.
- Menu items added to both `header_menu_items_legacy` and `header_menu_items_new` via a shared `append_collapse_expand_menu_items` helper, gated on the new flag + `has_changes`.
- Legacy header (`code_review_header/mod.rs`) shows the dropdown when the new feature is on, even without `DiffSetAsContext`.
- `has_menu_flags` in `render_header` includes the new flag so the new header's dropdown appears for users without the existing flags.

## Behavior

- Selecting **Expand all** expands every file diff; **Collapse all** collapses them. Files already in the target state are skipped (no-op, no churn).
- The per-repo `file_expanded` map is updated, so a manual expand/collapse via the chevron remains sticky across diff reloads.
- Find-in-code-review re-runs because its search index only includes expanded files.

## Test plan

- [x] `cargo build -p warp --lib` — full build passes
- [x] `cargo test -p warp --lib code_review` — 113/113 pass
- [x] `cargo fmt --check` — clean
- [ ] Manual test: open Code Review on a branch with 5+ changed files, open the overflow menu, click **Collapse all** — every file collapses and chevrons flip to ▶. Click **Expand all** — every file expands and chevrons flip to ▼.

## Out of scope (follow-ups)

- Keyboard shortcut (`Cmd+Shift+[` / `Cmd+Shift+]`) — issue calls this "a nice bonus"; happy to add in a follow-up.
- Telemetry — none of the related header items emit telemetry, so this stays consistent.
- Visual mocks — issue is labeled `needs-mocks`; design can revise icons (`ExpandUpAndDown` / `ListCollapsed`) if preferred.