### PR TITLE
Hide read CLI agent completion status

### DIFF
--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -10,6 +10,7 @@ use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use self::listener::CLIAgentSessionListener;
 use super::CLIAgent;
+use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::blocklist::InputConfig;
 
 /// Status of a tracked CLI agent session.
@@ -21,8 +22,7 @@ pub enum CLIAgentSessionStatus {
 }
 
 impl CLIAgentSessionStatus {
-    pub fn to_conversation_status(&self) -> crate::ai::agent::conversation::ConversationStatus {
-        use crate::ai::agent::conversation::ConversationStatus;
+    pub fn to_conversation_status(&self) -> ConversationStatus {
         match self {
             CLIAgentSessionStatus::InProgress => ConversationStatus::InProgress,
             CLIAgentSessionStatus::Success => ConversationStatus::Success,
@@ -159,6 +159,16 @@ impl CLIAgentSession {
     /// an actual rich notification arrives.
     pub fn supports_rich_status(&self) -> bool {
         self.received_rich_notification
+    }
+
+    /// Status shown in terminal chrome surfaces. A successful CLI turn is represented by the
+    /// unread notification badge first; once read, it should not leave a persistent checkmark.
+    pub fn terminal_chrome_status(&self) -> Option<ConversationStatus> {
+        match &self.status {
+            CLIAgentSessionStatus::Success => None,
+            _ if self.supports_rich_status() => Some(self.status.to_conversation_status()),
+            _ => None,
+        }
     }
 
     /// Clears state populated by `PermissionRequest`. Called whenever the

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -5,6 +5,7 @@ use super::{
     CLIAgentInputEntrypoint, CLIAgentInputState, CLIAgentSession, CLIAgentSessionContext,
     CLIAgentSessionStatus, CLIAgentSessionsModel,
 };
+use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::blocklist::{InputConfig, InputType};
 use crate::terminal::CLIAgent;
 
@@ -477,6 +478,47 @@ fn non_codex_session_rich_after_rich_notification() {
 
     session.received_rich_notification = true;
     assert!(session.supports_rich_status());
+}
+
+#[test]
+fn terminal_chrome_status_hides_success_after_completion_badge_is_read() {
+    let mut session = CLIAgentSession {
+        agent: CLIAgent::Claude,
+        status: CLIAgentSessionStatus::Success,
+        session_context: CLIAgentSessionContext::default(),
+        input_state: CLIAgentInputState::Closed,
+        should_auto_toggle_input: false,
+        listener: None,
+        plugin_version: None,
+        remote_host: None,
+        draft_text: None,
+        custom_command_prefix: None,
+        received_rich_notification: true,
+    };
+    assert_eq!(session.terminal_chrome_status(), None);
+
+    session.status = CLIAgentSessionStatus::InProgress;
+    session.received_rich_notification = false;
+    assert_eq!(session.terminal_chrome_status(), None);
+
+    session.received_rich_notification = true;
+    assert_eq!(
+        session.terminal_chrome_status(),
+        Some(ConversationStatus::InProgress),
+    );
+
+    session.status = CLIAgentSessionStatus::Blocked {
+        message: Some("approval required".to_string()),
+    };
+    assert_eq!(
+        session.terminal_chrome_status(),
+        Some(ConversationStatus::Blocked {
+            blocked_action: "approval required".to_string(),
+        }),
+    );
+
+    session.received_rich_notification = false;
+    assert_eq!(session.terminal_chrome_status(), None);
 }
 
 /// Constructs a session with permission-scoped state already populated, as if

--- a/app/src/ui_components/agent_icon.rs
+++ b/app/src/ui_components/agent_icon.rs
@@ -130,14 +130,14 @@ fn agent_icon_variant_from_terminal_inputs(
     inputs: &TerminalIconInputs,
 ) -> Option<IconWithStatusVariant> {
     // 1. CLI session with a known (non-Unknown) agent wins. Status is only meaningful when
-    //    the session is plugin-backed and the handler exposes rich status.
+    //    the session is plugin-backed and the handler exposes rich status. Success is
+    //    intentionally hidden after the unread completion badge is cleared.
     if let Some(session) = inputs
         .cli_session
         .as_ref()
         .filter(|s| !matches!(s.agent, CLIAgent::Unknown))
     {
-        let status =
-            (session.has_listener && session.supports_rich_status).then(|| session.status.clone());
+        let status = cli_session_terminal_icon_status(session);
         return Some(IconWithStatusVariant::CLIAgent {
             agent: session.agent,
             status,
@@ -170,6 +170,14 @@ fn agent_icon_variant_from_terminal_inputs(
     }
 
     None
+}
+
+fn cli_session_terminal_icon_status(session: &CLISessionInputs) -> Option<ConversationStatus> {
+    match &session.status {
+        ConversationStatus::Success => None,
+        _ if session.has_listener && session.supports_rich_status => Some(session.status.clone()),
+        _ => None,
+    }
 }
 
 /// Pure run-card logic: maps a [`Harness`], status, and ambient flag into an

--- a/app/src/ui_components/agent_icon_tests.rs
+++ b/app/src/ui_components/agent_icon_tests.rs
@@ -90,6 +90,8 @@ enum CanonicalRunState {
     LocalClaudePluginInProgress,
     /// Local Claude CLI session with a plugin listener (rich status), blocked.
     LocalClaudePluginBlocked,
+    /// Local Claude CLI session with a plugin listener (rich status), completed and read.
+    LocalClaudePluginSuccess,
     /// Local Claude CLI session detected via command matching only (no listener, no rich status).
     LocalClaudeCommandDetected,
 }
@@ -106,6 +108,7 @@ impl CanonicalRunState {
             ViewingCloudCodexTranscript,
             LocalClaudePluginInProgress,
             LocalClaudePluginBlocked,
+            LocalClaudePluginSuccess,
             LocalClaudeCommandDetected,
         ]
     }
@@ -160,7 +163,7 @@ impl CanonicalRunState {
                 }),
                 is_ambient: false,
             }),
-            LocalClaudeCommandDetected => Some(AgentIconFields {
+            LocalClaudePluginSuccess | LocalClaudeCommandDetected => Some(AgentIconFields {
                 is_cli: true,
                 cli_agent: Some(CLIAgent::Claude),
                 status: None,
@@ -243,6 +246,18 @@ impl CanonicalRunState {
                 selected_conversation_status: None,
                 has_selected_conversation: false,
             },
+            LocalClaudePluginSuccess => TerminalIconInputs {
+                is_ambient: false,
+                cli_session: Some(CLISessionInputs {
+                    agent: CLIAgent::Claude,
+                    has_listener: true,
+                    status: ConversationStatus::Success,
+                    supports_rich_status: true,
+                }),
+                selected_third_party_cli_agent: None,
+                selected_conversation_status: None,
+                has_selected_conversation: false,
+            },
             LocalClaudeCommandDetected => TerminalIconInputs {
                 is_ambient: false,
                 cli_session: Some(CLISessionInputs {
@@ -274,6 +289,7 @@ impl CanonicalRunState {
             | LocalOzInProgress
             | LocalClaudePluginInProgress
             | LocalClaudePluginBlocked
+            | LocalClaudePluginSuccess
             | LocalClaudeCommandDetected => None,
         }
     }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -923,11 +923,8 @@ fn summary_conversation_status_for_terminal(
     app: &AppContext,
 ) -> Option<ConversationStatus> {
     let cli_agent_session = CLIAgentSessionsModel::as_ref(app).session(terminal_view.id());
-    if let Some(session) = cli_agent_session
-        .filter(|s| s.supports_rich_status())
-        .filter(|s| !matches!(s.agent, CLIAgent::Unknown))
-    {
-        return Some(session.status.to_conversation_status());
+    if let Some(status) = cli_agent_session.and_then(cli_agent_display_status) {
+        return Some(status);
     }
 
     let is_ambient = terminal_view.is_ambient_agent_session(app);
@@ -937,6 +934,16 @@ fn summary_conversation_status_for_terminal(
     (has_conversation || is_ambient)
         .then(|| terminal_view.selected_conversation_status_for_display(app))
         .flatten()
+}
+
+fn cli_agent_display_status(
+    session: &crate::terminal::cli_agent_sessions::CLIAgentSession,
+) -> Option<ConversationStatus> {
+    if matches!(session.agent, CLIAgent::Unknown) {
+        return None;
+    }
+
+    session.terminal_chrome_status()
 }
 
 fn coalesce_summary_branch_entries(
@@ -6170,8 +6177,8 @@ fn render_terminal_detail_section(
     let (conversation_display_title, cli_agent_title) =
         preferred_agent_tab_titles(&agent_text, agent_tab_text_preference(app));
     let kind_label = terminal_kind_badge_label(agent_text.is_oz_agent, agent_text.cli_agent);
-    let status = if let Some(session) = cli_agent_session.filter(|s| s.supports_rich_status()) {
-        Some(session.status.to_conversation_status())
+    let status = if let Some(status) = cli_agent_session.and_then(cli_agent_display_status) {
+        Some(status)
     } else if agent_text.is_oz_agent {
         terminal_view.selected_conversation_status_for_display(app)
     } else {

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -26,6 +26,9 @@ use crate::context_chips::display_chip::GitLineChanges;
 use crate::pane_group::pane::IPaneType;
 use crate::pane_group::{PaneId, TerminalPaneId};
 use crate::safe_triangle::SafeTriangle;
+use crate::terminal::cli_agent_sessions::{
+    CLIAgentInputState, CLIAgentSession, CLIAgentSessionContext, CLIAgentSessionStatus,
+};
 use crate::terminal::CLIAgent;
 use crate::workspace::tab_settings::VerticalTabsDisplayGranularity;
 
@@ -1083,6 +1086,25 @@ fn sort_summary_primary_labels_moves_status_first_and_preserves_order() {
             },
         ]
     );
+}
+
+#[test]
+fn cli_agent_display_status_hides_success_badge_after_completion_is_read() {
+    let session = CLIAgentSession {
+        agent: CLIAgent::Claude,
+        status: CLIAgentSessionStatus::Success,
+        session_context: CLIAgentSessionContext::default(),
+        input_state: CLIAgentInputState::Closed,
+        should_auto_toggle_input: false,
+        listener: None,
+        plugin_version: None,
+        remote_host: None,
+        draft_text: None,
+        custom_command_prefix: None,
+        received_rich_notification: true,
+    };
+
+    assert_eq!(super::cli_agent_display_status(&session), None);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Hide the persistent success/check status for completed CLI agent sessions after the unread completion badge has already been read.

Previously, rich CLI agent sessions could continue to surface `ConversationStatus::Success` in terminal chrome surfaces. That made a completed/read session leave behind a stale gray check even though the actionable unread completion indicator had already been consumed.

This change adds a shared `terminal_chrome_status()` helper for CLI agent sessions and uses it in:

- terminal agent icon status
- vertical tab summary status
- vertical tab detail status

The helper preserves existing rich-status behavior for in-progress and blocked states, but maps success to `None`.

## Linked Issue

Part of #12329

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Automated:

```sh
cargo fmt --check
env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CARGO_INCREMENTAL=0 cargo test -p warp terminal_chrome_status_hides_success_after_completion_badge_is_read --features test-util
env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CARGO_INCREMENTAL=0 cargo test -p warp every_canonical_state_produces_consistent_icon_across_surfaces --features test-util
env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer CARGO_INCREMENTAL=0 cargo test -p warp cli_agent_display_status_hides_success_badge_after_completion_is_read --features test-util
```

Manual:

- Manual validation video was attached in a PR comment: https://github.com/warpdotdev/warp/pull/12330#issuecomment-4645271747

### Screenshots / Videos

https://github.com/user-attachments/assets/62d62b12-b656-4f94-b373-8a9321ebe112

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Hide stale CLI agent success checks after completion notifications are read.
