### PR TITLE
Clear permission state when blocking tool completes

### DIFF
--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -162,10 +162,11 @@ impl CLIAgentSession {
     }
 
     /// Clears state populated by `PermissionRequest`. Called whenever the
-    /// session leaves the permission flow (the user replied, a new prompt
-    /// is submitted, or the session ends successfully) so the permission
-    /// summary doesn't leak into later UI surfaces — most visibly the tab
-    /// title, which can fall back to `summary` when `query` is unset.
+    /// session leaves the permission flow (the user replied, a blocking tool
+    /// completed, a new prompt is submitted, or the session ends successfully)
+    /// so the permission summary doesn't leak into later UI surfaces — most
+    /// visibly the tab title, which can fall back to `summary` when `query`
+    /// is unset.
     fn clear_permission_scoped_state(&mut self) {
         self.session_context.summary = None;
         self.session_context.tool_name = None;
@@ -196,6 +197,7 @@ impl CLIAgentSession {
                 if !matches!(self.status, CLIAgentSessionStatus::Blocked { .. }) {
                     return None;
                 }
+                self.clear_permission_scoped_state();
                 CLIAgentSessionStatus::InProgress
             }
             CLIAgentEventType::Stop => {

--- a/app/src/terminal/cli_agent_sessions/mod_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/mod_tests.rs
@@ -606,6 +606,34 @@ fn prompt_submit_clears_permission_scoped_state() {
 }
 
 #[test]
+fn tool_complete_clears_permission_scoped_state() {
+    // GH-11082: answering an AskUserQuestion emits only ToolComplete (the
+    // plugin sends no PermissionReplied for it), so the Blocked -> InProgress
+    // transition here must also clear the stale summary. Otherwise the tab
+    // title keeps showing "Wants to run AskUserQuestion: ..." until the next
+    // prompt or Stop.
+    let mut session = blocked_claude_session_with_permission_state();
+
+    let event = CLIAgentEvent {
+        source: CLIAgentEventSource::RichPlugin,
+        v: 1,
+        agent: CLIAgent::Claude,
+        event: CLIAgentEventType::ToolComplete,
+        session_id: Some("abc".to_owned()),
+        cwd: None,
+        project: None,
+        payload: CLIAgentEventPayload::default(),
+    };
+
+    session.apply_event(&event);
+
+    assert_eq!(session.session_context.summary, None);
+    assert_eq!(session.session_context.tool_name, None);
+    assert_eq!(session.session_context.tool_input_preview, None);
+    assert!(matches!(session.status, CLIAgentSessionStatus::InProgress));
+}
+
+#[test]
 fn permission_request_still_populates_summary_and_tool_fields() {
     // Sanity: clearing permission-scoped state on Stop/Reply/Submit must not
     // also break the PermissionRequest path that initially populates them.


### PR DESCRIPTION
## Description

When Claude Code asks the user a question via its `AskUserQuestion` tool, the plugin emits a `permission_request` event, which populates `session_context.summary` with text like:

```
Wants to run AskUserQuestion: {"questions":[{"question":"What decision should the benchmark...
```

When the user answers the question, the plugin emits only a `tool_complete` event. It does not emit `permission_replied` for this flow. The `ToolComplete` handler flips the status from `Blocked` back to `InProgress` but leaves `summary` populated, so the tab title (which falls back to `summary` via `title_like_text()` when `query` is unset) stays stuck on the stale "Wants to run AskUserQuestion: ..." text until the next prompt or a `Stop` event. If the `Stop` event is dropped, it stays stuck indefinitely.

#9671 fixed the same class of bug for the `Stop`, `PermissionReplied`, and `PromptSubmit` transitions. This PR applies the same fix to the remaining transition out of the permission flow: `ToolComplete` now also calls `clear_permission_scoped_state()`. The call sits behind the existing `Blocked` guard, so it only runs when the session is actually leaving the permission flow.

## Linked Issue

Addresses the "stuck on wants to run..." half of #11082 (the manual rename problem reported there is separate and tracked in #9102 / #9110).

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

Added `tool_complete_clears_permission_scoped_state` to `mod_tests.rs`, mirroring the three regression tests from #9671. It builds a `Blocked` session with populated permission state, applies a `ToolComplete` event, and asserts the summary, tool name, and input preview are cleared and the status is `InProgress`.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed tab titles getting stuck on "Wants to run AskUserQuestion: ..." after answering a Claude Code question.
