### PR TITLE
Fix ghost group reappearing bug

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11368,7 +11368,7 @@ impl Workspace {
         self.tab_mru_order.retain(|id| *id != removed_pane_group_id);
 
         // If the closed tab was a group member, prune the group when it now
-        // has no remaining members. 
+        // has no remaining members.
         if let Some(group_id) = tab_data.group_id {
             self.prune_empty_tab_group(group_id, ctx);
         }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11367,6 +11367,12 @@ impl Workspace {
         let removed_pane_group_id = tab_data.pane_group.id();
         self.tab_mru_order.retain(|id| *id != removed_pane_group_id);
 
+        // If the closed tab was a group member, prune the group when it now
+        // has no remaining members. 
+        if let Some(group_id) = tab_data.group_id {
+            self.prune_empty_tab_group(group_id, ctx);
+        }
+
         // Re-adopted child tabs leave no useful tab contents to restore; the
         // live pane already moved back.
         if add_to_undo_stack && !re_adopted {


### PR DESCRIPTION
## Description

When the last tab of a group was closed, the group was not being deleted. This would cause it to reappear unexpectedly. 

The fix: when a tab is deleted and part of a group, call `prune_empty_tab_group` which will delete the group if it is empty

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4675/deleted-tab-group-reappearing

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

[Demo of bug](https://www.loom.com/share/6b858bd86979481d8cf24405c3837fe6)

[Demo after fix](https://www.loom.com/share/a942681a42774357be01edee2e0616d7)

The tab group no longer appears when dragging a tab from above where it used to be.
