### PR TITLE
Add colored tab groups

### DIFF
--- a/app/src/ui_components/color_dot.rs
+++ b/app/src/ui_components/color_dot.rs
@@ -1,16 +1,20 @@
+use std::sync::Arc;
+
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use ui_components::tooltip::{Params as TooltipParams, Tooltip as TooltipComponent};
 use ui_components::{Component as _, Options as ComponentOptions};
 use warp_core::ui::theme::{AnsiColorIdentifier, Fill as ThemeFill};
 use warpui::elements::{
-    Border, ChildAnchor, ConstrainedBox, Container, CornerRadius, Element, Hoverable,
-    MouseStateHandle, OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Radius,
-    Stack,
+    Border, ChildAnchor, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Element,
+    Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning,
+    ParentAnchor, ParentElement, ParentOffsetBounds, Radius, Stack,
 };
 use warpui::platform::Cursor;
+use warpui::Action;
 
 use crate::appearance::Appearance;
+use crate::menu::{MenuAction, MenuItem, MenuItemFields};
 use crate::ui_components::icons::Icon;
 
 const COLOR_DOT_SIZE: f32 = 16.;
@@ -23,6 +27,80 @@ pub(crate) const TAB_COLOR_OPTIONS: [AnsiColorIdentifier; 6] = [
     AnsiColorIdentifier::Magenta,
     AnsiColorIdentifier::Cyan,
 ];
+
+/// Builds a single custom menu item holding a row of clickable color dots: a
+/// "no color" option followed by `TAB_COLOR_OPTIONS`. The currently `selected`
+/// color is ringed. Clicking a dot dispatches the action produced by
+/// `on_select(chosen)` (where `None` means "clear color") and then closes the
+/// menu. Shared by the per-tab and per-tab-group color pickers.
+pub(crate) fn color_dot_picker_menu_item<A, F>(
+    selected: Option<AnsiColorIdentifier>,
+    on_select: F,
+) -> MenuItem<A>
+where
+    A: Action + Clone + 'static,
+    F: Fn(Option<AnsiColorIdentifier>) -> A + Clone + 'static,
+{
+    let mouse_states: Vec<MouseStateHandle> = (0..TAB_COLOR_OPTIONS.len() + 1)
+        .map(|_| MouseStateHandle::default())
+        .collect();
+
+    MenuItem::Item(
+        MenuItemFields::new_with_custom_label(
+            Arc::new(move |_is_selected, _is_hovered, appearance, _app| {
+                let theme = appearance.theme();
+                let terminal_colors = theme.terminal_colors().normal;
+                let ring_color: ColorU = theme.accent().into();
+
+                let mut row = Flex::row()
+                    .with_main_axis_alignment(MainAxisAlignment::SpaceEvenly)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_size(MainAxisSize::Max);
+
+                for (ansi_id, mouse_state) in std::iter::once(None)
+                    .chain(TAB_COLOR_OPTIONS.iter().copied().map(Some))
+                    .zip(mouse_states.iter().cloned())
+                {
+                    let is_selected = match ansi_id {
+                        None => selected.is_none(),
+                        Some(id) => selected == Some(id),
+                    };
+                    let dot_color: ColorU = match ansi_id {
+                        None => ColorU::transparent_black(),
+                        Some(id) => id.to_ansi_color(&terminal_colors).into(),
+                    };
+                    let tooltip = match ansi_id {
+                        None => "Default (no color)".to_string(),
+                        Some(id) => id.to_string(),
+                    };
+
+                    let on_select = on_select.clone();
+                    let dot = render_color_dot(
+                        mouse_state,
+                        dot_color,
+                        is_selected,
+                        ring_color,
+                        ansi_id.is_none(),
+                        theme.foreground(),
+                        tooltip,
+                        appearance,
+                    )
+                    .on_click(move |ctx, _, _| {
+                        ctx.dispatch_typed_action(on_select(ansi_id));
+                        ctx.dispatch_typed_action(MenuAction::Close(true));
+                    });
+
+                    row.add_child(dot.finish());
+                }
+
+                row.finish()
+            }),
+            None,
+        )
+        .no_highlight_on_hover()
+        .with_no_interaction_on_hover(),
+    )
+}
 
 /// Renders a hoverable color dot with selection ring, tooltip, and pointer cursor.
 /// For the no-color option, pass `is_no_color: true` to show a slash overlay.

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -183,6 +183,11 @@ pub enum WorkspaceAction {
     ToggleTabGroupCollapsed(TabGroupId),
     /// Opens an inline editor over the given group's header for renaming.
     RenameTabGroup(TabGroupId),
+    /// Sets (or clears, with `None`) the accent color of the given tab group.
+    SetTabGroupColor {
+        group_id: TabGroupId,
+        color: Option<AnsiColorIdentifier>,
+    },
     /// Creates a new tab group containing the tab at the given index.
     NewTabGroupFromTab(usize),
     /// Moves the tab at `tab_index` into `group_id`, appending it to the
@@ -856,6 +861,7 @@ impl WorkspaceAction {
             | CloseTabGroup(_)
             | ToggleTabGroupCollapsed(_)
             | RenameTabGroup(_)
+            | SetTabGroupColor { .. }
             | NewTabGroupFromTab(_)
             | MoveTabToGroup { .. }
             | RemoveTabFromGroup(_)

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -3,6 +3,8 @@
 use uuid::Uuid;
 use warpui::elements::DraggableState;
 
+use crate::themes::theme::AnsiColorIdentifier;
+
 /// Stable identity for a tab group.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TabGroupId(pub Uuid);
@@ -26,16 +28,21 @@ pub struct TabGroup {
     pub id: TabGroupId,
     pub name: Option<String>,
     pub collapsed: bool,
+    /// Optional accent color for the group, shown in the group header. `None`
+    /// renders the default (uncolored) header. Drawn from the same eight ANSI
+    /// terminal colors used for per-tab colors.
+    pub color: Option<AnsiColorIdentifier>,
     pub draggable_state: DraggableState,
 }
 
 impl TabGroup {
-    /// Creates a new, untitled, expanded tab group with a fresh id.
+    /// Creates a new, untitled, expanded, uncolored tab group with a fresh id.
     pub fn new() -> Self {
         Self {
             id: TabGroupId::new(),
             name: None,
             collapsed: false,
+            color: None,
             draggable_state: Default::default(),
         }
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -418,6 +418,7 @@ use crate::themes::theme_deletion_modal::{ThemeDeletionModal, ThemeDeletionModal
 use crate::tips::{TipsEvent, TipsView};
 use crate::ui_components::avatar::{Avatar, AvatarContent, StatusElementTypes};
 use crate::ui_components::buttons::{combo_inner_button, icon_button_with_color};
+use crate::ui_components::color_dot::color_dot_picker_menu_item;
 use crate::ui_components::red_notification_dot::RedNotificationDot;
 use crate::ui_components::window_focus_dimming::WindowFocusDimming;
 use crate::ui_components::{blended_colors, icons};
@@ -6852,6 +6853,19 @@ impl Workspace {
         }
     }
 
+    /// Sets (or clears, with `None`) the accent color of the given tab group.
+    pub fn set_tab_group_color(
+        &mut self,
+        group_id: TabGroupId,
+        color: Option<AnsiColorIdentifier>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(group) = self.tab_groups.get_mut(&group_id) {
+            group.color = color;
+            ctx.notify();
+        }
+    }
+
     /// Opens the inline rename editor over the given group's header.
     pub fn rename_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
         let Some(group) = self.tab_groups.get(&group_id) else {
@@ -9435,6 +9449,13 @@ impl Workspace {
             items
         };
 
+        let color_section = {
+            let current_color = self.tab_groups.get(&group_id).and_then(|group| group.color);
+            vec![color_dot_picker_menu_item(current_color, move |color| {
+                WorkspaceAction::SetTabGroupColor { group_id, color }
+            })]
+        };
+
         let mut menu_items = vec![];
         for section_items in [
             vec![
@@ -9449,6 +9470,7 @@ impl Workspace {
             vec![MenuItemFields::new("Rename")
                 .with_on_select_action(WorkspaceAction::RenameTabGroup(group_id))
                 .into_item()],
+            color_section,
             close_section,
         ] {
             if section_items.is_empty() {
@@ -22685,6 +22707,9 @@ impl TypedActionView for Workspace {
             CloseTabGroup(group_id) => self.close_tab_group(*group_id, ctx),
             ToggleTabGroupCollapsed(group_id) => self.toggle_tab_group_collapsed(*group_id, ctx),
             RenameTabGroup(group_id) => self.rename_tab_group(*group_id, ctx),
+            SetTabGroupColor { group_id, color } => {
+                self.set_tab_group_color(*group_id, *color, ctx)
+            }
             NewTabGroupFromTab(tab_index) => self.new_tab_group_from_tab(*tab_index, ctx),
             MoveTabToGroup {
                 tab_index,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -101,8 +101,6 @@ const GROUP_ACTION_BUTTON_GAP: f32 = 2.;
 const ROW_CORNER_RADIUS: f32 = 4.;
 const TAB_GROUP_MEMBER_INDENT: f32 = 12.;
 const TAB_GROUP_ICON_SIZE: f32 = 16.;
-/// Diameter of the accent color dot shown in a colored group's header.
-const GROUP_COLOR_DOT_SIZE: f32 = 10.;
 const TAB_GROUP_CONTENT_INSET: f32 = 4.;
 const BADGE_ICON_SIZE: f32 = 12.;
 const DETAIL_SIDECAR_DEFAULT_WIDTH: f32 = 320.;
@@ -2526,10 +2524,11 @@ fn render_grouped_tabs_header(
     let sub_text_color = theme.sub_text_color(theme.background());
     let group_id = group.id;
     // Resolved accent color for the group, if one is set. Drives the tinted
-    // chevron and the color dot shown next to the group title.
-    let group_color_fill: Option<WarpThemeFill> = group
+    // chevron and the colored header row (background tint + border).
+    let group_color: Option<ColorU> = group
         .color
         .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
+    let group_color_fill: Option<WarpThemeFill> = group_color.map(WarpThemeFill::Solid);
 
     let chevron_icon = if is_collapsed {
         WarpIcon::ChevronRight
@@ -2587,14 +2586,6 @@ fn render_grouped_tabs_header(
         .with_child(subtitle)
         .finish();
 
-    // Accent color dot, shown between the chevron and the title for colored groups.
-    let color_dot: Option<Box<dyn Element>> = group_color_fill.map(|fill| {
-        ConstrainedBox::new(UiIcon::Ellipse.to_warpui_icon(fill).finish())
-            .with_width(GROUP_COLOR_DOT_SIZE)
-            .with_height(GROUP_COLOR_DOT_SIZE)
-            .finish()
-    });
-
     let action_buttons = if show_action_buttons {
         let kebab_button = SavePosition::new(
             render_tab_group_header_icon_button(
@@ -2630,36 +2621,53 @@ fn render_grouped_tabs_header(
         Empty::new().finish()
     };
 
-    let mut inner_content = Flex::row()
-        .with_main_axis_size(MainAxisSize::Max)
-        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_spacing(ICON_WITH_STATUS_GAP)
-        .with_child(chevron_slot);
-    if let Some(dot) = color_dot {
-        inner_content.add_child(dot);
-    }
-    inner_content.add_child(Shrinkable::new(1., text_column).finish());
-
     let row = Flex::row()
         .with_main_axis_size(MainAxisSize::Max)
         .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_child(Shrinkable::new(1., inner_content.finish()).finish())
+        .with_child(
+            Shrinkable::new(
+                1.,
+                Flex::row()
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(ICON_WITH_STATUS_GAP)
+                    .with_child(chevron_slot)
+                    .with_child(Shrinkable::new(1., text_column).finish())
+                    .finish(),
+            )
+            .finish(),
+        )
         .with_child(action_buttons)
         .finish();
 
     let mut hoverable = Hoverable::new(mouse_states.header.clone(), move |state| {
-        let border_fill = if is_header_selected {
-            internal_colors::fg_overlay_3(theme)
-        } else {
-            WarpThemeFill::Solid(ColorU::transparent_black())
-        };
+        let hovered = is_header_selected || state.is_hovered();
         let mut container = Container::new(row)
             .with_padding(Padding::uniform(GROUP_HORIZONTAL_PADDING))
-            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
-            .with_border(Border::all(1.).with_border_fill(border_fill));
-        if is_header_selected || state.is_hovered() {
-            container = container.with_background(internal_colors::fg_overlay_2(theme));
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)));
+        if let Some(color) = group_color {
+            // Colored group: tint the whole header row with the accent color,
+            // brightening the fill on hover/selection. The border uses the full
+            // accent color so the group reads as colored at a glance.
+            let background = if hovered {
+                coloru_with_opacity(color, 26)
+            } else {
+                coloru_with_opacity(color, 16)
+            };
+            container = container
+                .with_border(Border::all(1.).with_border_fill(WarpThemeFill::Solid(color)))
+                .with_background(WarpThemeFill::Solid(background));
+        } else {
+            let border_fill = if is_header_selected {
+                internal_colors::fg_overlay_3(theme)
+            } else {
+                WarpThemeFill::Solid(ColorU::transparent_black())
+            };
+            container = container.with_border(Border::all(1.).with_border_fill(border_fill));
+            if hovered {
+                container = container.with_background(internal_colors::fg_overlay_2(theme));
+            }
         }
         container.finish()
     })

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -101,6 +101,8 @@ const GROUP_ACTION_BUTTON_GAP: f32 = 2.;
 const ROW_CORNER_RADIUS: f32 = 4.;
 const TAB_GROUP_MEMBER_INDENT: f32 = 12.;
 const TAB_GROUP_ICON_SIZE: f32 = 16.;
+/// Diameter of the accent color dot shown in a colored group's header.
+const GROUP_COLOR_DOT_SIZE: f32 = 10.;
 const TAB_GROUP_CONTENT_INSET: f32 = 4.;
 const BADGE_ICON_SIZE: f32 = 12.;
 const DETAIL_SIDECAR_DEFAULT_WIDTH: f32 = 320.;
@@ -2523,6 +2525,11 @@ fn render_grouped_tabs_header(
     let main_text_color = theme.main_text_color(theme.background());
     let sub_text_color = theme.sub_text_color(theme.background());
     let group_id = group.id;
+    // Resolved accent color for the group, if one is set. Drives the tinted
+    // chevron and the color dot shown next to the group title.
+    let group_color_fill: Option<WarpThemeFill> = group
+        .color
+        .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
 
     let chevron_icon = if is_collapsed {
         WarpIcon::ChevronRight
@@ -2532,7 +2539,7 @@ fn render_grouped_tabs_header(
     let chevron_button = render_tab_group_header_icon_button(
         chevron_icon,
         TAB_GROUP_ICON_SIZE,
-        main_text_color,
+        group_color_fill.unwrap_or(main_text_color),
         internal_colors::fg_overlay_2(theme),
         mouse_states.chevron.clone(),
         Some(WorkspaceAction::ToggleTabGroupCollapsed(group_id)),
@@ -2580,6 +2587,14 @@ fn render_grouped_tabs_header(
         .with_child(subtitle)
         .finish();
 
+    // Accent color dot, shown between the chevron and the title for colored groups.
+    let color_dot: Option<Box<dyn Element>> = group_color_fill.map(|fill| {
+        ConstrainedBox::new(UiIcon::Ellipse.to_warpui_icon(fill).finish())
+            .with_width(GROUP_COLOR_DOT_SIZE)
+            .with_height(GROUP_COLOR_DOT_SIZE)
+            .finish()
+    });
+
     let action_buttons = if show_action_buttons {
         let kebab_button = SavePosition::new(
             render_tab_group_header_icon_button(
@@ -2615,23 +2630,21 @@ fn render_grouped_tabs_header(
         Empty::new().finish()
     };
 
+    let mut inner_content = Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_spacing(ICON_WITH_STATUS_GAP)
+        .with_child(chevron_slot);
+    if let Some(dot) = color_dot {
+        inner_content.add_child(dot);
+    }
+    inner_content.add_child(Shrinkable::new(1., text_column).finish());
+
     let row = Flex::row()
         .with_main_axis_size(MainAxisSize::Max)
         .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .with_child(
-            Shrinkable::new(
-                1.,
-                Flex::row()
-                    .with_main_axis_size(MainAxisSize::Max)
-                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                    .with_spacing(ICON_WITH_STATUS_GAP)
-                    .with_child(chevron_slot)
-                    .with_child(Shrinkable::new(1., text_column).finish())
-                    .finish(),
-            )
-            .finish(),
-        )
+        .with_child(Shrinkable::new(1., inner_content.finish()).finish())
         .with_child(action_buttons)
         .finish();
 

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3275,6 +3275,64 @@ fn test_toggle_tab_group_collapsed_flips_state() {
 }
 
 #[test]
+fn test_set_tab_group_color_sets_and_clears() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[0]
+                .group_id
+                .expect("active tab should be in a group");
+            // New groups start uncolored.
+            assert_eq!(workspace.tab_groups[&group_id].color, None);
+
+            // Assigning a color is reflected on the group.
+            workspace.handle_action(
+                &WorkspaceAction::SetTabGroupColor {
+                    group_id,
+                    color: Some(AnsiColorIdentifier::Blue),
+                },
+                ctx,
+            );
+            assert_eq!(
+                workspace.tab_groups[&group_id].color,
+                Some(AnsiColorIdentifier::Blue)
+            );
+
+            // Reassigning replaces the previous color.
+            workspace.handle_action(
+                &WorkspaceAction::SetTabGroupColor {
+                    group_id,
+                    color: Some(AnsiColorIdentifier::Green),
+                },
+                ctx,
+            );
+            assert_eq!(
+                workspace.tab_groups[&group_id].color,
+                Some(AnsiColorIdentifier::Green)
+            );
+
+            // Passing `None` clears the color back to the default.
+            workspace.handle_action(
+                &WorkspaceAction::SetTabGroupColor {
+                    group_id,
+                    color: None,
+                },
+                ctx,
+            );
+            assert_eq!(workspace.tab_groups[&group_id].color, None);
+        });
+    });
+}
+
+#[test]
 fn test_close_tab_group_removes_group_and_members() {
     let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
 


### PR DESCRIPTION
## Description

Adds **colored tab groups**: you can assign an accent color to a tab group in the vertical tabs panel, alongside the existing rename / collapse controls. The whole group header takes the color — a translucent tinted background (brightening on hover/selection), a full‑color border, and a tinted chevron — so groups are distinguishable at a glance, similar to tab groups in Chrome/Arc.

Colors come from the same eight ANSI terminal colors already used for per‑tab colors, and the picker reuses the existing color‑dot UI (factored into a shared helper). A "no color" option clears it.

Gated at runtime by the existing `FeatureFlag::GroupedTabs` — no new flag introduced.

### What changed
- `app/src/workspace/tab_group.rs` — add `color: Option<AnsiColorIdentifier>` to `TabGroup`
- `app/src/workspace/action.rs` — `SetTabGroupColor { group_id, color }` action, categorized as save‑worthy workspace state
- `app/src/workspace/view.rs` — `set_tab_group_color` handler + a color‑picker row in the group right‑click menu
- `app/src/ui_components/color_dot.rs` — extract a reusable `color_dot_picker_menu_item`, now shared by the per‑tab and per‑group pickers
- `app/src/workspace/view/vertical_tabs.rs` — render the group header in the group's color

## Linked Issue
<!-- No linked issue yet — opening as a draft. Happy to file/link a triaged issue if this direction is wanted. -->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally (built `warp-oss` with `--features grouped_tabs,vertical_tabs`): created a tab group, assigned / changed / cleared its color from the group context menu, and verified the header tints accordingly and persists across the session.
- Added unit test `test_set_tab_group_color_sets_and_clears` (set → reassign → clear).

### Screenshots / Videos
<!-- TODO: attach a screenshot of a colored group header (e.g. a green "PANO" group). -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

### Notes
- Scope matches the existing grouped‑tabs feature: group color lives in memory like `name` / `collapsed` (the tab snapshot doesn't persist group membership yet), so it is not persisted across restarts. Happy to follow up with snapshot persistence if wanted.

<!--
CHANGELOG-NEW-FEATURE: Tab groups can now be assigned a color in the vertical tabs panel.
-->
