### PR TITLE
Persist tab group on app close

### DIFF
--- a/app/src/app_state.rs
+++ b/app/src/app_state.rs
@@ -20,6 +20,7 @@ use crate::settings_view::SettingsSection;
 use crate::tab::SelectedTabColor;
 use crate::terminal::ShellLaunchData;
 use crate::themes::theme::AnsiColorIdentifier;
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspace::view::left_panel::ToolPanelView;
 use crate::workspace::WorkspaceRegistry;
 
@@ -56,6 +57,16 @@ pub struct WindowSnapshot {
     pub left_panel_width: Option<f32>,
     pub right_panel_width: Option<f32>,
     pub agent_management_filters: Option<PersistedAgentManagementFilters>,
+    /// Tab groups defined in this window. Group order is implicit from
+    /// member tabs' positions, so no explicit ordering is persisted.
+    pub tab_groups: Vec<TabGroupSnapshot>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TabGroupSnapshot {
+    pub id: TabGroupId,
+    pub name: Option<String>,
+    pub collapsed: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -66,6 +77,8 @@ pub struct TabSnapshot {
     pub selected_color: SelectedTabColor,
     pub left_panel: Option<LeftPanelSnapshot>,
     pub right_panel: Option<RightPanelSnapshot>,
+    /// Tab group this tab belongs to, if any.
+    pub group_id: Option<TabGroupId>,
 }
 
 impl TabSnapshot {

--- a/app/src/app_state.rs
+++ b/app/src/app_state.rs
@@ -66,6 +66,7 @@ pub struct WindowSnapshot {
 pub struct TabGroupSnapshot {
     pub id: TabGroupId,
     pub name: Option<String>,
+    pub color: SelectedTabColor,
     pub collapsed: bool,
 }
 

--- a/app/src/launch_configs/launch_config_tests.rs
+++ b/app/src/launch_configs/launch_config_tests.rs
@@ -18,6 +18,7 @@ fn single_tab_snapshot(root: PaneNodeSnapshot) -> AppState {
                 root,
                 left_panel: None,
                 right_panel: None,
+                group_id: None,
             }],
             active_tab_index: 0,
             bounds: None,
@@ -32,6 +33,7 @@ fn single_tab_snapshot(root: PaneNodeSnapshot) -> AppState {
             left_panel_width: None,
             right_panel_width: None,
             agent_management_filters: None,
+            tab_groups: vec![],
         }],
         active_window_index: Some(0),
         block_lists: Default::default(),
@@ -56,6 +58,7 @@ fn multi_tab_snapshot(active_tab_index: usize, tabs: Vec<TabSnapshot>) -> AppSta
             left_panel_width: None,
             right_panel_width: None,
             agent_management_filters: None,
+            tab_groups: vec![],
         }],
         active_window_index: Some(0),
         block_lists: Default::default(),
@@ -254,7 +257,8 @@ fn test_config_with_active_tab_index() {
                     )],
                 }),
                 left_panel: None,
-                right_panel: None
+                right_panel: None,
+                group_id: None,
             };
             3
         ],
@@ -289,6 +293,7 @@ fn test_config_with_active_tab_index_and_filtered_tabs() {
                 }),
                 left_panel: None,
                 right_panel: None,
+                group_id: None,
             },
             TabSnapshot {
                 custom_title: None,
@@ -318,6 +323,7 @@ fn test_config_with_active_tab_index_and_filtered_tabs() {
                 }),
                 left_panel: None,
                 right_panel: None,
+                group_id: None,
             },
         ],
     );
@@ -359,6 +365,7 @@ fn test_config_with_active_tab_being_filtered() {
                 }),
                 left_panel: None,
                 right_panel: None,
+                group_id: None,
             },
             TabSnapshot {
                 custom_title: None,
@@ -380,6 +387,7 @@ fn test_config_with_active_tab_being_filtered() {
                 }),
                 left_panel: None,
                 right_panel: None,
+                group_id: None,
             },
         ],
     );

--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -942,6 +942,10 @@ fn save_app_state(conn: &mut SqliteConnection, app_state: &AppState) -> Result<(
                     .map(|group| NewTabGroup {
                         window_id,
                         name: group.name.clone(),
+                        color: match group.color {
+                            SelectedTabColor::Unset => None,
+                            _ => serde_yaml::to_string(&group.color).ok(),
+                        },
                         collapsed: group.collapsed,
                     })
                     .collect();
@@ -2458,151 +2462,160 @@ fn read_sqlite_data(
         .enumerate()
         .zip(db_tabs)
         .zip(db_tab_groups)
-        .map(|(((idx, window), tabs_for_window), tab_groups_for_window)| {
-            // Mint a fresh `TabGroupId` per row and build a `row id -> TabGroupId`
-            // map so tabs can be reattached to their group below.
-            let mut tab_group_id_by_row_id: HashMap<i32, TabGroupId> = HashMap::new();
-            let mut tab_groups_snapshots: Vec<TabGroupSnapshot> = Vec::new();
-            for group in tab_groups_for_window {
-                let tab_group_id = TabGroupId::new();
-                tab_group_id_by_row_id.insert(group.id, tab_group_id);
-                tab_groups_snapshots.push(TabGroupSnapshot {
-                    id: tab_group_id,
-                    name: group.name,
-                    collapsed: group.collapsed,
-                });
-            }
-            let saved_tabs: Vec<_> = tabs_for_window
-                .into_iter()
-                .filter_map(|tab| {
-                    let root = read_root_node(conn, tab.id).ok()?;
-                    let panel = db_panels.get(&tab.id);
-
-                    let left_panel = panel
-                        .and_then(|p| p.left_panel.as_ref())
-                        .and_then(|s| serde_json::from_str::<LeftPanelSnapshot>(s).ok());
-
-                    let right_panel = panel
-                        .and_then(|p| p.right_panel.as_ref())
-                        .and_then(|s| serde_json::from_str::<RightPanelSnapshot>(s).ok());
-
-                    let group_id = tab
-                        .tab_group_id
-                        .and_then(|row_id| tab_group_id_by_row_id.get(&row_id).copied());
-                    Some(TabSnapshot {
-                        root,
-                        custom_title: tab.custom_title,
-                        default_directory_color: None,
-                        selected_color: tab
-                            .color
-                            .as_deref()
-                            .and_then(|s| {
-                                serde_yaml::from_str::<SelectedTabColor>(s)
-                                    .ok()
-                                    .or_else(|| {
-                                        // Fall back to the old format which stored a bare AnsiColorIdentifier
-                                        serde_yaml::from_str::<AnsiColorIdentifier>(s)
-                                            .ok()
-                                            .map(SelectedTabColor::Color)
-                                    })
-                            })
-                            .unwrap_or_default(),
-                        left_panel,
-                        right_panel,
-                        group_id,
-                    })
-                })
-                .collect();
-
-            if active_window_id
-                .map(|window_id| window.id == window_id)
-                .unwrap_or(false)
-            {
-                active_window_index = Some(idx);
-            }
-
-            // Default active tab index to 0 if we overflow when converting.
-            let tab_index: usize = window.active_tab_index.try_into().unwrap_or(0);
-
-            let fullscreen_state_val =
-                FullscreenState::from_i32(window.fullscreen_state).unwrap_or_default();
-
-            // The origin and size of the bound should be all null or all non-null.
-            // Reject bounds smaller than the platform minimum window size so users
-            // with an already-corrupted warp.sqlite (see GH#10083) restore to
-            // default geometry instead of a sliver.
-            let bounds = match (
-                window.window_width,
-                window.window_height,
-                window.origin_x,
-                window.origin_y,
-            ) {
-                (Some(mut width), Some(mut height), Some(x), Some(y))
-                    if width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT =>
-                {
-                    // When fullscreen or maximized, the `inner_size` we snapshotted will be the
-                    // size of the full screen. This will cause problems with winit. When you set
-                    // maximized/fullscreen, setting the inner_size will by the size the window
-                    // takes _after_ the user toggles _out_ of fullscreen/maximized. Therefore, we
-                    // don't want to set the size to take the full screen because the window will
-                    // appear to remain in maximized/fullscreen. We multiply each dimension by 0.8
-                    // to prevent taking the full screen while choosing a reasonable size.
-                    if !cfg!(target_os = "macos") && fullscreen_state_val != FullscreenState::Normal
-                    {
-                        width *= 0.8;
-                        height *= 0.8;
-                    }
-                    Some(RectF::new(
-                        Vector2F::new(x, y),
-                        Vector2F::new(width, height),
-                    ))
-                }
-                _ => None,
-            };
-
-            let left_panel_width: Option<f32> = saved_tabs.get(tab_index).and_then(|tab| match tab
-                .left_panel
-                .as_ref()
-            {
-                Some(LeftPanelSnapshot { width, .. }) => Some(*width as f32),
-                _ => None,
-            });
-
-            let right_panel_width: Option<f32> =
-                saved_tabs
-                    .get(tab_index)
-                    .and_then(|tab| match tab.right_panel.as_ref() {
-                        Some(RightPanelSnapshot { width, .. }) => Some(*width as f32),
-                        _ => None,
+        .map(
+            |(((idx, window), tabs_for_window), tab_groups_for_window)| {
+                // Mint a fresh `TabGroupId` per row and build a `row id -> TabGroupId`
+                // map so tabs can be reattached to their group below.
+                let mut tab_group_id_by_row_id: HashMap<i32, TabGroupId> = HashMap::new();
+                let mut tab_groups_snapshots: Vec<TabGroupSnapshot> = Vec::new();
+                for group in tab_groups_for_window {
+                    let tab_group_id = TabGroupId::new();
+                    tab_group_id_by_row_id.insert(group.id, tab_group_id);
+                    let color = group
+                        .color
+                        .as_deref()
+                        .and_then(|s| serde_yaml::from_str::<SelectedTabColor>(s).ok())
+                        .unwrap_or_default();
+                    tab_groups_snapshots.push(TabGroupSnapshot {
+                        id: tab_group_id,
+                        name: group.name,
+                        color,
+                        collapsed: group.collapsed,
                     });
+                }
+                let saved_tabs: Vec<_> = tabs_for_window
+                    .into_iter()
+                    .filter_map(|tab| {
+                        let root = read_root_node(conn, tab.id).ok()?;
+                        let panel = db_panels.get(&tab.id);
 
-            let window_left_panel_open = window.left_panel_open.unwrap_or_else(|| {
-                saved_tabs
-                    .get(tab_index)
-                    .and_then(|tab| tab.left_panel.as_ref())
-                    .is_some()
-            });
+                        let left_panel = panel
+                            .and_then(|p| p.left_panel.as_ref())
+                            .and_then(|s| serde_json::from_str::<LeftPanelSnapshot>(s).ok());
 
-            WindowSnapshot {
-                tabs: saved_tabs,
-                active_tab_index: tab_index,
-                quake_mode: window.quake_mode,
-                bounds,
-                universal_search_width: window.universal_search_width,
-                warp_ai_width: window.warp_ai_width,
-                voltron_width: window.voltron_width,
-                warp_drive_index_width: window.warp_drive_index_width,
-                left_panel_open: window_left_panel_open,
-                vertical_tabs_panel_open: window.vertical_tabs_panel_open.unwrap_or(false),
-                fullscreen_state: fullscreen_state_val,
-                left_panel_width,
-                right_panel_width,
-                agent_management_filters: window
-                    .agent_management_filters
-                    .and_then(|s| serde_json::from_str(&s).ok()),
-                tab_groups: tab_groups_snapshots,
-            }
-        })
+                        let right_panel = panel
+                            .and_then(|p| p.right_panel.as_ref())
+                            .and_then(|s| serde_json::from_str::<RightPanelSnapshot>(s).ok());
+
+                        let group_id = tab
+                            .tab_group_id
+                            .and_then(|row_id| tab_group_id_by_row_id.get(&row_id).copied());
+                        Some(TabSnapshot {
+                            root,
+                            custom_title: tab.custom_title,
+                            default_directory_color: None,
+                            selected_color: tab
+                                .color
+                                .as_deref()
+                                .and_then(|s| {
+                                    serde_yaml::from_str::<SelectedTabColor>(s)
+                                        .ok()
+                                        .or_else(|| {
+                                            // Fall back to the old format which stored a bare AnsiColorIdentifier
+                                            serde_yaml::from_str::<AnsiColorIdentifier>(s)
+                                                .ok()
+                                                .map(SelectedTabColor::Color)
+                                        })
+                                })
+                                .unwrap_or_default(),
+                            left_panel,
+                            right_panel,
+                            group_id,
+                        })
+                    })
+                    .collect();
+
+                if active_window_id
+                    .map(|window_id| window.id == window_id)
+                    .unwrap_or(false)
+                {
+                    active_window_index = Some(idx);
+                }
+
+                // Default active tab index to 0 if we overflow when converting.
+                let tab_index: usize = window.active_tab_index.try_into().unwrap_or(0);
+
+                let fullscreen_state_val =
+                    FullscreenState::from_i32(window.fullscreen_state).unwrap_or_default();
+
+                // The origin and size of the bound should be all null or all non-null.
+                // Reject bounds smaller than the platform minimum window size so users
+                // with an already-corrupted warp.sqlite (see GH#10083) restore to
+                // default geometry instead of a sliver.
+                let bounds = match (
+                    window.window_width,
+                    window.window_height,
+                    window.origin_x,
+                    window.origin_y,
+                ) {
+                    (Some(mut width), Some(mut height), Some(x), Some(y))
+                        if width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT =>
+                    {
+                        // When fullscreen or maximized, the `inner_size` we snapshotted will be the
+                        // size of the full screen. This will cause problems with winit. When you set
+                        // maximized/fullscreen, setting the inner_size will by the size the window
+                        // takes _after_ the user toggles _out_ of fullscreen/maximized. Therefore, we
+                        // don't want to set the size to take the full screen because the window will
+                        // appear to remain in maximized/fullscreen. We multiply each dimension by 0.8
+                        // to prevent taking the full screen while choosing a reasonable size.
+                        if !cfg!(target_os = "macos")
+                            && fullscreen_state_val != FullscreenState::Normal
+                        {
+                            width *= 0.8;
+                            height *= 0.8;
+                        }
+                        Some(RectF::new(
+                            Vector2F::new(x, y),
+                            Vector2F::new(width, height),
+                        ))
+                    }
+                    _ => None,
+                };
+
+                let left_panel_width: Option<f32> =
+                    saved_tabs
+                        .get(tab_index)
+                        .and_then(|tab| match tab.left_panel.as_ref() {
+                            Some(LeftPanelSnapshot { width, .. }) => Some(*width as f32),
+                            _ => None,
+                        });
+
+                let right_panel_width: Option<f32> =
+                    saved_tabs
+                        .get(tab_index)
+                        .and_then(|tab| match tab.right_panel.as_ref() {
+                            Some(RightPanelSnapshot { width, .. }) => Some(*width as f32),
+                            _ => None,
+                        });
+
+                let window_left_panel_open = window.left_panel_open.unwrap_or_else(|| {
+                    saved_tabs
+                        .get(tab_index)
+                        .and_then(|tab| tab.left_panel.as_ref())
+                        .is_some()
+                });
+
+                WindowSnapshot {
+                    tabs: saved_tabs,
+                    active_tab_index: tab_index,
+                    quake_mode: window.quake_mode,
+                    bounds,
+                    universal_search_width: window.universal_search_width,
+                    warp_ai_width: window.warp_ai_width,
+                    voltron_width: window.voltron_width,
+                    warp_drive_index_width: window.warp_drive_index_width,
+                    left_panel_open: window_left_panel_open,
+                    vertical_tabs_panel_open: window.vertical_tabs_panel_open.unwrap_or(false),
+                    fullscreen_state: fullscreen_state_val,
+                    left_panel_width,
+                    right_panel_width,
+                    agent_management_filters: window
+                        .agent_management_filters
+                        .and_then(|s| serde_json::from_str(&s).ok()),
+                    tab_groups: tab_groups_snapshots,
+                }
+            },
+        )
         .collect();
 
     let read_context = load_cloud_object_read_context(conn, current_user_id)?;

--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -53,8 +53,8 @@ use super::block_list::{
 };
 use super::model::{
     self, ActiveMCPServer, CurrentUserInformation, MCPEnvironmentVariables, NewActiveMCPServer,
-    NewApp, NewCommand, NewServerExperiment, NewTab, NewTeam, NewWindow, NewWorkspace,
-    NewWorkspaceMetadata, NewWorkspaceTeam, Project, Tab, Window,
+    NewApp, NewCommand, NewServerExperiment, NewTab, NewTabGroup, NewTeam, NewWindow, NewWorkspace,
+    NewWorkspaceMetadata, NewWorkspaceTeam, Project, Tab, TabGroup, Window,
     WorkspaceMetadata as WorkspaceMetadataModel, AI_DOCUMENT_PANE_KIND, AI_FACT_PANE_KIND,
     CODE_PANE_KIND, ENV_VAR_COLLECTION_PANE_KIND, EXECUTION_PROFILE_EDITOR_PANE_KIND,
     MCP_SERVER_PANE_KIND, NOTEBOOK_PANE_KIND, SETTINGS_PANE_KIND, TERMINAL_PANE_KIND,
@@ -73,8 +73,8 @@ use crate::app_state::{
     AIFactPaneSnapshot, AmbientAgentPaneSnapshot, AppState, BranchSnapshot, CodePaneSnapShot,
     CodePaneTabSnapshot, CodeReviewPaneSnapshot, EnvVarCollectionPaneSnapshot, LeafContents,
     LeafSnapshot, LeftPanelSnapshot, NotebookPaneSnapshot, PaneFlex, PaneNodeSnapshot,
-    RightPanelSnapshot, SettingsPaneSnapshot, SplitDirection, TabSnapshot, TerminalPaneSnapshot,
-    WindowSnapshot, WorkflowPaneSnapshot,
+    RightPanelSnapshot, SettingsPaneSnapshot, SplitDirection, TabGroupSnapshot, TabSnapshot,
+    TerminalPaneSnapshot, WindowSnapshot, WorkflowPaneSnapshot,
 };
 use crate::auth::auth_manager::PersistedCurrentUserInformation;
 use crate::auth::auth_state::AuthStateProvider;
@@ -103,6 +103,7 @@ use crate::terminal::history::PersistedCommand;
 use crate::terminal::ShellLaunchData;
 use crate::themes::theme::AnsiColorIdentifier;
 use crate::workflows::WorkflowId;
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspaces::team::Team as TeamMetadata;
 use crate::workspaces::user_profiles::{user_profile_from_persistence, UserProfileWithUID};
 use crate::workspaces::workspace::{Workspace as WorkspaceMetadata, WorkspaceUid};
@@ -861,6 +862,7 @@ fn save_app_state(conn: &mut SqliteConnection, app_state: &AppState) -> Result<(
         diesel::delete(schema::pane_branches::dsl::pane_branches).execute(conn)?;
         diesel::delete(schema::pane_nodes::dsl::pane_nodes).execute(conn)?;
         diesel::delete(schema::tabs::dsl::tabs).execute(conn)?;
+        diesel::delete(schema::tab_groups::dsl::tab_groups).execute(conn)?;
         diesel::delete(schema::windows::dsl::windows).execute(conn)?;
         diesel::delete(schema::active_mcp_servers::dsl::active_mcp_servers).execute(conn)?;
         diesel::delete(schema::panels::dsl::panels).execute(conn)?;
@@ -930,6 +932,35 @@ fn save_app_state(conn: &mut SqliteConnection, app_state: &AppState) -> Result<(
                 active_window_id = Some(window_id)
             }
 
+            // Insert tab groups first so we can map each `TabGroupId` to a
+            // DB row id when inserting the tabs below.
+            let mut tab_group_row_ids: HashMap<TabGroupId, i32> = HashMap::new();
+            if !window.tab_groups.is_empty() {
+                let new_tab_groups: Vec<NewTabGroup> = window
+                    .tab_groups
+                    .iter()
+                    .map(|group| NewTabGroup {
+                        window_id,
+                        name: group.name.clone(),
+                        collapsed: group.collapsed,
+                    })
+                    .collect();
+                diesel::insert_into(schema::tab_groups::dsl::tab_groups)
+                    .values(new_tab_groups)
+                    .execute(conn)?;
+
+                // SQLite assigns ids in insertion order, so the inserted rows
+                // share the order of `window.tab_groups`.
+                let inserted_ids: Vec<i32> = schema::tab_groups::dsl::tab_groups
+                    .filter(schema::tab_groups::columns::window_id.eq(window_id))
+                    .select(schema::tab_groups::columns::id)
+                    .order(schema::tab_groups::columns::id.asc())
+                    .load(conn)?;
+                for (group, row_id) in window.tab_groups.iter().zip(inserted_ids.iter()) {
+                    tab_group_row_ids.insert(group.id, *row_id);
+                }
+            }
+
             let tabs: Vec<NewTab> = window
                 .tabs
                 .iter()
@@ -943,6 +974,9 @@ fn save_app_state(conn: &mut SqliteConnection, app_state: &AppState) -> Result<(
                         SelectedTabColor::Unset => None,
                         _ => serde_yaml::to_string(&tab.selected_color).ok(),
                     },
+                    tab_group_id: tab
+                        .group_id
+                        .and_then(|group_id| tab_group_row_ids.get(&group_id).copied()),
                 })
                 .collect();
 
@@ -2412,11 +2446,32 @@ fn read_sqlite_data(
         .map(|p| (p.tab_id, p))
         .collect::<HashMap<_, _>>();
 
+    // Load tab groups grouped per window so we can resolve `tabs.tab_group_id`
+    // through a per-window row-id lookup.
+    let db_tab_groups = TabGroup::belonging_to(&db_windows)
+        .order_by(schema::tab_groups::columns::id.asc())
+        .load::<TabGroup>(conn)?
+        .grouped_by(&db_windows);
+
     let saved_windows: Vec<_> = db_windows
         .into_iter()
         .enumerate()
         .zip(db_tabs)
-        .map(|((idx, window), tabs_for_window)| {
+        .zip(db_tab_groups)
+        .map(|(((idx, window), tabs_for_window), tab_groups_for_window)| {
+            // Mint a fresh `TabGroupId` per row and build a `row id -> TabGroupId`
+            // map so tabs can be reattached to their group below.
+            let mut tab_group_id_by_row_id: HashMap<i32, TabGroupId> = HashMap::new();
+            let mut tab_groups_snapshots: Vec<TabGroupSnapshot> = Vec::new();
+            for group in tab_groups_for_window {
+                let tab_group_id = TabGroupId::new();
+                tab_group_id_by_row_id.insert(group.id, tab_group_id);
+                tab_groups_snapshots.push(TabGroupSnapshot {
+                    id: tab_group_id,
+                    name: group.name,
+                    collapsed: group.collapsed,
+                });
+            }
             let saved_tabs: Vec<_> = tabs_for_window
                 .into_iter()
                 .filter_map(|tab| {
@@ -2431,6 +2486,9 @@ fn read_sqlite_data(
                         .and_then(|p| p.right_panel.as_ref())
                         .and_then(|s| serde_json::from_str::<RightPanelSnapshot>(s).ok());
 
+                    let group_id = tab
+                        .tab_group_id
+                        .and_then(|row_id| tab_group_id_by_row_id.get(&row_id).copied());
                     Some(TabSnapshot {
                         root,
                         custom_title: tab.custom_title,
@@ -2451,6 +2509,7 @@ fn read_sqlite_data(
                             .unwrap_or_default(),
                         left_panel,
                         right_panel,
+                        group_id,
                     })
                 })
                 .collect();
@@ -2541,6 +2600,7 @@ fn read_sqlite_data(
                 agent_management_filters: window
                     .agent_management_filters
                     .and_then(|s| serde_json::from_str(&s).ok()),
+                tab_groups: tab_groups_snapshots,
             }
         })
         .collect();

--- a/app/src/persistence/sqlite_tests.rs
+++ b/app/src/persistence/sqlite_tests.rs
@@ -28,6 +28,7 @@ use crate::server::ids::ClientId;
 use crate::tab::SelectedTabColor;
 use crate::terminal::model::block::SerializedBlock;
 use crate::terminal::ShellLaunchData;
+use crate::themes::theme::AnsiColorIdentifier;
 use crate::workspace::tab_group::TabGroupId;
 
 #[test]
@@ -575,6 +576,7 @@ fn test_sqlite_round_trips_tab_groups() {
             tab_groups: vec![TabGroupSnapshot {
                 id: group_id,
                 name: Some("Backend".to_string()),
+                color: SelectedTabColor::Color(AnsiColorIdentifier::Blue),
                 collapsed: true,
             }],
         }],
@@ -594,6 +596,10 @@ fn test_sqlite_round_trips_tab_groups() {
     assert_eq!(restored_window.tab_groups.len(), 1);
     let restored_group = &restored_window.tab_groups[0];
     assert_eq!(restored_group.name.as_deref(), Some("Backend"));
+    assert_eq!(
+        restored_group.color,
+        SelectedTabColor::Color(AnsiColorIdentifier::Blue)
+    );
     assert!(restored_group.collapsed);
 
     // The in-memory `TabGroupId` is minted fresh on restore, so we check that

--- a/app/src/persistence/sqlite_tests.rs
+++ b/app/src/persistence/sqlite_tests.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::app_state::{
     AppState, CodePaneSnapShot, CodePaneTabSnapshot, LeafContents, LeafSnapshot, PaneNodeSnapshot,
-    TabSnapshot, TerminalPaneSnapshot, WindowSnapshot,
+    TabGroupSnapshot, TabSnapshot, TerminalPaneSnapshot, WindowSnapshot,
 };
 use crate::cloud_object::{CloudObjectPermissions, Owner};
 use crate::code::editor_management::CodeSource;
@@ -28,6 +28,7 @@ use crate::server::ids::ClientId;
 use crate::tab::SelectedTabColor;
 use crate::terminal::model::block::SerializedBlock;
 use crate::terminal::ShellLaunchData;
+use crate::workspace::tab_group::TabGroupId;
 
 #[test]
 fn app_scope_database_path_matches_app_database_path() {
@@ -280,6 +281,7 @@ fn test_terminal_window_snapshot(vertical_tabs_panel_open: bool) -> WindowSnapsh
             selected_color: SelectedTabColor::default(),
             left_panel: None,
             right_panel: None,
+            group_id: None,
         }],
         active_tab_index: 0,
         bounds: None,
@@ -294,6 +296,7 @@ fn test_terminal_window_snapshot(vertical_tabs_panel_open: bool) -> WindowSnapsh
         left_panel_width: None,
         right_panel_width: None,
         agent_management_filters: None,
+        tab_groups: vec![],
     }
 }
 
@@ -363,6 +366,7 @@ fn test_sqlite_round_trips_custom_vertical_tabs_title() {
                 selected_color: SelectedTabColor::default(),
                 left_panel: None,
                 right_panel: None,
+                group_id: None,
             }],
             active_tab_index: 0,
             bounds: None,
@@ -377,6 +381,7 @@ fn test_sqlite_round_trips_custom_vertical_tabs_title() {
             left_panel_width: None,
             right_panel_width: None,
             agent_management_filters: None,
+            tab_groups: vec![],
         }],
         active_window_index: Some(0),
         block_lists: Default::default(),
@@ -437,6 +442,7 @@ fn test_sqlite_round_trips_code_pane_with_multiple_tabs() {
                 selected_color: SelectedTabColor::default(),
                 left_panel: None,
                 right_panel: None,
+                group_id: None,
             }],
             active_tab_index: 0,
             bounds: None,
@@ -451,6 +457,7 @@ fn test_sqlite_round_trips_code_pane_with_multiple_tabs() {
             left_panel_width: None,
             right_panel_width: None,
             agent_management_filters: None,
+            tab_groups: vec![],
         }],
         active_window_index: Some(0),
         block_lists: Default::default(),
@@ -484,6 +491,117 @@ fn test_sqlite_round_trips_code_pane_with_multiple_tabs() {
     assert_eq!(tabs[1].path, Some(PathBuf::from("/tmp/lib.rs")));
     assert_eq!(tabs[2].path, None);
     assert!(matches!(source, Some(CodeSource::FileTree { .. })));
+}
+
+/// Verifies that a tab group and its membership round-trip through save/restore.
+#[test]
+fn test_sqlite_round_trips_tab_groups() {
+    let tempdir = tempfile::tempdir().expect("tempdir should be created");
+    let database_path = tempdir.path().join("warp.sqlite");
+    let mut conn = setup_database(&database_path).expect("database should initialize");
+
+    let group_id = TabGroupId::new();
+    let tab_in_group = TabSnapshot {
+        custom_title: None,
+        root: PaneNodeSnapshot::Leaf(LeafSnapshot {
+            is_focused: true,
+            custom_vertical_tabs_title: None,
+            contents: LeafContents::Terminal(TerminalPaneSnapshot {
+                uuid: vec![1],
+                cwd: Some("/tmp/grouped".to_string()),
+                shell_launch_data: Some(ShellLaunchData::Executable {
+                    executable_path: PathBuf::from("/bin/zsh"),
+                    shell_type: crate::terminal::shell::ShellType::Zsh,
+                }),
+                is_active: true,
+                is_read_only: false,
+                input_config: None,
+                llm_model_override: None,
+                active_profile_id: None,
+                conversation_ids_to_restore: vec![],
+                active_conversation_id: None,
+            }),
+        }),
+        default_directory_color: None,
+        selected_color: SelectedTabColor::default(),
+        left_panel: None,
+        right_panel: None,
+        group_id: Some(group_id),
+    };
+    let tab_outside_group = TabSnapshot {
+        custom_title: None,
+        root: PaneNodeSnapshot::Leaf(LeafSnapshot {
+            is_focused: false,
+            custom_vertical_tabs_title: None,
+            contents: LeafContents::Terminal(TerminalPaneSnapshot {
+                uuid: vec![2],
+                cwd: Some("/tmp/ungrouped".to_string()),
+                shell_launch_data: Some(ShellLaunchData::Executable {
+                    executable_path: PathBuf::from("/bin/zsh"),
+                    shell_type: crate::terminal::shell::ShellType::Zsh,
+                }),
+                is_active: false,
+                is_read_only: false,
+                input_config: None,
+                llm_model_override: None,
+                active_profile_id: None,
+                conversation_ids_to_restore: vec![],
+                active_conversation_id: None,
+            }),
+        }),
+        default_directory_color: None,
+        selected_color: SelectedTabColor::default(),
+        left_panel: None,
+        right_panel: None,
+        group_id: None,
+    };
+
+    let app_state = AppState {
+        windows: vec![WindowSnapshot {
+            tabs: vec![tab_in_group, tab_outside_group],
+            active_tab_index: 0,
+            bounds: None,
+            fullscreen_state: Default::default(),
+            quake_mode: false,
+            universal_search_width: None,
+            warp_ai_width: None,
+            voltron_width: None,
+            warp_drive_index_width: None,
+            left_panel_open: false,
+            vertical_tabs_panel_open: false,
+            left_panel_width: None,
+            right_panel_width: None,
+            agent_management_filters: None,
+            tab_groups: vec![TabGroupSnapshot {
+                id: group_id,
+                name: Some("Backend".to_string()),
+                collapsed: true,
+            }],
+        }],
+        active_window_index: Some(0),
+        block_lists: Default::default(),
+        running_mcp_servers: Default::default(),
+    };
+
+    save_app_state(&mut conn, &app_state).expect("app state should save");
+
+    let restored = read_sqlite_data(&mut conn, None)
+        .expect("app state should load")
+        .app_state;
+
+    assert_eq!(restored.windows.len(), 1);
+    let restored_window = &restored.windows[0];
+    assert_eq!(restored_window.tab_groups.len(), 1);
+    let restored_group = &restored_window.tab_groups[0];
+    assert_eq!(restored_group.name.as_deref(), Some("Backend"));
+    assert!(restored_group.collapsed);
+
+    // The in-memory `TabGroupId` is minted fresh on restore, so we check that
+    // the grouped tab points at the restored group, and the ungrouped tab
+    // remains ungrouped.
+    assert_eq!(restored_window.tabs.len(), 2);
+    assert_eq!(restored_window.tabs[0].group_id, Some(restored_group.id));
+    assert_eq!(restored_window.tabs[1].group_id, None);
 }
 
 fn assert_encode_then_decode_preserves_original_path(original_path: PathBuf) {

--- a/app/src/workspace/tab_group.rs
+++ b/app/src/workspace/tab_group.rs
@@ -3,6 +3,8 @@
 use uuid::Uuid;
 use warpui::elements::DraggableState;
 
+use crate::tab::SelectedTabColor;
+
 /// Stable identity for a tab group.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TabGroupId(pub Uuid);
@@ -25,6 +27,7 @@ impl Default for TabGroupId {
 pub struct TabGroup {
     pub id: TabGroupId,
     pub name: Option<String>,
+    pub color: SelectedTabColor,
     pub collapsed: bool,
     pub draggable_state: DraggableState,
 }
@@ -35,6 +38,7 @@ impl TabGroup {
         Self {
             id: TabGroupId::new(),
             name: None,
+            color: SelectedTabColor::default(),
             collapsed: false,
             draggable_state: Default::default(),
         }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3769,6 +3769,7 @@ impl Workspace {
                                 TabGroup {
                                     id: group_snapshot.id,
                                     name: group_snapshot.name.clone(),
+                                    color: group_snapshot.color,
                                     collapsed: group_snapshot.collapsed,
                                     draggable_state: Default::default(),
                                 },
@@ -11059,6 +11060,7 @@ impl Workspace {
                 .map(|group| TabGroupSnapshot {
                     id: group.id,
                     name: group.name.clone(),
+                    color: group.color,
                     collapsed: group.collapsed,
                 })
                 .collect()

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -211,8 +211,8 @@ use crate::ai_assistant::panel::{AIAssistantPanelEvent, AIAssistantPanelView};
 use crate::ai_assistant::{AskAIType, AI_ASSISTANT_FEATURE_NAME, AI_ASSISTANT_LOGO_COLOR};
 use crate::app_state::{
     LeafContents, LeafSnapshot, LeftPanelDisplayedTab, LeftPanelSnapshot, NotebookPaneSnapshot,
-    PaneNodeSnapshot, PaneUuid, RightPanelSnapshot, SettingsPaneSnapshot, TabSnapshot,
-    TerminalPaneSnapshot, WindowSnapshot, WorkflowPaneSnapshot,
+    PaneNodeSnapshot, PaneUuid, RightPanelSnapshot, SettingsPaneSnapshot, TabGroupSnapshot,
+    TabSnapshot, TerminalPaneSnapshot, WindowSnapshot, WorkflowPaneSnapshot,
 };
 use crate::appearance::{Appearance, AppearanceManager};
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
@@ -3757,6 +3757,26 @@ impl Workspace {
                 let active_tab_index = window_snapshot.active_tab_index;
                 let restored_left_panel_open = window_snapshot.left_panel_open;
 
+                // Restore groups first so per-tab `group_id` assignments
+                // below can validate membership against a populated map.
+                if FeatureFlag::GroupedTabs.is_enabled() {
+                    self.tab_groups = window_snapshot
+                        .tab_groups
+                        .iter()
+                        .map(|group_snapshot| {
+                            (
+                                group_snapshot.id,
+                                TabGroup {
+                                    id: group_snapshot.id,
+                                    name: group_snapshot.name.clone(),
+                                    collapsed: group_snapshot.collapsed,
+                                    draggable_state: Default::default(),
+                                },
+                            )
+                        })
+                        .collect();
+                }
+
                 window_snapshot
                     .tabs
                     .iter()
@@ -3772,6 +3792,10 @@ impl Workspace {
                         self.tabs[tab_index].default_directory_color =
                             saved_tab.default_directory_color;
                         self.tabs[tab_index].selected_color = saved_tab.selected_color;
+                        // Drop the group reference if the group itself didn't restore.
+                        self.tabs[tab_index].group_id = saved_tab
+                            .group_id
+                            .filter(|group_id| self.tab_groups.contains_key(group_id));
 
                         let pane_group = self.tabs[tab_index].pane_group.clone();
 
@@ -6821,6 +6845,7 @@ impl Workspace {
         let indices: Vec<usize> = group_member_indices(&self.tabs, group_id).collect();
         if indices.is_empty() {
             self.tab_groups.remove(&group_id);
+            ctx.dispatch_global_action("workspace:save_app", ());
             ctx.notify();
             return;
         }
@@ -6848,6 +6873,7 @@ impl Workspace {
     ) {
         if let Some(group) = self.tab_groups.get_mut(&group_id) {
             group.collapsed = !group.collapsed;
+            ctx.dispatch_global_action("workspace:save_app", ());
             ctx.notify();
         }
     }
@@ -6986,6 +7012,7 @@ impl Workspace {
             }
         }
         self.tab_groups.remove(&group_id);
+        ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
     }
 
@@ -10957,7 +10984,7 @@ impl Workspace {
         } else {
             None
         };
-        let tabs = self
+        let tabs: Vec<TabSnapshot> = self
             .tab_views()
             .enumerate()
             .filter(|(tab_index, _)| Some(*tab_index) != transferred_tab_index)
@@ -10999,6 +11026,11 @@ impl Workspace {
                         .unwrap_or_default(),
                     left_panel,
                     right_panel,
+                    group_id: if FeatureFlag::GroupedTabs.is_enabled() {
+                        self.tabs.get(tab_index).and_then(|tab| tab.group_id)
+                    } else {
+                        None
+                    },
                 }
             })
             .filter(|tab| {
@@ -11015,6 +11047,24 @@ impl Workspace {
                 )
             })
             .collect();
+
+        // Skip orphan groups whose members were all filtered out above.
+        // This is a safety net and ensures empty groups are not saved/restored.
+        let tab_groups: Vec<TabGroupSnapshot> = if FeatureFlag::GroupedTabs.is_enabled() {
+            let referenced_group_ids: HashSet<TabGroupId> =
+                tabs.iter().filter_map(|tab| tab.group_id).collect();
+            self.tab_groups
+                .values()
+                .filter(|group| referenced_group_ids.contains(&group.id))
+                .map(|group| TabGroupSnapshot {
+                    id: group.id,
+                    name: group.name.clone(),
+                    collapsed: group.collapsed,
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         let resizable_data = ResizableData::handle(app);
         let modal_sizes = resizable_data.as_ref(app).get_all_handles(window_id);
@@ -11082,6 +11132,7 @@ impl Workspace {
             left_panel_width,
             right_panel_width,
             agent_management_filters,
+            tab_groups,
         }
     }
 

--- a/crates/persistence/build.rs
+++ b/crates/persistence/build.rs
@@ -5,11 +5,5 @@ fn main() -> Result<(), std::env::VarError> {
         println!("cargo:rustc-cfg=feature=\"local_fs\"");
     }
 
-    // `embed_migrations!` bakes the migration SQL into the binary at compile
-    // time. Tell cargo to rebuild this crate whenever any migration file
-    // changes, so editing SQL during development doesn't leave a stale,
-    // cached binary behind.
-    println!("cargo:rerun-if-changed=migrations");
-
     Ok(())
 }

--- a/crates/persistence/build.rs
+++ b/crates/persistence/build.rs
@@ -5,5 +5,11 @@ fn main() -> Result<(), std::env::VarError> {
         println!("cargo:rustc-cfg=feature=\"local_fs\"");
     }
 
+    // `embed_migrations!` bakes the migration SQL into the binary at compile
+    // time. Tell cargo to rebuild this crate whenever any migration file
+    // changes, so editing SQL during development doesn't leave a stale,
+    // cached binary behind.
+    println!("cargo:rerun-if-changed=migrations");
+
     Ok(())
 }

--- a/crates/persistence/migrations/2026-06-01-000000_add_tab_groups/down.sql
+++ b/crates/persistence/migrations/2026-06-01-000000_add_tab_groups/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tabs DROP COLUMN tab_group_id;
+DROP TABLE tab_groups;

--- a/crates/persistence/migrations/2026-06-01-000000_add_tab_groups/up.sql
+++ b/crates/persistence/migrations/2026-06-01-000000_add_tab_groups/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE tab_groups (
+  id INTEGER PRIMARY KEY NOT NULL,
+  window_id INTEGER NOT NULL,
+  name TEXT,
+  collapsed BOOLEAN NOT NULL,
+  FOREIGN KEY(window_id) REFERENCES windows(id)
+);
+
+ALTER TABLE tabs ADD COLUMN tab_group_id INTEGER REFERENCES tab_groups(id);

--- a/crates/persistence/migrations/2026-06-01-000000_add_tab_groups/up.sql
+++ b/crates/persistence/migrations/2026-06-01-000000_add_tab_groups/up.sql
@@ -2,6 +2,7 @@ CREATE TABLE tab_groups (
   id INTEGER PRIMARY KEY NOT NULL,
   window_id INTEGER NOT NULL,
   name TEXT,
+  color TEXT,
   collapsed BOOLEAN NOT NULL,
   FOREIGN KEY(window_id) REFERENCES windows(id)
 );

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -370,6 +370,7 @@ pub struct TabGroup {
     pub id: i32,
     pub window_id: i32,
     pub name: Option<String>,
+    pub color: Option<String>,
     pub collapsed: bool,
 }
 
@@ -378,6 +379,7 @@ pub struct TabGroup {
 pub struct NewTabGroup {
     pub window_id: i32,
     pub name: Option<String>,
+    pub color: Option<String>,
     pub collapsed: bool,
 }
 

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -15,9 +15,9 @@ use super::schema::{
     generic_string_objects, ignored_suggestions, mcp_environment_variables,
     mcp_server_installations, mcp_server_panes, notebook_panes, notebooks, object_actions,
     object_metadata, object_permissions, pane_branches, pane_leaves, pane_nodes, panels,
-    project_rules, projects, server_experiments, settings_panes, tabs, team_members, team_settings,
-    teams, terminal_panes, user_profiles, welcome_panes, windows, workflow_panes, workflows,
-    workspace_language_server, workspace_metadata, workspace_teams, workspaces,
+    project_rules, projects, server_experiments, settings_panes, tab_groups, tabs, team_members,
+    team_settings, teams, terminal_panes, user_profiles, welcome_panes, windows, workflow_panes,
+    workflows, workspace_language_server, workspace_metadata, workspace_teams, workspaces,
 };
 
 #[derive(Insertable)]
@@ -349,6 +349,7 @@ pub struct Tab {
     pub window_id: i32,
     pub custom_title: Option<String>,
     pub color: Option<String>,
+    pub tab_group_id: Option<i32>,
 }
 
 #[derive(Insertable)]
@@ -357,6 +358,27 @@ pub struct NewTab {
     pub window_id: i32,
     pub custom_title: Option<String>,
     pub color: Option<String>,
+    pub tab_group_id: Option<i32>,
+}
+
+/// Persisted form of a tab group. `name` is optional — untitled groups omit
+/// it and the UI falls back to a default label.
+#[derive(Identifiable, Queryable, Associations)]
+#[diesel(belongs_to(Window))]
+#[diesel(table_name = tab_groups)]
+pub struct TabGroup {
+    pub id: i32,
+    pub window_id: i32,
+    pub name: Option<String>,
+    pub collapsed: bool,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = tab_groups)]
+pub struct NewTabGroup {
+    pub window_id: i32,
+    pub name: Option<String>,
+    pub collapsed: bool,
 }
 
 /// The panes data model includes pane_nodes, pane_leaves and pane_branches.

--- a/crates/persistence/src/schema.rs
+++ b/crates/persistence/src/schema.rs
@@ -355,11 +355,21 @@ diesel::table! {
 }
 
 diesel::table! {
+    tab_groups (id) {
+        id -> Integer,
+        window_id -> Integer,
+        name -> Nullable<Text>,
+        collapsed -> Bool,
+    }
+}
+
+diesel::table! {
     tabs (id) {
         id -> Integer,
         window_id -> Integer,
         custom_title -> Nullable<Text>,
         color -> Nullable<Text>,
+        tab_group_id -> Nullable<Integer>,
     }
 }
 
@@ -509,6 +519,8 @@ diesel::joinable!(pane_branches -> pane_nodes (pane_node_id));
 diesel::joinable!(pane_leaves -> pane_nodes (pane_node_id));
 diesel::joinable!(pane_nodes -> tabs (tab_id));
 diesel::joinable!(panels -> tabs (tab_id));
+diesel::joinable!(tab_groups -> windows (window_id));
+diesel::joinable!(tabs -> tab_groups (tab_group_id));
 diesel::joinable!(tabs -> windows (window_id));
 diesel::joinable!(team_members -> teams (team_id));
 diesel::joinable!(team_settings -> teams (team_id));
@@ -521,6 +533,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     pane_leaves,
     pane_nodes,
     panels,
+    tab_groups,
     tabs,
     windows,
 );

--- a/crates/persistence/src/schema.rs
+++ b/crates/persistence/src/schema.rs
@@ -359,6 +359,7 @@ diesel::table! {
         id -> Integer,
         window_id -> Integer,
         name -> Nullable<Text>,
+        color -> Nullable<Text>,
         collapsed -> Bool,
     }
 }


### PR DESCRIPTION
## Description
Persists tab groups in the local SQLite session database so they survive an app restart, mirroring the existing behavior for tabs. When you close the app with groups defined — named or unnamed, expanded or collapsed, with any number of member tabs — they come back the same way on next launch, with the same tabs as members and in the same positions.

Also adds a color field to tab groups, replicating tab color styling.

## How it works

A new `tab_groups` table is added alongside the existing tabs table, with one row per group (name, collapsed state, and a reference to the parent window). A nullable `tab_group_id` column is added to tabs so each tab can point at its group, or stay NULL if it's ungrouped. The same three layers used for tabs already (workspace state → snapshot DTO → Diesel model) are extended to carry the new group data through the pipeline.

•  On save: insert the groups first, immediately query back the row ids SQLite assigned (since Diesel can't return them from the insert directly), and build a TabGroupId → row id map. Then when inserting tabs, we look up each tab's in-memory group id in that map and set tab_group_id to the matching row id.
•  On restore: load the groups, mint a fresh `TabGroupId` per row, and build the inverse row id → TabGroupId map. When building each restored tab, we look up its `persisted tab_group_id` row id in that map and populate the tab's in-memory `group_id`.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4637/persist-tab-group-on-app-close

## Testing
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo video](https://www.loom.com/share/1c36609bafe745c0a6868ecfdaa0de10)

Demo of app close and reopen. Tab groups are persisted.