### PR TITLE
Emit ConversationHandoff marker on first post-fork local request

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -993,6 +993,7 @@ codex_plugin = []
 cloud_mode_setup_v2 = ["cloud_mode"]
 cloud_mode_input_v2 = ["cloud_mode"]
 handoff_cloud_cloud = ["cloud_mode_setup_v2"]
+explicit_conversation_handoff = []
 git_credential_refresh = []
 
 [package.metadata.bundle.bin.warp-oss]

--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -452,6 +452,11 @@ fn convert_input_to_user_input(
         AIAgentInput::FetchReviewComments { .. } => Err(ConvertToAPITypeError::Ignore),
         AIAgentInput::CreateEnvironment { .. } => Err(ConvertToAPITypeError::Ignore),
         AIAgentInput::InvokeSkill { .. } => Err(ConvertToAPITypeError::Ignore),
+        AIAgentInput::ConversationHandoff => Ok(
+            api::request::input::user_inputs::user_input::Input::ConversationHandoff(
+                api::request::input::user_inputs::ConversationHandoff {},
+            ),
+        ),
         invalid_input => Err(anyhow!(
             "Cannot convert non user query or action result input into API UserInput: {invalid_input:?}"
         ).into()),

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -6,8 +6,9 @@ use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
 
 use super::convert_to::convert_input;
-use super::{ConvertToAPITypeError, RequestParams, ResponseStream};
+use super::{ConvertToAPITypeError, RequestParams, ResponseStream, ServerConversationToken};
 use crate::ai::agent::redaction;
+use crate::ai::agent::AIAgentInput;
 use crate::server::server_api::ServerApi;
 use crate::terminal::model::session::SessionType;
 
@@ -52,6 +53,12 @@ pub async fn generate_multi_agent_output(
     if params.should_redact_secrets {
         redaction::redact_inputs(&mut params.input);
     }
+
+    maybe_prepend_conversation_handoff(
+        &mut params.input,
+        params.conversation_token.as_ref(),
+        params.forked_from_conversation_token.as_ref(),
+    );
 
     let api_keys = api_keys_with_warp_credit_fallback_setting(
         params.api_keys,
@@ -144,6 +151,38 @@ pub async fn generate_multi_agent_output(
             let _ = tx.send(Err(e)).await;
             Ok(Box::pin(rx))
         }
+    }
+}
+
+/// Prepends a `ConversationHandoff` marker to the first local request after a cloud conversation
+/// is continued locally, so the server unwinds any inherited CLI subagent stack back to PRIMARY
+/// before routing the query. The marker rides in the same `UserInputs` batch as the user query.
+fn maybe_prepend_conversation_handoff(
+    inputs: &mut Vec<AIAgentInput>,
+    conversation_token: Option<&ServerConversationToken>,
+    forked_from_conversation_token: Option<&ServerConversationToken>,
+) {
+    if !FeatureFlag::ExplicitConversationHandoff.is_enabled() {
+        return;
+    }
+
+    // The forked-from token is only carried on the initial post-fork request, before the server
+    // assigns the forked conversation a new token.
+    let is_initial_forked_request =
+        conversation_token.is_none() && forked_from_conversation_token.is_some();
+    let has_normal_user_query = inputs.iter().any(|input| {
+        matches!(
+            input,
+            AIAgentInput::UserQuery {
+                static_query_type: None,
+                running_command: None,
+                ..
+            }
+        )
+    });
+
+    if is_initial_forked_request && has_normal_user_query {
+        inputs.insert(0, AIAgentInput::ConversationHandoff);
     }
 }
 

--- a/app/src/ai/agent/api/impl_tests.rs
+++ b/app/src/ai/agent/api/impl_tests.rs
@@ -1,12 +1,16 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use warp_core::features::FeatureFlag;
 use warp_core::HostId;
 use warp_multi_agent_api as api;
 
 use super::{
-    api_keys_with_warp_credit_fallback_setting, get_supported_cli_agent_tools, get_supported_tools,
-    supports_orchestration_v2,
+    api_keys_with_warp_credit_fallback_setting, convert_input, get_supported_cli_agent_tools,
+    get_supported_tools, maybe_prepend_conversation_handoff, supports_orchestration_v2,
 };
-use crate::ai::agent::api::RequestParams;
+use crate::ai::agent::api::{RequestParams, ServerConversationToken};
+use crate::ai::agent::{AIAgentInput, UserQueryMode};
 use crate::ai::blocklist::SessionContext;
 use crate::ai::llms::LLMId;
 use crate::terminal::model::session::SessionType;
@@ -194,4 +198,69 @@ fn remote_supported_tools_omit_search_codebase_when_remote_is_not_connected() {
 
     assert!(!supported_tools.contains(&api::ToolType::SearchCodebase));
     assert!(!supported_cli_agent_tools.contains(&api::ToolType::SearchCodebase));
+}
+
+fn normal_user_query_input(query: &str) -> AIAgentInput {
+    AIAgentInput::UserQuery {
+        query: query.to_string(),
+        context: Arc::from(Vec::new()),
+        static_query_type: None,
+        referenced_attachments: HashMap::new(),
+        user_query_mode: UserQueryMode::Normal,
+        running_command: None,
+        intended_agent: None,
+    }
+}
+
+#[test]
+fn forked_first_request_prepends_and_converts_conversation_handoff() {
+    let _flag = FeatureFlag::ExplicitConversationHandoff.override_enabled(true);
+    let mut params = request_params_with_ask_user_question_enabled(false);
+    params.forked_from_conversation_token =
+        Some(ServerConversationToken::new("cloud-token".to_string()));
+    params.input = vec![normal_user_query_input("continue here")];
+
+    maybe_prepend_conversation_handoff(
+        &mut params.input,
+        params.conversation_token.as_ref(),
+        params.forked_from_conversation_token.as_ref(),
+    );
+
+    assert_eq!(params.input.len(), 2);
+    assert!(matches!(
+        params.input.first(),
+        Some(AIAgentInput::ConversationHandoff)
+    ));
+
+    let converted = convert_input(params.input).expect("inputs should convert");
+    let Some(api::request::input::Type::UserInputs(user_inputs)) = converted.r#type else {
+        panic!("expected a UserInputs batch");
+    };
+    assert!(matches!(
+        user_inputs.inputs[0].input,
+        Some(api::request::input::user_inputs::user_input::Input::ConversationHandoff(_))
+    ));
+    assert!(matches!(
+        user_inputs.inputs[1].input,
+        Some(api::request::input::user_inputs::user_input::Input::UserQuery(_))
+    ));
+}
+
+#[test]
+fn non_forked_request_does_not_prepend_conversation_handoff() {
+    let _flag = FeatureFlag::ExplicitConversationHandoff.override_enabled(true);
+    let mut params = request_params_with_ask_user_question_enabled(false);
+    params.input = vec![normal_user_query_input("hello")];
+
+    maybe_prepend_conversation_handoff(
+        &mut params.input,
+        params.conversation_token.as_ref(),
+        params.forked_from_conversation_token.as_ref(),
+    );
+
+    assert_eq!(params.input.len(), 1);
+    assert!(matches!(
+        params.input.first(),
+        Some(AIAgentInput::UserQuery { .. })
+    ));
 }

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -2585,6 +2585,11 @@ pub enum AIAgentInput {
         config: OrchestrationConfig,
         status: OrchestrationConfigStatus,
     },
+
+    /// Marker accompanying the first local user query after a cloud conversation
+    /// is continued locally. Signals the server to unwind any inherited CLI
+    /// subagent stack back to PRIMARY before routing the query.
+    ConversationHandoff,
 }
 
 /// Data for a single message received by an agent from another agent.
@@ -2679,6 +2684,7 @@ impl Display for AIAgentInput {
             }
             Self::PassiveSuggestionResult { .. } => write!(f, "PassiveSuggestionResult"),
             Self::OrchestrationConfigUpdate { .. } => write!(f, "OrchestrationConfigUpdate"),
+            Self::ConversationHandoff => write!(f, "ConversationHandoff"),
         }
     }
 }
@@ -2737,7 +2743,8 @@ impl AIAgentInput {
             | Self::MessagesReceivedFromAgents { .. }
             | Self::EventsFromAgents { .. }
             | Self::PassiveSuggestionResult { .. }
-            | Self::OrchestrationConfigUpdate { .. } => None,
+            | Self::OrchestrationConfigUpdate { .. }
+            | Self::ConversationHandoff => None,
         }
     }
 
@@ -2835,7 +2842,8 @@ impl AIAgentInput {
             Self::SummarizeConversation { context, .. } => Some(context),
             Self::MessagesReceivedFromAgents { .. }
             | Self::EventsFromAgents { .. }
-            | Self::OrchestrationConfigUpdate { .. } => None,
+            | Self::OrchestrationConfigUpdate { .. }
+            | Self::ConversationHandoff => None,
         }
     }
 
@@ -2867,7 +2875,8 @@ impl AIAgentInput {
             | Self::MessagesReceivedFromAgents { .. }
             | Self::EventsFromAgents { .. }
             | Self::PassiveSuggestionResult { .. }
-            | Self::OrchestrationConfigUpdate { .. } => None,
+            | Self::OrchestrationConfigUpdate { .. }
+            | Self::ConversationHandoff => None,
         }
     }
 

--- a/app/src/ai/agent/redaction.rs
+++ b/app/src/ai/agent/redaction.rs
@@ -103,10 +103,11 @@ pub(crate) fn redact_inputs(inputs: &mut [AIAgentInput]) {
                     redact_secrets(&mut diff.diff_content);
                 }
             }
-            // No user-provided text to redact in inter-agent relay inputs.
+            // No user-provided text to redact in inter-agent relay inputs or the handoff marker.
             AIAgentInput::MessagesReceivedFromAgents { .. }
             | AIAgentInput::EventsFromAgents { .. }
-            | AIAgentInput::OrchestrationConfigUpdate { .. } => {}
+            | AIAgentInput::OrchestrationConfigUpdate { .. }
+            | AIAgentInput::ConversationHandoff => {}
             AIAgentInput::ActionResult { result, context } => {
                 redact_context(Arc::make_mut(context));
                 match &mut result.result {

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -45,7 +45,8 @@ pub mod text {
             }
             // These input types should not occur in a SDK-run agent.
             AIAgentInput::ResumeConversation { .. }
-            | AIAgentInput::TriggerPassiveSuggestion { .. } => Ok(()),
+            | AIAgentInput::TriggerPassiveSuggestion { .. }
+            | AIAgentInput::ConversationHandoff => Ok(()),
             AIAgentInput::ActionResult { result, .. } => match &result.result {
                 AIAgentActionResultType::RequestCommandOutput(result) => match result {
                     RequestCommandOutputResult::Completed {
@@ -792,7 +793,8 @@ pub mod json {
                 | AIAgentInput::OrchestrationConfigUpdate { .. } => None,
                 // These input types should not occur in a SDK-run agent.
                 AIAgentInput::ResumeConversation { .. }
-                | AIAgentInput::TriggerPassiveSuggestion { .. } => None,
+                | AIAgentInput::TriggerPassiveSuggestion { .. }
+                | AIAgentInput::ConversationHandoff => None,
                 AIAgentInput::ActionResult { result, .. } => {
                     Self::from_action_result(&result.result)
                 }

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1368,7 +1368,8 @@ impl AIAgentInput {
             | AIAgentInput::MessagesReceivedFromAgents { .. }
             | AIAgentInput::EventsFromAgents { .. }
             | AIAgentInput::PassiveSuggestionResult { .. }
-            | AIAgentInput::OrchestrationConfigUpdate { .. } => None,
+            | AIAgentInput::OrchestrationConfigUpdate { .. }
+            | AIAgentInput::ConversationHandoff => None,
         }
     }
 }

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -3491,7 +3491,8 @@ pub(super) fn query_prefix_highlight_len(
             | AIAgentInput::MessagesReceivedFromAgents { .. }
             | AIAgentInput::EventsFromAgents { .. }
             | AIAgentInput::PassiveSuggestionResult { .. }
-            | AIAgentInput::OrchestrationConfigUpdate { .. } => None,
+            | AIAgentInput::OrchestrationConfigUpdate { .. }
+            | AIAgentInput::ConversationHandoff => None,
         }
     }
 }

--- a/app/src/ai/blocklist/persistence.rs
+++ b/app/src/ai/blocklist/persistence.rs
@@ -91,7 +91,8 @@ impl TryFrom<&AIAgentInput> for PersistedAIInputType {
             | AIAgentInput::StartFromAmbientRunPrompt { .. }
             | AIAgentInput::MessagesReceivedFromAgents { .. }
             | AIAgentInput::EventsFromAgents { .. }
-            | AIAgentInput::OrchestrationConfigUpdate { .. } => Err(anyhow::anyhow!(
+            | AIAgentInput::OrchestrationConfigUpdate { .. }
+            | AIAgentInput::ConversationHandoff => Err(anyhow::anyhow!(
                 "This input type is not persisted. Only Query inputs are persisted for up-arrow history."
             )),
         }

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -489,6 +489,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::CloudModeInputV2,
         #[cfg(feature = "handoff_cloud_cloud")]
         FeatureFlag::HandoffCloudCloud,
+        #[cfg(feature = "explicit_conversation_handoff")]
+        FeatureFlag::ExplicitConversationHandoff,
         #[cfg(feature = "git_credential_refresh")]
         FeatureFlag::GitCredentialRefresh,
         #[cfg(feature = "remote_code_review")]

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1028,6 +1028,7 @@ pub enum AIAgentInput {
     EventsFromAgents { event_count: usize },
     PassiveSuggestionResult,
     OrchestrationConfigUpdate,
+    ConversationHandoff,
 }
 
 impl From<FullAIAgentInput> for AIAgentInput {
@@ -1069,6 +1070,7 @@ impl From<FullAIAgentInput> for AIAgentInput {
             },
             FullAIAgentInput::PassiveSuggestionResult { .. } => Self::PassiveSuggestionResult,
             FullAIAgentInput::OrchestrationConfigUpdate { .. } => Self::OrchestrationConfigUpdate,
+            FullAIAgentInput::ConversationHandoff => Self::ConversationHandoff,
         }
     }
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -874,6 +874,12 @@ pub enum FeatureFlag {
 
     /// Gates the Grouped Tabs feature.
     GroupedTabs,
+
+    /// Gates emitting a `ConversationHandoff` marker on the first local request
+    /// after a cloud conversation is continued locally, signalling the server to
+    /// unwind any inherited CLI subagent stack back to PRIMARY. Off until the
+    /// server understands the new input variant.
+    ExplicitConversationHandoff,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -941,6 +947,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::AsyncFind,
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
+    FeatureFlag::ExplicitConversationHandoff,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

### What
Adds client emission of a `ConversationHandoff` marker when a cloud conversation is continued locally. Includes:
- A new `AIAgentInput::ConversationHandoff` variant (+ all exhaustive-match arms: `Display`, `user_query`, `context`, `attachments`, telemetry `From`, redaction, persistence, view_impl, agent_sdk output).
- `convert_to.rs` mapping to `Input::ConversationHandoff`.
- Emission in `generate_multi_agent_output` (`maybe_prepend_conversation_handoff`): prepends the marker to the inputs only when the `ExplicitConversationHandoff` flag is enabled, `conversation_token` is absent, the `forked_from` token is present, and a normal user query is present. This yields a `[ConversationHandoff, UserQuery]` batch → `UserInputs`.
- A new `ExplicitConversationHandoff` feature flag (in `DOGFOOD_FLAGS`; not in stable/release), gating emission so older servers never receive the new variant.

### Why
When a cloud conversation is continued locally while a long-running-command CLI subagent is active, the local fork inherits a CLI agent monitoring a command that only existed on the cloud machine. Sending this marker on the first local request lets the server unwind that inherited subagent stack back to PRIMARY before routing the query, instead of erroring through a `commandNotFound` path.

### How
The marker rides in the same `UserInputs` batch as the user query (alongside, not replacing it). Emission is gated on the same `conversation_token.is_none() && forked_from.is_some()` condition that already controls the one-shot `forked_from_conversation_id` metadata, so it fires exactly once per fork.

## Testing
- [x] `cargo check -p warp --tests --features explicit_conversation_handoff` — pass
- [x] `cargo clippy -p warp --tests --features explicit_conversation_handoff -- -D warnings` and `-p warp_features` — clean
- [x] `cargo fmt -- --check` — clean
- [x] 2 new unit tests in `impl_tests.rs`: forked first request prepends the marker and converts to a `[ConversationHandoff, UserQuery]` `UserInputs` batch; non-forked request does not prepend.
- [ ] Full test binary execution pending — building the full app test binary is impractically slow in this environment. Tests are compiled/type-checked via `cargo check --tests`.

Validated against the proto branch via a local `Cargo.toml` path override (not committed).

## Stacked change / merge order
Depends on warpdotdev/warp-proto-apis#321 (the `ConversationHandoff` proto variant). CI here will be red until that proto PR merges and this repo's `warp_multi_agent_api` git rev is bumped to include it.

Note: the client's currently-pinned proto rev is behind proto `main` by two unrelated commits (background computer use, Google Cloud token). When the proto rev is bumped to the merged ConversationHandoff commit, those new fields must be initialized — a pre-existing drift cleanup, separate from this feature.

## Feature flag
Gated behind `ExplicitConversationHandoff` (dogfood-on, off for stable/release). No changelog entry yet since it is not user-visible on stable.

Co-Authored-By: Oz <oz-agent@warp.dev>