### PR TITLE
Promote owner ancestor event streaming

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -661,6 +661,7 @@ default = [
     "handoff_local_cloud",
     "run_agents_tool",
     "orchestration_viewer_streamer",
+    "owner_orchestration_ancestor_streamer",
     "pending_user_query_indicator",
     "queue_slash_command",
     "queued_prompts_v2",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -944,7 +944,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::AsyncFind,
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
-    FeatureFlag::OwnerOrchestrationAncestorStreamer,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

Promotes `OwnerOrchestrationAncestorStreamer` from Dogfood-only to the default feature set.

The server-side `include_self` ancestor event stream support has landed, and `orchestration_viewer_streamer` is enabled in prod on latest `warp-server` `origin/develop`, so owner-side orchestrator event delivery can now use the parent-family ancestor stream in regular builds.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Related: QUALITY-790.

## Testing

- [x] `./script/format`
- [x] `cargo check -p warp`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
