### PR TITLE
Fix pane spacing and add hover highlighting in tab groups

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -25,14 +25,15 @@ use uuid::Uuid;
 use warp_cli::agent::Harness;
 use warp_core::command::ExitCode;
 use warp_core::context_flag::ContextFlag;
+use warp_core::ui::theme::color::internal_colors;
 use warp_terminal::shell::{ShellName, ShellType};
 use warp_util::path::convert_wsl_to_windows_host_path;
 #[cfg(feature = "local_fs")]
 use warp_util::path::LineAndColumnArg;
 use warp_util::remote_path::RemotePath;
 use warpui::elements::{
-    ChildView, Clipped, CrossAxisAlignment, DispatchEventResult, Element, EventHandler, Flex,
-    MainAxisSize, ParentElement, Shrinkable, Stack,
+    Border, ChildView, Clipped, CrossAxisAlignment, DispatchEventResult, Element, EventHandler,
+    Flex, Hoverable, MainAxisSize, MouseStateHandle, ParentElement, Rect, Shrinkable, Stack,
 };
 use warpui::keymap::{Context, EditableBinding, FixedBinding};
 use warpui::notification::NotificationSendError;
@@ -934,6 +935,15 @@ pub struct PaneGroup {
 
     /// Tab-level custom title set via the rename-tab flow.
     custom_title: Option<String>,
+
+    /// Whether the tab containing this pane group belongs to a tab group.
+    /// Updated by the workspace whenever group membership changes.
+    /// Gated by `FeatureFlag::GroupedTabs`.
+    is_in_tab_group: bool,
+
+    /// Mouse state used to track hover over the entire pane group when it
+    /// belongs to a tab group, so sibling panes highlight together.
+    tab_group_hover_state: MouseStateHandle,
 }
 
 /// Origin metadata for a split-off child agent tab; used to re-adopt the
@@ -3109,6 +3119,8 @@ impl PaneGroup {
             transitively_shared_child_panes: HashMap::new(),
             child_agent_origin: None,
             custom_title: None,
+            is_in_tab_group: false,
+            tab_group_hover_state: Default::default(),
         };
 
         // Notify any restored panes that they belong to this pane group.
@@ -4178,6 +4190,15 @@ impl PaneGroup {
     /// Only considers visible panes (excludes panes hidden for close, move, job, etc.).
     pub fn pane_id_by_index(&self, pane_index: usize) -> Option<PaneId> {
         self.panes.visible_pane_ids().get(pane_index).copied()
+    }
+
+    /// Updates whether this pane group's tab belongs to a tab group.
+    /// Triggers a re-render when the value changes.
+    pub fn set_is_in_tab_group(&mut self, is_in_tab_group: bool, ctx: &mut ViewContext<Self>) {
+        if self.is_in_tab_group != is_in_tab_group {
+            self.is_in_tab_group = is_in_tab_group;
+            ctx.notify();
+        }
     }
 
     pub fn set_dim_even_if_focused_for_all_panes(
@@ -7875,6 +7896,17 @@ impl View for PaneGroup {
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
+        let in_tab_group = FeatureFlag::GroupedTabs.is_enabled() && self.is_in_tab_group;
+
+        // Read hover state synchronously before building the element tree.
+        // When hovered (and in a tab group), a subtle border is drawn around
+        // the entire pane group to make it clear all panes share the same tab.
+        let is_group_hovered = in_tab_group
+            && self
+                .tab_group_hover_state
+                .lock()
+                .expect("tab group hover state lock poisoned")
+                .is_hovered();
 
         let mut column = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
@@ -7891,7 +7923,7 @@ impl View for PaneGroup {
         let main_content = if self.is_focused_pane_maximized(app) {
             self.focused_pane_id(app).render(app)
         } else {
-            EventHandler::new(self.panes.render(appearance.theme(), app))
+            EventHandler::new(self.panes.render(appearance.theme(), in_tab_group, app))
                 .on_mouse_dragged(move |ctx, _, position| {
                     ctx.dispatch_typed_action(PaneGroupAction::ResizeMove(position));
                     DispatchEventResult::StopPropagation
@@ -7983,7 +8015,30 @@ impl View for PaneGroup {
             }
         }
 
-        stack.finish()
+        // When hovered inside a tab group, overlay a subtle 1px border so the
+        // user can clearly see which panes belong to the same tab.
+        if is_group_hovered {
+            let border_color = internal_colors::neutral_3(appearance.theme());
+            stack.add_child(
+                Rect::new()
+                    .with_border(Border::all(1.).with_border_color(border_color))
+                    .finish(),
+            );
+        }
+
+        let element = stack.finish();
+
+        // Wrap in Hoverable so that mouse-over/out changes trigger a re-render
+        // and update the border overlay above. Only active when the tab is in a
+        // tab group; no overhead otherwise.
+        if in_tab_group {
+            let hover_state = self.tab_group_hover_state.clone();
+            Hoverable::new(hover_state, move |_| element)
+                .on_hover(|_, ctx, _, _| ctx.notify())
+                .finish()
+        } else {
+            element
+        }
     }
 
     fn on_window_transferred(

--- a/app/src/pane_group/tree.rs
+++ b/app/src/pane_group/tree.rs
@@ -512,10 +512,15 @@ impl PaneData {
         self.len == 0
     }
 
-    pub fn render(&self, theme: &WarpTheme, app: &AppContext) -> Box<dyn Element> {
+    pub fn render(
+        &self,
+        theme: &WarpTheme,
+        in_tab_group: bool,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
         match &self.root {
             PaneNode::Leaf(pane) => pane.render(app),
-            PaneNode::Branch(node) => node.render(theme, &self.hidden_panes, app),
+            PaneNode::Branch(node) => node.render(theme, in_tab_group, &self.hidden_panes, app),
         }
     }
 
@@ -719,6 +724,7 @@ impl PaneNode {
     fn render(
         &self,
         theme: &WarpTheme,
+        in_tab_group: bool,
         hidden_panes: &Vec<HiddenPane>,
         app: &AppContext,
     ) -> Box<dyn Element> {
@@ -735,7 +741,7 @@ impl PaneNode {
                     })
                     .finish()
             }
-            PaneNode::Branch(branch) => branch.render(theme, hidden_panes, app),
+            PaneNode::Branch(branch) => branch.render(theme, in_tab_group, hidden_panes, app),
         }
     }
 
@@ -1055,6 +1061,7 @@ impl PaneBranch {
     fn render(
         &self,
         theme: &WarpTheme,
+        in_tab_group: bool,
         hidden_panes: &Vec<HiddenPane>,
         app: &AppContext,
     ) -> Box<dyn Element> {
@@ -1062,6 +1069,10 @@ impl PaneBranch {
             SplitDirection::Horizontal => Flex::row(),
             SplitDirection::Vertical => Flex::column(),
         };
+
+        // When the tab is in a tab group, omit the inter-pane dividers so split
+        // panes appear flush against each other.
+        let omit_dividers = in_tab_group && FeatureFlag::GroupedTabs.is_enabled();
 
         // Iterate through all the panes, skipping nodes that have no visible children
         // except when children are hidden for move operations (we need empty drop targets)
@@ -1088,10 +1099,17 @@ impl PaneBranch {
             }
 
             parent.add_child(
-                Shrinkable::new(flex_value, node.render(theme, hidden_panes, app)).finish(),
+                Shrinkable::new(
+                    flex_value,
+                    node.render(theme, in_tab_group, hidden_panes, app),
+                )
+                .finish(),
             );
             if let Some(divider) = dividers.next() {
                 if matches!(node, PaneNode::Leaf(id) if pane_hidden_for_move(hidden_panes, id)) {
+                    continue;
+                }
+                if omit_dividers {
                     continue;
                 }
                 // Store a position index to render the actual divider at after we've rendered all pane content.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6810,6 +6810,7 @@ impl Workspace {
             self.active_tab_index = 0;
         }
 
+        self.sync_tab_group_pane_groups(ctx);
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
 
@@ -6907,6 +6908,7 @@ impl Workspace {
             self.prune_empty_tab_group(prev_group_id, ctx);
         }
 
+        self.sync_tab_group_pane_groups(ctx);
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
 
@@ -6945,6 +6947,7 @@ impl Workspace {
             self.prune_empty_tab_group(prev, ctx);
         }
 
+        self.sync_tab_group_pane_groups(ctx);
         self.focus_active_tab(ctx);
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
@@ -6971,6 +6974,7 @@ impl Workspace {
 
         self.prune_empty_tab_group(previous_group_id, ctx);
 
+        self.sync_tab_group_pane_groups(ctx);
         self.focus_active_tab(ctx);
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
@@ -6986,6 +6990,7 @@ impl Workspace {
             }
         }
         self.tab_groups.remove(&group_id);
+        self.sync_tab_group_pane_groups(ctx);
         ctx.notify();
     }
 
@@ -7024,6 +7029,7 @@ impl Workspace {
             }
             self.move_tab_to_index(new_idx, target_index, ctx);
         }
+        self.sync_tab_group_pane_groups(ctx);
         ctx.notify();
     }
 
@@ -7206,6 +7212,7 @@ impl Workspace {
             self.prune_empty_tab_group(previous_group_id, ctx);
         }
 
+        self.sync_tab_group_pane_groups(ctx);
         ctx.notify();
     }
 
@@ -7215,6 +7222,22 @@ impl Workspace {
         if !has_members {
             self.tab_groups.remove(&group_id);
             ctx.notify();
+        }
+    }
+
+    /// Syncs each tab's `pane_group.is_in_tab_group` flag to match the tab's
+    /// current `group_id`. Call this after any mutation that changes group
+    /// membership so the pane group UI can update its spacing and hover state.
+    fn sync_tab_group_pane_groups(&mut self, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        for tab in &self.tabs {
+            let is_in_tab_group = tab.group_id.is_some();
+            let handle = tab.pane_group.clone();
+            handle.update(ctx, |pane_group, ctx| {
+                pane_group.set_is_in_tab_group(is_in_tab_group, ctx);
+            });
         }
     }
 
@@ -12037,12 +12060,13 @@ impl Workspace {
             }
         }
 
-        // Inherit the active tab's group membership. D
+        // Inherit the active tab's group membership.
         if let Some(group_id) = active_tab_group_id {
             let new_idx = self.active_tab_index;
             if let Some(new_tab) = self.tabs.get_mut(new_idx) {
                 new_tab.group_id = Some(group_id);
             }
+            self.sync_tab_group_pane_groups(ctx);
         }
 
         if !is_restoration {


### PR DESCRIPTION
- Remove the inter-pane dividers when a tab's panes are inside a tab
  group (gated behind FeatureFlag::GroupedTabs), so split panes appear
  flush against each other for a more unified look.

- Add a subtle 1px border highlight around the entire pane group on
  hover when the tab is in a tab group, so users can clearly see which
  panes all belong to the same tab. This highlight is intentionally
  absent in regular (non-grouped) tabs since the existing container
  already provides that visual cue.

- Sync is_in_tab_group on PaneGroup whenever tab group membership
  changes in the workspace (create, assign, move, remove, ungroup).

Co-Authored-By: Oz <oz-agent@warp.dev>

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
