### PR TITLE
Abort DirectoryFetcher futures

### DIFF
--- a/app/src/context_chips/directory_fetcher.rs
+++ b/app/src/context_chips/directory_fetcher.rs
@@ -150,6 +150,14 @@ impl Entity for DirectoryFetcher {
     type Event = DirectoryFetcherEvent;
 }
 
+impl Drop for DirectoryFetcher {
+    fn drop(&mut self) {
+        if let Some(handle) = self.fetch_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 pub enum DirectoryType {
     Directory,

--- a/app/src/context_chips/display_chip.rs
+++ b/app/src/context_chips/display_chip.rs
@@ -671,17 +671,16 @@ impl DisplayChip {
                 });
 
                 // Subscribe to DirectoryFetcher events to update menu
-                let directory_fetcher_clone = directory_fetcher.clone();
                 ctx.subscribe_to_model(
                     &directory_fetcher,
-                    move |display_chip, _model, event, ctx| {
+                    move |display_chip, model, event, ctx| {
                         match event {
                             DirectoryFetcherEvent::DirectoryContentsUpdated => {
                                 // Update the existing menu with new directory contents
                                 if let DisplayChipKind::WorkingDirectory { menu, .. } =
                                     &mut display_chip.display_chip_kind
                                 {
-                                    let new_files = directory_fetcher_clone
+                                    let new_files = model
                                         .read(ctx, |fetcher, _| fetcher.cached_files().to_vec());
                                     // Update the existing menu with new content instead of recreating it
                                     menu.update(ctx, |menu_view, menu_ctx| {


### PR DESCRIPTION
## Description
When you click the working directory chip in Warp's custom prompt, a popup lists the files in that directory. A background task reads the directory from disk each time the chip is created.

When switching between panes, the prompt is rebuilt, discarding old chips and creating new ones. Each new chip launches a fresh background directory-read task. Previously, the old tasks were never cancelled: they'd run to completion and hold memory even though their results were no longer needed.

Two issues worked together: a reference cycle (a strong `ModelHandle` captured in a subscription closure) kept the `DirectoryFetcher` model alive until the task completed, at which point cancellation was too late. This PR removes the unnecessary strong reference (the subscription callback's second parameter already provides the handle for the duration of the call) and adds a `Drop` impl that cancels any in-flight task when the model is dropped.

## Linked Issue
N/A

## Agent Mode
This PR was generated with [Oz](https://warp.dev/oz).

_Conversation: https://staging.warp.dev/conversation/abae452e-42e1-4326-97b7-dd8e60019f22_
_Run: https://oz.staging.warp.dev/runs/019ea845-f9f6-73cd-b2e4-2fd17ce73507_

_This PR was generated with [Oz](https://warp.dev/oz)._
