### PR TITLE
Update placement of group when created from tab(s)

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6883,8 +6883,10 @@ impl Workspace {
             });
     }
 
-    /// Creates a new group containing the tab and moves it to the top of
-    /// the tab list.
+    /// Creates a new group containing the tab, anchored at the tab's original
+    /// position. If the tab was pulled out of an existing group, leaving it in
+    /// place would split that group's contiguous run, so the new group lands
+    /// just past the old group's last remaining member instead.
     fn new_tab_group_from_tab(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
@@ -6900,8 +6902,21 @@ impl Workspace {
         self.tab_groups.insert(group_id, group);
 
         self.tabs[tab_index].group_id = Some(group_id);
-        self.move_tab_to_index(tab_index, 0, ctx);
-        self.set_active_tab_index(0, ctx);
+
+        // When the tab leaves an existing group, reposition it just past that
+        // group's last remaining member so the old group stays contiguous.
+        if let Some(prev_group_id) = previous_group_id {
+            if let Some(last) = group_member_indices(&self.tabs, prev_group_id).last() {
+                self.move_tab_to_index(tab_index, last + 1, ctx);
+            }
+        }
+
+        // The move above may have shifted the tab; the new group has exactly
+        // one member, so its position is the new active index.
+        let new_active = group_member_indices(&self.tabs, group_id)
+            .next()
+            .unwrap_or(tab_index);
+        self.set_active_tab_index(new_active, ctx);
 
         if let Some(prev_group_id) = previous_group_id {
             self.prune_empty_tab_group(prev_group_id, ctx);

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -160,8 +160,11 @@ impl Workspace {
     }
 
     /// "Create group from tabs" menu action. Group membership requires
-    /// tabs to be contiguous in the bar, so we relocate the selected tabs
-    /// to the top as a single block before binding them to the new group.
+    /// tabs to be contiguous in the bar, so we gather the selected tabs into
+    /// a single block anchored at the earliest selected tab's position before
+    /// binding them to the new group. When that earliest tab was itself in a
+    /// group, the block is placed just past that group's last remaining
+    /// member so the existing group stays contiguous instead of being split.
     pub(super) fn new_tab_group_from_selected_tabs(&mut self, ctx: &mut ViewContext<Self>) {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
@@ -195,6 +198,12 @@ impl Workspace {
             .get(self.active_tab_index)
             .map(|tab| tab.pane_group.id());
 
+        // Anchor the group block at the earliest selected tab. `selected_indices`
+        // is ascending, so its first entry is the earliest tab in the list, and
+        // we remember the group it currently belongs to (if any).
+        let anchor_index = selected_indices[0];
+        let anchor_previous_group_id = self.tabs[anchor_index].group_id;
+
         // Assign membership and clear flags for every selected tab.
         for &index in &selected_indices {
             let tab = &mut self.tabs[index];
@@ -203,12 +212,40 @@ impl Workspace {
         }
 
         // Split tabs into the new group's members and all other tabs.
-        let (selected_tabs, other_tabs): (Vec<_>, Vec<_>) = self
+        let (selected_tabs, mut other_tabs): (Vec<_>, Vec<_>) = self
             .tabs
             .drain(..)
             .partition(|tab| tab.group_id == Some(group_id));
-        // Place the group block at the top, with the rest of the tabs after.
-        self.tabs = selected_tabs.into_iter().chain(other_tabs).collect();
+
+        // Compute where to splice the new group block into `other_tabs`.
+        //
+        // Simple case — anchor tab was NOT in a group:
+        //   Every tab before `anchor_index` in the original list was unselected
+        //   (because `anchor_index` is the smallest selected index), so those
+        //   tabs are still at the front of `other_tabs` in their original order.
+        //   Inserting at `anchor_index` in `other_tabs` places the block exactly
+        //   where the anchor tab used to be.
+        //
+        // Edge case — anchor tab WAS in an existing group G:
+        //   Other surviving members of G are still in `other_tabs`. Inserting at
+        //   `anchor_index` could land in the middle of G's run and split it.
+        //   Example: tabs = [A(G), B(G), C(G), D] and we select B and D.
+        //   other_tabs = [A(G), C(G), D]. anchor_index = 1, which points at C —
+        //   inserting there would produce [A(G), B(new), D(new), C(G)], breaking
+        //   G's contiguity. Instead we search other_tabs from the right for the
+        //   last surviving G member (C, at index 1) and insert after it (index 2),
+        //   giving [A(G), C(G), B(new), D(new)].
+        let insert_at = anchor_previous_group_id
+            .and_then(|prev_group_id| {
+                other_tabs
+                    .iter()
+                    .rposition(|tab| tab.group_id == Some(prev_group_id))
+                    .map(|last| last + 1)
+            })
+            .unwrap_or(anchor_index);
+
+        other_tabs.splice(insert_at..insert_at, selected_tabs);
+        self.tabs = other_tabs;
 
         self.restore_active_tab_index(active_pane_group_id);
 

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3248,6 +3248,215 @@ fn test_create_new_tab_group_groups_active_tab() {
 }
 
 #[test]
+fn test_new_tab_group_from_tab_keeps_tab_in_place() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Build a three-tab workspace (starts with one tab).
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            assert_eq!(workspace.tab_count(), 3);
+
+            // Target the last tab so a move-to-top would be observable.
+            let target_index = workspace.tab_count() - 1;
+            let target_id = workspace.tabs[target_index].pane_group.id();
+
+            workspace.handle_action(&WorkspaceAction::NewTabGroupFromTab(target_index), ctx);
+
+            // The tab stays at its original index instead of jumping to the top.
+            assert_eq!(workspace.tabs[target_index].pane_group.id(), target_id);
+            assert_eq!(workspace.active_tab_index(), target_index);
+
+            let group_id = workspace.tabs[target_index]
+                .group_id
+                .expect("target tab should be assigned to the new group");
+            assert!(workspace.tab_groups.contains_key(&group_id));
+
+            // The other tabs remain ungrouped.
+            assert!(workspace.tabs[0].group_id.is_none());
+            assert!(workspace.tabs[1].group_id.is_none());
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_group_from_selected_tabs_anchors_at_earliest_tab() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Build a four-tab workspace (starts with one tab).
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            assert_eq!(workspace.tab_count(), 4);
+
+            let id0 = workspace.tabs[0].pane_group.id();
+            let id1 = workspace.tabs[1].pane_group.id();
+            let id2 = workspace.tabs[2].pane_group.id();
+            let id3 = workspace.tabs[3].pane_group.id();
+
+            // Select two non-adjacent tabs (indices 1 and 3) with the active
+            // tab among the selection so no extra tab is pulled in.
+            workspace.activate_tab(1, ctx);
+            workspace.tabs[1].in_multi_selection = true;
+            workspace.tabs[3].in_multi_selection = true;
+
+            workspace.handle_action(&WorkspaceAction::NewTabGroupFromSelectedTabs, ctx);
+
+            // The group block lands at the earliest selected tab's position
+            // (index 1), preserving the relative order of its members.
+            let order: Vec<_> = workspace
+                .tabs
+                .iter()
+                .map(|tab| tab.pane_group.id())
+                .collect();
+            assert_eq!(order, vec![id0, id1, id3, id2]);
+
+            // Both selected tabs share the new group; the others stay ungrouped.
+            let group_id = workspace.tabs[1]
+                .group_id
+                .expect("earliest selected tab should join the new group");
+            assert_eq!(workspace.tabs[2].group_id, Some(group_id));
+            assert!(workspace.tabs[0].group_id.is_none());
+            assert!(workspace.tabs[3].group_id.is_none());
+
+            // Selection flags are cleared after grouping.
+            assert!(workspace.tabs.iter().all(|tab| !tab.in_multi_selection));
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_group_from_tab_in_group_anchors_after_group() {
+    // Pulling a tab out of the middle of an existing group must not split
+    // that group: the new single-tab group should land just past the old
+    // group's last remaining member.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Build a four-tab workspace (starts with one tab).
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            assert_eq!(workspace.tab_count(), 4);
+
+            // Group the first three tabs (indices 0, 1, 2) into one group,
+            // leaving the last tab ungrouped.
+            let group = TabGroup::new();
+            let existing_group_id = group.id;
+            workspace.tab_groups.insert(existing_group_id, group);
+            for index in 0..3 {
+                workspace.tabs[index].group_id = Some(existing_group_id);
+            }
+
+            let id0 = workspace.tabs[0].pane_group.id();
+            let middle_id = workspace.tabs[1].pane_group.id();
+            let id2 = workspace.tabs[2].pane_group.id();
+            let id3 = workspace.tabs[3].pane_group.id();
+
+            // Create a new group from the middle member of the existing group.
+            workspace.handle_action(&WorkspaceAction::NewTabGroupFromTab(1), ctx);
+
+            // The pulled tab lands right after the old group's run, so the old
+            // group's members stay contiguous: [g0, g2, new, ungrouped].
+            let order: Vec<_> = workspace
+                .tabs
+                .iter()
+                .map(|tab| tab.pane_group.id())
+                .collect();
+            assert_eq!(order, vec![id0, id2, middle_id, id3]);
+
+            let new_group_id = workspace.tabs[2]
+                .group_id
+                .expect("pulled tab should be in the new group");
+            assert_ne!(new_group_id, existing_group_id);
+            assert_eq!(workspace.active_tab_index(), 2);
+
+            // The old group keeps its two contiguous members.
+            assert_eq!(workspace.tabs[0].group_id, Some(existing_group_id));
+            assert_eq!(workspace.tabs[1].group_id, Some(existing_group_id));
+            assert!(workspace.tabs[3].group_id.is_none());
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_group_from_selected_tabs_in_group_anchors_after_group() {
+    // When the earliest selected tab sits inside an existing group, the new
+    // group block is anchored past that group's last surviving member so the
+    // existing group is never split.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Build a five-tab workspace (starts with one tab).
+            for _ in 0..4 {
+                workspace.add_terminal_tab(false, ctx);
+            }
+            assert_eq!(workspace.tab_count(), 5);
+
+            // Group the first three tabs (indices 0, 1, 2); leave 3 and 4 loose.
+            let group = TabGroup::new();
+            let existing_group_id = group.id;
+            workspace.tab_groups.insert(existing_group_id, group);
+            for index in 0..3 {
+                workspace.tabs[index].group_id = Some(existing_group_id);
+            }
+
+            let id0 = workspace.tabs[0].pane_group.id();
+            let id1 = workspace.tabs[1].pane_group.id();
+            let id2 = workspace.tabs[2].pane_group.id();
+            let id3 = workspace.tabs[3].pane_group.id();
+            let id4 = workspace.tabs[4].pane_group.id();
+
+            // Select the middle member of the group (index 1) and the trailing
+            // ungrouped tab (index 4), with the active tab among the selection.
+            workspace.activate_tab(1, ctx);
+            workspace.tabs[1].in_multi_selection = true;
+            workspace.tabs[4].in_multi_selection = true;
+
+            workspace.handle_action(&WorkspaceAction::NewTabGroupFromSelectedTabs, ctx);
+
+            // The block is placed just past the old group's surviving run
+            // (g0, g2), keeping that group contiguous:
+            // [g0, g2, new1, new4, id3].
+            let order: Vec<_> = workspace
+                .tabs
+                .iter()
+                .map(|tab| tab.pane_group.id())
+                .collect();
+            assert_eq!(order, vec![id0, id2, id1, id4, id3]);
+
+            let new_group_id = workspace.tabs[2]
+                .group_id
+                .expect("selected tab should be in the new group");
+            assert_ne!(new_group_id, existing_group_id);
+            assert_eq!(workspace.tabs[3].group_id, Some(new_group_id));
+
+            // Old group stays contiguous with its two surviving members.
+            assert_eq!(workspace.tabs[0].group_id, Some(existing_group_id));
+            assert_eq!(workspace.tabs[1].group_id, Some(existing_group_id));
+            assert!(workspace.tabs[4].group_id.is_none());
+        });
+    });
+}
+
+#[test]
 fn test_toggle_tab_group_collapsed_flips_state() {
     let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
 


### PR DESCRIPTION
## Description

Changes the placement behavior for "New group with tab" (single tab) and "Create group from tabs" (multi-tab selection) so that the new group is created in-place rather than jumping to the top of the tab list.

## How it works 

Before: both actions relocated the selected tab(s) to index 0, so the new group always appeared at the very top regardless of where the tabs were.

After: the new group is anchored at the position of the earliest tab involved:
•  Single tab — the tab stays where it is; no reordering occurs.
•  Multi-tab selection — the group block is spliced in at the earliest selected tab's original position, with the remaining tabs closing the gap.

Edge case (for both single and multi tab cases): if the anchor tab was already a member of an existing group, inserting at its raw slot would split that group's contiguous run. In that case the new group is placed just past the last surviving member of the old group instead, keeping it intact.

## Linked Issue

https://linear.app/warpdotdev/project/tab-grouping-8d9778792fa7/issues

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo Video](https://www.loom.com/share/7989048815d44141b406743a1c80d883)

Demo video shows some basic cases: 
- creating group from single and multi tab creates the group at the first selected tab
as well as some weird edge cases: 
- creating a group from single and multi tab where the first selected tab is in a group, lands the new group after the existing group