### PR TITLE
Avoid cloning display menu items on every render

### DIFF
--- a/app/src/context_chips/display_menu.rs
+++ b/app/src/context_chips/display_menu.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use fuzzy_match::{match_indices_case_insensitive, FuzzyMatchResult};
@@ -206,7 +207,7 @@ pub struct DisplayChipMenu {
     list_state: UniformListState,
     scroll_state: ScrollStateHandle,
     menu_items: Vec<Arc<dyn GenericMenuItem>>,
-    filtered_items: Arc<Vec<FilteredMenuItem>>,
+    filtered_items: Rc<Vec<FilteredMenuItem>>,
     selected_index: usize,
     is_footer_selected: bool,
     fixed_footer: Option<FixedFooter>,
@@ -279,9 +280,6 @@ impl DisplayChipMenu {
         DropShadow::default()
     }
 
-    // `FilteredMenuItem` holds an `Arc<dyn GenericMenuItem>`, which is
-    // intentionally not `Send`/`Sync`; the menu lives on a single (UI) thread.
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new<T: GenericMenuItem>(
         menu_items: Vec<T>,
         fixed_footer_option: Option<FixedFooter>,
@@ -371,7 +369,7 @@ impl DisplayChipMenu {
             })
             .collect();
 
-        let filtered_items: Arc<Vec<FilteredMenuItem>> = Arc::new(
+        let filtered_items: Rc<Vec<FilteredMenuItem>> = Rc::new(
             menu_items
                 .iter()
                 .map(|item| FilteredMenuItem {
@@ -446,13 +444,10 @@ impl DisplayChipMenu {
         ctx.notify();
     }
 
-    // `FilteredMenuItem` holds an `Arc<dyn GenericMenuItem>`, which is
-    // intentionally not `Send`/`Sync`; the menu lives on a single (UI) thread.
-    #[allow(clippy::arc_with_non_send_sync)]
     fn update_filtered_items(&mut self) {
         if self.search_query.is_empty() {
             // No search query - show all items
-            self.filtered_items = Arc::new(
+            self.filtered_items = Rc::new(
                 self.menu_items
                     .iter()
                     .map(|item| FilteredMenuItem {
@@ -509,7 +504,7 @@ impl DisplayChipMenu {
             }
         }
 
-        self.filtered_items = Arc::new(filtered_items);
+        self.filtered_items = Rc::new(filtered_items);
     }
 
     pub fn update_search_query(&mut self, query: String, ctx: &mut ViewContext<Self>) {

--- a/app/src/context_chips/display_menu.rs
+++ b/app/src/context_chips/display_menu.rs
@@ -206,7 +206,7 @@ pub struct DisplayChipMenu {
     list_state: UniformListState,
     scroll_state: ScrollStateHandle,
     menu_items: Vec<Arc<dyn GenericMenuItem>>,
-    filtered_items: Vec<FilteredMenuItem>,
+    filtered_items: Arc<Vec<FilteredMenuItem>>,
     selected_index: usize,
     is_footer_selected: bool,
     fixed_footer: Option<FixedFooter>,
@@ -279,6 +279,9 @@ impl DisplayChipMenu {
         DropShadow::default()
     }
 
+    // `FilteredMenuItem` holds an `Arc<dyn GenericMenuItem>`, which is
+    // intentionally not `Send`/`Sync`; the menu lives on a single (UI) thread.
+    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new<T: GenericMenuItem>(
         menu_items: Vec<T>,
         fixed_footer_option: Option<FixedFooter>,
@@ -368,13 +371,15 @@ impl DisplayChipMenu {
             })
             .collect();
 
-        let filtered_items: Vec<FilteredMenuItem> = menu_items
-            .iter()
-            .map(|item| FilteredMenuItem {
-                item: item.clone(),
-                match_result: None,
-            })
-            .collect();
+        let filtered_items: Arc<Vec<FilteredMenuItem>> = Arc::new(
+            menu_items
+                .iter()
+                .map(|item| FilteredMenuItem {
+                    item: item.clone(),
+                    match_result: None,
+                })
+                .collect(),
+        );
 
         // Always start selection at the top (first item) for consistent behavior
         let initial_selected_index = 0;
@@ -441,22 +446,26 @@ impl DisplayChipMenu {
         ctx.notify();
     }
 
+    // `FilteredMenuItem` holds an `Arc<dyn GenericMenuItem>`, which is
+    // intentionally not `Send`/`Sync`; the menu lives on a single (UI) thread.
+    #[allow(clippy::arc_with_non_send_sync)]
     fn update_filtered_items(&mut self) {
         if self.search_query.is_empty() {
             // No search query - show all items
-            self.filtered_items = self
-                .menu_items
-                .iter()
-                .map(|item| FilteredMenuItem {
-                    item: item.clone(),
-                    match_result: None,
-                })
-                .collect();
+            self.filtered_items = Arc::new(
+                self.menu_items
+                    .iter()
+                    .map(|item| FilteredMenuItem {
+                        item: item.clone(),
+                        match_result: None,
+                    })
+                    .collect(),
+            );
             return;
         }
 
         // Filter items based on search query
-        self.filtered_items = self
+        let mut filtered_items: Vec<FilteredMenuItem> = self
             .menu_items
             .iter()
             .filter_map(|item| {
@@ -471,7 +480,7 @@ impl DisplayChipMenu {
             .collect();
 
         // Sort by match score (higher scores first)
-        self.filtered_items.sort_by(|a, b| {
+        filtered_items.sort_by(|a, b| {
             let score_a = a.match_result.as_ref().map(|r| r.score).unwrap_or(0);
             let score_b = b.match_result.as_ref().map(|r| r.score).unwrap_or(0);
             score_b.cmp(&score_a)
@@ -489,7 +498,7 @@ impl DisplayChipMenu {
             );
             if !already_matches_existing {
                 if let Some(synthetic) = builder(trimmed) {
-                    self.filtered_items.insert(
+                    filtered_items.insert(
                         0,
                         FilteredMenuItem {
                             item: synthetic,
@@ -499,6 +508,8 @@ impl DisplayChipMenu {
                 }
             }
         }
+
+        self.filtered_items = Arc::new(filtered_items);
     }
 
     pub fn update_search_query(&mut self, query: String, ctx: &mut ViewContext<Self>) {


### PR DESCRIPTION
## Description
Warp's working directory chip and git branch chip open popup menus that list files or branches. Each time one of these menus renders, the full list of (possibly-filtered) menu items was being copied so it could be handed to the list renderer, which requires owned data. For a working directory with many files, that meant a full allocation and copy of the list on every single frame.

This change wraps the items list in a reference-counted pointer (`Arc`) so the per-render handoff is a cheap O(1) pointer clone instead of copying the whole list. The places that actually change the list (when the search text changes, or when new directory contents arrive) still build a fresh list and wrap it in a new `Arc`. That keeps things correct because a previously rendered frame may still be holding the old list.

## Testing
Existing display menu tests cover filtering and selection behavior. No new tests are needed — this is a structural change to how the list is owned, not a logic change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/231a59c0-ef97-4c03-abb8-3a09a505f8b2_
_Run: https://oz.staging.warp.dev/runs/019ea845-f9f5-751b-81e8-1bc3d6a206d7_

_This PR was generated with [Oz](https://warp.dev/oz)._
