### PR TITLE
Allow orchestration agents to read plans by ID, even if the plan isn't loaded locally

### DIFF
--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -823,6 +823,10 @@ impl BlocklistAIActionExecutor {
                 self.search_codebase_executor.update(ctx, |executor, ctx| {
                     executor.cancel_execution(&running.action.id, ctx);
                 });
+            } else if matches!(running.action.action, AIAgentActionType::RunAgents(..)) {
+                self.run_agents_executor.update(ctx, |executor, ctx| {
+                    executor.cancel_execution(&running.action.id, ctx);
+                });
             }
             ctx.emit(BlocklistAIActionExecutorEvent::FinishedAction {
                 result: Arc::new(AIAgentActionResult {

--- a/app/src/ai/blocklist/action_model/execute/read_documents.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_documents.rs
@@ -3,10 +3,10 @@ use futures::FutureExt;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
-use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionType, DocumentContext, ReadDocumentsRequest, ReadDocumentsResult,
 };
+use crate::ai::blocklist::orchestration_topology::conversation_participates_in_orchestration;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel};
 
@@ -44,9 +44,13 @@ impl ReadDocumentsExecutor {
         };
 
         let (mut documents, mut missing_documents) = read_documents(document_ids, ctx);
-        if !missing_documents.is_empty()
-            && conversation_participates_in_orchestration(conversation_id, ctx)
-        {
+        // Orchestrated children may reference plans owned by their parent conversation, so their
+        // local document model can legitimately be missing a requested plan.
+        let participates_in_orchestration = conversation_participates_in_orchestration(
+            BlocklistAIHistoryModel::as_ref(ctx),
+            conversation_id,
+        );
+        if !missing_documents.is_empty() && participates_in_orchestration {
             AIDocumentModel::handle(ctx).update(ctx, |model, ctx| {
                 for document_id in &missing_documents {
                     if let Err(error) = model.hydrate_saved_plan_from_warp_drive(
@@ -89,6 +93,7 @@ impl ReadDocumentsExecutor {
 impl Entity for ReadDocumentsExecutor {
     type Event = ();
 }
+
 /// Reads requested documents and returns the IDs that are not loaded locally.
 fn read_documents(
     document_ids: &[AIDocumentId],
@@ -114,21 +119,6 @@ fn read_documents(
         });
     }
     (documents, missing_documents)
-}
-
-/// Returns whether a conversation is a parent or child in orchestration.
-fn conversation_participates_in_orchestration(
-    conversation_id: AIConversationId,
-    ctx: &AppContext,
-) -> bool {
-    let history = BlocklistAIHistoryModel::as_ref(ctx);
-    let has_parent = history
-        .conversation(&conversation_id)
-        .is_some_and(|conversation| conversation.is_child_agent_conversation());
-    has_parent
-        || !history
-            .child_conversation_ids_of(&conversation_id)
-            .is_empty()
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/action_model/execute/read_documents.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_documents.rs
@@ -1,12 +1,14 @@
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use warpui::{Entity, ModelContext, SingletonEntity};
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
+use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionType, DocumentContext, ReadDocumentsRequest, ReadDocumentsResult,
 };
-use crate::ai::document::ai_document_model::AIDocumentModel;
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel};
 
 pub struct ReadDocumentsExecutor;
 
@@ -29,7 +31,10 @@ impl ReadDocumentsExecutor {
         input: ExecuteActionInput,
         ctx: &mut ModelContext<Self>,
     ) -> impl Into<AnyActionExecution> {
-        let ExecuteActionInput { action, .. } = input;
+        let ExecuteActionInput {
+            action,
+            conversation_id,
+        } = input;
         let AIAgentAction {
             action: AIAgentActionType::ReadDocuments(ReadDocumentsRequest { document_ids }),
             ..
@@ -38,22 +43,36 @@ impl ReadDocumentsExecutor {
             return ActionExecution::<ReadDocumentsResult>::InvalidAction;
         };
 
-        // Access the model synchronously before the async block
-        let model = AIDocumentModel::handle(ctx);
-        let documents: Vec<DocumentContext> = document_ids
-            .iter()
-            .filter_map(|id| {
-                let model = model.as_ref(ctx);
-                let content = model.get_document_content(id, ctx)?;
-                let version = model.get_current_document(id)?.version;
-                Some(DocumentContext {
-                    document_id: *id,
-                    content,
-                    line_ranges: vec![],
-                    document_version: version,
-                })
-            })
-            .collect();
+        let (mut documents, mut missing_documents) = read_documents(document_ids, ctx);
+        if !missing_documents.is_empty()
+            && conversation_participates_in_orchestration(conversation_id, ctx)
+        {
+            AIDocumentModel::handle(ctx).update(ctx, |model, ctx| {
+                for document_id in &missing_documents {
+                    if let Err(error) = model.hydrate_saved_plan_from_warp_drive(
+                        *document_id,
+                        conversation_id,
+                        ctx,
+                    ) {
+                        log::warn!(
+                            "Failed to hydrate requested plan document {document_id} from Warp Drive: {error}"
+                        );
+                    }
+                }
+            });
+            (documents, missing_documents) = read_documents(document_ids, ctx);
+        }
+
+        if !missing_documents.is_empty() {
+            let missing_list = missing_documents
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            return ActionExecution::Sync(
+                ReadDocumentsResult::Error(format!("Document(s) not found: {missing_list}")).into(),
+            );
+        }
 
         ActionExecution::Sync(ReadDocumentsResult::Success { documents }.into())
     }
@@ -70,3 +89,48 @@ impl ReadDocumentsExecutor {
 impl Entity for ReadDocumentsExecutor {
     type Event = ();
 }
+/// Reads requested documents and returns the IDs that are not loaded locally.
+fn read_documents(
+    document_ids: &[AIDocumentId],
+    ctx: &AppContext,
+) -> (Vec<DocumentContext>, Vec<AIDocumentId>) {
+    let model = AIDocumentModel::as_ref(ctx);
+    let mut documents = Vec::with_capacity(document_ids.len());
+    let mut missing_documents = Vec::new();
+    for id in document_ids {
+        let Some(content) = model.get_document_content(id, ctx) else {
+            missing_documents.push(*id);
+            continue;
+        };
+        let Some(current_document) = model.get_current_document(id) else {
+            missing_documents.push(*id);
+            continue;
+        };
+        documents.push(DocumentContext {
+            document_id: *id,
+            content,
+            line_ranges: vec![],
+            document_version: current_document.version,
+        });
+    }
+    (documents, missing_documents)
+}
+
+/// Returns whether a conversation is a parent or child in orchestration.
+fn conversation_participates_in_orchestration(
+    conversation_id: AIConversationId,
+    ctx: &AppContext,
+) -> bool {
+    let history = BlocklistAIHistoryModel::as_ref(ctx);
+    let has_parent = history
+        .conversation(&conversation_id)
+        .is_some_and(|conversation| conversation.is_child_agent_conversation());
+    has_parent
+        || !history
+            .child_conversation_ids_of(&conversation_id)
+            .is_empty()
+}
+
+#[cfg(test)]
+#[path = "read_documents_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/action_model/execute/read_documents.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_documents.rs
@@ -6,8 +6,6 @@ use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessA
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionType, DocumentContext, ReadDocumentsRequest, ReadDocumentsResult,
 };
-use crate::ai::blocklist::orchestration_topology::conversation_participates_in_orchestration;
-use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel};
 
 pub struct ReadDocumentsExecutor;
@@ -43,28 +41,29 @@ impl ReadDocumentsExecutor {
             return ActionExecution::<ReadDocumentsResult>::InvalidAction;
         };
 
-        let (mut documents, mut missing_documents) = read_documents(document_ids, ctx);
-        // Orchestrated children may reference plans owned by their parent conversation, so their
-        // local document model can legitimately be missing a requested plan.
-        let participates_in_orchestration = conversation_participates_in_orchestration(
-            BlocklistAIHistoryModel::as_ref(ctx),
-            conversation_id,
-        );
-        if !missing_documents.is_empty() && participates_in_orchestration {
-            AIDocumentModel::handle(ctx).update(ctx, |model, ctx| {
-                for document_id in &missing_documents {
-                    if let Err(error) = model.hydrate_saved_plan_from_warp_drive(
-                        *document_id,
-                        conversation_id,
-                        ctx,
-                    ) {
+        // A requested plan may live in Warp Drive without being loaded into this conversation's
+        // document model (e.g. orchestration children reading parent plans, or plan IDs
+        // copy-pasted from another conversation), so fall back to hydrating it on a miss.
+        let mut documents = Vec::with_capacity(document_ids.len());
+        let mut missing_documents = Vec::new();
+        for id in document_ids {
+            let mut document = try_read_document(id, ctx);
+            if document.is_none() {
+                AIDocumentModel::handle(ctx).update(ctx, |model, ctx| {
+                    if let Err(error) =
+                        model.hydrate_saved_plan_from_warp_drive(*id, conversation_id, ctx)
+                    {
                         log::warn!(
-                            "Failed to hydrate requested plan document {document_id} from Warp Drive: {error}"
+                            "Failed to hydrate requested plan document {id} from Warp Drive: {error}"
                         );
                     }
-                }
-            });
-            (documents, missing_documents) = read_documents(document_ids, ctx);
+                });
+                document = try_read_document(id, ctx);
+            }
+            match document {
+                Some(document) => documents.push(document),
+                None => missing_documents.push(*id),
+            }
         }
 
         if !missing_documents.is_empty() {
@@ -94,31 +93,17 @@ impl Entity for ReadDocumentsExecutor {
     type Event = ();
 }
 
-/// Reads requested documents and returns the IDs that are not loaded locally.
-fn read_documents(
-    document_ids: &[AIDocumentId],
-    ctx: &AppContext,
-) -> (Vec<DocumentContext>, Vec<AIDocumentId>) {
+/// Reads one document, returning `None` if it is not loaded locally.
+fn try_read_document(id: &AIDocumentId, ctx: &AppContext) -> Option<DocumentContext> {
     let model = AIDocumentModel::as_ref(ctx);
-    let mut documents = Vec::with_capacity(document_ids.len());
-    let mut missing_documents = Vec::new();
-    for id in document_ids {
-        let Some(content) = model.get_document_content(id, ctx) else {
-            missing_documents.push(*id);
-            continue;
-        };
-        let Some(current_document) = model.get_current_document(id) else {
-            missing_documents.push(*id);
-            continue;
-        };
-        documents.push(DocumentContext {
-            document_id: *id,
-            content,
-            line_ranges: vec![],
-            document_version: current_document.version,
-        });
-    }
-    (documents, missing_documents)
+    let content = model.get_document_content(id, ctx)?;
+    let version = model.get_current_document(id)?.version;
+    Some(DocumentContext {
+        document_id: *id,
+        content,
+        line_ranges: vec![],
+        document_version: version,
+    })
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/action_model/execute/read_documents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_documents_tests.rs
@@ -1,0 +1,151 @@
+use warpui::{App, EntityId};
+
+use super::*;
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::task::TaskId;
+use crate::ai::agent::{
+    AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
+    ReadDocumentsRequest, ReadDocumentsResult,
+};
+use crate::ai::blocklist::BlocklistAIHistoryModel;
+use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel};
+use crate::appearance::Appearance;
+use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::{
+    CloudObjectMetadata, CloudObjectPermissions, CloudObjectStatuses, CloudObjectSyncStatus, Owner,
+};
+use crate::notebooks::{CloudNotebook, CloudNotebookModel};
+use crate::server::ids::SyncId;
+use crate::test_util::settings::initialize_settings_for_tests;
+
+fn initialize_app(app: &mut App) {
+    initialize_settings_for_tests(app);
+    app.add_singleton_model(|_| Appearance::mock());
+    app.add_singleton_model(|_| CloudModel::new(None, Vec::new(), None));
+    app.add_singleton_model(|_| AIDocumentModel::new_for_test());
+    app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+}
+
+fn read_action(document_id: AIDocumentId) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from("read-documents-action".to_string()),
+        task_id: TaskId::new("read-documents-task".to_string()),
+        requires_result: true,
+        action: AIAgentActionType::ReadDocuments(ReadDocumentsRequest {
+            document_ids: vec![document_id],
+        }),
+    }
+}
+
+fn add_saved_plan_notebook(app: &mut App, document_id: AIDocumentId, content: &str) {
+    let sync_id = SyncId::ServerId(123.into());
+    let notebook = CloudNotebook::new(
+        sync_id,
+        CloudNotebookModel {
+            title: "Saved plan".to_string(),
+            data: content.to_string(),
+            ai_document_id: Some(document_id),
+            conversation_id: None,
+        },
+        CloudObjectMetadata {
+            pending_changes_statuses: CloudObjectStatuses {
+                content_sync_status: CloudObjectSyncStatus::NoLocalChanges,
+                has_pending_metadata_change: false,
+                has_pending_permissions_change: false,
+                pending_untrash: false,
+                pending_delete: false,
+            },
+            folder_id: None,
+            revision: Default::default(),
+            metadata_last_updated_ts: Default::default(),
+            current_editor_uid: Default::default(),
+            trashed_ts: Default::default(),
+            is_welcome_object: false,
+            creator_uid: None,
+            last_editor_uid: None,
+            last_task_run_ts: None,
+        },
+        CloudObjectPermissions {
+            owner: Owner::mock_current_user(),
+            guests: Vec::new(),
+            permissions_last_updated_ts: None,
+            anyone_with_link: None,
+        },
+    );
+    CloudModel::handle(app).update(app, |cloud_model, _| {
+        cloud_model.add_object(sync_id, notebook);
+    });
+}
+
+#[test]
+fn execute_lazily_hydrates_missing_plan_for_remote_child_without_local_parent() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let executor = app.add_model(|_| ReadDocumentsExecutor::new());
+        let document_id = AIDocumentId::new();
+        add_saved_plan_notebook(&mut app, document_id, "# Remote child plan");
+        let child_conversation_id =
+            BlocklistAIHistoryModel::handle(&app).update(&mut app, |history, ctx| {
+                let child_conversation_id =
+                    history.start_new_conversation(EntityId::new(), false, false, false, ctx);
+                history
+                    .conversation_mut(&child_conversation_id)
+                    .expect("child conversation should exist")
+                    .set_parent_agent_id("non-local-parent-run-id".to_string());
+                child_conversation_id
+            });
+        let action = read_action(document_id);
+
+        let execution: AnyActionExecution = executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: child_conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+
+        let AnyActionExecution::Sync(AIAgentActionResultType::ReadDocuments(
+            ReadDocumentsResult::Success { documents },
+        )) = execution
+        else {
+            panic!("expected read_documents success");
+        };
+        assert_eq!(documents.len(), 1);
+        assert_eq!(documents[0].document_id, document_id);
+        assert_eq!(documents[0].content, "# Remote child plan\n");
+    });
+}
+
+#[test]
+fn execute_returns_error_for_missing_document_id() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let executor = app.add_model(|_| ReadDocumentsExecutor::new());
+        let missing_document_id = AIDocumentId::new();
+        let action = read_action(missing_document_id);
+
+        let execution: AnyActionExecution = executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: AIConversationId::new(),
+                    },
+                    ctx,
+                )
+                .into()
+        });
+
+        let AnyActionExecution::Sync(AIAgentActionResultType::ReadDocuments(
+            ReadDocumentsResult::Error(error),
+        )) = execution
+        else {
+            panic!("expected read_documents error");
+        };
+        assert!(error.contains(&missing_document_id.to_string()));
+    });
+}

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -17,7 +17,6 @@ use futures::FutureExt;
 use settings::Setting;
 use warp_cli::agent::Harness;
 use warp_core::execution_mode::AppExecutionMode;
-use warpui::r#async::FutureExt as WarpFutureExt;
 use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use super::start_agent::{StartAgentExecutor, StartAgentOutcome};
@@ -31,14 +30,15 @@ use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::blocklist::inline_action::orchestration_controls::OrchestrationEditState;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
-use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel, AIDocumentModelEvent};
+use crate::ai::document::plan_publication::{
+    prepare_plan_publications, wait_for_plan_publications,
+};
 use crate::ai::local_harness_setup::local_harness_product_disabled_message;
 
 /// Per-child spawn timeout. If a child agent doesn't report back within
 /// this window (e.g. binary not found, server error), the slot is failed
 /// rather than hanging the "Spawning agents" UI indefinitely.
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(30);
-const PLAN_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Snapshot of an in-flight dispatch, carried through
 /// [`RunAgentsExecutorEvent::SpawningStarted`].
@@ -187,61 +187,28 @@ impl RunAgentsExecutor {
             snapshot,
         });
 
-        if pending_plan_publications.is_empty() {
-            self.dispatch_children_for_prepared_request(
-                action_id,
-                request,
-                parent_conversation_id,
-                sender,
-                ctx,
-            );
-        } else {
-            let action_id_for_wait = action_id.clone();
-            ctx.spawn(
-                async move {
-                    // Wait briefly for each plan to become server-backed without blocking
-                    // launch on a failed or slow publication.
-                    futures::future::join_all(pending_plan_publications.into_iter().map(
-                        |pending| async move {
-                            match pending
-                                .save_wait
-                                .recv()
-                                .with_timeout(PLAN_PUBLICATION_TIMEOUT)
-                                .await
-                            {
-                                Ok(Ok(())) => {}
-                                Ok(Err(_)) => {
-                                    log::error!(
-                                        "Stopped waiting for plan document {} before it became server-backed.",
-                                        pending.document_id
-                                    );
-                                }
-                                Err(_) => {
-                                    log::error!(
-                                        "Timed out waiting for plan document {} to become server-backed before child-agent launch.",
-                                        pending.document_id
-                                    );
-                                }
-                            }
-                        },
-                    ))
-                    .await;
-                    request
-                },
-                move |me, request, ctx| {
-                    if !me.is_pending(&action_id_for_wait) {
-                        return;
-                    }
-                    me.dispatch_children_for_prepared_request(
-                        action_id_for_wait.clone(),
-                        request,
-                        parent_conversation_id,
-                        sender,
-                        ctx,
-                    )
-                },
-            );
-        }
+        let action_id_for_wait = action_id.clone();
+        ctx.spawn(
+            async move {
+                // Wait briefly for each plan to become server-backed without blocking
+                // launch on a failed or slow publication. Resolves immediately when
+                // there is nothing to wait on.
+                wait_for_plan_publications(pending_plan_publications).await;
+                request
+            },
+            move |me, request, ctx| {
+                if !me.is_pending(&action_id_for_wait) {
+                    return;
+                }
+                me.dispatch_children_for_prepared_request(
+                    action_id_for_wait.clone(),
+                    request,
+                    parent_conversation_id,
+                    sender,
+                    ctx,
+                )
+            },
+        );
 
         receiver
     }
@@ -476,56 +443,6 @@ mod tests;
 enum ChildSlot {
     Failed(String),
     Pending(async_channel::Receiver<StartAgentOutcome>),
-}
-
-struct PendingPlanPublication {
-    document_id: AIDocumentId,
-    save_wait: async_channel::Receiver<()>,
-}
-
-/// Publishes parent-owned plans and prepares waits for plans still being created.
-fn prepare_plan_publications(
-    parent_conversation_id: AIConversationId,
-    ctx: &mut ModelContext<RunAgentsExecutor>,
-) -> Vec<PendingPlanPublication> {
-    let document_model = AIDocumentModel::handle(ctx);
-    let awaiting_server_backing = document_model.update(ctx, |model, ctx| {
-        model.publish_documents_for_conversation(parent_conversation_id, ctx)
-    });
-
-    awaiting_server_backing
-        .into_iter()
-        .filter_map(|document_id| {
-            let (save_tx, save_rx) = async_channel::bounded(1);
-            ctx.subscribe_to_model(&document_model, move |_, event, ctx| {
-                let AIDocumentModelEvent::DocumentSaveStatusUpdated(saved_document_id) = event
-                else {
-                    return;
-                };
-                if *saved_document_id != document_id {
-                    return;
-                }
-                if AIDocumentModel::as_ref(ctx)
-                    .get_document_save_status(&document_id)
-                    .is_saved()
-                {
-                    let _ = save_tx.try_send(());
-                }
-            });
-            if document_model
-                .as_ref(ctx)
-                .get_document_save_status(&document_id)
-                .is_saved()
-            {
-                None
-            } else {
-                Some(PendingPlanPublication {
-                    document_id,
-                    save_wait: save_rx,
-                })
-            }
-        })
-        .collect()
 }
 
 fn approved_orchestration_config_can_autoexecute(

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -17,6 +17,7 @@ use futures::FutureExt;
 use settings::Setting;
 use warp_cli::agent::Harness;
 use warp_core::execution_mode::AppExecutionMode;
+use warpui::r#async::FutureExt as WarpFutureExt;
 use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
 use super::start_agent::{StartAgentExecutor, StartAgentOutcome};
@@ -30,12 +31,14 @@ use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::blocklist::inline_action::orchestration_controls::OrchestrationEditState;
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
+use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel, AIDocumentModelEvent};
 use crate::ai::local_harness_setup::local_harness_product_disabled_message;
 
 /// Per-child spawn timeout. If a child agent doesn't report back within
 /// this window (e.g. binary not found, server error), the slot is failed
 /// rather than hanging the "Spawning agents" UI indefinitely.
 const SPAWN_TIMEOUT: Duration = Duration::from_secs(30);
+const PLAN_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Snapshot of an in-flight dispatch, carried through
 /// [`RunAgentsExecutorEvent::SpawningStarted`].
@@ -45,7 +48,11 @@ pub struct RunAgentsSpawningSnapshot {
 }
 
 /// In-flight tracking per `RunAgents` action (idempotency guard).
-struct PendingRunAgents;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingRunAgents {
+    Publishing,
+    Spawning,
+}
 #[derive(Debug, Clone)]
 struct ExistingLaunchedAgent {
     name: String,
@@ -91,6 +98,23 @@ impl RunAgentsExecutor {
         self.pending.contains_key(action_id)
     }
 
+    /// Cancels a pending run so publication completion cannot fan out children.
+    pub(super) fn cancel_execution(
+        &mut self,
+        action_id: &AIAgentActionId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if matches!(
+            self.pending.get(action_id),
+            Some(PendingRunAgents::Publishing)
+        ) {
+            self.pending.remove(action_id);
+            ctx.emit(RunAgentsExecutorEvent::SpawningFinished {
+                action_id: action_id.clone(),
+            });
+        }
+    }
+
     fn record_launched_agents(
         &mut self,
         conversation_id: AIConversationId,
@@ -130,9 +154,7 @@ impl RunAgentsExecutor {
         )
     }
 
-    /// Fans out a prepared request into per-child dispatches and returns a
-    /// receiver for the aggregate `RunAgentsResult`. Validation failures
-    /// short-circuit synchronously.
+    /// Publishes parent plans and dispatches children after a bounded best-effort wait.
     fn dispatch_prepared_run_agents(
         &mut self,
         action_id: AIAgentActionId,
@@ -153,16 +175,66 @@ impl RunAgentsExecutor {
             let _ = sender.try_send(RunAgentsResult::Failure { error });
             return receiver;
         }
+        let pending_plan_publications = prepare_plan_publications(parent_conversation_id, ctx);
 
         let snapshot = RunAgentsSpawningSnapshot {
             agent_count: request.agent_run_configs.len(),
         };
-        self.pending.insert(action_id.clone(), PendingRunAgents);
+        self.pending
+            .insert(action_id.clone(), PendingRunAgents::Publishing);
         ctx.emit(RunAgentsExecutorEvent::SpawningStarted {
             action_id: action_id.clone(),
             snapshot,
         });
 
+        if pending_plan_publications.is_empty() {
+            self.dispatch_children_for_prepared_request(
+                action_id,
+                request,
+                parent_conversation_id,
+                sender,
+                ctx,
+            );
+        } else {
+            let action_id_for_wait = action_id.clone();
+            ctx.spawn(
+                async move {
+                    futures::future::join_all(
+                        pending_plan_publications
+                            .into_iter()
+                            .map(wait_for_plan_publication),
+                    )
+                    .await;
+                    request
+                },
+                move |me, request, ctx| {
+                    if !me.is_pending(&action_id_for_wait) {
+                        return;
+                    }
+                    me.dispatch_children_for_prepared_request(
+                        action_id_for_wait.clone(),
+                        request,
+                        parent_conversation_id,
+                        sender,
+                        ctx,
+                    )
+                },
+            );
+        }
+
+        receiver
+    }
+
+    fn dispatch_children_for_prepared_request(
+        &mut self,
+        action_id: AIAgentActionId,
+        request: RunAgentsRequest,
+        parent_conversation_id: AIConversationId,
+        sender: async_channel::Sender<RunAgentsResult>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.pending
+            .insert(action_id.clone(), PendingRunAgents::Spawning);
         let parent_run_id = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&parent_conversation_id)
             .and_then(|c| c.run_id());
@@ -303,8 +375,6 @@ impl RunAgentsExecutor {
                 let _ = sender.try_send(result);
             },
         );
-
-        receiver
     }
 
     pub(super) fn execute(
@@ -385,6 +455,80 @@ mod tests;
 enum ChildSlot {
     Failed(String),
     Pending(async_channel::Receiver<StartAgentOutcome>),
+}
+
+struct PendingPlanPublication {
+    document_id: AIDocumentId,
+    save_wait: async_channel::Receiver<()>,
+}
+
+/// Publishes parent-owned plans and prepares waits for plans still being created.
+fn prepare_plan_publications(
+    parent_conversation_id: AIConversationId,
+    ctx: &mut ModelContext<RunAgentsExecutor>,
+) -> Vec<PendingPlanPublication> {
+    let document_model = AIDocumentModel::handle(ctx);
+    let awaiting_server_backing = document_model.update(ctx, |model, ctx| {
+        model.publish_documents_for_conversation(parent_conversation_id, ctx)
+    });
+
+    awaiting_server_backing
+        .into_iter()
+        .filter_map(|document_id| {
+            let (save_tx, save_rx) = async_channel::bounded(1);
+            ctx.subscribe_to_model(&document_model, move |_, event, ctx| {
+                let AIDocumentModelEvent::DocumentSaveStatusUpdated(saved_document_id) = event
+                else {
+                    return;
+                };
+                if *saved_document_id != document_id {
+                    return;
+                }
+                if AIDocumentModel::as_ref(ctx)
+                    .get_document_save_status(&document_id)
+                    .is_saved()
+                {
+                    let _ = save_tx.try_send(());
+                }
+            });
+            if document_model
+                .as_ref(ctx)
+                .get_document_save_status(&document_id)
+                .is_saved()
+            {
+                None
+            } else {
+                Some(PendingPlanPublication {
+                    document_id,
+                    save_wait: save_rx,
+                })
+            }
+        })
+        .collect()
+}
+
+/// Waits briefly for one plan to become server-backed without blocking launch on failure.
+async fn wait_for_plan_publication(pending: PendingPlanPublication) {
+    match pending
+        .save_wait
+        .recv()
+        .with_timeout(PLAN_PUBLICATION_TIMEOUT)
+        .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {
+            log::error!(
+                "Stopped waiting for plan document {} before it became server-backed.",
+                pending.document_id
+            );
+        }
+        Err(_) => {
+            log::error!(
+                "Timed out waiting for plan document {} to become server-backed before child-agent launch.",
+                pending.document_id
+            );
+        }
+    }
 }
 
 fn approved_orchestration_config_can_autoexecute(

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -199,11 +199,32 @@ impl RunAgentsExecutor {
             let action_id_for_wait = action_id.clone();
             ctx.spawn(
                 async move {
-                    futures::future::join_all(
-                        pending_plan_publications
-                            .into_iter()
-                            .map(wait_for_plan_publication),
-                    )
+                    // Wait briefly for each plan to become server-backed without blocking
+                    // launch on a failed or slow publication.
+                    futures::future::join_all(pending_plan_publications.into_iter().map(
+                        |pending| async move {
+                            match pending
+                                .save_wait
+                                .recv()
+                                .with_timeout(PLAN_PUBLICATION_TIMEOUT)
+                                .await
+                            {
+                                Ok(Ok(())) => {}
+                                Ok(Err(_)) => {
+                                    log::error!(
+                                        "Stopped waiting for plan document {} before it became server-backed.",
+                                        pending.document_id
+                                    );
+                                }
+                                Err(_) => {
+                                    log::error!(
+                                        "Timed out waiting for plan document {} to become server-backed before child-agent launch.",
+                                        pending.document_id
+                                    );
+                                }
+                            }
+                        },
+                    ))
                     .await;
                     request
                 },
@@ -505,30 +526,6 @@ fn prepare_plan_publications(
             }
         })
         .collect()
-}
-
-/// Waits briefly for one plan to become server-backed without blocking launch on failure.
-async fn wait_for_plan_publication(pending: PendingPlanPublication) {
-    match pending
-        .save_wait
-        .recv()
-        .with_timeout(PLAN_PUBLICATION_TIMEOUT)
-        .await
-    {
-        Ok(Ok(())) => {}
-        Ok(Err(_)) => {
-            log::error!(
-                "Stopped waiting for plan document {} before it became server-backed.",
-                pending.document_id
-            );
-        }
-        Err(_) => {
-            log::error!(
-                "Timed out waiting for plan document {} to become server-backed before child-agent launch.",
-                pending.document_id
-            );
-        }
-    }
 }
 
 fn approved_orchestration_config_can_autoexecute(

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -7,20 +7,25 @@ use ai::agent::orchestration_config::{
 use settings::Setting;
 use warp_core::execution_mode::ExecutionMode;
 use warp_core::features::FeatureFlag;
-use warpui::{App, EntityId, ModelHandle};
+use warpui::{App, Entity, EntityId, ModelHandle};
 
 use super::*;
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::task::TaskId;
-use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
+use crate::ai::blocklist::{
+    BlocklistAIHistoryModel, BlocklistAIPermissions, StartAgentExecutorEvent, StartAgentRequest,
+};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
+use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentSaveStatus};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::execution_profiles::RunAgentsPermission;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
+use crate::appearance::Appearance;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::network::NetworkStatus;
 use crate::server::cloud_objects::update_manager::UpdateManager;
+use crate::server::ids::SyncId;
 use crate::server::sync_queue::SyncQueue;
 use crate::settings::PrivacySettings;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
@@ -34,6 +39,14 @@ use crate::{
 struct RunAgentsTestState {
     conversation_id: AIConversationId,
     executor: ModelHandle<RunAgentsExecutor>,
+    start_agent_executor: ModelHandle<StartAgentExecutor>,
+}
+
+#[derive(Default)]
+struct CapturedStartAgentRequests(Vec<StartAgentRequest>);
+
+impl Entity for CapturedStartAgentRequests {
+    type Event = ();
 }
 fn with_plan_id(mut action: AIAgentAction, plan_id: &str) -> AIAgentAction {
     let AIAgentActionType::RunAgents(request) = &mut action.action else {
@@ -165,6 +178,8 @@ fn initialize_run_agents_test(app: &mut App, mode: ExecutionMode) -> RunAgentsTe
     app.add_singleton_model(TeamTesterStatus::mock);
     app.add_singleton_model(UpdateManager::mock);
     app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(|_| Appearance::mock());
+    app.add_singleton_model(|_| AIDocumentModel::new_for_test());
     app.add_singleton_model(|_| TemplatableMCPServerManager::default());
     app.add_singleton_model(|ctx| {
         AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
@@ -176,12 +191,27 @@ fn initialize_run_agents_test(app: &mut App, mode: ExecutionMode) -> RunAgentsTe
     });
     let start_agent_executor = app.add_model(StartAgentExecutor::new);
     let executor =
-        app.add_model(|_| RunAgentsExecutor::new(start_agent_executor, terminal_view_id));
+        app.add_model(|_| RunAgentsExecutor::new(start_agent_executor.clone(), terminal_view_id));
 
     RunAgentsTestState {
         conversation_id,
         executor,
+        start_agent_executor,
     }
+}
+
+fn subscribe_to_start_agent_requests(
+    app: &mut App,
+    start_agent_executor: &ModelHandle<StartAgentExecutor>,
+) -> ModelHandle<CapturedStartAgentRequests> {
+    let captured = app.add_model(|_| CapturedStartAgentRequests::default());
+    captured.update(app, |_, ctx| {
+        ctx.subscribe_to_model(start_agent_executor, |captured, event, _ctx| {
+            let StartAgentExecutorEvent::CreateAgent(request) = event;
+            captured.0.push(request.clone());
+        });
+    });
+    captured
 }
 
 fn remote_run_agents_action(harness_type: &str) -> AIAgentAction {
@@ -411,6 +441,141 @@ fn autonomous_mode_autoexecutes_and_does_not_deny_missing_api_key() {
                 .into()
         });
         assert!(matches!(execution, AnyActionExecution::Async { .. }));
+    });
+}
+
+#[test]
+fn execute_publishes_every_parent_owned_plan_before_dispatch() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        BlocklistAIHistoryModel::handle(&app).update(&mut app, |model, ctx| {
+            model.assign_run_id_for_conversation(
+                state.conversation_id,
+                "00000000-0000-0000-0000-000000000001".to_string(),
+                None,
+                EntityId::new(),
+                ctx,
+            );
+        });
+        let unrelated_conversation_id = AIConversationId::new();
+        let (first_plan_id, second_plan_id, unrelated_plan_id) = AIDocumentModel::handle(&app)
+            .update(&mut app, |model, ctx| {
+                (
+                    model.create_document(
+                        "First plan",
+                        "# First",
+                        state.conversation_id,
+                        None,
+                        ctx,
+                    ),
+                    model.create_document(
+                        "Second plan",
+                        "# Second",
+                        state.conversation_id,
+                        None,
+                        ctx,
+                    ),
+                    model.create_document(
+                        "Unrelated plan",
+                        "# Unrelated",
+                        unrelated_conversation_id,
+                        None,
+                        ctx,
+                    ),
+                )
+            });
+        let captured = subscribe_to_start_agent_requests(&mut app, &state.start_agent_executor);
+        let action = remote_run_agents_action("oz");
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: state.conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+
+        assert!(matches!(execution, AnyActionExecution::Async { .. }));
+        captured.read(&app, |captured, _ctx| {
+            assert!(captured.0.is_empty());
+        });
+        AIDocumentModel::handle(&app).read(&app, |model, _ctx| {
+            assert!(matches!(
+                model.get_document_save_status(&first_plan_id),
+                AIDocumentSaveStatus::Saving
+            ));
+            assert!(matches!(
+                model.get_document_save_status(&second_plan_id),
+                AIDocumentSaveStatus::Saving
+            ));
+            assert!(matches!(
+                model.get_document_save_status(&unrelated_plan_id),
+                AIDocumentSaveStatus::NotSaved
+            ));
+        });
+    });
+}
+
+#[test]
+fn cancel_during_plan_publication_does_not_dispatch_children() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::Sdk);
+        BlocklistAIHistoryModel::handle(&app).update(&mut app, |model, ctx| {
+            model.assign_run_id_for_conversation(
+                state.conversation_id,
+                "00000000-0000-0000-0000-000000000001".to_string(),
+                None,
+                EntityId::new(),
+                ctx,
+            );
+        });
+        let plan_id = AIDocumentModel::handle(&app).update(&mut app, |model, ctx| {
+            model.create_document("Plan", "# Plan", state.conversation_id, None, ctx)
+        });
+        let captured = subscribe_to_start_agent_requests(&mut app, &state.start_agent_executor);
+        let action = remote_run_agents_action("oz");
+        let action_id = action.id.clone();
+
+        let execution = state.executor.update(&mut app, |executor, ctx| {
+            executor
+                .execute(
+                    ExecuteActionInput {
+                        action: &action,
+                        conversation_id: state.conversation_id,
+                    },
+                    ctx,
+                )
+                .into()
+        });
+        assert!(matches!(execution, AnyActionExecution::Async { .. }));
+        state.executor.update(&mut app, |executor, ctx| {
+            assert!(executor.is_pending(&action_id));
+            executor.cancel_execution(&action_id, ctx);
+            assert!(!executor.is_pending(&action_id));
+        });
+
+        AIDocumentModel::handle(&app).update(&mut app, |model, ctx| {
+            model.create_document_from_notebook(
+                plan_id,
+                SyncId::ServerId(123.into()),
+                "Plan",
+                "# Plan",
+                state.conversation_id,
+                None,
+                ctx,
+            );
+        });
+        for _ in 0..3 {
+            futures_lite::future::yield_now().await;
+        }
+
+        captured.read(&app, |captured, _ctx| {
+            assert!(captured.0.is_empty());
+        });
     });
 }
 

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -520,6 +520,11 @@ fn execute_publishes_every_parent_owned_plan_before_dispatch() {
     });
 }
 
+/// A run_agents call holds in the `Publishing` state while it waits for the parent's
+/// plans to become server-backed, then dispatches children. This verifies that
+/// cancelling mid-publication prevents fan-out: even when the plan finishes publishing
+/// afterwards (resolving the wait), the post-wait dispatch is skipped because
+/// `cancel_execution` cleared the pending marker that `is_pending` guards on.
 #[test]
 fn cancel_during_plan_publication_does_not_dispatch_children() {
     App::test((), |mut app| async move {
@@ -551,6 +556,7 @@ fn cancel_during_plan_publication_does_not_dispatch_children() {
                 )
                 .into()
         });
+        // The action is awaiting plan publication, so it's pending but no children dispatched yet.
         assert!(matches!(execution, AnyActionExecution::Async { .. }));
         state.executor.update(&mut app, |executor, ctx| {
             assert!(executor.is_pending(&action_id));
@@ -558,6 +564,7 @@ fn cancel_during_plan_publication_does_not_dispatch_children() {
             assert!(!executor.is_pending(&action_id));
         });
 
+        // Finish publishing the plan, which resolves the wait the dispatch was blocked on.
         AIDocumentModel::handle(&app).update(&mut app, |model, ctx| {
             model.create_document_from_notebook(
                 plan_id,
@@ -573,6 +580,7 @@ fn cancel_during_plan_publication_does_not_dispatch_children() {
             futures_lite::future::yield_now().await;
         }
 
+        // Cancellation won the race: the resolved wait does not fan out children.
         captured.read(&app, |captured, _ctx| {
             assert!(captured.0.is_empty());
         });

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -233,6 +233,21 @@ pub fn orchestration_aware_conversation_status(
     }
 }
 
+/// Returns whether a conversation is a participant in an orchestration tree,
+/// either as a child agent (has a parent) or as an orchestrator (has children).
+pub(crate) fn conversation_participates_in_orchestration(
+    history: &BlocklistAIHistoryModel,
+    conversation_id: AIConversationId,
+) -> bool {
+    let is_child = history
+        .conversation(&conversation_id)
+        .is_some_and(|conversation| conversation.is_child_agent_conversation());
+    is_child
+        || !history
+            .child_conversation_ids_of(&conversation_id)
+            .is_empty()
+}
+
 #[cfg(test)]
 #[path = "orchestration_topology_tests.rs"]
 mod tests;

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -233,21 +233,6 @@ pub fn orchestration_aware_conversation_status(
     }
 }
 
-/// Returns whether a conversation is a participant in an orchestration tree,
-/// either as a child agent (has a parent) or as an orchestrator (has children).
-pub(crate) fn conversation_participates_in_orchestration(
-    history: &BlocklistAIHistoryModel,
-    conversation_id: AIConversationId,
-) -> bool {
-    let is_child = history
-        .conversation(&conversation_id)
-        .is_some_and(|conversation| conversation.is_child_agent_conversation());
-    is_child
-        || !history
-            .child_conversation_ids_of(&conversation_id)
-            .is_empty()
-}
-
 #[cfg(test)]
 #[path = "orchestration_topology_tests.rs"]
 mod tests;

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -286,6 +286,72 @@ impl AIDocumentModel {
         }
     }
 
+    /// Publishes every document owned by a conversation before child-agent launch.
+    pub(in crate::ai) fn publish_documents_for_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) -> Vec<AIDocumentId> {
+        let document_ids = self
+            .documents
+            .iter()
+            .filter_map(|(document_id, document)| {
+                (document.conversation_id == conversation_id).then_some(*document_id)
+            })
+            .collect::<Vec<_>>();
+        let mut awaiting_server_backing = Vec::new();
+
+        for document_id in document_ids {
+            match self.get_document_save_status(&document_id) {
+                AIDocumentSaveStatus::Saved => {
+                    self.maybe_update_cloud_notebook_data(&document_id, ctx);
+                }
+                AIDocumentSaveStatus::Saving => {
+                    self.refresh_saving_document_content(&document_id, ctx);
+                    awaiting_server_backing.push(document_id);
+                }
+                AIDocumentSaveStatus::NotSaved => {
+                    if !self.sync_to_warp_drive(document_id, ctx) {
+                        log::error!(
+                            "Failed to publish plan document {document_id} to Warp Drive before child-agent launch."
+                        );
+                    } else if !self.get_document_save_status(&document_id).is_saved() {
+                        awaiting_server_backing.push(document_id);
+                    }
+                }
+            }
+        }
+
+        awaiting_server_backing
+    }
+
+    /// Refreshes the latest content for a plan whose Warp Drive creation is in progress.
+    fn refresh_saving_document_content(
+        &mut self,
+        document_id: &AIDocumentId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(document) = self.documents.get(document_id) else {
+            return;
+        };
+        let title = document.title.clone();
+        let content = document.editor.as_ref(ctx).markdown(ctx);
+        let sync_id = document.sync_id;
+
+        for pending in self
+            .pending_document_queue
+            .iter_mut()
+            .filter(|pending| pending.id == *document_id)
+        {
+            pending.title.clone_from(&title);
+            pending.content.clone_from(&content);
+        }
+
+        if sync_id.is_some_and(|sync_id| CloudModel::as_ref(ctx).get_notebook(&sync_id).is_some()) {
+            self.maybe_update_cloud_notebook_data(document_id, ctx);
+        }
+    }
+
     fn handle_update_manager_event(
         &mut self,
         event: &UpdateManagerEvent,
@@ -410,6 +476,58 @@ impl AIDocumentModel {
                 ai_document_id,
             ));
         }
+    }
+
+    /// Hydrates a saved plan notebook into the target conversation.
+    pub(in crate::ai) fn hydrate_saved_plan_from_warp_drive(
+        &mut self,
+        ai_document_id: AIDocumentId,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) -> Result<(), String> {
+        let notebook = CloudModel::as_ref(ctx)
+            .get_all_active_notebooks()
+            .find(|notebook| notebook.model().ai_document_id.as_ref() == Some(&ai_document_id))
+            .map(|notebook| {
+                (
+                    notebook.id,
+                    notebook.model().title.clone(),
+                    notebook.model().data.clone(),
+                )
+            })
+            .ok_or_else(|| {
+                format!("Plan document {ai_document_id} was not found in Warp Drive.")
+            })?;
+        let (sync_id, title, content) = notebook;
+        if sync_id.into_server().is_none() {
+            return Err(format!(
+                "Plan document {ai_document_id} is not backed by a saved Warp Drive notebook."
+            ));
+        }
+
+        self.latest_document_id_by_conversation_id
+            .insert(conversation_id, ai_document_id);
+
+        if let Some(document) = self.documents.get_mut(&ai_document_id) {
+            if document.sync_id != Some(sync_id) {
+                document.sync_id = Some(sync_id);
+                ctx.emit(AIDocumentModelEvent::DocumentSaveStatusUpdated(
+                    ai_document_id,
+                ));
+            }
+            return Ok(());
+        }
+
+        self.create_document_from_notebook(
+            ai_document_id,
+            sync_id,
+            title,
+            content,
+            conversation_id,
+            None,
+            ctx,
+        );
+        Ok(())
     }
 
     fn create_document_internal(

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -25,9 +25,9 @@ use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::appearance::Appearance;
 use crate::auth::auth_state::AuthStateProvider;
-use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::cloud_object::{CloudObject, CloudObjectEventEntrypoint, Owner};
-use crate::drive::folders::CloudFolder;
+use crate::drive::{folders::CloudFolder, CloudObjectTypeAndId};
 use crate::global_resource_handles::GlobalResourceHandlesProvider;
 use crate::notebooks::editor::model::{
     FileLinkResolutionContext, NotebooksEditorModel, RichTextEditorModelEvent,
@@ -192,6 +192,9 @@ impl AIDocumentModel {
         ctx.subscribe_to_model(&UpdateManager::handle(ctx), |me, event, ctx| {
             me.handle_update_manager_event(event, ctx);
         });
+        ctx.subscribe_to_model(&CloudModel::handle(ctx), |me, event, ctx| {
+            me.handle_cloud_model_event(event, ctx);
+        });
 
         // Subscribe to history events so we can hydrate the orchestration
         // config from OrchestrationConfigSnapshot messages that arrive
@@ -239,6 +242,9 @@ impl AIDocumentModel {
     /// Returns true if the create document request was sent successfully (or if there was already a notebook entry).
     /// Actually creating the notebook is done asynchronously in the background.
     pub fn sync_to_warp_drive(&mut self, id: AIDocumentId, ctx: &mut ModelContext<Self>) -> bool {
+        if self.reconcile_document_server_backing(&id, ctx) {
+            return true;
+        }
         let Some(document) = self.documents.get(&id) else {
             return false;
         };
@@ -292,6 +298,7 @@ impl AIDocumentModel {
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) -> Vec<AIDocumentId> {
+        self.reconcile_all_document_server_backing(ctx);
         let document_ids = self
             .documents
             .iter()
@@ -325,6 +332,34 @@ impl AIDocumentModel {
         awaiting_server_backing
     }
 
+    /// Reconciles a document with an existing server-backed Warp Drive notebook.
+    fn reconcile_document_server_backing(
+        &mut self,
+        document_id: &AIDocumentId,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let server_sync_id = CloudModel::as_ref(ctx)
+            .get_all_active_notebooks()
+            .find(|notebook| {
+                notebook.id.into_server().is_some()
+                    && notebook.model().ai_document_id.as_ref() == Some(document_id)
+            })
+            .map(|notebook| notebook.id);
+        let Some(server_sync_id) = server_sync_id else {
+            return false;
+        };
+        self.set_document_server_backing(*document_id, server_sync_id, ctx);
+        true
+    }
+
+    /// Reconciles all loaded documents with server-backed Warp Drive notebooks.
+    fn reconcile_all_document_server_backing(&mut self, ctx: &mut ModelContext<Self>) {
+        let document_ids = self.documents.keys().copied().collect::<Vec<_>>();
+        for document_id in document_ids {
+            self.reconcile_document_server_backing(&document_id, ctx);
+        }
+    }
+
     /// Refreshes the latest content for a plan whose Warp Drive creation is in progress.
     fn refresh_saving_document_content(
         &mut self,
@@ -351,6 +386,80 @@ impl AIDocumentModel {
             self.maybe_update_cloud_notebook_data(document_id, ctx);
         }
     }
+    fn handle_cloud_model_event(&mut self, event: &CloudModelEvent, ctx: &mut ModelContext<Self>) {
+        match event {
+            CloudModelEvent::ObjectSynced { server_id, .. } => {
+                self.reconcile_server_backed_notebook(SyncId::ServerId(*server_id), ctx);
+            }
+            CloudModelEvent::ObjectCreated {
+                type_and_id: CloudObjectTypeAndId::Notebook(sync_id),
+            }
+            | CloudModelEvent::ObjectUpdated {
+                type_and_id: CloudObjectTypeAndId::Notebook(sync_id),
+                ..
+            } => {
+                self.reconcile_server_backed_notebook(*sync_id, ctx);
+            }
+            CloudModelEvent::InitialLoadCompleted => {
+                self.reconcile_all_document_server_backing(ctx);
+            }
+            CloudModelEvent::ObjectMoved { .. }
+            | CloudModelEvent::ObjectUpdated { .. }
+            | CloudModelEvent::ObjectTrashed { .. }
+            | CloudModelEvent::ObjectUntrashed { .. }
+            | CloudModelEvent::ObjectDeleted { .. }
+            | CloudModelEvent::ObjectPermissionsUpdated { .. }
+            | CloudModelEvent::ObjectForceExpanded { .. }
+            | CloudModelEvent::ObjectCreated { .. }
+            | CloudModelEvent::NotebookEditorChangedFromServer { .. } => {}
+        }
+    }
+    /// Reconciles one server-backed notebook with its loaded AI document.
+    fn reconcile_server_backed_notebook(&mut self, sync_id: SyncId, ctx: &mut ModelContext<Self>) {
+        if sync_id.into_server().is_none() {
+            return;
+        }
+        let document_id = CloudModel::as_ref(ctx)
+            .get_notebook(&sync_id)
+            .and_then(|notebook| notebook.model().ai_document_id);
+        if let Some(document_id) = document_id {
+            self.set_document_server_backing(document_id, sync_id, ctx);
+        }
+    }
+
+    /// Updates a document and its conversation artifact with server backing.
+    fn set_document_server_backing(
+        &mut self,
+        document_id: AIDocumentId,
+        sync_id: SyncId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(document) = self.documents.get_mut(&document_id) else {
+            return;
+        };
+        if document.sync_id == Some(sync_id) {
+            return;
+        }
+        document.sync_id = Some(sync_id);
+        let conversation_id = document.conversation_id;
+        ctx.emit(AIDocumentModelEvent::DocumentSaveStatusUpdated(document_id));
+
+        let Some(server_id) = sync_id.into_server() else {
+            return;
+        };
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+            let terminal_view_id =
+                history_model.terminal_view_id_for_conversation(&conversation_id);
+            if let Some(conversation) = history_model.conversation_mut(&conversation_id) {
+                conversation.update_plan_notebook_uid(
+                    document_id,
+                    NotebookId::from(server_id),
+                    terminal_view_id,
+                    ctx,
+                );
+            }
+        });
+    }
 
     fn handle_update_manager_event(
         &mut self,
@@ -365,7 +474,7 @@ impl AIDocumentModel {
         {
             return;
         }
-        let (Some(client_id), Some(server_id)) = (result.client_id, result.server_id) else {
+        if result.server_id.is_none() {
             return;
         };
 
@@ -393,36 +502,6 @@ impl AIDocumentModel {
                 }
             }
         }
-
-        let Some((doc_id, doc)) = self
-            .documents
-            .iter_mut()
-            .find(|(_, doc)| doc.sync_id.and_then(|id| id.into_client()) == Some(client_id))
-        else {
-            return;
-        };
-
-        let conversation_id = doc.conversation_id;
-        let ai_document_id = *doc_id;
-        doc.sync_id = Some(SyncId::ServerId(server_id));
-        ctx.emit(AIDocumentModelEvent::DocumentSaveStatusUpdated(
-            ai_document_id,
-        ));
-
-        // Update the plan artifact's notebook_uid in the conversation
-        let notebook_uid = NotebookId::from(server_id);
-        BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-            let terminal_view_id =
-                history_model.terminal_view_id_for_conversation(&conversation_id);
-            if let Some(conversation) = history_model.conversation_mut(&conversation_id) {
-                conversation.update_plan_notebook_uid(
-                    ai_document_id,
-                    notebook_uid,
-                    terminal_view_id,
-                    ctx,
-                );
-            }
-        });
     }
 
     /// Create a new document with default title/content and return its ID.
@@ -1031,25 +1110,7 @@ impl AIDocumentModel {
             ctx,
         );
 
-        // Update the sync status of a document by checking if it exists in Warp Drive.
-        let Some(doc) = self.documents.get(&id) else {
-            return;
-        };
-
-        if doc.sync_id.is_some() {
-            return;
-        }
-
-        let matching_notebook = CloudModel::as_ref(ctx)
-            .get_all_active_notebooks()
-            .find(|notebook| notebook.model().ai_document_id == Some(id));
-
-        if let Some(notebook) = matching_notebook {
-            if let Some(doc) = self.documents.get_mut(&id) {
-                doc.sync_id = Some(notebook.id);
-                ctx.emit(AIDocumentModelEvent::DocumentSaveStatusUpdated(id));
-            }
-        }
+        self.reconcile_document_server_backing(&id, ctx);
     }
 
     /// This is used for restoring EditDocuments results where we already have the final content.

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -27,7 +27,8 @@ use crate::appearance::Appearance;
 use crate::auth::auth_state::AuthStateProvider;
 use crate::cloud_object::model::persistence::{CloudModel, CloudModelEvent};
 use crate::cloud_object::{CloudObject, CloudObjectEventEntrypoint, Owner};
-use crate::drive::{folders::CloudFolder, CloudObjectTypeAndId};
+use crate::drive::folders::CloudFolder;
+use crate::drive::CloudObjectTypeAndId;
 use crate::global_resource_handles::GlobalResourceHandlesProvider;
 use crate::notebooks::editor::model::{
     FileLinkResolutionContext, NotebooksEditorModel, RichTextEditorModelEvent,
@@ -386,6 +387,7 @@ impl AIDocumentModel {
             self.maybe_update_cloud_notebook_data(document_id, ctx);
         }
     }
+
     fn handle_cloud_model_event(&mut self, event: &CloudModelEvent, ctx: &mut ModelContext<Self>) {
         match event {
             CloudModelEvent::ObjectSynced { server_id, .. } => {

--- a/app/src/ai/document/ai_document_model_tests.rs
+++ b/app/src/ai/document/ai_document_model_tests.rs
@@ -19,6 +19,7 @@ fn initialize_app_for_ai_document_tests(app: &mut App) {
     initialize_settings_for_tests(app);
     app.add_singleton_model(|_| Appearance::mock());
     app.add_singleton_model(|_| CloudModel::new(None, Vec::new(), None));
+    app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
 }
 fn add_server_backed_plan_notebook(app: &mut App, document_id: AIDocumentId) -> SyncId {
     let sync_id = SyncId::ServerId(123.into());

--- a/app/src/ai/document/ai_document_model_tests.rs
+++ b/app/src/ai/document/ai_document_model_tests.rs
@@ -2,12 +2,13 @@ use std::ops::Range;
 
 use ai::diff_validation::DiffDelta;
 use chrono::Local;
-use warpui::App;
+use warpui::{App, SingletonEntity};
 
 use super::*;
 use crate::ai::agent::conversation::AIConversationId;
 use crate::appearance::Appearance;
 use crate::cloud_object::model::persistence::CloudModel;
+use crate::server::ids::SyncId;
 use crate::test_util::settings::initialize_settings_for_tests;
 
 fn initialize_app_for_ai_document_tests(app: &mut App) {
@@ -46,6 +47,59 @@ fn test_create_document() {
 
             // Should have no versions initially
             assert!(model.get_earlier_document_versions(&doc_id).is_none());
+        });
+    });
+}
+
+#[test]
+fn publish_refreshes_pending_saving_document_content() {
+    App::test((), |mut app| async move {
+        initialize_app_for_ai_document_tests(&mut app);
+        let model_handle = app.add_model(|_ctx| AIDocumentModel::new_for_test());
+        let conversation_id = AIConversationId::new();
+        let document_id = model_handle.update(&mut app, |model, ctx| {
+            let document_id =
+                model.create_document("Plan", "# Initial", conversation_id, None, ctx);
+            let editor = model
+                .documents
+                .get(&document_id)
+                .expect("document should exist")
+                .editor
+                .clone();
+            model
+                .documents
+                .get_mut(&document_id)
+                .expect("document should exist")
+                .sync_id = Some(SyncId::ClientId(ClientId::new()));
+            model.pending_document_queue.push(PendingDocument {
+                id: document_id,
+                title: "Plan".to_string(),
+                content: "# Initial".to_string(),
+            });
+            editor.update(ctx, |editor, ctx| {
+                editor.reset_with_markdown("# Latest", ctx);
+            });
+            document_id
+        });
+
+        model_handle.update(&mut app, |model, ctx| {
+            let latest_content = model
+                .documents
+                .get(&document_id)
+                .expect("document should exist")
+                .editor
+                .as_ref(ctx)
+                .markdown(ctx);
+            assert_eq!(
+                model.publish_documents_for_conversation(conversation_id, ctx),
+                vec![document_id]
+            );
+            let pending = model
+                .pending_document_queue
+                .iter()
+                .find(|pending| pending.id == document_id)
+                .expect("pending document should exist");
+            assert_eq!(pending.content, latest_content);
         });
     });
 }

--- a/app/src/ai/document/ai_document_model_tests.rs
+++ b/app/src/ai/document/ai_document_model_tests.rs
@@ -8,6 +8,10 @@ use super::*;
 use crate::ai::agent::conversation::AIConversationId;
 use crate::appearance::Appearance;
 use crate::cloud_object::model::persistence::CloudModel;
+use crate::cloud_object::{
+    CloudObjectMetadata, CloudObjectPermissions, CloudObjectStatuses, CloudObjectSyncStatus, Owner,
+};
+use crate::notebooks::{CloudNotebook, CloudNotebookModel};
 use crate::server::ids::SyncId;
 use crate::test_util::settings::initialize_settings_for_tests;
 
@@ -15,6 +19,46 @@ fn initialize_app_for_ai_document_tests(app: &mut App) {
     initialize_settings_for_tests(app);
     app.add_singleton_model(|_| Appearance::mock());
     app.add_singleton_model(|_| CloudModel::new(None, Vec::new(), None));
+}
+fn add_server_backed_plan_notebook(app: &mut App, document_id: AIDocumentId) -> SyncId {
+    let sync_id = SyncId::ServerId(123.into());
+    let notebook = CloudNotebook::new(
+        sync_id,
+        CloudNotebookModel {
+            title: "Plan".to_string(),
+            data: "# Server backed".to_string(),
+            ai_document_id: Some(document_id),
+            conversation_id: None,
+        },
+        CloudObjectMetadata {
+            pending_changes_statuses: CloudObjectStatuses {
+                content_sync_status: CloudObjectSyncStatus::NoLocalChanges,
+                has_pending_metadata_change: false,
+                has_pending_permissions_change: false,
+                pending_untrash: false,
+                pending_delete: false,
+            },
+            folder_id: None,
+            revision: Default::default(),
+            metadata_last_updated_ts: Default::default(),
+            current_editor_uid: Default::default(),
+            trashed_ts: Default::default(),
+            is_welcome_object: false,
+            creator_uid: None,
+            last_editor_uid: None,
+            last_task_run_ts: None,
+        },
+        CloudObjectPermissions {
+            owner: Owner::mock_current_user(),
+            guests: Vec::new(),
+            permissions_last_updated_ts: None,
+            anyone_with_link: None,
+        },
+    );
+    CloudModel::handle(app).update(app, |cloud_model, _| {
+        cloud_model.add_object(sync_id, notebook);
+    });
+    sync_id
 }
 
 #[test]
@@ -47,6 +91,47 @@ fn test_create_document() {
 
             // Should have no versions initially
             assert!(model.get_earlier_document_versions(&doc_id).is_none());
+        });
+    });
+}
+#[test]
+fn cloud_model_sync_event_reconciles_stale_document_client_id() {
+    App::test((), |mut app| async move {
+        initialize_app_for_ai_document_tests(&mut app);
+        let model_handle = app.add_model(|_| AIDocumentModel::new_for_test());
+        let conversation_id = AIConversationId::new();
+        let stale_client_id = ClientId::new();
+        let document_id = model_handle.update(&mut app, |model, ctx| {
+            let document_id = model.create_document("Plan", "# Local", conversation_id, None, ctx);
+            model
+                .documents
+                .get_mut(&document_id)
+                .expect("document should exist")
+                .sync_id = Some(SyncId::ClientId(stale_client_id));
+            document_id
+        });
+        let server_sync_id = add_server_backed_plan_notebook(&mut app, document_id);
+        let server_id = server_sync_id
+            .into_server()
+            .expect("test notebook should be server-backed");
+
+        model_handle.update(&mut app, |model, ctx| {
+            model.handle_cloud_model_event(
+                &CloudModelEvent::ObjectSynced {
+                    type_and_id: crate::drive::CloudObjectTypeAndId::Notebook(server_sync_id),
+                    client_id: stale_client_id,
+                    server_id,
+                },
+                ctx,
+            );
+            assert_eq!(
+                model
+                    .get_current_document(&document_id)
+                    .expect("document should exist")
+                    .sync_id,
+                Some(server_sync_id)
+            );
+            assert!(model.get_document_save_status(&document_id).is_saved());
         });
     });
 }

--- a/app/src/ai/document/mod.rs
+++ b/app/src/ai/document/mod.rs
@@ -1,2 +1,3 @@
 pub mod ai_document_model;
 pub mod orchestration_config_block;
+pub(in crate::ai) mod plan_publication;

--- a/app/src/ai/document/plan_publication.rs
+++ b/app/src/ai/document/plan_publication.rs
@@ -5,8 +5,6 @@
 //! proceeding with work that requires the plans to be server-backed.
 use std::time::Duration;
 
-use futures::future::BoxFuture;
-use futures::FutureExt;
 use warpui::r#async::FutureExt as WarpFutureExt;
 use warpui::{Entity, ModelContext, SingletonEntity};
 
@@ -71,9 +69,7 @@ pub(in crate::ai) fn prepare_plan_publications<E: Entity>(
 
 /// Waits (best-effort, bounded per plan) for each pending publication to
 /// become server-backed. Resolves immediately when `pending` is empty.
-pub(in crate::ai) fn wait_for_plan_publications(
-    pending: Vec<PendingPlanPublication>,
-) -> BoxFuture<'static, ()> {
+pub(in crate::ai) async fn wait_for_plan_publications(pending: Vec<PendingPlanPublication>) {
     futures::future::join_all(pending.into_iter().map(|pending| async move {
         match pending
             .save_wait
@@ -96,6 +92,5 @@ pub(in crate::ai) fn wait_for_plan_publications(
             }
         }
     }))
-    .map(|_| ())
-    .boxed()
+    .await;
 }

--- a/app/src/ai/document/plan_publication.rs
+++ b/app/src/ai/document/plan_publication.rs
@@ -1,0 +1,101 @@
+//! Publishing plan documents to Warp Drive ahead of child-agent launch.
+//!
+//! Callers first call [`prepare_plan_publications`] to kick off publication of
+//! a conversation's plans, then await [`wait_for_plan_publications`] before
+//! proceeding with work that requires the plans to be server-backed.
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use warpui::r#async::FutureExt as WarpFutureExt;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentModel, AIDocumentModelEvent};
+
+/// Bounded wait per plan so a failed or slow publication cannot stall callers
+/// indefinitely.
+const PLAN_PUBLICATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// A plan publication that has been started but is not yet server-backed.
+pub(in crate::ai) struct PendingPlanPublication {
+    document_id: AIDocumentId,
+    save_wait: async_channel::Receiver<()>,
+}
+
+/// Publishes every plan owned by the conversation and returns a pending entry
+/// for each plan that is not yet server-backed.
+pub(in crate::ai) fn prepare_plan_publications<E: Entity>(
+    conversation_id: AIConversationId,
+    ctx: &mut ModelContext<E>,
+) -> Vec<PendingPlanPublication> {
+    let document_model = AIDocumentModel::handle(ctx);
+    let awaiting_server_backing = document_model.update(ctx, |model, ctx| {
+        model.publish_documents_for_conversation(conversation_id, ctx)
+    });
+
+    awaiting_server_backing
+        .into_iter()
+        .filter_map(|document_id| {
+            let (save_tx, save_rx) = async_channel::bounded(1);
+            ctx.subscribe_to_model(&document_model, move |_, event, ctx| {
+                let AIDocumentModelEvent::DocumentSaveStatusUpdated(saved_document_id) = event
+                else {
+                    return;
+                };
+                if *saved_document_id != document_id {
+                    return;
+                }
+                if AIDocumentModel::as_ref(ctx)
+                    .get_document_save_status(&document_id)
+                    .is_saved()
+                {
+                    let _ = save_tx.try_send(());
+                }
+            });
+            if document_model
+                .as_ref(ctx)
+                .get_document_save_status(&document_id)
+                .is_saved()
+            {
+                None
+            } else {
+                Some(PendingPlanPublication {
+                    document_id,
+                    save_wait: save_rx,
+                })
+            }
+        })
+        .collect()
+}
+
+/// Waits (best-effort, bounded per plan) for each pending publication to
+/// become server-backed. Resolves immediately when `pending` is empty.
+pub(in crate::ai) fn wait_for_plan_publications(
+    pending: Vec<PendingPlanPublication>,
+) -> BoxFuture<'static, ()> {
+    futures::future::join_all(pending.into_iter().map(|pending| async move {
+        match pending
+            .save_wait
+            .recv()
+            .with_timeout(PLAN_PUBLICATION_TIMEOUT)
+            .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                log::error!(
+                    "Stopped waiting for plan document {} before it became server-backed.",
+                    pending.document_id
+                );
+            }
+            Err(_) => {
+                log::error!(
+                    "Timed out waiting for plan document {} to become server-backed before child-agent launch.",
+                    pending.document_id
+                );
+            }
+        }
+    }))
+    .map(|_| ())
+    .boxed()
+}

--- a/specs/QUALITY-721/TECH.md
+++ b/specs/QUALITY-721/TECH.md
@@ -18,14 +18,6 @@ Before `RunAgentsExecutor` dispatches children, it asks `AIDocumentModel` to pub
 - `BlocklistAIHistoryModel` knows child conversations for it.
 Hydration uses `AIDocumentModel::hydrate_saved_plan_from_warp_drive`, then retries the complete read so result ordering and all-or-nothing behavior remain unchanged. Missing IDs in non-orchestrated conversations, or IDs still missing after hydration, return the existing clear `Document(s) not found` error.
 Hydrated plans retain ordinary `EditDocumentsExecutor` behavior. No inherited-document write policy or stale-revision policy is introduced.
-## Removed transport
-QUALITY-721 does not add inherited plan fields to:
-- `StartAgentRequest` or `StartAgentExecutor::dispatch`;
-- local or remote child startup;
-- `SpawnAgentRequest`, ambient tasks, agent driver options, or task metadata;
-- child prompt attachments or synthetic plan-reference formatting;
-- server request, task, or execution schemas.
-Local and remote Oz children discover plans when an explicit plan ID in their assigned prompt is passed to `read_plans`, which lazily hydrates it when the acting conversation is orchestrated. Third-party harnesses do not expose Warp document tools; their assigned context must still forward the explicit ID, and required plan content must be supplied through a harness-appropriate prompt or context path.
 ## Testing and validation
 Focused Rust coverage verifies:
 - `RunAgentsExecutor` starts publication for every plan owned by the parent conversation before dispatch, without publishing unrelated plans;

--- a/specs/QUALITY-721/TECH.md
+++ b/specs/QUALITY-721/TECH.md
@@ -1,0 +1,42 @@
+# TECH: Orchestrated agents can read plans by explicit ID
+## Context
+Orchestrated child agents need to read parent-created plans when explicitly given a plan ID. Plan availability is backed by Warp Drive rather than inherited launch metadata or copied markdown.
+## Architecture
+### Publish parent plans before fan-out
+Before `RunAgentsExecutor` dispatches children, it asks `AIDocumentModel` to publish every document owned by the parent conversation.
+- Unbacked plans start Warp Drive creation.
+- Plans already being created refresh their queued or client-backed notebook content before remaining in the wait set.
+- Server-backed plans immediately queue their latest content for update instead of waiting for the normal two-second document save throttle.
+- Newly created or saving plans receive concurrent, bounded waits for server backing.
+- Publication failures and timeouts are logged per plan, and child launch always continues.
+- Cancelling `run_agents` during publication removes the pending launch, so publication completion cannot fan out children. Cancellation after fan-out preserves the existing spawning aggregation lifecycle.
+`RunAgentsRequest.plan_id` remains the orchestration-config key. It is not treated as inherited child context, and no plan IDs or plan content are added to child launch requests, prompts, server task metadata, or driver options.
+### Read plans by explicit ID
+`ReadDocumentsExecutor` first reads requested IDs from the local `AIDocumentModel`. If a requested plan is absent, it attempts Warp Drive hydration only when the acting conversation participates in orchestration:
+- the conversation identifies itself as a child through a local parent conversation ID or remote parent run ID; or
+- `BlocklistAIHistoryModel` knows child conversations for it.
+Hydration uses `AIDocumentModel::hydrate_saved_plan_from_warp_drive`, then retries the complete read so result ordering and all-or-nothing behavior remain unchanged. Missing IDs in non-orchestrated conversations, or IDs still missing after hydration, return the existing clear `Document(s) not found` error.
+Hydrated plans retain ordinary `EditDocumentsExecutor` behavior. No inherited-document write policy or stale-revision policy is introduced.
+## Removed transport
+QUALITY-721 does not add inherited plan fields to:
+- `StartAgentRequest` or `StartAgentExecutor::dispatch`;
+- local or remote child startup;
+- `SpawnAgentRequest`, ambient tasks, agent driver options, or task metadata;
+- child prompt attachments or synthetic plan-reference formatting;
+- server request, task, or execution schemas.
+Local and remote Oz children discover plans when an explicit plan ID in their assigned prompt is passed to `read_plans`, which lazily hydrates it when the acting conversation is orchestrated. Third-party harnesses do not expose Warp document tools; their assigned context must still forward the explicit ID, and required plan content must be supplied through a harness-appropriate prompt or context path.
+## Testing and validation
+Focused Rust coverage verifies:
+- `RunAgentsExecutor` starts publication for every plan owned by the parent conversation before dispatch, without publishing unrelated plans;
+- saving-plan publication refreshes content edited after Warp Drive creation began;
+- cancellation during the publication wait prevents child dispatch;
+- a remote child with only a parent run ID can lazily hydrate and read a requested saved plan;
+- a non-orchestrated conversation retains the missing-document error;
+Validation uses `cargo fmt` and targeted `cargo check`. Do not run the app, nextest, or presubmit for this change.
+## Risks and mitigations
+Warp Drive creation or update can be slow or unavailable.
+- Publication uses bounded waits only for plans that are not yet server-backed.
+- Failures and timeouts are logged per plan and never block child launch indefinitely.
+Explicit-ID discovery depends on the child receiving a relevant plan ID in its task prompt.
+- No implicit plan selection is attempted.
+- A missing or unavailable ID produces a clear `read_plans` error.

--- a/specs/QUALITY-721/TECH.md
+++ b/specs/QUALITY-721/TECH.md
@@ -4,6 +4,7 @@ Orchestrated child agents need to read parent-created plans when explicitly give
 ## Architecture
 ### Publish parent plans before fan-out
 Before `RunAgentsExecutor` dispatches children, it asks `AIDocumentModel` to publish every document owned by the parent conversation.
+- `AIDocumentModel` keeps its cached backing identity synchronized with `CloudModel`: live `ObjectSynced` events update matching plans by stable `ai_document_id`, initial-load completion reconciles restored documents, and explicit sync/publication calls reconcile defensively before creating or waiting.
 - Unbacked plans start Warp Drive creation.
 - Plans already being created refresh their queued or client-backed notebook content before remaining in the wait set.
 - Server-backed plans immediately queue their latest content for update instead of waiting for the normal two-second document save throttle.
@@ -29,6 +30,7 @@ Local and remote Oz children discover plans when an explicit plan ID in their as
 Focused Rust coverage verifies:
 - `RunAgentsExecutor` starts publication for every plan owned by the parent conversation before dispatch, without publishing unrelated plans;
 - saving-plan publication refreshes content edited after Warp Drive creation began;
+- already server-backed plans do not wait when their local document has a stale client sync ID;
 - cancellation during the publication wait prevents child dispatch;
 - a remote child with only a parent run ID can lazily hydrate and read a requested saved plan;
 - a non-orchestrated conversation retains the missing-document error;


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

With orchestration, agents can make plans and then reference these plans when talking to other agents. These other agents should be able to read said plans, even if the plan isn't loaded locally.

The way to do this is to make it so that the `AIDocumentModel` can dynamically load plans from the cloud if the agent requests to read a plan that isn't loaded locally. For now I kept this new ability limited to agents involved in orchestration, but if we see this being useful for all agents we could easily extend it to be allowed for all agents.

This is also coupled w/ [a change on the server](https://github.com/warpdotdev/warp-server/pull/11733) to prompt agents to include exact plan IDs when communicating with children/parents so that other agents can read plans correctly.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/baf688b4e36247e595a94fd8e4606494

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-BUG-FIX: Orchestrated child agents can now correctly read plans from parent agents.
-->
