### PR TITLE
Make Agent question cards fit content

### DIFF
--- a/app/src/ai/blocklist/block/number_shortcut_buttons.rs
+++ b/app/src/ai/blocklist/block/number_shortcut_buttons.rs
@@ -102,6 +102,7 @@ impl NumberShortcutButtonsConfig {
         self
     }
 
+    #[allow(dead_code)]
     pub fn with_scroll_state(mut self, scroll_state: ClippedScrollStateHandle) -> Self {
         self.scroll_state = Some(scroll_state);
         self

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -7,16 +7,14 @@ use ai::agent::action_result::{AskUserQuestionAnswerItem, AskUserQuestionResult}
 use itertools::Itertools;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::WarpTheme;
-use warpui::elements::new_scrollable::SingleAxisConfig;
 use warpui::elements::{
-    Border, ChildView, Clipped, ClippedScrollStateHandle, ConstrainedBox, Container, CornerRadius,
-    CrossAxisAlignment, Expanded, Fill, Flex, FormattedTextElement, MainAxisAlignment,
-    MainAxisSize, MouseStateHandle, ParentElement, Radius, Text, DEFAULT_UI_LINE_HEIGHT_RATIO,
+    Border, ChildView, Container, CornerRadius, CrossAxisAlignment, Flex, FormattedTextElement,
+    MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement, Radius, Text,
+    DEFAULT_UI_LINE_HEIGHT_RATIO,
 };
 use warpui::keymap::{FixedBinding, Keystroke};
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::ui_components::components::Coords;
-use warpui::units::Pixels;
 use warpui::{
     AppContext, Element, Entity, EntityId, FocusContext, ModelHandle, SingletonEntity,
     TypedActionView, View, ViewContext, ViewHandle,
@@ -38,17 +36,14 @@ use crate::ai::blocklist::block::view_impl::{
     CONTENT_ITEM_VERTICAL_MARGIN,
 };
 use crate::ai::blocklist::inline_action::inline_action_header::{
-    ExpandedConfig, HeaderConfig, InteractionMode, INLINE_ACTION_HEADER_VERTICAL_PADDING,
-    INLINE_ACTION_HORIZONTAL_PADDING,
+    ExpandedConfig, HeaderConfig, InteractionMode, INLINE_ACTION_HORIZONTAL_PADDING,
 };
 use crate::ai::blocklist::inline_action::inline_action_icons::{self, icon_size};
 use crate::ai::blocklist::inline_action::requested_action::CTRL_C_KEYSTROKE;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::execution_profiles::AskUserQuestionPermission;
-use crate::terminal::input::message_bar::common::{
-    render_standard_message, standard_message_bar_height, styles,
-};
+use crate::terminal::input::message_bar::common::{render_standard_message, styles};
 use crate::terminal::input::message_bar::{Message, MessageItem};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
@@ -62,54 +57,9 @@ use crate::Appearance;
 const ASK_USER_QUESTION_ACTIVE: &str = "AskUserQuestionActive";
 
 pub(crate) const ASK_USER_QUESTION_AUTO_ADVANCE_DELAY: Duration = Duration::from_millis(300);
-pub(crate) const ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT: f32 = 320.;
-pub(crate) const ASK_USER_QUESTION_OPTION_BUTTON_VERTICAL_SPACING: f32 = 4.;
 pub(crate) const ASK_USER_QUESTION_TEXT_TOP_PADDING: f32 = 16.;
 pub(crate) const ASK_USER_QUESTION_TEXT_BOTTOM_PADDING: f32 = 8.;
 pub(crate) const ASK_USER_QUESTION_OPTIONS_BOTTOM_PADDING: f32 = 16.;
-
-// Assumes single-line labels; wrapped text will be taller but the container
-// caps at ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT and scrolls on overflow.
-fn estimated_min_height_for_all_options(max_option_count: usize, monospace_font_size: f32) -> f32 {
-    (max_option_count as f32 * (monospace_font_size + 16.))
-        + (max_option_count.saturating_sub(1) as f32
-            * ASK_USER_QUESTION_OPTION_BUTTON_VERTICAL_SPACING)
-        + ASK_USER_QUESTION_OPTIONS_BOTTOM_PADDING
-}
-
-fn ask_user_question_text_height(appearance: &Appearance, app: &AppContext) -> f32 {
-    app.font_cache().line_height(
-        appearance.monospace_font_size(),
-        appearance.line_height_ratio(),
-    ) + ASK_USER_QUESTION_TEXT_TOP_PADDING
-        + ASK_USER_QUESTION_TEXT_BOTTOM_PADDING
-}
-
-fn ask_user_question_header_height(appearance: &Appearance, app: &AppContext) -> f32 {
-    let title_line_height = app.font_cache().line_height(
-        appearance.monospace_font_size(),
-        appearance.line_height_ratio(),
-    );
-    title_line_height
-        .max(icon_size(app))
-        .max(ButtonSize::InlineActionHeader.button_height(appearance, app))
-        + (2. * INLINE_ACTION_HEADER_VERTICAL_PADDING)
-}
-
-fn ask_user_question_container_height(
-    max_option_count: usize,
-    appearance: &Appearance,
-    has_nav_footer: bool,
-    app: &AppContext,
-) -> f32 {
-    let mut natural_height = ask_user_question_header_height(appearance, app)
-        + ask_user_question_text_height(appearance, app)
-        + estimated_min_height_for_all_options(max_option_count, appearance.monospace_font_size());
-    if has_nav_footer {
-        natural_height += standard_message_bar_height(app) + 1.;
-    }
-    natural_height.min(ASK_USER_QUESTION_MAX_CONTAINER_HEIGHT)
-}
 
 fn ask_user_question_auto_advance_enabled(is_multiselect: bool, is_last_question: bool) -> bool {
     is_last_question || !is_multiselect
@@ -419,14 +369,6 @@ impl AskUserQuestionSession {
         }
     }
 
-    fn max_option_count(&self) -> usize {
-        self.questions
-            .iter()
-            .map(AskUserQuestionItem::numbered_option_count)
-            .max()
-            .unwrap_or(1)
-    }
-
     // Centralize all state transitions so the view layer only maps UI events to actions and then
     // applies the returned effect.
     fn apply(&mut self, action: AskUserQuestionAction) -> AskUserQuestionEffect {
@@ -726,7 +668,6 @@ pub(crate) struct AskUserQuestionView {
     session: AskUserQuestionSession,
     buttons: ViewHandle<NumberShortcutButtons>,
     text_input: Option<ViewHandle<compact_agent_input::CompactAgentInput>>,
-    options_scroll_state: ClippedScrollStateHandle,
     auto_advance_timer_handle: Option<SpawnedFutureHandle>,
     pending_auto_advance_question_index: Option<usize>,
     is_expanded: bool,
@@ -752,17 +693,10 @@ impl AskUserQuestionView {
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let session = AskUserQuestionSession::new(questions);
-        let options_scroll_state = ClippedScrollStateHandle::new();
         let AskUserQuestionInteractiveViews {
             buttons,
             text_input,
-        } = Self::build_interactive_views(
-            session.current(),
-            None,
-            None,
-            options_scroll_state.clone(),
-            ctx,
-        );
+        } = Self::build_interactive_views(session.current(), None, None, ctx);
         let skip_button = CompactibleActionButton::new(
             "Skip all".to_string(),
             Some(KeystrokeSource::Fixed(CTRL_C_KEYSTROKE.clone())),
@@ -791,7 +725,6 @@ impl AskUserQuestionView {
             session,
             buttons,
             text_input,
-            options_scroll_state,
             auto_advance_timer_handle: None,
             pending_auto_advance_question_index: None,
             is_expanded: false,
@@ -946,7 +879,6 @@ impl AskUserQuestionView {
         current: Option<AskUserQuestionCurrent<'_>>,
         existing_text_input: Option<ViewHandle<compact_agent_input::CompactAgentInput>>,
         selected_button_index: Option<usize>,
-        options_scroll_state: ClippedScrollStateHandle,
         ctx: &mut ViewContext<Self>,
     ) -> AskUserQuestionInteractiveViews {
         let view_state = ask_user_question_view_state(current);
@@ -970,8 +902,7 @@ impl AskUserQuestionView {
                     selected_button_index,
                     NumberShortcutButtonsConfig::new()
                         .with_keyboard_navigation()
-                        .with_enter_to_activate(false)
-                        .with_scroll_state(options_scroll_state),
+                        .with_enter_to_activate(false),
                     ctx,
                 )
             }),
@@ -1138,7 +1069,6 @@ impl AskUserQuestionView {
             current,
             self.text_input.clone(),
             selected_button_index,
-            self.options_scroll_state.clone(),
             ctx,
         );
 
@@ -1246,7 +1176,6 @@ impl AskUserQuestionView {
             }
             AskUserQuestionEffect::ShowQuestion => {
                 self.rebuild_current_question(AskUserQuestionRebuildMode::ResetSelection, ctx);
-                self.options_scroll_state.scroll_to(Pixels::zero());
                 ctx.focus(&self.buttons);
             }
             AskUserQuestionEffect::ScheduleAutoAdvance => {
@@ -1268,15 +1197,9 @@ impl AskUserQuestionView {
             question_text.push_str(" (select all that apply)");
         }
         let has_nav_footer = self.session.has_multiple_questions();
-        let container_height = ask_user_question_container_height(
-            self.session.max_option_count(),
-            appearance,
-            has_nav_footer,
-            app,
-        );
 
         let mut content = Flex::column()
-            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
 
         let mut header_right = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
@@ -1292,13 +1215,7 @@ impl AskUserQuestionView {
                 .with_corner_radius_override(CornerRadius::with_top(Radius::Pixels(8.)))
                 .render_header(app, Some(header_right.finish())),
         );
-        content.add_child(
-            Expanded::new(
-                1.,
-                self.render_question_body(&question_text, appearance, theme),
-            )
-            .finish(),
-        );
+        content.add_child(self.render_question_body(&question_text, appearance, theme));
 
         if has_nav_footer {
             content.add_child(self.render_nav_footer(appearance, theme, app));
@@ -1306,15 +1223,11 @@ impl AskUserQuestionView {
 
         let border_color = blended_colors::neutral_4(theme);
         Some(
-            wrap_with_content_item_spacing(
-                ConstrainedBox::new(content.finish())
-                    .with_height(container_height)
-                    .finish(),
-            )
-            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
-            .with_background_color(theme.background().into_solid())
-            .with_border(Border::all(1.).with_border_fill(border_color))
-            .finish(),
+            wrap_with_content_item_spacing(content.finish())
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+                .with_background_color(theme.background().into_solid())
+                .with_border(Border::all(1.).with_border_fill(border_color))
+                .finish(),
         )
     }
 
@@ -1499,19 +1412,7 @@ impl AskUserQuestionView {
             .with_child(Self::render_question_text(question_text, appearance, theme))
             .with_child(self.render_options_list())
             .finish();
-
-        let scrollable = warpui::elements::NewScrollable::vertical(
-            SingleAxisConfig::Clipped {
-                handle: self.options_scroll_state.clone(),
-                child: body,
-            },
-            theme.nonactive_ui_detail().into(),
-            theme.active_ui_detail().into(),
-            Fill::None,
-        )
-        .finish();
-
-        Container::new(Clipped::new(scrollable).finish())
+        Container::new(body)
             .with_margin_left(INLINE_ACTION_HORIZONTAL_PADDING)
             .with_margin_right(12.)
             .finish()

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view_tests.rs
@@ -1,10 +1,27 @@
 use ai::agent::action::{AskUserQuestionItem, AskUserQuestionOption, AskUserQuestionType};
 use ai::agent::action_result::AskUserQuestionAnswerItem;
+use pathfinder_geometry::rect::RectF;
+use pathfinder_geometry::vector::{vec2f, Vector2F};
+use warp_core::ui::appearance::Appearance;
+use warpui::elements::{ParentElement, SavePosition, Stack};
+use warpui::platform::WindowStyle;
+use warpui::{
+    App, AppContext, Element, Entity, Presenter, SingletonEntity, TypedActionView, View,
+    ViewContext, ViewHandle, WindowId, WindowInvalidation,
+};
 
 use super::{
     ask_user_question_view_state, AskUserQuestionAction, AskUserQuestionEffect,
-    AskUserQuestionPhase, AskUserQuestionSession, AskUserQuestionViewState,
+    AskUserQuestionPhase, AskUserQuestionSession, AskUserQuestionView, AskUserQuestionViewAction,
+    AskUserQuestionViewState,
 };
+use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::AIAgentActionId;
+use crate::ai::blocklist::BlocklistAIActionModel;
+use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
+
+const ACTIVE_QUESTION_CARD_POSITION_ID: &str = "active-question-card";
+const PREVIOUS_ACTIVE_QUESTION_MAX_HEIGHT: f32 = 320.;
 
 fn build_question(
     question_id: &str,
@@ -40,6 +57,156 @@ fn view_state_for(session: &AskUserQuestionSession) -> AskUserQuestionViewState 
 
 fn current_draft(session: &AskUserQuestionSession) -> Option<&super::QuestionDraft> {
     session.current().and_then(|current| current.draft)
+}
+struct ActiveQuestionTestView {
+    question_view: ViewHandle<AskUserQuestionView>,
+}
+
+impl ActiveQuestionTestView {
+    fn new(
+        action_model: warpui::ModelHandle<BlocklistAIActionModel>,
+        question: AskUserQuestionItem,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let question_view = ctx.add_typed_action_view(move |ctx| {
+            AskUserQuestionView::new(
+                action_model,
+                AIConversationId::new(),
+                AIAgentActionId::from("layout-test".to_string()),
+                vec![question],
+                ctx,
+            )
+        });
+        Self { question_view }
+    }
+
+    fn last_option_position_id(&self, app: &AppContext) -> String {
+        let buttons_id = self.question_view.as_ref(app).buttons.id();
+        let last_option_index = self
+            .question_view
+            .as_ref(app)
+            .session
+            .current()
+            .expect("test question should exist")
+            .question
+            .numbered_option_count()
+            - 1;
+        format!("number_shortcut_buttons_{buttons_id}_{last_option_index}")
+    }
+}
+
+impl Entity for ActiveQuestionTestView {
+    type Event = ();
+}
+
+impl View for ActiveQuestionTestView {
+    fn ui_name() -> &'static str {
+        "ActiveQuestionTestView"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let card = self
+            .question_view
+            .as_ref(app)
+            .render_active(Appearance::as_ref(app), app)
+            .expect("test question should render");
+        Stack::new()
+            .with_child(SavePosition::new(card, ACTIVE_QUESTION_CARD_POSITION_ID).finish())
+            .finish()
+    }
+}
+
+impl TypedActionView for ActiveQuestionTestView {
+    type Action = AskUserQuestionViewAction;
+
+    fn handle_action(&mut self, _action: &Self::Action, _ctx: &mut ViewContext<Self>) {}
+}
+fn add_active_question_window(
+    app: &mut App,
+    question: AskUserQuestionItem,
+) -> (WindowId, ViewHandle<ActiveQuestionTestView>) {
+    let terminal = add_window_with_terminal(app, None);
+    let action_model = terminal.read(app, |terminal, _| {
+        terminal.ai_action_model_for_test().clone()
+    });
+    app.add_window(WindowStyle::NotStealFocus, move |ctx| {
+        ActiveQuestionTestView::new(action_model, question, ctx)
+    })
+}
+
+fn active_question_positions(
+    app: &mut App,
+    window_id: WindowId,
+    view: &ViewHandle<ActiveQuestionTestView>,
+    window_size: Vector2F,
+) -> (RectF, RectF) {
+    let last_option_position_id = view.read(app, |view, app| view.last_option_position_id(app));
+    let updated = app.read(|ctx| ctx.view_ids_for_window(window_id).into_iter().collect());
+    let invalidation = WindowInvalidation {
+        updated,
+        ..Default::default()
+    };
+    let mut presenter = Presenter::new(window_id);
+    app.update(move |ctx| {
+        presenter.invalidate(invalidation, ctx);
+        presenter.build_scene(window_size, 1., None, ctx);
+        let card = presenter
+            .position_cache()
+            .get_position(ACTIVE_QUESTION_CARD_POSITION_ID)
+            .expect("active question card should be laid out");
+        let last_option = presenter
+            .position_cache()
+            .get_position(last_option_position_id)
+            .expect("last option should be laid out");
+        (card, last_option)
+    })
+}
+
+#[test]
+fn active_question_card_grows_beyond_previous_height_cap_for_many_options() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let option_labels = (1..=12)
+            .map(|index| format!("Option {index}"))
+            .collect::<Vec<_>>();
+        let options = option_labels.iter().map(String::as_str).collect::<Vec<_>>();
+        let question = build_question("q1", "Choose one", false, false, &options);
+        let (window_id, view) = add_active_question_window(&mut app, question);
+
+        let (card, last_option) =
+            active_question_positions(&mut app, window_id, &view, vec2f(900., 2400.));
+
+        assert!(
+            card.size().y() > PREVIOUS_ACTIVE_QUESTION_MAX_HEIGHT,
+            "expected card to grow beyond the previous height cap, got {}",
+            card.size().y()
+        );
+        assert!(
+            last_option.max_y() <= card.max_y(),
+            "expected the last option to fit inside the card: option={last_option:?}, card={card:?}"
+        );
+    });
+}
+
+#[test]
+fn active_question_card_grows_to_contain_wrapped_option_text() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let wrapped_option = "This is a deliberately long option label that should wrap across \
+                              several lines in a narrow Agent questions card instead of being \
+                              clipped inside an internally scrollable region.";
+        let question = build_question("q1", "Choose one", false, false, &[wrapped_option]);
+        let (window_id, view) = add_active_question_window(&mut app, question);
+
+        let (card, last_option) =
+            active_question_positions(&mut app, window_id, &view, vec2f(360., 2400.));
+
+        assert!(
+            last_option.max_y() <= card.max_y(),
+            "expected wrapped option text to fit inside the card: option={last_option:?}, \
+             card={card:?}"
+        );
+    });
 }
 
 #[test]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7483,6 +7483,10 @@ impl TerminalView {
     pub fn ai_controller(&self) -> &ModelHandle<BlocklistAIController> {
         &self.ai_controller
     }
+    #[cfg(test)]
+    pub(crate) fn ai_action_model_for_test(&self) -> &ModelHandle<BlocklistAIActionModel> {
+        &self.ai_action_model
+    }
 
     pub fn ai_context_model(&self) -> &ModelHandle<BlocklistAIContextModel> {
         &self.ai_context_model


### PR DESCRIPTION
## Description
Make active Agent question cards grow to fit their question and answer options instead of capping the card at 320px and scrolling internally. This keeps all choices visible while leaving overflow handling to the outer conversation viewport. The change removes the card-specific height estimation and scroll state, and adds presenter-based layout regressions for many options and wrapped option text.

## Linked Issue
None.

## Testing
- `./script/format --check`
- `cargo clippy --manifest-path Cargo.toml -p warp --lib --tests -j 10 -- -D warnings`
- `cargo nextest run --manifest-path Cargo.toml -p warp -j 10 ask_user_question_view number_shortcut_buttons` — 28 passed
- `cargo nextest run -p warp_completer --features v2 -j 10` — 116 passed, 4 skipped
- `cargo test --doc -j 10` — passed
- `./script/presubmit` — format and clippy passed; workspace nextest hit three unrelated integration failures. Two passed on focused rerun; `test_legacy_ssh_into_zsh` failed again due to existing SSH generator decoding/login-shell output mismatch.
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not included; presenter-based layout tests validate the sizing regression.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/ef84272b-7369-45ee-876d-20f5adcbebd7

CHANGELOG-BUG-FIX: Fixed Agent question cards scrolling internally instead of fitting their questions and answer choices.

Co-Authored-By: Oz <oz-agent@warp.dev>
Co-Authored-By: Warp <agent@warp.dev>