### PR TITLE
Add basic tracing support for cloud agents.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14960,6 +14960,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "tracing",
  "url",
  "warp_features",
  "warp_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4918,9 +4918,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -9296,6 +9296,77 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "flate2",
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.3",
+ "reqwest",
+ "thiserror 2.0.17",
+ "zstd",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -13721,10 +13792,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.20"
+name = "tracing-opentelemetry"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -14555,6 +14640,9 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "onboarding",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "ordered-float 3.9.2",
  "os_info",
  "palette",
@@ -14628,6 +14716,8 @@ dependencies = [
  "toml 0.8.23",
  "toml_edit 0.25.6+spec-1.1.0",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "typed-path 0.10.0",
  "ui_components",
  "unicase",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9336,7 +9336,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost",
  "reqwest",
  "thiserror 2.0.17",
  "zstd",
@@ -9350,7 +9350,7 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13781,6 +13781,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14716,6 +14728,7 @@ dependencies = [
  "toml 0.8.23",
  "toml_edit 0.25.6+spec-1.1.0",
  "tracing",
+ "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "typed-path 0.10.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15508,6 +15508,7 @@ dependencies = [
  "thiserror 2.0.17",
  "titlecase",
  "tokio",
+ "tracing",
  "trait-set",
  "vec1",
  "warp_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,15 @@ notify-debouncer-full = { git = "https://github.com/warpdotdev/notify", rev = "9
 nom = "7.1.1"
 num-traits = "0.2"
 oauth2 = { version = "5.0.0", default-features = false }
+opentelemetry = { version = "0.32.0", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
+  "gzip-http",
+  "http-proto",
+  "reqwest-blocking-client",
+  "trace",
+  "zstd-http",
+] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace"] }
 openh264 = "0.8"
 static_assertions = "1.1.0"
 url = "2.5.4"
@@ -277,6 +286,11 @@ toml_edit = "0.25.5"
 tower = "0.5.2"
 tower-http = "0.6.6"
 tracing = "0.1.40"
+tracing-opentelemetry = { version = "0.33.0", default-features = false }
+tracing-subscriber = { version = "0.3.22", default-features = false, features = [
+  "registry",
+  "std",
+] }
 arborium = { version = "2", default-features = false, features = [
   "lang-rust",
   "lang-go",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,7 @@ toml_edit = "0.25.5"
 tower = "0.5.2"
 tower-http = "0.6.6"
 tracing = "0.1.40"
+tracing-futures = "0.2.5"
 tracing-opentelemetry = { version = "0.33.0", default-features = false }
 tracing-subscriber = { version = "0.3.22", default-features = false, features = [
   "registry",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -213,6 +213,7 @@ tikv-jemallocator = { version = "0.6", optional = true, features = [
 toml = "0.8.13"
 toml_edit.workspace = true
 tracing.workspace = true
+tracing-futures = { workspace = true, features = ["futures-03"] }
 ui_components.workspace = true
 unicase = "2.7.0"
 unicode-general-category.workspace = true

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -316,8 +316,13 @@ http_server.workspace = true
 hyper.workspace = true
 libsqlite3-sys = { version = "0.33.0", features = ["bundled"] }
 mio = { version = "1.1.1", features = ["os-poll", "os-ext"] }
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true
 
 # AWS SDK (loading credentials for BYO LLM)
 aws-config = { version = "1.8.16", features = ["credentials-login"] }

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -546,6 +546,12 @@ impl From<PrepareEnvironmentError> for AgentDriverError {
 }
 
 impl AgentDriver {
+    #[tracing::instrument(skip_all, err, fields(
+        tags.cloud_agent = true,
+        task_id = ?options.task_id,
+        parent_run_id = ?options.parent_run_id,
+        is_sandbox = tracing::field::Empty,
+    ))]
     pub fn new(
         options: AgentDriverOptions,
         ctx: &mut ModelContext<Self>,
@@ -626,6 +632,7 @@ impl AgentDriver {
         // so they allow root execution with permissive flags.
         if warp_isolation_platform::detect().is_some() {
             env_vars.insert(OsString::from("IS_SANDBOX"), OsString::from("1"));
+            tracing::Span::current().record("is_sandbox", true);
         }
 
         let resolved_env_vars = Arc::new(env_vars);
@@ -1782,6 +1789,7 @@ impl AgentDriver {
     /// Driving the agent mostly requires main-thread UI framework updates, but using `async` and
     /// a `ModelSpawner` lets us express the high-level process linearly rather than in a
     /// series of callbacks and state machine updates.
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
     async fn run_internal(
         task: Task,
         foreground: ModelSpawner<Self>,
@@ -3278,6 +3286,11 @@ impl AgentDriver {
     ) {
         match event {
             TerminalDriverEvent::SlowBootstrap => {
+                tracing::event!(
+                    tracing::Level::WARN,
+                    tags.cloud_agent = true,
+                    "slow bootstrap"
+                );
                 eprintln!(
                     "Warning: Terminal session is slow to bootstrap. See https://docs.warp.dev/support-and-community/troubleshooting-and-support/known-issues#shells to troubleshoot."
                 );
@@ -3286,6 +3299,12 @@ impl AgentDriver {
                 session_id,
                 join_url,
             } => {
+                tracing::event!(
+                    tracing::Level::INFO,
+                    tags.cloud_agent = true,
+                    session_id = %*session_id,
+                    "shared session established",
+                );
                 write_session_joined(join_url, self.output_format);
 
                 // If running as part of a task, store the session-sharing link.
@@ -3369,6 +3388,7 @@ impl AgentDriver {
     /// Invoke the end-of-run snapshot upload pipeline if the feature flag is enabled and this
     /// driver is associated with a cloud task. Errors are logged internally; this helper always
     /// returns so cleanup can proceed.
+    #[tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
     async fn run_snapshot_upload(spawner: &ModelSpawner<Self>) {
         if !FeatureFlag::OzHandoff.is_enabled() {
             return;

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -546,7 +546,7 @@ impl From<PrepareEnvironmentError> for AgentDriverError {
 }
 
 impl AgentDriver {
-    #[tracing::instrument(skip_all, err, fields(
+    #[tracing::instrument(name = "AgentDriver::new", skip_all, err, fields(
         tags.cloud_agent = true,
         task_id = ?options.task_id,
         parent_run_id = ?options.parent_run_id,
@@ -1789,7 +1789,7 @@ impl AgentDriver {
     /// Driving the agent mostly requires main-thread UI framework updates, but using `async` and
     /// a `ModelSpawner` lets us express the high-level process linearly rather than in a
     /// series of callbacks and state machine updates.
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(name = "AgentDriver::run_internal", skip_all, err, fields(tags.cloud_agent = true))]
     async fn run_internal(
         task: Task,
         foreground: ModelSpawner<Self>,

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -10,7 +10,6 @@ use ai::index::full_source_code_embedding::manager::{
 use futures::channel::oneshot;
 use futures::future::join_all;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
-use tracing::Instrument as _;
 use warp_cli::agent::Harness;
 use warp_completer::completer::CommandExitStatus;
 use warp_core::command::ExitCode;
@@ -131,13 +130,9 @@ async fn prepare_environment_impl(
     if !github_repos.is_empty() {
         setup_events
             .record_result(SetupStep::EnvironmentRepoClone, async {
-                clone_repos(github_repos, working_dir, spawner)
-                .instrument(tracing::info_span!("clone_repos", tags.cloud_agent = true))
-                .await?;
+                clone_repos(github_repos, working_dir, spawner).await?;
                 for repo in github_repos {
-                    register_cloned_repo(repo, working_dir, is_sandbox, spawner)
-                    .instrument(tracing::info_span!("register_cloned_repo", tags.cloud_agent = true, repo = %repo.repo))
-                    .await?;
+                    register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
                     if !is_sandbox && should_index_codebase {
                         let receiver = index_repo_codebase(
                             &repo.repo,
@@ -145,10 +140,6 @@ async fn prepare_environment_impl(
                             Arc::clone(&repo_channels),
                             spawner,
                         )
-                        .instrument(tracing::info_span!(
-                            "index_repo_codebase",
-                            tags.cloud_agent = true
-                        ))
                         .await?;
                         if let Some(receiver) = receiver {
                             codebase_context_receivers.push(receiver);
@@ -387,6 +378,7 @@ pub(super) async fn clone_repos(
 
 /// Clone a GitHub repository to `{working_dir}/{repo.repo}` if it does not already exist.
 /// This only performs the clone -- it does NOT register the repo with `DetectedRepositories`.
+#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo))]
 pub(super) async fn clone_repo(
     repo: &GithubRepo,
     working_dir: &Path,
@@ -447,6 +439,7 @@ pub(super) async fn clone_repo(
 
 /// Register a cloned GitHub repository with `DetectedRepositories` so that the
 /// skill watcher and other repo-aware subsystems can discover it.
+#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo, is_sandbox = is_sandbox))]
 pub(super) async fn register_cloned_repo(
     repo: &GithubRepo,
     working_dir: &Path,
@@ -555,6 +548,7 @@ async fn subscribe_to_codebase_index_events(
         .map_err(|_| PrepareEnvironmentError::InvalidRuntimeState)
 }
 
+#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo_name))]
 async fn index_repo_codebase(
     repo_name: &str,
     working_dir: &Path,

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -10,6 +10,7 @@ use ai::index::full_source_code_embedding::manager::{
 use futures::channel::oneshot;
 use futures::future::join_all;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
+use tracing::Instrument as _;
 use warp_cli::agent::Harness;
 use warp_completer::completer::CommandExitStatus;
 use warp_core::command::ExitCode;
@@ -130,9 +131,13 @@ async fn prepare_environment_impl(
     if !github_repos.is_empty() {
         setup_events
             .record_result(SetupStep::EnvironmentRepoClone, async {
-                clone_repos(github_repos, working_dir, spawner).await?;
+                clone_repos(github_repos, working_dir, spawner)
+                .instrument(tracing::info_span!("clone_repos", tags.cloud_agent = true))
+                .await?;
                 for repo in github_repos {
-                    register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
+                    register_cloned_repo(repo, working_dir, is_sandbox, spawner)
+                    .instrument(tracing::info_span!("register_cloned_repo", tags.cloud_agent = true, repo = %repo.repo))
+                    .await?;
                     if !is_sandbox && should_index_codebase {
                         let receiver = index_repo_codebase(
                             &repo.repo,
@@ -140,14 +145,15 @@ async fn prepare_environment_impl(
                             Arc::clone(&repo_channels),
                             spawner,
                         )
+                        .instrument(tracing::info_span!(
+                            "index_repo_codebase",
+                            tags.cloud_agent = true
+                        ))
                         .await?;
-                        if let Some(receiver) = receiver {
-                            codebase_context_receivers.push(receiver);
-                        }
                     }
-                }
-                Ok::<(), PrepareEnvironmentError>(())
-            })
+                    Ok::<(), PrepareEnvironmentError>(())
+                },
+            )
             .await?;
 
         if should_index_codebase {

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -150,10 +150,13 @@ async fn prepare_environment_impl(
                             tags.cloud_agent = true
                         ))
                         .await?;
+                        if let Some(receiver) = receiver {
+                            codebase_context_receivers.push(receiver);
+                        }
                     }
-                    Ok::<(), PrepareEnvironmentError>(())
-                },
-            )
+                }
+                Ok::<(), PrepareEnvironmentError>(())
+            })
             .await?;
 
         if should_index_codebase {

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -248,6 +248,10 @@ pub(crate) fn configure_git_identity(credentials: &[GitCredential]) {
 /// Returns `Ok(())` on success (including when the server returns no
 /// credentials). Returns `Err` when the workload-token issuance or the server
 /// API call fails — these are transient failures worth retrying.
+#[tracing::instrument(name = "git_credentials::try_refresh", skip_all, err, fields(
+    tags.cloud_agent = true,
+    task_id,
+))]
 async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<()> {
     let workload_token =
         warp_isolation_platform::issue_workload_token(Some(Duration::from_secs(5 * 60)))

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -8,8 +8,10 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::channel::oneshot;
+use futures::TryFutureExt as _;
 use session_sharing_protocol::common::{Role, SessionId};
 use session_sharing_protocol::sharer::SessionRetentionReason;
+use tracing::Instrument as _;
 use warp_cli::share::{ShareAccessLevel, ShareRequest, ShareSubject};
 use warp_completer::completer::CommandOutput;
 use warp_core::command::ExitCode;
@@ -547,11 +549,17 @@ impl TerminalDriver {
             session_bootstrapped
                 .wait()
                 .with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT)
-                .await
-                .map_err(|_| {
+                .map_err(|err| {
                     log::error!("Timed out waiting for session bootstrap");
+                    tracing::error!(error = %err);
+
                     AgentDriverError::BootstrapFailed
                 })
+                .instrument(tracing::info_span!(
+                    "wait_for_session_bootstrapped",
+                    tags.cloud_agent = true
+                ))
+                .await
         }
     }
 

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -120,6 +120,7 @@ fn maybe_warn_team_api_key(ctx: &AppContext) {
 }
 
 /// Run a Warp CLI command.
+#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
 pub fn run(
     ctx: &mut AppContext,
     command: CliCommand,

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -120,7 +120,7 @@ fn maybe_warn_team_api_key(ctx: &AppContext) {
 }
 
 /// Run a Warp CLI command.
-#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+#[tracing::instrument(name = "agent_sdk::run", skip_all, err, fields(tags.cloud_agent = true))]
 pub fn run(
     ctx: &mut AppContext,
     command: CliCommand,
@@ -1441,7 +1441,7 @@ impl AgentDriverRunner {
                 driver.add_share_requests(share_requests, ctx);
             }
             let span =
-                tracing::info_span!("run", tags.cloud_agent = true, ?task.model, ?task.harness);
+                tracing::info_span!("AgentDriver::run", tags.cloud_agent = true, ?task.model, ?task.harness);
             let agent_future = driver.run(task, ctx).instrument(span);
 
             ctx.spawn(agent_future, |_, result, ctx| match result {

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use driver::harness::{task_env_vars, validate_cli_installed, ClaudeHa
 pub use driver::AgentDriver;
 use driver::AgentDriverError;
 use telemetry::CliTelemetryEvent;
+use tracing::Instrument as _;
 use warp_cli::agent::{
     AgentCommand, AgentProfileCommand, Harness, OutputFormat, Prompt, RunAgentArgs,
 };
@@ -594,6 +595,12 @@ impl warpui::Entity for AgentDriverRunner {
 impl warpui::SingletonEntity for AgentDriverRunner {}
 
 impl AgentDriverRunner {
+    #[tracing::instrument(skip_all, err, fields(
+        tags.cloud_agent = true,
+        args.sandboxed = args.sandboxed,
+        args.computer_use = args.computer_use.computer_use,
+        args.no_computer_use = args.computer_use.no_computer_use
+    ))]
     async fn setup_and_run_driver(
         foreground: ModelSpawner<Self>,
         args: RunAgentArgs,
@@ -1305,6 +1312,7 @@ impl AgentDriverRunner {
     /// wraps the returned payload (if any) in [`driver::ResumeOptions::ThirdParty`]; each harness
     /// owns its server call and error mapping. Returns `None` if a third-party harness has no
     /// resume payload to surface.
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, conversation_id = conversation_id))]
     async fn load_conversation_information(
         foreground: &ModelSpawner<Self>,
         conversation_id: String,
@@ -1366,6 +1374,7 @@ impl AgentDriverRunner {
     }
 
     /// Resolve the environment and store into `driver_options`.
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, ?environment_id))]
     async fn resolve_environment(
         foreground: &ModelSpawner<Self>,
         environment_id: Option<String>,
@@ -1409,6 +1418,7 @@ impl AgentDriverRunner {
     }
 
     /// Create the AgentDriver and start running the task.
+    #[tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
     fn create_and_run_driver(
         ctx: &mut AppContext,
         driver_options: driver::AgentDriverOptions,
@@ -1429,7 +1439,9 @@ impl AgentDriverRunner {
             if let Some(share_requests) = share_requests {
                 driver.add_share_requests(share_requests, ctx);
             }
-            let agent_future = driver.run(task, ctx);
+            let span =
+                tracing::info_span!("run", tags.cloud_agent = true, ?task.model, ?task.harness);
+            let agent_future = driver.run(task, ctx).instrument(span);
 
             ctx.spawn(agent_future, |_, result, ctx| match result {
                 Ok(()) => {
@@ -1572,6 +1584,8 @@ fn report_fatal_error(err: anyhow::Error, ctx: &mut AppContext) {
     for cause in err.chain().skip(1) {
         let _ = write!(&mut message, "\n=> {cause}");
     }
+
+    tracing::event!(tracing::Level::ERROR, tags.cloud_agent = true, message);
 
     #[cfg(not(target_family = "wasm"))]
     {

--- a/app/src/ai/agent_sdk/setup_observability.rs
+++ b/app/src/ai/agent_sdk/setup_observability.rs
@@ -2,6 +2,8 @@ use std::future::Future;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use futures::FutureExt as _;
+use tracing::Instrument as _;
 use warpui::r#async::executor::Background;
 
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -37,16 +39,26 @@ impl SetupClientEventReporter {
         }
     }
 
-    pub(crate) async fn record_result<T, E>(
+    pub(crate) async fn record_result<T, E: std::error::Error>(
         &self,
         step: SetupStep,
         future: impl Future<Output = Result<T, E>>,
     ) -> Result<T, E> {
+        let (step_name, span) = step.to_event_name_and_span();
+
         let start_timestamp = Utc::now();
-        let result = future.await;
+        let result = future
+            .map(|result| {
+                result.inspect_err(|err| {
+                    tracing::error!(error = %err);
+                })
+            })
+            .instrument(span)
+            .await;
         let finish_timestamp = Utc::now();
+
         self.post_setup_metric_event_best_effort(
-            step,
+            step_name,
             start_timestamp,
             finish_timestamp,
             result.is_err(),
@@ -59,10 +71,18 @@ impl SetupClientEventReporter {
         step: SetupStep,
         future: impl Future<Output = T>,
     ) -> T {
+        let (step_name, span) = step.to_event_name_and_span();
+
         let start_timestamp = Utc::now();
-        let value = future.await;
+        let value = future.instrument(span).await;
         let finish_timestamp = Utc::now();
-        self.post_setup_metric_event_best_effort(step, start_timestamp, finish_timestamp, false);
+
+        self.post_setup_metric_event_best_effort(
+            step_name,
+            start_timestamp,
+            finish_timestamp,
+            false,
+        );
         value
     }
     pub(crate) fn record_value_detached<T>(
@@ -72,14 +92,16 @@ impl SetupClientEventReporter {
     ) where
         T: Send + 'static,
     {
+        let (step_name, span) = step.to_event_name_and_span();
+
         let reporter = self.clone();
         self.background
             .spawn(async move {
                 let start_timestamp = Utc::now();
-                future.await;
+                future.instrument(span).await;
                 let finish_timestamp = Utc::now();
                 reporter.post_setup_metric_event_best_effort(
-                    step,
+                    step_name,
                     start_timestamp,
                     finish_timestamp,
                     false,
@@ -100,7 +122,7 @@ impl SetupClientEventReporter {
 
     fn post_setup_metric_event_best_effort(
         &self,
-        step: SetupStep,
+        event_name: &'static str,
         start_timestamp: DateTime<Utc>,
         finish_timestamp: DateTime<Utc>,
         is_error: bool,
@@ -112,7 +134,6 @@ impl SetupClientEventReporter {
         let ai_client = self.ai_client.clone();
         self.background
             .spawn(async move {
-                let event_name = step.as_event_name();
                 let request = AgentRunClientEventRequest::setup_metric_event(
                     event_name,
                     start_timestamp,
@@ -130,6 +151,8 @@ impl SetupClientEventReporter {
         event_name: &'static str,
         request: AgentRunClientEventRequest,
     ) {
+        tracing::info!(event_name, tags.cloud_agent = true);
+
         if let Err(err) = ai_client
             .post_agent_run_client_event(&run_id, request)
             .await
@@ -181,33 +204,83 @@ pub(crate) enum SetupStep {
     ThirdPartyHarnessExternalConversation,
 }
 
+macro_rules! span_and_name {
+    ($name:literal) => {
+        ($name, tracing::info_span!($name, tags.cloud_agent = true))
+    };
+}
+
 impl SetupStep {
-    fn as_event_name(self) -> &'static str {
+    fn to_event_name_and_span(self) -> (&'static str, tracing::Span) {
         match self {
-            Self::TeamMetadataRefresh => "setup_team_metadata_refresh",
-            Self::WarpDriveSync => "setup_warp_drive_sync",
-            Self::TaskDataFetch => "setup_task_metadata_secrets_attachments_git_credentials_fetch",
-            Self::EnvironmentResolution => "setup_environment_resolution",
-            Self::SkillRepoClone => "setup_skill_repo_clone",
-            Self::TerminalBootstrap => "setup_terminal_bootstrap",
-            Self::CloudProviderSetup => "setup_cloud_provider_setup",
-            Self::McpServerStartup => "setup_mcp_server_startup",
-            Self::AgentProfileConfiguration => "setup_agent_profile_configuration",
-            Self::ProfileMcpServerStartup => "setup_profile_mcp_server_startup",
-            Self::SharedSessionEstablishment => "setup_shared_session_establishment",
-            Self::GlobalSkillResolution => "setup_global_skill_resolution",
-            Self::GlobalSkillRepoClone => "setup_global_skill_repo_clone",
-            Self::EnvironmentRepoClone => "setup_environment_repo_clone",
-            Self::EnvironmentSetupCommands => "setup_environment_setup_commands",
-            Self::EnvironmentCodebaseIndexing => "setup_environment_codebase_indexing",
-            Self::FileBasedMcpDiscovery => "setup_file_based_mcp_discovery",
-            Self::FileBasedMcpReadiness => "setup_file_based_mcp_readiness",
-            Self::EnvironmentSkillLoading => "setup_environment_skill_loading",
-            Self::GlobalSkillLoading => "setup_global_skill_loading",
-            Self::ConversationResumeLoading => "setup_conversation_resume_loading",
-            Self::ThirdPartyHarnessPreparation => "setup_third_party_harness_preparation",
+            Self::TeamMetadataRefresh => {
+                span_and_name!("setup_team_metadata_refresh")
+            }
+            Self::WarpDriveSync => {
+                span_and_name!("setup_warp_drive_sync")
+            }
+            Self::TaskDataFetch => {
+                span_and_name!("setup_task_metadata_secrets_attachments_git_credentials_fetch")
+            }
+            Self::EnvironmentResolution => {
+                span_and_name!("setup_environment_resolution")
+            }
+            Self::SkillRepoClone => {
+                span_and_name!("setup_skill_repo_clone")
+            }
+            Self::TerminalBootstrap => {
+                span_and_name!("setup_terminal_bootstrap")
+            }
+            Self::CloudProviderSetup => {
+                span_and_name!("setup_cloud_provider_setup")
+            }
+            Self::McpServerStartup => {
+                span_and_name!("setup_mcp_server_startup")
+            }
+            Self::AgentProfileConfiguration => {
+                span_and_name!("setup_agent_profile_configuration")
+            }
+            Self::ProfileMcpServerStartup => {
+                span_and_name!("setup_profile_mcp_server_startup")
+            }
+            Self::SharedSessionEstablishment => {
+                span_and_name!("setup_shared_session_establishment")
+            }
+            Self::GlobalSkillResolution => {
+                span_and_name!("setup_global_skill_resolution")
+            }
+            Self::GlobalSkillRepoClone => {
+                span_and_name!("setup_global_skill_repo_clone")
+            }
+            Self::EnvironmentRepoClone => {
+                span_and_name!("setup_environment_repo_clone")
+            }
+            Self::EnvironmentSetupCommands => {
+                span_and_name!("setup_environment_setup_commands")
+            }
+            Self::EnvironmentCodebaseIndexing => {
+                span_and_name!("setup_environment_codebase_indexing")
+            }
+            Self::FileBasedMcpDiscovery => {
+                span_and_name!("setup_file_based_mcp_discovery")
+            }
+            Self::FileBasedMcpReadiness => {
+                span_and_name!("setup_file_based_mcp_readiness")
+            }
+            Self::EnvironmentSkillLoading => {
+                span_and_name!("setup_environment_skill_loading")
+            }
+            Self::GlobalSkillLoading => {
+                span_and_name!("setup_global_skill_loading")
+            }
+            Self::ConversationResumeLoading => {
+                span_and_name!("setup_conversation_resume_loading")
+            }
+            Self::ThirdPartyHarnessPreparation => {
+                span_and_name!("setup_third_party_harness_preparation")
+            }
             Self::ThirdPartyHarnessExternalConversation => {
-                "setup_third_party_harness_external_conversation"
+                span_and_name!("setup_third_party_harness_external_conversation")
             }
         }
     }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -580,6 +580,7 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
 }
 
 /// Runs the app. If a subcommand was requested, it'll be run instead of the main application.
+#[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 pub fn run() -> Result<()> {
     // Perform any necessary platform-specific initialization.
     platform::init();
@@ -795,6 +796,11 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         .needs_profiling()
         .then(tracing::init)
         .transpose()?;
+
+    // Start the `run_internal` span here - we can't do it before this point
+    // because we need the tracing initialization to be complete first.
+    let span = ::tracing::info_span!("run_internal", tags.cloud_agent = true);
+    let _enter = span.enter();
 
     let log_destination = launch_mode.log_destination();
     let is_cli = log_destination.is_some();
@@ -1077,6 +1083,7 @@ pub struct UpdateQuakeModeEventArg {
     active_window_id: Option<WindowId>,
 }
 
+#[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 pub(crate) fn initialize_app(
     launch_mode: &LaunchMode,
     mut timer: IntervalTimer,
@@ -2547,6 +2554,8 @@ fn is_cloud_agent_web_home_launch_url(url: &Url) -> bool {
             .query_pairs()
             .any(|(key, value)| key == "source" && value == "web_home")
 }
+
+#[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode: LaunchMode) {
     IntervalTimer::handle(ctx).update(ctx, |timer, _ctx| {
         timer.mark_interval_end("APP_LAUNCHED");

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -657,11 +657,13 @@ pub fn run() -> Result<()> {
                 // It only needs logging to stderr since stdout is the protocol
                 // channel. No crash reporting, no initialize_app.
                 let launch_mode = LaunchMode::RemoteServerProxy;
+                let mut tracing_initialization = tracing::init()?;
                 warp_logging::init(warp_logging::LogConfig {
                     is_cli: true,
                     log_destination: launch_mode.log_destination(),
                     ..Default::default()
                 })?;
+                tracing_initialization.log_initialization_warning();
                 return crate::remote_server::run_proxy(args.identity_key.clone());
             }
             #[cfg(not(target_family = "wasm"))]
@@ -789,9 +791,10 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         sentry::Hub::main();
     }
 
-    if launch_mode.needs_profiling() {
-        tracing::init()?;
-    }
+    let mut tracing_initialization = launch_mode
+        .needs_profiling()
+        .then(tracing::init)
+        .transpose()?;
 
     let log_destination = launch_mode.log_destination();
     let is_cli = log_destination.is_some();
@@ -816,6 +819,9 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         }
     }
 
+    if let Some(initialization) = tracing_initialization.as_mut() {
+        initialization.log_initialization_warning();
+    }
     timer.mark_interval_end("LOG_FILE_SETUP_COMPLETE");
 
     #[cfg(windows)]
@@ -825,14 +831,6 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     // any children we spawn (like the terminal server) inherit our adjusted
     // rlimits.
     resource_limits::adjust_resource_limits();
-
-    // Configure rustls to use its default crypto provider.  This MUST be called
-    // before making any network requests that use TLS, otherwise rustls will
-    // panic.
-    #[cfg(not(target_family = "wasm"))]
-    rustls::crypto::aws_lc_rs::default_provider()
-        .install_default()
-        .expect("must be able to initialize crypto provider for TLS support");
 
     // For wasm builds we have this special case to parse out the intent
     // from the url that is used to visite the app on web.

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -938,15 +938,19 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     let pty_spawner =
         terminal::local_tty::spawner::PtySpawner::new().context("Failed to create pty spawner")?;
 
+    let callbacks = app_callbacks(
+        launch_mode.is_integration_test(),
+        tracing_initialization.take(),
+    );
     let mut app_builder = if launch_mode.is_headless() {
         warpui::platform::AppBuilder::new_headless(
-            app_callbacks(launch_mode.is_integration_test()),
+            callbacks,
             Box::new(ASSETS),
             launch_mode.take_test_driver(),
         )
     } else {
         warpui::platform::AppBuilder::new(
-            app_callbacks(launch_mode.is_integration_test()),
+            callbacks,
             Box::new(ASSETS),
             launch_mode.take_test_driver(),
         )
@@ -2095,7 +2099,10 @@ pub(crate) fn initialize_app(
     app_state
 }
 
-pub(crate) fn app_callbacks(is_integration_test: bool) -> warpui::platform::AppCallbacks {
+pub(crate) fn app_callbacks(
+    is_integration_test: bool,
+    mut tracing_initialization: Option<tracing::Initialization>,
+) -> warpui::platform::AppCallbacks {
     warpui::platform::AppCallbacks {
         on_internet_reachability_changed: Some(Box::new(move |reachable, ctx| {
             NetworkStatus::handle(ctx)
@@ -2214,6 +2221,9 @@ pub(crate) fn app_callbacks(is_integration_test: bool) -> warpui::platform::AppC
             crash_recovery::CrashRecovery::handle(ctx).update(ctx, |crash_recovery, _ctx| {
                 crash_recovery.teardown();
             });
+            if let Some(initialization) = tracing_initialization.as_mut() {
+                initialization.shutdown();
+            }
 
             // Tear down crash reporting as the last thing we do before the application
             // terminates.

--- a/app/src/persistence/mod.rs
+++ b/app/src/persistence/mod.rs
@@ -70,6 +70,7 @@ pub enum PersistenceScope {
 /// Returns the previously-persisted data, if any, and handles for
 /// writing updated data to persist, if the persistence subsystem is
 /// available.
+#[tracing::instrument(name = "persistence::initialize", skip_all, fields(tags.cloud_agent = true))]
 #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
 pub fn initialize(
     ctx: &mut AppContext,

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -34,6 +34,7 @@ use referral::ReferralsClient;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use team::TeamClient;
+use tracing_futures::Instrument as _;
 use url::Url;
 use warp_core::context_flag::ContextFlag;
 use warp_core::errors::{register_error, AnyhowErrorExt, ErrorExt};
@@ -1378,6 +1379,33 @@ impl ServerApi {
             .map(|item| item.map_err(Arc::new));
             result
         });
+
+        // Once we get the init event, add some identifiers to the trace span.
+        let output_stream = output_stream.inspect(|event| {
+            if let Ok(event) = &event {
+                match &event.r#type {
+                    Some(warp_multi_agent_api::response_event::Type::Init(init)) => {
+                        tracing::info!("StreamInit");
+                        tracing::Span::current().record("conversation_id", &init.conversation_id);
+                        tracing::Span::current().record("request_id", &init.request_id);
+                        tracing::Span::current().record("run_id", &init.run_id);
+                    }
+                    Some(warp_multi_agent_api::response_event::Type::Finished(_finished)) => {
+                        tracing::info!("StreamFinished");
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        // Wrap the output stream with a trace span.
+        let output_stream = output_stream.instrument(tracing::info_span!(
+            "generate_multi_agent_output",
+            tags.cloud_agent = true,
+            conversation_id = tracing::field::Empty,
+            request_id = tracing::field::Empty,
+            run_id = tracing::field::Empty,
+        ));
 
         cfg_if::cfg_if! {
             if #[cfg(target_family = "wasm")] {

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -1828,6 +1828,11 @@ impl AIClient for ServerApi {
         }
     }
 
+    #[tracing::instrument(skip_all, err, fields(
+        tags.cloud_agent = true,
+        config.worker_host = tracing::field::Empty,
+        config.harness = tracing::field::Empty
+    ))]
     async fn create_agent_task(
         &self,
         prompt: String,
@@ -1835,6 +1840,19 @@ impl AIClient for ServerApi {
         parent_run_id: Option<String>,
         config: Option<AgentConfigSnapshot>,
     ) -> anyhow::Result<AmbientAgentTaskId, anyhow::Error> {
+        if let Some(config) = &config {
+            if let Some(worker_host) = &config.worker_host {
+                tracing::Span::current().record("config.worker_host", worker_host);
+            }
+            if let Some(harness) = &config.harness {
+                let harness: Option<serde_json::Value> =
+                    serde_json::to_value(harness.harness_type).ok();
+                if let Some(serde_json::Value::String(harness)) = harness {
+                    tracing::Span::current().record("config.harness", harness);
+                }
+            }
+        }
+
         // Serialize the config to JSON if provided
         let agent_config_snapshot = config
             .map(|c| serde_json::to_string(&c))
@@ -1867,6 +1885,7 @@ impl AIClient for ServerApi {
         }
     }
 
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, ?task_state))]
     async fn update_agent_task(
         &self,
         task_id: AmbientAgentTaskId,
@@ -2012,6 +2031,7 @@ impl AIClient for ServerApi {
         }
     }
 
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
     async fn get_ai_conversation(
         &self,
         server_conversation_token: ServerConversationToken,

--- a/app/src/server/server_api/team.rs
+++ b/app/src/server/server_api/team.rs
@@ -166,6 +166,7 @@ pub trait TeamClient: 'static + Send + Sync {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl TeamClient for ServerApi {
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
     async fn workspaces_metadata(&self) -> Result<WorkspacesMetadataWithPricing> {
         let variables = GetWorkspacesMetadataForUserVariables {
             request_context: get_request_context(),

--- a/app/src/tracing.rs
+++ b/app/src/tracing.rs
@@ -1,12 +1,46 @@
-use tracing::subscriber;
+#[cfg(not(target_family = "wasm"))]
+mod native;
 
-pub fn init() -> anyhow::Result<()> {
-    // Configure the global tracing subscriber to not care about any spans or
-    // events.
-    //
-    // This is done so that we prevent the `tracing` crate from writing out log
-    // lines for spans and trace events.
-    subscriber::set_global_default(subscriber::NoSubscriber::new())?;
+pub fn init() -> anyhow::Result<Initialization> {
+    #[cfg(target_family = "wasm")]
+    {
+        // Configure the global tracing subscriber to not care about any spans or
+        // events.
+        //
+        // This is done so that we prevent the `tracing` crate from writing out log
+        // lines for spans and trace events.
+        tracing::subscriber::set_global_default(subscriber::NoSubscriber::new())?;
+        return Ok(Initialization {
+            initialization_warning: None,
+        });
+    }
 
-    Ok(())
+    #[cfg(not(target_family = "wasm"))]
+    native::init()
+}
+
+pub struct Initialization {
+    initialization_warning: Option<anyhow::Error>,
+    #[cfg(not(target_family = "wasm"))]
+    provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    #[cfg(not(target_family = "wasm"))]
+    shutdown_timeout: std::time::Duration,
+}
+
+impl Initialization {
+    pub fn log_initialization_warning(&mut self) {
+        if let Some(err) = self.initialization_warning.take() {
+            log::warn!("Failed to initialize cloud-agent OpenTelemetry exporting: {err:#}");
+        }
+    }
+}
+
+impl Drop for Initialization {
+    fn drop(&mut self) {
+        if let Some(provider) = self.provider.take() {
+            if let Err(err) = provider.shutdown_with_timeout(self.shutdown_timeout) {
+                log::warn!("Failed to shut down cloud-agent OpenTelemetry exporting: {err}");
+            }
+        }
+    }
 }

--- a/app/src/tracing.rs
+++ b/app/src/tracing.rs
@@ -1,22 +1,33 @@
 #[cfg(not(target_family = "wasm"))]
+use std::time::Duration;
+
+use tracing::subscriber;
+
+#[cfg(not(target_family = "wasm"))]
 mod native;
+
+#[cfg(not(target_family = "wasm"))]
+const DEFAULT_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub fn init() -> anyhow::Result<Initialization> {
     #[cfg(target_family = "wasm")]
     {
-        // Configure the global tracing subscriber to not care about any spans or
-        // events.
-        //
-        // This is done so that we prevent the `tracing` crate from writing out log
-        // lines for spans and trace events.
-        tracing::subscriber::set_global_default(subscriber::NoSubscriber::new())?;
-        return Ok(Initialization {
-            initialization_warning: None,
-        });
+        install_no_subscriber()?;
+        return Ok(Initialization::default());
     }
 
     #[cfg(not(target_family = "wasm"))]
     native::init()
+}
+
+fn install_no_subscriber() -> anyhow::Result<()> {
+    // Configure the global tracing subscriber to not care about any spans or
+    // events.
+    //
+    // This is done so that we prevent the `tracing` crate from writing out log
+    // lines for spans and trace events.
+    subscriber::set_global_default(subscriber::NoSubscriber::new())?;
+    Ok(())
 }
 
 pub struct Initialization {
@@ -27,6 +38,20 @@ pub struct Initialization {
     provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
     #[cfg(not(target_family = "wasm"))]
     shutdown_timeout: std::time::Duration,
+}
+
+impl Default for Initialization {
+    fn default() -> Self {
+        Self {
+            initialization_warning: None,
+            #[cfg(not(target_family = "wasm"))]
+            active_spans: None,
+            #[cfg(not(target_family = "wasm"))]
+            provider: None,
+            #[cfg(not(target_family = "wasm"))]
+            shutdown_timeout: DEFAULT_EXPORT_TIMEOUT,
+        }
+    }
 }
 
 impl Initialization {

--- a/app/src/tracing.rs
+++ b/app/src/tracing.rs
@@ -22,6 +22,8 @@ pub fn init() -> anyhow::Result<Initialization> {
 pub struct Initialization {
     initialization_warning: Option<anyhow::Error>,
     #[cfg(not(target_family = "wasm"))]
+    active_spans: Option<native::ActiveSpanRegistry>,
+    #[cfg(not(target_family = "wasm"))]
     provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
     #[cfg(not(target_family = "wasm"))]
     shutdown_timeout: std::time::Duration,
@@ -33,14 +35,33 @@ impl Initialization {
             log::warn!("Failed to initialize cloud-agent OpenTelemetry exporting: {err:#}");
         }
     }
+
+    pub(crate) fn shutdown(&mut self) {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            match (self.active_spans.take(), self.provider.take()) {
+                (Some(active_spans), Some(provider)) => {
+                    if let Err(err) = active_spans.shutdown(&provider, self.shutdown_timeout) {
+                        log::warn!(
+                            "Failed to shut down cloud-agent OpenTelemetry exporting: {err}"
+                        );
+                    }
+                }
+                (None, Some(provider)) => {
+                    if let Err(err) = provider.shutdown_with_timeout(self.shutdown_timeout) {
+                        log::warn!(
+                            "Failed to shut down cloud-agent OpenTelemetry exporting: {err}"
+                        );
+                    }
+                }
+                (Some(_), None) | (None, None) => {}
+            }
+        }
+    }
 }
 
 impl Drop for Initialization {
     fn drop(&mut self) {
-        if let Some(provider) = self.provider.take() {
-            if let Err(err) = provider.shutdown_with_timeout(self.shutdown_timeout) {
-                log::warn!("Failed to shut down cloud-agent OpenTelemetry exporting: {err}");
-            }
-        }
+        self.shutdown();
     }
 }

--- a/app/src/tracing.rs
+++ b/app/src/tracing.rs
@@ -13,7 +13,7 @@ pub fn init() -> anyhow::Result<Initialization> {
     #[cfg(target_family = "wasm")]
     {
         install_no_subscriber()?;
-        return Ok(Initialization::default());
+        Ok(Initialization::default())
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -30,6 +30,7 @@ fn install_no_subscriber() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(target_family = "wasm", derive(Default))]
 pub struct Initialization {
     initialization_warning: Option<anyhow::Error>,
     #[cfg(not(target_family = "wasm"))]
@@ -40,15 +41,13 @@ pub struct Initialization {
     shutdown_timeout: std::time::Duration,
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl Default for Initialization {
     fn default() -> Self {
         Self {
             initialization_warning: None,
-            #[cfg(not(target_family = "wasm"))]
             active_spans: None,
-            #[cfg(not(target_family = "wasm"))]
             provider: None,
-            #[cfg(not(target_family = "wasm"))]
             shutdown_timeout: DEFAULT_EXPORT_TIMEOUT,
         }
     }

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -1,0 +1,200 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Context as _};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::{KeyValue, Value};
+use opentelemetry_otlp::{Protocol, WithExportConfig as _};
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::resource::{EnvResourceDetector, TelemetryResourceDetector};
+use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+use opentelemetry_sdk::Resource;
+use tracing::subscriber;
+use tracing_subscriber::layer::SubscriberExt as _;
+use url::Url;
+
+use super::Initialization;
+use crate::channel::ChannelState;
+
+const CLOUD_AGENT_MARKER: &str = "tags.cloud_agent";
+const CLOUD_AGENT_OTLP_ENDPOINT: &str = "WARP_CLOUD_AGENT_OTLP_ENDPOINT";
+const DEFAULT_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
+const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
+
+pub fn init() -> anyhow::Result<Initialization> {
+    let Some(base_endpoint) = std::env::var(CLOUD_AGENT_OTLP_ENDPOINT)
+        .ok()
+        .filter(|endpoint| !endpoint.trim().is_empty())
+    else {
+        install_no_subscriber()?;
+        return Ok(Initialization {
+            initialization_warning: None,
+            provider: None,
+            shutdown_timeout: DEFAULT_EXPORT_TIMEOUT,
+        });
+    };
+
+    let shutdown_timeout = export_timeout();
+    let provider = match build_provider(base_endpoint.trim()) {
+        Ok(provider) => provider,
+        Err(err) => {
+            install_no_subscriber()?;
+            return Ok(Initialization {
+                initialization_warning: Some(err),
+                provider: None,
+                shutdown_timeout,
+            });
+        }
+    };
+
+    let tracer = provider.tracer("warp-cloud-agent");
+    let subscriber =
+        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+    subscriber::set_global_default(subscriber)?;
+
+    Ok(Initialization {
+        initialization_warning: None,
+        provider: Some(provider),
+        shutdown_timeout,
+    })
+}
+
+fn install_no_subscriber() -> anyhow::Result<()> {
+    // Configure the global tracing subscriber to not care about any spans or
+    // events.
+    //
+    // This is done so that we prevent the `tracing` crate from writing out log
+    // lines for spans and trace events.
+    subscriber::set_global_default(subscriber::NoSubscriber::new())?;
+    Ok(())
+}
+
+fn build_provider(base_endpoint: &str) -> anyhow::Result<SdkTracerProvider> {
+    let endpoint = traces_endpoint(base_endpoint)?;
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(endpoint)
+        .build()
+        .context("Failed to build the OTLP span exporter")?;
+
+    let resource = Resource::builder_empty()
+        .with_service_name("warp-cloud-agent")
+        .with_attribute(KeyValue::new(
+            "service.version",
+            ChannelState::app_version().unwrap_or("<no tag>"),
+        ))
+        .with_attribute(KeyValue::new(
+            "warp.channel",
+            ChannelState::channel().to_string(),
+        ))
+        .with_detector(Box::new(TelemetryResourceDetector))
+        .with_detector(Box::new(EnvResourceDetector::new()));
+    let resource = match std::env::var(OTEL_SERVICE_NAME) {
+        Ok(service_name) if !service_name.is_empty() => resource.with_service_name(service_name),
+        Ok(_) | Err(_) => resource,
+    }
+    .build();
+
+    Ok(SdkTracerProvider::builder()
+        .with_batch_exporter(CloudAgentSpanExporter { inner: exporter })
+        .with_resource(resource)
+        .build())
+}
+
+fn traces_endpoint(base_endpoint: &str) -> anyhow::Result<String> {
+    let mut endpoint = Url::parse(base_endpoint).context("Invalid cloud-agent OTLP endpoint")?;
+    if !matches!(endpoint.scheme(), "http" | "https") {
+        return Err(anyhow!("Cloud-agent OTLP endpoint must use HTTP or HTTPS"));
+    }
+
+    endpoint.set_query(None);
+    endpoint.set_fragment(None);
+    endpoint
+        .path_segments_mut()
+        .map_err(|_| anyhow!("Cloud-agent OTLP endpoint cannot be used as a base URL"))?
+        .pop_if_empty()
+        .extend(["v1", "traces"]);
+    Ok(endpoint.into())
+}
+
+fn export_timeout() -> Duration {
+    [
+        "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+        "OTEL_EXPORTER_OTLP_TIMEOUT",
+    ]
+    .into_iter()
+    .find_map(|name| {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Duration::from_millis)
+    })
+    .unwrap_or(DEFAULT_EXPORT_TIMEOUT)
+}
+
+#[derive(Debug)]
+struct CloudAgentSpanExporter {
+    inner: opentelemetry_otlp::SpanExporter,
+}
+
+impl SpanExporter for CloudAgentSpanExporter {
+    fn export(
+        &self,
+        batch: Vec<SpanData>,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+        let batch: Vec<_> = batch
+            .into_iter()
+            .filter_map(filter_cloud_agent_span)
+            .collect();
+
+        async move {
+            if batch.is_empty() {
+                return Ok(());
+            }
+
+            let result = self.inner.export(batch).await;
+            if let Err(err) = &result {
+                log::warn!("Failed to export cloud-agent OpenTelemetry spans: {err}");
+            }
+            result
+        }
+    }
+
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        let result = self.inner.shutdown_with_timeout(timeout);
+        if let Err(err) = &result {
+            log::warn!("Failed to shut down the cloud-agent OpenTelemetry span exporter: {err}");
+        }
+        result
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        let result = self.inner.force_flush();
+        if let Err(err) = &result {
+            log::warn!("Failed to flush the cloud-agent OpenTelemetry span exporter: {err}");
+        }
+        result
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        self.inner.set_resource(resource);
+    }
+}
+
+fn filter_cloud_agent_span(mut span: SpanData) -> Option<SpanData> {
+    let is_cloud_agent_span = span.attributes.iter().any(|attribute| {
+        attribute.key.as_str() == CLOUD_AGENT_MARKER && attribute.value == Value::Bool(true)
+    });
+    if !is_cloud_agent_span {
+        return None;
+    }
+
+    span.attributes
+        .retain(|attribute| attribute.key.as_str() != CLOUD_AGENT_MARKER);
+    for event in &mut span.events.events {
+        event
+            .attributes
+            .retain(|attribute| attribute.key.as_str() != CLOUD_AGENT_MARKER);
+    }
+    Some(span)
+}

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -21,10 +21,10 @@ use url::Url;
 
 use super::Initialization;
 use crate::channel::ChannelState;
+use crate::tracing::install_no_subscriber;
 
 const CLOUD_AGENT_MARKER: &str = "tags.cloud_agent";
 const CLOUD_AGENT_OTLP_ENDPOINT: &str = "WARP_CLOUD_AGENT_OTLP_ENDPOINT";
-const DEFAULT_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 
 pub fn init() -> anyhow::Result<Initialization> {
@@ -37,12 +37,7 @@ pub fn init() -> anyhow::Result<Initialization> {
         .filter(|endpoint| !endpoint.trim().is_empty())
     else {
         install_no_subscriber()?;
-        return Ok(Initialization {
-            initialization_warning: None,
-            active_spans: None,
-            provider: None,
-            shutdown_timeout: DEFAULT_EXPORT_TIMEOUT,
-        });
+        return Ok(Initialization::default());
     };
 
     let shutdown_timeout = export_timeout();
@@ -73,16 +68,6 @@ pub fn init() -> anyhow::Result<Initialization> {
         provider: Some(provider),
         shutdown_timeout,
     })
-}
-
-fn install_no_subscriber() -> anyhow::Result<()> {
-    // Configure the global tracing subscriber to not care about any spans or
-    // events.
-    //
-    // This is done so that we prevent the `tracing` crate from writing out log
-    // lines for spans and trace events.
-    subscriber::set_global_default(subscriber::NoSubscriber::new())?;
-    Ok(())
 }
 
 fn build_provider(base_endpoint: &str) -> anyhow::Result<SdkTracerProvider> {
@@ -146,7 +131,7 @@ fn export_timeout() -> Duration {
             .and_then(|value| value.parse::<u64>().ok())
             .map(Duration::from_millis)
     })
-    .unwrap_or(DEFAULT_EXPORT_TIMEOUT)
+    .unwrap_or(super::DEFAULT_EXPORT_TIMEOUT)
 }
 
 #[derive(Clone, Debug, Default)]

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -8,34 +8,41 @@
 //!
 //! # Why spans must be ended during shutdown
 //!
-//! An OpenTelemetry span is submitted to a span processor only after it ends. Shutting down an
-//! [`SdkTracerProvider`] flushes spans that have already reached its processors, but it does not end
-//! spans that are still active. Some `tracing::Span` references are intentionally propagated into
-//! asynchronous task machinery and can therefore remain alive when the application terminates.
-//! Shutting down the provider before those spans end would silently discard them.
+//! An OpenTelemetry span becomes exportable and passes owned span data to a processor's `on_end`
+//! callback only after it ends. Shutting down an [`SdkTracerProvider`] flushes spans that have
+//! reached `on_end`, but it does not end spans that are still active. Some `tracing::Span`
+//! references are intentionally propagated into asynchronous task machinery and can therefore
+//! remain alive when the application terminates. Shutting down the provider before those spans end
+//! would silently discard them.
 //!
 //! [`ShutdownAwareTracer`] and [`ShutdownAwareSpan`] wrap the SDK tracer and spans used by
 //! `tracing-opentelemetry`. This keeps existing `tracing` instrumentation unchanged while allowing
-//! [`ActiveSpanRegistry`] to explicitly end every started SDK span before shutting down the
-//! provider. The application retains [`Initialization`] in its termination callback so this
-//! ordering happens before platforms that terminate the process without running Rust destructors;
-//! [`Initialization`]'s `Drop` implementation remains a fallback for ordinary returns.
+//! [`ActiveSpanRegistry`] to explicitly end still-reachable, registered SDK spans before shutting
+//! down the provider. The standard application lifecycle retains [`Initialization`] in its
+//! termination callback so this ordering happens before platforms that terminate the process
+//! without running Rust destructors. [`Initialization`]'s `Drop` implementation remains a fallback
+//! for ordinary returns. Explicit process exits bypass both forms of cleanup.
 //!
 //! # Span ownership and synchronization
 //!
-//! `tracing-opentelemetry` creates SDK spans lazily, when a `tracing` span is first activated.
-//! Every SDK span that reaches [`ShutdownAwareTracer::build_with_context`] is wrapped in an
-//! `Arc<Mutex<_>>` and weakly registered. The wrapper remains the span's owner; the registry uses
-//! weak references so tracking does not extend normal span lifetimes. A `tracing` span that is
-//! never activated never creates an SDK span and therefore has nothing for this registry to end.
+//! `tracing-opentelemetry` creates SDK spans lazily during several `tracing` span lifecycle
+//! operations, including when it needs a span's context and when a span closes. Every SDK span that
+//! reaches [`ShutdownAwareTracer::build_with_context`] is wrapped in an `Arc<Mutex<_>>`. Before
+//! shutdown begins, it is weakly registered; after shutdown begins, it is immediately ended
+//! instead. The wrapper remains the span's owner; the registry uses weak references so tracking
+//! does not extend normal span lifetimes. An SDK span that has not yet been built when shutdown
+//! begins cannot reach `on_end` before provider shutdown. If it materializes later, it is ended too
+//! late for export.
 //!
-//! Span creation and shutdown are serialized by the registry-state mutex. Shutdown keeps that
-//! mutex locked while it ends active spans and shuts down the provider, preventing a span from
-//! being created in the otherwise-dangerous gap between those operations. The lock order is
-//! always registry state followed by an individual SDK span. Normal span operations lock only the
-//! individual SDK span and never attempt to lock the registry. Mutex acquisition recovers poisoned
-//! inner values because trace export and shutdown are best-effort cleanup that should continue
-//! after an unrelated panic.
+//! SDK-span creation and shutdown are serialized by the registry-state mutex. Shutdown keeps that
+//! mutex locked while it ends every still-upgradeable registered span and shuts down the provider,
+//! preventing an SDK span from being created in the otherwise-dangerous gap between those
+//! operations. A final span owner can begin dropping after its weak reference becomes impossible
+//! to upgrade, so shutdown cannot strictly guarantee that every previously registered span has
+//! finished ending. The lock order is always registry state followed by an individual SDK span.
+//! Normal span operations lock only the individual SDK span and never attempt to lock the registry.
+//! Mutex acquisition recovers poisoned inner values because trace export and shutdown are
+//! best-effort cleanup that should continue after an unrelated panic.
 
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex, Weak};
@@ -124,10 +131,10 @@ pub fn init() -> anyhow::Result<Initialization> {
 /// Builds the SDK provider and its batch exporter.
 ///
 /// A batch exporter keeps network export off instrumentation call sites. The provider is retained
-/// by [`Initialization`] so application termination can explicitly shut it down after active spans
-/// have been ended. Exported resources include Warp's version and channel alongside standard
-/// environment-detected OpenTelemetry attributes, with `OTEL_SERVICE_NAME` taking precedence over
-/// the default service name.
+/// by [`Initialization`] so application termination can explicitly shut it down after attempting
+/// to end registered active spans. Exported resources include Warp's version and channel alongside
+/// standard environment-detected OpenTelemetry attributes, with [`OTEL_SERVICE_NAME`] taking
+/// precedence over the default service name.
 fn build_provider(base_endpoint: &str) -> anyhow::Result<SdkTracerProvider> {
     let endpoint = traces_endpoint(base_endpoint)?;
     let exporter = opentelemetry_otlp::SpanExporter::builder()
@@ -197,7 +204,7 @@ fn export_timeout() -> Duration {
     .unwrap_or(super::DEFAULT_EXPORT_TIMEOUT)
 }
 
-/// Tracks started SDK spans so they can be ended before provider shutdown.
+/// A registry of started SDK spans used for best-effort ending before provider shutdown.
 ///
 /// This registry belongs beside the provider in [`Initialization`]. It stores only weak references
 /// so a span that ends normally can be dropped without first unregistering itself.
@@ -215,11 +222,11 @@ struct ActiveSpanRegistryState {
 }
 
 impl ActiveSpanRegistry {
-    /// Builds and registers an SDK span while excluding concurrent shutdown.
+    /// Builds an SDK span, registering it before shutdown or ending it after shutdown begins.
     ///
-    /// `tracing-opentelemetry` calls this lazily when it activates a `tracing` span. If shutdown
-    /// has already begun, the newly built span is ended immediately rather than being allowed to
-    /// outlive the provider.
+    /// `tracing-opentelemetry` calls this whenever it materializes an SDK span. If shutdown has
+    /// already begun, the newly built span is ended immediately rather than being allowed to
+    /// remain active.
     fn build_span(
         &self,
         tracer: &SdkTracer,
@@ -244,11 +251,12 @@ impl ActiveSpanRegistry {
         }
     }
 
-    /// Ends every registered span and then shuts down the provider.
+    /// Ends every still-upgradeable registered span and then shuts down the provider.
     ///
     /// The registry lock intentionally remains held through provider shutdown. This guarantees
-    /// that every span built before shutdown is ended first and that no span can be built between
-    /// the final end call and the provider becoming unable to accept ended spans.
+    /// that no SDK span can be built between the final end attempt and the provider becoming unable
+    /// to accept ended spans. It does not synchronize with the final drop of a span whose weak
+    /// reference can no longer be upgraded, so ending previously built spans remains best-effort.
     pub(super) fn shutdown(
         &self,
         provider: &SdkTracerProvider,
@@ -269,7 +277,7 @@ impl ActiveSpanRegistry {
     }
 }
 
-/// Adapts [`SdkTracer`] so spans created by `tracing-opentelemetry` are registered for shutdown.
+/// An [`SdkTracer`] adapter that routes spans through shutdown-aware construction.
 ///
 /// Wrapping the tracer, rather than the span processor, is necessary because processors receive
 /// only a temporary mutable reference in `on_start` and receive owned exportable data only after
@@ -298,7 +306,7 @@ impl opentelemetry::trace::Tracer for ShutdownAwareTracer {
     }
 }
 
-/// Provides synchronized access to an SDK span shared with [`ActiveSpanRegistry`].
+/// A synchronized wrapper around an SDK span shared with [`ActiveSpanRegistry`].
 ///
 /// The immutable [`SpanContext`] is cached outside the mutex because the OpenTelemetry
 /// [`opentelemetry::trace::Span`] trait must return it by reference. All mutable SDK-span operations
@@ -375,7 +383,8 @@ impl opentelemetry::trace::Span for ShutdownAwareSpan {
     }
 }
 
-/// Restricts the shared tracing subscriber's output to explicitly marked cloud-agent spans.
+/// An exporter that restricts the shared tracing subscriber's output to explicitly marked
+/// cloud-agent spans.
 ///
 /// Filtering here preserves normal parent/context propagation inside the application while
 /// ensuring unrelated application tracing is never sent to the configured cloud-agent endpoint.

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -1,3 +1,42 @@
+//! Configures opt-in OpenTelemetry export for cloud-agent traces on native platforms.
+//!
+//! The global `tracing` subscriber observes the whole application, while
+//! [`CloudAgentSpanExporter`] limits OTLP export to spans explicitly marked with
+//! [`CLOUD_AGENT_MARKER`]. Keeping this selection at the exporter boundary lets callers use the
+//! normal `tracing` macros and propagation machinery without installing a second subscriber or
+//! coupling generic task executors to cloud-agent tracing.
+//!
+//! # Why spans must be ended during shutdown
+//!
+//! An OpenTelemetry span is submitted to a span processor only after it ends. Shutting down an
+//! [`SdkTracerProvider`] flushes spans that have already reached its processors, but it does not end
+//! spans that are still active. Some `tracing::Span` references are intentionally propagated into
+//! asynchronous task machinery and can therefore remain alive when the application terminates.
+//! Shutting down the provider before those spans end would silently discard them.
+//!
+//! [`ShutdownAwareTracer`] and [`ShutdownAwareSpan`] wrap the SDK tracer and spans used by
+//! `tracing-opentelemetry`. This keeps existing `tracing` instrumentation unchanged while allowing
+//! [`ActiveSpanRegistry`] to explicitly end every started SDK span before shutting down the
+//! provider. The application retains [`Initialization`] in its termination callback so this
+//! ordering happens before platforms that terminate the process without running Rust destructors;
+//! [`Initialization`]'s `Drop` implementation remains a fallback for ordinary returns.
+//!
+//! # Span ownership and synchronization
+//!
+//! `tracing-opentelemetry` creates SDK spans lazily, when a `tracing` span is first activated.
+//! Every SDK span that reaches [`ShutdownAwareTracer::build_with_context`] is wrapped in an
+//! `Arc<Mutex<_>>` and weakly registered. The wrapper remains the span's owner; the registry uses
+//! weak references so tracking does not extend normal span lifetimes. A `tracing` span that is
+//! never activated never creates an SDK span and therefore has nothing for this registry to end.
+//!
+//! Span creation and shutdown are serialized by the registry-state mutex. Shutdown keeps that
+//! mutex locked while it ends active spans and shuts down the provider, preventing a span from
+//! being created in the otherwise-dangerous gap between those operations. The lock order is
+//! always registry state followed by an individual SDK span. Normal span operations lock only the
+//! individual SDK span and never attempt to lock the registry. Mutex acquisition recovers poisoned
+//! inner values because trace export and shutdown are best-effort cleanup that should continue
+//! after an unrelated panic.
+
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, SystemTime};
@@ -23,11 +62,23 @@ use super::Initialization;
 use crate::channel::ChannelState;
 use crate::tracing::install_no_subscriber;
 
+/// The tag used to mark spans related to cloud agents, which we use to filter out
+/// spans we don't care about (e.g.: ones from dependencies).
 const CLOUD_AGENT_MARKER: &str = "tags.cloud_agent";
+/// The environment variable used to configure the cloud agent OTLP endpoint.
 const CLOUD_AGENT_OTLP_ENDPOINT: &str = "WARP_CLOUD_AGENT_OTLP_ENDPOINT";
+/// The environment variable used to configure the OTel service name.
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 
+/// Installs the native tracing subscriber and optional cloud-agent OTLP exporter.
+///
+/// Export is deliberately opt-in through [`CLOUD_AGENT_OTLP_ENDPOINT`]. When the endpoint is
+/// absent or the exporter cannot be constructed, a no-op subscriber is installed so tracing
+/// instrumentation remains safe without producing output or partially initializing export.
 pub fn init() -> anyhow::Result<Initialization> {
+    // INFO is the default because this is a global subscriber and DEBUG-level application spans
+    // would otherwise create substantial work even though only marked cloud-agent spans are
+    // exported. RUST_LOG can still override this when deeper tracing is needed.
     let env_filter = EnvFilter::builder()
         .with_default_directive(tracing::Level::INFO.into())
         .from_env_lossy();
@@ -70,6 +121,13 @@ pub fn init() -> anyhow::Result<Initialization> {
     })
 }
 
+/// Builds the SDK provider and its batch exporter.
+///
+/// A batch exporter keeps network export off instrumentation call sites. The provider is retained
+/// by [`Initialization`] so application termination can explicitly shut it down after active spans
+/// have been ended. Exported resources include Warp's version and channel alongside standard
+/// environment-detected OpenTelemetry attributes, with `OTEL_SERVICE_NAME` taking precedence over
+/// the default service name.
 fn build_provider(base_endpoint: &str) -> anyhow::Result<SdkTracerProvider> {
     let endpoint = traces_endpoint(base_endpoint)?;
     let exporter = opentelemetry_otlp::SpanExporter::builder()
@@ -103,6 +161,10 @@ fn build_provider(base_endpoint: &str) -> anyhow::Result<SdkTracerProvider> {
         .build())
 }
 
+/// Converts the configured OTLP base URL into the HTTP/protobuf traces endpoint.
+///
+/// The configuration is treated as a base URL rather than a complete signal-specific URL, so any
+/// query or fragment is discarded before appending `v1/traces`.
 fn traces_endpoint(base_endpoint: &str) -> anyhow::Result<String> {
     let mut endpoint = Url::parse(base_endpoint).context("Invalid cloud-agent OTLP endpoint")?;
     if !matches!(endpoint.scheme(), "http" | "https") {
@@ -119,6 +181,7 @@ fn traces_endpoint(base_endpoint: &str) -> anyhow::Result<String> {
     Ok(endpoint.into())
 }
 
+/// Returns the export shutdown timeout using the standard OpenTelemetry environment variables.
 fn export_timeout() -> Duration {
     [
         "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
@@ -134,6 +197,10 @@ fn export_timeout() -> Duration {
     .unwrap_or(super::DEFAULT_EXPORT_TIMEOUT)
 }
 
+/// Tracks started SDK spans so they can be ended before provider shutdown.
+///
+/// This registry belongs beside the provider in [`Initialization`]. It stores only weak references
+/// so a span that ends normally can be dropped without first unregistering itself.
 #[derive(Clone, Debug, Default)]
 pub(super) struct ActiveSpanRegistry {
     state: Arc<Mutex<ActiveSpanRegistryState>>,
@@ -141,11 +208,18 @@ pub(super) struct ActiveSpanRegistry {
 
 #[derive(Debug, Default)]
 struct ActiveSpanRegistryState {
+    /// Prevents new spans from remaining active after shutdown begins.
     shutting_down: bool,
+    /// Weak references avoid extending the lifetime of spans that end normally.
     spans: Vec<Weak<Mutex<SdkSpan>>>,
 }
 
 impl ActiveSpanRegistry {
+    /// Builds and registers an SDK span while excluding concurrent shutdown.
+    ///
+    /// `tracing-opentelemetry` calls this lazily when it activates a `tracing` span. If shutdown
+    /// has already begun, the newly built span is ended immediately rather than being allowed to
+    /// outlive the provider.
     fn build_span(
         &self,
         tracer: &SdkTracer,
@@ -159,6 +233,8 @@ impl ActiveSpanRegistry {
         if state.shutting_down {
             span.lock().unwrap_or_else(|err| err.into_inner()).end();
         } else {
+            // Dead weak references are pruned opportunistically to avoid requiring normal span
+            // completion to acquire the registry lock.
             state.spans.retain(|span| span.strong_count() > 0);
             state.spans.push(Arc::downgrade(&span));
         }
@@ -168,6 +244,11 @@ impl ActiveSpanRegistry {
         }
     }
 
+    /// Ends every registered span and then shuts down the provider.
+    ///
+    /// The registry lock intentionally remains held through provider shutdown. This guarantees
+    /// that every span built before shutdown is ended first and that no span can be built between
+    /// the final end call and the provider becoming unable to accept ended spans.
     pub(super) fn shutdown(
         &self,
         provider: &SdkTracerProvider,
@@ -188,6 +269,11 @@ impl ActiveSpanRegistry {
     }
 }
 
+/// Adapts [`SdkTracer`] so spans created by `tracing-opentelemetry` are registered for shutdown.
+///
+/// Wrapping the tracer, rather than the span processor, is necessary because processors receive
+/// only a temporary mutable reference in `on_start` and receive owned exportable data only after
+/// `on_end`. A processor therefore cannot retain handles to, or end, active spans during shutdown.
 #[derive(Clone, Debug)]
 struct ShutdownAwareTracer {
     inner: SdkTracer,
@@ -212,6 +298,12 @@ impl opentelemetry::trace::Tracer for ShutdownAwareTracer {
     }
 }
 
+/// Provides synchronized access to an SDK span shared with [`ActiveSpanRegistry`].
+///
+/// The immutable [`SpanContext`] is cached outside the mutex because the OpenTelemetry
+/// [`opentelemetry::trace::Span`] trait must return it by reference. All mutable SDK-span operations
+/// are forwarded through the mutex, allowing shutdown to end the same underlying span. Repeated
+/// end calls are harmless because SDK spans export only once.
 #[derive(Debug)]
 struct ShutdownAwareSpan {
     span_context: SpanContext,
@@ -283,6 +375,12 @@ impl opentelemetry::trace::Span for ShutdownAwareSpan {
     }
 }
 
+/// Restricts the shared tracing subscriber's output to explicitly marked cloud-agent spans.
+///
+/// Filtering here preserves normal parent/context propagation inside the application while
+/// ensuring unrelated application tracing is never sent to the configured cloud-agent endpoint.
+/// The marker is a per-span routing attribute rather than an inherited property, so every span
+/// intended for export must set it explicitly.
 #[derive(Debug)]
 struct CloudAgentSpanExporter {
     inner: opentelemetry_otlp::SpanExporter,
@@ -332,6 +430,8 @@ impl SpanExporter for CloudAgentSpanExporter {
     }
 }
 
+/// Removes unrelated spans and strips the internal routing marker from spans and events before
+/// export.
 fn filter_cloud_agent_span(mut span: SpanData) -> Option<SpanData> {
     let is_cloud_agent_span = span.attributes.iter().any(|attribute| {
         attribute.key.as_str() == CLOUD_AGENT_MARKER && attribute.value == Value::Bool(true)

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -1,15 +1,22 @@
-use std::time::Duration;
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, Context as _};
-use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::{KeyValue, Value};
+use opentelemetry::trace::{
+    Span as _, SpanBuilder, SpanContext, Status, Tracer as _, TracerProvider as _,
+};
+use opentelemetry::{Context as OtelContext, KeyValue, Value};
 use opentelemetry_otlp::{Protocol, WithExportConfig as _};
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::resource::{EnvResourceDetector, TelemetryResourceDetector};
-use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+use opentelemetry_sdk::trace::{
+    SdkTracer, SdkTracerProvider, Span as SdkSpan, SpanData, SpanExporter,
+};
 use opentelemetry_sdk::Resource;
 use tracing::subscriber;
 use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::EnvFilter;
 use url::Url;
 
 use super::Initialization;
@@ -21,6 +28,10 @@ const DEFAULT_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 
 pub fn init() -> anyhow::Result<Initialization> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(tracing::Level::INFO.into())
+        .from_env_lossy();
+
     let Some(base_endpoint) = std::env::var(CLOUD_AGENT_OTLP_ENDPOINT)
         .ok()
         .filter(|endpoint| !endpoint.trim().is_empty())
@@ -28,6 +39,7 @@ pub fn init() -> anyhow::Result<Initialization> {
         install_no_subscriber()?;
         return Ok(Initialization {
             initialization_warning: None,
+            active_spans: None,
             provider: None,
             shutdown_timeout: DEFAULT_EXPORT_TIMEOUT,
         });
@@ -40,19 +52,24 @@ pub fn init() -> anyhow::Result<Initialization> {
             install_no_subscriber()?;
             return Ok(Initialization {
                 initialization_warning: Some(err),
+                active_spans: None,
                 provider: None,
                 shutdown_timeout,
             });
         }
     };
 
-    let tracer = provider.tracer("warp-cloud-agent");
-    let subscriber =
-        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+    let active_spans = ActiveSpanRegistry::default();
+    let tracer =
+        ShutdownAwareTracer::new(provider.tracer("warp-cloud-agent"), active_spans.clone());
+    let subscriber = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_opentelemetry::layer().with_tracer(tracer));
     subscriber::set_global_default(subscriber)?;
 
     Ok(Initialization {
         initialization_warning: None,
+        active_spans: Some(active_spans),
         provider: Some(provider),
         shutdown_timeout,
     })
@@ -130,6 +147,155 @@ fn export_timeout() -> Duration {
             .map(Duration::from_millis)
     })
     .unwrap_or(DEFAULT_EXPORT_TIMEOUT)
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct ActiveSpanRegistry {
+    state: Arc<Mutex<ActiveSpanRegistryState>>,
+}
+
+#[derive(Debug, Default)]
+struct ActiveSpanRegistryState {
+    shutting_down: bool,
+    spans: Vec<Weak<Mutex<SdkSpan>>>,
+}
+
+impl ActiveSpanRegistry {
+    fn build_span(
+        &self,
+        tracer: &SdkTracer,
+        builder: SpanBuilder,
+        parent_cx: &OtelContext,
+    ) -> ShutdownAwareSpan {
+        let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
+        let span = tracer.build_with_context(builder, parent_cx);
+        let span_context = span.span_context().clone();
+        let span = Arc::new(Mutex::new(span));
+        if state.shutting_down {
+            span.lock().unwrap_or_else(|err| err.into_inner()).end();
+        } else {
+            state.spans.retain(|span| span.strong_count() > 0);
+            state.spans.push(Arc::downgrade(&span));
+        }
+        ShutdownAwareSpan {
+            span_context,
+            inner: span,
+        }
+    }
+
+    pub(super) fn shutdown(
+        &self,
+        provider: &SdkTracerProvider,
+        timeout: Duration,
+    ) -> OTelSdkResult {
+        let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
+        state.shutting_down = true;
+        let spans = std::mem::take(&mut state.spans);
+
+        for span in spans {
+            if let Some(span) = span.upgrade() {
+                span.lock().unwrap_or_else(|err| err.into_inner()).end();
+            }
+        }
+        let result = provider.shutdown_with_timeout(timeout);
+        drop(state);
+        result
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ShutdownAwareTracer {
+    inner: SdkTracer,
+    active_spans: ActiveSpanRegistry,
+}
+
+impl ShutdownAwareTracer {
+    fn new(inner: SdkTracer, active_spans: ActiveSpanRegistry) -> Self {
+        Self {
+            inner,
+            active_spans,
+        }
+    }
+}
+
+impl opentelemetry::trace::Tracer for ShutdownAwareTracer {
+    type Span = ShutdownAwareSpan;
+
+    fn build_with_context(&self, builder: SpanBuilder, parent_cx: &OtelContext) -> Self::Span {
+        self.active_spans
+            .build_span(&self.inner, builder, parent_cx)
+    }
+}
+
+#[derive(Debug)]
+struct ShutdownAwareSpan {
+    span_context: SpanContext,
+    inner: Arc<Mutex<SdkSpan>>,
+}
+
+impl opentelemetry::trace::Span for ShutdownAwareSpan {
+    fn add_event_with_timestamp<T>(
+        &mut self,
+        name: T,
+        timestamp: SystemTime,
+        attributes: Vec<KeyValue>,
+    ) where
+        T: Into<Cow<'static, str>>,
+    {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .add_event_with_timestamp(name, timestamp, attributes);
+    }
+
+    fn span_context(&self) -> &SpanContext {
+        &self.span_context
+    }
+
+    fn is_recording(&self) -> bool {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .is_recording()
+    }
+
+    fn set_attribute(&mut self, attribute: KeyValue) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .set_attribute(attribute);
+    }
+
+    fn set_status(&mut self, status: Status) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .set_status(status);
+    }
+
+    fn update_name<T>(&mut self, new_name: T)
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .update_name(new_name);
+    }
+
+    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue>) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .add_link(span_context, attributes);
+    }
+
+    fn end_with_timestamp(&mut self, timestamp: SystemTime) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .end_with_timestamp(timestamp);
+    }
 }
 
 #[derive(Debug)]

--- a/crates/warp_core/Cargo.toml
+++ b/crates/warp_core/Cargo.toml
@@ -41,6 +41,7 @@ strum.workspace = true
 strum_macros.workspace = true
 sysinfo.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 concat-idents.workspace = true
 url.workspace = true
 regex.workspace = true

--- a/crates/warp_core/src/interval_timer.rs
+++ b/crates/warp_core/src/interval_timer.rs
@@ -37,8 +37,10 @@ impl IntervalTimer {
     }
 
     pub fn mark_interval_end(&mut self, name: impl Into<String>) {
+        let name = name.into();
+        tracing::info!(name);
         self.intervals
-            .push(TimingInterval::new(name.into(), Instant::now()))
+            .push(TimingInterval::new(name, Instant::now()))
     }
 
     pub fn compute_duration_for_interval(&self, name: &str) -> Option<Duration> {

--- a/crates/warpui_core/Cargo.toml
+++ b/crates/warpui_core/Cargo.toml
@@ -74,6 +74,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 titlecase = "1.0"
 tokio.workspace = true
+tracing.workspace = true
 trait-set = "0.3.0"
 vec1.workspace = true
 warp_util.workspace = true

--- a/crates/warpui_core/src/async/mod.rs
+++ b/crates/warpui_core/src/async/mod.rs
@@ -18,6 +18,7 @@ cfg_if::cfg_if! {
 pub use futures_util::future::LocalBoxFuture;
 // Re-export a variety of symbols from the internal implementation modules.
 pub use imp::{block_on, BoxFuture, Spawnable, SpawnableOutput, Stream, Timer, TransportStream};
+use thiserror::Error;
 
 pub mod executor {
     #[derive(thiserror::Error, Debug)]
@@ -106,7 +107,8 @@ impl futures_util::task::Spawn for executor::Background {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("Timed out waiting for future")]
 pub struct TimeoutError;
 
 pub trait FutureExt: Future {

--- a/crates/warpui_core/src/async/native/executor.rs
+++ b/crates/warpui_core/src/async/native/executor.rs
@@ -9,6 +9,7 @@ use async_executor::LocalExecutor;
 use futures::future::{BoxFuture, LocalBoxFuture};
 use futures::{Future, FutureExt};
 use futures_util::future::{AbortHandle, Abortable};
+use tracing::Instrument as _;
 
 use crate::platform;
 use crate::r#async::executor::Error;
@@ -85,6 +86,7 @@ impl Foreground {
     /// less code than a generic implementation, with no noticeable performance
     /// impact.
     pub fn spawn_boxed(&self, future: LocalBoxFuture<'static, ()>) -> ForegroundTask {
+        let future = future.instrument(tracing::Span::current());
         match self {
             Foreground::Platform {
                 not_send_or_sync: _,
@@ -191,6 +193,7 @@ impl Background {
     /// less code than a generic implementation, with no noticeable performance
     /// impact.
     pub fn spawn_boxed(&self, future: BoxFuture<'static, ()>) -> BackgroundTask {
+        let future = future.instrument(tracing::Span::current());
         let inner = match &self.runtime {
             Some(runtime) => Some(runtime.spawn(future)),
             None => {

--- a/crates/warpui_core/src/async/wasm/executor.rs
+++ b/crates/warpui_core/src/async/wasm/executor.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use futures::future::LocalBoxFuture;
 use futures::{Future, FutureExt};
 use futures_util::future::{AbortHandle, Abortable};
+use tracing::Instrument as _;
 use wasm_bindgen_futures::spawn_local;
 
 use crate::platform;
@@ -53,7 +54,7 @@ impl Foreground {
     /// less code than a generic implementation, with no noticeable performance
     /// impact.
     pub fn spawn_boxed(&self, future: LocalBoxFuture<'static, ()>) -> ForegroundTask {
-        spawn_local(future);
+        spawn_local(future.instrument(tracing::Span::current()));
         ForegroundTask
     }
 
@@ -106,7 +107,7 @@ impl Background {
     /// less code than a generic implementation, with no noticeable performance
     /// impact.
     pub fn spawn_boxed(&self, future: LocalBoxFuture<'static, ()>) -> BackgroundTask {
-        spawn_local(future);
+        spawn_local(future.instrument(tracing::Span::current()));
         BackgroundTask
     }
 

--- a/crates/warpui_core/src/core/model/context.rs
+++ b/crates/warpui_core/src/core/model/context.rs
@@ -634,9 +634,11 @@ impl<M> ModelSpawner<M> {
         work: impl FnOnce(&mut M, &mut ModelContext<M>) -> R + Send + 'static,
     ) -> Result<R, ModelDropped> {
         let (tx, rx) = futures::channel::oneshot::channel();
+        let span = tracing::Span::current();
 
         self.task_sender
             .send(Box::new(move |me, ctx| {
+                let _guard = span.enter();
                 let result = work(me, ctx);
                 // If the background task has dropped the receiver, then we don't need to send
                 // the result, and there's no one to inform regardless.

--- a/crates/warpui_core/src/core/view/context.rs
+++ b/crates/warpui_core/src/core/view/context.rs
@@ -826,9 +826,11 @@ impl<V> ViewSpawner<V> {
         work: impl FnOnce(&mut V, &mut ViewContext<V>) -> R + Send + 'static,
     ) -> Result<R, ViewDropped> {
         let (tx, rx) = futures::channel::oneshot::channel();
+        let span = tracing::Span::current();
 
         self.task_sender
             .send(Box::new(move |me, ctx| {
+                let _guard = span.enter();
                 let result = work(me, ctx);
                 // If the background task has dropped the receiver, then we don't need to send
                 // the result, and there's no one to inform regardless.


### PR DESCRIPTION
## Description

Adds opt-in OpenTelemetry tracing for cloud-agent runs so we can inspect end-to-end execution when debugging latency and failures.

When `WARP_CLOUD_AGENT_OTLP_ENDPOINT` is configured, the native app installs an OTLP/HTTP trace exporter; otherwise tracing remains a no-op. Cloud-agent spans are explicitly marked, and filtering at the exporter boundary prevents unrelated application spans from being sent. This also adds spans and events across the cloud-agent lifecycle, server APIs, and driver setup, and propagates the current span through asynchronous tasks and streams.

The tracing provider is retained through the standard application shutdown path, with a best-effort active-span registry that ends still-reachable spans before shutting down the provider so long-lived asynchronous work is less likely to be lost.

## Linked Issue

None.

## Testing

- [x] Manually tested locally with `./script/run -- agent run --prompt "hello world"`.
- [x] Ran `./script/format`.
- [x] Ran `cargo check -p warp --features gui`.
- [x] Ran `cargo doc -p warp --features gui --no-deps`.

No automated tests were added; this is opt-in observability plumbing that was validated through the cloud-agent command path and focused compilation/documentation checks.

> [!NOTE]
> note from dstern: i ended up working with an agent to do an end-to-end test of the fully-authenticated flow with a local cloud agent running via a self-hosted worker host; everything appears to work.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>