### PR TITLE
Authenticate cloud-agent OTLP trace export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9322,7 +9322,6 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
 ]
 
 [[package]]
@@ -9338,7 +9337,6 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
  "thiserror 2.0.17",
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9309,6 +9309,7 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.17",
+ "tracing",
 ]
 
 [[package]]
@@ -14653,6 +14654,7 @@ dependencies = [
  "onboarding",
  "once_cell",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "ordered-float 3.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,7 @@ nom = "7.1.1"
 num-traits = "0.2"
 oauth2 = { version = "5.0.0", default-features = false }
 opentelemetry = { version = "0.32.0", default-features = false, features = ["trace"] }
+opentelemetry-http = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
   "gzip-http",
   "http-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,6 @@ opentelemetry-http = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
   "gzip-http",
   "http-proto",
-  "reqwest-blocking-client",
   "trace",
   "zstd-http",
 ] }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -318,6 +318,7 @@ hyper.workspace = true
 libsqlite3-sys = { version = "0.33.0", features = ["bundled"] }
 mio = { version = "1.1.1", features = ["os-poll", "os-ext"] }
 opentelemetry.workspace = true
+opentelemetry-http.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 tokio.workspace = true

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1175,6 +1175,8 @@ pub(crate) fn initialize_app(
     let server_api = server_api_provider.as_ref(ctx).get();
     let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
     #[cfg(not(target_family = "wasm"))]
+    // Refresh starts only after the authenticated server client exists; tracing initialization
+    // remains responsible for deciding whether this process opted in to cloud-agent export.
     tracing::start_auth_refresh(
         server_api_provider.as_ref(ctx).get_managed_secrets_client(),
         ctx,

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1174,6 +1174,11 @@ pub(crate) fn initialize_app(
 
     let server_api = server_api_provider.as_ref(ctx).get();
     let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
+    #[cfg(not(target_family = "wasm"))]
+    tracing::start_auth_refresh(
+        server_api_provider.as_ref(ctx).get_managed_secrets_client(),
+        ctx,
+    );
 
     ctx.add_singleton_model(|_ctx| AuthStateProvider::new(auth_state.clone()));
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1173,6 +1173,13 @@ pub(crate) fn initialize_app(
     });
 
     let server_api = server_api_provider.as_ref(ctx).get();
+    #[cfg(not(target_family = "wasm"))]
+    if let Ok(run_id) = std::env::var(warp_cli::OZ_RUN_ID_ENV) {
+        match run_id.parse() {
+            Ok(task_id) => server_api.set_ambient_agent_task_id(Some(task_id)),
+            Err(err) => log::warn!("Ignoring invalid {}: {err}", warp_cli::OZ_RUN_ID_ENV),
+        }
+    }
     let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
     #[cfg(not(target_family = "wasm"))]
     // Refresh starts only after the authenticated server client exists; tracing initialization

--- a/app/src/tracing.rs
+++ b/app/src/tracing.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use tracing::subscriber;
 
 #[cfg(not(target_family = "wasm"))]
-mod auth;
+mod cloud_agent_auth;
 #[cfg(not(target_family = "wasm"))]
 mod native;
 
@@ -23,6 +23,11 @@ pub fn init() -> anyhow::Result<Initialization> {
 }
 
 #[cfg(not(target_family = "wasm"))]
+/// Starts cloud-agent trace credential refresh after authenticated application services exist.
+///
+/// The exporter and dispatch credential are initialized earlier by [`init`]. This later lifecycle
+/// hook supplies the authenticated managed-secrets client needed to mint replacements without
+/// broadening tracing initialization to ordinary application processes.
 pub fn start_auth_refresh(
     client: std::sync::Arc<dyn warp_managed_secrets::client::ManagedSecretsClient>,
     ctx: &mut warpui::AppContext,

--- a/app/src/tracing.rs
+++ b/app/src/tracing.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 use tracing::subscriber;
 
 #[cfg(not(target_family = "wasm"))]
+mod auth;
+#[cfg(not(target_family = "wasm"))]
 mod native;
 
 #[cfg(not(target_family = "wasm"))]
@@ -18,6 +20,14 @@ pub fn init() -> anyhow::Result<Initialization> {
 
     #[cfg(not(target_family = "wasm"))]
     native::init()
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub fn start_auth_refresh(
+    client: std::sync::Arc<dyn warp_managed_secrets::client::ManagedSecretsClient>,
+    ctx: &mut warpui::AppContext,
+) {
+    native::start_auth_refresh(client, ctx);
 }
 
 fn install_no_subscriber() -> anyhow::Result<()> {

--- a/app/src/tracing/auth.rs
+++ b/app/src/tracing/auth.rs
@@ -10,7 +10,7 @@ use futures_util::stream::AbortHandle;
 use http::header::{HeaderValue, AUTHORIZATION};
 use opentelemetry_http::{Bytes, HttpClient, HttpError, Request, Response};
 use warp_managed_secrets::client::{IdentityTokenOptions, ManagedSecretsClient, TaskIdentityToken};
-use warpui::r#async::Timer;
+use warpui::r#async::{FutureExt as _, Timer};
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 const CLOUD_AGENT_OTLP_TOKEN: &str = "WARP_CLOUD_AGENT_OTLP_TOKEN";
@@ -22,6 +22,7 @@ const PROACTIVE_REFRESH_JITTER: Duration = Duration::from_secs(2 * 60);
 const INITIAL_FAILURE_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_FAILURE_BACKOFF: Duration = Duration::from_secs(5 * 60);
 const FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
+const REFRESH_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub(super) struct AuthContext {
@@ -131,8 +132,9 @@ struct TokenSnapshot {
 
 impl TokenSnapshot {
     fn new(token: String, expires_at: DateTime<Utc>) -> anyhow::Result<Self> {
-        let authorization_header = HeaderValue::from_str(&format!("Bearer {token}"))
+        let mut authorization_header = HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|_| anyhow!("Cloud-agent OTLP token cannot be used as an HTTP header"))?;
+        authorization_header.set_sensitive(true);
         Ok(Self {
             authorization_header,
             expires_at,
@@ -276,7 +278,9 @@ impl AuthRefreshCoordinator {
                         requested_duration: REFRESHED_TOKEN_DURATION,
                         subject_template: vec1::vec1!["principal".to_owned()],
                     })
+                    .with_timeout(REFRESH_REQUEST_TIMEOUT)
                     .await
+                    .map_err(|_| anyhow!("Cloud-agent OTLP authorization refresh timed out"))?
             },
             |coordinator, result, ctx| coordinator.finish_refresh(result, ctx),
         );
@@ -429,5 +433,23 @@ mod tests {
 
         assert!(!debug_output.contains("secret-test-token"));
         assert!(debug_output.contains("expires_at"));
+    }
+
+    #[test]
+    fn authorized_request_debug_redacts_token() {
+        let client = client_with_expiry(
+            "secret-request-test-token",
+            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+        );
+        let mut request = Request::builder().body(Bytes::new()).unwrap();
+
+        client.authorize_request(&mut request).unwrap();
+        let request_debug = format!("{request:?}");
+        let headers_debug = format!("{:?}", request.headers());
+
+        assert!(!request_debug.contains("secret-request-test-token"));
+        assert!(!headers_debug.contains("secret-request-test-token"));
+        assert!(request_debug.contains("Sensitive"));
+        assert!(headers_debug.contains("Sensitive"));
     }
 }

--- a/app/src/tracing/auth.rs
+++ b/app/src/tracing/auth.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context as _};
 use async_channel::{Receiver, Sender};
 use async_trait::async_trait;
+use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use futures_util::stream::AbortHandle;
 use http::header::{HeaderValue, AUTHORIZATION};
@@ -15,6 +16,7 @@ use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
 const CLOUD_AGENT_OTLP_TOKEN: &str = "WARP_CLOUD_AGENT_OTLP_TOKEN";
 const CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT: &str = "WARP_CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT";
+const OZ_RUN_ID: &str = "OZ_RUN_ID";
 const COLLECTOR_AUDIENCE: &str = "warp-cloud-agent-otel";
 const REFRESHED_TOKEN_DURATION: Duration = Duration::from_secs(60 * 60);
 const PROACTIVE_REFRESH_BUFFER: Duration = Duration::from_secs(20 * 60);
@@ -27,6 +29,7 @@ const REFRESH_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 #[derive(Clone)]
 pub(super) struct AuthContext {
     token_store: TokenStore,
+    expected_run_id: Option<Arc<str>>,
     refresh_hint_sender: Sender<()>,
     refresh_hint_receiver: Arc<Mutex<Option<Receiver<()>>>>,
 }
@@ -52,11 +55,15 @@ impl AuthContext {
             expires_at > Utc::now(),
             "Cloud-agent OTLP token is already expired"
         );
+        let expected_run_id = std::env::var(OZ_RUN_ID)
+            .ok()
+            .filter(|run_id| !run_id.trim().is_empty());
 
         let token_store = TokenStore::new(token, expires_at)?;
         let (refresh_hint_sender, refresh_hint_receiver) = async_channel::bounded(1);
         Ok(Self {
             token_store,
+            expected_run_id: expected_run_id.map(Into::into),
             refresh_hint_sender,
             refresh_hint_receiver: Arc::new(Mutex::new(Some(refresh_hint_receiver))),
         })
@@ -113,6 +120,16 @@ impl TokenStore {
         *self.inner.write().unwrap_or_else(|err| err.into_inner()) = snapshot;
         Ok(())
     }
+
+    fn replace_refreshed(
+        &self,
+        token: String,
+        expires_at: DateTime<Utc>,
+        expected_run_id: Option<&str>,
+    ) -> anyhow::Result<()> {
+        validate_refreshed_token_run_id(&token, expected_run_id)?;
+        self.replace(token, expires_at)
+    }
 }
 
 impl fmt::Debug for TokenStore {
@@ -150,6 +167,50 @@ impl fmt::Debug for TokenSnapshot {
             .field("expires_at", &self.expires_at)
             .finish()
     }
+}
+
+/// Checks the unverified refreshed-token payload as a rejection-only sanity gate.
+///
+/// The collector remains responsible for cryptographically verifying the token.
+fn validate_refreshed_token_run_id(
+    token: &str,
+    expected_run_id: Option<&str>,
+) -> anyhow::Result<()> {
+    let expected_run_id = expected_run_id
+        .filter(|run_id| !run_id.trim().is_empty())
+        .context("Expected cloud-agent run ID is missing or empty")?;
+
+    let mut segments = token.split('.');
+    let _header = segments
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .context("Refreshed cloud-agent OTLP token is not a valid JWT")?;
+    let payload = segments
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .context("Refreshed cloud-agent OTLP token is not a valid JWT")?;
+    let _signature = segments
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .context("Refreshed cloud-agent OTLP token is not a valid JWT")?;
+    anyhow::ensure!(
+        segments.next().is_none(),
+        "Refreshed cloud-agent OTLP token is not a valid JWT"
+    );
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| anyhow!("Refreshed cloud-agent OTLP token payload is not valid base64"))?;
+    let payload: serde_json::Value = serde_json::from_slice(&payload)
+        .map_err(|_| anyhow!("Refreshed cloud-agent OTLP token payload is not valid JSON"))?;
+    let run_id = payload
+        .get("run_id")
+        .and_then(serde_json::Value::as_str)
+        .context("Refreshed cloud-agent OTLP token has no string run ID")?;
+    anyhow::ensure!(
+        run_id == expected_run_id,
+        "Refreshed cloud-agent OTLP token run ID does not match"
+    );
+    Ok(())
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -226,12 +287,19 @@ pub(super) fn start_refresh_coordinator(
         return;
     };
     ctx.add_singleton_model(move |ctx| {
-        AuthRefreshCoordinator::new(auth_context.token_store, refresh_hint_receiver, client, ctx)
+        AuthRefreshCoordinator::new(
+            auth_context.token_store,
+            auth_context.expected_run_id,
+            refresh_hint_receiver,
+            client,
+            ctx,
+        )
     });
 }
 
 struct AuthRefreshCoordinator {
     token_store: TokenStore,
+    expected_run_id: Option<Arc<str>>,
     client: Arc<dyn ManagedSecretsClient>,
     refresh_in_flight: bool,
     consecutive_failures: u32,
@@ -242,12 +310,14 @@ struct AuthRefreshCoordinator {
 impl AuthRefreshCoordinator {
     fn new(
         token_store: TokenStore,
+        expected_run_id: Option<Arc<str>>,
         refresh_hint_receiver: Receiver<()>,
         client: Arc<dyn ManagedSecretsClient>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let mut coordinator = Self {
             token_store,
+            expected_run_id,
             client,
             refresh_in_flight: false,
             consecutive_failures: 0,
@@ -295,7 +365,11 @@ impl AuthRefreshCoordinator {
         match result {
             Ok(token) => {
                 let expires_at = token.expires_at;
-                if self.token_store.replace(token.token, expires_at).is_ok() {
+                if self
+                    .token_store
+                    .replace_refreshed(token.token, expires_at, self.expected_run_id.as_deref())
+                    .is_ok()
+                {
                     self.consecutive_failures = 0;
                     log::info!("Cloud-agent OTLP authorization refreshed");
                     self.schedule_proactive_refresh(expires_at, ctx);
@@ -372,9 +446,16 @@ impl SingletonEntity for AuthRefreshCoordinator {}
 
 #[cfg(test)]
 mod tests {
+    use base64::Engine as _;
     use chrono::TimeDelta;
 
     use super::*;
+    fn jwt_with_payload(payload: serde_json::Value) -> String {
+        let encoder = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let header = encoder.encode(br#"{"alg":"none"}"#);
+        let payload = encoder.encode(serde_json::to_vec(&payload).unwrap());
+        format!("{header}.{payload}.test-signature")
+    }
 
     fn client_with_expiry(token: &str, expires_at: DateTime<Utc>) -> AuthenticatedHttpClient {
         let (refresh_hint_sender, _) = async_channel::bounded(1);
@@ -451,5 +532,74 @@ mod tests {
         assert!(!headers_debug.contains("secret-request-test-token"));
         assert!(request_debug.contains("Sensitive"));
         assert!(headers_debug.contains("Sensitive"));
+    }
+
+    #[test]
+    fn refreshed_token_run_id_exactly_matches() {
+        let token = jwt_with_payload(serde_json::json!({ "run_id": "expected-run-id" }));
+
+        validate_refreshed_token_run_id(&token, Some("expected-run-id")).unwrap();
+    }
+
+    #[test]
+    fn refreshed_token_run_id_is_required() {
+        let token = jwt_with_payload(serde_json::json!({}));
+        assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
+    }
+
+    #[test]
+    fn expected_run_id_is_required() {
+        let token = jwt_with_payload(serde_json::json!({ "run_id": "expected-run-id" }));
+
+        assert!(validate_refreshed_token_run_id(&token, None).is_err());
+        assert!(validate_refreshed_token_run_id(&token, Some("")).is_err());
+    }
+
+    #[test]
+    fn refreshed_token_run_id_must_match() {
+        let token = jwt_with_payload(serde_json::json!({ "run_id": "wrong-run-id" }));
+
+        assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
+    }
+
+    #[test]
+    fn refreshed_token_run_id_must_be_a_string() {
+        let token = jwt_with_payload(serde_json::json!({ "run_id": 123 }));
+        assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
+    }
+
+    #[test]
+    fn malformed_refreshed_tokens_are_rejected() {
+        let invalid_json = {
+            let encoder = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+            let payload = encoder.encode(b"not-json");
+            format!("header.{payload}.signature")
+        };
+
+        for token in ["not-a-jwt", "header.!!!.signature", &invalid_json] {
+            assert!(validate_refreshed_token_run_id(token, Some("expected-run-id")).is_err());
+        }
+    }
+
+    #[test]
+    fn rejected_refreshed_token_preserves_previous_token() {
+        let token_store = TokenStore::new(
+            "current-test-token".to_owned(),
+            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+        )
+        .unwrap();
+        let wrong_run_token = jwt_with_payload(serde_json::json!({ "run_id": "wrong-run-id" }));
+
+        assert!(token_store
+            .replace_refreshed(
+                wrong_run_token,
+                Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+                Some("expected-run-id"),
+            )
+            .is_err());
+        assert_eq!(
+            token_store.valid_authorization_header().unwrap(),
+            "Bearer current-test-token"
+        );
     }
 }

--- a/app/src/tracing/auth.rs
+++ b/app/src/tracing/auth.rs
@@ -1,0 +1,433 @@
+use std::fmt;
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
+
+use anyhow::{anyhow, Context as _};
+use async_channel::{Receiver, Sender};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures_util::stream::AbortHandle;
+use http::header::{HeaderValue, AUTHORIZATION};
+use opentelemetry_http::{Bytes, HttpClient, HttpError, Request, Response};
+use warp_managed_secrets::client::{IdentityTokenOptions, ManagedSecretsClient, TaskIdentityToken};
+use warpui::r#async::Timer;
+use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
+
+const CLOUD_AGENT_OTLP_TOKEN: &str = "WARP_CLOUD_AGENT_OTLP_TOKEN";
+const CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT: &str = "WARP_CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT";
+const COLLECTOR_AUDIENCE: &str = "warp-cloud-agent-otel";
+const REFRESHED_TOKEN_DURATION: Duration = Duration::from_secs(60 * 60);
+const PROACTIVE_REFRESH_BUFFER: Duration = Duration::from_secs(20 * 60);
+const PROACTIVE_REFRESH_JITTER: Duration = Duration::from_secs(2 * 60);
+const INITIAL_FAILURE_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_FAILURE_BACKOFF: Duration = Duration::from_secs(5 * 60);
+const FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Clone)]
+pub(super) struct AuthContext {
+    token_store: TokenStore,
+    refresh_hint_sender: Sender<()>,
+    refresh_hint_receiver: Arc<Mutex<Option<Receiver<()>>>>,
+}
+
+impl AuthContext {
+    pub(super) fn from_environment() -> anyhow::Result<Self> {
+        let token = std::env::var(CLOUD_AGENT_OTLP_TOKEN)
+            .context("Cloud-agent OTLP token is missing")?
+            .trim()
+            .to_owned();
+        anyhow::ensure!(!token.is_empty(), "Cloud-agent OTLP token is empty");
+
+        let expires_at = std::env::var(CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT)
+            .context("Cloud-agent OTLP token expiry is missing")?;
+        let expires_at = DateTime::parse_from_rfc3339(expires_at.trim())
+            .context("Cloud-agent OTLP token expiry is not valid RFC3339")?;
+        anyhow::ensure!(
+            expires_at.offset().local_minus_utc() == 0,
+            "Cloud-agent OTLP token expiry is not UTC"
+        );
+        let expires_at = expires_at.with_timezone(&Utc);
+        anyhow::ensure!(
+            expires_at > Utc::now(),
+            "Cloud-agent OTLP token is already expired"
+        );
+
+        let token_store = TokenStore::new(token, expires_at)?;
+        let (refresh_hint_sender, refresh_hint_receiver) = async_channel::bounded(1);
+        Ok(Self {
+            token_store,
+            refresh_hint_sender,
+            refresh_hint_receiver: Arc::new(Mutex::new(Some(refresh_hint_receiver))),
+        })
+    }
+
+    pub(super) fn http_client(&self) -> AuthenticatedHttpClient {
+        AuthenticatedHttpClient {
+            inner: reqwest::blocking::Client::new(),
+            token_store: self.token_store.clone(),
+            refresh_hint_sender: self.refresh_hint_sender.clone(),
+        }
+    }
+
+    fn take_refresh_hint_receiver(&self) -> Option<Receiver<()>> {
+        self.refresh_hint_receiver
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .take()
+    }
+}
+
+impl fmt::Debug for AuthContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthContext")
+            .field("token_store", &self.token_store)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone)]
+struct TokenStore {
+    inner: Arc<RwLock<TokenSnapshot>>,
+}
+
+impl TokenStore {
+    fn new(token: String, expires_at: DateTime<Utc>) -> anyhow::Result<Self> {
+        Ok(Self {
+            inner: Arc::new(RwLock::new(TokenSnapshot::new(token, expires_at)?)),
+        })
+    }
+
+    fn valid_authorization_header(&self) -> Option<HeaderValue> {
+        let snapshot = self.inner.read().unwrap_or_else(|err| err.into_inner());
+        (snapshot.expires_at > Utc::now()).then(|| snapshot.authorization_header.clone())
+    }
+
+    fn replace(&self, token: String, expires_at: DateTime<Utc>) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            expires_at > Utc::now(),
+            "Refreshed cloud-agent OTLP token is already expired"
+        );
+        let snapshot = TokenSnapshot::new(token, expires_at)?;
+        *self.inner.write().unwrap_or_else(|err| err.into_inner()) = snapshot;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for TokenStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let snapshot = self.inner.read().unwrap_or_else(|err| err.into_inner());
+        formatter
+            .debug_struct("TokenStore")
+            .field("expires_at", &snapshot.expires_at)
+            .finish_non_exhaustive()
+    }
+}
+
+struct TokenSnapshot {
+    authorization_header: HeaderValue,
+    expires_at: DateTime<Utc>,
+}
+
+impl TokenSnapshot {
+    fn new(token: String, expires_at: DateTime<Utc>) -> anyhow::Result<Self> {
+        let authorization_header = HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|_| anyhow!("Cloud-agent OTLP token cannot be used as an HTTP header"))?;
+        Ok(Self {
+            authorization_header,
+            expires_at,
+        })
+    }
+}
+
+impl fmt::Debug for TokenSnapshot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TokenSnapshot")
+            .field("authorization_header", &"<redacted>")
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum AuthenticatedHttpError {
+    #[error("No unexpired cloud-agent OTLP token is available")]
+    NoValidToken,
+    #[error("Cloud-agent OTLP request failed with HTTP status {0}")]
+    HttpStatus(u16),
+}
+
+/// Injects the latest valid token immediately before each OTLP request.
+///
+/// The token-store lock is released before network I/O begins. A manual `Debug` implementation
+/// prevents either the cached token or a request's authorization header from being formatted.
+pub(super) struct AuthenticatedHttpClient {
+    inner: reqwest::blocking::Client,
+    token_store: TokenStore,
+    refresh_hint_sender: Sender<()>,
+}
+
+impl fmt::Debug for AuthenticatedHttpClient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthenticatedHttpClient")
+            .field("token_store", &self.token_store)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AuthenticatedHttpClient {
+    fn authorize_request(
+        &self,
+        request: &mut Request<Bytes>,
+    ) -> Result<(), AuthenticatedHttpError> {
+        request.headers_mut().remove(AUTHORIZATION);
+        let authorization = self
+            .token_store
+            .valid_authorization_header()
+            .ok_or(AuthenticatedHttpError::NoValidToken)?;
+        request.headers_mut().insert(AUTHORIZATION, authorization);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl HttpClient for AuthenticatedHttpClient {
+    async fn send_bytes(&self, mut request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
+        self.authorize_request(&mut request)?;
+
+        let request: reqwest::blocking::Request = request.try_into()?;
+        let mut response = self.inner.execute(request)?;
+        let status = response.status();
+        if status == http::StatusCode::UNAUTHORIZED {
+            let _ = self.refresh_hint_sender.try_send(());
+        }
+
+        if !status.is_success() {
+            return Err(AuthenticatedHttpError::HttpStatus(status.as_u16()).into());
+        }
+
+        let headers = std::mem::take(response.headers_mut());
+        let mut response = Response::builder().status(status).body(response.bytes()?)?;
+        *response.headers_mut() = headers;
+        Ok(response)
+    }
+}
+
+pub(super) fn start_refresh_coordinator(
+    auth_context: AuthContext,
+    client: Arc<dyn ManagedSecretsClient>,
+    ctx: &mut AppContext,
+) {
+    let Some(refresh_hint_receiver) = auth_context.take_refresh_hint_receiver() else {
+        return;
+    };
+    ctx.add_singleton_model(move |ctx| {
+        AuthRefreshCoordinator::new(auth_context.token_store, refresh_hint_receiver, client, ctx)
+    });
+}
+
+struct AuthRefreshCoordinator {
+    token_store: TokenStore,
+    client: Arc<dyn ManagedSecretsClient>,
+    refresh_in_flight: bool,
+    consecutive_failures: u32,
+    scheduled_refresh: Option<AbortHandle>,
+    last_failure_diagnostic: Option<std::time::Instant>,
+}
+
+impl AuthRefreshCoordinator {
+    fn new(
+        token_store: TokenStore,
+        refresh_hint_receiver: Receiver<()>,
+        client: Arc<dyn ManagedSecretsClient>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        let mut coordinator = Self {
+            token_store,
+            client,
+            refresh_in_flight: false,
+            consecutive_failures: 0,
+            scheduled_refresh: None,
+            last_failure_diagnostic: None,
+        };
+        let _ = ctx.spawn_stream_local(
+            refresh_hint_receiver,
+            |coordinator, (), ctx| coordinator.start_refresh(ctx),
+            |_, _| {},
+        );
+        coordinator.start_refresh(ctx);
+        coordinator
+    }
+
+    fn start_refresh(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.refresh_in_flight {
+            return;
+        }
+        self.cancel_scheduled_refresh();
+        self.refresh_in_flight = true;
+        let client = self.client.clone();
+        ctx.spawn(
+            async move {
+                client
+                    .issue_task_identity_token(IdentityTokenOptions {
+                        audience: COLLECTOR_AUDIENCE.to_owned(),
+                        requested_duration: REFRESHED_TOKEN_DURATION,
+                        subject_template: vec1::vec1!["principal".to_owned()],
+                    })
+                    .await
+            },
+            |coordinator, result, ctx| coordinator.finish_refresh(result, ctx),
+        );
+    }
+
+    fn finish_refresh(
+        &mut self,
+        result: anyhow::Result<TaskIdentityToken>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.refresh_in_flight = false;
+        match result {
+            Ok(token) => {
+                let expires_at = token.expires_at;
+                if self.token_store.replace(token.token, expires_at).is_ok() {
+                    self.consecutive_failures = 0;
+                    log::info!("Cloud-agent OTLP authorization refreshed");
+                    self.schedule_proactive_refresh(expires_at, ctx);
+                } else {
+                    self.warn_refresh_failure();
+                    self.schedule_failure_retry(ctx);
+                }
+            }
+            Err(_) => {
+                self.warn_refresh_failure();
+                self.schedule_failure_retry(ctx);
+            }
+        }
+    }
+
+    fn schedule_proactive_refresh(
+        &mut self,
+        expires_at: DateTime<Utc>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let jitter = PROACTIVE_REFRESH_JITTER.mul_f64(rand::random::<f64>());
+        let refresh_buffer = PROACTIVE_REFRESH_BUFFER.saturating_add(jitter);
+        let remaining = (expires_at - Utc::now()).to_std().unwrap_or_default();
+        self.schedule_refresh(remaining.saturating_sub(refresh_buffer), ctx);
+    }
+
+    fn schedule_failure_retry(&mut self, ctx: &mut ModelContext<Self>) {
+        let exponent = self.consecutive_failures.min(31);
+        let upper_bound = INITIAL_FAILURE_BACKOFF
+            .saturating_mul(1u32 << exponent)
+            .min(MAX_FAILURE_BACKOFF);
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let delay = upper_bound.mul_f64(rand::random::<f64>());
+        self.schedule_refresh(delay, ctx);
+    }
+
+    fn schedule_refresh(&mut self, delay: Duration, ctx: &mut ModelContext<Self>) {
+        self.cancel_scheduled_refresh();
+        let task = ctx.spawn(
+            async move {
+                Timer::after(delay).await;
+            },
+            |coordinator, _, ctx| {
+                coordinator.scheduled_refresh = None;
+                coordinator.start_refresh(ctx);
+            },
+        );
+        self.scheduled_refresh = Some(task.abort_handle());
+    }
+
+    fn cancel_scheduled_refresh(&mut self) {
+        if let Some(handle) = self.scheduled_refresh.take() {
+            handle.abort();
+        }
+    }
+
+    fn warn_refresh_failure(&mut self) {
+        let now = std::time::Instant::now();
+        if self
+            .last_failure_diagnostic
+            .is_none_or(|last| now.duration_since(last) >= FAILURE_LOG_INTERVAL)
+        {
+            self.last_failure_diagnostic = Some(now);
+            log::warn!("Cloud-agent OTLP authorization refresh failed");
+        }
+    }
+}
+
+impl Entity for AuthRefreshCoordinator {
+    type Event = ();
+}
+
+impl SingletonEntity for AuthRefreshCoordinator {}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeDelta;
+
+    use super::*;
+
+    fn client_with_expiry(token: &str, expires_at: DateTime<Utc>) -> AuthenticatedHttpClient {
+        let (refresh_hint_sender, _) = async_channel::bounded(1);
+        AuthenticatedHttpClient {
+            inner: reqwest::blocking::Client::new(),
+            token_store: TokenStore::new(token.to_owned(), expires_at).unwrap(),
+            refresh_hint_sender,
+        }
+    }
+
+    #[test]
+    fn authorization_overwrites_supplied_header() {
+        let client = client_with_expiry(
+            "current-test-token",
+            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+        );
+        let mut request = Request::builder()
+            .header(AUTHORIZATION, "Bearer stale-test-token")
+            .body(Bytes::new())
+            .unwrap();
+
+        client.authorize_request(&mut request).unwrap();
+
+        assert_eq!(
+            request.headers().get(AUTHORIZATION).unwrap(),
+            "Bearer current-test-token"
+        );
+    }
+
+    #[test]
+    fn expired_token_is_refused_and_supplied_header_is_removed() {
+        let client = client_with_expiry(
+            "expired-test-token",
+            Utc::now() - TimeDelta::try_minutes(5).unwrap(),
+        );
+        let mut request = Request::builder()
+            .header(AUTHORIZATION, "Bearer stale-test-token")
+            .body(Bytes::new())
+            .unwrap();
+
+        assert!(matches!(
+            client.authorize_request(&mut request),
+            Err(AuthenticatedHttpError::NoValidToken)
+        ));
+        assert!(!request.headers().contains_key(AUTHORIZATION));
+    }
+
+    #[test]
+    fn debug_output_redacts_token() {
+        let client = client_with_expiry(
+            "secret-test-token",
+            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+        );
+
+        let debug_output = format!("{client:?}");
+
+        assert!(!debug_output.contains("secret-test-token"));
+        assert!(debug_output.contains("expires_at"));
+    }
+}

--- a/app/src/tracing/cloud_agent_auth.rs
+++ b/app/src/tracing/cloud_agent_auth.rs
@@ -1,3 +1,21 @@
+//! Provides authenticated OTLP trace transport and credential refresh for opted-in cloud agents.
+//!
+//! Dispatch bootstraps tracing with a bearer token and expiry in the process environment. The
+//! exporter is built once around [`AuthenticatedHttpClient`], which reads a shared token snapshot
+//! immediately before every request so refresh never requires rebuilding the exporter. Processes
+//! without the endpoint switch or a currently valid dispatch credential never initialize this
+//! module.
+//!
+//! Refresh begins only after the application has an authenticated managed-secrets client. A
+//! successful mint replaces the dispatch credential only after the returned JWT's unverified
+//! payload contains a string `run_id` exactly matching the immutable startup `OZ_RUN_ID`. This
+//! payload inspection is only a rejection gate; the collector remains responsible for verifying
+//! the token's signature, audience, expiry, and trusted trace resource attributes. Every refresh
+//! failure preserves the last valid credential and enters bounded jittered backoff.
+//!
+//! Tokens must never appear in diagnostics or formatted values. Cached authorization headers are
+//! marked sensitive, manual `Debug` implementations omit secrets, and token-store locks are always
+//! released before network I/O.
 use std::fmt;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
@@ -14,17 +32,27 @@ use warp_managed_secrets::client::{IdentityTokenOptions, ManagedSecretsClient, T
 use warpui::r#async::{FutureExt as _, Timer};
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
+/// The environment variables form the immutable dispatch-time authentication bootstrap.
 const CLOUD_AGENT_OTLP_TOKEN: &str = "WARP_CLOUD_AGENT_OTLP_TOKEN";
 const CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT: &str = "WARP_CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT";
 const OZ_RUN_ID: &str = "OZ_RUN_ID";
+/// The collector audience and requested lifetime are fixed by the cloud-agent trace contract.
 const COLLECTOR_AUDIENCE: &str = "warp-cloud-agent-otel";
 const REFRESHED_TOKEN_DURATION: Duration = Duration::from_secs(60 * 60);
+/// Proactive refresh starts roughly twenty minutes before expiry, with jitter to spread load.
 const PROACTIVE_REFRESH_BUFFER: Duration = Duration::from_secs(20 * 60);
 const PROACTIVE_REFRESH_JITTER: Duration = Duration::from_secs(2 * 60);
+/// Failed refreshes use bounded full-jitter exponential backoff and rate-limited diagnostics.
 const INITIAL_FAILURE_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_FAILURE_BACKOFF: Duration = Duration::from_secs(5 * 60);
 const FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
+/// A stalled identity-token request must release the single in-flight refresh slot.
 const REFRESH_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+/// Shares dispatch authentication state between the exporter and the later refresh coordinator.
+///
+/// The optional expected run ID intentionally does not gate initial tracing: a valid dispatch
+/// credential remains usable when `OZ_RUN_ID` is missing or empty, but every refreshed credential
+/// is rejected until an immutable expected run ID is available to the replacement gate.
 
 #[derive(Clone)]
 pub(super) struct AuthContext {
@@ -35,6 +63,10 @@ pub(super) struct AuthContext {
 }
 
 impl AuthContext {
+    /// Seeds authentication from a currently valid dispatch credential in the environment.
+    ///
+    /// The caller treats failure as an opt-out so normal processes and partially rolled-out cloud
+    /// agents retain no-op tracing behavior.
     pub(super) fn from_environment() -> anyhow::Result<Self> {
         let token = std::env::var(CLOUD_AGENT_OTLP_TOKEN)
             .context("Cloud-agent OTLP token is missing")?
@@ -69,6 +101,7 @@ impl AuthContext {
         })
     }
 
+    /// Creates a transport sharing the latest credential while leaving the exporter itself stable.
     pub(super) fn http_client(&self) -> AuthenticatedHttpClient {
         AuthenticatedHttpClient {
             inner: reqwest::blocking::Client::new(),
@@ -77,6 +110,7 @@ impl AuthContext {
         }
     }
 
+    /// Transfers the bounded refresh-hint receiver to the one allowed coordinator.
     fn take_refresh_hint_receiver(&self) -> Option<Receiver<()>> {
         self.refresh_hint_receiver
             .lock()
@@ -94,23 +128,31 @@ impl fmt::Debug for AuthContext {
     }
 }
 
+/// Stores the latest credential snapshot behind a short-lived reader/writer lock.
+///
+/// Readers clone only the sensitive authorization header, and no caller holds this lock during
+/// network I/O. Replacement constructs and validates a complete snapshot before taking the write
+/// lock so failures preserve the last valid credential.
 #[derive(Clone)]
 struct TokenStore {
     inner: Arc<RwLock<TokenSnapshot>>,
 }
 
 impl TokenStore {
+    /// Creates the initial store from the validated dispatch credential.
     fn new(token: String, expires_at: DateTime<Utc>) -> anyhow::Result<Self> {
         Ok(Self {
             inner: Arc::new(RwLock::new(TokenSnapshot::new(token, expires_at)?)),
         })
     }
 
+    /// Returns a cloned sensitive header only while the current credential remains unexpired.
     fn valid_authorization_header(&self) -> Option<HeaderValue> {
         let snapshot = self.inner.read().unwrap_or_else(|err| err.into_inner());
         (snapshot.expires_at > Utc::now()).then(|| snapshot.authorization_header.clone())
     }
 
+    /// Atomically replaces the current snapshot only with a usable unexpired credential.
     fn replace(&self, token: String, expires_at: DateTime<Utc>) -> anyhow::Result<()> {
         anyhow::ensure!(
             expires_at > Utc::now(),
@@ -121,6 +163,8 @@ impl TokenStore {
         Ok(())
     }
 
+    /// Applies the exact-run rejection gate before allowing a refreshed credential to replace the
+    /// dispatch or previous refresh credential.
     fn replace_refreshed(
         &self,
         token: String,
@@ -142,12 +186,14 @@ impl fmt::Debug for TokenStore {
     }
 }
 
+/// Caches the already-parsed sensitive authorization header with its trusted server expiry.
 struct TokenSnapshot {
     authorization_header: HeaderValue,
     expires_at: DateTime<Utc>,
 }
 
 impl TokenSnapshot {
+    /// Constructs a snapshot whose header redacts its value from standard debug formatting.
     fn new(token: String, expires_at: DateTime<Utc>) -> anyhow::Result<Self> {
         let mut authorization_header = HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|_| anyhow!("Cloud-agent OTLP token cannot be used as an HTTP header"))?;
@@ -169,9 +215,11 @@ impl fmt::Debug for TokenSnapshot {
     }
 }
 
-/// Checks the unverified refreshed-token payload as a rejection-only sanity gate.
+/// Requires the unverified refreshed-token payload to name the immutable expected run exactly.
 ///
-/// The collector remains responsible for cryptographically verifying the token.
+/// This local decode never establishes token authenticity. The collector remains responsible for
+/// cryptographically verifying the token, while malformed or mismatched tokens fail closed here
+/// before replacement and leave the existing credential untouched.
 fn validate_refreshed_token_run_id(
     token: &str,
     expected_run_id: Option<&str>,
@@ -213,6 +261,7 @@ fn validate_refreshed_token_run_id(
     Ok(())
 }
 
+/// Reports only token-free transport failure categories to the exporter.
 #[derive(thiserror::Error, Debug)]
 enum AuthenticatedHttpError {
     #[error("No unexpired cloud-agent OTLP token is available")]
@@ -221,10 +270,12 @@ enum AuthenticatedHttpError {
     HttpStatus(u16),
 }
 
-/// Injects the latest valid token immediately before each OTLP request.
+/// Injects the latest valid token immediately before each request from the exporter built at
+/// startup.
 ///
 /// The token-store lock is released before network I/O begins. A manual `Debug` implementation
-/// prevents either the cached token or a request's authorization header from being formatted.
+/// prevents the client from formatting cached state, while sensitive [`HeaderValue`] instances
+/// redact request headers. Expired credentials are removed and refused rather than sent.
 pub(super) struct AuthenticatedHttpClient {
     inner: reqwest::blocking::Client,
     token_store: TokenStore,
@@ -241,6 +292,10 @@ impl fmt::Debug for AuthenticatedHttpClient {
 }
 
 impl AuthenticatedHttpClient {
+    /// Overwrites any supplied authorization header with the latest unexpired credential.
+    ///
+    /// Removing the supplied header first ensures an expired store fails closed rather than
+    /// accidentally sending a stale or caller-provided credential.
     fn authorize_request(
         &self,
         request: &mut Request<Bytes>,
@@ -264,6 +319,7 @@ impl HttpClient for AuthenticatedHttpClient {
         let mut response = self.inner.execute(request)?;
         let status = response.status();
         if status == http::StatusCode::UNAUTHORIZED {
+            // The bounded nonblocking hint cannot recurse into or delay this export request.
             let _ = self.refresh_hint_sender.try_send(());
         }
 
@@ -278,6 +334,10 @@ impl HttpClient for AuthenticatedHttpClient {
     }
 }
 
+/// Starts the one refresh coordinator after authenticated server connectivity is available.
+///
+/// Consuming the bounded hint receiver coalesces concurrent starts, and the coordinator immediately
+/// mints once so the short-lived dispatch credential is replaced as soon as possible.
 pub(super) fn start_refresh_coordinator(
     auth_context: AuthContext,
     client: Arc<dyn ManagedSecretsClient>,
@@ -297,6 +357,10 @@ pub(super) fn start_refresh_coordinator(
     });
 }
 
+/// Owns serialized credential minting, proactive scheduling, failure backoff, and diagnostics.
+///
+/// At most one mint is in flight and one scheduled wakeup is retained. A bounded nonblocking 401
+/// hint can accelerate refresh without recursing into or blocking the export request.
 struct AuthRefreshCoordinator {
     token_store: TokenStore,
     expected_run_id: Option<Arc<str>>,
@@ -308,6 +372,7 @@ struct AuthRefreshCoordinator {
 }
 
 impl AuthRefreshCoordinator {
+    /// Installs the hint stream and immediately starts the first bounded refresh request.
     fn new(
         token_store: TokenStore,
         expected_run_id: Option<Arc<str>>,
@@ -333,6 +398,10 @@ impl AuthRefreshCoordinator {
         coordinator
     }
 
+    /// Starts one mint and coalesces all triggers while it remains in flight.
+    ///
+    /// Each request asks for the fixed collector audience and principal-only subject, and the
+    /// timeout guarantees a stalled request eventually enters the ordinary failure path.
     fn start_refresh(&mut self, ctx: &mut ModelContext<Self>) {
         if self.refresh_in_flight {
             return;
@@ -356,6 +425,10 @@ impl AuthRefreshCoordinator {
         );
     }
 
+    /// Accepts a refreshed credential only after all replacement gates succeed.
+    ///
+    /// Any mint, timeout, expiry, header, or run-ID failure retains the last valid token and enters
+    /// the same bounded retry path without logging token contents.
     fn finish_refresh(
         &mut self,
         result: anyhow::Result<TaskIdentityToken>,
@@ -385,6 +458,7 @@ impl AuthRefreshCoordinator {
         }
     }
 
+    /// Schedules successful refreshes around twenty minutes before server-returned expiry.
     fn schedule_proactive_refresh(
         &mut self,
         expires_at: DateTime<Utc>,
@@ -396,6 +470,7 @@ impl AuthRefreshCoordinator {
         self.schedule_refresh(remaining.saturating_sub(refresh_buffer), ctx);
     }
 
+    /// Schedules a full-jitter exponential retry capped at five minutes.
     fn schedule_failure_retry(&mut self, ctx: &mut ModelContext<Self>) {
         let exponent = self.consecutive_failures.min(31);
         let upper_bound = INITIAL_FAILURE_BACKOFF
@@ -406,6 +481,7 @@ impl AuthRefreshCoordinator {
         self.schedule_refresh(delay, ctx);
     }
 
+    /// Replaces the one scheduled wakeup so proactive, retry, and hint triggers stay coalesced.
     fn schedule_refresh(&mut self, delay: Duration, ctx: &mut ModelContext<Self>) {
         self.cancel_scheduled_refresh();
         let task = ctx.spawn(
@@ -420,12 +496,14 @@ impl AuthRefreshCoordinator {
         self.scheduled_refresh = Some(task.abort_handle());
     }
 
+    /// Cancels the prior wakeup without affecting a refresh already in flight.
     fn cancel_scheduled_refresh(&mut self) {
         if let Some(handle) = self.scheduled_refresh.take() {
             handle.abort();
         }
     }
 
+    /// Emits a local token-free failure diagnostic at most once per configured interval.
     fn warn_refresh_failure(&mut self) {
         let now = std::time::Instant::now();
         if self
@@ -445,161 +523,5 @@ impl Entity for AuthRefreshCoordinator {
 impl SingletonEntity for AuthRefreshCoordinator {}
 
 #[cfg(test)]
-mod tests {
-    use base64::Engine as _;
-    use chrono::TimeDelta;
-
-    use super::*;
-    fn jwt_with_payload(payload: serde_json::Value) -> String {
-        let encoder = base64::engine::general_purpose::URL_SAFE_NO_PAD;
-        let header = encoder.encode(br#"{"alg":"none"}"#);
-        let payload = encoder.encode(serde_json::to_vec(&payload).unwrap());
-        format!("{header}.{payload}.test-signature")
-    }
-
-    fn client_with_expiry(token: &str, expires_at: DateTime<Utc>) -> AuthenticatedHttpClient {
-        let (refresh_hint_sender, _) = async_channel::bounded(1);
-        AuthenticatedHttpClient {
-            inner: reqwest::blocking::Client::new(),
-            token_store: TokenStore::new(token.to_owned(), expires_at).unwrap(),
-            refresh_hint_sender,
-        }
-    }
-
-    #[test]
-    fn authorization_overwrites_supplied_header() {
-        let client = client_with_expiry(
-            "current-test-token",
-            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
-        );
-        let mut request = Request::builder()
-            .header(AUTHORIZATION, "Bearer stale-test-token")
-            .body(Bytes::new())
-            .unwrap();
-
-        client.authorize_request(&mut request).unwrap();
-
-        assert_eq!(
-            request.headers().get(AUTHORIZATION).unwrap(),
-            "Bearer current-test-token"
-        );
-    }
-
-    #[test]
-    fn expired_token_is_refused_and_supplied_header_is_removed() {
-        let client = client_with_expiry(
-            "expired-test-token",
-            Utc::now() - TimeDelta::try_minutes(5).unwrap(),
-        );
-        let mut request = Request::builder()
-            .header(AUTHORIZATION, "Bearer stale-test-token")
-            .body(Bytes::new())
-            .unwrap();
-
-        assert!(matches!(
-            client.authorize_request(&mut request),
-            Err(AuthenticatedHttpError::NoValidToken)
-        ));
-        assert!(!request.headers().contains_key(AUTHORIZATION));
-    }
-
-    #[test]
-    fn debug_output_redacts_token() {
-        let client = client_with_expiry(
-            "secret-test-token",
-            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
-        );
-
-        let debug_output = format!("{client:?}");
-
-        assert!(!debug_output.contains("secret-test-token"));
-        assert!(debug_output.contains("expires_at"));
-    }
-
-    #[test]
-    fn authorized_request_debug_redacts_token() {
-        let client = client_with_expiry(
-            "secret-request-test-token",
-            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
-        );
-        let mut request = Request::builder().body(Bytes::new()).unwrap();
-
-        client.authorize_request(&mut request).unwrap();
-        let request_debug = format!("{request:?}");
-        let headers_debug = format!("{:?}", request.headers());
-
-        assert!(!request_debug.contains("secret-request-test-token"));
-        assert!(!headers_debug.contains("secret-request-test-token"));
-        assert!(request_debug.contains("Sensitive"));
-        assert!(headers_debug.contains("Sensitive"));
-    }
-
-    #[test]
-    fn refreshed_token_run_id_exactly_matches() {
-        let token = jwt_with_payload(serde_json::json!({ "run_id": "expected-run-id" }));
-
-        validate_refreshed_token_run_id(&token, Some("expected-run-id")).unwrap();
-    }
-
-    #[test]
-    fn refreshed_token_run_id_is_required() {
-        let token = jwt_with_payload(serde_json::json!({}));
-        assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
-    }
-
-    #[test]
-    fn expected_run_id_is_required() {
-        let token = jwt_with_payload(serde_json::json!({ "run_id": "expected-run-id" }));
-
-        assert!(validate_refreshed_token_run_id(&token, None).is_err());
-        assert!(validate_refreshed_token_run_id(&token, Some("")).is_err());
-    }
-
-    #[test]
-    fn refreshed_token_run_id_must_match() {
-        let token = jwt_with_payload(serde_json::json!({ "run_id": "wrong-run-id" }));
-
-        assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
-    }
-
-    #[test]
-    fn refreshed_token_run_id_must_be_a_string() {
-        let token = jwt_with_payload(serde_json::json!({ "run_id": 123 }));
-        assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
-    }
-
-    #[test]
-    fn malformed_refreshed_tokens_are_rejected() {
-        let invalid_json = {
-            let encoder = base64::engine::general_purpose::URL_SAFE_NO_PAD;
-            let payload = encoder.encode(b"not-json");
-            format!("header.{payload}.signature")
-        };
-
-        for token in ["not-a-jwt", "header.!!!.signature", &invalid_json] {
-            assert!(validate_refreshed_token_run_id(token, Some("expected-run-id")).is_err());
-        }
-    }
-
-    #[test]
-    fn rejected_refreshed_token_preserves_previous_token() {
-        let token_store = TokenStore::new(
-            "current-test-token".to_owned(),
-            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
-        )
-        .unwrap();
-        let wrong_run_token = jwt_with_payload(serde_json::json!({ "run_id": "wrong-run-id" }));
-
-        assert!(token_store
-            .replace_refreshed(
-                wrong_run_token,
-                Utc::now() + TimeDelta::try_minutes(5).unwrap(),
-                Some("expected-run-id"),
-            )
-            .is_err());
-        assert_eq!(
-            token_store.valid_authorization_header().unwrap(),
-            "Bearer current-test-token"
-        );
-    }
-}
+#[path = "cloud_agent_auth_tests.rs"]
+mod tests;

--- a/app/src/tracing/cloud_agent_auth.rs
+++ b/app/src/tracing/cloud_agent_auth.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context as _};
 use async_channel::{Receiver, Sender};
+use async_compat::Compat;
 use async_trait::async_trait;
 use base64::Engine as _;
 use chrono::{DateTime, Utc};
@@ -104,7 +105,7 @@ impl AuthContext {
     /// Creates a transport sharing the latest credential while leaving the exporter itself stable.
     pub(super) fn http_client(&self) -> AuthenticatedHttpClient {
         AuthenticatedHttpClient {
-            inner: reqwest::blocking::Client::new(),
+            inner: reqwest::Client::new(),
             token_store: self.token_store.clone(),
             refresh_hint_sender: self.refresh_hint_sender.clone(),
         }
@@ -277,7 +278,7 @@ enum AuthenticatedHttpError {
 /// prevents the client from formatting cached state, while sensitive [`HeaderValue`] instances
 /// redact request headers. Expired credentials are removed and refused rather than sent.
 pub(super) struct AuthenticatedHttpClient {
-    inner: reqwest::blocking::Client,
+    inner: reqwest::Client,
     token_store: TokenStore,
     refresh_hint_sender: Sender<()>,
 }
@@ -315,20 +316,29 @@ impl HttpClient for AuthenticatedHttpClient {
     async fn send_bytes(&self, mut request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
         self.authorize_request(&mut request)?;
 
-        let request: reqwest::blocking::Request = request.try_into()?;
-        let mut response = self.inner.execute(request)?;
-        let status = response.status();
+        let request: reqwest::Request = request.try_into()?;
+        // Reqwest requires a Tokio-compatible context, while the exporter may use another executor.
+        let (status, response) = Compat::new(async {
+            let mut response = self.inner.execute(request).await?;
+            let status = response.status();
+            let response = if status.is_success() {
+                let headers = std::mem::take(response.headers_mut());
+                Some((headers, response.bytes().await?))
+            } else {
+                None
+            };
+            Ok::<_, reqwest::Error>((status, response))
+        })
+        .await?;
         if status == http::StatusCode::UNAUTHORIZED {
             // The bounded nonblocking hint cannot recurse into or delay this export request.
             let _ = self.refresh_hint_sender.try_send(());
         }
-
-        if !status.is_success() {
+        let Some((headers, body)) = response else {
             return Err(AuthenticatedHttpError::HttpStatus(status.as_u16()).into());
-        }
+        };
 
-        let headers = std::mem::take(response.headers_mut());
-        let mut response = Response::builder().status(status).body(response.bytes()?)?;
+        let mut response = Response::builder().status(status).body(body)?;
         *response.headers_mut() = headers;
         Ok(response)
     }

--- a/app/src/tracing/cloud_agent_auth.rs
+++ b/app/src/tracing/cloud_agent_auth.rs
@@ -49,12 +49,12 @@ const MAX_FAILURE_BACKOFF: Duration = Duration::from_secs(5 * 60);
 const FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
 /// A stalled identity-token request must release the single in-flight refresh slot.
 const REFRESH_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
-/// Shares dispatch authentication state between the exporter and the later refresh coordinator.
+
+/// Shared dispatch authentication state between the exporter and the later refresh coordinator.
 ///
 /// The optional expected run ID intentionally does not gate initial tracing: a valid dispatch
 /// credential remains usable when `OZ_RUN_ID` is missing or empty, but every refreshed credential
 /// is rejected until an immutable expected run ID is available to the replacement gate.
-
 #[derive(Clone)]
 pub(super) struct AuthContext {
     token_store: TokenStore,
@@ -129,7 +129,7 @@ impl fmt::Debug for AuthContext {
     }
 }
 
-/// Stores the latest credential snapshot behind a short-lived reader/writer lock.
+/// A snapshot of the latest credential, stored behind a short-lived reader/writer lock.
 ///
 /// Readers clone only the sensitive authorization header, and no caller holds this lock during
 /// network I/O. Replacement constructs and validates a complete snapshot before taking the write
@@ -187,7 +187,7 @@ impl fmt::Debug for TokenStore {
     }
 }
 
-/// Caches the already-parsed sensitive authorization header with its trusted server expiry.
+/// An already-parsed sensitive authorization header and its trusted server expiry.
 struct TokenSnapshot {
     authorization_header: HeaderValue,
     expires_at: DateTime<Utc>,
@@ -216,7 +216,7 @@ impl fmt::Debug for TokenSnapshot {
     }
 }
 
-/// Requires the unverified refreshed-token payload to name the immutable expected run exactly.
+/// Validates that the unverified refreshed-token payload names the immutable expected run exactly.
 ///
 /// This local decode never establishes token authenticity. The collector remains responsible for
 /// cryptographically verifying the token, while malformed or mismatched tokens fail closed here
@@ -262,7 +262,7 @@ fn validate_refreshed_token_run_id(
     Ok(())
 }
 
-/// Reports only token-free transport failure categories to the exporter.
+/// The set of errors that can occur when making an HTTP request using [`AuthenticatedHttpClient`].
 #[derive(thiserror::Error, Debug)]
 enum AuthenticatedHttpError {
     #[error("No unexpired cloud-agent OTLP token is available")]
@@ -271,8 +271,7 @@ enum AuthenticatedHttpError {
     HttpStatus(u16),
 }
 
-/// Injects the latest valid token immediately before each request from the exporter built at
-/// startup.
+/// An HTTP client that injects the latest valid token immediately before each request.
 ///
 /// The token-store lock is released before network I/O begins. A manual `Debug` implementation
 /// prevents the client from formatting cached state, while sensitive [`HeaderValue`] instances

--- a/app/src/tracing/cloud_agent_auth.rs
+++ b/app/src/tracing/cloud_agent_auth.rs
@@ -28,6 +28,7 @@ use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use futures_util::stream::AbortHandle;
 use http::header::{HeaderValue, AUTHORIZATION};
+use instant::Instant;
 use opentelemetry_http::{Bytes, HttpClient, HttpError, Request, Response};
 use warp_managed_secrets::client::{IdentityTokenOptions, ManagedSecretsClient, TaskIdentityToken};
 use warpui::r#async::{FutureExt as _, Timer};
@@ -379,7 +380,7 @@ struct AuthRefreshCoordinator {
     refresh_in_flight: bool,
     consecutive_failures: u32,
     scheduled_refresh: Option<AbortHandle>,
-    last_failure_diagnostic: Option<std::time::Instant>,
+    last_failure_diagnostic: Option<Instant>,
 }
 
 impl AuthRefreshCoordinator {
@@ -523,7 +524,7 @@ impl AuthRefreshCoordinator {
 
     /// Emits a local token-free failure diagnostic at most once per configured interval.
     fn warn_refresh_failure(&mut self) {
-        let now = std::time::Instant::now();
+        let now = Instant::now();
         if self
             .last_failure_diagnostic
             .is_none_or(|last| now.duration_since(last) >= FAILURE_LOG_INTERVAL)

--- a/app/src/tracing/cloud_agent_auth.rs
+++ b/app/src/tracing/cloud_agent_auth.rs
@@ -43,6 +43,7 @@ const REFRESHED_TOKEN_DURATION: Duration = Duration::from_secs(60 * 60);
 /// Proactive refresh starts roughly twenty minutes before expiry, with jitter to spread load.
 const PROACTIVE_REFRESH_BUFFER: Duration = Duration::from_secs(20 * 60);
 const PROACTIVE_REFRESH_JITTER: Duration = Duration::from_secs(2 * 60);
+const MIN_PROACTIVE_REFRESH_DELAY: Duration = Duration::from_secs(1);
 /// Failed refreshes use bounded full-jitter exponential backoff and rate-limited diagnostics.
 const INITIAL_FAILURE_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_FAILURE_BACKOFF: Duration = Duration::from_secs(5 * 60);
@@ -69,10 +70,11 @@ impl AuthContext {
     /// The caller treats failure as an opt-out so normal processes and partially rolled-out cloud
     /// agents retain no-op tracing behavior.
     pub(super) fn from_environment() -> anyhow::Result<Self> {
-        let token = std::env::var(CLOUD_AGENT_OTLP_TOKEN)
-            .context("Cloud-agent OTLP token is missing")?
-            .trim()
-            .to_owned();
+        let token =
+            std::env::var(CLOUD_AGENT_OTLP_TOKEN).context("Cloud-agent OTLP token is missing")?;
+        // Remove the bootstrap secret as soon as it is owned so child processes cannot inherit it.
+        std::env::remove_var(CLOUD_AGENT_OTLP_TOKEN);
+        let token = token.trim().to_owned();
         anyhow::ensure!(!token.is_empty(), "Cloud-agent OTLP token is empty");
 
         let expires_at = std::env::var(CLOUD_AGENT_OTLP_TOKEN_EXPIRES_AT)
@@ -467,7 +469,10 @@ impl AuthRefreshCoordinator {
         }
     }
 
-    /// Schedules successful refreshes around twenty minutes before server-returned expiry.
+    /// Schedules a refresh to occur before the current token expires.
+    ///
+    /// This leaves some buffer for retries in case the refresh fails, but also guarantees
+    /// some minimum amount of time before the first refresh attempt.
     fn schedule_proactive_refresh(
         &mut self,
         expires_at: DateTime<Utc>,
@@ -476,7 +481,11 @@ impl AuthRefreshCoordinator {
         let jitter = PROACTIVE_REFRESH_JITTER.mul_f64(rand::random::<f64>());
         let refresh_buffer = PROACTIVE_REFRESH_BUFFER.saturating_add(jitter);
         let remaining = (expires_at - Utc::now()).to_std().unwrap_or_default();
-        self.schedule_refresh(remaining.saturating_sub(refresh_buffer), ctx);
+        let delay = remaining
+            .saturating_sub(refresh_buffer)
+            .max(remaining.mul_f64(0.5))
+            .max(MIN_PROACTIVE_REFRESH_DELAY);
+        self.schedule_refresh(delay, ctx);
     }
 
     /// Schedules a full-jitter exponential retry capped at five minutes.

--- a/app/src/tracing/cloud_agent_auth_tests.rs
+++ b/app/src/tracing/cloud_agent_auth_tests.rs
@@ -1,0 +1,157 @@
+use base64::Engine as _;
+use chrono::TimeDelta;
+
+use super::*;
+
+fn jwt_with_payload(payload: serde_json::Value) -> String {
+    let encoder = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = encoder.encode(br#"{"alg":"none"}"#);
+    let payload = encoder.encode(serde_json::to_vec(&payload).unwrap());
+    format!("{header}.{payload}.test-signature")
+}
+
+fn client_with_expiry(token: &str, expires_at: DateTime<Utc>) -> AuthenticatedHttpClient {
+    let (refresh_hint_sender, _) = async_channel::bounded(1);
+    AuthenticatedHttpClient {
+        inner: reqwest::blocking::Client::new(),
+        token_store: TokenStore::new(token.to_owned(), expires_at).unwrap(),
+        refresh_hint_sender,
+    }
+}
+
+#[test]
+fn authorization_overwrites_supplied_header() {
+    let client = client_with_expiry(
+        "current-test-token",
+        Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+    );
+    let mut request = Request::builder()
+        .header(AUTHORIZATION, "Bearer stale-test-token")
+        .body(Bytes::new())
+        .unwrap();
+
+    client.authorize_request(&mut request).unwrap();
+
+    assert_eq!(
+        request.headers().get(AUTHORIZATION).unwrap(),
+        "Bearer current-test-token"
+    );
+}
+
+#[test]
+fn expired_token_is_refused_and_supplied_header_is_removed() {
+    let client = client_with_expiry(
+        "expired-test-token",
+        Utc::now() - TimeDelta::try_minutes(5).unwrap(),
+    );
+    let mut request = Request::builder()
+        .header(AUTHORIZATION, "Bearer stale-test-token")
+        .body(Bytes::new())
+        .unwrap();
+
+    assert!(matches!(
+        client.authorize_request(&mut request),
+        Err(AuthenticatedHttpError::NoValidToken)
+    ));
+    assert!(!request.headers().contains_key(AUTHORIZATION));
+}
+
+#[test]
+fn debug_output_redacts_token() {
+    let client = client_with_expiry(
+        "secret-test-token",
+        Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+    );
+
+    let debug_output = format!("{client:?}");
+
+    assert!(!debug_output.contains("secret-test-token"));
+    assert!(debug_output.contains("expires_at"));
+}
+
+#[test]
+fn authorized_request_debug_redacts_token() {
+    let client = client_with_expiry(
+        "secret-request-test-token",
+        Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+    );
+    let mut request = Request::builder().body(Bytes::new()).unwrap();
+
+    client.authorize_request(&mut request).unwrap();
+    let request_debug = format!("{request:?}");
+    let headers_debug = format!("{:?}", request.headers());
+
+    assert!(!request_debug.contains("secret-request-test-token"));
+    assert!(!headers_debug.contains("secret-request-test-token"));
+    assert!(request_debug.contains("Sensitive"));
+    assert!(headers_debug.contains("Sensitive"));
+}
+
+#[test]
+fn refreshed_token_run_id_exactly_matches() {
+    let token = jwt_with_payload(serde_json::json!({ "run_id": "expected-run-id" }));
+
+    validate_refreshed_token_run_id(&token, Some("expected-run-id")).unwrap();
+}
+
+#[test]
+fn refreshed_token_run_id_is_required() {
+    let token = jwt_with_payload(serde_json::json!({}));
+    assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
+}
+
+#[test]
+fn expected_run_id_is_required() {
+    let token = jwt_with_payload(serde_json::json!({ "run_id": "expected-run-id" }));
+
+    assert!(validate_refreshed_token_run_id(&token, None).is_err());
+    assert!(validate_refreshed_token_run_id(&token, Some("")).is_err());
+}
+
+#[test]
+fn refreshed_token_run_id_must_match() {
+    let token = jwt_with_payload(serde_json::json!({ "run_id": "wrong-run-id" }));
+
+    assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
+}
+
+#[test]
+fn refreshed_token_run_id_must_be_a_string() {
+    let token = jwt_with_payload(serde_json::json!({ "run_id": 123 }));
+    assert!(validate_refreshed_token_run_id(&token, Some("expected-run-id")).is_err());
+}
+
+#[test]
+fn malformed_refreshed_tokens_are_rejected() {
+    let invalid_json = {
+        let encoder = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let payload = encoder.encode(b"not-json");
+        format!("header.{payload}.signature")
+    };
+
+    for token in ["not-a-jwt", "header.!!!.signature", &invalid_json] {
+        assert!(validate_refreshed_token_run_id(token, Some("expected-run-id")).is_err());
+    }
+}
+
+#[test]
+fn rejected_refreshed_token_preserves_previous_token() {
+    let token_store = TokenStore::new(
+        "current-test-token".to_owned(),
+        Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+    )
+    .unwrap();
+    let wrong_run_token = jwt_with_payload(serde_json::json!({ "run_id": "wrong-run-id" }));
+
+    assert!(token_store
+        .replace_refreshed(
+            wrong_run_token,
+            Utc::now() + TimeDelta::try_minutes(5).unwrap(),
+            Some("expected-run-id"),
+        )
+        .is_err());
+    assert_eq!(
+        token_store.valid_authorization_header().unwrap(),
+        "Bearer current-test-token"
+    );
+}

--- a/app/src/tracing/cloud_agent_auth_tests.rs
+++ b/app/src/tracing/cloud_agent_auth_tests.rs
@@ -13,7 +13,7 @@ fn jwt_with_payload(payload: serde_json::Value) -> String {
 fn client_with_expiry(token: &str, expires_at: DateTime<Utc>) -> AuthenticatedHttpClient {
     let (refresh_hint_sender, _) = async_channel::bounded(1);
     AuthenticatedHttpClient {
-        inner: reqwest::blocking::Client::new(),
+        inner: reqwest::Client::new(),
         token_store: TokenStore::new(token.to_owned(), expires_at).unwrap(),
         refresh_hint_sender,
     }

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -65,7 +65,7 @@ use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::EnvFilter;
 use url::Url;
 
-use super::auth::{self, AuthContext};
+use super::cloud_agent_auth::{self, AuthContext};
 use super::Initialization;
 use crate::channel::ChannelState;
 use crate::tracing::install_no_subscriber;
@@ -81,6 +81,11 @@ const CLOUD_AGENT_OTLP_ENDPOINT: &str = "WARP_CLOUD_AGENT_OTLP_ENDPOINT";
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 /// The minimum interval between local export failure diagnostics.
 const EXPORT_FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
+/// Retains bootstrap authentication only when the endpoint and dispatch credential enabled export.
+///
+/// The exporter is built once during [`init`], while the stored context later starts dynamic
+/// credential refresh after authenticated application services become available, and this static
+/// remains unset for processes that did not opt in.
 
 static AUTH_CONTEXT: OnceLock<AuthContext> = OnceLock::new();
 
@@ -147,7 +152,8 @@ pub fn init() -> anyhow::Result<Initialization> {
 /// by [`Initialization`] so application termination can explicitly shut it down after attempting
 /// to end registered active spans. Exported resources include Warp's version and channel alongside
 /// standard environment-detected OpenTelemetry attributes, with [`OTEL_SERVICE_NAME`] taking
-/// precedence over the default service name.
+/// precedence over the default service name. The exporter is built once with a dynamic HTTP client
+/// so credential refresh can update requests without reconstructing provider state.
 fn build_provider(
     base_endpoint: &str,
     auth_context: &AuthContext,
@@ -189,9 +195,12 @@ fn build_provider(
 }
 
 /// Starts the single refresh coordinator after the authenticated server client exists.
+///
+/// Processes that did not opt in with both an endpoint and valid dispatch credential have no
+/// retained [`AUTH_CONTEXT`] and remain no-ops here.
 pub(super) fn start_auth_refresh(client: Arc<dyn ManagedSecretsClient>, ctx: &mut AppContext) {
     if let Some(auth_context) = AUTH_CONTEXT.get() {
-        auth::start_refresh_coordinator(auth_context.clone(), client, ctx);
+        cloud_agent_auth::start_refresh_coordinator(auth_context.clone(), client, ctx);
     }
 }
 
@@ -473,12 +482,14 @@ impl SpanExporter for CloudAgentSpanExporter {
     }
 }
 
+/// Rate-limits local token-free export diagnostics independently of exporter retries.
 #[derive(Debug, Default)]
 struct RateLimitedDiagnostics {
     last_export_failure: Mutex<Option<Instant>>,
 }
 
 impl RateLimitedDiagnostics {
+    /// Emits at most one local export-failure warning per configured interval.
     fn warn_export_failure(&self) {
         let now = Instant::now();
         let mut last_failure = self

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -45,15 +45,15 @@
 //! best-effort cleanup that should continue after an unrelated panic.
 
 use std::borrow::Cow;
-use std::sync::{Arc, Mutex, Weak};
-use std::time::{Duration, SystemTime};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{anyhow, Context as _};
 use opentelemetry::trace::{
     Span as _, SpanBuilder, SpanContext, Status, Tracer as _, TracerProvider as _,
 };
 use opentelemetry::{Context as OtelContext, KeyValue, Value};
-use opentelemetry_otlp::{Protocol, WithExportConfig as _};
+use opentelemetry_otlp::{Protocol, WithExportConfig as _, WithHttpConfig as _};
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::resource::{EnvResourceDetector, TelemetryResourceDetector};
 use opentelemetry_sdk::trace::{
@@ -65,9 +65,12 @@ use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::EnvFilter;
 use url::Url;
 
+use super::auth::{self, AuthContext};
 use super::Initialization;
 use crate::channel::ChannelState;
 use crate::tracing::install_no_subscriber;
+use warp_managed_secrets::client::ManagedSecretsClient;
+use warpui::AppContext;
 
 /// The tag used to mark spans related to cloud agents, which we use to filter out
 /// spans we don't care about (e.g.: ones from dependencies).
@@ -76,12 +79,17 @@ const CLOUD_AGENT_MARKER: &str = "tags.cloud_agent";
 const CLOUD_AGENT_OTLP_ENDPOINT: &str = "WARP_CLOUD_AGENT_OTLP_ENDPOINT";
 /// The environment variable used to configure the OTel service name.
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
+/// The minimum interval between local export failure diagnostics.
+const EXPORT_FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
+
+static AUTH_CONTEXT: OnceLock<AuthContext> = OnceLock::new();
 
 /// Installs the native tracing subscriber and optional cloud-agent OTLP exporter.
 ///
-/// Export is deliberately opt-in through [`CLOUD_AGENT_OTLP_ENDPOINT`]. When the endpoint is
-/// absent or the exporter cannot be constructed, a no-op subscriber is installed so tracing
-/// instrumentation remains safe without producing output or partially initializing export.
+/// Export is deliberately opt-in through [`CLOUD_AGENT_OTLP_ENDPOINT`] plus a currently valid
+/// dispatch token. When either is absent or the exporter cannot be constructed, a no-op subscriber
+/// is installed so tracing instrumentation remains safe without producing output or partially
+/// initializing export.
 pub fn init() -> anyhow::Result<Initialization> {
     // INFO is the default because this is a global subscriber and DEBUG-level application spans
     // would otherwise create substantial work even though only marked cloud-agent spans are
@@ -97,9 +105,13 @@ pub fn init() -> anyhow::Result<Initialization> {
         install_no_subscriber()?;
         return Ok(Initialization::default());
     };
+    let Ok(auth_context) = AuthContext::from_environment() else {
+        install_no_subscriber()?;
+        return Ok(Initialization::default());
+    };
 
     let shutdown_timeout = export_timeout();
-    let provider = match build_provider(base_endpoint.trim()) {
+    let provider = match build_provider(base_endpoint.trim(), &auth_context) {
         Ok(provider) => provider,
         Err(err) => {
             install_no_subscriber()?;
@@ -111,6 +123,7 @@ pub fn init() -> anyhow::Result<Initialization> {
             });
         }
     };
+    let _ = AUTH_CONTEXT.set(auth_context);
 
     let active_spans = ActiveSpanRegistry::default();
     let tracer =
@@ -135,10 +148,14 @@ pub fn init() -> anyhow::Result<Initialization> {
 /// to end registered active spans. Exported resources include Warp's version and channel alongside
 /// standard environment-detected OpenTelemetry attributes, with [`OTEL_SERVICE_NAME`] taking
 /// precedence over the default service name.
-fn build_provider(base_endpoint: &str) -> anyhow::Result<SdkTracerProvider> {
+fn build_provider(
+    base_endpoint: &str,
+    auth_context: &AuthContext,
+) -> anyhow::Result<SdkTracerProvider> {
     let endpoint = traces_endpoint(base_endpoint)?;
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
+        .with_http_client(auth_context.http_client())
         .with_protocol(Protocol::HttpBinary)
         .with_endpoint(endpoint)
         .build()
@@ -163,9 +180,19 @@ fn build_provider(base_endpoint: &str) -> anyhow::Result<SdkTracerProvider> {
     .build();
 
     Ok(SdkTracerProvider::builder()
-        .with_batch_exporter(CloudAgentSpanExporter { inner: exporter })
+        .with_batch_exporter(CloudAgentSpanExporter {
+            inner: exporter,
+            diagnostics: RateLimitedDiagnostics::default(),
+        })
         .with_resource(resource)
         .build())
+}
+
+/// Starts the single refresh coordinator after the authenticated server client exists.
+pub(super) fn start_auth_refresh(client: Arc<dyn ManagedSecretsClient>, ctx: &mut AppContext) {
+    if let Some(auth_context) = AUTH_CONTEXT.get() {
+        auth::start_refresh_coordinator(auth_context.clone(), client, ctx);
+    }
 }
 
 /// Converts the configured OTLP base URL into the HTTP/protobuf traces endpoint.
@@ -390,9 +417,16 @@ impl opentelemetry::trace::Span for ShutdownAwareSpan {
 /// ensuring unrelated application tracing is never sent to the configured cloud-agent endpoint.
 /// The marker is a per-span routing attribute rather than an inherited property, so every span
 /// intended for export must set it explicitly.
-#[derive(Debug)]
 struct CloudAgentSpanExporter {
     inner: opentelemetry_otlp::SpanExporter,
+    diagnostics: RateLimitedDiagnostics,
+}
+impl std::fmt::Debug for CloudAgentSpanExporter {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CloudAgentSpanExporter")
+            .finish_non_exhaustive()
+    }
 }
 
 impl SpanExporter for CloudAgentSpanExporter {
@@ -411,8 +445,8 @@ impl SpanExporter for CloudAgentSpanExporter {
             }
 
             let result = self.inner.export(batch).await;
-            if let Err(err) = &result {
-                log::warn!("Failed to export cloud-agent OpenTelemetry spans: {err}");
+            if result.is_err() {
+                self.diagnostics.warn_export_failure();
             }
             result
         }
@@ -436,6 +470,25 @@ impl SpanExporter for CloudAgentSpanExporter {
 
     fn set_resource(&mut self, resource: &Resource) {
         self.inner.set_resource(resource);
+    }
+}
+
+#[derive(Debug, Default)]
+struct RateLimitedDiagnostics {
+    last_export_failure: Mutex<Option<Instant>>,
+}
+
+impl RateLimitedDiagnostics {
+    fn warn_export_failure(&self) {
+        let now = Instant::now();
+        let mut last_failure = self
+            .last_export_failure
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        if last_failure.is_none_or(|last| now.duration_since(last) >= EXPORT_FAILURE_LOG_INTERVAL) {
+            *last_failure = Some(now);
+            log::warn!("Failed to export cloud-agent OpenTelemetry spans");
+        }
     }
 }
 

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -81,12 +81,12 @@ const CLOUD_AGENT_OTLP_ENDPOINT: &str = "WARP_CLOUD_AGENT_OTLP_ENDPOINT";
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 /// The minimum interval between local export failure diagnostics.
 const EXPORT_FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(60);
-/// Retains bootstrap authentication only when the endpoint and dispatch credential enabled export.
+
+/// Process-global authentication context for cloud-agent OTLP export.
 ///
 /// The exporter is built once during [`init`], while the stored context later starts dynamic
 /// credential refresh after authenticated application services become available, and this static
 /// remains unset for processes that did not opt in.
-
 static AUTH_CONTEXT: OnceLock<AuthContext> = OnceLock::new();
 
 /// Installs the native tracing subscriber and optional cloud-agent OTLP exporter.

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -63,7 +63,7 @@ use opentelemetry_sdk::Resource;
 use tracing::subscriber;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::EnvFilter;
-use url::Url;
+use url::{Host, Url};
 
 use super::cloud_agent_auth::{self, AuthContext};
 use super::Initialization;
@@ -207,11 +207,19 @@ pub(super) fn start_auth_refresh(client: Arc<dyn ManagedSecretsClient>, ctx: &mu
 /// Converts the configured OTLP base URL into the HTTP/protobuf traces endpoint.
 ///
 /// The configuration is treated as a base URL rather than a complete signal-specific URL, so any
-/// query or fragment is discarded before appending `v1/traces`.
+/// query or fragment is discarded before appending `v1/traces`. Authenticated export requires
+/// HTTPS unless the configured host is guaranteed to resolve to the local machine.
 fn traces_endpoint(base_endpoint: &str) -> anyhow::Result<String> {
     let mut endpoint = Url::parse(base_endpoint).context("Invalid cloud-agent OTLP endpoint")?;
-    if !matches!(endpoint.scheme(), "http" | "https") {
-        return Err(anyhow!("Cloud-agent OTLP endpoint must use HTTP or HTTPS"));
+    match endpoint.scheme() {
+        "https" => {}
+        "http" if endpoint_host_is_loopback(&endpoint) => {}
+        "http" => {
+            return Err(anyhow!(
+                "Cloud-agent OTLP endpoint must use HTTPS unless its host is loopback"
+            ));
+        }
+        _ => return Err(anyhow!("Cloud-agent OTLP endpoint must use HTTP or HTTPS")),
     }
 
     endpoint.set_query(None);
@@ -222,6 +230,15 @@ fn traces_endpoint(base_endpoint: &str) -> anyhow::Result<String> {
         .pop_if_empty()
         .extend(["v1", "traces"]);
     Ok(endpoint.into())
+}
+/// Returns whether the endpoint host is guaranteed to resolve to the local machine.
+fn endpoint_host_is_loopback(endpoint: &Url) -> bool {
+    match endpoint.host() {
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    }
 }
 
 /// Returns the export shutdown timeout using the standard OpenTelemetry environment variables.

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -64,13 +64,13 @@ use tracing::subscriber;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::EnvFilter;
 use url::{Host, Url};
+use warp_managed_secrets::client::ManagedSecretsClient;
+use warpui::AppContext;
 
 use super::cloud_agent_auth::{self, AuthContext};
 use super::Initialization;
 use crate::channel::ChannelState;
 use crate::tracing::install_no_subscriber;
-use warp_managed_secrets::client::ManagedSecretsClient;
-use warpui::AppContext;
 
 /// The tag used to mark spans related to cloud agents, which we use to filter out
 /// spans we don't care about (e.g.: ones from dependencies).

--- a/app/src/tracing/native.rs
+++ b/app/src/tracing/native.rs
@@ -46,9 +46,10 @@
 
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex, OnceLock, Weak};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, Context as _};
+use instant::Instant;
 use opentelemetry::trace::{
     Span as _, SpanBuilder, SpanContext, Status, Tracer as _, TracerProvider as _,
 };


### PR DESCRIPTION
## Description

This stacked PR builds on `david/basic-otel-tracing-for-cloud-agents` so opted-in cloud-agent processes can export traces to the collector without relying on a static bearer header.

It builds the OTLP exporter once around a dynamic authenticated HTTP client that injects the latest unexpired credential immediately before each request. Refresh starts only after authenticated server connectivity exists, uses bounded requests with jittered proactive scheduling and exponential backoff, and preserves the last valid credential when refresh fails.

Refreshed credentials are accepted only when their decoded JWT payload contains a string `run_id` exactly matching the immutable startup `OZ_RUN_ID`. This is a rejection-only safeguard; the collector remains responsible for cryptographic verification. Authorization headers and diagnostics are redacted, expired credentials fail closed, and refresh/export failures never log token contents.

The client-specific transport and refresh invariants are documented in `tracing::cloud_agent_auth`, with its focused tests kept in a separate test module.

## Testing

- `cargo fmt --manifest-path Cargo.toml --all -- --check`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo check --manifest-path Cargo.toml -p warp`
- `MACOSX_DEPLOYMENT_TARGET=10.14 cargo nextest run --manifest-path Cargo.toml -p warp -E 'test(cloud_agent_auth)'` — 11 passed

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/b33ece50-3b6a-435b-8e25-96b5176e5840_
_Run: https://oz.staging.warp.dev/runs/019ea85a-7da3-73b4-a008-60c729489af0_
_This PR was generated with [Oz](https://warp.dev/oz)._
