### PR TITLE
Cloud mode: add text input to interactive setup command blocks (REMOTE-1890)

### DIFF
--- a/app/src/terminal/view/ambient_agent/block/setup_command.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command.rs
@@ -3,10 +3,12 @@ use std::sync::Arc;
 use parking_lot::FairMutex;
 use warp_core::ui::appearance::Appearance;
 use warp_terminal::model::BlockId;
-use warpui::prelude::{Container, Empty, MouseStateHandle};
+use warpui::elements::ParentElement;
+use warpui::prelude::{ChildView, Container, Empty, Flex, MainAxisSize, MouseStateHandle};
 use warpui::scene::{CornerRadius, Radius};
 use warpui::{
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
 };
 
 use crate::ai::agent::icons::{failed_icon, yellow_running_icon};
@@ -21,6 +23,7 @@ use crate::terminal::view::ambient_agent::{
     AmbientAgentViewModel, AmbientAgentViewModelEvent, SetupCommandGroupId,
 };
 use crate::terminal::TerminalModel;
+use crate::view_components::{SubmittableTextInput, SubmittableTextInputEvent};
 
 enum Status {
     Running,
@@ -36,6 +39,9 @@ pub struct CloudModeSetupCommandBlock {
     terminal_model: Arc<FairMutex<TerminalModel>>,
     is_expanded: bool,
     mouse_state: MouseStateHandle,
+    /// Input view for sending text to the running interactive command.
+    /// Only shown when the block is expanded and the command is still running.
+    input_view: ViewHandle<SubmittableTextInput>,
 }
 
 impl CloudModeSetupCommandBlock {
@@ -88,6 +94,21 @@ impl CloudModeSetupCommandBlock {
             }
         });
 
+        // Create the text input for sending stdin to interactive setup commands.
+        let input_view = ctx.add_typed_action_view(|ctx| {
+            let mut input = SubmittableTextInput::new(ctx);
+            input.set_placeholder_text("Type to send input to this command (Enter to send)", ctx);
+            input.set_outer_margins(8., 8., ctx);
+            input
+        });
+        ctx.subscribe_to_view(&input_view, |me, _, event, ctx| {
+            if let SubmittableTextInputEvent::Submit(text) = event {
+                // Append a newline so the command receives a complete line.
+                let line = format!("{text}\n");
+                ctx.emit(CloudModeSetupCommandBlockEvent::SendInputToCommand(line));
+            }
+        });
+
         let command = terminal_model
             .lock()
             .block_list()
@@ -103,6 +124,7 @@ impl CloudModeSetupCommandBlock {
             is_expanded: false,
             status: Status::Running,
             mouse_state: Default::default(),
+            input_view,
         }
     }
 }
@@ -110,6 +132,8 @@ impl CloudModeSetupCommandBlock {
 #[derive(Debug, Clone)]
 pub enum CloudModeSetupCommandBlockEvent {
     ToggleBlockVisibility(BlockId),
+    /// The user has typed input that should be forwarded to the running command's stdin.
+    SendInputToCommand(String),
 }
 
 impl Entity for CloudModeSetupCommandBlock {
@@ -169,7 +193,22 @@ impl View for CloudModeSetupCommandBlock {
             config = config.with_corner_radius_override(CornerRadius::with_top(Radius::Pixels(8.)))
         }
 
-        let mut container = Container::new(config.render(app));
+        let header = config.render(app);
+
+        // When the block is expanded and still running, show a text input so the user
+        // can type responses to interactive prompts (e.g. "[y/n]" confirmations).
+        let show_input = self.is_expanded && matches!(self.status, Status::Running);
+
+        if show_input {
+            let column = Flex::column()
+                .with_main_axis_size(MainAxisSize::Min)
+                .with_child(header)
+                .with_child(ChildView::new(&self.input_view).finish())
+                .finish();
+            return Container::new(column).finish();
+        }
+
+        let mut container = Container::new(header);
 
         if !self.is_expanded {
             container = super::cloud_mode_setup_row_spacing(

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -515,11 +515,23 @@ impl TerminalView {
             )
         });
         ctx.subscribe_to_view(&setup_command_block, |me, _, event, _| {
-            let super::CloudModeSetupCommandBlockEvent::ToggleBlockVisibility(block_id) = event;
-            me.model
-                .lock()
-                .block_list_mut()
-                .toggle_visibility_of_block(block_id);
+            match event {
+                super::CloudModeSetupCommandBlockEvent::ToggleBlockVisibility(block_id) => {
+                    me.model
+                        .lock()
+                        .block_list_mut()
+                        .toggle_visibility_of_block(block_id);
+                }
+                super::CloudModeSetupCommandBlockEvent::SendInputToCommand(text) => {
+                    // Forward user-typed input to the running setup command's stdin.
+                    // This sends bytes through the shared-session write-to-PTY channel,
+                    // which the session-sharing server routes to the cloud agent's PTY.
+                    let bytes = text.as_bytes().to_vec();
+                    me.model
+                        .lock()
+                        .send_write_to_pty_events_for_shared_session(bytes);
+                }
+            }
         });
         self.insert_rich_content(
             None,


### PR DESCRIPTION
## Description

When a cloud-mode setup command runs an interactive program that prompts for user input (e.g. `[y/n]` confirmations, password prompts), users were stuck because there was no way to type into the running command block.

This PR adds a text input field to the expanded `CloudModeSetupCommandBlock`. When a setup command is still running and the user expands the block (by clicking on it), a text input appears below the block header. The user can type their response and press Enter to send it to the command's stdin.

**How it works:**
1. The `CloudModeSetupCommandBlock` now creates a `SubmittableTextInput` view on construction.
2. When the block is expanded and the command is still running (`Status::Running`), the input is rendered below the block header using a `Flex::column` layout.
3. On submission, the text (with a trailing newline) is emitted as a `SendInputToCommand(String)` event.
4. The terminal view subscribes to this event and calls `send_write_to_pty_events_for_shared_session`, which routes the bytes through the shared-session network to the cloud agent's PTY.

The input field is hidden once the command completes (transitions to `Status::Completed`), so it only appears when actually useful.

## Linked Issue

- Linear: [REMOTE-1890](https://linear.app/warp/issue/REMOTE-1890) – Cloud mode: can't provide input to interactive setup command blocks

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Manual testing requires a cloud run with a setup command that prompts for user input (e.g. a setup command that runs `read -p "Press Enter to continue" && echo "OK"`). After expanding the running block, a text input should appear; typing and pressing Enter should send the input to the command.

**Note:** This is labeled as "from-feedback-bot" since the issue was delegated from the Feedback Bot.

<!-- CHANGELOG-IMPROVEMENT: Cloud mode: users can now type responses to interactive prompts in setup command blocks by expanding the running block. -->

_Conversation: https://staging.warp.dev/conversation/dd564d55-3638-4a64-9e41-ad338b286df2_
_Run: https://oz.staging.warp.dev/runs/019ea89f-ffda-70b6-80e6-acb74a000ee1_

_This PR was generated with [Oz](https://warp.dev/oz)._
