### PR TITLE
Fix stale git chips when .git is removed

### DIFF
--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1394,17 +1394,8 @@ impl CurrentPrompt {
             }
         }
 
-        // Repo detached, clear git chips that require repository metadata.
         if handle.is_none() {
-            for chip_kind in [
-                ContextChipKind::GitDiffStats,
-                ContextChipKind::GitBranchStatus,
-            ] {
-                if let Some(state) = self.states.get_mut(&chip_kind) {
-                    state.clear_abort_handlers();
-                    state.clear_cache();
-                }
-            }
+            self.clear_git_backed_chips();
             let _ = self.update_tx.try_send(());
             return;
         }
@@ -1482,6 +1473,8 @@ impl CurrentPrompt {
             .and_then(|h| h.as_ref(ctx).metadata(ctx).cloned());
 
         let Some(metadata) = metadata else {
+            self.clear_git_backed_chips();
+            let _ = self.update_tx.try_send(());
             return;
         };
 
@@ -1538,6 +1531,21 @@ impl CurrentPrompt {
             .cloned();
         if current_pr != new_pr_value {
             self.update_chip_value(&ContextChipKind::GithubPullRequest, new_pr_value);
+        }
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn clear_git_backed_chips(&mut self) {
+        for chip_kind in [
+            ContextChipKind::ShellGitBranch,
+            ContextChipKind::GitBranchStatus,
+            ContextChipKind::GitDiffStats,
+            ContextChipKind::GithubPullRequest,
+        ] {
+            if let Some(state) = self.states.get_mut(&chip_kind) {
+                state.clear_abort_handlers();
+                state.clear_cache();
+            }
         }
     }
 

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -711,6 +711,142 @@ fn test_git_status_change_updates_branch_status_chip_value() {
 
 #[cfg(feature = "local_fs")]
 #[test]
+fn test_git_status_metadata_none_clears_git_chip_values() {
+    let _flag_guard = FeatureFlag::GithubPrPromptChip.override_enabled(true);
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| {
+            Prompt::mock_with(
+                [
+                    ContextChipKind::ShellGitBranch,
+                    ContextChipKind::GitBranchStatus,
+                    ContextChipKind::GitDiffStats,
+                    ContextChipKind::GithubPullRequest,
+                ],
+                false,
+                WarpPromptSeparator::None,
+            )
+        });
+        app.add_singleton_model(SessionSettings::new_with_defaults);
+        app.add_singleton_model(|_ctx| {
+            settings::PublicPreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+        app.add_singleton_model(|_| {
+            settings::PrivatePreferences::new(
+                Box::<user_preferences::in_memory::InMemoryPreferences>::default(),
+            )
+        });
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let watcher_handle = app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        let repo_handle = watcher_handle.update(&mut app, |watcher, ctx| {
+            watcher
+                .add_directory(
+                    warp_util::standardized_path::StandardizedPath::from_local_canonicalized(
+                        temp_dir.path(),
+                    )
+                    .unwrap(),
+                    ctx,
+                )
+                .unwrap()
+        });
+
+        let branch_tracking_status = GitBranchTrackingStatus::new(
+            "feature-a".to_string(),
+            Some("origin/feature-a".to_string()),
+            3,
+            1,
+        );
+        let initial_metadata = GitStatusMetadata {
+            current_branch_name: "feature-a".to_string(),
+            main_branch_name: "main".to_string(),
+            stats_against_head: DiffStats {
+                files_changed: 1,
+                total_additions: 4,
+                total_deletions: 2,
+            },
+            branch_tracking_status: branch_tracking_status.clone(),
+        };
+        let git_status = app
+            .add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repo_handle, None, ctx));
+        let github_repo_model = {
+            let git_status = git_status.clone();
+            app.add_model(move |ctx| GitHubRepoModel::new_local_for_test(git_status, ctx))
+        };
+
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
+
+        current_prompt.update(&mut app, |cp, ctx| {
+            cp.set_git_repo_status(Some(git_status.downgrade()), ctx);
+            cp.set_github_repo_model(Some(github_repo_model.downgrade()), ctx);
+            cp.update_states_with_new_context(ctx);
+        });
+
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(Some(initial_metadata), ctx);
+        });
+        github_repo_model.update(&mut app, |model, ctx| {
+            model.set_pr_info_for_test(
+                Some(PrInfo {
+                    number: 123,
+                    url: "https://github.com/warp/warp/pull/123".to_string(),
+                    state: "OPEN".to_string(),
+                    draft: false,
+                    base_branch: "main".to_string(),
+                }),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            assert_eq!(
+                cp.latest_chip_value(&ContextChipKind::ShellGitBranch),
+                Some(&crate::context_chips::ChipValue::Text(
+                    "feature-a".to_string(),
+                )),
+            );
+            assert_eq!(
+                cp.latest_chip_value(&ContextChipKind::GitBranchStatus),
+                Some(&crate::context_chips::ChipValue::GitBranchStatus(
+                    branch_tracking_status,
+                )),
+            );
+            assert!(cp
+                .latest_chip_value(&ContextChipKind::GitDiffStats)
+                .is_some());
+            assert_eq!(
+                cp.latest_chip_value(&ContextChipKind::GithubPullRequest),
+                Some(&crate::context_chips::ChipValue::Text(
+                    "https://github.com/warp/warp/pull/123".to_string(),
+                )),
+            );
+        });
+
+        git_status.update(&mut app, |model, ctx| {
+            model.set_metadata_for_test(None, ctx);
+        });
+
+        app.read(|ctx| {
+            let cp = current_prompt.as_ref(ctx);
+            assert_eq!(cp.latest_chip_value(&ContextChipKind::ShellGitBranch), None);
+            assert_eq!(
+                cp.latest_chip_value(&ContextChipKind::GitBranchStatus),
+                None
+            );
+            assert_eq!(cp.latest_chip_value(&ContextChipKind::GitDiffStats), None);
+            assert_eq!(
+                cp.latest_chip_value(&ContextChipKind::GithubPullRequest),
+                None
+            );
+        });
+    });
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
 fn test_git_status_pr_info_updates_github_pr_chip_value() {
     let _flag_guard = FeatureFlag::GithubPrPromptChip.override_enabled(true);
     App::test((), |mut app| async move {

--- a/crates/repo_metadata/src/repositories.rs
+++ b/crates/repo_metadata/src/repositories.rs
@@ -110,12 +110,14 @@ impl DetectedRepositories {
                         if let Some(repository) = DirectoryWatcher::as_ref(ctx)
                             .get_watched_directory_for_path(&local_path)
                         {
-                            ctx.emit(DetectedRepositoriesEvent::DetectedGitRepo {
-                                repository: repository.clone(),
-                                source,
-                            });
-                            // Watcher is alive — use the cached result.
-                            return Either::Right(ready(path.to_local_path()));
+                            if Self::cached_local_repository_is_valid(repository.as_ref(ctx)) {
+                                ctx.emit(DetectedRepositoriesEvent::DetectedGitRepo {
+                                    repository: repository.clone(),
+                                    source,
+                                });
+                                return Either::Right(ready(path.to_local_path()));
+                            }
+                            self.repository_roots.remove(key);
                         }
                         // Watcher was cleaned up (e.g. diff state model dropped
                         // and recreated). Fall through to the full scan which
@@ -127,6 +129,7 @@ impl DetectedRepositories {
             }
 
             let local_path_for_search = path.to_local_path();
+            let path_for_stale_cleanup = path.clone();
             let (tx, rx) = oneshot::channel::<Option<PathBuf>>();
             let spawned_handle = ctx.spawn(
                 async move {
@@ -177,9 +180,11 @@ impl DetectedRepositories {
                             }
                         } else {
                             // No working tree path; do not treat git_dir_path as a repository path.
+                            me.remove_stale_local_roots_for_path(&path_for_stale_cleanup);
                             let _ = tx.send(None);
                         }
                     } else {
+                        me.remove_stale_local_roots_for_path(&path_for_stale_cleanup);
                         let _ = tx.send(None);
                     }
                 },
@@ -204,6 +209,51 @@ impl DetectedRepositories {
     #[cfg(test)]
     pub fn spawned_futures(&self) -> &[FutureId] {
         &self.spawned_futures
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn cached_local_repository_is_valid(repository: &Repository) -> bool {
+        let Some(root_dir) = repository.root_dir().to_local_path() else {
+            return false;
+        };
+
+        let dot_git_path = root_dir.join(".git");
+        let Ok(dot_git_metadata) = std::fs::metadata(&dot_git_path) else {
+            return false;
+        };
+
+        if dot_git_metadata.is_dir() {
+            return dot_git_path.join("HEAD").is_file();
+        }
+
+        if dot_git_metadata.is_file() {
+            let Ok(git_file_contents) = std::fs::read_to_string(&dot_git_path) else {
+                return false;
+            };
+            let Some(git_dir) = git_file_contents.trim().strip_prefix("gitdir:") else {
+                return false;
+            };
+
+            let git_dir = PathBuf::from(git_dir.trim());
+            let git_dir = if git_dir.is_absolute() {
+                git_dir
+            } else {
+                root_dir.join(git_dir)
+            };
+            return git_dir.join("HEAD").is_file();
+        }
+
+        false
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn remove_stale_local_roots_for_path(&mut self, path: &StandardizedPath) {
+        self.repository_roots.retain(|root| match root {
+            LocalOrRemotePath::Local(local_root) => StandardizedPath::try_from_local(local_root)
+                .map(|local_root| !path.starts_with(&local_root))
+                .unwrap_or(true),
+            LocalOrRemotePath::Remote(_) => true,
+        });
     }
 
     /// Given a local path, return its corresponding watched repository, if any.

--- a/crates/repo_metadata/src/repositories_tests.rs
+++ b/crates/repo_metadata/src/repositories_tests.rs
@@ -168,6 +168,71 @@ fn test_detect_possible_local_git_repo_nested_repo_created_after_parent_registra
 
 #[test]
 #[cfg(feature = "local_fs")]
+fn test_detect_possible_local_git_repo_invalidates_cached_root_when_git_dir_removed() {
+    VirtualFS::test("detect_removed_git_dir", |dirs, mut vfs| {
+        stub_git_repository(&mut vfs, "repo");
+
+        let repo_path = dirs.tests().join("repo");
+        let repo_canonical_path = StandardizedPath::from_local_canonicalized(&repo_path).unwrap();
+
+        App::test((), |mut app| async move {
+            app.add_singleton_model(DirectoryWatcher::new);
+            let repo_handle = app.add_model(|_| DetectedRepositories::default());
+
+            repo_handle
+                .update(&mut app, |repo, ctx| {
+                    std::mem::drop(repo.detect_possible_local_git_repo(
+                        &repo_path.to_string_lossy(),
+                        RepoDetectionSource::TerminalNavigation,
+                        ctx,
+                    ));
+                    let future_id = repo.spawned_futures().last().unwrap();
+                    ctx.await_spawned_future(*future_id)
+                })
+                .await;
+
+            repo_handle.read(&app, |repo, _ctx| {
+                assert!(repo
+                    .get_root_for_path(&LocalOrRemotePath::Local(
+                        repo_canonical_path.to_local_path().unwrap(),
+                    ))
+                    .is_some());
+            });
+
+            fs::remove_dir_all(repo_path.join(".git")).expect("remove .git directory");
+            let spawned_future_count = repo_handle.read(&app, |repo, _ctx| {
+                let key = LocalOrRemotePath::Local(repo_canonical_path.to_local_path().unwrap());
+                assert!(repo.repository_roots.contains(&key));
+                repo.spawned_futures().len()
+            });
+
+            repo_handle.update(&mut app, |repo, ctx| {
+                std::mem::drop(repo.detect_possible_local_git_repo(
+                    &repo_path.to_string_lossy(),
+                    RepoDetectionSource::TerminalNavigation,
+                    ctx,
+                ));
+            });
+
+            let future_id = repo_handle.read(&app, |repo, _ctx| {
+                assert_eq!(repo.spawned_futures().len(), spawned_future_count + 1);
+                *repo.spawned_futures().last().unwrap()
+            });
+            repo_handle
+                .update(&mut app, |_repo, ctx| ctx.await_spawned_future(future_id))
+                .await;
+
+            repo_handle.read(&app, |repo, _ctx| {
+                let key = LocalOrRemotePath::Local(repo_canonical_path.to_local_path().unwrap());
+                assert!(!repo.repository_roots.contains(&key));
+                assert!(repo.get_root_for_path(&key).is_none());
+            });
+        });
+    });
+}
+
+#[test]
+#[cfg(feature = "local_fs")]
 fn test_find_git_repo_with_worktree() {
     VirtualFS::test("find_git_repo_worktree", |dirs, mut vfs| {
         // Set up a primary repository with a worktree directory.


### PR DESCRIPTION
## Description
Fixes stale git prompt chips when an open pane starts in a Git repository and that repository is disabled in place by deleting `.git`.

Root cause:
- `DetectedRepositories` reused cached local repository roots while `DirectoryWatcher` still had a watcher for the path, without validating that the `.git` entry still existed.
- `CurrentPrompt` returned early when `GitRepoStatusModel` metadata became `None`, leaving old branch, diff, and PR chip values in the prompt state.

This PR:
- Revalidates cached local repo roots before reuse by checking `.git/HEAD`, or a gitfile target `HEAD` for worktree-style `.git` files.
- Removes stale cached local roots when fresh repo detection finds no Git repository.
- Clears `ShellGitBranch`, `GitDiffStats`, and `GithubPullRequest` chip state when repo metadata disappears or the prompt detaches from a repo.
- Adds regression coverage for both the repo cache invalidation and prompt chip clearing paths.

## Linked Issue
Fixes #12366

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
  - Note: I attempted to add `ready-to-implement`, but my GitHub account does not have upstream label permission.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p repo_metadata --features local_fs test_detect_possible_local_git_repo_invalidates_cached_root_when_git_dir_removed`
- [x] `cargo test -p warp test_git_status_metadata_none_clears_git_chip_values`
- [x] `cargo clippy -p repo_metadata --features local_fs --tests -- -D warnings`
- [x] `cargo clippy -p warp --tests -- -D warnings`
- [x] Manual verification: built WarpOSS locally and confirmed that deleting `.git` clears the stale git chip info in the existing pane.

- [ ] I have manually tested my changes locally with `./script/run`
  - Manual verification was performed with a local WarpOSS build rather than `./script/run`.

### Screenshots / Videos
Not included; the behavior was manually verified in a local WarpOSS build using a throwaway Git repo.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed stale git prompt chips that could remain visible after deleting a repository's `.git` directory.

Co-Authored-By: Warp <agent@warp.dev>