### PR TITLE
Fix header horizontal alignment in markdown viewer

### DIFF
--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -121,7 +121,7 @@ pub const BROKEN_LINK_SPACING: BlockSpacing = BlockSpacing {
 };
 
 pub const HEADER_SPACING: BlockSpacing = BlockSpacing {
-    margin: Margin::uniform(4.)
+    margin: Margin::uniform(0.)
         .with_top(4.)
         .with_bottom(4.)
         .with_right(16.),


### PR DESCRIPTION
## Description

Fix horizontal alignment of markdown headers in the markdown viewer. Headers were misaligned 4px to the right relative to paragraph text due to an unintended left margin in `HEADER_SPACING`.

**Root cause:** `HEADER_SPACING` was defined using `Margin::uniform(4.)` which sets all sides to 4px (including left), but only top, bottom, and right were explicitly overridden. The `left` margin remained at 4px while `TEXT_SPACING` has `left: 0`. Since `content_origin()` uses `spacing.left_offset()` to set the horizontal starting position, headers appeared 4px to the right of paragraph text.

**Fix:** Change `Margin::uniform(4.)` to `Margin::uniform(0.)` in `HEADER_SPACING`, so only top (4px), bottom (4px), and right (16px) margins are set — matching the intended behavior.

## Linked Issue

Fixes https://github.com/warpdotdev/warp/issues/12351

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Visual verification via computer use confirmed that after the fix, all heading levels (H1, H2) and paragraph text share the same left edge — no horizontal offset.

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Verified with computer use: headers and paragraph text are now horizontally aligned at the same left edge.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed header text alignment in markdown viewer — headers now share the same left edge as paragraph text.
-->

_Conversation: https://staging.warp.dev/conversation/e9f4d67c-0b95-4a2c-a48b-356f645c98ca_
_Run: https://oz.staging.warp.dev/runs/019ea8a6-829a-79d4-9281-048ad57e4706_
_This PR was generated with [Oz](https://warp.dev/oz)._
