### PR TITLE
Fix terminal find rerun freeze

### DIFF
--- a/app/src/terminal/find/model.rs
+++ b/app/src/terminal/find/model.rs
@@ -444,8 +444,19 @@ impl TerminalFindModel {
 
     /// Reruns find with the same options applied to the current run, to be called if terminal
     /// contents have changed since the last find run.
-    pub fn rerun_find_on_active_grid(&mut self, ctx: &mut ModelContext<Self>) {
+    ///
+    /// `force_full_rescan` should be used for resize/reflow/query-option changes where content
+    /// coordinates may have changed even if no terminal rows are marked dirty. Wakeups from
+    /// normal output should pass `false` so unchanged grids can skip expensive sync rescans.
+    pub fn rerun_find_on_active_grid(
+        &mut self,
+        force_full_rescan: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
         if self.terminal_model.lock().is_alt_screen_active() {
+            if !force_full_rescan && !self.is_find_bar_open {
+                return;
+            }
             if let Some(old_find_state) = self.alt_screen_find_run.take() {
                 self.alt_screen_find_run =
                     Some(old_find_state.rerun(self.terminal_model.lock().alt_screen()));
@@ -467,45 +478,79 @@ impl TerminalFindModel {
             let mut model = self.terminal_model.lock();
             let active_block_index = model.block_list().active_block_index();
 
-            // Consume dirty ranges from both grids. We need mutable access
-            // because take_find_dirty_rows_range is destructive.
-            let active_block = model.block_list_mut().active_block_mut();
-            let output_dirty_info =
-                active_block
-                    .grid_of_type_mut(GridType::Output)
+            let (output_dirty_info, command_dirty_info) = if force_full_rescan {
+                (None, None)
+            } else {
+                // Consume dirty ranges from both grids. We need mutable access
+                // because take_find_dirty_rows_range is destructive.
+                let active_block = model.block_list_mut().active_block_mut();
+                let output_dirty_info =
+                    active_block
+                        .grid_of_type_mut(GridType::Output)
+                        .and_then(|grid| {
+                            let dirty = grid.grid_handler_mut().take_find_dirty_rows_range()?;
+                            let truncated = grid.grid_handler().num_lines_truncated();
+                            Some((dirty, GridType::Output, truncated))
+                        });
+                let command_dirty_info = active_block
+                    .grid_of_type_mut(GridType::PromptAndCommand)
                     .and_then(|grid| {
                         let dirty = grid.grid_handler_mut().take_find_dirty_rows_range()?;
                         let truncated = grid.grid_handler().num_lines_truncated();
-                        Some((dirty, GridType::Output, truncated))
+                        Some((dirty, GridType::PromptAndCommand, truncated))
                     });
-            let command_dirty_info = active_block
-                .grid_of_type_mut(GridType::PromptAndCommand)
-                .and_then(|grid| {
-                    let dirty = grid.grid_handler_mut().take_find_dirty_rows_range()?;
-                    let truncated = grid.grid_handler().num_lines_truncated();
-                    Some((dirty, GridType::PromptAndCommand, truncated))
-                });
+                (output_dirty_info, command_dirty_info)
+            };
 
             // Drop the model lock before emitting events.
             drop(model);
 
-            self.invalidate_async_find_block(active_block_index, output_dirty_info, ctx);
-            if let Some(info) = command_dirty_info {
-                self.invalidate_async_find_block(active_block_index, Some(info), ctx);
+            if force_full_rescan {
+                self.invalidate_async_find_block(active_block_index, None, ctx);
+            } else {
+                if output_dirty_info.is_none() && command_dirty_info.is_none() {
+                    return;
+                }
+                self.invalidate_async_find_block(active_block_index, output_dirty_info, ctx);
+                if let Some(info) = command_dirty_info {
+                    self.invalidate_async_find_block(active_block_index, Some(info), ctx);
+                }
             }
             return;
         }
 
         // Sync find path.
-        // Find the last block index. This is the only block whose state may change.
-        let last_block_index = self
-            .terminal_model
-            .lock()
-            .block_list()
-            .last_non_hidden_block_by_index()
-            .unwrap_or_default();
+        let (last_block_index, should_rerun) = {
+            let mut model = self.terminal_model.lock();
+            let last_block_index = model
+                .block_list()
+                .last_non_hidden_block_by_index()
+                .unwrap_or_default();
 
-        // Call find on the the last block's command and output grids.
+            let has_dirty_rows = model
+                .block_list_mut()
+                .block_at_mut(last_block_index)
+                .map(|block| {
+                    let output_dirty = block
+                        .grid_of_type_mut(GridType::Output)
+                        .and_then(|grid| grid.grid_handler_mut().take_find_dirty_rows_range())
+                        .is_some();
+                    let command_dirty = block
+                        .grid_of_type_mut(GridType::PromptAndCommand)
+                        .and_then(|grid| grid.grid_handler_mut().take_find_dirty_rows_range())
+                        .is_some();
+                    output_dirty || command_dirty
+                })
+                .unwrap_or(false);
+
+            (last_block_index, force_full_rescan || has_dirty_rows)
+        };
+
+        if !should_rerun {
+            return;
+        }
+
+        // Call find on the last block's command and output grids.
         // If the block is a new finished block, the matches are inserted at a new key, the block's index in the blocklist.
         // If the block is an active, running block, its matches are overwritten in the terminal's block_matches.
         if let Some(block) = self
@@ -572,6 +617,24 @@ impl TerminalFindModel {
         for view in self.rich_content_views.values() {
             view.clear_matches(ctx);
         }
+    }
+
+    /// Cancels active find work while preserving the most recent find options for
+    /// reopening the find bar.
+    pub fn cancel_active_scan_preserve_options(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.terminal_model.lock().is_alt_screen_active() {
+            if let Some(run) = self.alt_screen_find_run.take() {
+                self.alt_screen_find_run = Some(run.cleared());
+            }
+        } else if let Some(controller) = &mut self.async_find_controller {
+            controller.cancel_active_scan_preserve_options(ctx);
+        } else if let Some(run) = self.block_list_find_run.take() {
+            for rich_content_view in self.rich_content_views.values() {
+                rich_content_view.clear_matches(ctx);
+            }
+            self.block_list_find_run = Some(run.cleared());
+        }
+        ctx.emit(FindEvent::RanFind);
     }
 
     /// Clears matches in the active find run, if any.

--- a/app/src/terminal/find/model/async_find.rs
+++ b/app/src/terminal/find/model/async_find.rs
@@ -890,10 +890,12 @@ impl AsyncFindController {
     /// Dropping the senders closes the result and throttle streams naturally.
     /// The find configuration is preserved so `has_active_find()` remains true.
     pub fn cancel_current_find(&mut self) {
-        // Close the work queue, which causes the background task's pop() to
-        // return Err(QueueClosed) and exit.
+        // Cancel queued work immediately. `close()` drains pending items, which
+        // is correct for normal completion but wrong for query changes/close: a
+        // cancelled find must not keep scanning stale chunks behind the terminal
+        // model lock.
         if let Some(queue) = self.work_queue.take() {
-            queue.close();
+            queue.cancel();
         }
 
         // Abort the background future so it stops being polled.
@@ -905,6 +907,24 @@ impl AsyncFindController {
         self.result_tx = None;
         self.throttle_tx = None;
         self.status = AsyncFindStatus::Idle;
+    }
+
+    /// Cancels active work and clears active config/results while preserving the
+    /// last find options so reopening the find bar can restore the query.
+    pub fn cancel_active_scan_preserve_options(
+        &mut self,
+        ctx: &mut ModelContext<TerminalFindModel>,
+    ) {
+        self.cancel_current_find();
+        self.current_config = None;
+        self.block_results.clear();
+        self.focused_match_index = None;
+        self.cached_focused_match = None;
+        self.status = AsyncFindStatus::Idle;
+
+        for view in self.rich_content_views.values() {
+            view.clear_matches(ctx);
+        }
     }
 
     /// Clears all find results and resets state.

--- a/app/src/terminal/find/model/async_find/background_task.rs
+++ b/app/src/terminal/find/model/async_find/background_task.rs
@@ -70,7 +70,11 @@ async fn run_find_task_loop(
     };
 
     while let Ok((item, queue_drained)) = queue.pop().await {
-        match item {
+        if result_tx.is_closed() {
+            return;
+        }
+
+        let should_continue = match item {
             FindWorkItem::FullBlock { block_index } => {
                 scan_terminal_block_chunked(
                     block_index,
@@ -79,7 +83,7 @@ async fn run_find_task_loop(
                     &result_tx,
                     config.block_sort_direction,
                 )
-                .await;
+                .await
             }
             FindWorkItem::DirtyRange {
                 block_index,
@@ -99,27 +103,32 @@ async fn run_find_task_loop(
                     &dfas,
                     &result_tx,
                 )
-                .await;
+                .await
             }
             FindWorkItem::AIBlock {
                 view_id,
                 total_index,
             } => {
                 // Forward to main thread for execution.
-                let _ = result_tx
+                result_tx
                     .send(FindTaskMessage::ScanAIBlock {
                         view_id,
                         total_index,
                     })
-                    .await;
+                    .await
+                    .is_ok()
             }
+        };
+
+        if !should_continue || result_tx.is_closed() {
+            return;
         }
 
         // The emptiness flag is checked atomically with the pop inside
         // the queue lock, avoiding the TOCTOU race of a separate
         // `is_empty()` call.
-        if queue_drained {
-            let _ = result_tx.send(FindTaskMessage::Done).await;
+        if queue_drained && result_tx.send(FindTaskMessage::Done).await.is_err() {
+            return;
         }
     }
 }
@@ -131,7 +140,7 @@ async fn scan_terminal_block_chunked(
     dfas: &RegexDFAs,
     result_tx: &async_channel::Sender<FindTaskMessage>,
     block_sort_direction: crate::terminal::model::terminal_model::BlockSortDirection,
-) {
+) -> bool {
     // Determine grid order based on sort direction.
     let grid_order = match block_sort_direction {
         crate::terminal::model::terminal_model::BlockSortDirection::MostRecentFirst => {
@@ -143,7 +152,7 @@ async fn scan_terminal_block_chunked(
     };
 
     for &grid_type in grid_order {
-        scan_grid_chunked(
+        if !scan_grid_chunked(
             block_index,
             grid_type,
             0,
@@ -153,8 +162,12 @@ async fn scan_terminal_block_chunked(
             dfas,
             result_tx,
         )
-        .await;
+        .await
+        {
+            return false;
+        }
     }
+    true
 }
 
 /// Controls how each chunk's matches are sent to the main thread.
@@ -191,23 +204,27 @@ async fn scan_grid_chunked(
     terminal_model: &Arc<FairMutex<TerminalModel>>,
     dfas: &RegexDFAs,
     result_tx: &async_channel::Sender<FindTaskMessage>,
-) {
+) -> bool {
     let mut current_row = start_row;
 
     loop {
+        if result_tx.is_closed() {
+            return false;
+        }
+
         let chunk_result = {
             let lock_start = Instant::now();
             let model = terminal_model.lock();
 
             let Some(block) = model.block_list().block_at(block_index) else {
                 // Block no longer exists.
-                return;
+                return true;
             };
 
             let grid = match grid_type {
                 GridType::Output => block.output_grid(),
                 GridType::PromptAndCommand => block.prompt_and_command_grid(),
-                _ => return,
+                _ => return true,
             };
 
             let grid_handler = grid.grid_handler();
@@ -215,7 +232,7 @@ async fn scan_grid_chunked(
             let effective_end = end_row.unwrap_or(total_rows).min(total_rows);
 
             if current_row >= effective_end {
-                return;
+                return true;
             }
 
             let chunk_end = (current_row + ROWS_PER_CHUNK).min(effective_end);
@@ -239,13 +256,17 @@ async fn scan_grid_chunked(
         match &mode {
             ScanResultMode::FullBlock => {
                 if !matches.is_empty() {
-                    let _ = result_tx
+                    if result_tx
                         .send(FindTaskMessage::BlockGridMatches {
                             block_index,
                             grid_type,
                             matches,
                         })
-                        .await;
+                        .await
+                        .is_err()
+                    {
+                        return false;
+                    }
                 }
             }
             ScanResultMode::DirtyRange {
@@ -253,14 +274,18 @@ async fn scan_grid_chunked(
             } => {
                 let absolute_start = current_row as u64 + num_lines_truncated;
                 let absolute_end = (chunk_end - 1) as u64 + num_lines_truncated;
-                let _ = result_tx
+                if result_tx
                     .send(FindTaskMessage::DirtyRangeMatches {
                         block_index,
                         grid_type,
                         dirty_range: absolute_start..=absolute_end,
                         matches,
                     })
-                    .await;
+                    .await
+                    .is_err()
+                {
+                    return false;
+                }
             }
         }
 
@@ -270,11 +295,18 @@ async fn scan_grid_chunked(
 
         current_row = chunk_end;
 
-        // Yield to let other tasks run if we held the lock for a while.
-        if elapsed.as_millis() > MAX_LOCK_DURATION_MS as u128 / 2 {
-            yield_now().await;
+        // Always yield between chunks so cancellation and UI work are cooperative
+        // even when each individual chunk is fast.
+        if elapsed.as_millis() > MAX_LOCK_DURATION_MS as u128 {
+            log::trace!(
+                "[async_find] chunk held terminal model lock for {}ms",
+                elapsed.as_millis()
+            );
         }
+        yield_now().await;
     }
+
+    true
 }
 
 /// Scans a range of rows in a grid for matches.

--- a/app/src/terminal/find/model/async_find/work_queue.rs
+++ b/app/src/terminal/find/model/async_find/work_queue.rs
@@ -43,6 +43,7 @@ pub struct QueueClosed;
 struct FindWorkQueueInner {
     items: VecDeque<FindWorkItem>,
     closed: bool,
+    cancelled: bool,
 }
 
 /// A shared work queue for async find operations.
@@ -63,6 +64,7 @@ impl FindWorkQueue {
             inner: Arc::new(Mutex::new(FindWorkQueueInner {
                 items: VecDeque::new(),
                 closed: false,
+                cancelled: false,
             })),
             event: Arc::new(Event::new()),
         }
@@ -145,6 +147,9 @@ impl FindWorkQueue {
             // Check for an available item or closed state.
             {
                 let mut inner = self.inner.lock().unwrap();
+                if inner.cancelled {
+                    return Err(QueueClosed);
+                }
                 if let Some(item) = inner.items.pop_front() {
                     let is_empty = inner.items.is_empty();
                     return Ok((item, is_empty));
@@ -161,6 +166,9 @@ impl FindWorkQueue {
             // Re-check after registering the listener.
             {
                 let mut inner = self.inner.lock().unwrap();
+                if inner.cancelled {
+                    return Err(QueueClosed);
+                }
                 if let Some(item) = inner.items.pop_front() {
                     let is_empty = inner.items.is_empty();
                     return Ok((item, is_empty));
@@ -178,9 +186,20 @@ impl FindWorkQueue {
     /// Closes the queue, waking any blocked [`pop`](FindWorkQueue::pop) call.
     ///
     /// After closing, `pop` will drain remaining items and then return
-    /// `Err(QueueClosed)`.
+    /// `Err(QueueClosed)`. Use [`Self::cancel`] when pending work should be
+    /// discarded immediately.
     pub fn close(&self) {
         let mut inner = self.inner.lock().unwrap();
+        inner.closed = true;
+        drop(inner);
+        self.event.notify(usize::MAX);
+    }
+
+    /// Cancels the queue and discards pending work immediately.
+    pub fn cancel(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.items.clear();
+        inner.cancelled = true;
         inner.closed = true;
         drop(inner);
         self.event.notify(usize::MAX);
@@ -200,5 +219,40 @@ impl FindWorkQueue {
     /// Returns the number of pending items.
     pub fn len(&self) -> usize {
         self.inner.lock().unwrap().items.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_lite::future::block_on;
+
+    use super::*;
+
+    #[test]
+    fn close_drains_pending_work_before_reporting_closed() {
+        let queue = FindWorkQueue::new();
+        queue.invalidate_block(BlockIndex::zero(), None);
+
+        queue.close();
+
+        let (item, is_empty) = block_on(queue.pop()).expect("closed queue should drain first");
+        assert!(matches!(
+            item,
+            FindWorkItem::FullBlock { block_index } if block_index == BlockIndex::zero()
+        ));
+        assert!(is_empty);
+        assert!(block_on(queue.pop()).is_err());
+    }
+
+    #[test]
+    fn cancel_discards_pending_work_immediately() {
+        let queue = FindWorkQueue::new();
+        queue.invalidate_block(BlockIndex::zero(), None);
+        assert_eq!(queue.len(), 1);
+
+        queue.cancel();
+
+        assert_eq!(queue.len(), 0);
+        assert!(block_on(queue.pop()).is_err());
     }
 }

--- a/app/src/terminal/find/model/async_find_tests.rs
+++ b/app/src/terminal/find/model/async_find_tests.rs
@@ -253,6 +253,71 @@ fn test_async_find_cancellation() {
 }
 
 #[test]
+fn test_cancel_active_scan_preserves_find_options_but_clears_active_find() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        let mut mock_terminal_model = TerminalModel::mock(None, None);
+        mock_terminal_model.simulate_block("cmd1", "needle\r\n");
+
+        let terminal_model = Arc::new(FairMutex::new(mock_terminal_model));
+        let test_model = app.add_model(|ctx| {
+            let mut model = TerminalFindModel::new(terminal_model.clone(), ctx);
+            if model.async_find_controller.is_none() {
+                model.async_find_controller =
+                    Some(AsyncFindController::new(terminal_model.clone()));
+            }
+            model
+        });
+
+        let options = FindOptions {
+            query: Some("needle".to_owned().into()),
+            is_regex_enabled: false,
+            is_case_sensitive: false,
+            ..Default::default()
+        };
+
+        test_model.update(&mut app, |model, ctx| {
+            model.async_find_controller.as_mut().unwrap().start_find(
+                &options,
+                BlockSortDirection::MostRecentLast,
+                ctx,
+            );
+        });
+
+        test_model.update(&mut app, |model, ctx| {
+            model
+                .async_find_controller
+                .as_mut()
+                .unwrap()
+                .cancel_active_scan_preserve_options(ctx);
+        });
+
+        let (has_active_find, saved_query, status) = test_model.update(&mut app, |model, _ctx| {
+            let controller = model.async_find_controller.as_ref().unwrap();
+            (
+                controller.has_active_find(),
+                controller
+                    .find_options()
+                    .and_then(|opts| opts.query.clone()),
+                controller.status().clone(),
+            )
+        });
+
+        assert!(
+            !has_active_find,
+            "closing find should clear active config so wakeup reruns stop"
+        );
+        assert_eq!(
+            saved_query,
+            Some("needle".to_owned().into()),
+            "closing find should preserve saved options for query restore"
+        );
+        assert_eq!(status, AsyncFindStatus::Idle);
+    });
+}
+
+#[test]
 fn test_message_processing_updates_state() {
     App::test((), |mut app| async move {
         initialize_settings_for_tests(&mut app);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -670,6 +670,7 @@ pub const NOTIFICATIONS_TROUBLESHOOT_URL: &str =
     "https://docs.warp.dev/terminal/more-features/notifications#troubleshooting-notifications";
 
 const DEBOUNCE_PERIOD: Duration = Duration::from_millis(40);
+const FIND_RERUN_DEBOUNCE_PERIOD: Duration = Duration::from_millis(100);
 
 /// Key used in user defaults to save whether the user has seen the banner.
 pub const ALIAS_EXPANSION_BANNER_SEEN_KEY: &str = "AliasExpansionBannerSeen";
@@ -2344,6 +2345,12 @@ struct TerminalViewMouseStates {
     breadcrumbs_horizontal_scroll: ClippedScrollStateHandle,
 }
 
+struct PendingFindRerun {
+    generation: u64,
+    force_full_rescan: bool,
+    abort_handle: SpawnedFutureHandle,
+}
+
 /// Where content was routed when sent to a CLI agent.
 /// Returned by [`TerminalView::try_send_text_to_cli_agent_or_rich_input`]
 /// so callers can report the correct telemetry destination without a
@@ -2727,6 +2734,8 @@ pub struct TerminalView {
     input_hoverable_handle: MouseStateHandle,
 
     find_model: ModelHandle<TerminalFindModel>,
+    pending_find_rerun: Option<PendingFindRerun>,
+    find_rerun_generation: u64,
 
     warpify_state: WarpifyState,
 
@@ -4278,6 +4287,8 @@ impl TerminalView {
             input_position_id,
             input_hoverable_handle: Default::default(),
             find_model,
+            pending_find_rerun: None,
+            find_rerun_generation: 0,
             warpify_state: Default::default(),
             cancel_command_keystroke: keybinding_name_to_keystroke(CANCEL_COMMAND_KEYBINDING, ctx),
             is_file_drop_target: false,
@@ -9012,15 +9023,73 @@ impl TerminalView {
         }
     }
 
+    fn has_active_find_query(&self, ctx: &AppContext) -> bool {
+        self.find_model.as_ref(ctx).is_find_bar_open()
+            && self
+                .find_model
+                .as_ref(ctx)
+                .active_find_options()
+                .and_then(|options| options.query.as_ref())
+                .is_some_and(|query| !query.trim().is_empty())
+    }
+
+    fn bump_find_rerun_generation(&mut self) {
+        self.find_rerun_generation = self.find_rerun_generation.wrapping_add(1);
+        if let Some(pending) = self.pending_find_rerun.take() {
+            pending.abort_handle.abort();
+        }
+    }
+
+    fn schedule_find_rerun(&mut self, force_full_rescan: bool, ctx: &mut ViewContext<Self>) {
+        if !self.has_active_find_query(ctx) {
+            return;
+        }
+
+        let generation = self.find_rerun_generation;
+        let force_full_rescan = force_full_rescan
+            || self
+                .pending_find_rerun
+                .as_ref()
+                .is_some_and(|pending| pending.force_full_rescan);
+
+        if let Some(pending) = self.pending_find_rerun.take() {
+            pending.abort_handle.abort();
+        }
+
+        let abort_handle = ctx.spawn_abortable(
+            Timer::after(FIND_RERUN_DEBOUNCE_PERIOD),
+            move |me, _, ctx| {
+                let Some(pending) = me.pending_find_rerun.take() else {
+                    return;
+                };
+
+                if pending.generation != generation
+                    || me.find_rerun_generation != generation
+                    || !me.has_active_find_query(ctx)
+                {
+                    return;
+                }
+
+                me.find_model.update(ctx, |find_model, ctx| {
+                    find_model.rerun_find_on_active_grid(pending.force_full_rescan, ctx);
+                });
+            },
+            |_, _| (),
+        );
+
+        self.pending_find_rerun = Some(PendingFindRerun {
+            generation,
+            force_full_rescan,
+            abort_handle,
+        });
+    }
+
     /// This function is invoked every time there is some form of view event
     /// such as a state change or terminal wakeup to update the view context.
     fn handle_terminal_wakeup(&mut self, _: (), ctx: &mut ViewContext<Self>) {
-        // If find bar is active, we update the matches for the last/active block or the alt screen.
-        if self.find_model.as_ref(ctx).is_find_bar_open() {
-            self.find_model.update(ctx, |find_model, ctx| {
-                find_model.rerun_find_on_active_grid(ctx);
-            });
-        }
+        // If find bar is active, schedule a coalesced rerun instead of synchronously
+        // rescanning on every wakeup.
+        self.schedule_find_rerun(false, ctx);
 
         // For simplicity, we simply rescan the entire block for block filter matches.
         self.model
@@ -15990,9 +16059,7 @@ impl TerminalView {
 
         // Update model with new size info.
         self.model.lock().resize(size_update);
-        self.find_model.update(ctx, |find_model, ctx| {
-            find_model.rerun_find_on_active_grid(ctx);
-        });
+        self.schedule_find_rerun(true, ctx);
         // Resizing the model already clears selected text, but
         // we also need to clear selections in any rich content blocks (e.g. AI blocks).
         if size_update.rows_or_columns_changed() {
@@ -19378,6 +19445,7 @@ impl TerminalView {
     }
 
     fn close_find_bar(&mut self, ctx: &mut ViewContext<Self>) {
+        self.bump_find_rerun_generation();
         self.find_model.update(ctx, |find_model, ctx| {
             find_model.set_is_find_bar_open(false);
             // Notify rich-content child views (e.g. AI blocks) to repaint and
@@ -19386,11 +19454,9 @@ impl TerminalView {
             // separate child views that won't repaint on their own when the
             // find bar closes.
             //
-            // Uses `clear_rich_content_matches` (rich-content only) rather
-            // than the broader `clear_matches`: on the async-find path the
-            // latter drops `current_find_options`, breaking `open_find_bar`'s
-            // restore-previous-query path (it reads `active_find_options`).
-            find_model.clear_rich_content_matches(ctx);
+            // Cancel active work but preserve the previous find options so
+            // `open_find_bar` can restore the query.
+            find_model.cancel_active_scan_preserve_options(ctx);
         });
         ctx.notify();
     }
@@ -19399,7 +19465,7 @@ impl TerminalView {
         if self.find_model.as_ref(ctx).is_find_bar_open()
             && !self.model.lock().is_alt_screen_active()
         {
-            let mut find_options = self
+            let find_options = self
                 .find_model
                 .as_ref(ctx)
                 .active_find_options()
@@ -19415,20 +19481,22 @@ impl TerminalView {
             if find_options.blocks_to_include_in_results.as_ref()
                 != new_blocks_to_include_in_results.as_ref()
             {
-                self.find_bar.update(ctx, |view, ctx| {
-                    if new_blocks_to_include_in_results.is_none() {
-                        // If there aren't any selected blocks, turn off find in block
+                let find_options = find_options
+                    .with_blocks_to_include_in_results(new_blocks_to_include_in_results.clone());
+
+                if new_blocks_to_include_in_results.is_none() {
+                    self.find_bar.update(ctx, |view, ctx| {
+                        // If there aren't any selected blocks, turn off find in block.
                         view.display_find_within_block = FindWithinBlockState::Disabled;
-                    }
-
-                    find_options = find_options
-                        .with_blocks_to_include_in_results(new_blocks_to_include_in_results);
-
-                    self.find_model.update(ctx, |find_model, ctx| {
-                        find_model.run_find(find_options, ctx)
+                        ctx.notify();
                     });
-                    ctx.notify();
+                }
+
+                self.bump_find_rerun_generation();
+                self.find_model.update(ctx, |find_model, ctx| {
+                    find_model.run_find(find_options, ctx)
                 });
+                ctx.notify();
             }
         }
     }
@@ -19451,6 +19519,7 @@ impl TerminalView {
     /// Note that the meaning of "first" varies depending on whether the block list is inverted
     /// or not.
     fn run_find(&mut self, mut options: FindOptions, ctx: &mut ViewContext<Self>) {
+        self.bump_find_rerun_generation();
         let blocks_to_include_in_results = matches!(
             self.find_bar.as_ref(ctx).display_find_within_block,
             FindWithinBlockState::Enabled

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -7063,5 +7063,15 @@ fn close_find_bar_preserves_options_on_async_find_path() {
             Some(needle_options().query),
             "closing the find bar must preserve the saved query on the async path"
         );
+        assert!(
+            !terminal.read(&app, |view, ctx| view
+                .find_model
+                .as_ref(ctx)
+                .async_find_controller
+                .as_ref()
+                .unwrap()
+                .has_active_find()),
+            "closing the find bar must clear the active find run so terminal wakeups stop rescanning"
+        );
     })
 }


### PR DESCRIPTION
## Summary
- Debounce terminal find reruns from wakeup/resize events so a live terminal with the find bar open does not synchronously rescan on every wakeup.
- Cancel pending async find work immediately on query changes / find close, and make the background scanner exit on closed result channels or send failures.
- Preserve previous find options when closing the find bar while clearing active find state, so reopening still restores the query but wakeups stop rescanning.
- Add regression coverage for queue cancel-vs-close behavior and async close preserving options while clearing active config.

## Why
A frozen Warp instance was burning CPU in repeated terminal-find rescans while the find bar was active on a large live terminal. The hot path was `TerminalView::handle_terminal_wakeup -> TerminalFindModel::rerun_find_on_active_grid -> run_find_on_block -> RegexDFAs::search`, repeated on every wakeup.

## Validation
- `cargo fmt --manifest-path ./Cargo.toml -p warp`
- `PATH=/tmp/warp-fake-xcrun:$PATH RUSTC=$(rustup which --toolchain 1.92.0 rustc) $(rustup which --toolchain 1.92.0 cargo) check -p warp --tests` ✅
  - Note: local machine is missing Xcode's Metal toolchain, so I used a fake `xcrun` only to satisfy shader build outputs during type-check. No runtime binary produced from that workaround.
- Lope validator review: `pi` PASS; direct Claude review PASS. Lope's `claude` adapter timed out and `antigravity` returned empty output, so those are not counted as passes.
