### PR TITLE
Introduce single-host BundledSkill abstraction

### DIFF
--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use ai::skills::{parse_bundled_skill, ParsedSkill};
+use anyhow::Context;
+use futures::TryStreamExt;
+use warp_core::channel::ChannelState;
+use warp_core::ui::icons::Icon;
+use warp_core::{report_error, safe_warn};
+use warpui::{AppContext, SingletonEntity};
+
+use crate::ai::mcp::{McpIntegration, TemplatableMCPServerManager};
+use crate::keyboard::keybinding_file_path;
+use crate::settings::user_preferences_toml_file_path;
+
+/// Activation condition for a bundled skill.
+#[derive(Debug, Clone)]
+pub enum BundledSkillActivation {
+    /// Always active.
+    Always,
+    /// Active only when a specific MCP server is running.
+    RequiresMcp(McpIntegration),
+    /// Active only when a specific file exists on disk.
+    RequiresFile(PathBuf),
+}
+
+impl BundledSkillActivation {
+    pub fn is_enabled(&self, ctx: &AppContext) -> bool {
+        match self {
+            Self::Always => true,
+            Self::RequiresMcp(integration) => {
+                TemplatableMCPServerManager::as_ref(ctx).is_mcp_server_running(*integration)
+            }
+            Self::RequiresFile(path) => path.exists(),
+        }
+    }
+}
+
+/// A bundled skill with its activation condition and icon.
+#[derive(Debug, Clone)]
+pub struct BundledSkill {
+    pub skill: ParsedSkill,
+    pub activation: BundledSkillActivation,
+    pub icon: Icon,
+}
+
+/// Load skill definitions bundled with Warp.
+pub(crate) async fn load_bundled_skills() -> HashMap<String, BundledSkill> {
+    let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
+        return HashMap::new();
+    };
+    let skills_dir = resources_dir.join("bundled").join("skills");
+    read_bundled_skills(&skills_dir)
+        .await
+        .into_iter()
+        .map(|(id, skill)| {
+            let icon = icon_for_bundled_skill(&id);
+            let activation = activation_for_bundled_skill(&id, &resources_dir);
+            let bundled = BundledSkill {
+                skill,
+                activation,
+                icon,
+            };
+            (id, bundled)
+        })
+        .collect()
+}
+
+/// Read bundled skill definitions from the specified directory.
+pub(crate) async fn read_bundled_skills(skills_dir: &Path) -> HashMap<String, ParsedSkill> {
+    let mut skills = HashMap::new();
+    let context = build_bundled_skill_context();
+
+    let Ok(mut entries) = async_fs::read_dir(skills_dir).await else {
+        return skills;
+    };
+
+    while let Ok(Some(entry)) = entries.try_next().await {
+        let entry_path = entry.path();
+        if !entry_path.is_dir() {
+            continue;
+        }
+
+        let skill_file_path = entry_path.join("SKILL.md");
+        let mut skill = match parse_bundled_skill(&skill_file_path) {
+            Ok(skill) => skill,
+            Err(err) => {
+                report_error!(err.context(format!(
+                    "Failed to parse bundled skill at {}",
+                    skill_file_path.display()
+                )));
+                continue;
+            }
+        };
+
+        // We use the directory name as the skill ID (guaranteed unique within bundled skills).
+        let Some(skill_id) = entry_path.file_name().and_then(|s| s.to_str()) else {
+            safe_warn!(
+                safe: ("Could not resolve bundled skill ID, skipping skill"),
+                full: ("Could not resolve bundled skill ID from {}, skipping skill", skill.path.display_path())
+            );
+            continue;
+        };
+
+        // Apply variable substitution to the skill content.
+        skill.content = handlebars::render_template(&skill.content, &context);
+        skills.insert(skill_id.to_owned(), skill);
+    }
+
+    log::info!("Read {} bundled skills", skills.len());
+
+    skills
+}
+
+/// Builds the context map for bundled skill variable substitution.
+///
+/// Supported variables:
+/// - `{{warp_server_url}}` - The server root URL (e.g., `https://api.warp.dev`)
+/// - `{{warp_cli_binary_name}}` - The CLI binary name (e.g., `warp` or `warp-cli`)
+/// - `{{warp_url_scheme}}` - The URL scheme (e.g., `warp`, `warpdev`, `warppreview`)
+/// - `{{settings_schema_path}}` - Path to the bundled JSON settings schema
+/// - `{{settings_file_path}}` - Path to the user's settings TOML file
+/// - `{{keybindings_file_path}}` - Path to the user's keybindings YAML file
+pub(crate) fn build_bundled_skill_context() -> HashMap<String, String> {
+    let mut context: HashMap<String, String> = [
+        (
+            "warp_server_url".to_owned(),
+            ChannelState::server_root_url().into_owned(),
+        ),
+        (
+            "warp_cli_binary_name".to_owned(),
+            ChannelState::channel().cli_command_name().to_owned(),
+        ),
+        (
+            "warp_url_scheme".to_owned(),
+            ChannelState::url_scheme().to_owned(),
+        ),
+        (
+            "settings_file_path".to_owned(),
+            user_preferences_toml_file_path().display().to_string(),
+        ),
+        (
+            "keybindings_file_path".to_owned(),
+            keybinding_file_path().display().to_string(),
+        ),
+    ]
+    .into_iter()
+    .collect();
+
+    if let Some(schema_path) =
+        warp_core::paths::bundled_resources_dir().map(|dir| dir.join("settings_schema.json"))
+    {
+        context.insert(
+            "settings_schema_path".to_owned(),
+            schema_path.display().to_string(),
+        );
+    }
+
+    context
+}
+
+/// Returns the icon for a bundled skill, given its directory-based ID.
+/// Skills with a known brand (e.g. `pr-comments` → GitHub) get a
+/// branded icon; everything else falls back to the Warp logo.
+pub(crate) fn icon_for_bundled_skill(skill_id: &str) -> Icon {
+    match skill_id {
+        "pr-comments" => Icon::Github,
+        _ => Icon::WarpLogoLight,
+    }
+}
+
+/// Returns the activation condition for a bundled skill.
+///
+/// Most skills are always active. Skills that depend on a bundled resource
+/// file use `RequiresFile` so they only appear when the resource is present.
+fn activation_for_bundled_skill(skill_id: &str, resources_dir: &Path) -> BundledSkillActivation {
+    match skill_id {
+        "modify-settings" => {
+            BundledSkillActivation::RequiresFile(resources_dir.join("settings_schema.json"))
+        }
+        _ => BundledSkillActivation::Always,
+    }
+}

--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -1,14 +1,15 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use ai::skills::{parse_bundled_skill, ParsedSkill};
-use anyhow::Context;
+use ai::skills::{parse_bundled_skill, ParsedSkill, SkillReference};
 use futures::TryStreamExt;
 use warp_core::channel::ChannelState;
 use warp_core::ui::icons::Icon;
 use warp_core::{report_error, safe_warn};
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, SingletonEntity};
 
+use super::SkillDescriptor;
 use crate::ai::mcp::{McpIntegration, TemplatableMCPServerManager};
 use crate::keyboard::keybinding_file_path;
 use crate::settings::user_preferences_toml_file_path;
@@ -36,16 +37,85 @@ impl BundledSkillActivation {
     }
 }
 
-/// A bundled skill with its activation condition and icon.
+/// A bundled skill definition with its activation condition and icon.
 #[derive(Debug, Clone)]
+struct BundledSkillDefinition {
+    skill: ParsedSkill,
+    activation: BundledSkillActivation,
+    icon: Icon,
+}
+
+/// Skills bundled with Warp for a single host.
+#[derive(Debug, Default)]
 pub struct BundledSkill {
-    pub skill: ParsedSkill,
-    pub activation: BundledSkillActivation,
-    pub icon: Icon,
+    definitions: HashMap<String, BundledSkillDefinition>,
+}
+
+impl BundledSkill {
+    /// Detect all skill definitions bundled with Warp for the local host.
+    pub async fn detect() -> Self {
+        let (mut definitions, figma_definitions) = futures::join!(
+            load_bundled_skill_definitions(),
+            load_figma_skill_definitions()
+        );
+        definitions.extend(figma_definitions);
+        Self { definitions }
+    }
+
+    /// Returns descriptors for bundled skills whose activation conditions are met.
+    pub fn active_descriptors(&self, ctx: &AppContext) -> Vec<SkillDescriptor> {
+        self.definitions
+            .iter()
+            .filter(|(_, definition)| definition.activation.is_enabled(ctx))
+            .map(|(id, definition)| {
+                SkillDescriptor::new_bundled(id.clone(), definition.skill.clone(), definition.icon)
+            })
+            .collect()
+    }
+
+    /// Returns a bundled skill reference when the path belongs to a bundled skill.
+    pub fn reference_for_path(&self, path: &LocalOrRemotePath) -> Option<SkillReference> {
+        self.definitions
+            .iter()
+            .find(|(_, definition)| definition.skill.path == *path)
+            .map(|(id, _)| SkillReference::BundledSkillId(id.clone()))
+    }
+
+    /// Returns a bundled skill definition by ID.
+    pub fn skill(&self, id: &str) -> Option<&ParsedSkill> {
+        self.definitions.get(id).map(|definition| &definition.skill)
+    }
+
+    /// Returns a bundled skill by ID only if its activation condition is met.
+    pub fn active_skill(&self, id: &str, ctx: &AppContext) -> Option<&ParsedSkill> {
+        let definition = self.definitions.get(id)?;
+        definition
+            .activation
+            .is_enabled(ctx)
+            .then_some(&definition.skill)
+    }
+
+    #[cfg(test)]
+    pub fn insert_for_testing(
+        &mut self,
+        id: impl Into<String>,
+        skill: ParsedSkill,
+        activation: BundledSkillActivation,
+    ) {
+        let id = id.into();
+        self.definitions.insert(
+            id.clone(),
+            BundledSkillDefinition {
+                skill,
+                activation,
+                icon: icon_for_bundled_skill(&id),
+            },
+        );
+    }
 }
 
 /// Load skill definitions bundled with Warp.
-pub(crate) async fn load_bundled_skills() -> HashMap<String, BundledSkill> {
+async fn load_bundled_skill_definitions() -> HashMap<String, BundledSkillDefinition> {
     let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
         return HashMap::new();
     };
@@ -56,10 +126,33 @@ pub(crate) async fn load_bundled_skills() -> HashMap<String, BundledSkill> {
         .map(|(id, skill)| {
             let icon = icon_for_bundled_skill(&id);
             let activation = activation_for_bundled_skill(&id, &resources_dir);
-            let bundled = BundledSkill {
+            let bundled = BundledSkillDefinition {
                 skill,
                 activation,
                 icon,
+            };
+            (id, bundled)
+        })
+        .collect()
+}
+
+/// Load Figma-specific bundled skills from the `figma/` subdirectory.
+async fn load_figma_skill_definitions() -> HashMap<String, BundledSkillDefinition> {
+    let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
+        return HashMap::new();
+    };
+    let figma_skills_dir = resources_dir
+        .join("bundled")
+        .join("mcp_skills")
+        .join("figma");
+    read_bundled_skills(&figma_skills_dir)
+        .await
+        .into_iter()
+        .map(|(id, skill)| {
+            let bundled = BundledSkillDefinition {
+                skill,
+                activation: BundledSkillActivation::RequiresMcp(McpIntegration::Figma),
+                icon: Icon::Figma,
             };
             (id, bundled)
         })

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -4,6 +4,10 @@ use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 mod telemetry;
 pub use telemetry::{SkillOpenOrigin, SkillTelemetryEvent};
+#[cfg(feature = "local_fs")]
+mod bundled;
+#[cfg(all(feature = "local_fs", test))]
+pub use bundled::BundledSkillActivation;
 
 cfg_if::cfg_if! {
     if #[cfg(not(feature = "local_fs"))] {
@@ -62,7 +66,5 @@ cfg_if::cfg_if! {
         pub use skill_manager::{
             read_skills_from_directories, SkillManager, SkillWatcher,
         };
-        #[cfg(test)]
-        pub use skill_manager::BundledSkillActivation;
     }
 }

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -3,53 +3,24 @@ mod file_watchers;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use ai::skills::{parse_bundled_skill, provider_rank, ParsedSkill, SkillProvider, SkillReference};
+use ai::skills::{provider_rank, ParsedSkill, SkillProvider, SkillReference};
 pub use file_watchers::{
     extract_skill_parent_directory, read_skills_from_directories, SkillWatcher, SkillWatcherEvent,
 };
-use warp_core::channel::ChannelState;
 use warp_core::features::FeatureFlag;
 use warp_core::ui::icons::Icon;
-use warp_core::{report_error, safe_warn};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
+#[cfg(test)]
+use super::bundled::build_bundled_skill_context;
+use super::bundled::{
+    icon_for_bundled_skill, load_bundled_skills, read_bundled_skills, BundledSkill,
+    BundledSkillActivation,
+};
 use super::{SkillDescriptor, SkillPathQuery};
-use crate::ai::mcp::{McpIntegration, TemplatableMCPServerManager};
+use crate::ai::mcp::McpIntegration;
 use crate::ai::skills::skill_utils::unique_skills;
-use crate::keyboard::keybinding_file_path;
-use crate::settings::user_preferences_toml_file_path;
-
-/// Activation condition for a bundled skill.
-#[derive(Debug, Clone)]
-pub enum BundledSkillActivation {
-    /// Always active.
-    Always,
-    /// Active only when a specific MCP server is running.
-    RequiresMcp(McpIntegration),
-    /// Active only when a specific file exists on disk.
-    RequiresFile(PathBuf),
-}
-
-impl BundledSkillActivation {
-    pub fn is_enabled(&self, ctx: &AppContext) -> bool {
-        match self {
-            Self::Always => true,
-            Self::RequiresMcp(integration) => {
-                TemplatableMCPServerManager::as_ref(ctx).is_mcp_server_running(*integration)
-            }
-            Self::RequiresFile(path) => path.exists(),
-        }
-    }
-}
-
-/// A bundled skill with its activation condition and icon.
-#[derive(Debug, Clone)]
-pub struct BundledSkill {
-    pub skill: ParsedSkill,
-    pub activation: BundledSkillActivation,
-    pub icon: Icon,
-}
 
 pub struct SkillManager {
     /// Maps a directory path to the set of skill file paths defined in that directory.
@@ -95,7 +66,7 @@ impl SkillManager {
         let skill_watcher = ctx.add_model(|ctx| SkillWatcher::new(ctx, skill_watcher_tx));
 
         if FeatureFlag::BundledSkills.is_enabled() {
-            ctx.spawn(Self::load_bundled_skills(), |me, result, _| {
+            ctx.spawn(load_bundled_skills(), |me, result, _| {
                 me.bundled_skills = result;
             });
             ctx.spawn(Self::load_figma_skills(), |me, figma_skills, _| {
@@ -463,28 +434,6 @@ impl SkillManager {
         }
     }
 
-    /// Load skill definitions bundled with Warp.
-    async fn load_bundled_skills() -> HashMap<String, BundledSkill> {
-        let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
-            return HashMap::new();
-        };
-        let skills_dir = resources_dir.join("bundled").join("skills");
-        read_bundled_skills(&skills_dir)
-            .await
-            .into_iter()
-            .map(|(id, skill)| {
-                let icon = icon_for_bundled_skill(&id);
-                let activation = activation_for_bundled_skill(&id, &resources_dir);
-                let bundled = BundledSkill {
-                    skill,
-                    activation,
-                    icon,
-                };
-                (id, bundled)
-            })
-            .collect()
-    }
-
     /// Load Figma-specific bundled skills from the `figma/` subdirectory.
     async fn load_figma_skills() -> HashMap<String, BundledSkill> {
         let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
@@ -534,124 +483,6 @@ impl SkillManager {
                 icon: icon_for_bundled_skill(&id),
             },
         );
-    }
-}
-
-/// Read bundled skill definitions from the specified directory.
-async fn read_bundled_skills(skills_dir: &Path) -> HashMap<String, ParsedSkill> {
-    use futures::TryStreamExt;
-
-    let mut skills = HashMap::new();
-    let context = build_bundled_skill_context();
-
-    let Ok(mut entries) = async_fs::read_dir(skills_dir).await else {
-        return skills;
-    };
-
-    while let Ok(Some(entry)) = entries.try_next().await {
-        let entry_path = entry.path();
-        if !entry_path.is_dir() {
-            continue;
-        }
-
-        let skill_file_path = entry_path.join("SKILL.md");
-        let mut skill = match parse_bundled_skill(&skill_file_path) {
-            Ok(skill) => skill,
-            Err(err) => {
-                report_error!(err.context(format!(
-                    "Failed to parse bundled skill at {}",
-                    skill_file_path.display()
-                )));
-                continue;
-            }
-        };
-
-        // We use the directory name as the skill ID (guaranteed unique within bundled skills).
-        let Some(skill_id) = entry_path.file_name().and_then(|s| s.to_str()) else {
-            safe_warn!(
-                safe: ("Could not resolve bundled skill ID, skipping skill"),
-                full: ("Could not resolve bundled skill ID from {}, skipping skill", skill.path.display_path())
-            );
-            continue;
-        };
-
-        // Apply variable substitution to the skill content.
-        skill.content = handlebars::render_template(&skill.content, &context);
-        skills.insert(skill_id.to_owned(), skill);
-    }
-
-    log::info!("Read {} bundled skills", skills.len());
-
-    skills
-}
-
-/// Builds the context map for bundled skill variable substitution.
-///
-/// Supported variables:
-/// - `{{warp_server_url}}` - The server root URL (e.g., `https://api.warp.dev`)
-/// - `{{warp_cli_binary_name}}` - The CLI binary name (e.g., `warp` or `warp-cli`)
-/// - `{{warp_url_scheme}}` - The URL scheme (e.g., `warp`, `warpdev`, `warppreview`)
-/// - `{{settings_schema_path}}` - Path to the bundled JSON settings schema
-/// - `{{settings_file_path}}` - Path to the user's settings TOML file
-/// - `{{keybindings_file_path}}` - Path to the user's keybindings YAML file
-fn build_bundled_skill_context() -> HashMap<String, String> {
-    let mut context: HashMap<String, String> = [
-        (
-            "warp_server_url".to_owned(),
-            ChannelState::server_root_url().into_owned(),
-        ),
-        (
-            "warp_cli_binary_name".to_owned(),
-            ChannelState::channel().cli_command_name().to_owned(),
-        ),
-        (
-            "warp_url_scheme".to_owned(),
-            ChannelState::url_scheme().to_owned(),
-        ),
-        (
-            "settings_file_path".to_owned(),
-            user_preferences_toml_file_path().display().to_string(),
-        ),
-        (
-            "keybindings_file_path".to_owned(),
-            keybinding_file_path().display().to_string(),
-        ),
-    ]
-    .into_iter()
-    .collect();
-
-    if let Some(schema_path) =
-        warp_core::paths::bundled_resources_dir().map(|dir| dir.join("settings_schema.json"))
-    {
-        context.insert(
-            "settings_schema_path".to_owned(),
-            schema_path.display().to_string(),
-        );
-    }
-
-    context
-}
-
-/// Returns the icon for a bundled skill, given its directory-based ID.
-/// Skills with a known brand (e.g. `pr-comments` → GitHub) get a
-/// branded icon; everything else falls back to the Warp logo.
-fn icon_for_bundled_skill(skill_id: &str) -> Icon {
-    match skill_id {
-        "pr-comments" => Icon::Github,
-        _ => Icon::WarpLogoLight,
-    }
-}
-
-/// Returns the activation condition for a bundled skill.
-///
-/// Most skills are always active. Skills that depend on a bundled resource
-/// file use `RequiresFile` so they only appear when the resource is present.
-fn activation_for_bundled_skill(skill_id: &str, resources_dir: &Path) -> BundledSkillActivation {
-    match skill_id {
-        "modify-settings" => {
-            BundledSkillActivation::RequiresFile(resources_dir.join("settings_schema.json"))
-        }
-        _ => BundledSkillActivation::Always,
     }
 }
 

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -8,18 +8,13 @@ pub use file_watchers::{
     extract_skill_parent_directory, read_skills_from_directories, SkillWatcher, SkillWatcherEvent,
 };
 use warp_core::features::FeatureFlag;
-use warp_core::ui::icons::Icon;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
+use super::bundled::BundledSkill;
 #[cfg(test)]
-use super::bundled::build_bundled_skill_context;
-use super::bundled::{
-    icon_for_bundled_skill, load_bundled_skills, read_bundled_skills, BundledSkill,
-    BundledSkillActivation,
-};
+use super::bundled::{build_bundled_skill_context, read_bundled_skills, BundledSkillActivation};
 use super::{SkillDescriptor, SkillPathQuery};
-use crate::ai::mcp::McpIntegration;
 use crate::ai::skills::skill_utils::unique_skills;
 
 pub struct SkillManager {
@@ -39,8 +34,8 @@ pub struct SkillManager {
     /// Reverse lookup: skill name → set of paths with that name.
     /// This allows efficient lookup by skill name without scanning all paths.
     skills_by_name: HashMap<String, HashSet<LocalOrRemotePath>>,
-    /// Skills bundled into Warp, each with activation condition and icon.
-    bundled_skills: HashMap<String, BundledSkill>,
+    /// Skills bundled into Warp for the local host.
+    bundled_skill: BundledSkill,
     /// When true, all skills in `directory_skills` are in scope regardless of
     /// the current working directory. Set by `AgentDriver` when a cloud
     /// environment with configured repos is active, so the agent sees every
@@ -66,11 +61,8 @@ impl SkillManager {
         let skill_watcher = ctx.add_model(|ctx| SkillWatcher::new(ctx, skill_watcher_tx));
 
         if FeatureFlag::BundledSkills.is_enabled() {
-            ctx.spawn(load_bundled_skills(), |me, result, _| {
-                me.bundled_skills = result;
-            });
-            ctx.spawn(Self::load_figma_skills(), |me, figma_skills, _| {
-                me.bundled_skills.extend(figma_skills);
+            ctx.spawn(BundledSkill::detect(), |me, result, _| {
+                me.bundled_skill = result;
             });
         }
 
@@ -78,7 +70,7 @@ impl SkillManager {
             directory_skills: HashMap::new(),
             skills_by_path: HashMap::new(),
             skills_by_name: HashMap::new(),
-            bundled_skills: HashMap::new(),
+            bundled_skill: BundledSkill::default(),
             is_cloud_environment: false,
             skill_watcher,
         }
@@ -170,18 +162,7 @@ impl SkillManager {
 
         // Append bundled skills whose activation condition is met.
         if FeatureFlag::BundledSkills.is_enabled() {
-            skills.extend(
-                self.bundled_skills
-                    .iter()
-                    .filter(|(_, bundled)| bundled.activation.is_enabled(ctx))
-                    .map(|(id, bundled)| {
-                        SkillDescriptor::new_bundled(
-                            id.clone(),
-                            bundled.skill.clone(),
-                            bundled.icon,
-                        )
-                    }),
-            );
+            skills.extend(self.bundled_skill.active_descriptors(ctx));
         }
 
         skills
@@ -318,10 +299,8 @@ impl SkillManager {
     ) -> SkillReference {
         let skill_path = skill_path.to_skill_location();
         // Check if this path belongs to a bundled skill.
-        for (id, bundled) in &self.bundled_skills {
-            if bundled.skill.path == skill_path {
-                return SkillReference::BundledSkillId(id.clone());
-            }
+        if let Some(reference) = self.bundled_skill.reference_for_path(&skill_path) {
+            return reference;
         }
         // Default to path-based reference.
         SkillReference::Path(skill_path)
@@ -331,9 +310,7 @@ impl SkillManager {
     pub fn skill_by_reference(&self, reference: &SkillReference) -> Option<&ParsedSkill> {
         match reference {
             SkillReference::Path(path) => self.skills_by_path.get(path),
-            SkillReference::BundledSkillId(id) => {
-                self.bundled_skills.get(id).map(|bundled| &bundled.skill)
-            }
+            SkillReference::BundledSkillId(id) => self.bundled_skill.skill(id),
         }
     }
 
@@ -355,8 +332,7 @@ impl SkillManager {
 
     /// Returns a bundled skill by ID only if its activation condition is met.
     pub fn active_bundled_skill(&self, id: &str, ctx: &AppContext) -> Option<&ParsedSkill> {
-        let bundled = self.bundled_skills.get(id)?;
-        bundled.activation.is_enabled(ctx).then_some(&bundled.skill)
+        self.bundled_skill.active_skill(id, ctx)
     }
 
     fn handle_skill_watcher_event(&mut self, event: SkillWatcherEvent) {
@@ -434,29 +410,6 @@ impl SkillManager {
         }
     }
 
-    /// Load Figma-specific bundled skills from the `figma/` subdirectory.
-    async fn load_figma_skills() -> HashMap<String, BundledSkill> {
-        let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
-            return HashMap::new();
-        };
-        let figma_skills_dir = resources_dir
-            .join("bundled")
-            .join("mcp_skills")
-            .join("figma");
-        read_bundled_skills(&figma_skills_dir)
-            .await
-            .into_iter()
-            .map(|(id, skill)| {
-                let bundled = BundledSkill {
-                    skill,
-                    activation: BundledSkillActivation::RequiresMcp(McpIntegration::Figma),
-                    icon: Icon::Figma,
-                };
-                (id, bundled)
-            })
-            .collect()
-    }
-
     /// Adds a skill to the skill manager for testing purposes.
     #[cfg(test)]
     pub fn add_skill_for_testing(&mut self, skill: ParsedSkill) {
@@ -474,15 +427,7 @@ impl SkillManager {
         skill: ParsedSkill,
         activation: BundledSkillActivation,
     ) {
-        let id = id.into();
-        self.bundled_skills.insert(
-            id.clone(),
-            BundledSkill {
-                skill,
-                activation,
-                icon: icon_for_bundled_skill(&id),
-            },
-        );
+        self.bundled_skill.insert_for_testing(id, skill, activation);
     }
 }
 


### PR DESCRIPTION
## Description

Introduces `BundledSkill`, a single-host catalog that owns bundled-skill detection, activation-filtered descriptors, path-to-reference resolution, and definition lookup.

`SkillManager` now delegates its existing local bundled-skill behavior to this catalog. This is a no-op refactor that establishes the abstraction used by the stacked remote-host support PR.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format --check`
- `cargo test -p warp --lib ai::skills::skill_manager::tests`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
