### PR TITLE
Install bundled skills globally on remote hosts and push daemon-parsed catalogs

### DIFF
--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -6,6 +6,7 @@ use futures::TryStreamExt;
 use warp_core::channel::ChannelState;
 use warp_core::ui::icons::Icon;
 use warp_core::{report_error, safe_warn};
+use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, SingletonEntity};
 
@@ -37,7 +38,54 @@ impl BundledSkillActivation {
     }
 }
 
-/// A bundled skill definition with its activation condition and icon.
+/// Catalogs of bundled skills for the local host and connected remote hosts.
+#[derive(Debug, Default)]
+pub struct BundledSkills {
+    local: BundledSkill,
+    remote_by_host: HashMap<HostId, BundledSkill>,
+}
+
+impl BundledSkills {
+    pub fn set_local(&mut self, bundled_skill: BundledSkill) {
+        self.local = bundled_skill;
+    }
+
+    pub fn local(&self) -> &BundledSkill {
+        &self.local
+    }
+
+    /// Installs the catalog for a connected remote host, replacing any
+    /// previous catalog from an earlier connection.
+    pub fn insert_remote(&mut self, host_id: HostId, bundled_skill: BundledSkill) {
+        self.remote_by_host.insert(host_id, bundled_skill);
+    }
+
+    /// Removes all catalog state for a disconnected remote host.
+    pub fn remove_remote(&mut self, host_id: &HostId) {
+        self.remote_by_host.remove(host_id);
+    }
+
+    /// Returns the catalog for a connected remote host.
+    ///
+    /// Agent Mode catalog selection is wired up in the stacked follow-up; until
+    /// then this read path is exercised by tests only.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn remote(&self, host_id: &HostId) -> Option<&BundledSkill> {
+        self.remote_by_host.get(host_id)
+    }
+
+    #[cfg(test)]
+    pub fn insert_local_for_testing(
+        &mut self,
+        id: impl Into<String>,
+        skill: ParsedSkill,
+        activation: BundledSkillActivation,
+    ) {
+        self.local.insert_for_testing(id, skill, activation);
+    }
+}
+
+/// One bundled skill definition with its activation condition and icon.
 #[derive(Debug, Clone)]
 struct BundledSkillDefinition {
     skill: ParsedSkill,
@@ -54,9 +102,21 @@ pub struct BundledSkill {
 impl BundledSkill {
     /// Detect all skill definitions bundled with Warp for the local host.
     pub async fn detect() -> Self {
+        let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
+            return Self::default();
+        };
+        Self::detect_for_resources_dir(LocalOrRemotePath::Local(resources_dir)).await
+    }
+
+    /// Detect all client-shipped skill definitions, rendering their paths for
+    /// the host that owns `resources_dir`.
+    pub async fn detect_for_resources_dir(resources_dir: LocalOrRemotePath) -> Self {
+        let Some(source_resources_dir) = warp_core::paths::bundled_resources_dir() else {
+            return Self::default();
+        };
         let (mut definitions, figma_definitions) = futures::join!(
-            load_bundled_skill_definitions(),
-            load_figma_skill_definitions()
+            load_bundled_skill_definitions(&source_resources_dir, &resources_dir),
+            load_figma_skill_definitions(&source_resources_dir, &resources_dir)
         );
         definitions.extend(figma_definitions);
         Self { definitions }
@@ -115,17 +175,18 @@ impl BundledSkill {
 }
 
 /// Load skill definitions bundled with Warp.
-async fn load_bundled_skill_definitions() -> HashMap<String, BundledSkillDefinition> {
-    let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
-        return HashMap::new();
-    };
-    let skills_dir = resources_dir.join("bundled").join("skills");
-    read_bundled_skills(&skills_dir)
+async fn load_bundled_skill_definitions(
+    source_resources_dir: &Path,
+    resources_dir: &LocalOrRemotePath,
+) -> HashMap<String, BundledSkillDefinition> {
+    let skills_dir = source_resources_dir.join("bundled").join("skills");
+    let host_skills_dir = resources_dir.join("bundled").join("skills");
+    read_bundled_skills(&skills_dir, &host_skills_dir, resources_dir)
         .await
         .into_iter()
         .map(|(id, skill)| {
             let icon = icon_for_bundled_skill(&id);
-            let activation = activation_for_bundled_skill(&id, &resources_dir);
+            let activation = activation_for_bundled_skill(&id, source_resources_dir);
             let bundled = BundledSkillDefinition {
                 skill,
                 activation,
@@ -137,15 +198,19 @@ async fn load_bundled_skill_definitions() -> HashMap<String, BundledSkillDefinit
 }
 
 /// Load Figma-specific bundled skills from the `figma/` subdirectory.
-async fn load_figma_skill_definitions() -> HashMap<String, BundledSkillDefinition> {
-    let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
-        return HashMap::new();
-    };
-    let figma_skills_dir = resources_dir
+async fn load_figma_skill_definitions(
+    source_resources_dir: &Path,
+    resources_dir: &LocalOrRemotePath,
+) -> HashMap<String, BundledSkillDefinition> {
+    let figma_skills_dir = source_resources_dir
         .join("bundled")
         .join("mcp_skills")
         .join("figma");
-    read_bundled_skills(&figma_skills_dir)
+    let host_figma_skills_dir = resources_dir
+        .join("bundled")
+        .join("mcp_skills")
+        .join("figma");
+    read_bundled_skills(&figma_skills_dir, &host_figma_skills_dir, resources_dir)
         .await
         .into_iter()
         .map(|(id, skill)| {
@@ -160,9 +225,12 @@ async fn load_figma_skill_definitions() -> HashMap<String, BundledSkillDefinitio
 }
 
 /// Read bundled skill definitions from the specified directory.
-pub(crate) async fn read_bundled_skills(skills_dir: &Path) -> HashMap<String, ParsedSkill> {
+pub(crate) async fn read_bundled_skills(
+    skills_dir: &Path,
+    host_skills_dir: &LocalOrRemotePath,
+    resources_dir: &LocalOrRemotePath,
+) -> HashMap<String, ParsedSkill> {
     let mut skills = HashMap::new();
-    let context = build_bundled_skill_context();
 
     let Ok(mut entries) = async_fs::read_dir(skills_dir).await else {
         return skills;
@@ -194,9 +262,12 @@ pub(crate) async fn read_bundled_skills(skills_dir: &Path) -> HashMap<String, Pa
             );
             continue;
         };
+        let host_skill_dir = host_skills_dir.join(skill_id);
+        let context = build_bundled_skill_context(resources_dir, &host_skill_dir);
 
         // Apply variable substitution to the skill content.
         skill.content = handlebars::render_template(&skill.content, &context);
+        skill.path = host_skill_dir.join("SKILL.md");
         skills.insert(skill_id.to_owned(), skill);
     }
 
@@ -212,10 +283,14 @@ pub(crate) async fn read_bundled_skills(skills_dir: &Path) -> HashMap<String, Pa
 /// - `{{warp_cli_binary_name}}` - The CLI binary name (e.g., `warp` or `warp-cli`)
 /// - `{{warp_url_scheme}}` - The URL scheme (e.g., `warp`, `warpdev`, `warppreview`)
 /// - `{{settings_schema_path}}` - Path to the bundled JSON settings schema
+/// - `{{skill_dir}}` - Path to the bundled skill's directory
 /// - `{{settings_file_path}}` - Path to the user's settings TOML file
 /// - `{{keybindings_file_path}}` - Path to the user's keybindings YAML file
-pub(crate) fn build_bundled_skill_context() -> HashMap<String, String> {
-    let mut context: HashMap<String, String> = [
+pub(crate) fn build_bundled_skill_context(
+    resources_dir: &LocalOrRemotePath,
+    skill_dir: &LocalOrRemotePath,
+) -> HashMap<String, String> {
+    [
         (
             "warp_server_url".to_owned(),
             ChannelState::server_root_url().into_owned(),
@@ -236,20 +311,14 @@ pub(crate) fn build_bundled_skill_context() -> HashMap<String, String> {
             "keybindings_file_path".to_owned(),
             keybinding_file_path().display().to_string(),
         ),
+        (
+            "settings_schema_path".to_owned(),
+            resources_dir.join("settings_schema.json").display_path(),
+        ),
+        ("skill_dir".to_owned(), skill_dir.display_path()),
     ]
     .into_iter()
-    .collect();
-
-    if let Some(schema_path) =
-        warp_core::paths::bundled_resources_dir().map(|dir| dir.join("settings_schema.json"))
-    {
-        context.insert(
-            "settings_schema_path".to_owned(),
-            schema_path.display().to_string(),
-        );
-    }
-
-    context
+    .collect()
 }
 
 /// Returns the icon for a bundled skill, given its directory-based ID.
@@ -274,3 +343,7 @@ fn activation_for_bundled_skill(skill_id: &str, resources_dir: &Path) -> Bundled
         _ => BundledSkillActivation::Always,
     }
 }
+
+#[cfg(test)]
+#[path = "bundled_tests.rs"]
+mod tests;

--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -66,12 +66,37 @@ impl BundledSkills {
     }
 
     /// Returns the catalog for a connected remote host.
-    ///
-    /// Agent Mode catalog selection is wired up in the stacked follow-up; until
-    /// then this read path is exercised by tests only.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn remote(&self, host_id: &HostId) -> Option<&BundledSkill> {
         self.remote_by_host.get(host_id)
+    }
+
+    /// Returns the remote catalog skill matching `path`, looked up in the
+    /// catalog of the host that owns the path. Remote bundled skills are
+    /// addressed by path (their paths are real files on the remote host),
+    /// unlike local bundled skills which are addressed by
+    /// [`SkillReference::BundledSkillId`].
+    pub fn remote_skill_by_path(&self, path: &LocalOrRemotePath) -> Option<&ParsedSkill> {
+        let LocalOrRemotePath::Remote(remote_path) = path else {
+            return None;
+        };
+        self.remote_by_host
+            .get(&remote_path.host_id)?
+            .skill_by_path(path)
+    }
+
+    /// Like [`Self::remote_skill_by_path`], but only returns the skill when
+    /// its activation condition is met.
+    pub fn remote_active_skill_by_path(
+        &self,
+        path: &LocalOrRemotePath,
+        ctx: &AppContext,
+    ) -> Option<&ParsedSkill> {
+        let LocalOrRemotePath::Remote(remote_path) = path else {
+            return None;
+        };
+        self.remote_by_host
+            .get(&remote_path.host_id)?
+            .active_skill_by_path(path, ctx)
     }
 
     #[cfg(test)]
@@ -105,18 +130,19 @@ impl BundledSkill {
         let Some(resources_dir) = warp_core::paths::bundled_resources_dir() else {
             return Self::default();
         };
-        Self::detect_for_resources_dir(LocalOrRemotePath::Local(resources_dir)).await
+        Self::detect_in_resources_dir(resources_dir).await
     }
 
-    /// Detect all client-shipped skill definitions, rendering their paths for
-    /// the host that owns `resources_dir`.
-    pub async fn detect_for_resources_dir(resources_dir: LocalOrRemotePath) -> Self {
-        let Some(source_resources_dir) = warp_core::paths::bundled_resources_dir() else {
-            return Self::default();
-        };
+    /// Detect all skill definitions under the given resources root on the
+    /// local filesystem, rendering skill content against this host.
+    ///
+    /// Called directly by the remote-server daemon, whose resources live at
+    /// the global install location rather than inside an app bundle (which
+    /// is what [`warp_core::paths::bundled_resources_dir`] resolves).
+    pub(crate) async fn detect_in_resources_dir(resources_dir: PathBuf) -> Self {
         let (mut definitions, figma_definitions) = futures::join!(
-            load_bundled_skill_definitions(&source_resources_dir, &resources_dir),
-            load_figma_skill_definitions(&source_resources_dir, &resources_dir)
+            load_bundled_skill_definitions(&resources_dir),
+            load_figma_skill_definitions(&resources_dir)
         );
         definitions.extend(figma_definitions);
         Self { definitions }
@@ -155,6 +181,62 @@ impl BundledSkill {
             .then_some(&definition.skill)
     }
 
+    /// Returns a bundled skill by its `SKILL.md` path.
+    pub fn skill_by_path(&self, path: &LocalOrRemotePath) -> Option<&ParsedSkill> {
+        self.definitions
+            .values()
+            .map(|definition| &definition.skill)
+            .find(|skill| skill.path == *path)
+    }
+
+    /// Returns a bundled skill by its `SKILL.md` path only if its activation
+    /// condition is met.
+    pub fn active_skill_by_path(
+        &self,
+        path: &LocalOrRemotePath,
+        ctx: &AppContext,
+    ) -> Option<&ParsedSkill> {
+        self.definitions
+            .values()
+            .find(|definition| definition.skill.path == *path)
+            .filter(|definition| definition.activation.is_enabled(ctx))
+            .map(|definition| &definition.skill)
+    }
+
+    /// Builds a catalog from pre-parsed definitions. Used for catalogs
+    /// received from a remote host's daemon, which parses and renders the
+    /// skills against its own filesystem.
+    pub(crate) fn from_definitions(
+        definitions: impl IntoIterator<Item = (String, ParsedSkill, BundledSkillActivation)>,
+    ) -> Self {
+        let definitions = definitions
+            .into_iter()
+            .map(|(id, skill, activation)| {
+                let icon = icon_for_bundled_skill(&id);
+                (
+                    id,
+                    BundledSkillDefinition {
+                        skill,
+                        activation,
+                        icon,
+                    },
+                )
+            })
+            .collect();
+        Self { definitions }
+    }
+
+    /// Iterates the catalog's definitions as `(id, skill, activation)`.
+    /// Used by the daemon to serialize its catalog for the
+    /// `BundledSkillsSnapshot` push.
+    pub(crate) fn iter_definitions(
+        &self,
+    ) -> impl Iterator<Item = (&str, &ParsedSkill, &BundledSkillActivation)> {
+        self.definitions
+            .iter()
+            .map(|(id, definition)| (id.as_str(), &definition.skill, &definition.activation))
+    }
+
     #[cfg(test)]
     pub fn insert_for_testing(
         &mut self,
@@ -176,17 +258,15 @@ impl BundledSkill {
 
 /// Load skill definitions bundled with Warp.
 async fn load_bundled_skill_definitions(
-    source_resources_dir: &Path,
-    resources_dir: &LocalOrRemotePath,
+    resources_dir: &Path,
 ) -> HashMap<String, BundledSkillDefinition> {
-    let skills_dir = source_resources_dir.join("bundled").join("skills");
-    let host_skills_dir = resources_dir.join("bundled").join("skills");
-    read_bundled_skills(&skills_dir, &host_skills_dir, resources_dir)
+    let skills_dir = resources_dir.join("bundled").join("skills");
+    read_bundled_skills(&skills_dir, resources_dir)
         .await
         .into_iter()
         .map(|(id, skill)| {
             let icon = icon_for_bundled_skill(&id);
-            let activation = activation_for_bundled_skill(&id, source_resources_dir);
+            let activation = activation_for_bundled_skill(&id, resources_dir);
             let bundled = BundledSkillDefinition {
                 skill,
                 activation,
@@ -199,18 +279,13 @@ async fn load_bundled_skill_definitions(
 
 /// Load Figma-specific bundled skills from the `figma/` subdirectory.
 async fn load_figma_skill_definitions(
-    source_resources_dir: &Path,
-    resources_dir: &LocalOrRemotePath,
+    resources_dir: &Path,
 ) -> HashMap<String, BundledSkillDefinition> {
-    let figma_skills_dir = source_resources_dir
+    let figma_skills_dir = resources_dir
         .join("bundled")
         .join("mcp_skills")
         .join("figma");
-    let host_figma_skills_dir = resources_dir
-        .join("bundled")
-        .join("mcp_skills")
-        .join("figma");
-    read_bundled_skills(&figma_skills_dir, &host_figma_skills_dir, resources_dir)
+    read_bundled_skills(&figma_skills_dir, resources_dir)
         .await
         .into_iter()
         .map(|(id, skill)| {
@@ -224,11 +299,12 @@ async fn load_figma_skill_definitions(
         .collect()
 }
 
-/// Read bundled skill definitions from the specified directory.
+/// Read bundled skill definitions from the specified directory, rendering
+/// handlebars variables against this host's filesystem (`resources_dir` is
+/// the resources root the skills belong to).
 pub(crate) async fn read_bundled_skills(
     skills_dir: &Path,
-    host_skills_dir: &LocalOrRemotePath,
-    resources_dir: &LocalOrRemotePath,
+    resources_dir: &Path,
 ) -> HashMap<String, ParsedSkill> {
     let mut skills = HashMap::new();
 
@@ -262,12 +338,10 @@ pub(crate) async fn read_bundled_skills(
             );
             continue;
         };
-        let host_skill_dir = host_skills_dir.join(skill_id);
-        let context = build_bundled_skill_context(resources_dir, &host_skill_dir);
+        let context = build_bundled_skill_context(resources_dir, &entry_path);
 
         // Apply variable substitution to the skill content.
         skill.content = handlebars::render_template(&skill.content, &context);
-        skill.path = host_skill_dir.join("SKILL.md");
         skills.insert(skill_id.to_owned(), skill);
     }
 
@@ -287,8 +361,8 @@ pub(crate) async fn read_bundled_skills(
 /// - `{{settings_file_path}}` - Path to the user's settings TOML file
 /// - `{{keybindings_file_path}}` - Path to the user's keybindings YAML file
 pub(crate) fn build_bundled_skill_context(
-    resources_dir: &LocalOrRemotePath,
-    skill_dir: &LocalOrRemotePath,
+    resources_dir: &Path,
+    skill_dir: &Path,
 ) -> HashMap<String, String> {
     [
         (
@@ -313,9 +387,12 @@ pub(crate) fn build_bundled_skill_context(
         ),
         (
             "settings_schema_path".to_owned(),
-            resources_dir.join("settings_schema.json").display_path(),
+            resources_dir
+                .join("settings_schema.json")
+                .display()
+                .to_string(),
         ),
-        ("skill_dir".to_owned(), skill_dir.display_path()),
+        ("skill_dir".to_owned(), skill_dir.display().to_string()),
     ]
     .into_iter()
     .collect()

--- a/app/src/ai/skills/bundled_tests.rs
+++ b/app/src/ai/skills/bundled_tests.rs
@@ -1,0 +1,75 @@
+use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+
+use super::*;
+
+fn bundled_skill(content: &str) -> BundledSkill {
+    let mut bundled_skill = BundledSkill::default();
+    bundled_skill.insert_for_testing(
+        "test-skill",
+        ParsedSkill {
+            name: "test-skill".to_string(),
+            description: "Test skill".to_string(),
+            path: LocalOrRemotePath::Local("/bundled/skills/test-skill/SKILL.md".into()),
+            content: content.to_string(),
+            line_range: None,
+            provider: SkillProvider::Warp,
+            scope: SkillScope::Bundled,
+        },
+        BundledSkillActivation::Always,
+    );
+    bundled_skill
+}
+
+fn remote_content<'a>(bundled_skills: &'a BundledSkills, host_id: &HostId) -> Option<&'a str> {
+    bundled_skills
+        .remote(host_id)?
+        .skill("test-skill")
+        .map(|skill| skill.content.as_str())
+}
+
+#[test]
+fn local_and_remote_catalogs_are_isolated() {
+    let first_host_id = HostId::new("first-host".to_string());
+    let second_host_id = HostId::new("second-host".to_string());
+    let mut bundled_skills = BundledSkills::default();
+    bundled_skills.set_local(bundled_skill("local"));
+    bundled_skills.insert_remote(first_host_id.clone(), bundled_skill("first"));
+    bundled_skills.insert_remote(second_host_id.clone(), bundled_skill("second"));
+
+    assert_eq!(
+        bundled_skills
+            .local()
+            .skill("test-skill")
+            .map(|skill| skill.content.as_str()),
+        Some("local")
+    );
+    assert_eq!(remote_content(&bundled_skills, &first_host_id), Some("first"));
+    assert_eq!(
+        remote_content(&bundled_skills, &second_host_id),
+        Some("second")
+    );
+
+    // A reconnect refresh replaces the host's catalog wholesale.
+    bundled_skills.insert_remote(first_host_id.clone(), bundled_skill("first-refreshed"));
+    assert_eq!(
+        remote_content(&bundled_skills, &first_host_id),
+        Some("first-refreshed")
+    );
+
+    // Disconnecting one host leaves the local and sibling-host catalogs intact.
+    bundled_skills.remove_remote(&first_host_id);
+    assert_eq!(
+        bundled_skills
+            .local()
+            .skill("test-skill")
+            .map(|skill| skill.content.as_str()),
+        Some("local")
+    );
+    assert_eq!(remote_content(&bundled_skills, &first_host_id), None);
+    assert_eq!(
+        remote_content(&bundled_skills, &second_host_id),
+        Some("second")
+    );
+}

--- a/app/src/ai/skills/bundled_tests.rs
+++ b/app/src/ai/skills/bundled_tests.rs
@@ -45,7 +45,10 @@ fn local_and_remote_catalogs_are_isolated() {
             .map(|skill| skill.content.as_str()),
         Some("local")
     );
-    assert_eq!(remote_content(&bundled_skills, &first_host_id), Some("first"));
+    assert_eq!(
+        remote_content(&bundled_skills, &first_host_id),
+        Some("first")
+    );
     assert_eq!(
         remote_content(&bundled_skills, &second_host_id),
         Some("second")

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -4,6 +4,10 @@ use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 mod telemetry;
 pub use telemetry::{SkillOpenOrigin, SkillTelemetryEvent};
+#[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
+mod remote;
+#[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
+pub(crate) use remote::wire_remote_bundled_skills;
 #[cfg(feature = "local_fs")]
 mod bundled;
 #[cfg(all(feature = "local_fs", test))]

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -7,9 +7,11 @@ pub use telemetry::{SkillOpenOrigin, SkillTelemetryEvent};
 #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
 mod remote;
 #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
-pub(crate) use remote::wire_remote_bundled_skills;
+pub(crate) use remote::{bundled_skills_snapshot_protos, wire_remote_bundled_skills};
 #[cfg(feature = "local_fs")]
 mod bundled;
+#[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
+pub(crate) use bundled::BundledSkill;
 #[cfg(all(feature = "local_fs", test))]
 pub use bundled::BundledSkillActivation;
 

--- a/app/src/ai/skills/remote.rs
+++ b/app/src/ai/skills/remote.rs
@@ -1,0 +1,100 @@
+use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
+use warp_core::features::FeatureFlag;
+use warp_util::host_id::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
+use warpui::{AppContext, ModelContext, SingletonEntity};
+
+use super::bundled::BundledSkill;
+use super::SkillManager;
+
+pub(crate) fn wire_remote_bundled_skills(ctx: &mut AppContext) {
+    SkillManager::handle(ctx).update(ctx, |manager, ctx| {
+        manager.subscribe_to_remote_bundled_skills(ctx);
+    });
+}
+
+impl SkillManager {
+    fn subscribe_to_remote_bundled_skills(&mut self, ctx: &mut ModelContext<Self>) {
+        let remote_server_manager = RemoteServerManager::handle(ctx);
+        ctx.subscribe_to_model(&remote_server_manager, |me, event, ctx| match event {
+            RemoteServerManagerEvent::HostConnected { host_id } => {
+                me.bootstrap_remote_bundled_skill(host_id.clone(), ctx);
+            }
+            RemoteServerManagerEvent::HostDisconnected { host_id } => {
+                me.remove_remote_bundled_skill(host_id);
+            }
+            RemoteServerManagerEvent::SessionConnecting { .. }
+            | RemoteServerManagerEvent::SessionConnected { .. }
+            | RemoteServerManagerEvent::SessionConnectionFailed { .. }
+            | RemoteServerManagerEvent::SessionDisconnected { .. }
+            | RemoteServerManagerEvent::SessionReconnected { .. }
+            | RemoteServerManagerEvent::SessionDeregistered { .. }
+            | RemoteServerManagerEvent::NavigatedToDirectory { .. }
+            | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
+            | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
+            | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
+            | RemoteServerManagerEvent::CodebaseIndexStatusesSnapshot { .. }
+            | RemoteServerManagerEvent::CodebaseIndexStatusUpdated { .. }
+            | RemoteServerManagerEvent::BufferUpdated { .. }
+            | RemoteServerManagerEvent::BufferConflictDetected { .. }
+            | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
+            | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
+            | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. }
+            | RemoteServerManagerEvent::GetBranchesResponse { .. }
+            | RemoteServerManagerEvent::SetupStateChanged { .. }
+            | RemoteServerManagerEvent::BinaryCheckComplete { .. }
+            | RemoteServerManagerEvent::BinaryInstallComplete { .. }
+            | RemoteServerManagerEvent::ClientRequestFailed { .. }
+            | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
+            | RemoteServerManagerEvent::ServerMessageDecodingError { .. } => {}
+        });
+
+        let connected_host_ids = remote_server_manager
+            .as_ref(ctx)
+            .connected_host_ids()
+            .cloned()
+            .collect::<Vec<_>>();
+        for host_id in connected_host_ids {
+            self.bootstrap_remote_bundled_skill(host_id, ctx);
+        }
+    }
+
+    fn bootstrap_remote_bundled_skill(&mut self, host_id: HostId, ctx: &mut ModelContext<Self>) {
+        if !FeatureFlag::BundledSkills.is_enabled() {
+            return;
+        }
+        let Some(advertised_dir) = RemoteServerManager::as_ref(ctx)
+            .bundled_resources_dir_for_host(&host_id)
+            .map(str::to_owned)
+        else {
+            log::warn!("Remote host {host_id} did not advertise a bundled resources directory");
+            return;
+        };
+        let Ok(resources_dir) = StandardizedPath::try_new(&advertised_dir) else {
+            log::warn!(
+                "Remote host {host_id} advertised an invalid bundled resources directory: {advertised_dir}"
+            );
+            return;
+        };
+        let resources_dir =
+            LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), resources_dir));
+
+        ctx.spawn(
+            BundledSkill::detect_for_resources_dir(resources_dir),
+            move |me, bundled_skill, ctx| {
+                // Stale-completion guard: the advertised directory is cleared on
+                // final disconnect and may change across reconnects (e.g. after
+                // a daemon upgrade). Only install a catalog rendered against the
+                // host's current resources.
+                if RemoteServerManager::as_ref(ctx).bundled_resources_dir_for_host(&host_id)
+                    != Some(advertised_dir.as_str())
+                {
+                    return;
+                }
+                me.set_remote_bundled_skill(host_id, bundled_skill);
+            },
+        );
+    }
+}

--- a/app/src/ai/skills/remote.rs
+++ b/app/src/ai/skills/remote.rs
@@ -1,13 +1,17 @@
+use ai::skills::{parse_skill_content_at_location, SkillProvider, SkillScope};
 use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
+use remote_server::proto::BundledSkillProto;
 use warp_core::features::FeatureFlag;
+use warp_core::safe_warn;
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::{AppContext, ModelContext, SingletonEntity};
 
-use super::bundled::BundledSkill;
+use super::bundled::{BundledSkill, BundledSkillActivation};
 use super::SkillManager;
+use crate::ai::mcp::McpIntegration;
 
 pub(crate) fn wire_remote_bundled_skills(ctx: &mut AppContext) {
     SkillManager::handle(ctx).update(ctx, |manager, ctx| {
@@ -18,9 +22,17 @@ pub(crate) fn wire_remote_bundled_skills(ctx: &mut AppContext) {
 impl SkillManager {
     fn subscribe_to_remote_bundled_skills(&mut self, ctx: &mut ModelContext<Self>) {
         let remote_server_manager = RemoteServerManager::handle(ctx);
-        ctx.subscribe_to_model(&remote_server_manager, |me, event, ctx| match event {
-            RemoteServerManagerEvent::HostConnected { host_id } => {
-                me.bootstrap_remote_bundled_skill(host_id.clone(), ctx);
+        ctx.subscribe_to_model(&remote_server_manager, |me, event, _ctx| match event {
+            RemoteServerManagerEvent::BundledSkillsSnapshot { host_id, skills } => {
+                if !FeatureFlag::BundledSkills.is_enabled() {
+                    return;
+                }
+                // A fresh snapshot replaces any previous catalog for the
+                // host (e.g. after a reconnect following a daemon upgrade).
+                me.set_remote_bundled_skill(
+                    host_id.clone(),
+                    bundled_skill_from_protos(host_id, skills),
+                );
             }
             RemoteServerManagerEvent::HostDisconnected { host_id } => {
                 me.remove_remote_bundled_skill(host_id);
@@ -31,6 +43,7 @@ impl SkillManager {
             | RemoteServerManagerEvent::SessionDisconnected { .. }
             | RemoteServerManagerEvent::SessionReconnected { .. }
             | RemoteServerManagerEvent::SessionDeregistered { .. }
+            | RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::NavigatedToDirectory { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
@@ -43,6 +56,12 @@ impl SkillManager {
             | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
             | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. }
             | RemoteServerManagerEvent::GetBranchesResponse { .. }
+            | RemoteServerManagerEvent::CommitChainResponse { .. }
+            | RemoteServerManagerEvent::GitPushResponse { .. }
+            | RemoteServerManagerEvent::CreatePrResponse { .. }
+            | RemoteServerManagerEvent::GenerateCommitMessageResponse { .. }
+            | RemoteServerManagerEvent::GetPrInfoResponse { .. }
+            | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. }
             | RemoteServerManagerEvent::SetupStateChanged { .. }
             | RemoteServerManagerEvent::BinaryCheckComplete { .. }
             | RemoteServerManagerEvent::BinaryInstallComplete { .. }
@@ -50,51 +69,107 @@ impl SkillManager {
             | RemoteServerManagerEvent::CodebaseIndexMutationFailed { .. }
             | RemoteServerManagerEvent::ServerMessageDecodingError { .. } => {}
         });
-
-        let connected_host_ids = remote_server_manager
-            .as_ref(ctx)
-            .connected_host_ids()
-            .cloned()
-            .collect::<Vec<_>>();
-        for host_id in connected_host_ids {
-            self.bootstrap_remote_bundled_skill(host_id, ctx);
-        }
-    }
-
-    fn bootstrap_remote_bundled_skill(&mut self, host_id: HostId, ctx: &mut ModelContext<Self>) {
-        if !FeatureFlag::BundledSkills.is_enabled() {
-            return;
-        }
-        let Some(advertised_dir) = RemoteServerManager::as_ref(ctx)
-            .bundled_resources_dir_for_host(&host_id)
-            .map(str::to_owned)
-        else {
-            log::warn!("Remote host {host_id} did not advertise a bundled resources directory");
-            return;
-        };
-        let Ok(resources_dir) = StandardizedPath::try_new(&advertised_dir) else {
-            log::warn!(
-                "Remote host {host_id} advertised an invalid bundled resources directory: {advertised_dir}"
-            );
-            return;
-        };
-        let resources_dir =
-            LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), resources_dir));
-
-        ctx.spawn(
-            BundledSkill::detect_for_resources_dir(resources_dir),
-            move |me, bundled_skill, ctx| {
-                // Stale-completion guard: the advertised directory is cleared on
-                // final disconnect and may change across reconnects (e.g. after
-                // a daemon upgrade). Only install a catalog rendered against the
-                // host's current resources.
-                if RemoteServerManager::as_ref(ctx).bundled_resources_dir_for_host(&host_id)
-                    != Some(advertised_dir.as_str())
-                {
-                    return;
-                }
-                me.set_remote_bundled_skill(host_id, bundled_skill);
-            },
-        );
     }
 }
+
+/// Stable wire identifier for an MCP integration in [`BundledSkillProto`].
+fn mcp_integration_wire_id(integration: McpIntegration) -> &'static str {
+    match integration {
+        McpIntegration::Figma => "figma",
+    }
+}
+
+fn mcp_integration_from_wire_id(wire_id: &str) -> Option<McpIntegration> {
+    match wire_id {
+        "figma" => Some(McpIntegration::Figma),
+        _ => None,
+    }
+}
+
+/// Converts a daemon-pushed snapshot into a catalog whose skill paths are
+/// remote paths on `host_id`.
+fn bundled_skill_from_protos(host_id: &HostId, skills: &[BundledSkillProto]) -> BundledSkill {
+    let definitions = skills.iter().filter_map(|proto| {
+        let path = match StandardizedPath::try_new(&proto.path) {
+            Ok(path) => LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), path)),
+            Err(_) => {
+                safe_warn!(
+                    safe: ("Skipping bundled skill with an invalid remote path"),
+                    full: ("Skipping bundled skill {} with an invalid remote path: {}", proto.id, proto.path)
+                );
+                return None;
+            }
+        };
+        // Re-parse the daemon-rendered content so name, description, and
+        // line range are derived exactly as they are for local skills.
+        let skill = match parse_skill_content_at_location(
+            path,
+            &proto.content,
+            SkillProvider::Warp,
+            SkillScope::Bundled,
+        ) {
+            Ok(skill) => skill,
+            Err(err) => {
+                safe_warn!(
+                    safe: ("Skipping bundled skill that failed to parse"),
+                    full: ("Skipping bundled skill {} that failed to parse: {err:#}", proto.id)
+                );
+                return None;
+            }
+        };
+        let activation = match proto.requires_mcp.as_deref() {
+            None => BundledSkillActivation::Always,
+            Some(wire_id) => match mcp_integration_from_wire_id(wire_id) {
+                Some(integration) => BundledSkillActivation::RequiresMcp(integration),
+                None => {
+                    // Unknown integration (e.g. a newer daemon): the client
+                    // cannot evaluate the condition, so skip the skill.
+                    safe_warn!(
+                        safe: ("Skipping bundled skill with an unknown MCP integration"),
+                        full: ("Skipping bundled skill {} with an unknown MCP integration: {wire_id}", proto.id)
+                    );
+                    return None;
+                }
+            },
+        };
+        Some((proto.id.clone(), skill, activation))
+    });
+    BundledSkill::from_definitions(definitions)
+}
+
+/// Serializes a daemon-side catalog for the `BundledSkillsSnapshot` push.
+///
+/// `RequiresFile` activations are evaluated here — the daemon owns the
+/// files — so the client only ever receives `Always` or `RequiresMcp`
+/// conditions.
+pub(crate) fn bundled_skills_snapshot_protos(catalog: &BundledSkill) -> Vec<BundledSkillProto> {
+    catalog
+        .iter_definitions()
+        .filter_map(|(id, skill, activation)| {
+            let requires_mcp = match activation {
+                BundledSkillActivation::Always => None,
+                BundledSkillActivation::RequiresMcp(integration) => {
+                    Some(mcp_integration_wire_id(*integration).to_owned())
+                }
+                BundledSkillActivation::RequiresFile(path) => {
+                    if !path.exists() {
+                        return None;
+                    }
+                    None
+                }
+            };
+            Some(BundledSkillProto {
+                id: id.to_owned(),
+                name: skill.name.clone(),
+                description: skill.description.clone(),
+                path: skill.path.display_path(),
+                content: skill.content.clone(),
+                requires_mcp,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "remote_tests.rs"]
+mod tests;

--- a/app/src/ai/skills/remote_tests.rs
+++ b/app/src/ai/skills/remote_tests.rs
@@ -1,0 +1,133 @@
+use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
+use tempfile::TempDir;
+
+use super::*;
+
+fn daemon_skill(id: &str, content: &str) -> ParsedSkill {
+    ParsedSkill {
+        name: id.to_string(),
+        description: format!("{id} description"),
+        path: LocalOrRemotePath::Local(format!("/daemon/bundled/skills/{id}/SKILL.md").into()),
+        content: content.to_string(),
+        line_range: None,
+        provider: SkillProvider::Warp,
+        scope: SkillScope::Bundled,
+    }
+}
+
+#[test]
+fn snapshot_protos_serialize_activation_conditions() {
+    let temp_dir = TempDir::new().unwrap();
+    let present_file = temp_dir.path().join("settings_schema.json");
+    std::fs::write(&present_file, "{}").unwrap();
+    let missing_file = temp_dir.path().join("missing.json");
+
+    let catalog = BundledSkill::from_definitions([
+        (
+            "always-skill".to_string(),
+            daemon_skill("always-skill", "# always"),
+            BundledSkillActivation::Always,
+        ),
+        (
+            "figma-skill".to_string(),
+            daemon_skill("figma-skill", "# figma"),
+            BundledSkillActivation::RequiresMcp(McpIntegration::Figma),
+        ),
+        (
+            "file-present-skill".to_string(),
+            daemon_skill("file-present-skill", "# file"),
+            BundledSkillActivation::RequiresFile(present_file),
+        ),
+        (
+            "file-missing-skill".to_string(),
+            daemon_skill("file-missing-skill", "# missing"),
+            BundledSkillActivation::RequiresFile(missing_file),
+        ),
+    ]);
+
+    let mut protos = bundled_skills_snapshot_protos(&catalog);
+    protos.sort_by(|a, b| a.id.cmp(&b.id));
+
+    // `RequiresFile` is evaluated daemon-side: the missing-file skill is
+    // dropped, the present-file skill ships as unconditionally active.
+    let ids: Vec<&str> = protos.iter().map(|proto| proto.id.as_str()).collect();
+    assert_eq!(ids, ["always-skill", "figma-skill", "file-present-skill"]);
+
+    let figma = protos
+        .iter()
+        .find(|proto| proto.id == "figma-skill")
+        .unwrap();
+    assert_eq!(figma.requires_mcp.as_deref(), Some("figma"));
+    for proto in protos.iter().filter(|proto| proto.id != "figma-skill") {
+        assert_eq!(proto.requires_mcp, None);
+    }
+
+    let always = protos
+        .iter()
+        .find(|proto| proto.id == "always-skill")
+        .unwrap();
+    assert_eq!(always.path, "/daemon/bundled/skills/always-skill/SKILL.md");
+    assert_eq!(always.content, "# always");
+}
+
+#[test]
+fn bundled_skill_from_protos_builds_host_scoped_catalog() {
+    let host_id = HostId::new("remote-host".to_string());
+    let protos = vec![
+        BundledSkillProto {
+            id: "test-skill".to_string(),
+            name: "ignored".to_string(),
+            description: "ignored".to_string(),
+            path: "/remote/bundled/skills/test-skill/SKILL.md".to_string(),
+            content: "---\nname: test-skill\ndescription: A test skill\n---\nbody".to_string(),
+            requires_mcp: None,
+        },
+        BundledSkillProto {
+            id: "figma-skill".to_string(),
+            name: "figma-skill".to_string(),
+            description: "Figma helper".to_string(),
+            path: "/remote/bundled/skills/figma-skill/SKILL.md".to_string(),
+            content: "# figma".to_string(),
+            requires_mcp: Some("figma".to_string()),
+        },
+        // Unknown integration (e.g. a newer daemon): the client cannot
+        // evaluate the condition, so the skill is skipped.
+        BundledSkillProto {
+            id: "unknown-mcp-skill".to_string(),
+            name: "unknown-mcp-skill".to_string(),
+            description: "Unknown".to_string(),
+            path: "/remote/bundled/skills/unknown-mcp-skill/SKILL.md".to_string(),
+            content: "# unknown".to_string(),
+            requires_mcp: Some("not-a-real-integration".to_string()),
+        },
+        // Invalid (relative) path: skipped.
+        BundledSkillProto {
+            id: "bad-path-skill".to_string(),
+            name: "bad-path-skill".to_string(),
+            description: "Bad path".to_string(),
+            path: "relative/SKILL.md".to_string(),
+            content: "# bad".to_string(),
+            requires_mcp: None,
+        },
+    ];
+
+    let catalog = bundled_skill_from_protos(&host_id, &protos);
+
+    let skill = catalog.skill("test-skill").expect("test-skill present");
+    // The skill's identity is re-parsed from the daemon-rendered content.
+    assert_eq!(skill.name, "test-skill");
+    assert_eq!(skill.description, "A test skill");
+    assert_eq!(
+        skill.path,
+        LocalOrRemotePath::Remote(RemotePath::new(
+            host_id.clone(),
+            StandardizedPath::try_new("/remote/bundled/skills/test-skill/SKILL.md").unwrap(),
+        ))
+    );
+    assert_eq!(skill.scope, SkillScope::Bundled);
+    assert_eq!(skill.provider, SkillProvider::Warp);
+
+    assert!(catalog.skill("figma-skill").is_some());
+    assert!(catalog.skill("unknown-mcp-skill").is_none());
+    assert!(catalog.skill("bad-path-skill").is_none());
+}

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -8,12 +8,13 @@ pub use file_watchers::{
     extract_skill_parent_directory, read_skills_from_directories, SkillWatcher, SkillWatcherEvent,
 };
 use warp_core::features::FeatureFlag;
+use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
-use super::bundled::BundledSkill;
 #[cfg(test)]
 use super::bundled::{build_bundled_skill_context, read_bundled_skills, BundledSkillActivation};
+use super::bundled::{BundledSkill, BundledSkills};
 use super::{SkillDescriptor, SkillPathQuery};
 use crate::ai::skills::skill_utils::unique_skills;
 
@@ -34,8 +35,8 @@ pub struct SkillManager {
     /// Reverse lookup: skill name → set of paths with that name.
     /// This allows efficient lookup by skill name without scanning all paths.
     skills_by_name: HashMap<String, HashSet<LocalOrRemotePath>>,
-    /// Skills bundled into Warp for the local host.
-    bundled_skill: BundledSkill,
+    /// Skills bundled into Warp for the local host and connected remote hosts.
+    bundled_skills: BundledSkills,
     /// When true, all skills in `directory_skills` are in scope regardless of
     /// the current working directory. Set by `AgentDriver` when a cloud
     /// environment with configured repos is active, so the agent sees every
@@ -62,7 +63,7 @@ impl SkillManager {
 
         if FeatureFlag::BundledSkills.is_enabled() {
             ctx.spawn(BundledSkill::detect(), |me, result, _| {
-                me.bundled_skill = result;
+                me.bundled_skills.set_local(result);
             });
         }
 
@@ -70,7 +71,7 @@ impl SkillManager {
             directory_skills: HashMap::new(),
             skills_by_path: HashMap::new(),
             skills_by_name: HashMap::new(),
-            bundled_skill: BundledSkill::default(),
+            bundled_skills: BundledSkills::default(),
             is_cloud_environment: false,
             skill_watcher,
         }
@@ -162,7 +163,7 @@ impl SkillManager {
 
         // Append bundled skills whose activation condition is met.
         if FeatureFlag::BundledSkills.is_enabled() {
-            skills.extend(self.bundled_skill.active_descriptors(ctx));
+            skills.extend(self.bundled_skills.local().active_descriptors(ctx));
         }
 
         skills
@@ -299,7 +300,7 @@ impl SkillManager {
     ) -> SkillReference {
         let skill_path = skill_path.to_skill_location();
         // Check if this path belongs to a bundled skill.
-        if let Some(reference) = self.bundled_skill.reference_for_path(&skill_path) {
+        if let Some(reference) = self.bundled_skills.local().reference_for_path(&skill_path) {
             return reference;
         }
         // Default to path-based reference.
@@ -310,7 +311,7 @@ impl SkillManager {
     pub fn skill_by_reference(&self, reference: &SkillReference) -> Option<&ParsedSkill> {
         match reference {
             SkillReference::Path(path) => self.skills_by_path.get(path),
-            SkillReference::BundledSkillId(id) => self.bundled_skill.skill(id),
+            SkillReference::BundledSkillId(id) => self.bundled_skills.local().skill(id),
         }
     }
 
@@ -332,7 +333,19 @@ impl SkillManager {
 
     /// Returns a bundled skill by ID only if its activation condition is met.
     pub fn active_bundled_skill(&self, id: &str, ctx: &AppContext) -> Option<&ParsedSkill> {
-        self.bundled_skill.active_skill(id, ctx)
+        self.bundled_skills.local().active_skill(id, ctx)
+    }
+
+    pub(super) fn set_remote_bundled_skill(
+        &mut self,
+        host_id: HostId,
+        bundled_skill: BundledSkill,
+    ) {
+        self.bundled_skills.insert_remote(host_id, bundled_skill);
+    }
+
+    pub(super) fn remove_remote_bundled_skill(&mut self, host_id: &HostId) {
+        self.bundled_skills.remove_remote(host_id);
     }
 
     fn handle_skill_watcher_event(&mut self, event: SkillWatcherEvent) {
@@ -427,7 +440,8 @@ impl SkillManager {
         skill: ParsedSkill,
         activation: BundledSkillActivation,
     ) {
-        self.bundled_skill.insert_for_testing(id, skill, activation);
+        self.bundled_skills
+            .insert_local_for_testing(id, skill, activation);
     }
 }
 

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -161,9 +161,20 @@ impl SkillManager {
             }
         }
 
-        // Append bundled skills whose activation condition is met.
+        // Append bundled skills whose activation condition is met, from the
+        // catalog of the host that owns the working directory: SSH sessions
+        // see the remote daemon's catalog (empty until its snapshot arrives),
+        // never the local client's.
         if FeatureFlag::BundledSkills.is_enabled() {
-            skills.extend(self.bundled_skills.local().active_descriptors(ctx));
+            let bundled = match working_directory {
+                Some(LocalOrRemotePath::Remote(remote)) => {
+                    self.bundled_skills.remote(&remote.host_id)
+                }
+                Some(LocalOrRemotePath::Local(_)) | None => Some(self.bundled_skills.local()),
+            };
+            if let Some(bundled) = bundled {
+                skills.extend(bundled.active_descriptors(ctx));
+            }
         }
 
         skills
@@ -285,11 +296,15 @@ impl SkillManager {
     }
 
     /// Returns a reference to a parsed skill for a specific SKILL.md file path, if it is cached.
+    /// Falls through to remote bundled catalogs, whose skills are addressed by path.
     pub fn skill_by_path<P: SkillPathQuery + ?Sized>(
         &self,
         skill_path: &P,
     ) -> Option<&ParsedSkill> {
-        self.skills_by_path.get(&skill_path.to_skill_location())
+        let location = skill_path.to_skill_location();
+        self.skills_by_path
+            .get(&location)
+            .or_else(|| self.bundled_skills.remote_skill_by_path(&location))
     }
 
     /// Returns the appropriate `SkillReference` for a skill at the given path.
@@ -310,7 +325,10 @@ impl SkillManager {
     /// Get the definition of a skill, if it is cached.
     pub fn skill_by_reference(&self, reference: &SkillReference) -> Option<&ParsedSkill> {
         match reference {
-            SkillReference::Path(path) => self.skills_by_path.get(path),
+            SkillReference::Path(path) => self
+                .skills_by_path
+                .get(path)
+                .or_else(|| self.bundled_skills.remote_skill_by_path(path)),
             SkillReference::BundledSkillId(id) => self.bundled_skills.local().skill(id),
         }
     }
@@ -318,15 +336,19 @@ impl SkillManager {
     /// Get the definition of a skill only if it is currently available for invocation.
     ///
     /// Path-based user skills are always controlled by normal path scoping. Bundled
-    /// skills additionally respect their runtime activation state so stale references
-    /// cannot invoke disabled bundled skills.
+    /// skills (the local catalog's ID-addressed entries and remote catalogs'
+    /// path-addressed entries) additionally respect their runtime activation
+    /// state so stale references cannot invoke disabled bundled skills.
     pub fn active_skill_by_reference(
         &self,
         reference: &SkillReference,
         ctx: &AppContext,
     ) -> Option<&ParsedSkill> {
         match reference {
-            SkillReference::Path(path) => self.skill_by_path(path),
+            SkillReference::Path(path) => self
+                .skills_by_path
+                .get(path)
+                .or_else(|| self.bundled_skills.remote_active_skill_by_path(path, ctx)),
             SkillReference::BundledSkillId(id) => self.active_bundled_skill(id, ctx),
         }
     }

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -376,7 +376,8 @@ fn cloud_environment_skills_always_included() {
 #[test]
 fn test_read_bundled_skills_with_variable_substitution() {
     let temp_dir = TempDir::new().unwrap();
-    let skills_dir = temp_dir.path();
+    let resources_dir = temp_dir.path();
+    let skills_dir = resources_dir.join("bundled/skills");
 
     // Create a test skill with variables
     let skill_dir = skills_dir.join("test-skill");
@@ -394,7 +395,13 @@ Run `{{warp_cli_binary_name}}` to connect to {{warp_server_url}}.
     )
     .unwrap();
 
-    let skills = futures::executor::block_on(read_bundled_skills(skills_dir));
+    let resources_dir = LocalOrRemotePath::Local(resources_dir.to_path_buf());
+    let host_skills_dir = LocalOrRemotePath::Local(skills_dir.clone());
+    let skills = futures::executor::block_on(read_bundled_skills(
+        &skills_dir,
+        &host_skills_dir,
+        &resources_dir,
+    ));
 
     assert_eq!(skills.len(), 1);
     let skill = skills.get("test-skill").unwrap();
@@ -407,9 +414,57 @@ Run `{{warp_cli_binary_name}}` to connect to {{warp_server_url}}.
 }
 
 #[test]
+fn test_read_bundled_skills_renders_remote_host_paths() {
+    let temp_dir = TempDir::new().unwrap();
+    let source_skills_dir = temp_dir.path().join("bundled/skills");
+    let source_skill_dir = source_skills_dir.join("test-skill");
+    fs::create_dir_all(&source_skill_dir).unwrap();
+    fs::write(
+        source_skill_dir.join("SKILL.md"),
+        r#"---
+name: test-skill
+description: Test remote rendering
+---
+
+Use {{skill_dir}} and {{settings_schema_path}}.
+"#,
+    )
+    .unwrap();
+
+    let host_id = HostId::new("remote-host".to_string());
+    let remote_resources_dir = LocalOrRemotePath::Remote(RemotePath::new(
+        host_id.clone(),
+        StandardizedPath::try_new("/opt/warp/resources").unwrap(),
+    ));
+    let remote_skills_dir = remote_resources_dir.join("bundled/skills");
+    let skills = futures::executor::block_on(read_bundled_skills(
+        &source_skills_dir,
+        &remote_skills_dir,
+        &remote_resources_dir,
+    ));
+
+    let skill = skills.get("test-skill").unwrap();
+    assert_eq!(
+        skill.path,
+        LocalOrRemotePath::Remote(RemotePath::new(
+            host_id,
+            StandardizedPath::try_new("/opt/warp/resources/bundled/skills/test-skill/SKILL.md")
+                .unwrap(),
+        ))
+    );
+    assert!(skill
+        .content
+        .contains("/opt/warp/resources/bundled/skills/test-skill"));
+    assert!(skill
+        .content
+        .contains("/opt/warp/resources/settings_schema.json"));
+}
+
+#[test]
 fn test_read_bundled_skills_preserves_other_content() {
     let temp_dir = TempDir::new().unwrap();
-    let skills_dir = temp_dir.path();
+    let resources_dir = temp_dir.path();
+    let skills_dir = resources_dir.join("bundled/skills");
 
     // Create a test skill with both warp and non-warp variables
     let skill_dir = skills_dir.join("test-skill");
@@ -422,26 +477,34 @@ name: test-skill
 description: Test skill with mixed variables
 ---
 
-Use {{other_var}} and {{warp_cli_binary_name}} together.
+Use {{other_var}}, {{warp_cli_binary_name}}, and {{skill_dir}} together.
 "#,
     )
     .unwrap();
 
-    let skills = futures::executor::block_on(read_bundled_skills(skills_dir));
+    let resources_dir = LocalOrRemotePath::Local(resources_dir.to_path_buf());
+    let host_skills_dir = LocalOrRemotePath::Local(skills_dir.clone());
+    let skills = futures::executor::block_on(read_bundled_skills(
+        &skills_dir,
+        &host_skills_dir,
+        &resources_dir,
+    ));
 
     assert_eq!(skills.len(), 1);
     let skill = skills.get("test-skill").unwrap();
 
     let expected_cli = ChannelState::channel().cli_command_name();
     assert!(skill.content.contains(&format!(
-        "Use {{{{other_var}}}} and {expected_cli} together."
+        "Use {{{{other_var}}}}, {expected_cli}, and {} together.",
+        skill_dir.display()
     )));
 }
 
 #[test]
 fn test_read_bundled_skills_no_variables() {
     let temp_dir = TempDir::new().unwrap();
-    let skills_dir = temp_dir.path();
+    let resources_dir = temp_dir.path();
+    let skills_dir = resources_dir.join("bundled/skills");
 
     // Create a test skill with no variables
     let skill_dir = skills_dir.join("test-skill");
@@ -459,7 +522,13 @@ Plain content with no variables.
     )
     .unwrap();
 
-    let skills = futures::executor::block_on(read_bundled_skills(skills_dir));
+    let resources_dir = LocalOrRemotePath::Local(resources_dir.to_path_buf());
+    let host_skills_dir = LocalOrRemotePath::Local(skills_dir.clone());
+    let skills = futures::executor::block_on(read_bundled_skills(
+        &skills_dir,
+        &host_skills_dir,
+        &resources_dir,
+    ));
 
     assert_eq!(skills.len(), 1);
     let skill = skills.get("test-skill").unwrap();
@@ -468,16 +537,31 @@ Plain content with no variables.
 
 #[test]
 fn test_build_bundled_skill_context() {
-    let context = build_bundled_skill_context();
+    let temp_dir = TempDir::new().unwrap();
+    let resources_dir = temp_dir.path();
+    let skill_dir = resources_dir.join("bundled/skills/test-skill");
+    let context = build_bundled_skill_context(
+        &LocalOrRemotePath::Local(resources_dir.to_path_buf()),
+        &LocalOrRemotePath::Local(skill_dir.clone()),
+    );
 
-    // At least 5 entries: server_url, cli_binary_name, url_scheme, settings_file_path, keybindings_file_path.
-    // settings_schema_path is only present when bundled_resources_dir() returns Some.
-    assert!(context.len() >= 5);
+    assert_eq!(context.len(), 7);
     assert!(context.contains_key("warp_server_url"));
     assert!(context.contains_key("warp_cli_binary_name"));
     assert!(context.contains_key("warp_url_scheme"));
     assert!(context.contains_key("settings_file_path"));
     assert!(context.contains_key("keybindings_file_path"));
+    assert_eq!(
+        context.get("settings_schema_path").unwrap(),
+        &resources_dir
+            .join("settings_schema.json")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        context.get("skill_dir").unwrap(),
+        &skill_dir.display().to_string()
+    );
 
     assert_eq!(
         context.get("warp_server_url").unwrap(),

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -395,13 +395,7 @@ Run `{{warp_cli_binary_name}}` to connect to {{warp_server_url}}.
     )
     .unwrap();
 
-    let resources_dir = LocalOrRemotePath::Local(resources_dir.to_path_buf());
-    let host_skills_dir = LocalOrRemotePath::Local(skills_dir.clone());
-    let skills = futures::executor::block_on(read_bundled_skills(
-        &skills_dir,
-        &host_skills_dir,
-        &resources_dir,
-    ));
+    let skills = futures::executor::block_on(read_bundled_skills(&skills_dir, temp_dir.path()));
 
     assert_eq!(skills.len(), 1);
     let skill = skills.get("test-skill").unwrap();
@@ -414,16 +408,17 @@ Run `{{warp_cli_binary_name}}` to connect to {{warp_server_url}}.
 }
 
 #[test]
-fn test_read_bundled_skills_renders_remote_host_paths() {
+fn test_read_bundled_skills_renders_host_paths() {
     let temp_dir = TempDir::new().unwrap();
-    let source_skills_dir = temp_dir.path().join("bundled/skills");
-    let source_skill_dir = source_skills_dir.join("test-skill");
-    fs::create_dir_all(&source_skill_dir).unwrap();
+    let resources_dir = temp_dir.path();
+    let skills_dir = resources_dir.join("bundled/skills");
+    let skill_dir = skills_dir.join("test-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
     fs::write(
-        source_skill_dir.join("SKILL.md"),
+        skill_dir.join("SKILL.md"),
         r#"---
 name: test-skill
-description: Test remote rendering
+description: Test path rendering
 ---
 
 Use {{skill_dir}} and {{settings_schema_path}}.
@@ -431,33 +426,22 @@ Use {{skill_dir}} and {{settings_schema_path}}.
     )
     .unwrap();
 
-    let host_id = HostId::new("remote-host".to_string());
-    let remote_resources_dir = LocalOrRemotePath::Remote(RemotePath::new(
-        host_id.clone(),
-        StandardizedPath::try_new("/opt/warp/resources").unwrap(),
-    ));
-    let remote_skills_dir = remote_resources_dir.join("bundled/skills");
-    let skills = futures::executor::block_on(read_bundled_skills(
-        &source_skills_dir,
-        &remote_skills_dir,
-        &remote_resources_dir,
-    ));
+    let skills = futures::executor::block_on(read_bundled_skills(&skills_dir, resources_dir));
 
     let skill = skills.get("test-skill").unwrap();
+    // The skill's reported path and rendered variables are anchored to the
+    // resources root the skills were read from.
     assert_eq!(
         skill.path,
-        LocalOrRemotePath::Remote(RemotePath::new(
-            host_id,
-            StandardizedPath::try_new("/opt/warp/resources/bundled/skills/test-skill/SKILL.md")
-                .unwrap(),
-        ))
+        LocalOrRemotePath::Local(skill_dir.join("SKILL.md"))
     );
-    assert!(skill
-        .content
-        .contains("/opt/warp/resources/bundled/skills/test-skill"));
-    assert!(skill
-        .content
-        .contains("/opt/warp/resources/settings_schema.json"));
+    assert!(skill.content.contains(&skill_dir.display().to_string()));
+    assert!(skill.content.contains(
+        &resources_dir
+            .join("settings_schema.json")
+            .display()
+            .to_string()
+    ));
 }
 
 #[test]
@@ -482,13 +466,7 @@ Use {{other_var}}, {{warp_cli_binary_name}}, and {{skill_dir}} together.
     )
     .unwrap();
 
-    let resources_dir = LocalOrRemotePath::Local(resources_dir.to_path_buf());
-    let host_skills_dir = LocalOrRemotePath::Local(skills_dir.clone());
-    let skills = futures::executor::block_on(read_bundled_skills(
-        &skills_dir,
-        &host_skills_dir,
-        &resources_dir,
-    ));
+    let skills = futures::executor::block_on(read_bundled_skills(&skills_dir, resources_dir));
 
     assert_eq!(skills.len(), 1);
     let skill = skills.get("test-skill").unwrap();
@@ -522,13 +500,7 @@ Plain content with no variables.
     )
     .unwrap();
 
-    let resources_dir = LocalOrRemotePath::Local(resources_dir.to_path_buf());
-    let host_skills_dir = LocalOrRemotePath::Local(skills_dir.clone());
-    let skills = futures::executor::block_on(read_bundled_skills(
-        &skills_dir,
-        &host_skills_dir,
-        &resources_dir,
-    ));
+    let skills = futures::executor::block_on(read_bundled_skills(&skills_dir, resources_dir));
 
     assert_eq!(skills.len(), 1);
     let skill = skills.get("test-skill").unwrap();
@@ -540,10 +512,7 @@ fn test_build_bundled_skill_context() {
     let temp_dir = TempDir::new().unwrap();
     let resources_dir = temp_dir.path();
     let skill_dir = resources_dir.join("bundled/skills/test-skill");
-    let context = build_bundled_skill_context(
-        &LocalOrRemotePath::Local(resources_dir.to_path_buf()),
-        &LocalOrRemotePath::Local(skill_dir.clone()),
-    );
+    let context = build_bundled_skill_context(resources_dir, &skill_dir);
 
     assert_eq!(context.len(), 7);
     assert!(context.contains_key("warp_server_url"));
@@ -650,6 +619,22 @@ fn get_skills_for_working_directory_respects_location() {
         provider: SkillProvider::Warp,
         scope: SkillScope::Bundled,
     };
+    // A bundled skill from the remote host's daemon-pushed catalog.
+    let remote_bundled_skill = ParsedSkill {
+        name: "remote-bundled".to_string(),
+        description: "remote bundled skill".to_string(),
+        path: LocalOrRemotePath::Remote(RemotePath::new(
+            same_host_id.clone(),
+            StandardizedPath::try_new(
+                "/home/user/.warp/remote-server/bundled_resources/bundled/skills/remote-bundled/SKILL.md",
+            )
+            .unwrap(),
+        )),
+        content: "# remote-bundled".to_string(),
+        line_range: None,
+        provider: SkillProvider::Warp,
+        scope: SkillScope::Bundled,
+    };
 
     let mut directory_skills = HashMap::new();
     let mut skills_by_path = HashMap::new();
@@ -684,8 +669,18 @@ fn get_skills_for_working_directory_respects_location() {
                 bundled_skill,
                 BundledSkillActivation::Always,
             );
+            manager.set_remote_bundled_skill(
+                same_host_id.clone(),
+                BundledSkill::from_definitions([(
+                    "remote-bundled".to_string(),
+                    remote_bundled_skill,
+                    BundledSkillActivation::Always,
+                )]),
+            );
         });
 
+        // A remote working directory sees the remote host's bundled catalog,
+        // never the local client's.
         let remote_skills = handle.read(&app, |manager, ctx| {
             manager.get_skills_for_working_directory(Some(&same_host_dir), ctx)
         });
@@ -694,7 +689,8 @@ fn get_skills_for_working_directory_respects_location() {
             .map(|skill| skill.name.as_str())
             .collect();
         assert!(remote_names.contains("same-host-project"));
-        assert!(remote_names.contains("bundled"));
+        assert!(remote_names.contains("remote-bundled"));
+        assert!(!remote_names.contains("bundled"));
         assert!(!remote_names.contains("local-home"));
         assert!(!remote_names.contains("local-project"));
         assert!(!remote_names.contains("other-host-project"));
@@ -718,6 +714,7 @@ fn get_skills_for_working_directory_respects_location() {
         assert!(local_names.contains("local-home"));
         assert!(local_names.contains("local-project"));
         assert!(local_names.contains("bundled"));
+        assert!(!local_names.contains("remote-bundled"));
         assert!(!local_names.contains("same-host-project"));
         assert!(!local_names.contains("other-host-project"));
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1897,6 +1897,8 @@ pub(crate) fn initialize_app(
 
     // SkillManager is used to cache SKILL.md files for all active terminal views and their working directories
     ctx.add_singleton_model(SkillManager::new);
+    #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
+    ai::skills::wire_remote_bundled_skills(ctx);
 
     // CloudViewModel subscribes to UpdateManager so that it can be notified when objects are
     // created on the server.

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -451,6 +451,7 @@ impl RemoteCodebaseIndexModel {
             RemoteServerManagerEvent::SessionConnecting { .. }
             | RemoteServerManagerEvent::SessionConnectionFailed { .. }
             | RemoteServerManagerEvent::HostConnected { .. }
+            | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -90,6 +90,21 @@ use crate::terminal::model::session::command_executor::{
 };
 use crate::util::git;
 
+/// Resolves packaged resources installed beside the standalone remote-server executable.
+///
+/// This deliberately does not use `warp_core::paths::bundled_resources_dir`,
+/// whose macOS behavior resolves resources inside an app bundle. Remote-server
+/// executables use the same sibling `resources` layout on every supported host.
+fn bundled_resources_dir_for_executable(executable: &Path) -> Option<PathBuf> {
+    let executable = std::fs::canonicalize(executable).ok()?;
+    let resources_dir = executable.parent()?.join("resources");
+    resources_dir.is_dir().then_some(resources_dir)
+}
+
+fn remote_server_bundled_resources_dir() -> Option<PathBuf> {
+    bundled_resources_dir_for_executable(&std::env::current_exe().ok()?)
+}
+
 /// Outcome of dispatching a request-style `ClientMessage`.
 ///
 /// Notifications (fire-and-forget messages like `SessionBootstrapped` and
@@ -230,6 +245,8 @@ pub struct ServerModel {
     /// Returned in every `InitializeResponse` so clients can deduplicate
     /// host-scoped models.
     host_id: String,
+    /// Packaged resources installed beside this daemon executable.
+    bundled_resources_dir: Option<PathBuf>,
     /// Per-session command executors created from `SessionBootstrapped` notifications.
     executors: HashMap<SessionId, Arc<LocalCommandExecutor>>,
     /// Tracks in-flight file write/delete operations and handles cleanup.
@@ -266,6 +283,7 @@ impl ServerModel {
             grace_timer_cancel: None,
             in_progress: HashMap::new(),
             host_id,
+            bundled_resources_dir: remote_server_bundled_resources_dir(),
             executors: HashMap::new(),
             pending_file_ops: PendingFileOps::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
@@ -1466,6 +1484,11 @@ impl ServerModel {
             InitializeResponse {
                 server_version,
                 host_id: self.host_id.clone(),
+                bundled_resources_dir: self
+                    .bundled_resources_dir
+                    .as_deref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_default(),
             },
         ))
     }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -39,11 +39,12 @@ use super::proto::{
     git_get_pr_info_response, git_push_response, host_scoped_request, notification,
     resolve_conflict_response, run_command_response, save_buffer_response, server_message,
     session_scoped_request, write_file_response, Abort, Authenticate, BranchInfo, BufferEdit,
-    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexLimits, CodebaseIndexStatus,
-    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, CodebaseResyncMode, DeleteFile,
-    DeleteFileResponse, DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse,
-    DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
-    FileContextProto, FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
+    BufferUpdatedPush, BundledSkillProto, BundledSkillsSnapshot, ClientMessage, CloseBuffer,
+    CodebaseIndexLimits, CodebaseIndexStatus, CodebaseIndexStatusUpdated,
+    CodebaseIndexStatusesSnapshot, CodebaseResyncMode, DeleteFile, DeleteFileResponse,
+    DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse, DiscardFilesSuccess,
+    DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead, FileContextProto,
+    FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
     FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
@@ -81,6 +82,7 @@ use super::protocol::RequestId;
 use crate::ai::agent::FileLocations;
 use crate::ai::blocklist::handoff::snapshot::upload_result_to_proto;
 use crate::ai::blocklist::{read_local_file_context, ReadFileContextResult};
+use crate::ai::skills::{bundled_skills_snapshot_protos, BundledSkill};
 use crate::auth::auth_state::{AuthState, AuthStateProvider};
 use crate::code_review::git_actions;
 use crate::features::FeatureFlag;
@@ -90,19 +92,19 @@ use crate::terminal::model::session::command_executor::{
 };
 use crate::util::git;
 
-/// Resolves packaged resources installed beside the standalone remote-server executable.
+/// Resolves the global bundled resources directory populated by the install
+/// script (see [`remote_server::setup::remote_server_bundled_resources_dir`]),
+/// expanding the shell-form `~/` prefix against this process's home directory.
 ///
 /// This deliberately does not use `warp_core::paths::bundled_resources_dir`,
-/// whose macOS behavior resolves resources inside an app bundle. Remote-server
-/// executables use the same sibling `resources` layout on every supported host.
-fn bundled_resources_dir_for_executable(executable: &Path) -> Option<PathBuf> {
-    let executable = std::fs::canonicalize(executable).ok()?;
-    let resources_dir = executable.parent()?.join("resources");
-    resources_dir.is_dir().then_some(resources_dir)
-}
-
-fn remote_server_bundled_resources_dir() -> Option<PathBuf> {
-    bundled_resources_dir_for_executable(&std::env::current_exe().ok()?)
+/// whose macOS behavior resolves resources inside an app bundle. The global
+/// location is version-independent: the last install wins, and slight skew
+/// against this daemon's version is accepted.
+fn daemon_bundled_resources_dir() -> Option<PathBuf> {
+    let dir = remote_server::setup::remote_server_bundled_resources_dir();
+    let suffix = dir.strip_prefix("~/")?;
+    let dir = dirs::home_dir()?.join(suffix);
+    dir.is_dir().then_some(dir)
 }
 
 /// Outcome of dispatching a request-style `ClientMessage`.
@@ -245,8 +247,10 @@ pub struct ServerModel {
     /// Returned in every `InitializeResponse` so clients can deduplicate
     /// host-scoped models.
     host_id: String,
-    /// Packaged resources installed beside this daemon executable.
-    bundled_resources_dir: Option<PathBuf>,
+    /// The bundled skill catalog, pre-parsed and serialized for the
+    /// `BundledSkillsSnapshot` push. `None` until startup parsing completes
+    /// (or forever, when the global resources directory is absent).
+    bundled_skills: Option<Vec<BundledSkillProto>>,
     /// Per-session command executors created from `SessionBootstrapped` notifications.
     executors: HashMap<SessionId, Arc<LocalCommandExecutor>>,
     /// Tracks in-flight file write/delete operations and handles cleanup.
@@ -283,7 +287,7 @@ impl ServerModel {
             grace_timer_cancel: None,
             in_progress: HashMap::new(),
             host_id,
-            bundled_resources_dir: remote_server_bundled_resources_dir(),
+            bundled_skills: None,
             executors: HashMap::new(),
             pending_file_ops: PendingFileOps::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
@@ -617,6 +621,29 @@ impl ServerModel {
                 me.handle_diff_state_update(dispatch);
             });
         }
+        // Parse the bundled skill catalog from the global install location.
+        // Parsing never blocks the initialize handshake: connections that
+        // initialize before parsing completes receive the catalog via the
+        // completion broadcast instead. Deliberately not feature-flag gated:
+        // the flag controls exposure on the client (catalog storage and
+        // skill selection), where the connecting user's flag state actually
+        // lives — a headless daemon only sees its own channel defaults.
+        if let Some(resources_dir) = daemon_bundled_resources_dir() {
+            ctx.spawn(
+                BundledSkill::detect_in_resources_dir(resources_dir),
+                |me, catalog, _| {
+                    let skills = bundled_skills_snapshot_protos(&catalog);
+                    log::info!("Daemon parsed {} bundled skills", skills.len());
+                    me.bundled_skills = Some(skills);
+                    me.broadcast_bundled_skills_snapshot();
+                },
+            );
+        } else {
+            log::info!(
+                "Daemon found no global bundled resources directory; \
+                 bundled skills unavailable on this host"
+            );
+        }
         // Start the grace timer immediately so the daemon exits if no proxy
         // connects within GRACE_PERIOD. In practice the spawning proxy connects
         // within milliseconds, so the risk of premature shutdown is negligible;
@@ -624,6 +651,19 @@ impl ServerModel {
         // arrives.
         model.start_grace_timer(ctx);
         model
+    }
+
+    /// Broadcasts the parsed bundled skill catalog to all connections.
+    /// No-op until startup parsing has completed.
+    fn broadcast_bundled_skills_snapshot(&mut self) {
+        let Some(skills) = self.bundled_skills.clone() else {
+            return;
+        };
+        self.send_server_message(
+            None,
+            None,
+            server_message::Message::BundledSkillsSnapshot(BundledSkillsSnapshot { skills }),
+        );
     }
 
     /// Called when a proxy connects.  Inserts `conn_tx` into the connection
@@ -806,7 +846,7 @@ impl ServerModel {
             Some(client_message::Message::SessionScoped(wrapper)) => {
                 let outcome = match wrapper.message {
                     Some(session_scoped_request::Message::Initialize(m)) => {
-                        self.handle_initialize(m, &request_id, ctx)
+                        self.handle_initialize(m, &request_id, conn_id, ctx)
                     }
                     Some(session_scoped_request::Message::NavigatedToDirectory(m)) => {
                         self.handle_navigated_to_directory(m, &request_id, conn_id, ctx)
@@ -1454,12 +1494,16 @@ impl ServerModel {
     /// Handles `Initialize` by returning the server version and host id.
     ///
     /// Also configures Sentry crash reporting based on the user's identity
-    /// and preferences supplied by the connecting client.
+    /// and preferences supplied by the connecting client, and sends the
+    /// bundled skill catalog to the initializing connection when startup
+    /// parsing has already completed (otherwise the parse-completion
+    /// broadcast delivers it).
     #[cfg_attr(not(feature = "crash_reporting"), allow(unused_variables))]
     fn handle_initialize(
         &mut self,
         msg: Initialize,
         request_id: &RequestId,
+        conn_id: ConnectionId,
         ctx: &mut ModelContext<Self>,
     ) -> HandlerOutcome {
         log::info!("Handling Initialize (request_id={request_id})");
@@ -1479,16 +1523,22 @@ impl ServerModel {
             }
         }
 
+        // Push the bundled skill catalog to this connection if it is already
+        // parsed. Enqueued on the same channel as the response below, so the
+        // client buffers it as a push event during the handshake.
+        if let Some(skills) = self.bundled_skills.clone() {
+            self.send_server_message(
+                Some(conn_id),
+                None,
+                server_message::Message::BundledSkillsSnapshot(BundledSkillsSnapshot { skills }),
+            );
+        }
+
         let server_version = ChannelState::app_version().unwrap_or("").to_string();
         HandlerOutcome::Sync(server_message::Message::InitializeResponse(
             InitializeResponse {
                 server_version,
                 host_id: self.host_id.clone(),
-                bundled_resources_dir: self
-                    .bundled_resources_dir
-                    .as_deref()
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_default(),
             },
         ))
     }

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -11,7 +11,7 @@ use super::super::proto::{
 };
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{ConnectionId, PendingFileOps, ServerModel};
+use super::{bundled_resources_dir_for_executable, ConnectionId, PendingFileOps, ServerModel};
 use crate::auth::auth_state::AuthState;
 use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
@@ -23,6 +23,7 @@ fn test_model(app: &mut App) -> ServerModel {
         grace_timer_cancel: None,
         in_progress: HashMap::new(),
         host_id: "test-host-id".to_string(),
+        bundled_resources_dir: None,
         executors: HashMap::new(),
         pending_file_ops: PendingFileOps::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
@@ -39,6 +40,27 @@ fn test_key(repo: &str, mode: DiffMode) -> DiffModelKey {
         repo_path: StandardizedPath::try_new(repo).unwrap(),
         mode,
     }
+}
+
+/// The compatibility symlink must resolve resources from its canonical bundle.
+#[cfg(unix)]
+#[test]
+fn bundled_resources_dir_is_discovered_beside_canonical_executable() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let bundle_dir = temp_dir.path().join("bundle");
+    let executable = bundle_dir.join("oz");
+    let resources_dir = bundle_dir.join("resources");
+    let compatibility_symlink = temp_dir.path().join("oz");
+    std::fs::create_dir_all(&resources_dir).unwrap();
+    std::fs::write(&executable, "").unwrap();
+    symlink(&executable, &compatibility_symlink).unwrap();
+
+    assert_eq!(
+        bundled_resources_dir_for_executable(&compatibility_symlink),
+        Some(std::fs::canonicalize(resources_dir).unwrap())
+    );
 }
 
 #[test]

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -6,12 +6,12 @@ use warpui::App;
 
 use super::super::diff_state_tracker::RemoteDiffStateManager;
 use super::super::proto::{
-    server_message, write_file_response, Authenticate, Initialize, ServerMessage,
-    WriteFileResponse, WriteFileSuccess,
+    server_message, write_file_response, Authenticate, BundledSkillProto, Initialize,
+    ServerMessage, WriteFileResponse, WriteFileSuccess,
 };
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{bundled_resources_dir_for_executable, ConnectionId, PendingFileOps, ServerModel};
+use super::{ConnectionId, PendingFileOps, ServerModel};
 use crate::auth::auth_state::AuthState;
 use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
@@ -23,7 +23,7 @@ fn test_model(app: &mut App) -> ServerModel {
         grace_timer_cancel: None,
         in_progress: HashMap::new(),
         host_id: "test-host-id".to_string(),
-        bundled_resources_dir: None,
+        bundled_skills: None,
         executors: HashMap::new(),
         pending_file_ops: PendingFileOps::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
@@ -42,25 +42,52 @@ fn test_key(repo: &str, mode: DiffMode) -> DiffModelKey {
     }
 }
 
-/// The compatibility symlink must resolve resources from its canonical bundle.
-#[cfg(unix)]
+fn test_bundled_skill_proto(id: &str) -> BundledSkillProto {
+    BundledSkillProto {
+        id: id.to_string(),
+        name: id.to_string(),
+        description: format!("{id} description"),
+        path: format!(
+            "/home/user/.warp/remote-server/bundled_resources/bundled/skills/{id}/SKILL.md"
+        ),
+        content: format!("# {id}"),
+        requires_mcp: None,
+    }
+}
+
+/// Parse completion broadcasts the catalog to every connection.
 #[test]
-fn bundled_resources_dir_is_discovered_beside_canonical_executable() {
-    use std::os::unix::fs::symlink;
+fn bundled_skills_broadcast_reaches_all_connections() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        let (first_tx, first_rx) = async_channel::unbounded();
+        let (second_tx, second_rx) = async_channel::unbounded();
+        model
+            .connection_senders
+            .insert(uuid::Uuid::new_v4(), first_tx);
+        model
+            .connection_senders
+            .insert(uuid::Uuid::new_v4(), second_tx);
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let bundle_dir = temp_dir.path().join("bundle");
-    let executable = bundle_dir.join("oz");
-    let resources_dir = bundle_dir.join("resources");
-    let compatibility_symlink = temp_dir.path().join("oz");
-    std::fs::create_dir_all(&resources_dir).unwrap();
-    std::fs::write(&executable, "").unwrap();
-    symlink(&executable, &compatibility_symlink).unwrap();
+        // Before parsing completes the broadcast is a no-op.
+        model.broadcast_bundled_skills_snapshot();
+        assert!(first_rx.try_recv().is_err());
 
-    assert_eq!(
-        bundled_resources_dir_for_executable(&compatibility_symlink),
-        Some(std::fs::canonicalize(resources_dir).unwrap())
-    );
+        model.bundled_skills = Some(vec![test_bundled_skill_proto("test-skill")]);
+        model.broadcast_bundled_skills_snapshot();
+
+        for rx in [first_rx, second_rx] {
+            let msg = rx.try_recv().expect("connection should receive snapshot");
+            assert!(msg.request_id.is_empty(), "snapshot must be a push message");
+            match msg.message {
+                Some(server_message::Message::BundledSkillsSnapshot(snapshot)) => {
+                    assert_eq!(snapshot.skills.len(), 1);
+                    assert_eq!(snapshot.skills[0].id, "test-skill");
+                }
+                other => panic!("expected BundledSkillsSnapshot, got {other:?}"),
+            }
+        }
+    });
 }
 
 #[test]

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -160,17 +160,18 @@ impl RemoteTransport for SshTransport {
                 remote_server::setup::CHECK_TIMEOUT,
             )
             .await?;
-            // `<binary> --version` exits 0 when present, executable, and
-            // functional. Exit 127 means the binary was not found, and 126
-            // means it exists but is not executable. Any other non-zero
-            // exit (e.g. SSH exit 255 for a dead connection, or signal
-            // termination) is treated as a transport-level failure.
+            // The bundle checks exit 0 when the compatibility symlink,
+            // executable, and resources are all present and functional.
+            // Exit 1 means a `test` failed, 127 means the binary was not
+            // found, and 126 means it exists but is not executable. Any other
+            // non-zero exit (e.g. SSH exit 255 for a dead connection, or
+            // signal termination) is treated as a transport-level failure.
             let code = output.status.code();
             let stdout = String::from_utf8_lossy(&output.stdout);
             log::info!("Binary check result: exit={code:?} stdout={stdout}");
             match code {
                 Some(0) => Ok(true),
-                Some(126) | Some(127) => Ok(false),
+                Some(1) | Some(126) | Some(127) => Ok(false),
                 Some(code) => {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     Err(Error::Other(anyhow::anyhow!(
@@ -286,8 +287,8 @@ impl RemoteTransport for SshTransport {
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
-            let cmd = format!("rm -f {}", remote_server::setup::remote_server_binary());
-            log::info!("Removing stale remote server binary: {cmd}");
+            let cmd = remote_server::setup::remote_server_removal_command();
+            log::info!("Removing stale remote server install: {cmd}");
             let output = remote_server::ssh::run_ssh_command(
                 &socket_path,
                 &cmd,
@@ -298,7 +299,9 @@ impl RemoteTransport for SshTransport {
                 Ok(())
             } else {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                Err(anyhow::anyhow!("Failed to remove binary: {stderr}"))
+                Err(anyhow::anyhow!(
+                    "Failed to remove remote server install: {stderr}"
+                ))
             }
         })
     }

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -160,18 +160,17 @@ impl RemoteTransport for SshTransport {
                 remote_server::setup::CHECK_TIMEOUT,
             )
             .await?;
-            // The bundle checks exit 0 when the compatibility symlink,
-            // executable, and resources are all present and functional.
-            // Exit 1 means a `test` failed, 127 means the binary was not
-            // found, and 126 means it exists but is not executable. Any other
-            // non-zero exit (e.g. SSH exit 255 for a dead connection, or
-            // signal termination) is treated as a transport-level failure.
+            // `<binary> --version` exits 0 when present, executable, and
+            // functional. Exit 127 means the binary was not found, and 126
+            // means it exists but is not executable. Any other non-zero
+            // exit (e.g. SSH exit 255 for a dead connection, or signal
+            // termination) is treated as a transport-level failure.
             let code = output.status.code();
             let stdout = String::from_utf8_lossy(&output.stdout);
             log::info!("Binary check result: exit={code:?} stdout={stdout}");
             match code {
                 Some(0) => Ok(true),
-                Some(1) | Some(126) | Some(127) => Ok(false),
+                Some(126) | Some(127) => Ok(false),
                 Some(code) => {
                     let stderr = String::from_utf8_lossy(&output.stderr);
                     Err(Error::Other(anyhow::anyhow!(
@@ -288,7 +287,7 @@ impl RemoteTransport for SshTransport {
         let socket_path = self.socket_path.clone();
         Box::pin(async move {
             let cmd = remote_server::setup::remote_server_removal_command();
-            log::info!("Removing stale remote server install: {cmd}");
+            log::info!("Removing stale remote server binary: {cmd}");
             let output = remote_server::ssh::run_ssh_command(
                 &socket_path,
                 &cmd,
@@ -299,9 +298,7 @@ impl RemoteTransport for SshTransport {
                 Ok(())
             } else {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                Err(anyhow::anyhow!(
-                    "Failed to remove remote server install: {stderr}"
-                ))
+                Err(anyhow::anyhow!("Failed to remove binary: {stderr}"))
             }
         })
     }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -169,6 +169,7 @@ impl Sessions {
                 | RemoteServerManagerEvent::SessionConnectionFailed { .. }
                 | RemoteServerManagerEvent::HostConnected { .. }
                 | RemoteServerManagerEvent::HostDisconnected { .. }
+                | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
                 | RemoteServerManagerEvent::NavigatedToDirectory { .. }
                 | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                 | RemoteServerManagerEvent::RepoMetadataUpdated { .. }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4717,6 +4717,7 @@ impl TerminalView {
                     }
                     RemoteServerManagerEvent::SessionConnecting { .. }
                     | RemoteServerManagerEvent::HostConnected { .. }
+                    | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -138,6 +138,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::SessionDeregistered { .. }
             | RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::HostDisconnected { .. }
+            | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
             | RemoteServerManagerEvent::NavigatedToDirectory { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -170,6 +170,9 @@ message Abort {
 message InitializeResponse {
   string server_version = 1;
   string host_id = 2;
+  // Absolute path to the packaged resources installed beside the daemon.
+  // Empty when the daemon has no packaged resources available.
+  string bundled_resources_dir = 3;
 }
 
 // Sent by the client after the SSH session has been bootstrapped.
@@ -238,6 +241,7 @@ message ErrorResponse {
   ErrorCode code = 1;
   string message = 2;
 }
+
 
 // ── Shared repo metadata sub-messages ─────────────────────────────
 // Mirror the Rust types in repo_metadata/src/file_tree_update.rs.

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -118,6 +118,7 @@ message ServerMessage {
     GitGetPrInfoResponse git_get_pr_info_response = 30;
     GitGenerateCommitMessageResponse git_generate_commit_message_response = 31;
     GitGetCommittedBranchFilesResponse git_get_committed_branch_files_response = 32;
+    BundledSkillsSnapshot bundled_skills_snapshot = 33;
   }
 }
 
@@ -170,9 +171,6 @@ message Abort {
 message InitializeResponse {
   string server_version = 1;
   string host_id = 2;
-  // Absolute path to the packaged resources installed beside the daemon.
-  // Empty when the daemon has no packaged resources available.
-  string bundled_resources_dir = 3;
 }
 
 // Sent by the client after the SSH session has been bootstrapped.
@@ -242,6 +240,32 @@ message ErrorResponse {
   string message = 2;
 }
 
+// ── Bundled skills ────────────────────────────────────────────────
+
+// One bundled skill, pre-parsed and handlebars-rendered by the daemon
+// against its own filesystem. Named with the `Proto` suffix (like
+// `FileContextProto`) to avoid colliding with the app's `BundledSkill`.
+message BundledSkillProto {
+  // Directory-based skill ID (unique within the bundled catalog).
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  // Absolute path to the skill's SKILL.md on this host.
+  string path = 4;
+  // Skill content with handlebars variables rendered for this host.
+  string content = 5;
+  // When set, the skill is only active while the named MCP integration
+  // is running on the client (e.g. "figma"). Evaluated client-side.
+  optional string requires_mcp = 6;
+}
+
+// Server → client push: the daemon's bundled skill catalog. Sent to a
+// connection after its Initialize completes (when parsing has already
+// finished) and broadcast to all connections when parsing completes.
+// Never blocks the initialize handshake.
+message BundledSkillsSnapshot {
+  repeated BundledSkillProto skills = 1;
+}
 
 // ── Shared repo metadata sub-messages ─────────────────────────────
 // Mirror the Rust types in repo_metadata/src/file_tree_update.rs.

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -15,10 +15,11 @@ use crate::codebase_index_proto::{
 };
 use crate::proto::{
     notification, server_message, session_scoped_request, Abort, Authenticate, BufferEdit,
-    ClientMessage, CloseBuffer, CodebaseIndexLimits, DiffMode, DiffStateFileDelta,
-    DiffStateMetadataUpdate, DiffStateSnapshot, ErrorCode, Initialize, InitializeResponse,
-    LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse, RunCommandRequest,
-    RunCommandResponse, ServerMessage, SessionBootstrapped, TextEdit, UnsubscribeDiffState,
+    BundledSkillProto, ClientMessage, CloseBuffer, CodebaseIndexLimits, DiffMode,
+    DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot, ErrorCode, Initialize,
+    InitializeResponse, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse,
+    RunCommandRequest, RunCommandResponse, ServerMessage, SessionBootstrapped, TextEdit,
+    UnsubscribeDiffState,
 };
 use crate::repo_metadata_proto::{proto_snapshot_to_update, proto_to_repo_metadata_update};
 
@@ -125,6 +126,8 @@ pub enum ClientEvent {
         mode: DiffMode,
         delta: DiffStateFileDelta,
     },
+    /// The daemon pushed its pre-parsed bundled skill catalog.
+    BundledSkillsSnapshotReceived { skills: Vec<BundledSkillProto> },
 }
 
 /// Parameters for the `Initialize` handshake, sent to the daemon at
@@ -666,6 +669,11 @@ impl RemoteServerClient {
                     repo_path,
                     mode,
                     delta,
+                })
+            }
+            server_message::Message::BundledSkillsSnapshot(snapshot) => {
+                Some(ClientEvent::BundledSkillsSnapshotReceived {
+                    skills: snapshot.skills,
                 })
             }
             other => {

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -165,6 +165,7 @@ async fn initialize_round_trip() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
+            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -194,6 +195,7 @@ async fn initialize_sends_empty_auth_token_when_none() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
+            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -221,6 +223,7 @@ async fn initialize_sends_auth_token_when_provided() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
+            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -332,6 +335,7 @@ async fn is_disconnected_starts_false() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
+            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -378,6 +382,7 @@ async fn concurrent_in_flight_requests() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
+            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
     let client = std::sync::Arc::new(client);
@@ -423,6 +428,7 @@ async fn mock_server_with_error_handling(
                         InitializeResponse {
                             server_version: "test-0.1.0".to_string(),
                             host_id: "test-host-id".to_string(),
+                            bundled_resources_dir: "/opt/warp/resources".to_string(),
                         },
                     )),
                 };

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -6,10 +6,10 @@ use warpui_core::r#async::executor;
 use super::*;
 use crate::proto::{
     client_message, host_scoped_request, notification, run_command_response, server_message,
-    session_scoped_request, ClientMessage, CodebaseIndexStatus, CodebaseIndexStatusState,
-    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, ErrorCode, GetDiffStateResponse,
-    InitializeResponse, OpenBufferResponse, RunCommandResponse, RunCommandSuccess, ServerMessage,
-    WriteFile,
+    session_scoped_request, BundledSkillsSnapshot, ClientMessage, CodebaseIndexStatus,
+    CodebaseIndexStatusState, CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, ErrorCode,
+    GetDiffStateResponse, InitializeResponse, OpenBufferResponse, RunCommandResponse,
+    RunCommandSuccess, ServerMessage, WriteFile,
 };
 use crate::protocol;
 
@@ -130,6 +130,49 @@ async fn codebase_index_push_messages_become_client_events() {
     }
 }
 
+#[tokio::test]
+async fn bundled_skills_snapshot_push_becomes_client_event() {
+    let (client_stream, server_stream) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    drop(server_read);
+
+    let executor = executor::Background::default();
+    let (_client, event_rx, _failure_rx, _host_rx) =
+        RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
+    let mut writer = server_write.compat_write();
+
+    protocol::write_server_message(
+        &mut writer,
+        &ServerMessage {
+            request_id: String::new(),
+            message: Some(server_message::Message::BundledSkillsSnapshot(
+                BundledSkillsSnapshot {
+                    skills: vec![crate::proto::BundledSkillProto {
+                        id: "test-skill".to_string(),
+                        name: "test-skill".to_string(),
+                        description: "A test skill".to_string(),
+                        path: "/remote/SKILL.md".to_string(),
+                        content: "body".to_string(),
+                        requires_mcp: None,
+                    }],
+                },
+            )),
+        },
+    )
+    .await
+    .unwrap();
+    writer.flush().await.unwrap();
+
+    match event_rx.recv().await.unwrap() {
+        ClientEvent::BundledSkillsSnapshotReceived { skills } => {
+            assert_eq!(skills.len(), 1);
+            assert_eq!(skills[0].id, "test-skill");
+        }
+        other => panic!("Expected BundledSkillsSnapshotReceived, got {other:?}"),
+    }
+}
+
 /// Sets up a duplex stream, spawns `mock_server_with` with the given responder,
 /// and returns a connected `RemoteServerClient`, its event receiver, and the
 /// background executor (which must be kept alive for the test duration).
@@ -165,7 +208,6 @@ async fn initialize_round_trip() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
-            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -195,7 +237,6 @@ async fn initialize_sends_empty_auth_token_when_none() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
-            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -223,7 +264,6 @@ async fn initialize_sends_auth_token_when_provided() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
-            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -335,7 +375,6 @@ async fn is_disconnected_starts_false() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
-            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
 
@@ -382,7 +421,6 @@ async fn concurrent_in_flight_requests() {
         server_message::Message::InitializeResponse(InitializeResponse {
             server_version: "test-0.1.0".to_string(),
             host_id: "test-host-id".to_string(),
-            bundled_resources_dir: "/opt/warp/resources".to_string(),
         })
     });
     let client = std::sync::Arc::new(client);
@@ -428,7 +466,6 @@ async fn mock_server_with_error_handling(
                         InitializeResponse {
                             server_version: "test-0.1.0".to_string(),
                             host_id: "test-host-id".to_string(),
-                            bundled_resources_dir: "/opt/warp/resources".to_string(),
                         },
                     )),
                 };

--- a/crates/remote_server/src/install_remote_server.sh
+++ b/crates/remote_server/src/install_remote_server.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
-# Installs the Warp remote server binary on a remote host.
+# Installs the Warp remote server on a remote host.
+#
+# Install layout:
+#
+#   {install_dir}/
+#   ├── bundles/{bundle_version}/      ← the artifact's shipped layout, unchanged:
+#   │   ├── {binary_name}                 the executable...
+#   │   └── resources/                    ...and its sibling resources
+#   └── {binary_name}{version_suffix}  ── symlink ─▶ bundles/{bundle_version}/{binary_name}
+#
+# The bundle preserves the executable-beside-resources pairing exactly as the
+# release artifact ships it, because the daemon locates its resources by
+# canonicalizing its own executable path and reading the sibling `resources/`
+# directory. Bundles are version-scoped because the daemon outlives client
+# updates: an older daemon may still be running while a newer client installs,
+# and a single shared resources directory would swap skills and schema files
+# out from under it. The version-suffixed symlink keeps the launch path that
+# every client codepath already uses, while the shipped binary keeps its
+# unsuffixed name inside the bundle.
 #
 # Placeholders (substituted at runtime by setup.rs):
 #   {download_base_url}         — e.g. https://app.warp.dev/download/cli
@@ -8,6 +26,8 @@
 #   {binary_name}               — e.g. oz | oz-dev | oz-preview
 #   {version_query}             — e.g. &version=v0.2026... (empty when no release tag)
 #   {version_suffix}            — e.g. -v0.2026...        (empty when no release tag)
+#   {bundle_version}            — version-scoped bundle directory name
+#   {binary_symlink_target}     — relative target for the compatibility symlink
 #   {no_http_client_exit_code}  — exit code when neither curl nor wget is available
 #   {staging_tarball_path}      — path to a pre-uploaded tarball (SCP fallback; empty normally)
 set -e
@@ -52,6 +72,12 @@ tmpdir=$(mktemp -d "$install_dir/.install.XXXXXX")
 # instead of clobbering with the cleanup's exit code.
 cleanup() {
   rm -rf "$tmpdir" 2>/dev/null || true
+  if [ -n "${install_bundle_tmp:-}" ]; then
+    rm -rf "$install_bundle_tmp" 2>/dev/null || true
+  fi
+  if [ -n "${symlink_tmp:-}" ]; then
+    rm -f "$symlink_tmp" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 
@@ -79,7 +105,49 @@ fi
 
 tar -xzf "$tmpdir/oz.tar.gz" -C "$tmpdir"
 
-bin=$(find "$tmpdir" -type f -name 'oz*' ! -name '*.tar.gz' | head -n1)
+# The executable and its resources are siblings in the artifact. Exclude the
+# resources tree from the search: bundled skills may ship companion files
+# whose names also start with `oz`.
+bin=$(find "$tmpdir" -type f -name 'oz*' ! -name '*.tar.gz' ! -path '*/resources/*' | head -n1)
 if [ -z "$bin" ]; then echo "no binary found in tarball" >&2; exit 1; fi
+resources="$(dirname "$bin")/resources"
+if [ ! -d "$resources" ]; then echo "no resources directory found in tarball" >&2; exit 1; fi
+
+# Assemble the complete bundle in the temp dir first: assembly takes multiple
+# moves, so it must happen at a path nothing launches from. The shipped
+# executable-beside-resources pairing is preserved as-is.
+staged_bundle="$tmpdir/bundle"
+mkdir -p "$staged_bundle"
 chmod +x "$bin"
-mv "$bin" "$install_dir/{binary_name}{version_suffix}"
+mv "$bin" "$staged_bundle/{binary_name}"
+mv "$resources" "$staged_bundle/resources"
+
+bundles_dir="$install_dir/bundles"
+bundle_dir="$bundles_dir/{bundle_version}"
+mkdir -p "$bundles_dir"
+
+# Install the staged bundle with a single directory rename so the bundle
+# either exists in full or not at all — an interrupted install must never
+# leave a binary without its resources at a launchable path. The temp name is
+# dot-prefixed and PID-suffixed so concurrent installs cannot collide.
+# Replacing an existing bundle is only needed to repair an incomplete install
+# at this version; healthy bundles are skipped by the pre-install binary check.
+install_bundle_tmp="$bundles_dir/.{bundle_version}.install.$$"
+rm -rf "$install_bundle_tmp"
+mv "$staged_bundle" "$install_bundle_tmp"
+rm -rf "$bundle_dir"
+mv "$install_bundle_tmp" "$bundle_dir"
+
+# Point the historical launch path at the bundle. Clients launch the
+# version-suffixed path they have always used, while the shipped binary keeps
+# its unsuffixed name beside its resources — the symlink bridges the two, and
+# because the daemon canonicalizes through it, the daemon resolves its own
+# bundle's resources. The target is relative to keep the install relocatable.
+# The link is created at a temp name and renamed into place because `ln -s`
+# cannot atomically replace an existing path (including a legacy regular-file
+# binary being upgraded to the bundle layout).
+binary_path="$install_dir/{binary_name}{version_suffix}"
+symlink_tmp="$install_dir/.{binary_name}{version_suffix}.link.$$"
+rm -f "$symlink_tmp"
+ln -s "{binary_symlink_target}" "$symlink_tmp"
+mv -f "$symlink_tmp" "$binary_path"

--- a/crates/remote_server/src/install_remote_server.sh
+++ b/crates/remote_server/src/install_remote_server.sh
@@ -1,23 +1,15 @@
 #!/usr/bin/env bash
-# Installs the Warp remote server on a remote host.
-#
-# Install layout:
+# Installs the Warp remote server binary on a remote host, plus the
+# artifact's `resources/` tree (bundled skills, settings schema) at a
+# global, version-independent location:
 #
 #   {install_dir}/
-#   ├── bundles/{bundle_version}/      ← the artifact's shipped layout, unchanged:
-#   │   ├── {binary_name}                 the executable...
-#   │   └── resources/                    ...and its sibling resources
-#   └── {binary_name}{version_suffix}  ── symlink ─▶ bundles/{bundle_version}/{binary_name}
+#   ├── {binary_name}{version_suffix}   ← the executable
+#   └── bundled_resources/              ← the artifact's resources tree
 #
-# The bundle preserves the executable-beside-resources pairing exactly as the
-# release artifact ships it, because the daemon locates its resources by
-# canonicalizing its own executable path and reading the sibling `resources/`
-# directory. Bundles are version-scoped because the daemon outlives client
-# updates: an older daemon may still be running while a newer client installs,
-# and a single shared resources directory would swap skills and schema files
-# out from under it. The version-suffixed symlink keeps the launch path that
-# every client codepath already uses, while the shipped binary keeps its
-# unsuffixed name inside the bundle.
+# Resources are deliberately decoupled from the binary version: the last
+# install wins. An older daemon that is still running parsed its skills at
+# startup, so a slightly newer resources tree underneath it is accepted.
 #
 # Placeholders (substituted at runtime by setup.rs):
 #   {download_base_url}         — e.g. https://app.warp.dev/download/cli
@@ -26,8 +18,7 @@
 #   {binary_name}               — e.g. oz | oz-dev | oz-preview
 #   {version_query}             — e.g. &version=v0.2026... (empty when no release tag)
 #   {version_suffix}            — e.g. -v0.2026...        (empty when no release tag)
-#   {bundle_version}            — version-scoped bundle directory name
-#   {binary_symlink_target}     — relative target for the compatibility symlink
+#   {bundled_resources_dir_name} — global resources directory name (e.g. bundled_resources)
 #   {no_http_client_exit_code}  — exit code when neither curl nor wget is available
 #   {staging_tarball_path}      — path to a pre-uploaded tarball (SCP fallback; empty normally)
 set -e
@@ -72,12 +63,6 @@ tmpdir=$(mktemp -d "$install_dir/.install.XXXXXX")
 # instead of clobbering with the cleanup's exit code.
 cleanup() {
   rm -rf "$tmpdir" 2>/dev/null || true
-  if [ -n "${install_bundle_tmp:-}" ]; then
-    rm -rf "$install_bundle_tmp" 2>/dev/null || true
-  fi
-  if [ -n "${symlink_tmp:-}" ]; then
-    rm -f "$symlink_tmp" 2>/dev/null || true
-  fi
 }
 trap cleanup EXIT
 
@@ -110,44 +95,18 @@ tar -xzf "$tmpdir/oz.tar.gz" -C "$tmpdir"
 # whose names also start with `oz`.
 bin=$(find "$tmpdir" -type f -name 'oz*' ! -name '*.tar.gz' ! -path '*/resources/*' | head -n1)
 if [ -z "$bin" ]; then echo "no binary found in tarball" >&2; exit 1; fi
-resources="$(dirname "$bin")/resources"
-if [ ! -d "$resources" ]; then echo "no resources directory found in tarball" >&2; exit 1; fi
-
-# Assemble the complete bundle in the temp dir first: assembly takes multiple
-# moves, so it must happen at a path nothing launches from. The shipped
-# executable-beside-resources pairing is preserved as-is.
-staged_bundle="$tmpdir/bundle"
-mkdir -p "$staged_bundle"
 chmod +x "$bin"
-mv "$bin" "$staged_bundle/{binary_name}"
-mv "$resources" "$staged_bundle/resources"
 
-bundles_dir="$install_dir/bundles"
-bundle_dir="$bundles_dir/{bundle_version}"
-mkdir -p "$bundles_dir"
+# Install the resources tree at the global, version-independent location
+# the daemon reads. `$tmpdir` lives inside `$install_dir`, so the `mv` is a
+# same-filesystem rename. Installed before the binary so an interrupted
+# install never leaves a new binary without its resources — the binary miss
+# re-triggers this script. A tarball without resources is not an error: the
+# daemon simply has no bundled skills.
+resources="$(dirname "$bin")/resources"
+if [ -d "$resources" ]; then
+  rm -rf "$install_dir/{bundled_resources_dir_name}"
+  mv "$resources" "$install_dir/{bundled_resources_dir_name}"
+fi
 
-# Install the staged bundle with a single directory rename so the bundle
-# either exists in full or not at all — an interrupted install must never
-# leave a binary without its resources at a launchable path. The temp name is
-# dot-prefixed and PID-suffixed so concurrent installs cannot collide.
-# Replacing an existing bundle is only needed to repair an incomplete install
-# at this version; healthy bundles are skipped by the pre-install binary check.
-install_bundle_tmp="$bundles_dir/.{bundle_version}.install.$$"
-rm -rf "$install_bundle_tmp"
-mv "$staged_bundle" "$install_bundle_tmp"
-rm -rf "$bundle_dir"
-mv "$install_bundle_tmp" "$bundle_dir"
-
-# Point the historical launch path at the bundle. Clients launch the
-# version-suffixed path they have always used, while the shipped binary keeps
-# its unsuffixed name beside its resources — the symlink bridges the two, and
-# because the daemon canonicalizes through it, the daemon resolves its own
-# bundle's resources. The target is relative to keep the install relocatable.
-# The link is created at a temp name and renamed into place because `ln -s`
-# cannot atomically replace an existing path (including a legacy regular-file
-# binary being upgraded to the bundle layout).
-binary_path="$install_dir/{binary_name}{version_suffix}"
-symlink_tmp="$install_dir/.{binary_name}{version_suffix}.link.$$"
-rm -f "$symlink_tmp"
-ln -s "{binary_symlink_target}" "$symlink_tmp"
-mv -f "$symlink_tmp" "$binary_path"
+mv "$bin" "$install_dir/{binary_name}{version_suffix}"

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -74,6 +74,7 @@ struct ReconnectParams {
 #[cfg(not(target_family = "wasm"))]
 struct InitializeHandshake {
     host_id: HostId,
+    bundled_resources_dir: Option<String>,
     event_rx: async_channel::Receiver<ClientEvent>,
     failure_rx: async_channel::Receiver<crate::client::RequestFailedEvent>,
     host_response_rx: async_channel::Receiver<crate::proto::ServerMessage>,
@@ -1237,6 +1238,8 @@ pub struct RemoteServerManager {
     sessions: HashMap<SessionId, RemoteSessionState>,
     /// Reverse index: host → sessions for O(1) lookup by `HostId`.
     host_to_sessions: HashMap<HostId, HashSet<SessionId>>,
+    /// Packaged resources directory advertised by each connected remote host.
+    bundled_resources_dirs: HashMap<HostId, String>,
     /// User-facing connection labels by session, applied after the initialize
     /// handshake returns a host ID.
     session_labels: HashMap<SessionId, String>,
@@ -1283,6 +1286,7 @@ impl RemoteServerManager {
         Self {
             sessions: HashMap::new(),
             host_to_sessions: HashMap::new(),
+            bundled_resources_dirs: HashMap::new(),
             session_labels: HashMap::new(),
             spawner: ctx.spawner(),
             last_navigation: HashMap::new(),
@@ -2220,6 +2224,8 @@ impl RemoteServerManager {
 
         Ok(InitializeHandshake {
             host_id: HostId::new(resp.host_id),
+            bundled_resources_dir: (!resp.bundled_resources_dir.is_empty())
+                .then_some(resp.bundled_resources_dir),
             event_rx,
             failure_rx,
             host_response_rx,
@@ -2420,6 +2426,15 @@ impl RemoteServerManager {
     /// reverse index.
     pub fn sessions_for_host(&self, host_id: &HostId) -> Option<&HashSet<SessionId>> {
         self.host_to_sessions.get(host_id)
+    }
+    /// Returns all host IDs with at least one connected session.
+    pub fn connected_host_ids(&self) -> impl Iterator<Item = &HostId> {
+        self.host_to_sessions.keys()
+    }
+
+    /// Returns the packaged resources directory advertised by a connected host.
+    pub fn bundled_resources_dir_for_host(&self, host_id: &HostId) -> Option<&str> {
+        self.bundled_resources_dirs.get(host_id).map(String::as_str)
     }
 
     fn connected_session_for_host(
@@ -3436,6 +3451,7 @@ impl RemoteServerManager {
     ) {
         let InitializeHandshake {
             host_id,
+            bundled_resources_dir,
             event_rx,
             failure_rx,
             host_response_rx,
@@ -3469,6 +3485,10 @@ impl RemoteServerManager {
             .entry(host_id.clone())
             .or_default()
             .insert(session_id);
+        if let Some(bundled_resources_dir) = bundled_resources_dir {
+            self.bundled_resources_dirs
+                .insert(host_id.clone(), bundled_resources_dir);
+        }
         ctx.spawn_stream_local(
             event_rx,
             move |me, event, ctx| {
@@ -3916,6 +3936,7 @@ impl RemoteServerManager {
     /// fails any pending host-scoped requests that targeted this host.
     fn handle_host_disconnected(&mut self, host_id: &HostId, ctx: &mut ModelContext<Self>) {
         if !self.host_to_sessions.contains_key(host_id) {
+            self.bundled_resources_dirs.remove(host_id);
             ctx.emit(RemoteServerManagerEvent::HostDisconnected {
                 host_id: host_id.clone(),
             });

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -74,7 +74,6 @@ struct ReconnectParams {
 #[cfg(not(target_family = "wasm"))]
 struct InitializeHandshake {
     host_id: HostId,
-    bundled_resources_dir: Option<String>,
     event_rx: async_channel::Receiver<ClientEvent>,
     failure_rx: async_channel::Receiver<crate::client::RequestFailedEvent>,
     host_response_rx: async_channel::Receiver<crate::proto::ServerMessage>,
@@ -284,6 +283,7 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::DiffStateSnapshotReceived { .. } => "diff_state_snapshot",
         ClientEvent::DiffStateMetadataUpdateReceived { .. } => "diff_state_metadata_update",
         ClientEvent::DiffStateFileDeltaReceived { .. } => "diff_state_file_delta",
+        ClientEvent::BundledSkillsSnapshotReceived { .. } => "bundled_skills_snapshot",
         ClientEvent::MessageDecodingError => "message_decoding_error",
     }
 }
@@ -463,6 +463,14 @@ pub enum RemoteServerManagerEvent {
     /// The last session for this host was disconnected or deregistered.
     /// Downstream features should tear down per-host models.
     HostDisconnected { host_id: HostId },
+    /// The daemon pushed its pre-parsed bundled skill catalog. Sent after
+    /// a connection initializes (when the daemon has already parsed) and
+    /// broadcast when daemon-side parsing completes; a newer snapshot for
+    /// the same host replaces the previous one.
+    BundledSkillsSnapshot {
+        host_id: HostId,
+        skills: Vec<crate::proto::BundledSkillProto>,
+    },
 
     // --- Repo metadata events (forwarded from ClientEvent push channel) ---
     /// Response to a `navigate_to_directory` request.
@@ -672,6 +680,7 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::GetBranchesResponse { session_id, .. } => Some(*session_id),
             RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::HostDisconnected { .. }
+            | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
@@ -1238,8 +1247,6 @@ pub struct RemoteServerManager {
     sessions: HashMap<SessionId, RemoteSessionState>,
     /// Reverse index: host → sessions for O(1) lookup by `HostId`.
     host_to_sessions: HashMap<HostId, HashSet<SessionId>>,
-    /// Packaged resources directory advertised by each connected remote host.
-    bundled_resources_dirs: HashMap<HostId, String>,
     /// User-facing connection labels by session, applied after the initialize
     /// handshake returns a host ID.
     session_labels: HashMap<SessionId, String>,
@@ -1286,7 +1293,6 @@ impl RemoteServerManager {
         Self {
             sessions: HashMap::new(),
             host_to_sessions: HashMap::new(),
-            bundled_resources_dirs: HashMap::new(),
             session_labels: HashMap::new(),
             spawner: ctx.spawner(),
             last_navigation: HashMap::new(),
@@ -2224,8 +2230,6 @@ impl RemoteServerManager {
 
         Ok(InitializeHandshake {
             host_id: HostId::new(resp.host_id),
-            bundled_resources_dir: (!resp.bundled_resources_dir.is_empty())
-                .then_some(resp.bundled_resources_dir),
             event_rx,
             failure_rx,
             host_response_rx,
@@ -2426,15 +2430,6 @@ impl RemoteServerManager {
     /// reverse index.
     pub fn sessions_for_host(&self, host_id: &HostId) -> Option<&HashSet<SessionId>> {
         self.host_to_sessions.get(host_id)
-    }
-    /// Returns all host IDs with at least one connected session.
-    pub fn connected_host_ids(&self) -> impl Iterator<Item = &HostId> {
-        self.host_to_sessions.keys()
-    }
-
-    /// Returns the packaged resources directory advertised by a connected host.
-    pub fn bundled_resources_dir_for_host(&self, host_id: &HostId) -> Option<&str> {
-        self.bundled_resources_dirs.get(host_id).map(String::as_str)
     }
 
     fn connected_session_for_host(
@@ -3432,6 +3427,9 @@ impl RemoteServerManager {
                     delta,
                 });
             }
+            ClientEvent::BundledSkillsSnapshotReceived { skills } => {
+                ctx.emit(RemoteServerManagerEvent::BundledSkillsSnapshot { host_id, skills });
+            }
             ClientEvent::Disconnected => {
                 // Handled by the drain loop's completion callback.
             }
@@ -3451,7 +3449,6 @@ impl RemoteServerManager {
     ) {
         let InitializeHandshake {
             host_id,
-            bundled_resources_dir,
             event_rx,
             failure_rx,
             host_response_rx,
@@ -3485,10 +3482,6 @@ impl RemoteServerManager {
             .entry(host_id.clone())
             .or_default()
             .insert(session_id);
-        if let Some(bundled_resources_dir) = bundled_resources_dir {
-            self.bundled_resources_dirs
-                .insert(host_id.clone(), bundled_resources_dir);
-        }
         ctx.spawn_stream_local(
             event_rx,
             move |me, event, ctx| {
@@ -3936,7 +3929,6 @@ impl RemoteServerManager {
     /// fails any pending host-scoped requests that targeted this host.
     fn handle_host_disconnected(&mut self, host_id: &HostId, ctx: &mut ModelContext<Self>) {
         if !self.host_to_sessions.contains_key(host_id) {
-            self.bundled_resources_dirs.remove(host_id);
             ctx.emit(RemoteServerManagerEvent::HostDisconnected {
                 host_id: host_id.clone(),
             });

--- a/crates/remote_server/src/protocol_tests.rs
+++ b/crates/remote_server/src/protocol_tests.rs
@@ -40,6 +40,7 @@ async fn round_trip_server_message() {
             InitializeResponse {
                 server_version: "0.1.0".to_string(),
                 host_id: "test-host".to_string(),
+                bundled_resources_dir: "/opt/warp/resources".to_string(),
             },
         )),
     };
@@ -54,6 +55,7 @@ async fn round_trip_server_message() {
     match decoded.message {
         Some(server_message::Message::InitializeResponse(resp)) => {
             assert_eq!(resp.server_version, "0.1.0");
+            assert_eq!(resp.bundled_resources_dir, "/opt/warp/resources");
         }
         other => panic!("unexpected message variant: {other:?}"),
     }

--- a/crates/remote_server/src/protocol_tests.rs
+++ b/crates/remote_server/src/protocol_tests.rs
@@ -2,8 +2,8 @@ use prost::Message;
 
 use super::*;
 use crate::proto::{
-    client_message, server_message, session_scoped_request, ClientMessage, Initialize,
-    InitializeResponse, ServerMessage,
+    client_message, server_message, session_scoped_request, BundledSkillProto,
+    BundledSkillsSnapshot, ClientMessage, Initialize, InitializeResponse, ServerMessage,
 };
 
 #[tokio::test]
@@ -40,7 +40,6 @@ async fn round_trip_server_message() {
             InitializeResponse {
                 server_version: "0.1.0".to_string(),
                 host_id: "test-host".to_string(),
-                bundled_resources_dir: "/opt/warp/resources".to_string(),
             },
         )),
     };
@@ -55,7 +54,49 @@ async fn round_trip_server_message() {
     match decoded.message {
         Some(server_message::Message::InitializeResponse(resp)) => {
             assert_eq!(resp.server_version, "0.1.0");
-            assert_eq!(resp.bundled_resources_dir, "/opt/warp/resources");
+            assert_eq!(resp.host_id, "test-host");
+        }
+        other => panic!("unexpected message variant: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn round_trip_bundled_skills_snapshot() {
+    let msg = ServerMessage {
+        request_id: String::new(),
+        message: Some(server_message::Message::BundledSkillsSnapshot(
+            BundledSkillsSnapshot {
+                skills: vec![BundledSkillProto {
+                    id: "pr-comments".to_string(),
+                    name: "pr-comments".to_string(),
+                    description: "Fetch PR comments".to_string(),
+                    path: "/home/user/.warp/remote-server/bundled_resources/bundled/skills/pr-comments/SKILL.md".to_string(),
+                    content: "---\nname: pr-comments\n---\nbody".to_string(),
+                    requires_mcp: None,
+                }, BundledSkillProto {
+                    id: "figma-skill".to_string(),
+                    name: "figma-skill".to_string(),
+                    description: "Figma helper".to_string(),
+                    path: "/path/SKILL.md".to_string(),
+                    content: "body".to_string(),
+                    requires_mcp: Some("figma".to_string()),
+                }],
+            },
+        )),
+    };
+
+    let mut buf = Vec::new();
+    write_server_message(&mut buf, &msg).await.unwrap();
+
+    let mut cursor = &buf[..];
+    let decoded: ServerMessage = read_server_message(&mut cursor).await.unwrap();
+
+    match decoded.message {
+        Some(server_message::Message::BundledSkillsSnapshot(snapshot)) => {
+            assert_eq!(snapshot.skills.len(), 2);
+            assert_eq!(snapshot.skills[0].id, "pr-comments");
+            assert_eq!(snapshot.skills[0].requires_mcp, None);
+            assert_eq!(snapshot.skills[1].requires_mcp, Some("figma".to_string()));
         }
         other => panic!("unexpected message variant: {other:?}"),
     }

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -467,8 +467,8 @@ pub fn binary_name() -> &'static str {
     ChannelState::channel().cli_command_name()
 }
 
-/// Returns the full remote binary path for the current channel and client
-/// version.
+/// Returns the compatibility symlink path used to launch the remote binary for
+/// the current channel and client version.
 ///
 /// The path-versioning rule is keyed strictly off [`Channel`]:
 ///
@@ -495,15 +495,36 @@ pub fn remote_server_binary() -> String {
     }
 }
 
-/// Returns the shell command to verify the remote server binary is
-/// installed and functional by running it with `--version`.
+/// Returns the shell command to verify the complete remote-server bundle is
+/// installed and functional by running its compatibility symlink with
+/// `--version`.
 ///
-/// Exits 0 when the binary is present, executable, and can parse its
-/// own arguments. A missing binary produces exit 127 (command not
-/// found) or 126 (not executable), and a corrupted binary will fail
-/// with a non-zero exit of its own.
+/// Exits 0 when the compatibility path is a symlink, the bundle executable is
+/// present and executable, the bundle resources directory exists, and the
+/// executable can parse its own arguments.
 pub fn binary_check_command() -> String {
-    format!("{} --version", remote_server_binary())
+    format!(
+        "test -L {} && test \"$(readlink {})\" = \"{}\" && test -x {} && test -d {} && {} --version",
+        remote_server_binary(),
+        remote_server_binary(),
+        remote_server_binary_symlink_target(),
+        remote_server_bundle_binary(),
+        remote_server_bundle_resources_dir(),
+        remote_server_binary(),
+    )
+}
+
+/// Returns the shell command to remove the current remote-server install.
+///
+/// Removes both the compatibility path and its version-scoped bundle. This is
+/// safe for legacy binary-only installs because `rm -f` also removes a regular
+/// file at the compatibility path and `rm -rf` tolerates a missing bundle.
+pub fn remote_server_removal_command() -> String {
+    format!(
+        "rm -f {} && rm -rf {}",
+        remote_server_binary(),
+        remote_server_bundle_dir()
+    )
 }
 
 /// Returns the version string used to pin remote-server installs on
@@ -531,6 +552,42 @@ pub fn remote_server_artifact_version() -> &'static str {
             pinned_version()
         }
     }
+}
+/// Returns the version-scoped directory containing the remote-server
+/// executable and its resources.
+///
+/// Keeping the executable and resources together ensures
+/// [`warp_core::paths::bundled_resources_dir`] can find the resources after
+/// canonicalizing the compatibility symlink returned by
+/// [`remote_server_binary`].
+pub fn remote_server_bundle_dir() -> String {
+    format!(
+        "{}/bundles/{}",
+        remote_server_dir(),
+        remote_server_artifact_version()
+    )
+}
+
+/// Returns the executable path inside the current version-scoped bundle.
+pub fn remote_server_bundle_binary() -> String {
+    format!("{}/{}", remote_server_bundle_dir(), binary_name())
+}
+
+/// Returns the resources directory inside the current version-scoped bundle.
+pub fn remote_server_bundle_resources_dir() -> String {
+    format!("{}/resources", remote_server_bundle_dir())
+}
+
+/// Returns the relative symlink target used by [`remote_server_binary`].
+///
+/// A relative target keeps installs relocatable with the remote user's home
+/// directory while still resolving to [`remote_server_bundle_binary`].
+fn remote_server_binary_symlink_target() -> String {
+    format!(
+        "bundles/{}/{}",
+        remote_server_artifact_version(),
+        binary_name()
+    )
 }
 
 /// The install script template, loaded from a standalone `.sh` file for
@@ -565,6 +622,11 @@ pub fn install_script(staging_tarball_path: Option<&str>) -> String {
         .replace("{binary_name}", binary_name())
         .replace("{version_query}", &vq)
         .replace("{version_suffix}", &version_suffix)
+        .replace("{bundle_version}", remote_server_artifact_version())
+        .replace(
+            "{binary_symlink_target}",
+            &remote_server_binary_symlink_target(),
+        )
         .replace(
             "{no_http_client_exit_code}",
             &NO_HTTP_CLIENT_EXIT_CODE.to_string(),

--- a/crates/remote_server/src/setup.rs
+++ b/crates/remote_server/src/setup.rs
@@ -467,8 +467,8 @@ pub fn binary_name() -> &'static str {
     ChannelState::channel().cli_command_name()
 }
 
-/// Returns the compatibility symlink path used to launch the remote binary for
-/// the current channel and client version.
+/// Returns the full remote binary path for the current channel and client
+/// version.
 ///
 /// The path-versioning rule is keyed strictly off [`Channel`]:
 ///
@@ -495,36 +495,24 @@ pub fn remote_server_binary() -> String {
     }
 }
 
-/// Returns the shell command to verify the complete remote-server bundle is
-/// installed and functional by running its compatibility symlink with
-/// `--version`.
+/// Returns the shell command to verify the remote server binary is
+/// installed and functional by running it with `--version`.
 ///
-/// Exits 0 when the compatibility path is a symlink, the bundle executable is
-/// present and executable, the bundle resources directory exists, and the
-/// executable can parse its own arguments.
+/// Exits 0 when the binary is present, executable, and can parse its
+/// own arguments. A missing binary produces exit 127 (command not
+/// found) or 126 (not executable), and a corrupted binary will fail
+/// with a non-zero exit of its own.
 pub fn binary_check_command() -> String {
-    format!(
-        "test -L {} && test \"$(readlink {})\" = \"{}\" && test -x {} && test -d {} && {} --version",
-        remote_server_binary(),
-        remote_server_binary(),
-        remote_server_binary_symlink_target(),
-        remote_server_bundle_binary(),
-        remote_server_bundle_resources_dir(),
-        remote_server_binary(),
-    )
+    format!("{} --version", remote_server_binary())
 }
 
-/// Returns the shell command to remove the current remote-server install.
+/// Returns the shell command to remove the current remote-server binary.
 ///
-/// Removes both the compatibility path and its version-scoped bundle. This is
-/// safe for legacy binary-only installs because `rm -f` also removes a regular
-/// file at the compatibility path and `rm -rf` tolerates a missing bundle.
+/// The global bundled resources directory is deliberately left in place:
+/// the next install overwrites it, and an older daemon that is still
+/// running parsed its skills at startup.
 pub fn remote_server_removal_command() -> String {
-    format!(
-        "rm -f {} && rm -rf {}",
-        remote_server_binary(),
-        remote_server_bundle_dir()
-    )
+    format!("rm -f {}", remote_server_binary())
 }
 
 /// Returns the version string used to pin remote-server installs on
@@ -553,41 +541,21 @@ pub fn remote_server_artifact_version() -> &'static str {
         }
     }
 }
-/// Returns the version-scoped directory containing the remote-server
-/// executable and its resources.
+
+/// Name of the global, version-independent resources directory inside
+/// [`remote_server_dir`], populated by the install script from the
+/// artifact's `resources/` tree (bundled skills, settings schema).
+pub const BUNDLED_RESOURCES_DIR_NAME: &str = "bundled_resources";
+
+/// Returns the global, version-independent directory where the install
+/// script places the artifact's `resources/` tree. Shell-form path
+/// (`~/...`); the daemon expands it against its own home directory.
 ///
-/// Keeping the executable and resources together ensures
-/// [`warp_core::paths::bundled_resources_dir`] can find the resources after
-/// canonicalizing the compatibility symlink returned by
-/// [`remote_server_binary`].
-pub fn remote_server_bundle_dir() -> String {
-    format!(
-        "{}/bundles/{}",
-        remote_server_dir(),
-        remote_server_artifact_version()
-    )
-}
-
-/// Returns the executable path inside the current version-scoped bundle.
-pub fn remote_server_bundle_binary() -> String {
-    format!("{}/{}", remote_server_bundle_dir(), binary_name())
-}
-
-/// Returns the resources directory inside the current version-scoped bundle.
-pub fn remote_server_bundle_resources_dir() -> String {
-    format!("{}/resources", remote_server_bundle_dir())
-}
-
-/// Returns the relative symlink target used by [`remote_server_binary`].
-///
-/// A relative target keeps installs relocatable with the remote user's home
-/// directory while still resolving to [`remote_server_bundle_binary`].
-fn remote_server_binary_symlink_target() -> String {
-    format!(
-        "bundles/{}/{}",
-        remote_server_artifact_version(),
-        binary_name()
-    )
+/// Deliberately not version-scoped: the last install wins, and slight
+/// version skew between the resources and a running daemon is accepted
+/// (the daemon parses its skills once at startup).
+pub fn remote_server_bundled_resources_dir() -> String {
+    format!("{}/{}", remote_server_dir(), BUNDLED_RESOURCES_DIR_NAME)
 }
 
 /// The install script template, loaded from a standalone `.sh` file for
@@ -622,11 +590,7 @@ pub fn install_script(staging_tarball_path: Option<&str>) -> String {
         .replace("{binary_name}", binary_name())
         .replace("{version_query}", &vq)
         .replace("{version_suffix}", &version_suffix)
-        .replace("{bundle_version}", remote_server_artifact_version())
-        .replace(
-            "{binary_symlink_target}",
-            &remote_server_binary_symlink_target(),
-        )
+        .replace("{bundled_resources_dir_name}", BUNDLED_RESOURCES_DIR_NAME)
         .replace(
             "{no_http_client_exit_code}",
             &NO_HTTP_CLIENT_EXIT_CODE.to_string(),

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -1,3 +1,11 @@
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::process::Stdio;
+
+#[cfg(unix)]
+use command::blocking::Command;
+
 use super::*;
 
 #[test]
@@ -240,6 +248,166 @@ fn parse_preinstall_unsupported_non_glibc() {
     assert!(!result.is_supported());
 }
 
+#[test]
+fn remote_server_bundle_paths_are_version_scoped() {
+    let expected_bundle_dir = format!(
+        "{}/bundles/{}",
+        remote_server_dir(),
+        remote_server_artifact_version()
+    );
+
+    assert_eq!(remote_server_bundle_dir(), expected_bundle_dir);
+    assert_eq!(
+        remote_server_bundle_binary(),
+        format!("{expected_bundle_dir}/{}", binary_name())
+    );
+    assert_eq!(
+        remote_server_bundle_resources_dir(),
+        format!("{expected_bundle_dir}/resources")
+    );
+}
+
+#[test]
+fn binary_check_requires_symlink_executable_and_resources() {
+    let command = binary_check_command();
+
+    assert!(command.contains(&format!("test -L {}", remote_server_binary())));
+    assert!(command.contains(&format!(
+        "test \"$(readlink {})\" = \"{}\"",
+        remote_server_binary(),
+        remote_server_binary_symlink_target()
+    )));
+    assert!(command.contains(&format!("test -x {}", remote_server_bundle_binary())));
+    assert!(command.contains(&format!("test -d {}", remote_server_bundle_resources_dir())));
+    assert!(command.ends_with(&format!("{} --version", remote_server_binary())));
+}
+
+#[test]
+fn removal_command_removes_compatibility_path_and_bundle() {
+    assert_eq!(
+        remote_server_removal_command(),
+        format!(
+            "rm -f {} && rm -rf {}",
+            remote_server_binary(),
+            remote_server_bundle_dir()
+        )
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn install_script_installs_complete_bundle_and_compatibility_symlink() {
+    let test_root = std::env::temp_dir().join(format!(
+        "remote-server-bundle-install-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let fake_home = test_root.join("home");
+    let tar_source = test_root.join("tar-source");
+    let resources = tar_source.join("resources/bundled/skills/test-skill");
+    let tarball = test_root.join("oz.tar.gz");
+    fs::create_dir_all(&fake_home).unwrap();
+    fs::create_dir_all(&resources).unwrap();
+    fs::write(
+        tar_source.join("oz-test"),
+        "#!/usr/bin/env bash\n[ \"$1\" = \"--version\" ]\n",
+    )
+    .unwrap();
+    fs::write(resources.join("SKILL.md"), "test skill").unwrap();
+    // Decoy: skills may ship companion files whose names also start with `oz`.
+    // The installer must not mistake them for the executable.
+    fs::write(
+        resources.join("oz-decoy.sh"),
+        "#!/usr/bin/env bash\nexit 1\n",
+    )
+    .unwrap();
+
+    let tar_output = Command::new("tar")
+        .arg("-czf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(&tar_source)
+        .arg("oz-test")
+        .arg("resources")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to create test tarball");
+    assert!(
+        tar_output.status.success(),
+        "tar failed: {}",
+        String::from_utf8_lossy(&tar_output.stderr)
+    );
+
+    let script = install_script(Some(tarball.to_str().unwrap()));
+    let install_output = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .env("HOME", &fake_home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run install script");
+    assert!(
+        install_output.status.success(),
+        "install failed: {}",
+        String::from_utf8_lossy(&install_output.stderr)
+    );
+
+    let resolve_remote_path = |path: String| path.replacen('~', fake_home.to_str().unwrap(), 1);
+    let compatibility_binary = resolve_remote_path(remote_server_binary());
+    let bundle_binary = resolve_remote_path(remote_server_bundle_binary());
+    let bundle_resources = resolve_remote_path(remote_server_bundle_resources_dir());
+
+    assert!(fs::symlink_metadata(&compatibility_binary)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    assert_eq!(
+        fs::read_link(&compatibility_binary).unwrap(),
+        std::path::PathBuf::from(remote_server_binary_symlink_target())
+    );
+    assert_eq!(
+        fs::canonicalize(&compatibility_binary).unwrap(),
+        fs::canonicalize(&bundle_binary).unwrap()
+    );
+    assert!(fs::metadata(&bundle_binary).unwrap().is_file());
+    assert!(fs::metadata(&bundle_resources).unwrap().is_dir());
+    assert!(std::path::Path::new(&bundle_resources)
+        .join("bundled/skills/test-skill/SKILL.md")
+        .is_file());
+    assert!(std::path::Path::new(&bundle_resources)
+        .join("bundled/skills/test-skill/oz-decoy.sh")
+        .is_file());
+
+    let check_output = Command::new("bash")
+        .arg("-c")
+        .arg(binary_check_command())
+        .env("HOME", &fake_home)
+        .output()
+        .expect("failed to run binary check command");
+    assert!(check_output.status.success());
+    fs::remove_dir_all(&bundle_resources).unwrap();
+    let missing_resources_check = Command::new("bash")
+        .arg("-c")
+        .arg(binary_check_command())
+        .env("HOME", &fake_home)
+        .output()
+        .expect("failed to run binary check command without resources");
+    assert!(!missing_resources_check.status.success());
+
+    let removal_output = Command::new("bash")
+        .arg("-c")
+        .arg(remote_server_removal_command())
+        .env("HOME", &fake_home)
+        .output()
+        .expect("failed to run removal command");
+    assert!(removal_output.status.success());
+    assert!(!std::path::Path::new(&compatibility_binary).exists());
+    assert!(!std::path::Path::new(&bundle_binary).exists());
+
+    fs::remove_dir_all(test_root).unwrap();
+}
+
 /// Regression: the install script's tilde-expansion logic must work
 /// across the bash versions we actually invoke at install time
 /// (`run_ssh_script` pipes the script into `bash -s` on the remote).
@@ -270,10 +438,6 @@ fn parse_preinstall_unsupported_non_glibc() {
 #[cfg(unix)]
 #[test]
 fn install_script_tilde_expansion_resolves_correctly() {
-    use std::process::Stdio;
-
-    use command::blocking::Command;
-
     let bash = if std::path::Path::new("/bin/bash").exists() {
         "/bin/bash"
     } else {

--- a/crates/remote_server/src/setup_tests.rs
+++ b/crates/remote_server/src/setup_tests.rs
@@ -249,77 +249,64 @@ fn parse_preinstall_unsupported_non_glibc() {
 }
 
 #[test]
-fn remote_server_bundle_paths_are_version_scoped() {
-    let expected_bundle_dir = format!(
-        "{}/bundles/{}",
-        remote_server_dir(),
-        remote_server_artifact_version()
+fn bundled_resources_dir_is_global_and_version_independent() {
+    let dir = remote_server_bundled_resources_dir();
+    assert_eq!(
+        dir,
+        format!("{}/{}", remote_server_dir(), BUNDLED_RESOURCES_DIR_NAME)
     );
+    // The whole point of the global location: no version in the path.
+    assert!(!dir.contains(remote_server_artifact_version()));
+}
 
-    assert_eq!(remote_server_bundle_dir(), expected_bundle_dir);
+#[test]
+fn binary_check_runs_version() {
     assert_eq!(
-        remote_server_bundle_binary(),
-        format!("{expected_bundle_dir}/{}", binary_name())
-    );
-    assert_eq!(
-        remote_server_bundle_resources_dir(),
-        format!("{expected_bundle_dir}/resources")
+        binary_check_command(),
+        format!("{} --version", remote_server_binary())
     );
 }
 
 #[test]
-fn binary_check_requires_symlink_executable_and_resources() {
-    let command = binary_check_command();
-
-    assert!(command.contains(&format!("test -L {}", remote_server_binary())));
-    assert!(command.contains(&format!(
-        "test \"$(readlink {})\" = \"{}\"",
-        remote_server_binary(),
-        remote_server_binary_symlink_target()
-    )));
-    assert!(command.contains(&format!("test -x {}", remote_server_bundle_binary())));
-    assert!(command.contains(&format!("test -d {}", remote_server_bundle_resources_dir())));
-    assert!(command.ends_with(&format!("{} --version", remote_server_binary())));
+fn removal_command_removes_binary_but_leaves_global_resources() {
+    let command = remote_server_removal_command();
+    assert_eq!(command, format!("rm -f {}", remote_server_binary()));
+    assert!(!command.contains(BUNDLED_RESOURCES_DIR_NAME));
 }
 
 #[test]
-fn removal_command_removes_compatibility_path_and_bundle() {
-    assert_eq!(
-        remote_server_removal_command(),
-        format!(
-            "rm -f {} && rm -rf {}",
-            remote_server_binary(),
-            remote_server_bundle_dir()
-        )
-    );
+fn install_script_substitutes_bundled_resources_dir_name() {
+    let script = install_script(None);
+    assert!(!script.contains("{bundled_resources_dir_name}"));
+    assert!(script.contains(&format!("$install_dir/{BUNDLED_RESOURCES_DIR_NAME}")));
 }
 
 #[cfg(unix)]
-#[test]
-fn install_script_installs_complete_bundle_and_compatibility_symlink() {
-    let test_root = std::env::temp_dir().join(format!(
-        "remote-server-bundle-install-{}",
-        uuid::Uuid::new_v4()
-    ));
-    let fake_home = test_root.join("home");
-    let tar_source = test_root.join("tar-source");
+fn make_test_tarball(
+    test_root: &std::path::Path,
+    tarball_name: &str,
+    skill_content: &str,
+    include_decoy: bool,
+) -> std::path::PathBuf {
+    let tar_source = test_root.join(format!("tar-source-{tarball_name}"));
     let resources = tar_source.join("resources/bundled/skills/test-skill");
-    let tarball = test_root.join("oz.tar.gz");
-    fs::create_dir_all(&fake_home).unwrap();
+    let tarball = test_root.join(format!("{tarball_name}.tar.gz"));
     fs::create_dir_all(&resources).unwrap();
     fs::write(
         tar_source.join("oz-test"),
         "#!/usr/bin/env bash\n[ \"$1\" = \"--version\" ]\n",
     )
     .unwrap();
-    fs::write(resources.join("SKILL.md"), "test skill").unwrap();
-    // Decoy: skills may ship companion files whose names also start with `oz`.
-    // The installer must not mistake them for the executable.
-    fs::write(
-        resources.join("oz-decoy.sh"),
-        "#!/usr/bin/env bash\nexit 1\n",
-    )
-    .unwrap();
+    fs::write(resources.join("SKILL.md"), skill_content).unwrap();
+    if include_decoy {
+        // Decoy: skills may ship companion files whose names also start
+        // with `oz`. The installer must not mistake them for the executable.
+        fs::write(
+            resources.join("oz-decoy.sh"),
+            "#!/usr/bin/env bash\nexit 1\n",
+        )
+        .unwrap();
+    }
 
     let tar_output = Command::new("tar")
         .arg("-czf")
@@ -337,12 +324,16 @@ fn install_script_installs_complete_bundle_and_compatibility_symlink() {
         "tar failed: {}",
         String::from_utf8_lossy(&tar_output.stderr)
     );
+    tarball
+}
 
+#[cfg(unix)]
+fn run_install_script(tarball: &std::path::Path, fake_home: &std::path::Path) {
     let script = install_script(Some(tarball.to_str().unwrap()));
     let install_output = Command::new("bash")
         .arg("-c")
         .arg(&script)
-        .env("HOME", &fake_home)
+        .env("HOME", fake_home)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -352,30 +343,30 @@ fn install_script_installs_complete_bundle_and_compatibility_symlink() {
         "install failed: {}",
         String::from_utf8_lossy(&install_output.stderr)
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn install_script_installs_binary_and_global_resources() {
+    let test_root = std::env::temp_dir().join(format!(
+        "remote-server-global-install-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let fake_home = test_root.join("home");
+    fs::create_dir_all(&fake_home).unwrap();
+
+    let tarball = make_test_tarball(&test_root, "first", "test skill", true);
+    run_install_script(&tarball, &fake_home);
 
     let resolve_remote_path = |path: String| path.replacen('~', fake_home.to_str().unwrap(), 1);
-    let compatibility_binary = resolve_remote_path(remote_server_binary());
-    let bundle_binary = resolve_remote_path(remote_server_bundle_binary());
-    let bundle_resources = resolve_remote_path(remote_server_bundle_resources_dir());
+    let binary = resolve_remote_path(remote_server_binary());
+    let resources = resolve_remote_path(remote_server_bundled_resources_dir());
+    let skill_md = std::path::Path::new(&resources).join("bundled/skills/test-skill/SKILL.md");
 
-    assert!(fs::symlink_metadata(&compatibility_binary)
-        .unwrap()
-        .file_type()
-        .is_symlink());
-    assert_eq!(
-        fs::read_link(&compatibility_binary).unwrap(),
-        std::path::PathBuf::from(remote_server_binary_symlink_target())
-    );
-    assert_eq!(
-        fs::canonicalize(&compatibility_binary).unwrap(),
-        fs::canonicalize(&bundle_binary).unwrap()
-    );
-    assert!(fs::metadata(&bundle_binary).unwrap().is_file());
-    assert!(fs::metadata(&bundle_resources).unwrap().is_dir());
-    assert!(std::path::Path::new(&bundle_resources)
-        .join("bundled/skills/test-skill/SKILL.md")
-        .is_file());
-    assert!(std::path::Path::new(&bundle_resources)
+    assert!(fs::metadata(&binary).unwrap().is_file());
+    assert!(fs::metadata(&resources).unwrap().is_dir());
+    assert_eq!(fs::read_to_string(&skill_md).unwrap(), "test skill");
+    assert!(std::path::Path::new(&resources)
         .join("bundled/skills/test-skill/oz-decoy.sh")
         .is_file());
 
@@ -386,15 +377,19 @@ fn install_script_installs_complete_bundle_and_compatibility_symlink() {
         .output()
         .expect("failed to run binary check command");
     assert!(check_output.status.success());
-    fs::remove_dir_all(&bundle_resources).unwrap();
-    let missing_resources_check = Command::new("bash")
-        .arg("-c")
-        .arg(binary_check_command())
-        .env("HOME", &fake_home)
-        .output()
-        .expect("failed to run binary check command without resources");
-    assert!(!missing_resources_check.status.success());
 
+    // A later install fully replaces the global resources (last install
+    // wins): updated content lands and files absent from the new artifact
+    // disappear, proving a swap rather than a merge.
+    let second_tarball = make_test_tarball(&test_root, "second", "updated skill", false);
+    run_install_script(&second_tarball, &fake_home);
+    assert_eq!(fs::read_to_string(&skill_md).unwrap(), "updated skill");
+    assert!(!std::path::Path::new(&resources)
+        .join("bundled/skills/test-skill/oz-decoy.sh")
+        .exists());
+
+    // Removal deletes the binary but leaves the global resources for the
+    // next install to overwrite.
     let removal_output = Command::new("bash")
         .arg("-c")
         .arg(remote_server_removal_command())
@@ -402,8 +397,49 @@ fn install_script_installs_complete_bundle_and_compatibility_symlink() {
         .output()
         .expect("failed to run removal command");
     assert!(removal_output.status.success());
-    assert!(!std::path::Path::new(&compatibility_binary).exists());
-    assert!(!std::path::Path::new(&bundle_binary).exists());
+    assert!(!std::path::Path::new(&binary).exists());
+    assert!(fs::metadata(&resources).unwrap().is_dir());
+
+    fs::remove_dir_all(test_root).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn install_script_tolerates_tarball_without_resources() {
+    let test_root = std::env::temp_dir().join(format!(
+        "remote-server-no-resources-install-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let fake_home = test_root.join("home");
+    let tar_source = test_root.join("tar-source");
+    let tarball = test_root.join("oz.tar.gz");
+    fs::create_dir_all(&fake_home).unwrap();
+    fs::create_dir_all(&tar_source).unwrap();
+    fs::write(
+        tar_source.join("oz-test"),
+        "#!/usr/bin/env bash\n[ \"$1\" = \"--version\" ]\n",
+    )
+    .unwrap();
+
+    let tar_output = Command::new("tar")
+        .arg("-czf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(&tar_source)
+        .arg("oz-test")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to create test tarball");
+    assert!(tar_output.status.success());
+
+    run_install_script(&tarball, &fake_home);
+
+    let resolve_remote_path = |path: String| path.replacen('~', fake_home.to_str().unwrap(), 1);
+    let binary = resolve_remote_path(remote_server_binary());
+    let resources = resolve_remote_path(remote_server_bundled_resources_dir());
+    assert!(fs::metadata(&binary).unwrap().is_file());
+    assert!(!std::path::Path::new(&resources).exists());
 
     fs::remove_dir_all(test_root).unwrap();
 }

--- a/resources/bundled/skills/create-skill/SKILL.md
+++ b/resources/bundled/skills/create-skill/SKILL.md
@@ -227,7 +227,7 @@ Once all runs are done:
 
 2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
    ```bash
-   python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+   python {{skill_dir}}/scripts/aggregate_benchmark.py <workspace>/iteration-N --skill-name <name>
    ```
    This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
 Put each with_skill version before its baseline counterpart.
@@ -236,7 +236,7 @@ Put each with_skill version before its baseline counterpart.
 
 4. **Launch the viewer** with both qualitative outputs and quantitative data:
    ```bash
-   nohup python <skill-creator-path>/eval-viewer/generate_review.py \
+   nohup python {{skill_dir}}/eval-viewer/generate_review.py \
      <workspace>/iteration-N \
      --skill-name "my-skill" \
      --benchmark <workspace>/iteration-N/benchmark.json \

--- a/resources/bundled/skills/modify-settings/SKILL.md
+++ b/resources/bundled/skills/modify-settings/SKILL.md
@@ -33,7 +33,7 @@ grep -i "font" {{settings_schema_path}}
 Once you have a candidate key name, run the bundled script to get the **full dotted path**, the setting's properties, and any parent context. This is critical — the schema has multiple sections with similar names (e.g. several `input` keys), so never assume the nesting from grep output alone.
 
 ```sh
-python3 <skill_dir>/scripts/find_setting.py {{settings_schema_path}} <key_name>
+python3 {{skill_dir}}/scripts/find_setting.py {{settings_schema_path}} <key_name>
 ```
 
 The output gives you the unambiguous full path (e.g. `properties.appearance.properties.input.properties.input_mode`) and the setting's full definition including valid values.

--- a/resources/bundled/skills/pr-comments/SKILL.md
+++ b/resources/bundled/skills/pr-comments/SKILL.md
@@ -12,7 +12,7 @@ Fetch all review comments from the current branch's GitHub PR and display them v
 1. Run the bundled script (must be inside a git repo with an open PR on the current branch).
    Use `do_not_summarize_output: true` when running this shell command so the JSON output is not truncated.
    ```bash
-   python3 <skill_dir>/scripts/fetch_github_review_comments.py
+   python3 {{skill_dir}}/scripts/fetch_github_review_comments.py
    ```
    The script prints JSON to stdout.
    If the script fails to fetch comments, run the fallback `gh` commands instead.

--- a/script/deploy_remote_server
+++ b/script/deploy_remote_server
@@ -113,6 +113,7 @@ FEATURES="release_bundle,crash_reporting,standalone,agent_mode_debug,remote_code
 WARP_BIN="warp"
 BINARY_NAME="oz-local"
 REMOTE_DIR=".warp-local/remote-server"
+BUNDLE_VERSION="unversioned"
 
 # Determine the output directory
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT/target}"
@@ -125,6 +126,7 @@ case "$CARGO_PROFILE" in
     ;;
 esac
 BUILT_BINARY="$OUTPUT_DIR/$WARP_BIN"
+LOCAL_BUNDLE_DIR="$OUTPUT_DIR/remote-server-bundle"
 
 echo "==> Building Oz CLI for $TARGET (profile=$CARGO_PROFILE)"
 echo "    Binary: $WARP_BIN -> $BINARY_NAME"
@@ -150,6 +152,16 @@ fi
 BINARY_SIZE=$(du -h "$BUILT_BINARY" | cut -f1)
 echo ""
 echo "==> Build complete ($BINARY_SIZE)"
+# Prepare the same executable + resources layout used by downloaded remote
+# server bundles. The compatibility binary path on the remote will symlink to
+# this bundle so canonicalizing the executable finds its sibling resources.
+rm -rf "$LOCAL_BUNDLE_DIR"
+mkdir -p "$LOCAL_BUNDLE_DIR"
+cp "$BUILT_BINARY" "$LOCAL_BUNDLE_DIR/$BINARY_NAME"
+"$WORKSPACE_ROOT/script/prepare_bundled_resources" \
+  "$LOCAL_BUNDLE_DIR/resources" \
+  local \
+  "$CARGO_PROFILE"
 
 # Resolve $HOME on the remote so our upload lands in the same directory the
 # Warp client checks. The client runs `test -x ~/.warp-local/...` and lets
@@ -164,6 +176,7 @@ if [[ -z "$REMOTE_HOME" ]]; then
 fi
 
 REMOTE_ABS_DIR="$REMOTE_HOME/$REMOTE_DIR"
+REMOTE_ABS_BUNDLE_DIR="$REMOTE_ABS_DIR/bundles/$BUNDLE_VERSION"
 
 # Ensure rsync is available on the remote host
 if ! ssh "$HOST" "command -v rsync" &>/dev/null; then
@@ -175,19 +188,38 @@ if ! ssh "$HOST" "command -v rsync" &>/dev/null; then
   fi
 fi
 
-# Ensure the remote directory exists
-ssh "$HOST" "mkdir -p $REMOTE_ABS_DIR"
+# Ensure the remote bundle directory exists
+ssh "$HOST" "mkdir -p $REMOTE_ABS_BUNDLE_DIR"
 
-echo "==> Uploading to $HOST:$REMOTE_ABS_DIR/$BINARY_NAME"
+echo "==> Uploading bundle to $HOST:$REMOTE_ABS_BUNDLE_DIR"
 
 # Upload via rsync with delta transfer and compression.
 # After the first deploy, only changed bytes are transferred.
-rsync -z -t --partial --progress \
-  "$BUILT_BINARY" \
-  "$HOST:$REMOTE_ABS_DIR/$BINARY_NAME"
+rsync -z -rlt --delete --partial --progress \
+  "$LOCAL_BUNDLE_DIR/" \
+  "$HOST:$REMOTE_ABS_BUNDLE_DIR/"
 
 # Set executable permissions (done separately for openrsync compatibility on macOS)
-ssh "$HOST" "chmod 755 $REMOTE_ABS_DIR/$BINARY_NAME"
+ssh "$HOST" "chmod 755 $REMOTE_ABS_BUNDLE_DIR/$BINARY_NAME"
+
+# Atomically replace the historical expected binary path with a relative
+# symlink into the complete bundle.
+ssh "$HOST" bash -s -- "$REMOTE_ABS_DIR" "$BUNDLE_VERSION" "$BINARY_NAME" <<'EOF'
+set -euo pipefail
+
+remote_dir="$1"
+bundle_version="$2"
+binary_name="$3"
+symlink_tmp="$remote_dir/.$binary_name.link.$$"
+
+cleanup() {
+  rm -f "$symlink_tmp"
+}
+trap cleanup EXIT
+
+ln -s "bundles/$bundle_version/$binary_name" "$symlink_tmp"
+mv -f "$symlink_tmp" "$remote_dir/$binary_name"
+EOF
 
 echo "==> Stopping stale remote-server daemons on $HOST"
 ssh "$HOST" bash <<'EOF'
@@ -231,5 +263,6 @@ done
 EOF
 
 echo ""
-echo "==> Done! Binary deployed to $HOST:$REMOTE_ABS_DIR/$BINARY_NAME"
+echo "==> Done! Bundle deployed to $HOST:$REMOTE_ABS_BUNDLE_DIR"
+echo "    Compatibility symlink: $REMOTE_ABS_DIR/$BINARY_NAME"
 echo "    (resolved from ~/$REMOTE_DIR/$BINARY_NAME on remote)"

--- a/script/deploy_remote_server
+++ b/script/deploy_remote_server
@@ -113,7 +113,9 @@ FEATURES="release_bundle,crash_reporting,standalone,agent_mode_debug,remote_code
 WARP_BIN="warp"
 BINARY_NAME="oz-local"
 REMOTE_DIR=".warp-local/remote-server"
-BUNDLE_VERSION="unversioned"
+# Global, version-independent resources location read by the daemon. Must
+# match BUNDLED_RESOURCES_DIR_NAME in crates/remote_server/src/setup.rs.
+BUNDLED_RESOURCES_DIR_NAME="bundled_resources"
 
 # Determine the output directory
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT/target}"
@@ -126,7 +128,7 @@ case "$CARGO_PROFILE" in
     ;;
 esac
 BUILT_BINARY="$OUTPUT_DIR/$WARP_BIN"
-LOCAL_BUNDLE_DIR="$OUTPUT_DIR/remote-server-bundle"
+LOCAL_RESOURCES_DIR="$OUTPUT_DIR/remote-server-resources"
 
 echo "==> Building Oz CLI for $TARGET (profile=$CARGO_PROFILE)"
 echo "    Binary: $WARP_BIN -> $BINARY_NAME"
@@ -152,14 +154,11 @@ fi
 BINARY_SIZE=$(du -h "$BUILT_BINARY" | cut -f1)
 echo ""
 echo "==> Build complete ($BINARY_SIZE)"
-# Prepare the same executable + resources layout used by downloaded remote
-# server bundles. The compatibility binary path on the remote will symlink to
-# this bundle so canonicalizing the executable finds its sibling resources.
-rm -rf "$LOCAL_BUNDLE_DIR"
-mkdir -p "$LOCAL_BUNDLE_DIR"
-cp "$BUILT_BINARY" "$LOCAL_BUNDLE_DIR/$BINARY_NAME"
+# Prepare the bundled resources tree (skills, settings schema) deployed to
+# the global, version-independent location the daemon reads.
+rm -rf "$LOCAL_RESOURCES_DIR"
 "$WORKSPACE_ROOT/script/prepare_bundled_resources" \
-  "$LOCAL_BUNDLE_DIR/resources" \
+  "$LOCAL_RESOURCES_DIR" \
   local \
   "$CARGO_PROFILE"
 
@@ -176,7 +175,6 @@ if [[ -z "$REMOTE_HOME" ]]; then
 fi
 
 REMOTE_ABS_DIR="$REMOTE_HOME/$REMOTE_DIR"
-REMOTE_ABS_BUNDLE_DIR="$REMOTE_ABS_DIR/bundles/$BUNDLE_VERSION"
 
 # Ensure rsync is available on the remote host
 if ! ssh "$HOST" "command -v rsync" &>/dev/null; then
@@ -188,38 +186,24 @@ if ! ssh "$HOST" "command -v rsync" &>/dev/null; then
   fi
 fi
 
-# Ensure the remote bundle directory exists
-ssh "$HOST" "mkdir -p $REMOTE_ABS_BUNDLE_DIR"
+# Ensure the remote install directory exists
+ssh "$HOST" "mkdir -p $REMOTE_ABS_DIR"
 
-echo "==> Uploading bundle to $HOST:$REMOTE_ABS_BUNDLE_DIR"
+echo "==> Uploading binary to $HOST:$REMOTE_ABS_DIR/$BINARY_NAME"
 
 # Upload via rsync with delta transfer and compression.
 # After the first deploy, only changed bytes are transferred.
-rsync -z -rlt --delete --partial --progress \
-  "$LOCAL_BUNDLE_DIR/" \
-  "$HOST:$REMOTE_ABS_BUNDLE_DIR/"
+rsync -z -t --partial --progress \
+  "$BUILT_BINARY" \
+  "$HOST:$REMOTE_ABS_DIR/$BINARY_NAME"
 
 # Set executable permissions (done separately for openrsync compatibility on macOS)
-ssh "$HOST" "chmod 755 $REMOTE_ABS_BUNDLE_DIR/$BINARY_NAME"
+ssh "$HOST" "chmod 755 $REMOTE_ABS_DIR/$BINARY_NAME"
 
-# Atomically replace the historical expected binary path with a relative
-# symlink into the complete bundle.
-ssh "$HOST" bash -s -- "$REMOTE_ABS_DIR" "$BUNDLE_VERSION" "$BINARY_NAME" <<'EOF'
-set -euo pipefail
-
-remote_dir="$1"
-bundle_version="$2"
-binary_name="$3"
-symlink_tmp="$remote_dir/.$binary_name.link.$$"
-
-cleanup() {
-  rm -f "$symlink_tmp"
-}
-trap cleanup EXIT
-
-ln -s "bundles/$bundle_version/$binary_name" "$symlink_tmp"
-mv -f "$symlink_tmp" "$remote_dir/$binary_name"
-EOF
+echo "==> Uploading bundled resources to $HOST:$REMOTE_ABS_DIR/$BUNDLED_RESOURCES_DIR_NAME"
+rsync -z -rlt --delete --partial --progress \
+  "$LOCAL_RESOURCES_DIR/" \
+  "$HOST:$REMOTE_ABS_DIR/$BUNDLED_RESOURCES_DIR_NAME/"
 
 echo "==> Stopping stale remote-server daemons on $HOST"
 ssh "$HOST" bash <<'EOF'
@@ -263,6 +247,6 @@ done
 EOF
 
 echo ""
-echo "==> Done! Bundle deployed to $HOST:$REMOTE_ABS_BUNDLE_DIR"
-echo "    Compatibility symlink: $REMOTE_ABS_DIR/$BINARY_NAME"
-echo "    (resolved from ~/$REMOTE_DIR/$BINARY_NAME on remote)"
+echo "==> Done! Binary deployed to $HOST:$REMOTE_ABS_DIR/$BINARY_NAME"
+echo "    Bundled resources: $REMOTE_ABS_DIR/$BUNDLED_RESOURCES_DIR_NAME"
+echo "    (resolved from ~/$REMOTE_DIR on remote)"

--- a/script/deploy_remote_server_to_test_vm
+++ b/script/deploy_remote_server_to_test_vm
@@ -122,13 +122,17 @@ if ! rustup target list --installed 2>/dev/null | grep -q "$TARGET"; then
   exit 1
 fi
 
-BINARY_NAME="oz-integration-$(app_version)"
+BUNDLE_VERSION="$(app_version)"
+BUNDLE_BINARY_NAME="oz-integration"
+BINARY_NAME="$BUNDLE_BINARY_NAME-$BUNDLE_VERSION"
 
 # ── Build ─────────────────────────────────────────────────────────
 
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT/target}"
 OUTPUT_DIR="$CARGO_TARGET_DIR/$TARGET/$CARGO_PROFILE"
 BUILT_BINARY="$OUTPUT_DIR/$WARP_BIN"
+LOCAL_BUNDLE_DIR="$OUTPUT_DIR/remote-server-integration-bundle"
+LOCAL_BUNDLE_TARBALL="$OUTPUT_DIR/remote-server-integration-bundle.tar.gz"
 
 echo "==> Building Integration-channel Oz CLI for $TARGET (profile=$CARGO_PROFILE)"
 
@@ -150,6 +154,15 @@ fi
 
 BINARY_SIZE=$(du -h "$BUILT_BINARY" | cut -f1)
 echo "==> Build complete ($BINARY_SIZE)"
+
+rm -rf "$LOCAL_BUNDLE_DIR"
+mkdir -p "$LOCAL_BUNDLE_DIR"
+cp "$BUILT_BINARY" "$LOCAL_BUNDLE_DIR/$BUNDLE_BINARY_NAME"
+"$WORKSPACE_ROOT/script/prepare_bundled_resources" \
+  "$LOCAL_BUNDLE_DIR/resources" \
+  integration \
+  "$CARGO_PROFILE"
+tar -czf "$LOCAL_BUNDLE_TARBALL" -C "$LOCAL_BUNDLE_DIR" .
 
 # ── Upload via SCP through GCP IAP tunnel ─────────────────────────
 # The test VM uses password auth (same as the SSH integration tests).
@@ -210,24 +223,59 @@ for PID_FILE in "$REMOTE_ROOT"/*/server.pid; do
   rm -f "$DAEMON_DIR/server.sock" "$DAEMON_DIR/server.pid"
 done
 
-rm -f "$REMOTE_ROOT"/oz-integration-*.tmp.*
+rm -f "$REMOTE_ROOT"/remote-server-integration-bundle-*.tar.gz
 REMOTE_SCRIPT
 
-  TMP_BINARY_NAME="$BINARY_NAME.tmp.${GITHUB_RUN_ID:-local}.$$.${REMOTE_USER}"
-  echo "==> Uploading binary to ${REMOTE_USER}@${REMOTE_HOST}:~/$REMOTE_DIR/$TMP_BINARY_NAME"
+  TMP_BUNDLE_NAME="remote-server-integration-bundle-${GITHUB_RUN_ID:-local}-$$-${REMOTE_USER}.tar.gz"
+  echo "==> Uploading bundle to ${REMOTE_USER}@${REMOTE_HOST}:~/$REMOTE_DIR/$TMP_BUNDLE_NAME"
   "${SCP_CMD[@]}" -P "$REMOTE_PORT" \
     -o "ProxyCommand=$PROXY_COMMAND" \
     -o PreferredAuthentications=password \
     -o PubkeyAuthentication=no \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
-    "$BUILT_BINARY" \
-    "${REMOTE_USER}@${REMOTE_HOST}:~/$REMOTE_DIR/$TMP_BINARY_NAME"
+    "$LOCAL_BUNDLE_TARBALL" \
+    "${REMOTE_USER}@${REMOTE_HOST}:~/$REMOTE_DIR/$TMP_BUNDLE_NAME"
 
-  echo "==> Installing binary for ${REMOTE_USER}"
+  echo "==> Installing bundle for ${REMOTE_USER}"
   "${SSH_CMD[@]}" "${SSH_OPTS[@]}" "${REMOTE_USER}@${REMOTE_HOST}" \
-    "chmod 755 ~/$REMOTE_DIR/$TMP_BINARY_NAME && mv -f ~/$REMOTE_DIR/$TMP_BINARY_NAME ~/$REMOTE_DIR/$BINARY_NAME && test -x ~/$REMOTE_DIR/$BINARY_NAME"
+    "bash -s -- '$REMOTE_DIR' '$TMP_BUNDLE_NAME' '$BUNDLE_VERSION' '$BUNDLE_BINARY_NAME' '$BINARY_NAME'" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+REMOTE_ROOT="$HOME/$1"
+TARBALL="$REMOTE_ROOT/$2"
+BUNDLE_VERSION="$3"
+BUNDLE_BINARY_NAME="$4"
+COMPATIBILITY_NAME="$5"
+BUNDLES_DIR="$REMOTE_ROOT/bundles"
+BUNDLE_DIR="$BUNDLES_DIR/$BUNDLE_VERSION"
+BUNDLE_TMP="$BUNDLES_DIR/.$BUNDLE_VERSION.install.$$"
+SYMLINK_TMP="$REMOTE_ROOT/.$COMPATIBILITY_NAME.link.$$"
+
+cleanup() {
+  rm -f "$TARBALL" "$SYMLINK_TMP"
+  rm -rf "$BUNDLE_TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$BUNDLE_TMP"
+tar -xzf "$TARBALL" -C "$BUNDLE_TMP"
+chmod 755 "$BUNDLE_TMP/$BUNDLE_BINARY_NAME"
+test -x "$BUNDLE_TMP/$BUNDLE_BINARY_NAME"
+test -d "$BUNDLE_TMP/resources"
+
+rm -rf "$BUNDLE_DIR"
+mv "$BUNDLE_TMP" "$BUNDLE_DIR"
+ln -s "bundles/$BUNDLE_VERSION/$BUNDLE_BINARY_NAME" "$SYMLINK_TMP"
+mv -f "$SYMLINK_TMP" "$REMOTE_ROOT/$COMPATIBILITY_NAME"
+
+test -L "$REMOTE_ROOT/$COMPATIBILITY_NAME"
+test -x "$BUNDLE_DIR/$BUNDLE_BINARY_NAME"
+test -d "$BUNDLE_DIR/resources"
+"$REMOTE_ROOT/$COMPATIBILITY_NAME" --version
+REMOTE_SCRIPT
 done
 
 echo ""
-echo "==> Done! Binary deployed to ${REMOTE_HOST}:~/$REMOTE_DIR/$BINARY_NAME for users: ${REMOTE_USERS[*]}"
+echo "==> Done! Bundle deployed to ${REMOTE_HOST}:~/$REMOTE_DIR/bundles/$BUNDLE_VERSION for users: ${REMOTE_USERS[*]}"
+echo "    Compatibility symlink: ~/$REMOTE_DIR/$BINARY_NAME"

--- a/script/deploy_remote_server_to_test_vm
+++ b/script/deploy_remote_server_to_test_vm
@@ -237,45 +237,30 @@ REMOTE_SCRIPT
     "$LOCAL_BUNDLE_TARBALL" \
     "${REMOTE_USER}@${REMOTE_HOST}:~/$REMOTE_DIR/$TMP_BUNDLE_NAME"
 
-  echo "==> Installing bundle for ${REMOTE_USER}"
+  echo "==> Installing binary and resources for ${REMOTE_USER}"
+  # Args: <remote dir> <tarball name> <binary name in tarball> <installed name>.
+  # The tarball ships the unversioned binary beside its resources/ tree; the
+  # installed binary carries the version suffix the Integration channel
+  # launches. The resources tree lands at `bundled_resources`, the global
+  # version-independent location the daemon reads (must match
+  # BUNDLED_RESOURCES_DIR_NAME in crates/remote_server/src/setup.rs).
   "${SSH_CMD[@]}" "${SSH_OPTS[@]}" "${REMOTE_USER}@${REMOTE_HOST}" \
-    "bash -s -- '$REMOTE_DIR' '$TMP_BUNDLE_NAME' '$BUNDLE_VERSION' '$BUNDLE_BINARY_NAME' '$BINARY_NAME'" <<'REMOTE_SCRIPT'
+    "bash -s -- '$REMOTE_DIR' '$TMP_BUNDLE_NAME' '$BUNDLE_BINARY_NAME' '$BINARY_NAME'" <<'REMOTE_SCRIPT'
 set -euo pipefail
 
-REMOTE_ROOT="$HOME/$1"
-TARBALL="$REMOTE_ROOT/$2"
-BUNDLE_VERSION="$3"
-BUNDLE_BINARY_NAME="$4"
-COMPATIBILITY_NAME="$5"
-BUNDLES_DIR="$REMOTE_ROOT/bundles"
-BUNDLE_DIR="$BUNDLES_DIR/$BUNDLE_VERSION"
-BUNDLE_TMP="$BUNDLES_DIR/.$BUNDLE_VERSION.install.$$"
-SYMLINK_TMP="$REMOTE_ROOT/.$COMPATIBILITY_NAME.link.$$"
+cd "$HOME/$1"
+tar -xzf "$2"
+rm -f "$2"
 
-cleanup() {
-  rm -f "$TARBALL" "$SYMLINK_TMP"
-  rm -rf "$BUNDLE_TMP"
-}
-trap cleanup EXIT
+rm -rf bundled_resources
+mv resources bundled_resources
 
-mkdir -p "$BUNDLE_TMP"
-tar -xzf "$TARBALL" -C "$BUNDLE_TMP"
-chmod 755 "$BUNDLE_TMP/$BUNDLE_BINARY_NAME"
-test -x "$BUNDLE_TMP/$BUNDLE_BINARY_NAME"
-test -d "$BUNDLE_TMP/resources"
-
-rm -rf "$BUNDLE_DIR"
-mv "$BUNDLE_TMP" "$BUNDLE_DIR"
-ln -s "bundles/$BUNDLE_VERSION/$BUNDLE_BINARY_NAME" "$SYMLINK_TMP"
-mv -f "$SYMLINK_TMP" "$REMOTE_ROOT/$COMPATIBILITY_NAME"
-
-test -L "$REMOTE_ROOT/$COMPATIBILITY_NAME"
-test -x "$BUNDLE_DIR/$BUNDLE_BINARY_NAME"
-test -d "$BUNDLE_DIR/resources"
-"$REMOTE_ROOT/$COMPATIBILITY_NAME" --version
+chmod 755 "$3"
+mv -f "$3" "$4"
+"./$4" --version
 REMOTE_SCRIPT
 done
 
 echo ""
-echo "==> Done! Bundle deployed to ${REMOTE_HOST}:~/$REMOTE_DIR/bundles/$BUNDLE_VERSION for users: ${REMOTE_USERS[*]}"
-echo "    Compatibility symlink: ~/$REMOTE_DIR/$BINARY_NAME"
+echo "==> Done! Binary deployed to ${REMOTE_HOST}:~/$REMOTE_DIR/$BINARY_NAME for users: ${REMOTE_USERS[*]}"
+echo "    Bundled resources: ~/$REMOTE_DIR/bundled_resources"


### PR DESCRIPTION
## Description

Ships bundled skills to remote hosts as a single **global, version-independent resources install**, with the daemon parsing skills against its own filesystem and pushing the catalog to clients.

**Install** (`install_remote_server.sh`, `setup.rs`): the binary install stays exactly as before (flat, version-suffixed path, `--version` check). The installer additionally moves the artifact's `resources/` tree to `{install_dir}/bundled_resources` — a global location deliberately decoupled from the binary version: the last install wins, and slight skew against an older running daemon is accepted (it parsed its skills at startup). A tarball without resources is non-fatal. The binary `find` excludes the `resources/` tree so bundled-skill companion files named `oz-*` can never be mistaken for the executable.

**Daemon** (`server_model.rs`): at startup, parses and handlebars-renders the skills under `bundled_resources` against its own paths (`{{skill_dir}}`, `{{settings_schema_path}}`), then pushes the pre-parsed catalog as a `BundledSkillsSnapshot` notification — broadcast on parse completion and sent to each connection right after its `Initialize`. The handshake is never blocked, and no resources path is advertised in `InitializeResponse` anymore. `RequiresFile` activations are evaluated daemon-side; `RequiresMcp` ships as a wire hint the client evaluates. Parsing is deliberately not feature-flag gated: exposure is controlled on the client, where the connecting user's flag state actually lives.

**Client** (`manager.rs`, `remote.rs`, `skill_manager.rs`): the snapshot flows `ClientEvent` → `RemoteServerManagerEvent::BundledSkillsSnapshot { host_id, skills }`. `SkillManager` re-parses the daemon-rendered content, wraps paths as `RemotePath`s, and stores one catalog per connected host in `BundledSkills` (`HostDisconnected` tears it down; a fresh snapshot after reconnect replaces it wholesale). Skill selection is now host-aware: SSH sessions see the remote daemon's catalog — never the local client's — and local sessions see only the local one. Remote bundled skills resolve by path with activation re-checked at invocation.

<img width="2210" height="247" alt="Screenshot 2026-06-12 at 2 31 49 PM" src="https://github.com/user-attachments/assets/045be408-47b3-42c3-8878-83d7f6589fb3" />

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Install-script integration tests cover the global resources install, last-install-wins replacement, the resources-less tarball path, the `oz-*` decoy exclusion, and removal leaving `bundled_resources` intact.
- Proto round-trip and client push-event tests for `BundledSkillsSnapshot`; daemon broadcast tests (no-op before parse, reaches all connections after).
- Conversion tests for daemon→proto serialization (activation handling) and proto→catalog (host-scoped paths, unknown-integration and invalid-path skipping).
- `SkillManager` tests for host-aware catalog selection (remote cwd → remote catalog only) and path-based resolution of remote bundled skills.
- `cargo nextest run -p remote_server` and targeted `-p warp` suites pass; `./script/format` and Clippy clean.
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
