### PR TITLE
Fix file search filtering

### DIFF
--- a/app/src/search/ai_context_menu/files/data_source.rs
+++ b/app/src/search/ai_context_menu/files/data_source.rs
@@ -62,7 +62,7 @@ pub fn file_data_source_for_current_repo(
                     last_opened,
                 }
             } else {
-                let contents = file_search_model.get_repo_contents(app);
+                let contents = file_search_model.get_repo_contents(&query.text, app);
                 FileSnapshot {
                     contents,
                     git_changed_files: HashSet::new(),

--- a/app/src/search/command_palette/files/data_source.rs
+++ b/app/src/search/command_palette/files/data_source.rs
@@ -109,11 +109,11 @@ impl FileDataSource {
         }
     }
 
-    fn contents(&self, app: &AppContext) -> Arc<Vec<FileSearchResult>> {
+    fn contents(&self, query: &str, app: &AppContext) -> Arc<Vec<FileSearchResult>> {
         match &self.mode {
             FileDataSourceMode::Repo => {
                 let file_search_model = FileSearchModel::as_ref(app);
-                file_search_model.get_repo_contents(app)
+                file_search_model.get_repo_contents(query, app)
             }
             FileDataSourceMode::CurrentFolder { cached_contents } => {
                 Arc::new(cached_contents.clone())
@@ -195,8 +195,6 @@ impl FileDataSource {
     > {
         let file_search_model = FileSearchModel::as_ref(app);
 
-        let contents = self.contents(app);
-
         // Strip any trailing : in case user is in the middle of typing a line / column arg.
         let query_text = query_text.strip_suffix(':').unwrap_or(query_text);
 
@@ -242,6 +240,11 @@ impl FileDataSource {
         let opened_files = repo_root_location
             .and_then(|repo_root| opened_files.opened_files_for_repo(&repo_root))
             .cloned();
+
+        // Fetch contents using the finalized query so it is pushed down into
+        // the repo-metadata traversal as a filter (matching files are not
+        // truncated away before fuzzy matching).
+        let contents = self.contents(&query_file_content, app);
 
         const CHUNK_SIZE: usize = 50;
 

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -188,19 +188,31 @@ impl FileSearchModel {
     }
 
     /// Gets repository contents (files and directories) for the current working directory.
-    /// Supports both local and remote repos. Results are cached per repo root location
-    /// and invalidated when the file tree changes.
+    /// Supports both local and remote repos.
+    ///
+    /// When `query` is non-empty, it is pushed down into the repo-metadata
+    /// traversal as a filter so the result cap applies to *matching* files
+    /// rather than the first files encountered in traversal order. These
+    /// query-specific results are not cached. When `query` is empty (zero
+    /// state) the full unfiltered contents are returned and cached per repo
+    /// root location, invalidated when the file tree changes.
     #[cfg(feature = "local_fs")]
-    pub fn get_repo_contents(&self, app: &AppContext) -> Arc<Vec<FileSearchResult>> {
+    pub fn get_repo_contents(&self, query: &str, app: &AppContext) -> Arc<Vec<FileSearchResult>> {
         let Some(repo_root) = self.repo_root_location(app) else {
             return Arc::new(Vec::new());
         };
+
+        // Query-filtered results are query-specific, so bypass the per-repo
+        // cache and traverse the in-memory index fresh.
+        if !query.is_empty() {
+            return Arc::new(self.get_contents_from_repo(&repo_root, query, app));
+        }
 
         if let Some(cached) = self.repo_contents_cache.borrow().get(&repo_root) {
             return cached.clone();
         }
 
-        let contents = self.get_contents_from_repo(&repo_root, app);
+        let contents = self.get_contents_from_repo(&repo_root, query, app);
 
         let arc = Arc::new(contents);
         self.repo_contents_cache
@@ -216,7 +228,7 @@ impl FileSearchModel {
         &self,
         app: &AppContext,
     ) -> (Arc<Vec<FileSearchResult>>, HashSet<String>) {
-        let contents = self.get_repo_contents(app);
+        let contents = self.get_repo_contents("", app);
         let git_changed_files = self
             .repo_root(app)
             .and_then(|repo_root| self.get_git_changed_files(&repo_root).ok())
@@ -226,7 +238,7 @@ impl FileSearchModel {
 
     /// Gets repository contents from the LocalRepoMetadataModel for the current working directory (WASM stub)
     #[cfg(not(feature = "local_fs"))]
-    pub fn get_repo_contents(&self, _app: &AppContext) -> Arc<Vec<FileSearchResult>> {
+    pub fn get_repo_contents(&self, _query: &str, _app: &AppContext) -> Arc<Vec<FileSearchResult>> {
         Arc::new(Vec::new())
     }
 
@@ -239,12 +251,40 @@ impl FileSearchModel {
         (Arc::new(Vec::new()), HashSet::new())
     }
 
+    /// Builds the [`GetContentsArgs`] used to traverse repo metadata.
+    ///
+    /// For an empty `query` this returns the default args (unfiltered). For a
+    /// non-empty `query` it installs a traversal filter that keeps only entries
+    /// whose repo-relative path (produced by `relative_path`) fuzzy-matches the
+    /// query. Pushing the query into traversal ensures the result cap applies
+    /// to *matching* files rather than the first files encountered.
+    #[cfg(feature = "local_fs")]
+    fn contents_args<F>(query: &str, relative_path: F) -> GetContentsArgs
+    where
+        F: for<'a> Fn(&repo_metadata::RepoContent<'a>) -> Option<String> + Send + Sync + 'static,
+    {
+        if query.is_empty() {
+            return GetContentsArgs::default();
+        }
+        let query = query.to_string();
+        GetContentsArgs::default().with_filter(move |content| {
+            relative_path(content)
+                .is_some_and(|path| FileSearchModel::fuzzy_match_path(&path, &query).is_some())
+        })
+    }
+
     /// Gets repository contents for a local or remote repo root, converting
     /// absolute paths to repo-relative `FileSearchResult`s.
+    ///
+    /// When `query` is non-empty it is pushed down as a traversal filter (see
+    /// [`Self::contents_args`]) so the repo-metadata result cap applies to
+    /// matching files rather than the first files encountered in traversal
+    /// order.
     #[cfg(feature = "local_fs")]
     fn get_contents_from_repo(
         &self,
         repo_root: &LocalOrRemotePath,
+        query: &str,
         app: &AppContext,
     ) -> Vec<FileSearchResult> {
         let repo_metadata = RepoMetadataModel::as_ref(app);
@@ -257,14 +297,30 @@ impl FileSearchModel {
                 let Some(id) = RepositoryIdentifier::try_local(local_path) else {
                     return Vec::new();
                 };
+                let args = Self::contents_args(query, {
+                    let canonical_repo_path = canonical_repo_path.clone();
+                    move |content| {
+                        let local = match content {
+                            repo_metadata::RepoContent::File(file) => {
+                                file.path.to_local_path_lossy()
+                            }
+                            repo_metadata::RepoContent::Directory(dir) => {
+                                dir.path.to_local_path_lossy()
+                            }
+                        };
+                        local
+                            .strip_prefix(&canonical_repo_path)
+                            .ok()
+                            .map(|relative| relative.to_string_lossy().to_string())
+                    }
+                });
                 // Truncated results (capped at the repo metadata budget) are
                 // intentionally used as-is to return partial matches rather
                 // than nothing.
-                let contents =
-                    match repo_metadata.get_repo_contents(&id, GetContentsArgs::default(), app) {
-                        Ok(repo_contents) => repo_contents.contents,
-                        Err(_) => return Vec::new(),
-                    };
+                let contents = match repo_metadata.get_repo_contents(&id, args, app) {
+                    Ok(repo_contents) => repo_contents.contents,
+                    Err(_) => return Vec::new(),
+                };
                 contents
                     .iter()
                     .filter_map(|content| match content {
@@ -301,14 +357,23 @@ impl FileSearchModel {
             }
             LocalOrRemotePath::Remote(remote_path) => {
                 let id = RepositoryIdentifier::Remote(remote_path.clone());
+                let args = Self::contents_args(query, {
+                    let root = remote_path.path.clone();
+                    move |content| {
+                        let path_std = match content {
+                            repo_metadata::RepoContent::File(file) => &*file.path,
+                            repo_metadata::RepoContent::Directory(dir) => &*dir.path,
+                        };
+                        path_std.strip_prefix(&root).map(str::to_owned)
+                    }
+                });
                 // Truncated results (capped at the repo metadata budget) are
                 // intentionally used as-is to return partial matches rather
                 // than nothing.
-                let contents =
-                    match repo_metadata.get_repo_contents(&id, GetContentsArgs::default(), app) {
-                        Ok(repo_contents) => repo_contents.contents,
-                        Err(_) => return Vec::new(),
-                    };
+                let contents = match repo_metadata.get_repo_contents(&id, args, app) {
+                    Ok(repo_contents) => repo_contents.contents,
+                    Err(_) => return Vec::new(),
+                };
                 let root_std_path = &remote_path.path;
                 contents
                     .iter()

--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -285,11 +285,7 @@ fn test_get_repo_contents() {
 
             // Test getting all files
             model_handle.read(&app, |model, _ctx| {
-                let args = GetContentsArgs {
-                    include_folders: false,
-                    include_ignored: false,
-                    filter: None,
-                };
+                let args = GetContentsArgs::default().exclude_folders();
                 let result = model
                     .get_repo_contents(
                         &StandardizedPath::from_local_canonicalized(&test_repo).unwrap(),
@@ -303,11 +299,7 @@ fn test_get_repo_contents() {
 
                 // Test with non-existent repository
                 let non_existent = StandardizedPath::try_new("/non_existent_repo").unwrap();
-                let args = GetContentsArgs {
-                    include_folders: false,
-                    include_ignored: false,
-                    filter: None,
-                };
+                let args = GetContentsArgs::default().exclude_folders();
                 let non_existent_result = model.get_repo_contents(&non_existent, args);
                 assert!(matches!(
                     non_existent_result,
@@ -343,14 +335,7 @@ fn test_get_repo_contents_truncates_to_max_results() {
         .insert(repo_path.clone(), IndexedRepoState::Indexed(state));
 
     let result = model
-        .get_repo_contents(
-            &repo_path,
-            GetContentsArgs {
-                include_folders: false,
-                include_ignored: false,
-                filter: None,
-            },
-        )
+        .get_repo_contents(&repo_path, GetContentsArgs::default().exclude_folders())
         .unwrap();
 
     // The result is capped and flagged as truncated rather than erroring.
@@ -359,6 +344,59 @@ fn test_get_repo_contents_truncates_to_max_results() {
         crate::local_model::MAX_REPO_CONTENTS_RESULTS
     );
     assert!(result.truncated);
+}
+
+/// A query-style traversal filter must be evaluated *before* an entry counts
+/// toward the result cap, so a matching file that sorts well past the cap in
+/// traversal order is still returned. This is the core guarantee that keeps
+/// file search from truncating matches away.
+#[test]
+fn test_get_repo_contents_filter_applies_before_cap() {
+    let base = std::env::temp_dir().join("filter_before_cap_repo");
+    let repo_path = StandardizedPath::try_from_local(&base).unwrap();
+
+    // Many non-matching files, then a single matching "needle" file placed last
+    // so it is well beyond the default result cap in traversal order.
+    let noise_count = crate::local_model::MAX_REPO_CONTENTS_RESULTS + 50;
+    let mut children: Vec<Entry> = (0..noise_count)
+        .map(|i| Entry::File(FileMetadata::new(base.join(format!("file{i}.txt")), false)))
+        .collect();
+    children.push(Entry::File(FileMetadata::new(
+        base.join("needle.rs"),
+        false,
+    )));
+    let root = Entry::Directory(DirectoryEntry {
+        path: repo_path.clone(),
+        children,
+        ignored: false,
+        loaded: true,
+    });
+    let state = FileTreeState::new(root, Vec::new(), None);
+
+    let mut model = LocalRepoMetadataModel::new_for_test();
+    model
+        .repositories
+        .insert(repo_path.clone(), IndexedRepoState::Indexed(state));
+
+    let args = GetContentsArgs::default().with_filter(|content| match content {
+        crate::RepoContent::File(file) => file
+            .path
+            .to_local_path_lossy()
+            .to_string_lossy()
+            .contains("needle"),
+        crate::RepoContent::Directory(_) => false,
+    });
+    let result = model.get_repo_contents(&repo_path, args).unwrap();
+
+    // The single matching file is returned despite sorting past the cap, and
+    // the result is not truncated because only one entry matched.
+    assert_eq!(result.contents.len(), 1);
+    assert!(!result.truncated);
+    assert!(matches!(
+        &result.contents[0],
+        crate::RepoContent::File(file)
+            if file.path.to_local_path_lossy() == base.join("needle.rs")
+    ));
 }
 
 #[cfg(feature = "local_fs")]
@@ -732,11 +770,7 @@ fn test_get_repo_contents_include_ignored() {
 
             // Test with include_ignored = false (should exclude ignored files and directories)
             model_handle.read(&app, |model, _ctx| {
-                let args = GetContentsArgs {
-                    include_folders: true,
-                    include_ignored: false,
-                    filter: None,
-                };
+                let args = GetContentsArgs::default();
                 let contents = model
                     .get_repo_contents(
                         &StandardizedPath::from_local_canonicalized(&test_repo).unwrap(),
@@ -766,11 +800,7 @@ fn test_get_repo_contents_include_ignored() {
 
             // Test with include_ignored = true (should include everything)
             model_handle.read(&app, |model, _ctx| {
-                let args = GetContentsArgs {
-                    include_folders: true,
-                    include_ignored: true,
-                    filter: None,
-                };
+                let args = GetContentsArgs::default().include_ignored();
                 let contents = model
                     .get_repo_contents(
                         &StandardizedPath::from_local_canonicalized(&test_repo).unwrap(),


### PR DESCRIPTION
## Description
Fixes a regression where cmd-O (command palette file search) and `@` context file search stopped finding files that exist in the repo.

### Source issue
File search fuzzy-matches over a list of repo contents returned by `RepoMetadataModel::get_repo_contents`. That traversal caps results at `MAX_REPO_CONTENTS_RESULTS = 100` (`crates/repo_metadata/src/local_model.rs`) and was being called with no filter, so it returned the **first 100 files in traversal order**. The fuzzy matcher then only ever saw those 100 files. In any repo with more than 100 indexed files, matches outside that prefix were silently dropped — so searching for a real file often returned nothing.

In other words, the search was reversed: we truncated first and matched second, instead of matching first and truncating second.

### Fix
Push the query down into the traversal as a filter so the 100-result cap applies to **matching** files rather than the first files encountered:
- `FileSearchModel::get_repo_contents` / `get_contents_from_repo` now take the query and, for non-empty queries, build `GetContentsArgs::with_filter(...)` whose predicate strips the repo-root prefix and keeps entries where `fuzzy_match_path(relative_path, query).is_some()`. Reusing `fuzzy_match_path` keeps the filter consistent with downstream scoring and handles multi-term/wildcard queries.
- The filter is evaluated *before* an entry counts toward the cap (`collect_contents_recursive`), so a match that sorts past the first 100 entries is still returned.
- Empty (zero-state) queries keep the existing cached, unfiltered behavior. Query-specific results bypass the per-repo cache since they aren't reusable.
- cmd-O and the `@` context menu pass their finalized query into `get_repo_contents`.

### Why we don't fully remove the post-search match
A natural follow-up is "we filter in `get_repo_contents` now, so drop the per-item match in the data sources." We intentionally keep it, because it isn't a pure filter:
- **Scoring + highlighting.** The per-item `fuzzy_match_path` produces the `FuzzyMatchResult` stored on `FileSearchItem.match_result`, which drives both ranking (`score()` → `k_largest_relaxed_by_key`, plus opened-file/recency/directory boosts) and the matched-character highlighting in `render_file_search_row`. The traversal filter only returns a `bool` and discards the score and matched indices, so removing the downstream match would lose relevance ranking and highlighting.
- **Non-filtered folder sources.** Both surfaces also feed cached, *unfiltered* listings through the same code path — cmd-O's `CurrentFolder` mode and the `@` menu's `file_data_source_for_pwd`. For those, the per-item match is the only place filtering happens, so removing it would show the entire folder listing regardless of the query.

So the two passes aren't redundant: the upstream filter bounds the candidate set (the actual fix), and the downstream match scores/highlights and still filters the folder modes.

That being said, this can definitely be optimized. But I am punting on it to get the urgent fix out first. Eitherway, this will be a significant performance improvement since we are not building up a huge in-memory list of every file in the repo metadata as we search

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

Automated tests (in `crates/repo_metadata/src/local_model_tests.rs`):
- `test_get_repo_contents_filter_applies_before_cap` — a matching file placed well past the 100-entry cap in traversal order is still returned, and `truncated` stays `false` when only one entry matches. This is the core guarantee of the fix.
- Existing `get_repo_contents` traversal/truncation/gitignore tests continue to pass.

Manual: cmd-O and `@` search in a large repo (this `warp` checkout) now surface deeply-nested files that previously didn't appear.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed file search (cmd-O and `@` context) failing to find files in repositories with more than 100 indexed files.
-->
