### PR TITLE
Support passing parameters to Tab Configs via URI and CLI

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -746,10 +746,34 @@ pub fn run() -> Result<()> {
     }
 
     let api_key = args.api_key().cloned();
-    run_internal(LaunchMode::App {
-        args: args.into_app_args(),
-        api_key,
-    })
+    let mut app_args = args.into_app_args();
+
+    // If --tab-config is provided, synthesize a warp://tab_config URI and append it.
+    if let Some(tab_config) = app_args.tab_config.take() {
+        let mut uri = url::Url::parse(&format!(
+            "{}://tab_config/{}",
+            ChannelState::url_scheme(),
+            tab_config
+        ))
+        .unwrap_or_else(|_| {
+            // Fallback: try to encode the path as a URI path segment.
+            let mut url = url::Url::parse(&format!("{}://tab_config/", ChannelState::url_scheme()))
+                .expect("valid base URL");
+            url.set_path(&format!("/{}", tab_config));
+            url
+        });
+
+        // Append any --param values as query parameters.
+        for param in app_args.params.drain(..) {
+            if let Some((key, value)) = param.split_once('=') {
+                let _ = uri.query_pairs_mut().append_pair(key, value);
+            }
+        }
+
+        app_args.urls.push(uri);
+    }
+
+    run_internal(LaunchMode::App { args: app_args, api_key })
 }
 
 /// Runs an integration test using the provided test driver.

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -747,33 +747,32 @@ pub fn run() -> Result<()> {
 
     let api_key = args.api_key().cloned();
     let mut app_args = args.into_app_args();
+    append_tab_config_url_from_cli_args(&mut app_args);
 
-    // If --tab-config is provided, synthesize a warp://tab_config URI and append it.
-    if let Some(tab_config) = app_args.tab_config.take() {
-        let mut uri = url::Url::parse(&format!(
-            "{}://tab_config/{}",
-            ChannelState::url_scheme(),
-            tab_config
-        ))
-        .unwrap_or_else(|_| {
-            // Fallback: try to encode the path as a URI path segment.
-            let mut url = url::Url::parse(&format!("{}://tab_config/", ChannelState::url_scheme()))
-                .expect("valid base URL");
-            url.set_path(&format!("/{}", tab_config));
-            url
-        });
+    run_internal(LaunchMode::App {
+        args: app_args,
+        api_key,
+    })
+}
 
-        // Append any --param values as query parameters.
-        for param in app_args.params.drain(..) {
-            if let Some((key, value)) = param.split_once('=') {
-                let _ = uri.query_pairs_mut().append_pair(key, value);
-            }
+fn append_tab_config_url_from_cli_args(app_args: &mut warp_cli::AppArgs) {
+    let Some(tab_config) = app_args.tab_config.take() else {
+        return;
+    };
+
+    let mut uri = url::Url::parse(&format!("{}://tab_config/", ChannelState::url_scheme()))
+        .expect("valid tab config URI base");
+    uri.path_segments_mut()
+        .expect("tab config URI supports path segments")
+        .push(&tab_config);
+
+    for param in app_args.params.drain(..) {
+        if let Some((key, value)) = param.split_once('=') {
+            uri.query_pairs_mut().append_pair(key, value);
         }
-
-        app_args.urls.push(uri);
     }
 
-    run_internal(LaunchMode::App { args: app_args, api_key })
+    app_args.urls.push(uri);
 }
 
 /// Runs an integration test using the provided test driver.
@@ -2657,4 +2656,59 @@ fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode
 fn init_logging_for_unit_tests_glue() {
     // Initialize terminal-friendly logging for tests from the shared logger crate.
     warp_logging::init_logging_for_unit_tests();
+}
+
+#[cfg(test)]
+mod tab_config_cli_url_tests {
+    use super::*;
+
+    #[test]
+    fn appends_tab_config_url_from_cli_args() {
+        let mut app_args = warp_cli::AppArgs {
+            tab_config: Some("deploy config".to_string()),
+            params: vec![
+                "branch=feature/foo".to_string(),
+                "repo=/Users/me/project".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        append_tab_config_url_from_cli_args(&mut app_args);
+
+        assert!(app_args.tab_config.is_none());
+        assert!(app_args.params.is_empty());
+        assert_eq!(app_args.urls.len(), 1);
+
+        let url = &app_args.urls[0];
+        assert_eq!(url.host_str(), Some("tab_config"));
+        assert_eq!(
+            url.path_segments().and_then(|mut segments| segments.next()),
+            Some("deploy%20config"),
+        );
+        let params = url.query_pairs().collect::<Vec<_>>();
+        assert_eq!(params[0], ("branch".into(), "feature/foo".into()));
+        assert_eq!(params[1], ("repo".into(), "/Users/me/project".into()));
+    }
+
+    #[test]
+    fn encodes_tab_config_name_that_looks_like_query_or_fragment() {
+        let mut app_args = warp_cli::AppArgs {
+            tab_config: Some("deploy?branch=wrong#fragment".to_string()),
+            params: vec!["branch=right".to_string()],
+            ..Default::default()
+        };
+
+        append_tab_config_url_from_cli_args(&mut app_args);
+
+        let url = &app_args.urls[0];
+        assert_eq!(url.fragment(), None);
+        assert_eq!(
+            url.path_segments().and_then(|mut segments| segments.next()),
+            Some("deploy%3Fbranch=wrong%23fragment"),
+        );
+        assert_eq!(
+            url.query_pairs().collect::<Vec<_>>(),
+            vec![("branch".into(), "right".into())],
+        );
+    }
 }

--- a/app/src/tab_configs/params_modal.rs
+++ b/app/src/tab_configs/params_modal.rs
@@ -184,10 +184,13 @@ impl TabConfigParamsModal {
     ///
     /// Builds one field per param in `config`. `cwd` is the active terminal's
     /// working directory, used to seed the branch picker's git lookup.
+    /// `prefilled_params` optionally overrides default values for params that were
+    /// provided via URI or CLI.
     pub fn on_open(
         &mut self,
         config: TabConfig,
         cwd: Option<PathBuf>,
+        prefilled_params: Option<HashMap<String, String>>,
         ctx: &mut ViewContext<Self>,
     ) {
         self.param_fields.clear();
@@ -226,9 +229,12 @@ impl TabConfigParamsModal {
         };
 
         for (i, (name, param)) in params.iter().enumerate() {
+            // Use the prefilled value if available, otherwise fall back to the TOML default.
+            let prefilled_value = prefilled_params.as_ref().and_then(|m| m.get(name).cloned());
+
             let field = match param.param_type {
                 TabConfigParamType::Branch => {
-                    let default_value = param.default.clone();
+                    let default_value = prefilled_value.clone().or_else(|| param.default.clone());
                     let branch_cwd = branch_initial_cwd.clone();
                     let style = PickerStyle {
                         width: picker_style.width,
@@ -247,11 +253,11 @@ impl TabConfigParamsModal {
                     });
                     ParamField::Branch {
                         picker,
-                        selected: param.default.clone(),
+                        selected: prefilled_value.clone().or_else(|| param.default.clone()),
                     }
                 }
                 TabConfigParamType::Repo => {
-                    let default_value = param.default.clone();
+                    let default_value = prefilled_value.clone().or_else(|| param.default.clone());
                     let style = PickerStyle {
                         width: picker_style.width,
                         background: picker_style.background,
@@ -275,11 +281,13 @@ impl TabConfigParamsModal {
                     });
                     ParamField::Repo {
                         picker,
-                        selected: param.default.clone(),
+                        selected: prefilled_value.clone().or_else(|| param.default.clone()),
                     }
                 }
                 TabConfigParamType::Text => {
-                    let default_text = param.default.clone().unwrap_or_default();
+                    let default_text = prefilled_value.clone().unwrap_or_else(|| {
+                        param.default.clone().unwrap_or_default()
+                    });
                     let placeholder = if default_text.is_empty() {
                         format!("Enter {name}")
                     } else {

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -114,7 +114,9 @@ impl FromStr for UriHost {
             "mcp" => Ok(Self::Mcp),
             "codex" => Ok(Self::Codex),
             "linear" => Ok(Self::Linear),
-            "tab_config" if FeatureFlag::TabConfigs.is_enabled() => Ok(Self::TabConfig),
+            "tab_config" | "tab-config" if FeatureFlag::TabConfigs.is_enabled() => {
+                Ok(Self::TabConfig)
+            }
             "session" => Ok(Self::Session),
             _ => Err(anyhow!("Received url with unexpected host: {}", s)),
         }
@@ -753,6 +755,13 @@ fn handle_tab_config_uri(primary_window_id: Option<WindowId>, url: &Url, ctx: &m
         .query_pairs()
         .any(|(k, v)| k == "new_window" && matches!(v.as_ref(), "1" | "true"));
 
+    // Extract query parameters that correspond to tab config params (excluding known keys).
+    let provided_params: HashMap<String, String> = url
+        .query_pairs()
+        .filter(|(k, _)| k != "new_window")
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
     let target_window_id = if force_new_window {
         None
     } else {
@@ -776,7 +785,7 @@ fn handle_tab_config_uri(primary_window_id: Option<WindowId>, url: &Url, ctx: &m
     };
 
     workspace.update(ctx, |workspace, ctx| {
-        workspace.open_tab_config(config, ctx);
+        workspace.open_tab_config_with_prefilled_params(config, Some(provided_params), ctx);
     });
 }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6694,10 +6694,8 @@ impl Workspace {
             }
         }
 
-        let has_unfilled_params = tab_config.params.iter().any(|(name, param)| {
-            param_values.get(name).map_or(true, |v| v.is_empty())
-                && param.default.is_none()
-        });
+        let has_unfilled_params =
+            Self::tab_config_has_unfilled_required_params(&tab_config, &param_values);
 
         if !has_unfilled_params {
             let worktree_branch_name = self.maybe_generate_worktree_name(&tab_config);
@@ -6732,6 +6730,18 @@ impl Workspace {
             self.current_workspace_state.is_tab_config_params_modal_open = true;
             ctx.notify();
         }
+    }
+
+    fn tab_config_has_unfilled_required_params(
+        tab_config: &crate::tab_configs::TabConfig,
+        param_values: &HashMap<String, String>,
+    ) -> bool {
+        tab_config.params.iter().any(|(name, param)| {
+            param.default.is_none()
+                && param_values
+                    .get(name)
+                    .map_or(true, |value| value.trim().is_empty())
+        })
     }
 
     /// Writes the default tab config template to an unused path in `~/.warp/tab_configs/`
@@ -27434,6 +27444,73 @@ fn compute_default_panel_widths(
         (left, right)
     } else {
         (DEFAULT_LEFT_PANEL_WIDTH, DEFAULT_RIGHT_PANEL_WIDTH)
+    }
+}
+
+#[cfg(test)]
+mod tab_config_prefilled_param_tests {
+    use super::*;
+
+    fn tab_config_with_params(
+        params: HashMap<String, crate::tab_configs::TabConfigParam>,
+    ) -> crate::tab_configs::TabConfig {
+        crate::tab_configs::TabConfig {
+            name: "Deploy".to_string(),
+            title: None,
+            color: None,
+            panes: vec![],
+            params,
+            source_path: None,
+        }
+    }
+
+    fn text_param(default: Option<&str>) -> crate::tab_configs::TabConfigParam {
+        crate::tab_configs::TabConfigParam {
+            description: None,
+            default: default.map(str::to_string),
+            param_type: crate::tab_configs::TabConfigParamType::Text,
+        }
+    }
+
+    #[test]
+    fn provided_required_params_are_satisfied() {
+        let mut params = HashMap::new();
+        params.insert("branch".to_string(), text_param(None));
+        let tab_config = tab_config_with_params(params);
+        let mut values = tab_config.default_param_values();
+        values.insert("branch".to_string(), "feature-x".to_string());
+
+        assert!(!Workspace::tab_config_has_unfilled_required_params(
+            &tab_config,
+            &values
+        ));
+    }
+
+    #[test]
+    fn blank_required_params_are_unfilled() {
+        let mut params = HashMap::new();
+        params.insert("branch".to_string(), text_param(None));
+        let tab_config = tab_config_with_params(params);
+        let mut values = tab_config.default_param_values();
+        values.insert("branch".to_string(), "   ".to_string());
+
+        assert!(Workspace::tab_config_has_unfilled_required_params(
+            &tab_config,
+            &values
+        ));
+    }
+
+    #[test]
+    fn params_with_defaults_are_satisfied() {
+        let mut params = HashMap::new();
+        params.insert("branch".to_string(), text_param(Some("main")));
+        let tab_config = tab_config_with_params(params);
+        let values = tab_config.default_param_values();
+
+        assert!(!Workspace::tab_config_has_unfilled_required_params(
+            &tab_config,
+            &values
+        ));
     }
 }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6668,10 +6668,39 @@ impl Workspace {
         tab_config: crate::tab_configs::TabConfig,
         ctx: &mut ViewContext<Self>,
     ) {
-        if tab_config.params.is_empty() {
-            let is_worktree_config = tab_config.is_worktree();
+        self.open_tab_config_with_prefilled_params(tab_config, None, ctx);
+    }
+
+    /// Opens a tab config, optionally pre-filling parameters from the caller.
+    ///
+    /// When `prefilled_params` is provided, any declared tab config params that
+    /// are present in the map are filled in. If all params are satisfied (either
+    /// by the caller or by their default value) the tab opens directly. Otherwise
+    /// the modal is shown with any pre-filled values already entered.
+    pub(crate) fn open_tab_config_with_prefilled_params(
+        &mut self,
+        tab_config: crate::tab_configs::TabConfig,
+        prefilled_params: Option<HashMap<String, String>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let is_worktree_config = tab_config.is_worktree();
+        let mut param_values = tab_config.default_param_values();
+
+        if let Some(prefilled) = &prefilled_params {
+            for (k, v) in prefilled {
+                if tab_config.params.contains_key(k) {
+                    param_values.insert(k.clone(), v.clone());
+                }
+            }
+        }
+
+        let has_unfilled_params = tab_config.params.iter().any(|(name, param)| {
+            param_values.get(name).map_or(true, |v| v.is_empty())
+                && param.default.is_none()
+        });
+
+        if !has_unfilled_params {
             let worktree_branch_name = self.maybe_generate_worktree_name(&tab_config);
-            let param_values = tab_config.default_param_values();
             self.open_tab_config_with_params(
                 tab_config,
                 param_values,
@@ -6696,7 +6725,7 @@ impl Workspace {
             self.tab_config_params_modal.view.update(ctx, |modal, ctx| {
                 modal.body().update(ctx, |body, ctx| {
                     body.set_title(modal_title);
-                    body.on_open(tab_config, cwd, ctx);
+                    body.on_open(tab_config, cwd, prefilled_params, ctx);
                 });
             });
             self.tab_config_params_modal.open();

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -170,6 +170,14 @@ pub struct AppArgs {
     /// URLs to open in Warp.
     #[arg(hide = true)]
     pub urls: Vec<Url>,
+
+    /// Path to a tab config file to open on startup.
+    #[arg(long = "tab-config", hide = true)]
+    pub tab_config: Option<String>,
+
+    /// Parameter values for the tab config (format: key=value). Can be specified multiple times.
+    #[arg(long = "param", hide = true)]
+    pub params: Vec<String>,
 }
 
 impl Args {

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -128,6 +128,38 @@ fn model_list_parses() {
 }
 
 #[test]
+fn app_args_accept_tab_config_and_params() {
+    let args = Args::try_parse_from([
+        "warp",
+        "--tab-config",
+        "deploy",
+        "--param",
+        "branch=feature-x",
+        "--param",
+        "repo=/Users/me/project",
+    ])
+    .unwrap();
+
+    assert_eq!(args.args.tab_config.as_deref(), Some("deploy"));
+    assert_eq!(
+        args.args.params,
+        vec![
+            "branch=feature-x".to_string(),
+            "repo=/Users/me/project".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn app_args_preserve_param_values_containing_equals() {
+    let args = Args::try_parse_from(["warp", "--tab-config", "deploy", "--param", "token=abc=123"])
+        .unwrap();
+
+    assert_eq!(args.args.tab_config.as_deref(), Some("deploy"));
+    assert_eq!(args.args.params, vec!["token=abc=123".to_string()]);
+}
+
+#[test]
 fn login_parses() {
     let args = Args::try_parse_from(["warp", "login"]).unwrap();
 


### PR DESCRIPTION
## Description
This PR adds support for opening Tab Configs with pre-filled parameters via URI and CLI flags, as requested in #12343.

- **URI handling**: Query parameters in "warp://tab_config/<name>?key=value" are now parsed and passed to the tab config opener.
- **Params modal**: Pre-fills modal fields with values from the URI. If all required params are provided, the modal is skipped and the tab opens directly.
- **CLI flags**: Added hidden "--tab-config" and "--param" flags (e.g., "warp --tab-config my_dev_setup --param branch_name=feature-x"). These are converted to a URI internally.
- **Host alias**: The URI handler accepts both "tab_config" and "tab-config" as the host name.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (Note: #12343 is currently labeled `triaged` and `enhancement`; the feature request is for opening Tab Configs with pre-filled parameters via CLI/URI.)
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

### Note on manual testing
The `warp` package build requires macOS Metal developer tools (`xcrun metal`) which are not installed in this environment, so I was unable to run `./script/run`. However, `cargo check --package warp_cli` succeeded, and the changes are purely additive with no modifications to existing shader or rendering code.

### Screenshots / Videos
N/A — The change is non-visual (URI parsing and CLI argument handling). The UI impact is limited to the existing Params modal being pre-filled or skipped.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: {{Tab Configs can now be opened with pre-filled parameters via URI (warp://tab_config/<name>?key=value) and hidden CLI flags (--tab-config and --param).}}