### PR TITLE
Improve MAA network error message

### DIFF
--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -658,13 +658,6 @@ impl RenderableAIError {
         error.status().is_none()
     }
 
-    fn request_failed_error(value: &AIApiError) -> Self {
-        Self::Other {
-            error_message: format!("Request failed with error: {value:?}"),
-            will_attempt_resume: false,
-            waiting_for_network: false,
-        }
-    }
     pub fn is_invalid_api_key(&self) -> bool {
         matches!(self, Self::InvalidApiKey { .. })
     }
@@ -700,7 +693,11 @@ impl From<&AIApiError> for RenderableAIError {
             {
                 Self::transient_network_error(false, false)
             }
-            _ => Self::request_failed_error(value),
+            _ => Self::Other {
+                error_message: format!("Request failed with error: {value:?}"),
+                will_attempt_resume: false,
+                waiting_for_network: false,
+            },
         }
     }
 }

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -651,6 +651,20 @@ impl RenderableAIError {
             waiting_for_network,
         }
     }
+
+    fn is_transient_network_transport_error(error: &reqwest::Error) -> bool {
+        // If reqwest has an HTTP status, the server responded. Preserve the existing generic
+        // rendering for those failures rather than calling them lost connections.
+        error.status().is_none()
+    }
+
+    fn request_failed_error(value: &AIApiError) -> Self {
+        Self::Other {
+            error_message: format!("Request failed with error: {value:?}"),
+            will_attempt_resume: false,
+            waiting_for_network: false,
+        }
+    }
     pub fn is_invalid_api_key(&self) -> bool {
         matches!(self, Self::InvalidApiKey { .. })
     }
@@ -680,15 +694,15 @@ impl From<&AIApiError> for RenderableAIError {
                 user_display_message: user_display_message.clone(),
             },
             AIApiError::ServerOverloaded => Self::ServerOverloaded,
-            AIApiError::Transport(_)
-            | AIApiError::Deserialization(DeserializationError::Transport(_)) => {
-                Self::transient_network_error(false, false)
+            AIApiError::Transport(error)
+            | AIApiError::Deserialization(DeserializationError::Transport(error)) => {
+                if Self::is_transient_network_transport_error(error) {
+                    Self::transient_network_error(false, false)
+                } else {
+                    Self::request_failed_error(value)
+                }
             }
-            _ => Self::Other {
-                error_message: format!("Request failed with error: {value:?}"),
-                will_attempt_resume: false,
-                waiting_for_network: false,
-            },
+            _ => Self::request_failed_error(value),
         }
     }
 }

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -49,7 +49,7 @@ use crate::code_review::comments::{
     AttachedReviewComment as CodeReviewComment, ReviewCommentBatch,
 };
 use crate::search::slash_command_menu::static_commands::commands;
-use crate::server::server_api::AIApiError;
+use crate::server::server_api::{AIApiError, DeserializationError};
 use crate::terminal::model::block::BlockId;
 use crate::terminal::shell::ShellType;
 use crate::terminal::view::block_onboarding::onboarding_agentic_suggestions_block::OnboardingChipType;
@@ -642,6 +642,15 @@ pub enum RenderableAIError {
 }
 
 impl RenderableAIError {
+    const TRANSIENT_NETWORK_ERROR_MESSAGE: &'static str =
+        "Warp lost connection while receiving the agent response. This is usually temporary.";
+    pub fn transient_network_error(will_attempt_resume: bool, waiting_for_network: bool) -> Self {
+        Self::Other {
+            error_message: Self::TRANSIENT_NETWORK_ERROR_MESSAGE.to_string(),
+            will_attempt_resume,
+            waiting_for_network,
+        }
+    }
     pub fn is_invalid_api_key(&self) -> bool {
         matches!(self, Self::InvalidApiKey { .. })
     }
@@ -671,6 +680,10 @@ impl From<&AIApiError> for RenderableAIError {
                 user_display_message: user_display_message.clone(),
             },
             AIApiError::ServerOverloaded => Self::ServerOverloaded,
+            AIApiError::Transport(_)
+            | AIApiError::Deserialization(DeserializationError::Transport(_)) => {
+                Self::transient_network_error(false, false)
+            }
             _ => Self::Other {
                 error_message: format!("Request failed with error: {value:?}"),
                 will_attempt_resume: false,

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -695,12 +695,10 @@ impl From<&AIApiError> for RenderableAIError {
             },
             AIApiError::ServerOverloaded => Self::ServerOverloaded,
             AIApiError::Transport(error)
-            | AIApiError::Deserialization(DeserializationError::Transport(error)) => {
-                if Self::is_transient_network_transport_error(error) {
-                    Self::transient_network_error(false, false)
-                } else {
-                    Self::request_failed_error(value)
-                }
+            | AIApiError::Deserialization(DeserializationError::Transport(error))
+                if Self::is_transient_network_transport_error(error) =>
+            {
+                Self::transient_network_error(false, false)
             }
             _ => Self::request_failed_error(value),
         }

--- a/app/src/ai/agent/mod_tests.rs
+++ b/app/src/ai/agent/mod_tests.rs
@@ -8,6 +8,7 @@ use crate::ai::agent::{
     AIAgentContext, AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, AIAgentText,
     AIAgentTextSection, AgentOutputImage, AgentOutputImageLayout, AgentOutputMermaidDiagram,
     AnyFileContent, FileContext, FormattedTextWrapper, MessageId, ProgrammingLanguage,
+    RenderableAIError,
 };
 use crate::terminal::shell::ShellType;
 
@@ -84,6 +85,27 @@ fn pull_request_number_deserializer_rejects_unsupported_json_types() {
             "expected {number_json} to fail deserialization",
         );
     }
+}
+
+#[test]
+fn transient_network_error_uses_user_facing_message() {
+    let error = RenderableAIError::transient_network_error(false, false);
+
+    assert_eq!(
+        error.to_string(),
+        "Warp lost connection while receiving the agent response. This is usually temporary."
+    );
+    assert!(!error.will_attempt_resume());
+    assert_eq!(
+        error,
+        RenderableAIError::Other {
+            error_message:
+                "Warp lost connection while receiving the agent response. This is usually temporary."
+                    .to_string(),
+            will_attempt_resume: false,
+            waiting_for_network: false,
+        }
+    );
 }
 #[test]
 fn test_convert_files() {

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2765,14 +2765,9 @@ impl BlocklistAIController {
                         "generate_multi_agent_output stream ended without emitting StreamFinished event."
                     );
 
-                    let error_message = "Request did not successfully complete";
                     history_model.update(ctx, |history_model, ctx| {
                         history_model.mark_response_stream_completed_with_error(
-                            RenderableAIError::Other {
-                                error_message: error_message.to_string(),
-                                will_attempt_resume: false,
-                                waiting_for_network: false,
-                            },
+                            RenderableAIError::transient_network_error(false, false),
                             &stream_id,
                             conversation_id,
                             self.terminal_view_id,


### PR DESCRIPTION
## Description
Improves MAA network failure UX by rendering transport/interrupted-stream failures as a transient network error instead of raw `reqwest` / `hyper` debug output or the generic `Request did not successfully complete` fallback.

New message:
> Warp lost connection while receiving the agent response. This is usually temporary.

Changes:
- Map status-less `AIApiError::Transport(_)` and status-less transport-shaped deserialization errors to the friendly message.
- Preserve the existing generic rendering for `reqwest` errors with HTTP statuses, since those are server responses rather than lost connections.
- Use the same message when the response stream ends without `StreamFinished`.
- Add a focused unit test for the renderable error.

## Investigation / scope
REMOTE-971 reported raw transport internals in the UI. I tried to reproduce the exact production error with a simulated server-side transport abort; locally it hit the sibling EOF fallback instead. Since both bad strings are synthesized by client rendering paths, this PR keeps the fix client-side.

A server-side error contract may still help later, but it would not cover transport resets where the client never receives a valid error payload.

## Follow-ups
- Retry cloud-agent/MAA networking failures more aggressively where safe.
- Avoid marking cloud runs failed while retrying or about to resume.
- Consider structured server-side MAA network error events/codes when the server can emit them cleanly.

## Linked Issue
Linear: REMOTE-971

## Testing
- `./script/format`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo test -p warp --lib transient_network_error_uses_user_facing_message`

Example - with forced error on server-side:
<img width="896" height="243" alt="image" src="https://github.com/user-attachments/assets/ef55cbf7-1649-44a3-9a07-a68b2d8ac64f" />


CHANGELOG-IMPROVEMENT: Improved the error message shown when Warp loses connection while receiving an agent response.

Co-Authored-By: Oz <oz-agent@warp.dev>