### PR TITLE
Resolve tab group bugs: new tab group expansion, pane name duplication, and settings tab splitting group

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6879,6 +6879,14 @@ impl Workspace {
         }
     }
 
+    /// Ensures the group is expanded (not collapsed). No-op if the group does
+    /// not exist or is already expanded.
+    fn expand_tab_group(&mut self, group_id: TabGroupId) {
+        if let Some(group) = self.tab_groups.get_mut(&group_id) {
+            group.collapsed = false;
+        }
+    }
+
     /// Opens the inline rename editor over the given group's header.
     pub fn rename_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
         let Some(group) = self.tab_groups.get(&group_id) else {
@@ -6981,6 +6989,7 @@ impl Workspace {
             .map(|i| i + 1)
             .unwrap_or(self.tabs.len());
         self.tabs[tab_index].group_id = Some(group_id);
+        self.expand_tab_group(group_id);
         self.move_tab_to_index(tab_index, target_index, ctx);
 
         if let Some(prev) = previous_group_id {
@@ -7067,6 +7076,7 @@ impl Workspace {
             }
             self.move_tab_to_index(new_idx, target_index, ctx);
         }
+        self.expand_tab_group(group_id);
         ctx.notify();
     }
 
@@ -12102,7 +12112,22 @@ impl Workspace {
                         .push(self.tabs.last().unwrap().pane_group.id());
                     self.activate_tab_internal(self.tab_count() - 1, ctx);
                 } else {
-                    let insert_idx = self.active_tab_index + 1;
+                    // When the new tab won't inherit the active tab's group
+                    // (e.g. settings, notebooks, or other restoration-based tabs)
+                    // but the active tab is inside a group, land after the group's
+                    // last member so the group isn't split in two.
+                    let insert_idx = if active_tab_group_id.is_none() {
+                        active_tab
+                            .and_then(|t| t.group_id)
+                            .and_then(|gid| {
+                                group_member_indices(&self.tabs, gid)
+                                    .last()
+                                    .map(|last| last + 1)
+                            })
+                            .unwrap_or(self.active_tab_index + 1)
+                    } else {
+                        self.active_tab_index + 1
+                    };
                     self.tabs.insert(insert_idx, TabData::new(new_pane_group));
                     self.tab_mru_order
                         .push(self.tabs[insert_idx].pane_group.id());
@@ -12111,12 +12136,13 @@ impl Workspace {
             }
         }
 
-        // Inherit the active tab's group membership. D
+        // Inherit the active tab's group membership.
         if let Some(group_id) = active_tab_group_id {
             let new_idx = self.active_tab_index;
             if let Some(new_tab) = self.tabs.get_mut(new_idx) {
                 new_tab.group_id = Some(group_id);
             }
+            self.expand_tab_group(group_id);
         }
 
         if !is_restoration {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6881,9 +6881,10 @@ impl Workspace {
 
     /// Ensures the group is expanded (not collapsed). No-op if the group does
     /// not exist or is already expanded.
-    fn expand_tab_group(&mut self, group_id: TabGroupId) {
+    fn expand_tab_group(&mut self, group_id: TabGroupId, ctx: &mut ViewContext<Self>) {
         if let Some(group) = self.tab_groups.get_mut(&group_id) {
             group.collapsed = false;
+            ctx.notify();
         }
     }
 
@@ -6989,7 +6990,7 @@ impl Workspace {
             .map(|i| i + 1)
             .unwrap_or(self.tabs.len());
         self.tabs[tab_index].group_id = Some(group_id);
-        self.expand_tab_group(group_id);
+        self.expand_tab_group(group_id, ctx);
         self.move_tab_to_index(tab_index, target_index, ctx);
 
         if let Some(prev) = previous_group_id {
@@ -7076,8 +7077,7 @@ impl Workspace {
             }
             self.move_tab_to_index(new_idx, target_index, ctx);
         }
-        self.expand_tab_group(group_id);
-        ctx.notify();
+        self.expand_tab_group(group_id, ctx);
     }
 
     /// Moves the whole group up or down by one "slot", where a slot is the
@@ -12112,11 +12112,11 @@ impl Workspace {
                         .push(self.tabs.last().unwrap().pane_group.id());
                     self.activate_tab_internal(self.tab_count() - 1, ctx);
                 } else {
-                    // When the new tab won't inherit the active tab's group
-                    // (e.g. settings, notebooks, or other restoration-based tabs)
-                    // but the active tab is inside a group, land after the group's
-                    // last member so the group isn't split in two.
-                    let insert_idx = if active_tab_group_id.is_none() {
+                    // Restoration-based tabs (settings, notebooks, etc.) don't
+                    // inherit the active tab's group. If the active tab is inside
+                    // a group, land after the group's last member so we don't
+                    // split it.
+                    let insert_idx = if is_restoration {
                         active_tab
                             .and_then(|t| t.group_id)
                             .and_then(|gid| {
@@ -12142,7 +12142,7 @@ impl Workspace {
             if let Some(new_tab) = self.tabs.get_mut(new_idx) {
                 new_tab.group_id = Some(group_id);
             }
-            self.expand_tab_group(group_id);
+            self.expand_tab_group(group_id, ctx);
         }
 
         if !is_restoration {

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -45,10 +45,9 @@ impl Workspace {
             .collect();
 
         // Expand any groups within the selected range, so user can see what they are selecting.
-        self.tab_groups
-            .iter_mut()
-            .filter(|(group_id, _)| crossed_group_ids.contains(group_id))
-            .for_each(|(_, group)| group.collapsed = false);
+        for group_id in &crossed_group_ids {
+            self.expand_tab_group(*group_id);
+        }
 
         // Add tabs in the selected range to the multi-selection.
         self.tabs
@@ -326,6 +325,8 @@ impl Workspace {
         self.tabs = rest;
 
         self.restore_active_tab_index(active_pane_group_id);
+
+        self.expand_tab_group(group_id);
 
         // Prune any groups that are now empty.
         for previous_group_id in previous_group_ids {

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -46,7 +46,7 @@ impl Workspace {
 
         // Expand any groups within the selected range, so user can see what they are selecting.
         for group_id in &crossed_group_ids {
-            self.expand_tab_group(*group_id);
+            self.expand_tab_group(*group_id, ctx);
         }
 
         // Add tabs in the selected range to the multi-selection.
@@ -326,7 +326,7 @@ impl Workspace {
 
         self.restore_active_tab_index(active_pane_group_id);
 
-        self.expand_tab_group(group_id);
+        self.expand_tab_group(group_id, ctx);
 
         // Prune any groups that are now empty.
         for previous_group_id in previous_group_ids {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2029,9 +2029,19 @@ fn render_tab_group_internal(
     let is_being_renamed = is_active && workspace.current_workspace_state.is_tab_being_renamed();
     let rename_editor = workspace.tab_rename_editor.clone();
     let has_custom_title = pane_group.custom_title(app).is_some();
-    let displayed_tab_title_override = (!uses_outer_group_container)
-        .then(|| pane_group.custom_title(app))
-        .flatten();
+    // In Panes view, tabs inside a group render individual pane rows, so each
+    // pane keeps its own generated title. Propagating the tab's custom title as
+    // an override here would shadow every pane's title with the same string.
+    // In Tabs/Summary modes there is only one row per tab, so the tab-level
+    // custom title is still the right thing to show.
+    let displayed_tab_title_override =
+        if in_tab_group && matches!(display_granularity, VerticalTabsDisplayGranularity::Panes) {
+            None
+        } else {
+            (!uses_outer_group_container)
+                .then(|| pane_group.custom_title(app))
+                .flatten()
+        };
     let is_menu_open_for_tab = workspace
         .show_tab_right_click_menu
         .is_some_and(|(idx, _)| idx == tab_index);

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3690,3 +3690,186 @@ fn test_new_tab_with_after_current_tab_setting_lands_after_active_tab_in_group()
         });
     });
 }
+
+// --- expand-on-add tests ---
+
+#[test]
+fn test_move_tab_to_group_expands_collapsed_group() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group and a second ungrouped tab.
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+            workspace.add_terminal_tab(false, ctx);
+
+            // Find the ungrouped tab.
+            let ungrouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id.is_none())
+                .expect("expected an ungrouped tab");
+
+            // Collapse the group, then move the ungrouped tab into it.
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(
+                workspace.tab_groups[&group_id].collapsed,
+                "group should be collapsed"
+            );
+
+            workspace.handle_action(
+                &WorkspaceAction::MoveTabToGroup {
+                    tab_index: ungrouped_idx,
+                    group_id,
+                },
+                ctx,
+            );
+
+            assert!(
+                !workspace.tab_groups[&group_id].collapsed,
+                "group should expand when a tab is moved into it"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_move_selected_tabs_to_group_expands_collapsed_group() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Add two extra tabs while no group exists so they remain ungrouped.
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+
+            // Create a group from the first tab (moves it to index 0) leaving
+            // the other two tabs ungrouped.
+            workspace.handle_action(&WorkspaceAction::NewTabGroupFromTab(0), ctx);
+            let group_id = workspace.tabs[0]
+                .group_id
+                .expect("tab 0 should be in the new group");
+
+            // Collapse the group.
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(
+                workspace.tab_groups[&group_id].collapsed,
+                "group should be collapsed"
+            );
+
+            // Select the two ungrouped tabs and move them to the group.
+            let ungrouped_indices: Vec<usize> = workspace
+                .tabs
+                .iter()
+                .enumerate()
+                .filter(|(_, t)| t.group_id.is_none())
+                .map(|(i, _)| i)
+                .collect();
+            assert_eq!(ungrouped_indices.len(), 2);
+            workspace.activate_tab(ungrouped_indices[0], ctx);
+            workspace.tabs[ungrouped_indices[0]].in_multi_selection = true;
+            workspace.tabs[ungrouped_indices[1]].in_multi_selection = true;
+
+            workspace.handle_action(&WorkspaceAction::MoveSelectedTabsToGroup { group_id }, ctx);
+
+            assert!(
+                !workspace.tab_groups[&group_id].collapsed,
+                "group should expand when selected tabs are moved into it"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_in_group_expands_collapsed_group_non_member_active() {
+    // When the active tab is NOT a member of the group, `new_tab_in_group`
+    // must still expand the target group.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            // Create a group, then activate an ungrouped tab so the active
+            // tab is NOT a member of the group.
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+            workspace.add_terminal_tab(false, ctx);
+
+            let ungrouped_idx = workspace
+                .tabs
+                .iter()
+                .position(|t| t.group_id.is_none())
+                .expect("expected an ungrouped tab");
+            workspace.activate_tab(ungrouped_idx, ctx);
+
+            // Collapse the group, then open a new tab inside it.
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(
+                workspace.tab_groups[&group_id].collapsed,
+                "group should be collapsed"
+            );
+
+            workspace.handle_action(&WorkspaceAction::NewTabInGroup(group_id), ctx);
+
+            assert!(
+                !workspace.tab_groups[&group_id].collapsed,
+                "group should expand when a new tab is opened in it"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_new_tab_in_group_expands_collapsed_group_member_active() {
+    // When the active tab IS a member of the group, `new_tab_in_group` takes
+    // the inheritance path; the group must still expand.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+                ctx,
+            );
+            let group_id = workspace.tabs[workspace.active_tab_index()]
+                .group_id
+                .expect("active tab should be in a group");
+
+            // Collapse the group, keeping the group member as the active tab.
+            workspace.handle_action(&WorkspaceAction::ToggleTabGroupCollapsed(group_id), ctx);
+            assert!(
+                workspace.tab_groups[&group_id].collapsed,
+                "group should be collapsed"
+            );
+
+            workspace.handle_action(&WorkspaceAction::NewTabInGroup(group_id), ctx);
+
+            assert!(
+                !workspace.tab_groups[&group_id].collapsed,
+                "group should expand when a new tab is opened in it"
+            );
+        });
+    });
+}

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -3691,8 +3691,6 @@ fn test_new_tab_with_after_current_tab_setting_lands_after_active_tab_in_group()
     });
 }
 
-// --- expand-on-add tests ---
-
 #[test]
 fn test_move_tab_to_group_expands_collapsed_group() {
     let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);


### PR DESCRIPTION
## Description

This PR resolves several tab grouping bugs, including the following:
- Tab groups not expanding when tabs were added/moved to them. 
- Settings could split a group with "After current tab" placement.
- All panes in a multi-pane tab showed the same (tab) name when moved inside a tab group

The new behavior is as follows:
- Moving tab(s) to a group, or adding tab(s) to a group now expand the target group
- Opening settings via keyboard shortcuts or menu opens the settings tab after the group of the current active tab (if a group exists)
- Panes in a multi-pane tab keep their original name when moved inside a tab group, rather than inheriting the tabs name (only relevant for pane view)

## Linked Issues

[Tab group expansion](https://linear.app/warpdotdev/issue/APP-4678/adding-a-new-tab-expands-group)
[Tab naming bug](https://linear.app/warpdotdev/issue/APP-4677/named-tabs-cause-pane-renaming-when-added-to-a-group)
[Opening settings cause tab group split](https://linear.app/warpdotdev/issue/APP-4690/opening-settings-splits-a-tab-group)

Videos can be found on issues for more context.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo video for adding/moving tab(s) to group](https://www.loom.com/share/0f7cb551b7bd479f9ead480b05c1e850)

[Demo video for opening settings](https://www.loom.com/share/baea696ecb264d139184ca99dff0facf)

[Demo video for tab naming fix](https://www.loom.com/share/24a31435965e4429a14c4816a3a7c19d)