### PR TITLE
Fix CLI subagent interactions for oz agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12052,7 +12052,7 @@ dependencies = [
 [[package]]
 name = "session-sharing-protocol"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/session-sharing-protocol.git?rev=c2226e8d9d2c87ac0bea4b01f98e0027355e1a5d#c2226e8d9d2c87ac0bea4b01f98e0027355e1a5d"
+source = "git+https://github.com/warpdotdev/session-sharing-protocol.git?rev=b30fdd06379a3d073b398eabd106abed5b443aae#b30fdd06379a3d073b398eabd106abed5b443aae"
 dependencies = [
  "byte-unit",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,7 +261,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 serde_urlencoded = "0.7"
 serde_with = "2.0.1"
 serde_yaml = "0.8"
-session-sharing-protocol = { git = "https://github.com/warpdotdev/session-sharing-protocol.git", rev = "c2226e8d9d2c87ac0bea4b01f98e0027355e1a5d" }
+session-sharing-protocol = { git = "https://github.com/warpdotdev/session-sharing-protocol.git", rev = "b30fdd06379a3d073b398eabd106abed5b443aaez" }
 similar = { version = "2.7", features = ["inline"] }
 simplelog = "0.12.2"
 smallvec = "1.6.1"
@@ -532,3 +532,7 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
 # warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
+
+[patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
+# Uncomment for local development of session-sharing-protocol
+# session-sharing-protocol = { path = "../session-sharing-protocol" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,7 +261,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 serde_urlencoded = "0.7"
 serde_with = "2.0.1"
 serde_yaml = "0.8"
-session-sharing-protocol = { git = "https://github.com/warpdotdev/session-sharing-protocol.git", rev = "b30fdd06379a3d073b398eabd106abed5b443aaez" }
+session-sharing-protocol = { git = "https://github.com/warpdotdev/session-sharing-protocol.git", rev = "b30fdd06379a3d073b398eabd106abed5b443aae" }
 similar = { version = "2.7", features = ["inline"] }
 simplelog = "0.12.2"
 smallvec = "1.6.1"

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2104,8 +2104,10 @@ impl AIConversation {
         self.write_updated_conversation_state(ctx);
 
         // Don't mark the conversation as Cancelled if we're just cancelling to send a follow-up
-        // on the same conversation. The conversation will be immediately set back to InProgress.
-        if !reason.is_follow_up_for_same_conversation() {
+        // on the same conversation (it will be immediately set back to InProgress), or if the
+        // user manually took over the long-running command (the conversation remains in progress
+        // and will resume once the command finishes or control is handed back).
+        if !reason.should_preserve_in_progress_status() {
             self.update_status(ConversationStatus::Cancelled, terminal_view_id, ctx);
         }
         Ok(())

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -102,6 +102,12 @@ pub enum CancellationReason {
     /// The long-running command completed while the agent was still streaming.
     /// This should be treated as a successful completion, not a cancellation.
     OptimisticCLISubagentCompletion,
+
+    /// The user manually took control of a long-running command away from the agent.
+    /// The agent conversation is still in progress — it will resume after the command
+    /// finishes or once the user hands control back. The stream is cancelled only to
+    /// stop the CLI subagent monitoring loop, not to end the conversation.
+    CLISubagentUserTakeover,
 }
 
 impl Display for CancellationReason {
@@ -115,6 +121,9 @@ impl Display for CancellationReason {
             CancellationReason::Deleted => write!(f, "deleted"),
             CancellationReason::OptimisticCLISubagentCompletion => {
                 write!(f, "LRC command completed")
+            }
+            CancellationReason::CLISubagentUserTakeover => {
+                write!(f, "CLI subagent user takeover")
             }
         }
     }
@@ -142,6 +151,19 @@ impl CancellationReason {
 
     pub fn is_lrc_command_completed(&self) -> bool {
         matches!(self, CancellationReason::OptimisticCLISubagentCompletion)
+    }
+
+    /// Returns true when the stream was cancelled because the user took manual
+    /// control of the long-running command. The conversation remains in progress
+    /// and the ambient agent task should not be reported as cancelled.
+    pub fn is_cli_subagent_user_takeover(&self) -> bool {
+        matches!(self, CancellationReason::CLISubagentUserTakeover)
+    }
+
+    /// Returns true when the stream cancellation should NOT transition the
+    /// conversation status away from InProgress.
+    pub fn should_preserve_in_progress_status(&self) -> bool {
+        self.is_follow_up_for_same_conversation() || self.is_cli_subagent_user_takeover()
     }
 }
 

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1262,7 +1262,7 @@ impl BlocklistAIActionModel {
             .get(&conversation_id)
             .is_none_or(|actions| actions.is_empty())
         {
-            if !cancellation_reason.is_some_and(|r| r.is_follow_up_for_same_conversation()) {
+            if !cancellation_reason.is_some_and(|r| r.should_preserve_in_progress_status()) {
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
                     let status = if self
                         .finished_action_results

--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -331,13 +331,18 @@ impl CLISubagentController {
         // model lock before actually cancelling the conversation.
         drop(terminal_model);
 
-        // Only cancel conversation if user manually took control (not when agent transfers control).
+        // Cancel the in-flight stream to stop the CLI subagent monitoring loop.
+        // When the user manually takes over, we use CLISubagentUserTakeover so the
+        // conversation status stays InProgress — the agent will resume once the command
+        // finishes or the user hands control back. We do NOT use ManuallyCancelled here
+        // because that would mark the conversation (and ambient task) as cancelled,
+        // which is incorrect since the conversation is still proceeding.
         if should_cancel_conversation {
             if let Some(conversation_id) = conversation_id {
                 self.controller.update(ctx, |controller, ctx| {
                     controller.cancel_conversation_progress(
                         conversation_id,
-                        CancellationReason::ManuallyCancelled,
+                        CancellationReason::CLISubagentUserTakeover,
                         ctx,
                     );
                 });

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1220,7 +1220,7 @@ fn should_render_stopped_output(props: Props, app: &AppContext) -> bool {
 
     let status = props.model.status(app);
     let cancellation_reason = status.cancellation_reason().cloned();
-    if cancellation_reason.is_some_and(|reason| reason.is_follow_up_for_same_conversation()) {
+    if cancellation_reason.is_some_and(|reason| reason.should_preserve_in_progress_status()) {
         return false;
     }
 

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -474,6 +474,8 @@ impl BlocklistAIController {
 
             let is_lrc_command_completed =
                 cancellation_reason.is_some_and(|reason| reason.is_lrc_command_completed());
+            let should_preserve_in_progress_status = cancellation_reason
+                .is_some_and(|reason| reason.should_preserve_in_progress_status());
             let should_trigger_follow_up_request = (!is_passive_code_diff
                 && !is_lrc_command_completed
                 && finished_action_results
@@ -481,6 +483,9 @@ impl BlocklistAIController {
                     .any(|result| result.result.should_trigger_request_upon_completion()))
                 || has_manual_follow_up;
             if !should_trigger_follow_up_request {
+                if should_preserve_in_progress_status {
+                    return;
+                }
                 // We also check if there's an in-flight req, because it's possible that this
                 // subscription callback was queued in response to auto-cancelling pending actions
                 // in the process of constructing a request. In such cases, we don't want to update
@@ -2737,12 +2742,13 @@ impl BlocklistAIController {
 
                 if let Some(stream_cancellation) = &cancellation {
                     // If this is a shared session, send a synthetic StreamFinished event to notify viewers
-                    // of any user-initiated cancellation. We skip FollowUpSubmitted because that's an internal
-                    // cancellation for continuing the conversation.
+                    // of any user-initiated cancellation. We skip internal cancellations that preserve
+                    // the conversation's InProgress status, such as follow-ups and CLI subagent user
+                    // takeover, because those do not end the conversation.
                     if FeatureFlag::AgentSharedSessions.is_enabled()
                         && !stream_cancellation
                             .reason
-                            .is_follow_up_for_same_conversation()
+                            .should_preserve_in_progress_status()
                     {
                         self.send_cancellation_to_viewers(ctx);
                     }
@@ -2757,7 +2763,11 @@ impl BlocklistAIController {
                         );
                     });
 
-                    if !was_passive_request {
+                    if !was_passive_request
+                        && !stream_cancellation
+                            .reason
+                            .should_preserve_in_progress_status()
+                    {
                         self.set_input_mode_for_cancellation(ctx);
                     }
                 } else if is_any_exchange_unfinished {

--- a/app/src/terminal/event.rs
+++ b/app/src/terminal/event.rs
@@ -113,6 +113,7 @@ pub enum Event {
     /// Users "Tag an agent in" when they ask the agent to take over a long running command
     /// that was started outside of a conversation (and they tag the agent out when they take control back).
     AgentTaggedInChanged {
+        block_id: BlockId,
         is_tagged_in: bool,
     },
     Handler(HandlerEvent),
@@ -487,8 +488,14 @@ impl Debug for Event {
             Event::PromptUpdated => write!(f, "PromptUpdated"),
             Event::HonorPS1OutOfSync => write!(f, "HonorPS1OutOfSync"),
             Event::Typeahead => write!(f, "Typeahead"),
-            Event::AgentTaggedInChanged { is_tagged_in } => {
-                write!(f, "AgentTaggedInChanged(is_tagged_in: {is_tagged_in})")
+            Event::AgentTaggedInChanged {
+                block_id,
+                is_tagged_in,
+            } => {
+                write!(
+                    f,
+                    "AgentTaggedInChanged(block_id: {block_id:?}, is_tagged_in: {is_tagged_in})"
+                )
             }
             Event::Handler(handler_event) => write!(f, "Handler({handler_event:?}))"),
             Event::RemoteServerReady { session_id } => {

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -2194,8 +2194,8 @@ impl TerminalManager {
                     } else if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
-                        // TODO (roland): this is kept around for backward compatibility. Remove after 6 weeks once clients have
-                        // updated to use context_update.long_running_command_agent_interaction above.
+                        // TODO (roland): this is kept around for backward compatibility. Remove after 6 weeks (around Jul 23, 2026) 
+                        // once clients have updated to use context_update.long_running_command_agent_interaction above
                         terminal_view.update(ctx, |view, ctx| {
                             view.apply_long_running_command_agent_interaction_state(
                                 interaction_state,

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -14,8 +14,8 @@ use parking_lot::{FairMutex, Mutex};
 use pathfinder_geometry::vector::Vector2F;
 use session_sharing_protocol::common::{
     ActivePrompt, AgentPromptFailureReason, CLIAgentSessionState, CommandExecutionFailureReason,
-    ControlAction, ControlActionFailureReason, SelectedAgentModel,
-    UniversalDeveloperInputContextUpdate, WriteToPtyFailureReason,
+    ControlAction, ControlActionFailureReason, LongRunningCommandAgentInteraction,
+    SelectedAgentModel, UniversalDeveloperInputContextUpdate, WriteToPtyFailureReason,
 };
 #[cfg(not(any(test, feature = "integration_tests")))]
 use session_sharing_protocol::common::{
@@ -1445,21 +1445,30 @@ impl TerminalManager {
                     )
                     .and_then(|update| update.selected_conversation);
 
-                let long_running_command_agent_interaction_state = {
+                let (
+                    long_running_command_agent_interaction_state,
+                    long_running_command_agent_interaction,
+                ) = {
                     let model = model.lock();
                     let active_block = model.block_list().active_block();
-                    let state = if active_block.is_active_and_long_running() {
-                        if active_block.is_agent_in_control() {
-                            LongRunningCommandAgentInteractionState::InControl
-                        } else if active_block.is_agent_tagged_in() {
-                            LongRunningCommandAgentInteractionState::TaggedIn
-                        } else {
-                            LongRunningCommandAgentInteractionState::NotInteracting
-                        }
+                    if active_block.is_active_and_long_running() {
+                        let state = if active_block.is_agent_in_control() {
+                                LongRunningCommandAgentInteractionState::InControl
+                            } else if active_block.is_agent_tagged_in() {
+                                LongRunningCommandAgentInteractionState::TaggedIn
+                            } else {
+                                LongRunningCommandAgentInteractionState::NotInteracting
+                            };
+                        (
+                            Some(state),
+                            Some(LongRunningCommandAgentInteraction {
+                                block_id: active_block.id().clone().into(),
+                                state,
+                            }),
+                        )
                     } else {
-                        LongRunningCommandAgentInteractionState::NotInteracting
-                    };
-                    Some(state)
+                        (Some(LongRunningCommandAgentInteractionState::NotInteracting), None)
+                    }
                 };
 
                 // Include CLI agent session state in initial context so
@@ -1482,6 +1491,7 @@ impl TerminalManager {
                     auto_approve_agent_actions: Some(auto_approve_agent_actions),
                     selected_model: None,
                     long_running_command_agent_interaction_state,
+                    long_running_command_agent_interaction,
                     cli_agent_session,
                 };
 
@@ -2175,12 +2185,21 @@ impl TerminalManager {
                     .active_block()
                     .is_active_and_long_running()
                 {
-                    if let Some(interaction_state) =
+                    if let Some(interaction) =
+                        context_update.long_running_command_agent_interaction.clone()
+                    {
+                        terminal_view.update(ctx, |view, ctx| {
+                            view.apply_long_running_command_agent_interaction(interaction, ctx);
+                        });
+                    } else if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
+                        // TODO (roland): this is kept around for backward compatibility. Remove after 6 weeks once clients have
+                        // updated to use context_update.long_running_command_agent_interaction above.
                         terminal_view.update(ctx, |view, ctx| {
                             view.apply_long_running_command_agent_interaction_state(
                                 interaction_state,
+                                None,
                                 ctx,
                             );
                         });
@@ -2462,16 +2481,27 @@ impl TerminalManager {
                     });
                 }
             }
-            TerminalViewEvent::LongRunningCommandAgentInteractionStateChanged { state } => {
+            TerminalViewEvent::LongRunningCommandAgentInteractionStateChanged {
+                state,
+                block_id,
+            } => {
                 if !sharer_remote_update_guard.should_broadcast() {
                     return;
                 }
 
                 if let Some(network) = session_sharer.borrow().as_ref() {
+                    let interaction =
+                        block_id
+                            .clone()
+                            .map(|block_id| LongRunningCommandAgentInteraction {
+                                block_id: block_id.into(),
+                                state: *state,
+                            });
                     network.update(ctx, |network, _| {
                         network.send_universal_developer_input_context_update(
                             UniversalDeveloperInputContextUpdate {
                                 long_running_command_agent_interaction_state: Some(*state),
+                                long_running_command_agent_interaction: interaction,
                                 ..Default::default()
                             },
                         )

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -54,6 +54,7 @@ impl Block {
     }
 
     pub fn set_is_agent_tagged_in(&mut self, value: bool) {
+        let block_id = self.id().clone();
         if let InteractionMode::User(UserMode {
             ref mut did_user_tag_in_agent,
         }) = &mut self.interaction_mode
@@ -62,6 +63,7 @@ impl Block {
                 *did_user_tag_in_agent = value;
                 self.event_proxy
                     .send_terminal_event(Event::AgentTaggedInChanged {
+                        block_id,
                         is_tagged_in: value,
                     });
             }

--- a/app/src/terminal/model_events.rs
+++ b/app/src/terminal/model_events.rs
@@ -289,9 +289,13 @@ impl ModelEventDispatcher {
                 image_protocol,
             },
             Event::BootstrapPrecmdDone => ModelEvent::BootstrapPrecmdDone,
-            Event::AgentTaggedInChanged { is_tagged_in } => {
-                ModelEvent::AgentTaggedInChanged { is_tagged_in }
-            }
+            Event::AgentTaggedInChanged {
+                block_id,
+                is_tagged_in,
+            } => ModelEvent::AgentTaggedInChanged {
+                block_id,
+                is_tagged_in,
+            },
             Event::PluggableNotification { title, body } => {
                 ModelEvent::PluggableNotification { title, body }
             }
@@ -474,6 +478,7 @@ pub enum ModelEvent {
     },
     BootstrapPrecmdDone,
     AgentTaggedInChanged {
+        block_id: BlockId,
         is_tagged_in: bool,
     },
     /// A pluggable notification triggered via OSC 9 or OSC 777 escape sequences.

--- a/app/src/terminal/shared_session/viewer/event_loop.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop.rs
@@ -16,6 +16,7 @@ use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::ansi::{self};
 use crate::terminal::model::block::AgentInteractionMetadata;
 use crate::terminal::shared_session::ai_agent::decode_agent_response_event;
+use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
 use crate::terminal::shared_session::{decode_scrollback, SharedSessionStatus};
 use crate::terminal::view::ambient_agent::is_cloud_agent_pre_first_exchange;
 use crate::terminal::{TerminalModel, TerminalView};
@@ -58,6 +59,7 @@ pub struct EventLoop {
     sink: Sink,
 
     channel_event_listener: ChannelEventListener,
+    remote_update_guard: RemoteUpdateGuard,
 
     /// The next event number we need from the server.
     next_event_no: usize,
@@ -81,6 +83,7 @@ impl EventLoop {
         scrollback: Scrollback,
         catching_up_to_event_no: Option<usize>,
         load_mode: SharedSessionInitialLoadMode,
+        remote_update_guard: RemoteUpdateGuard,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let scrollback_blocks = decode_scrollback(&scrollback);
@@ -126,6 +129,7 @@ impl EventLoop {
             parser: ansi::Processor::new(),
             sink: sink(),
             channel_event_listener,
+            remote_update_guard,
             // Eventually once we have pagination, the server might need to tell us this.
             next_event_no: 0,
             buffer: HashMap::new(),
@@ -175,6 +179,7 @@ impl EventLoop {
 
         // Flush out as many contiguous events as we can.
         while let Some(next_event) = self.buffer.remove(&self.next_event_no) {
+            let _active_remote_update = self.remote_update_guard.start_remote_update();
             match next_event {
                 OrderedTerminalEventType::PtyBytesRead { bytes } => {
                     let mut model = self.terminal_model.lock();

--- a/app/src/terminal/shared_session/viewer/event_loop_tests.rs
+++ b/app/src/terminal/shared_session/viewer/event_loop_tests.rs
@@ -11,6 +11,7 @@ use warpui::{App, ViewHandle};
 use crate::ai::blocklist::agent_view::AgentViewState;
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::block::{BlockId, SerializedBlock};
+use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
 use crate::terminal::shared_session::tests::terminal_model_for_viewer;
 use crate::terminal::shared_session::viewer::event_loop::{
     EventLoop, SharedSessionInitialLoadMode,
@@ -98,6 +99,7 @@ fn test_terminal_model_is_correct() {
                 },
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -188,6 +190,7 @@ fn test_append_followup_scrollback_skips_duplicates() {
                 },
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -215,6 +218,7 @@ fn test_append_followup_scrollback_skips_duplicates() {
                 },
                 None,
                 SharedSessionInitialLoadMode::AppendFollowupScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -267,6 +271,7 @@ fn test_append_followup_scrollback_skips_duplicates() {
                 },
                 None,
                 SharedSessionInitialLoadMode::AppendFollowupScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -324,6 +329,7 @@ fn test_append_followup_scrollback_with_completed_last_block_creates_active_bloc
                 },
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -347,6 +353,7 @@ fn test_append_followup_scrollback_with_completed_last_block_creates_active_bloc
                 },
                 None,
                 SharedSessionInitialLoadMode::AppendFollowupScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -406,6 +413,7 @@ fn test_append_followup_replay_marks_existing_conversations_suppressible() {
                 empty_scrollback(),
                 None,
                 SharedSessionInitialLoadMode::AppendFollowupScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -461,6 +469,7 @@ fn test_fresh_session_replay_does_not_suppress_existing_conversations() {
                 empty_scrollback(),
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -507,6 +516,7 @@ fn test_out_of_order_buffering() {
                 },
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -574,6 +584,7 @@ fn test_pty_bytes_buffered_before_command_execution_started() {
                 },
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -646,6 +657,7 @@ fn test_cloud_mode_setup_phase_ended_clears_setup_state() {
                 empty_scrollback(),
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -733,6 +745,7 @@ fn test_cloud_mode_setup_phase_ended_when_flag_already_false() {
                 empty_scrollback(),
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });
@@ -804,6 +817,7 @@ fn test_cloud_mode_setup_phase_ended_is_idempotent() {
                 empty_scrollback(),
                 None,
                 SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                RemoteUpdateGuard::new(),
                 ctx,
             )
         });

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -149,6 +149,7 @@ pub struct Network {
 }
 
 impl Network {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         session_id: SessionId,
         channel_event_proxy: ChannelEventListener,

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -44,6 +44,7 @@ use crate::server::telemetry::telemetry_context;
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::block::BlockId;
 use crate::terminal::shared_session::network::heartbeat::{Event as HeartbeatEvent, Heartbeat};
+use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
 use crate::terminal::shared_session::viewer::event_loop::{
     EventLoop, SharedSessionInitialLoadMode,
 };
@@ -118,6 +119,7 @@ pub struct Network {
     channel_event_proxy: ChannelEventListener,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     initial_load_mode: SharedSessionInitialLoadMode,
+    remote_update_guard: RemoteUpdateGuard,
 
     stage: Stage,
 
@@ -154,6 +156,7 @@ impl Network {
         terminal_model: Arc<FairMutex<TerminalModel>>,
         write_to_pty_events_rx: Receiver<Vec<u8>>,
         initial_load_mode: SharedSessionInitialLoadMode,
+        remote_update_guard: RemoteUpdateGuard,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
@@ -172,6 +175,7 @@ impl Network {
             channel_event_proxy,
             terminal_model,
             initial_load_mode,
+            remote_update_guard,
             terminal_view,
             stage: Stage::BeforeJoined,
             id: None,
@@ -211,6 +215,7 @@ impl Network {
         terminal_view: WeakViewHandle<TerminalView>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
         write_to_pty_events_rx: Receiver<Vec<u8>>,
+        remote_update_guard: RemoteUpdateGuard,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         use session_sharing_protocol::common::SessionId;
@@ -235,6 +240,7 @@ impl Network {
             channel_event_proxy,
             terminal_model,
             initial_load_mode: SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+            remote_update_guard,
             terminal_view,
             stage: Stage::BeforeJoined,
             id: Some(viewer_id.clone()),
@@ -593,6 +599,7 @@ impl Network {
                         *scrollback,
                         latest_event_no,
                         self.initial_load_mode,
+                        self.remote_update_guard.clone(),
                         ctx,
                     )
                 });

--- a/app/src/terminal/shared_session/viewer/network_tests.rs
+++ b/app/src/terminal/shared_session/viewer/network_tests.rs
@@ -10,6 +10,7 @@ use warpui::{App, ModelHandle};
 
 use super::{Network, PtyBytesBatchStatus, Stage};
 use crate::terminal::event_listener::ChannelEventListener;
+use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
 use crate::terminal::TerminalModel;
 use crate::test_util::add_window_with_terminal;
 use crate::test_util::terminal::initialize_app_for_terminal_view;
@@ -27,6 +28,7 @@ fn create_network(app: &mut App) -> (ModelHandle<Network>, Sender<Vec<u8>>) {
             terminal_view,
             terminal_model,
             write_to_pty_events_rx,
+            RemoteUpdateGuard::new(),
             ctx,
         )
     });

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -773,6 +773,9 @@ impl TerminalManager {
                             ctx,
                         );
                     }
+                    // TODO(roland): we do not apply universal_developer_input_context.long_running_command_agent_interaction here
+                    // because the block it should apply to won't exist yet, until the `OrderedTerminalEvents` that come after are processed.
+                    // We should try to apply it after catching up to the latest state.
                 }
                 let Some(view) = weak_view_handle.upgrade(ctx) else {
                     return;

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -996,8 +996,8 @@ impl TerminalManager {
                     } else if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
-                        // TODO (roland): this is kept around for backward compatibility. Remove after 6 weeks once clients have
-                        // updated to use context_update.long_running_command_agent_interaction above.
+                        // TODO (roland): this is kept around for backward compatibility. Remove after 6 weeks (around Jul 23, 2026) 
+                        // once clients have updated to use context_update.long_running_command_agent_interaction above.
                         if let Some(view) = weak_view_handle.upgrade(ctx) {
                             view.update(ctx, |view, ctx| {
                                 view.apply_long_running_command_agent_interaction_state(

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -6,9 +6,9 @@ use parking_lot::FairMutex;
 use pathfinder_geometry::vector::Vector2F;
 use session_sharing_protocol::common::{
     ActivePrompt, AddGuestsResponse, CLIAgentSessionState, CommandExecutionFailureReason,
-    LinkAccessLevelUpdateResponse, RemoveGuestResponse, SelectedAgentModel, SessionId,
-    TeamAccessLevelUpdateResponse, UniversalDeveloperInputContextUpdate,
-    UpdatePendingUserRoleResponse,
+    LinkAccessLevelUpdateResponse, LongRunningCommandAgentInteraction, RemoveGuestResponse,
+    SelectedAgentModel, SessionId, TeamAccessLevelUpdateResponse,
+    UniversalDeveloperInputContextUpdate, UpdatePendingUserRoleResponse,
 };
 use session_sharing_protocol::sharer::SessionSourceType;
 use session_sharing_protocol::viewer::SessionEndedReason;
@@ -466,6 +466,7 @@ impl TerminalManager {
                 self.model.clone(),
                 write_to_pty_events_rx,
                 initial_load_mode,
+                self.viewer_remote_update_guard.clone(),
                 ctx,
             )
         });
@@ -984,13 +985,24 @@ impl TerminalManager {
                     .active_block()
                     .is_active_and_long_running()
                 {
-                    if let Some(interaction_state) =
+                    if let Some(interaction) =
+                        context_update.long_running_command_agent_interaction.clone()
+                    {
+                        if let Some(view) = weak_view_handle.upgrade(ctx) {
+                            view.update(ctx, |view, ctx| {
+                                view.apply_long_running_command_agent_interaction(interaction, ctx);
+                            });
+                        }
+                    } else if let Some(interaction_state) =
                         context_update.long_running_command_agent_interaction_state
                     {
+                        // TODO (roland): this is kept around for backward compatibility. Remove after 6 weeks once clients have
+                        // updated to use context_update.long_running_command_agent_interaction above.
                         if let Some(view) = weak_view_handle.upgrade(ctx) {
                             view.update(ctx, |view, ctx| {
                                 view.apply_long_running_command_agent_interaction_state(
                                     interaction_state,
+                                    None,
                                     ctx,
                                 );
                             });
@@ -1527,13 +1539,24 @@ impl TerminalManager {
                     network.send_report_terminal_size(*window_size);
                 });
             }
-            TerminalViewEvent::LongRunningCommandAgentInteractionStateChanged { state } => {
+            TerminalViewEvent::LongRunningCommandAgentInteractionStateChanged {
+                state,
+                block_id,
+            } => {
+                let interaction =
+                    block_id
+                        .clone()
+                        .map(|block_id| LongRunningCommandAgentInteraction {
+                            block_id: block_id.into(),
+                            state: *state,
+                        });
                 Self::send_input_context_update_to_current_network(
                     &viewer_remote_update_guard,
                     &model,
                     &current_network,
                     UniversalDeveloperInputContextUpdate {
                         long_running_command_agent_interaction_state: Some(*state),
+                        long_running_command_agent_interaction: interaction,
                         ..Default::default()
                     },
                     ctx,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8040,14 +8040,20 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         if let Some(block_id) = block_id {
-            let should_apply = {
+            let (is_active_block_long_running, active_block_id) = {
                 let model = self.model.lock();
                 let active_block = model.block_list().active_block();
-                active_block.is_active_and_long_running() && active_block.id() == block_id
+                (
+                    active_block.is_active_and_long_running(),
+                    active_block.id().clone(),
+                )
             };
+            let should_apply = is_active_block_long_running && active_block_id == *block_id;
             if !should_apply {
                 log::info!(
-                    "Ignoring stale shared-session LRC interaction_state={state:?} for block_id={block_id:?}"
+                    "Ignoring stale shared-session LRC interaction_state={state:?} for block_id={block_id:?}. Currently active block id={} is_active_and_long_running={}",
+                    active_block_id,
+                    is_active_block_long_running,
                 );
                 return;
             }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -112,8 +112,9 @@ use repo_metadata::repositories::RepoDetectionSource;
 use serde::Serialize;
 use serde_json::json;
 use session_sharing_protocol::common::{
-    AgentAttachment, LongRunningCommandAgentInteractionState, ParticipantId, Role, RoleRequestId,
-    RoleRequestResponse, ServerConversationToken as SessionSharingServerConversationToken,
+    AgentAttachment, LongRunningCommandAgentInteraction, LongRunningCommandAgentInteractionState,
+    ParticipantId, Role, RoleRequestId, RoleRequestResponse,
+    ServerConversationToken as SessionSharingServerConversationToken,
     WindowSize as SessionSharingWindowSize,
 };
 use session_sharing_protocol::sharer::{
@@ -1952,6 +1953,7 @@ pub enum Event {
     /// Emitted when the agent's interaction state with a long-running command changes.
     LongRunningCommandAgentInteractionStateChanged {
         state: LongRunningCommandAgentInteractionState,
+        block_id: Option<BlockId>,
     },
     /// A pluggable notification triggered via OSC 9 or OSC 777 escape sequences.
     /// Used to show an in-app toast notification.
@@ -6347,11 +6349,14 @@ impl TerminalView {
                 }
             }
             CLISubagentEvent::UpdatedControl {
-                agent_has_control, ..
+                block_id,
+                agent_has_control,
+                ..
             } => {
                 self.redetermine_terminal_focus(ctx);
                 self.emit_long_running_command_agent_interaction_state_changed(
                     *agent_has_control,
+                    block_id.clone(),
                     ctx,
                 );
             }
@@ -8005,32 +8010,48 @@ impl TerminalView {
     fn emit_long_running_command_agent_interaction_state_changed(
         &self,
         agent_has_control: bool,
+        block_id: BlockId,
         ctx: &mut ViewContext<Self>,
     ) {
         let state = if agent_has_control {
             LongRunningCommandAgentInteractionState::InControl
-        } else {
-            let is_tagged_in = self
-                .model
-                .lock()
+        } else if {
+            let model = self.model.lock();
+            model
                 .block_list()
-                .active_block()
-                .is_agent_tagged_in();
-            if is_tagged_in {
-                LongRunningCommandAgentInteractionState::TaggedIn
-            } else {
-                LongRunningCommandAgentInteractionState::NotInteracting
-            }
+                .block_with_id(&block_id)
+                .is_some_and(|block| block.is_agent_tagged_in())
+        } {
+            LongRunningCommandAgentInteractionState::TaggedIn
+        } else {
+            LongRunningCommandAgentInteractionState::NotInteracting
         };
-        ctx.emit(Event::LongRunningCommandAgentInteractionStateChanged { state });
+        ctx.emit(Event::LongRunningCommandAgentInteractionStateChanged {
+            state,
+            block_id: Some(block_id),
+        });
     }
 
     /// Applies a long-running command agent interaction state received from a shared session participant.
     pub fn apply_long_running_command_agent_interaction_state(
         &mut self,
         state: LongRunningCommandAgentInteractionState,
+        block_id: Option<&BlockId>,
         ctx: &mut ViewContext<Self>,
     ) {
+        if let Some(block_id) = block_id {
+            let should_apply = {
+                let model = self.model.lock();
+                let active_block = model.block_list().active_block();
+                active_block.is_active_and_long_running() && active_block.id() == block_id
+            };
+            if !should_apply {
+                log::info!(
+                    "Ignoring stale shared-session LRC interaction_state={state:?} for block_id={block_id:?}"
+                );
+                return;
+            }
+        }
         if self.current_long_running_command_agent_interaction_state() == state {
             return;
         }
@@ -8056,6 +8077,20 @@ impl TerminalView {
         }
     }
 
+    /// Applies a block-scoped long-running command agent interaction state received from a shared
+    /// session participant.
+    pub fn apply_long_running_command_agent_interaction(
+        &mut self,
+        interaction: LongRunningCommandAgentInteraction,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let block_id = BlockId::from(interaction.block_id);
+        self.apply_long_running_command_agent_interaction_state(
+            interaction.state,
+            Some(&block_id),
+            ctx,
+        );
+    }
     /// Shows or hides the CLI agent footer from a shared session update.
     pub fn apply_cli_agent_footer_visibility(&mut self, show: bool, ctx: &mut ViewContext<Self>) {
         if show {
@@ -12649,13 +12684,19 @@ impl TerminalView {
             ModelEvent::BootstrapPrecmdDone => {
                 self.execute_pending_command((), ctx);
             }
-            ModelEvent::AgentTaggedInChanged { is_tagged_in } => {
+            ModelEvent::AgentTaggedInChanged {
+                block_id,
+                is_tagged_in,
+            } => {
                 let state = if *is_tagged_in {
                     LongRunningCommandAgentInteractionState::TaggedIn
                 } else {
                     LongRunningCommandAgentInteractionState::NotInteracting
                 };
-                ctx.emit(Event::LongRunningCommandAgentInteractionStateChanged { state });
+                ctx.emit(Event::LongRunningCommandAgentInteractionStateChanged {
+                    state,
+                    block_id: Some(block_id.clone()),
+                });
             }
             ModelEvent::PluggableNotification { title, body } => {
                 // Intercept structured CLI agent notifications (e.g. from Claude Code plugin).

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8055,7 +8055,9 @@ impl TerminalView {
         if self.current_long_running_command_agent_interaction_state() == state {
             return;
         }
-        log::info!("Applying shared-session LRC interaction_state={state:?}");
+        log::info!(
+            "Applying shared-session LRC interaction_state={state:?} to block_id={block_id:?}"
+        );
         match state {
             LongRunningCommandAgentInteractionState::InControl => {
                 self.cli_subagent_controller.update(ctx, |controller, ctx| {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8015,13 +8015,13 @@ impl TerminalView {
     ) {
         let state = if agent_has_control {
             LongRunningCommandAgentInteractionState::InControl
-        } else if {
-            let model = self.model.lock();
-            model
-                .block_list()
-                .block_with_id(&block_id)
-                .is_some_and(|block| block.is_agent_tagged_in())
-        } {
+        } else if self
+            .model
+            .lock()
+            .block_list()
+            .block_with_id(&block_id)
+            .is_some_and(|block| block.is_agent_tagged_in())
+        {
             LongRunningCommandAgentInteractionState::TaggedIn
         } else {
             LongRunningCommandAgentInteractionState::NotInteracting


### PR DESCRIPTION
## Description

Was investigating sources of ambient agent tasks becoming canceled by user automatically: https://linear.app/warpdotdev/issue/REMOTE-1887/maa-requests-getting-canceled#comment-75459dec

It can happen when we receive a NotInteracting LRC state, which is interpreted as user takeover of a CLI subagent monitored requested command. This is meant to cancel the conversation stream because the agent is no longer monitoring, but it also set the conversation status to canceled, which updates the ambient agent state to canceled by user.

But I also see the sharer receiving NotInteracting from the viewer when not expected. I believe there may be stale updates from the viewer causing this. We definitely should have LRC state updates apply to a specific block so we can discard stale updates.

And finally, some bugs with cloud mode were causing echoes of LRC state updates. The problematic flow was:
- Sharer updates LRC state, fans out result
- Cloud mode viewer applies LRC update from sharer locally
- But cloud mode viewer mutation locally would result in LRC update, which gets fanned out to sharer because cloud mode viewer has write permission
- Sharer receives echo of its LRC update, as if viewer wrote it

So this is a combination of 3 fixes:
- User takeover of a LRC should keep the conversation and task status in progress
- In shared sessions, LRC state updates should apply to specific blocks so stale updates can't apply
- Prevent viewer replaying sharer LRC updates from writing again to shared session

Requires protocol change to be merged first, before updating cargo.toml: https://github.com/warpdotdev/session-sharing-protocol/pull/27

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Tested with https://github.com/warpdotdev/session-sharing-protocol/pull/27

https://www.loom.com/share/f09e7b1d7e35412a99a7c2947104a460


