### PR TITLE
spec: add Kiro CLI agent integration spec for GH#9066

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,8 @@ crates/command-signatures-v2/js/node_modules
 # For testing changes to the channel versions file
 channel_versions_test.json
 
-# Don't include any profiling output by accident.
+# Don't include any CPU profiling output by accident.
 profile.pb
-*.mm_profdata
-chrome_profiler.json
 
 # Don't include any files that we write for testing purposes.
 crates/warp_files/test_data/test_write
@@ -51,14 +49,14 @@ app/src/persistence/schema.rs.orig
 # Don't include personal Claude Code settings
 .claude/settings.local.json
 
+# External context files (Confluence exports, API specs, etc.)
+.artifacts/
+
+# Kiro agent configuration and knowledge base
+.kiro/
+
 # Don't include Claude Code worktrees
 .claude/worktrees/
-
-# Don't include Claude Code scheduled task lock
-.claude/scheduled_tasks.lock
-
-# Don't include ctags output
-tags
 
 # Tab drag development notes
 pr_cleanup.md
@@ -66,6 +64,3 @@ desired_behavior.md
 
 # Don't include the python cache for bundled skills.
 __pycache__/
-
-# Project notes
-.note/

--- a/specs/GH9066/product.md
+++ b/specs/GH9066/product.md
@@ -1,0 +1,112 @@
+# PRODUCT.md — Support Kiro CLI Agent Integration in Warp
+
+Issue: https://github.com/warpdotdev/warp/issues/9066
+
+## Summary
+
+Add Kiro CLI (`kiro`) as a first-class supported CLI agent in Warp, alongside
+Claude Code, Codex, Gemini CLI, and the other agents already integrated. When a
+user runs `kiro` in a Warp terminal, Warp detects the session, displays the
+Kiro-branded agent footer, enables the rich input composer (Ctrl-G), and tracks
+session status (in-progress, blocked, success) using the same plugin event
+protocol used by other agents.
+
+Figma: none provided.
+
+## Goals / Non-goals
+
+In-scope:
+
+- Detecting `kiro` as a CLI agent session in the terminal.
+- Displaying the Kiro-branded footer and toolbar chip while a `kiro` session is
+  active.
+- Enabling the rich input composer (Ctrl-G / footer button) for composing
+  prompts to send to Kiro.
+- Showing plugin install/update instructions when the Warp plugin is not
+  installed or is out of date.
+- Tracking session status (InProgress, Blocked, Success) via the Warp plugin
+  event protocol.
+- Surfacing Kiro in the "Third party CLI agents" settings page.
+- Telemetry for Kiro sessions consistent with other agents.
+- macOS support (primary). Linux support follows the same code path and is
+  included. Windows support is not in scope for this spec.
+
+Out of scope:
+
+- Changes to the Warp built-in agent, execution profiles, or onboarding.
+- A new `SkillProvider::Kiro` variant — Kiro CLI supports the existing
+  `SkillProvider::Agents` skill format; no Kiro-specific skill provider is
+  needed at this time.
+- Custom toolbar commands or user-configured regex patterns for Kiro.
+- Remote (SSH) session support beyond what the existing plugin infrastructure
+  already provides generically.
+
+## Behavior
+
+1. When a user runs `kiro` (or a command whose first token is `kiro`) in a Warp
+   terminal pane, Warp detects an active Kiro CLI session and begins tracking it
+   in `CLIAgentSessionsModel`.
+
+2. While a Kiro session is active, the Kiro-branded agent footer is displayed at
+   the bottom of the terminal pane. The footer shows the Kiro logo, the session
+   status, and the rich input button. Layout, interaction model, and dismiss
+   behavior are identical to the Claude Code and Gemini footers.
+
+3. Pressing Ctrl-G (or clicking the rich input button in the footer) opens the
+   rich input composer. The composer accepts free-form text and slash-command
+   skills from `SkillProvider::Agents`. The skill command prefix is `/`.
+
+4. Submitting a prompt from the rich input composer sends it to the running
+   `kiro` process via the terminal PTY, exactly as it does for other agents.
+
+5. When the Warp plugin for Kiro is installed and active, session status updates
+   (InProgress, Blocked, Success) are reflected in the footer in real time.
+   When the plugin is not installed, the footer still appears (via command
+   detection) but status tracking is unavailable.
+
+6. When the Warp plugin is not installed, Warp displays plugin install
+   instructions in the footer's plugin pane. The instructions guide the user
+   through installing the plugin so that status tracking becomes available.
+
+7. _(Deferred)_ When the installed plugin version is below the minimum required
+   version, Warp displays plugin update instructions in the same pane. This
+   behavior is not delivered in the initial release: no versioned Kiro Warp
+   plugin exists yet, so version detection (`is_installed()`, `needs_update()`)
+   is not implemented and `supports_update()` returns `false`. The update pane
+   will never appear. This requirement is carried as a follow-up for when a
+   versioned Kiro plugin is published.
+
+8. The Kiro agent entry appears in the "Third party CLI agents" settings page
+   under Settings → Agents → Third party CLI agents, alongside Claude Code,
+   Codex, Gemini, and the other supported agents, when
+   `FeatureFlag::KiroCLIAgent` is enabled. The entry shows the Kiro logo and
+   name. When the flag is disabled, Kiro is hidden from the selector, and any
+   persisted command mapping to Kiro is displayed as "Other" in the settings UI
+   (without exposing Kiro as a selectable option) until the flag is re-enabled.
+   A documentation link is not included in the initial implementation because
+   the current settings UI does not render per-agent documentation links for any
+   agent; adding that capability is a follow-up item.
+
+9. Session start, status changes, and session end are reported to telemetry
+   using the same `CLIAgentType` telemetry event structure used by other agents,
+   with `CLIAgentType::Kiro` as the agent discriminant.
+
+10. In a remote SSH terminal pane, the Kiro footer and rich input still appear
+    when a `kiro` command is detected (via command detection, same as local).
+    The plugin install and update instructions pane also appears in remote
+    sessions, consistent with the existing generic plugin-chip behavior for all
+    other CLI agents. If the Warp plugin is already running on the remote system
+    and emitting events, real-time status tracking works normally. If it is not,
+    the footer shows the install instructions pane (same as a local session with
+    no plugin installed).
+
+11. Kiro sessions are included in shared session state sync (the `cli_agent`
+    field in the shared session protocol) using the serialized name `"Kiro"`.
+
+12. The `kiro` command is not treated as a custom/unknown agent — it maps
+    directly to `CLIAgent::Kiro` and receives the full first-class treatment
+    (branded footer, logo, install instructions) rather than the generic
+    "CLI Agent" fallback.
+
+13. No existing agent's behavior, settings, or telemetry is changed by this
+    addition.

--- a/specs/GH9066/tech.md
+++ b/specs/GH9066/tech.md
@@ -1,0 +1,464 @@
+# TECH.md — Support Kiro CLI Agent Integration in Warp
+
+Issue: https://github.com/warpdotdev/warp/issues/9066
+Product spec: `specs/GH9066/product.md`
+
+## Context
+
+Warp's CLI agent integration is built around the `CLIAgent` enum
+(`app/src/terminal/cli_agent.rs`). Every supported agent is a variant of that
+enum. The enum drives:
+
+- Command detection (matching the first token of a terminal command against
+  `command_prefix()`).
+- Display (logo icon, brand color, display name).
+- Plugin management (install/update instructions, version checks, auto-install).
+- Skill support (which `SkillProvider` variants are shown in the rich input
+  slash menu).
+- Telemetry (`CLIAgentType` in `app/src/server/telemetry/events.rs`).
+- Shared session serialization (`to_serialized_name` / `from_serialized_name`).
+
+Adding a new agent requires touching a fixed set of files, all following the
+same pattern established by Claude, Codex, Gemini, Amp, and the others. No
+changes to the session model, event system, rich input, or footer rendering are
+needed — those are generic over `CLIAgent`.
+
+Relevant files:
+
+- `app/src/terminal/cli_agent.rs` — `CLIAgent` enum and all its `impl` blocks.
+  Lines 116–350 (approximately). Every `match self` arm must be extended.
+- `app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs` — factory that
+  maps `CLIAgent` variants to `CliAgentPluginManager` trait objects. Lines 1–30
+  (module declarations) and the factory `match` (lines ~60–80).
+- `app/src/terminal/cli_agent_sessions/plugin_manager/codex.rs` — reference
+  implementation for a simple plugin manager (no auto-install, manual steps
+  only). New `kiro.rs` follows this pattern.
+- `app/src/server/telemetry/events.rs` — `CLIAgentType` enum at line 491.
+- `crates/warp_features/src/lib.rs` — `FeatureFlag` enum and rollout lists
+  (`DOGFOOD_FLAGS`, `PREVIEW_FLAGS`, `RELEASE_FLAGS`). New feature flag gates
+  the Kiro variant until the plugin is ready for general availability.
+- `app/src/features.rs` — re-export used by app code (`pub use
+  warp_core::features::*;`) when importing `FeatureFlag`.
+- `app/src/ui_components/icons.rs` (or the equivalent icon registry) — `Icon`
+  enum. A `KiroLogo` variant is needed.
+- `app/src/settings_view/ai_page.rs` — the file that renders the "Third party
+  CLI agents" subpage (navigated to via Settings → Agents → Third party CLI
+  agents in the UI; the sidebar umbrella label is "Agents", defined in
+  `app/src/settings_view/mod.rs`). The agent-assignment dropdown is populated by
+  iterating `all::<CLIAgent>()` (via `enum_iterator::Sequence`) at line ~2121,
+  filtering out `CLIAgent::Unknown`. The current settings UI does not render a
+  per-agent documentation link — entries are driven entirely by
+  `agent.display_name()` and `agent.icon()`. The product spec behavior #8
+  ("a link to the Kiro CLI documentation") therefore cannot be satisfied by the
+  current settings UI without a UI change. **Resolution**: the documentation
+  link requirement is deferred to a follow-up; the initial implementation adds
+  Kiro to the dropdown only (consistent with all other agents). This file needs
+  two explicit behavior guards: exclude `CLIAgent::Kiro` from dropdown items
+  when the feature flag is disabled, and coerce persisted `CLIAgent::Kiro`
+  assignments to "Other" in the selected label when the flag is disabled (see
+  feature flag section below).
+
+## Proposed changes
+
+### 1. Add `CLIAgent::Kiro` to the enum and implement all match arms
+
+In `app/src/terminal/cli_agent.rs`:
+
+```rust
+pub enum CLIAgent {
+    Claude,
+    Gemini,
+    Codex,
+    // ... existing variants ...
+    Kiro,   // ← new
+    Unknown,
+}
+```
+
+Implement every exhaustive `match self` arm (exhaustive matching is required by
+the codebase's coding standards — no `_` wildcards):
+
+| Method | Value |
+|--------|-------|
+| `command_prefix` | `"kiro"` |
+| `display_name` | `"Kiro"` |
+| `icon` | `Some(Icon::KiroLogo)` |
+| `brand_color` | `Some(KIRO_COLOR)` — see color note below |
+| `brand_icon_color` | `ColorU::white()` (default) |
+| `supported_skill_providers` | `&[SkillProvider::Agents]` |
+| `skill_command_prefix` | `"/"` (default, no arm needed if using `_`) — but add explicit arm per exhaustive-match rule |
+| `supports_bash_mode` | `false` (not confirmed supported; add to the `matches!` list if confirmed later) |
+
+**Brand color**: Kiro's brand uses a blue-purple (`#5B4FE8` approximately, from
+kiro.dev). Define a constant:
+
+```rust
+const KIRO_COLOR: ColorU = ColorU {
+    r: 91,
+    g: 79,
+    b: 232,
+    a: 255,
+};
+```
+
+Confirm the exact hex against the Kiro brand guide before merging; the value
+above is a reasonable starting point from the kiro.dev website.
+
+### 2. Add `Icon::KiroLogo` to the icon registry
+
+In `app/src/ui_components/icons.rs` (or wherever `Icon` is defined), add:
+
+```rust
+KiroLogo,
+```
+
+The icon asset (SVG or bundled image) must be added to `app/assets/` following
+the same pattern as `ClaudeLogo`, `GeminiLogo`, etc. The asset path and
+embedding macro call follow the existing pattern in the icon registry.
+
+### 3. Add `CLIAgentType::Kiro` to the telemetry enum
+
+In `app/src/server/telemetry/events.rs`, extend `CLIAgentType`:
+
+```rust
+pub enum CLIAgentType {
+    // ... existing variants ...
+    Kiro,
+}
+```
+
+Update the conversion from `CLIAgent` to `CLIAgentType` (wherever that mapping
+lives — typically a `From<CLIAgent>` impl or a match in the telemetry module) to
+map `CLIAgent::Kiro => CLIAgentType::Kiro`.
+
+### 4. Add a feature flag
+
+In `crates/warp_features/src/lib.rs`, add:
+
+```rust
+pub enum FeatureFlag {
+    // ... existing variants ...
+    KiroCLIAgent,
+}
+```
+
+Gate the `CLIAgent::Kiro` variant's detection in the command-matching path
+behind `FeatureFlag::KiroCLIAgent.is_enabled()`. This allows the feature to be
+enabled in dogfood/preview before stable release, consistent with how other
+agents were rolled out. Add `FeatureFlag::KiroCLIAgent` to `DOGFOOD_FLAGS`
+initially.
+
+**Important — all enum-iteration surfaces must be gated, not just command
+detection.** Adding `CLIAgent::Kiro` to the enum automatically exposes it
+through every consumer of `enum_iterator::all::<CLIAgent>()`. There are three
+additional enum-iteration surfaces that must be gated, plus the plugin-manager
+factory, plus one deserialization path that bypasses enum iteration entirely:
+
+1. **`CLIAgent::detect()` in `app/src/terminal/cli_agent.rs`** — the
+   `enum_iterator::all::<CLIAgent>()` loop that matches commands. Add a
+   `.filter()` step to exclude `CLIAgent::Kiro` when the flag is off:
+
+   ```rust
+   enum_iterator::all::<CLIAgent>()
+       .filter(|agent| !matches!(agent, CLIAgent::Unknown))
+       .filter(|agent| {
+           !matches!(agent, CLIAgent::Kiro)
+               || FeatureFlag::KiroCLIAgent.is_enabled()
+       })
+       .find(|agent| { ... })
+   ```
+
+2. **Settings dropdown in `app/src/settings_view/ai_page.rs`** — the
+   `for agent in all::<CLIAgent>()` loop at line ~2121 that populates the
+   agent-assignment dropdown. Add the same guard and disabled-state selection
+   fallback:
+
+   ```rust
+   for agent in all::<CLIAgent>() {
+       if matches!(agent, CLIAgent::Unknown) {
+           continue;
+       }
+       if matches!(agent, CLIAgent::Kiro) && !FeatureFlag::KiroCLIAgent.is_enabled() {
+           continue;
+       }
+       // ... existing item construction
+   }
+   let selected_name = if matches!(current_agent, CLIAgent::Unknown)
+       || (matches!(current_agent, CLIAgent::Kiro)
+           && !FeatureFlag::KiroCLIAgent.is_enabled())
+   {
+       "Other"
+   } else {
+       current_agent.display_name()
+   };
+   ```
+
+3. **`resolve_agent()` in `app/src/terminal/cli_agent_sessions/event/v1.rs`**
+   — plugin event parsing also iterates `all::<CLIAgent>()`. Apply the same
+   feature-flag guard so disabled variants do not resolve from incoming event
+   payloads:
+
+   ```rust
+   enum_iterator::all::<CLIAgent>()
+       .filter(|agent| !matches!(agent, CLIAgent::Unknown))
+       .filter(|agent| {
+           !matches!(agent, CLIAgent::Kiro)
+               || FeatureFlag::KiroCLIAgent.is_enabled()
+       })
+       .find(|agent| agent.command_prefix() == incoming_agent_name)
+   ```
+
+4. **`plugin_manager_for_with_shell()` in
+   `app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs`** — the factory
+   match already uses per-agent feature flag guards (e.g.
+   `CLIAgent::Codex if FeatureFlag::CodexNotifications.is_enabled() && ...`).
+   Follow the same pattern for Kiro:
+
+   ```rust
+   CLIAgent::Kiro
+       if FeatureFlag::KiroCLIAgent.is_enabled()
+           && FeatureFlag::HOANotifications.is_enabled() =>
+   {
+       Some(Box::new(kiro::KiroPluginManager))
+   }
+   ```
+
+   Both guards are required: `HOANotifications` is the global kill switch that
+   disables all non-Claude notification plugin managers (see `mod.rs` — every
+   agent except Claude checks `FeatureFlag::HOANotifications.is_enabled()`).
+   The catch-all `CLIAgent::Kiro` arm (either flag disabled) falls through to
+   `None`, consistent with how other agents behave when their flag is off.
+
+5. **`CompiledCommandsForCodingAgentToolbar::matched_agent` (custom-command
+   deserialization path)** — persisted custom-command mappings are serialized
+   as `"Kiro"` via `CLIAgent::to_serialized_name()` and deserialized back
+   through `CLIAgent::from_serialized_name()`. This path does not go through
+   `enum_iterator::all::<CLIAgent>()`, so the filters above do not protect it.
+   A user who saved a Kiro mapping while the flag was on and then had the flag
+   turned off would otherwise still activate `CLIAgent::Kiro` via their custom
+   regex — bypassing the flag entirely. Add a flag guard at the
+   `matched_agent` call site (or at the point where the deserialized agent is
+   consumed to start a session) so that a resolved `CLIAgent::Kiro` is treated
+   as `CLIAgent::Unknown` when `FeatureFlag::KiroCLIAgent` is disabled:
+
+   ```rust
+   let agent = CompiledCommandsForCodingAgentToolbar::matched_agent(...);
+   let agent = if matches!(agent, CLIAgent::Kiro)
+       && !FeatureFlag::KiroCLIAgent.is_enabled()
+   {
+       CLIAgent::Unknown
+   } else {
+       agent
+   };
+   ```
+
+   This satisfies product behavior #8: persisted Kiro mappings display as
+   "Other" and do not activate Kiro while the flag is off.
+
+### 5. Add the Kiro plugin manager
+
+Create `app/src/terminal/cli_agent_sessions/plugin_manager/kiro.rs`:
+
+```rust
+use std::sync::LazyLock;
+
+use async_trait::async_trait;
+
+use super::{CliAgentPluginManager, PluginInstructionStep, PluginInstructions};
+
+pub(super) struct KiroPluginManager;
+
+#[async_trait]
+impl CliAgentPluginManager for KiroPluginManager {
+    fn minimum_plugin_version(&self) -> &'static str {
+        "0.0.0"  // No versioned plugin yet; version gating is inactive
+    }
+
+    fn can_auto_install(&self) -> bool {
+        false  // Manual install until the plugin is stable
+    }
+
+    fn supports_update(&self) -> bool {
+        false
+    }
+
+    fn install_instructions(&self) -> &'static PluginInstructions {
+        &INSTALL_INSTRUCTIONS
+    }
+
+    fn update_instructions(&self) -> &'static PluginInstructions {
+        &EMPTY_INSTRUCTIONS
+    }
+}
+
+static INSTALL_INSTRUCTIONS: LazyLock<PluginInstructions> = LazyLock::new(|| {
+    PluginInstructions {
+        title: "Install Kiro CLI",
+        subtitle: "Install the Kiro CLI to enable the branded footer and rich input composer in Warp. Real-time session status tracking will activate automatically once a Kiro release ships Warp event-protocol support (see follow-ups).",
+        steps: &[
+            PluginInstructionStep {
+                description: "Install the Kiro CLI from the official download page (.dmg installer on macOS, .deb/.rpm on Linux).",
+                command: "",
+                executable: false,
+                link: Some("https://kiro.dev/downloads/"),
+            },
+            PluginInstructionStep {
+                description: "Verify the install by running `kiro --version` in a new Warp terminal.",
+                command: "kiro --version",
+                executable: true,
+                link: None,
+            },
+        ],
+        post_install_notes: &[
+            "Restart your terminal session after installation so the `kiro` binary is on PATH.",
+            "Status tracking (InProgress / Blocked / Success) requires Kiro CLI to emit Warp's structured event protocol. Until a Kiro release ships that support, only the branded footer and rich input composer are available.",
+        ],
+    }
+});
+
+static EMPTY_INSTRUCTIONS: LazyLock<PluginInstructions> =
+    LazyLock::new(|| PluginInstructions {
+        title: "",
+        subtitle: "",
+        steps: &[],
+        post_install_notes: &[],
+    });
+```
+
+Create the corresponding test file
+`app/src/terminal/cli_agent_sessions/plugin_manager/kiro_tests.rs` following
+the pattern in `codex_tests.rs`.
+
+In `app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs`, add:
+
+```rust
+pub(crate) mod kiro;
+```
+
+And extend the factory `match` in `plugin_manager_for_with_shell()` to include
+the Kiro arms, following the same pattern as Codex and Gemini (both the
+agent-specific flag and the HOA kill switch must be enabled; the disabled arm
+falls through to the existing catch-all `None` list):
+
+```rust
+CLIAgent::Kiro
+    if FeatureFlag::KiroCLIAgent.is_enabled()
+        && FeatureFlag::HOANotifications.is_enabled() =>
+{
+    Some(Box::new(kiro::KiroPluginManager))
+}
+```
+
+Add `CLIAgent::Kiro` to the existing catch-all `None` arm alongside the other
+agents that return `None` when their flag is off:
+
+```rust
+CLIAgent::OpenCode
+| CLIAgent::Codex
+| CLIAgent::Gemini
+| CLIAgent::Amp
+| CLIAgent::Droid
+| CLIAgent::Copilot
+| CLIAgent::Pi
+| CLIAgent::Auggie
+| CLIAgent::CursorCli
+| CLIAgent::Goose
+| CLIAgent::Kiro      // ← add here (flag-disabled fallthrough)
+| CLIAgent::Unknown => None,
+```
+
+**Note on the Warp plugin protocol**: The Kiro CLI must emit structured JSON
+events to stdout (the same `SessionStart`, `PromptSubmit`, `Stop`,
+`PermissionRequest`, `QuestionAsked`, `PermissionReplied`, `ToolComplete`,
+`IdlePrompt` event types defined in
+`app/src/terminal/cli_agent_sessions/event/`) for status tracking to work. If
+Kiro CLI does not yet support this protocol, the plugin manager should set
+`can_auto_install = false` and `minimum_plugin_version = "0.0.0"` (as above),
+and the install instructions should be updated once the protocol is supported.
+The footer and rich input work without the plugin; only status tracking requires
+it.
+
+## End-to-end flow
+
+1. User runs `kiro` in a Warp terminal pane.
+2. `FeatureFlag::KiroCLIAgent.is_enabled()` → true (in dogfood/preview).
+3. Command detection matches `"kiro"` → `CLIAgent::Kiro`.
+4. `CLIAgentSessionsModel::set_session` creates a new session with
+   `agent: CLIAgent::Kiro`, `status: InProgress`.
+5. The terminal view renders the Kiro-branded footer (logo from `Icon::KiroLogo`,
+   brand color `KIRO_COLOR`).
+6. If the Warp plugin is installed and emitting events, `CLIAgentSessionListener`
+   parses them and calls `CLIAgentSessionsModel::update_from_event`, updating
+   status in real time.
+7. If the plugin is not installed, the footer shows the install instructions
+   pane from `KiroPluginManager::install_instructions()`.
+8. Ctrl-G opens the rich input composer; submitting sends the prompt to the PTY.
+9. When `kiro` exits, `remove_session` is called and the footer disappears.
+
+## Testing and validation
+
+- `cargo fmt` and `cargo clippy --workspace --all-targets --all-features --tests
+  -- -D warnings` must pass.
+- `cargo nextest run --no-fail-fast --workspace --exclude command-signatures-v2`
+  must pass. In particular:
+  - `CLIAgent::Kiro` must be covered by any existing exhaustive-match tests in
+    `app/src/terminal/cli_agent_tests.rs` (if present) or
+    `app/src/terminal/cli_agent_sessions/mod_tests.rs`.
+  - `kiro_tests.rs` must include at minimum smoke tests that
+    `KiroPluginManager::install_instructions()` returns a non-empty title and at
+    least one step, that `supports_update()` returns `false`, and that
+    `update_instructions()` returns empty content — mirroring `codex_tests.rs`.
+  - The `CLIAgentType` conversion test (if one exists) must cover `Kiro`.
+
+Behavior-to-verification mapping (from `product.md`):
+
+| Behavior | Verification |
+|----------|-------------|
+| #1 — detection | Run `kiro` in a Warp pane with the feature flag enabled; confirm `CLIAgentSessionsModel` has an active session. |
+| #2 — footer | Confirm the Kiro logo and brand color appear in the footer. |
+| #3, #4 — rich input | Press Ctrl-G; type a prompt; confirm it is sent to the PTY. |
+| #5 — status tracking | With the plugin installed and emitting events, confirm the footer status updates. |
+| #6 — install instructions | With the plugin absent (local session), confirm the install instructions pane renders with the correct steps. |
+| #7 — update instructions | `supports_update()` returns `false` and `minimum_plugin_version` is `"0.0.0"`; the outdated-plugin path is unreachable in this release. Confirm the update chip never appears. Full update support (version detection via `is_installed()`/`needs_update()` overrides and a real minimum version) is deferred to a follow-up once a versioned Kiro Warp plugin exists. |
+| #10 — remote session | In a remote SSH pane, confirm the footer appears and the install/update instructions pane renders (same as a local session with no plugin installed). |
+| #8 — settings page | Open Settings → Agents → Third party CLI agents; with the flag enabled confirm Kiro appears in the list, and with the flag disabled confirm Kiro is hidden and persisted Kiro mappings display as "Other". |
+| #9 — telemetry | Confirm `CLIAgentType::Kiro` events are emitted on session start/end. |
+| #11 — shared sessions | Confirm `CLIAgent::Kiro.to_serialized_name() == "Kiro"` and `CLIAgent::from_serialized_name("Kiro") == CLIAgent::Kiro`. |
+| #12 — not Unknown | Confirm `kiro` does not fall through to `CLIAgent::Unknown`. |
+| #13 — no regressions | Run the full test suite; confirm no existing agent tests fail. |
+
+## Risks and mitigations
+
+- **Plugin protocol not yet supported by Kiro CLI**: The footer and rich input
+  work without the plugin. Status tracking degrades gracefully to "no status"
+  rather than breaking. The install instructions pane is shown but can be
+  dismissed. This is the same degraded-mode behavior as other agents before
+  their plugins were available.
+- **Brand color accuracy**: The `KIRO_COLOR` constant should be confirmed
+  against the official Kiro brand guide before the PR is merged. An incorrect
+  color is a cosmetic issue only and does not affect functionality.
+- **Exhaustive match compile errors**: Adding `CLIAgent::Kiro` will cause
+  compile errors at every `match self` that lacks a `Kiro` arm. This is
+  intentional — the compiler enforces completeness. All arms must be added
+  before the build passes.
+- **Feature flag rollout**: Starting in `DOGFOOD_FLAGS` means the feature is
+  only visible to internal users until explicitly promoted to `PREVIEW_FLAGS`
+  and then `RELEASE_FLAGS`. This is the standard rollout path.
+
+## Follow-ups
+
+- Once the Kiro CLI publishes a Warp plugin that emits the structured event
+  protocol, update `minimum_plugin_version`, `can_auto_install`, and
+  `install_instructions` in `kiro.rs` to enable auto-install and real-time
+  status tracking.
+- Once a versioned Kiro Warp plugin exists, implement full update support in
+  `KiroPluginManager`: set `minimum_plugin_version` to the actual minimum,
+  override `is_installed()` and `needs_update()` with real version detection,
+  and set `supports_update()` to `true`. This unblocks product behavior #7
+  (the outdated-plugin update instructions pane).
+- Promote `FeatureFlag::KiroCLIAgent` from `DOGFOOD_FLAGS` to `PREVIEW_FLAGS`
+  and then `RELEASE_FLAGS` once the integration is validated.
+- If Kiro CLI adds support for bash mode (`!` prefix in rich input), add
+  `CLIAgent::Kiro` to the `supports_bash_mode` match arm.
+- Consider adding `SkillProvider::Kiro` if Kiro CLI develops a native skill
+  format distinct from the generic `SkillProvider::Agents` format.


### PR DESCRIPTION
## Description
Add product and tech specs for supporting Kiro CLI as a first-class CLI agent in Warp, alongside Claude Code, Codex, Gemini, and others.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [X] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

Closes #9066

(Issue is labeled `ready-to-spec` — this is a spec PR per CONTRIBUTING.md.)

## What's Included

specs/GH9066/product.md — 13 behavior invariants covering:
- Command detection and Kiro-branded footer
- Rich input composer (Ctrl-G) and prompt submission via PTY
- Plugin install/update instructions pane (update deferred until a versioned Kiro Warp plugin exists)
- Real-time session status tracking (InProgress/Blocked/Success)
- Settings page entry, telemetry, shared session serialization
- Graceful degradation when plugin is not installed

specs/GH9066/tech.md — concrete code changes:
- CLIAgent::Kiro variant + all exhaustive match arms (cli_agent.rs)
- Icon::KiroLogo + brand color constant (icons.rs + assets/)
- CLIAgentType::Kiro telemetry variant (events.rs)
- FeatureFlag::KiroCLIAgent gating in DOGFOOD_FLAGS (features.rs), applied to every enum-iteration surface plus the custom-command deserialization path so disabling the flag fully hides Kiro
- KiroPluginManager + kiro.rs + kiro_tests.rs (plugin_manager/), guarded by both KiroCLIAgent and the global HOANotifications kill switch
- Concrete, actionable in-app install instructions (kiro.dev download link plus `kiro --version` verification) instead of a generic docs handoff

Also adds .kiro/ to .gitignore.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?
-->
- verified both files render correctly in github
- reviewed PR change requests with Oz and Claude

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Kiro CLI as a first-class CLI agent in Warp