### PR TITLE
M2: TUI view layer (TuiBackend, TuiView, handle/context) in warpui_core

### DIFF
--- a/crates/warpui_core/src/async/mod.rs
+++ b/crates/warpui_core/src/async/mod.rs
@@ -81,7 +81,9 @@ pub struct SpawnedLocalStream {
 }
 
 impl SpawnedLocalStream {
+    // Only used by GUI element tests, which are compiled out on a TUI build.
     #[cfg(test)]
+    #[cfg_attr(feature = "tui", allow(dead_code))]
     pub(crate) fn into_future(self) -> LocalBoxFuture<'static, ()> {
         self.future
     }

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -17,15 +17,25 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
 use pathfinder_geometry::rect::RectF;
+#[cfg(not(feature = "tui"))]
 use pathfinder_geometry::vector::Vector2F;
 use rustc_hash::FxHashMap;
 
+#[cfg(not(feature = "tui"))]
+use super::GuiBackend;
 use super::{
-    autotracking, ActionCallback, Backend, BlurContext, FocusContext, GlobalActionCallback,
-    GlobalShortcut, GuiBackend, GuiPresenterState, Observation, PendingUnsubscribes, RefCounts,
-    Subscription, TaskCallback, TypedActionCallback, ViewType,
+    autotracking, ActionCallback, ActiveBackend, Backend, BlurContext, FocusContext,
+    GlobalActionCallback, GlobalShortcut, GuiPresenterState, Observation, PendingUnsubscribes,
+    RefCounts, Subscription, TaskCallback, TypedActionCallback, ViewType,
 };
-use crate::accessibility::{AccessibilityVerbosity, ActionAccessibilityContent};
+#[cfg(feature = "tui")]
+use super::{
+    AnyTuiView, BackendView, TuiReadView, TuiTypedActionView, TuiUpdateView, TuiView, TuiViewAsRef,
+    TuiViewContext, TuiViewHandle,
+};
+use crate::accessibility::AccessibilityVerbosity;
+#[cfg(not(feature = "tui"))]
+use crate::accessibility::ActionAccessibilityContent;
 use crate::actions::StandardAction;
 use crate::app_focus_telemetry::AppFocusInfo;
 use crate::assets::asset_cache::{AssetCache, AssetHandle, AssetSource, AssetState};
@@ -55,13 +65,15 @@ use crate::r#async::{block_on, FutureId, SpawnableOutput, Timer};
 use crate::util::post_inc;
 use crate::windowing::{self, WindowCallbacks, WindowManager};
 use crate::{
-    assets, rendering, AccessibilityData, Action, AddSingletonModel, AddWindowOptions, AnyModel,
-    AnyModelHandle, AnyView, ApplicationBundleInfo, Clipboard, CursorInfo, Effect, Element, Entity,
-    EntityId, Event, GetSingletonModelHandle, ModelAsRef, ModelContext, ModelHandle,
+    assets, rendering, Action, AddSingletonModel, AddWindowOptions, AnyModel, AnyModelHandle,
+    ApplicationBundleInfo, Clipboard, CursorInfo, Effect, Element, Entity, EntityId, Event,
+    GetSingletonModelHandle, ModelAsRef, ModelContext, ModelHandle,
     NextNewWindowsHasThisWindowsBoundsUponClose, Presenter, ReadModel, ReadView, Scene,
-    SingletonEntity, SpawnedFuture, TaskId, TypedActionView, UpdateModel, UpdateView, View,
-    ViewAsRef, ViewContext, ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
+    SingletonEntity, SpawnedFuture, TaskId, UpdateModel, UpdateView, View, ViewAsRef, ViewContext,
+    ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
 };
+#[cfg(not(feature = "tui"))]
+use crate::{AccessibilityData, AnyView, TypedActionView};
 
 lazy_static! {
     static ref LAST_USER_ACTION_UNIX_TIMESTAMP: AtomicI64 = AtomicI64::new(0);
@@ -167,6 +179,7 @@ impl App {
     /// Adds an action with a given handler that is executed when the action is dispatched. The
     /// action handler should return whether the action was handled. If it returns false this means
     /// a parent view that listens on the same action name will receive the action.
+    #[cfg(not(feature = "tui"))]
     pub fn add_action<S, V, T, F>(&self, name: S, handler: F)
     where
         S: Into<String>,
@@ -294,6 +307,7 @@ impl App {
         self.0.borrow().get_singleton_model_handle()
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_window_with_bounds<T, F>(
         &mut self,
         style: WindowStyle,
@@ -314,6 +328,7 @@ impl App {
         )
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_window<T, F>(
         &mut self,
         style: WindowStyle,
@@ -338,6 +353,7 @@ impl App {
         self.0.borrow().root_view_id(window_id)
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_view<T, F>(&mut self, window_id: WindowId, build_view: F) -> ViewHandle<T>
     where
         T: View,
@@ -350,6 +366,7 @@ impl App {
         handle
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_typed_action_view<V, F>(
         &mut self,
         window_id: WindowId,
@@ -364,6 +381,7 @@ impl App {
             .add_typed_action_view(window_id, build_view)
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_option_view<T, F>(
         &mut self,
         window_id: WindowId,
@@ -492,6 +510,42 @@ impl ViewAsRef for App {
 
     fn try_view<T: View>(&self, _handle: &ViewHandle<T>) -> Option<&T> {
         unimplemented!("Read from [`App::read_view`] instead");
+    }
+}
+
+#[cfg(feature = "tui")]
+impl TuiViewAsRef for App {
+    // Unimplemented for the same borrow-gymnastics reason as the GUI
+    // [`ViewAsRef`] impl above; use [`App::read`] / [`TuiReadView`] instead.
+    fn tui_view<T: TuiView>(&self, _handle: &TuiViewHandle<T>) -> &T {
+        unimplemented!("Read via TuiReadView instead");
+    }
+
+    fn try_tui_view<T: TuiView>(&self, _handle: &TuiViewHandle<T>) -> Option<&T> {
+        unimplemented!("Read via TuiReadView instead");
+    }
+}
+
+#[cfg(feature = "tui")]
+impl TuiReadView for App {
+    fn read_tui_view<T, F, S>(&self, handle: &TuiViewHandle<T>, read: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        let state = self.0.borrow();
+        state.read_tui_view(handle, read)
+    }
+}
+
+#[cfg(feature = "tui")]
+impl TuiUpdateView for App {
+    fn update_tui_view<T, F, S>(&mut self, handle: &TuiViewHandle<T>, update: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S,
+    {
+        self.as_mut().update_tui_view(handle, update)
     }
 }
 
@@ -716,6 +770,8 @@ pub struct AppContextImpl<B: Backend> {
 /// in a later milestone.
 #[cfg(not(feature = "tui"))]
 pub type AppContext = AppContextImpl<GuiBackend>;
+#[cfg(feature = "tui")]
+pub type AppContext = AppContextImpl<super::TuiBackend>;
 
 impl AppContext {
     pub(crate) fn new(
@@ -1199,6 +1255,7 @@ impl AppContext {
     ///
     /// Creates a handler which will dispatch to `TypedActionView::handle_action` for the given
     /// View + Action combination.
+    #[cfg(not(feature = "tui"))]
     fn add_typed_action<V>(&mut self)
     where
         V: TypedActionView + View,
@@ -1252,6 +1309,7 @@ impl AppContext {
             .or_insert(handler);
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_action<S, V, T, F>(&mut self, name: S, mut handler: F)
     where
         S: Into<String>,
@@ -1343,6 +1401,7 @@ impl AppContext {
 
     /// Returns the [`AccessibilityData`] of the focused view, or a parent of that view in its
     /// responder chain.
+    #[cfg(not(feature = "tui"))]
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub fn focused_view_accessibility_data(
         &mut self,
@@ -2244,6 +2303,7 @@ impl AppContext {
 
     /// Creates a new window with the view returned by the `build_root_view` function as its root
     /// view.
+    #[cfg(not(feature = "tui"))]
     pub fn add_window<T, F>(
         &mut self,
         options: AddWindowOptions,
@@ -2256,6 +2316,7 @@ impl AppContext {
         self.insert_window(options, build_root_view)
     }
 
+    #[cfg(not(feature = "tui"))]
     fn insert_window<T, F>(
         &mut self,
         add_window_options: AddWindowOptions,
@@ -2788,6 +2849,7 @@ impl AppContext {
         self.build_scene(window_id, window.as_ctx());
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_view<T, F>(&mut self, window_id: WindowId, build_view: F) -> ViewHandle<T>
     where
         T: View,
@@ -2797,6 +2859,7 @@ impl AppContext {
             .unwrap()
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_option_view<T, F>(
         &mut self,
         window_id: WindowId,
@@ -2837,6 +2900,7 @@ impl AppContext {
     ///
     /// Note: This is intended to be the replacement for `add_view` with the conversion to typed
     /// actions (and will subsequently be renamed to `add_view` once that is complete)
+    #[cfg(not(feature = "tui"))]
     pub(crate) fn add_typed_action_view_with_parent<V, F>(
         &mut self,
         window_id: WindowId,
@@ -2857,6 +2921,7 @@ impl AppContext {
     ///
     /// Note: This is intended to be the replacement for `add_view` with the conversion to typed
     /// actions (and will subsequently be renamed to `add_view` once that is complete)
+    #[cfg(not(feature = "tui"))]
     pub fn add_typed_action_view<V, F>(
         &mut self,
         window_id: WindowId,
@@ -2869,6 +2934,7 @@ impl AppContext {
         self.add_typed_action_view_internal(window_id, build_view, None)
     }
 
+    #[cfg(not(feature = "tui"))]
     fn add_typed_action_view_internal<V, F>(
         &mut self,
         window_id: WindowId,
@@ -4236,6 +4302,7 @@ impl AppContext {
         }
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn open_view_tree_debug_window(&mut self, target_window_id: WindowId) {
         let Some(presenter) = self.presenter(target_window_id) else {
             return;
@@ -4381,7 +4448,7 @@ impl AddSingletonModel for AppContext {
 
 pub struct ClosedWindowData {
     pub window_id: WindowId,
-    window: Window<GuiBackend>,
+    window: Window<ActiveBackend>,
     subscriptions: HashMap<EntityId, Vec<Subscription>>,
     observations: HashMap<EntityId, Vec<Observation>>,
     view_to_window: HashMap<EntityId, WindowId>,
@@ -4484,6 +4551,7 @@ impl AppContext {
             .unwrap_or_default()
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn render_view(&self, window_id: WindowId, view_id: EntityId) -> Result<Box<dyn Element>> {
         // surfacing the error of a missing window earlier
         let window = self
@@ -4497,6 +4565,19 @@ impl AppContext {
             .ok_or_else(|| anyhow!("view not found"))
     }
 
+    /// TUI stub: the GUI presenter/render path is inert on a TUI build (the real
+    /// TUI render path arrives in a later milestone via `B::Presenter`). This
+    /// keeps the GUI presenter module type-checking without producing elements.
+    #[cfg(feature = "tui")]
+    pub fn render_view(
+        &self,
+        _window_id: WindowId,
+        _view_id: EntityId,
+    ) -> Result<Box<dyn Element>> {
+        Err(anyhow!("render_view is not supported on the TUI backend"))
+    }
+
+    #[cfg(not(feature = "tui"))]
     pub fn render_views(&self, window_id: WindowId) -> Result<HashMap<EntityId, Box<dyn Element>>> {
         self.windows
             .get(&window_id)
@@ -4507,6 +4588,15 @@ impl AppContext {
                     .collect::<HashMap<_, _>>()
             })
             .ok_or_else(|| anyhow!("window not found"))
+    }
+
+    /// TUI stub mirroring [`render_view`]; see its note.
+    #[cfg(feature = "tui")]
+    pub fn render_views(
+        &self,
+        _window_id: WindowId,
+    ) -> Result<HashMap<EntityId, Box<dyn Element>>> {
+        Ok(HashMap::new())
     }
 
     /// Returns the cached element position from the last rendered frame, if there is one.
@@ -4629,5 +4719,287 @@ impl AppContext {
                 );
             }
         }
+    }
+}
+
+/// TUI-backend view lifecycle, mirroring the GUI `add_view`/`update_view`/etc.
+/// entry points. These are the methods that coerce a concrete view into the
+/// window's erased box (`Box<dyn AnyTuiView>`) and therefore cannot be shared
+/// with the GUI bodies; everything else (dispatch, effects, async, subscription)
+/// is the shared, backend-agnostic core.
+#[cfg(feature = "tui")]
+impl AppContext {
+    /// Adds a [`TuiView`] to the given window, returning a strong handle to it.
+    pub fn add_tui_view<T, F>(&mut self, window_id: WindowId, build_view: F) -> TuiViewHandle<T>
+    where
+        T: TuiView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        self.add_option_tui_view(window_id, |ctx| Some(build_view(ctx)))
+            .unwrap()
+    }
+
+    /// Adds a [`TuiView`] that may decline to be created.
+    pub fn add_option_tui_view<T, F>(
+        &mut self,
+        window_id: WindowId,
+        build_view: F,
+    ) -> Option<TuiViewHandle<T>>
+    where
+        T: TuiView,
+        F: FnOnce(&mut TuiViewContext<T>) -> Option<T>,
+    {
+        let view_id = EntityId::new();
+        self.pending_flushes += 1;
+        let mut ctx = TuiViewContext::new(self, window_id, view_id);
+        let handle = if let Some(view) = build_view(&mut ctx) {
+            if let Some(window) = self.windows.get_mut(&window_id) {
+                window
+                    .views
+                    .insert(view_id, BackendView::into_any_view(Box::new(view)));
+            } else {
+                panic!("Window does not exist");
+            }
+            self.view_to_window.insert(view_id, window_id);
+            self.presentation
+                .window_invalidations
+                .entry(window_id)
+                .or_default()
+                .updated
+                .insert(view_id);
+            Some(TuiViewHandle::new(window_id, view_id, &self.ref_counts))
+        } else {
+            None
+        };
+        self.flush_effects();
+        handle
+    }
+
+    /// Adds a [`TuiTypedActionView`], registering its typed-action handler.
+    pub fn add_typed_action_tui_view<V, F>(
+        &mut self,
+        window_id: WindowId,
+        build_view: F,
+    ) -> TuiViewHandle<V>
+    where
+        V: TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<V>) -> V,
+    {
+        self.add_typed_action_tui_view_internal(window_id, build_view, None)
+    }
+
+    pub(crate) fn add_typed_action_tui_view_with_parent<V, F>(
+        &mut self,
+        window_id: WindowId,
+        build_view: F,
+        parent_view_id: EntityId,
+    ) -> TuiViewHandle<V>
+    where
+        V: TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<V>) -> V,
+    {
+        self.add_typed_action_tui_view_internal(window_id, build_view, Some(parent_view_id))
+    }
+
+    fn add_typed_action_tui_view_internal<V, F>(
+        &mut self,
+        window_id: WindowId,
+        build_view: F,
+        parent_view_id: Option<EntityId>,
+    ) -> TuiViewHandle<V>
+    where
+        V: TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<V>) -> V,
+    {
+        self.pending_flushes += 1;
+        let view_id = EntityId::new();
+        let mut ctx = TuiViewContext::new(self, window_id, view_id);
+        let view = build_view(&mut ctx);
+        let window = self
+            .windows
+            .get_mut(&window_id)
+            .expect("Window does not exist");
+        window
+            .views
+            .insert(view_id, BackendView::into_any_view(Box::new(view)));
+        self.view_to_window.insert(view_id, window_id);
+        if let Some(parent_view_id) = parent_view_id {
+            self.structural_child_to_parent
+                .insert(view_id, parent_view_id);
+            self.structural_parent_to_children
+                .entry(parent_view_id)
+                .or_default()
+                .insert(view_id);
+        }
+        self.add_typed_action_tui::<V>();
+        self.presentation
+            .window_invalidations
+            .entry(window_id)
+            .or_default()
+            .updated
+            .insert(view_id);
+        self.flush_effects();
+        TuiViewHandle::new(window_id, view_id, &self.ref_counts)
+    }
+
+    /// Registers the handler that dispatches to [`TuiTypedActionView::handle_action`]
+    /// for the given view + action combination. Keyed by `(ActionType, ViewType)`
+    /// in the same `typed_actions` registry the GUI backend uses.
+    fn add_typed_action_tui<V>(&mut self)
+    where
+        V: TuiTypedActionView,
+    {
+        let handler = Box::new(
+            |view: &mut dyn AnyTuiView,
+             action: &dyn Any,
+             app: &mut AppContext,
+             window_id: WindowId,
+             view_id: EntityId| {
+                let action = action
+                    .downcast_ref()
+                    .expect("Handlers are hashed by action type");
+                let view = view
+                    .as_any_mut()
+                    .downcast_mut()
+                    .expect("Handlers are hashed by view type");
+                let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                V::handle_action(view, action, &mut ctx);
+            },
+        );
+
+        self.typed_actions
+            .entry(ActionType::of::<V::Action>())
+            .or_default()
+            .entry(ViewType::of::<V>())
+            .or_insert(handler);
+    }
+
+    /// Returns a handle to the window's root [`TuiView`], if it is of type `T`.
+    pub fn root_view_tui<T: TuiView>(&self, window_id: WindowId) -> Option<TuiViewHandle<T>> {
+        self.windows
+            .get(&window_id)
+            .and_then(|window| window.root_view.as_ref())
+            .and_then(|root_view| root_view.clone().downcast_tui::<T>())
+    }
+
+    /// Returns all the [`TuiView`]s of type `T` within `window_id`.
+    pub fn views_of_type_tui<T: TuiView>(
+        &self,
+        window_id: WindowId,
+    ) -> Option<Vec<TuiViewHandle<T>>> {
+        let ref_counts = &self.ref_counts;
+        self.windows.get(&window_id).map(|window| {
+            window
+                .views
+                .iter()
+                .filter(|(_, v)| (*v).as_any().type_id() == TypeId::of::<T>())
+                .map(|(view_id, _)| TuiViewHandle::new(window_id, *view_id, ref_counts))
+                .collect::<Vec<TuiViewHandle<T>>>()
+        })
+    }
+
+    /// Creates a new window whose root view is the [`TuiTypedActionView`] returned
+    /// by `build_root_view`. Reuses the backend-agnostic window machinery.
+    pub fn add_tui_window<T, F>(
+        &mut self,
+        options: AddWindowOptions,
+        build_root_view: F,
+    ) -> (WindowId, TuiViewHandle<T>)
+    where
+        T: TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<T>) -> T,
+    {
+        let (window_id, _root_view_id) =
+            self.insert_window_internal(None, options, |window_id, ctx| {
+                ctx.windows.insert(window_id, Window::default());
+                let root_handle = ctx.add_typed_action_tui_view(window_id, build_root_view);
+                let root_view_id = root_handle.id();
+                ctx.windows
+                    .get_mut(&window_id)
+                    .expect("this window was just inserted and should still exist")
+                    .root_view = Some(root_handle.into());
+                root_view_id
+            });
+        (
+            window_id,
+            self.root_view_tui(window_id)
+                .expect("should have just inserted a window and root view"),
+        )
+    }
+}
+
+#[cfg(feature = "tui")]
+impl TuiViewAsRef for AppContext {
+    fn tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> &T {
+        let window_id = handle.window_id(self);
+        if let Some(window) = self.windows.get(&window_id) {
+            if let Some(view) = window.views.get(&handle.id()) {
+                view.as_any()
+                    .downcast_ref()
+                    .expect("downcast should be type safe")
+            } else {
+                panic!(
+                    "circular view reference for view type {}",
+                    std::any::type_name::<T>()
+                );
+            }
+        } else {
+            panic!("window does not exist");
+        }
+    }
+
+    fn try_tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> Option<&T> {
+        let window_id = handle.window_id(self);
+        self.windows
+            .get(&window_id)?
+            .views
+            .get(&handle.id())?
+            .as_any()
+            .downcast_ref()
+    }
+}
+
+#[cfg(feature = "tui")]
+impl TuiReadView for AppContext {
+    fn read_tui_view<T, F, S>(&self, handle: &TuiViewHandle<T>, read: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        read(self.tui_view(handle), self)
+    }
+}
+
+#[cfg(feature = "tui")]
+impl TuiUpdateView for AppContext {
+    fn update_tui_view<T, F, S>(&mut self, handle: &TuiViewHandle<T>, update: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S,
+    {
+        self.pending_flushes += 1;
+        let window_id = handle.window_id(self);
+        let mut view = if let Some(window) = self.windows.get_mut(&window_id) {
+            if let Some(view) = window.views.remove(&handle.id()) {
+                view
+            } else {
+                panic!("Circular view update");
+            }
+        } else {
+            panic!("Window does not exist");
+        };
+
+        let mut ctx = TuiViewContext::new(self, window_id, handle.id());
+        let result = update(
+            view.as_any_mut()
+                .downcast_mut()
+                .expect("Downcast is type safe"),
+            &mut ctx,
+        );
+        if let Some(window) = self.windows.get_mut(&window_id) {
+            window.views.insert(handle.id(), view);
+        }
+        self.flush_effects();
+        result
     }
 }

--- a/crates/warpui_core/src/core/autotracking/mod.rs
+++ b/crates/warpui_core/src/core/autotracking/mod.rs
@@ -99,7 +99,7 @@
 
 mod tracked;
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "autotracking_tests.rs"]
 mod tests;
 
@@ -171,6 +171,8 @@ where
 ///
 /// This function requires that only one view is rendered at a time, so the callback cannot result
 /// in a recursive call to `render`
+// Only reached through the GUI render path, which is compiled out on a TUI build.
+#[cfg_attr(feature = "tui", allow(dead_code))]
 pub(super) fn render_view<F, R>(window_id: WindowId, view_id: EntityId, render_callback: F) -> R
 where
     F: FnOnce() -> R,

--- a/crates/warpui_core/src/core/backend.rs
+++ b/crates/warpui_core/src/core/backend.rs
@@ -14,9 +14,13 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use super::{AnyView, AppContextImpl, InvalidationCallback};
+#[cfg(not(feature = "tui"))]
+use super::AnyView;
+use super::{AppContextImpl, InvalidationCallback};
 use crate::presenter::PositionCache;
-use crate::{Element, Presenter, View, WindowId, WindowInvalidation};
+#[cfg(not(feature = "tui"))]
+use crate::{Element, View};
+use crate::{Presenter, WindowId, WindowInvalidation};
 
 /// Marker trait selecting a UI backend (GUI or TUI).
 ///
@@ -68,12 +72,14 @@ pub trait BackendView<B: Backend>: 'static {
 /// The GUI backend marker.
 pub struct GuiBackend;
 
+#[cfg(not(feature = "tui"))]
 impl Backend for GuiBackend {
     type RenderOutput = Box<dyn Element>;
     type AnyView = dyn AnyView;
     type Presenter = GuiPresenterState;
 }
 
+#[cfg(not(feature = "tui"))]
 impl ErasedView<GuiBackend> for dyn AnyView {
     fn render(&self, app: &AppContextImpl<GuiBackend>) -> Box<dyn Element> {
         AnyView::render(self, app)
@@ -84,6 +90,7 @@ impl ErasedView<GuiBackend> for dyn AnyView {
     }
 }
 
+#[cfg(not(feature = "tui"))]
 impl<T: View> BackendView<GuiBackend> for T {
     fn into_any_view(self: Box<Self>) -> Box<dyn AnyView> {
         self

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -4,6 +4,10 @@ mod autotracking;
 mod backend;
 mod entity;
 mod model;
+#[cfg(feature = "tui")]
+mod tui_backend;
+#[cfg(feature = "tui")]
+mod tui_view;
 mod view;
 mod window;
 
@@ -28,6 +32,13 @@ use futures_util::future::BoxFuture;
 pub use model::*;
 use pathfinder_geometry::rect::RectF;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "tui")]
+pub use tui_backend::TuiBackend;
+#[cfg(feature = "tui")]
+pub use tui_view::{
+    AnyTuiView, TuiReadView, TuiTypedActionView, TuiUpdateView, TuiView, TuiViewAsRef,
+    TuiViewContext, TuiViewHandle, WeakTuiViewHandle,
+};
 pub use view::*;
 pub use window::*;
 
@@ -133,11 +144,30 @@ impl fmt::Display for TaskId {
 
 pub type OptionalPlatformWindow = Option<Rc<dyn platform::Window>>;
 
+/// The active backend marker for this build (GUI by default, TUI under `tui`).
+/// Used by `B`-free types/fields that must name the concrete active backend.
+#[cfg(not(feature = "tui"))]
+pub(crate) type ActiveBackend = GuiBackend;
+#[cfg(feature = "tui")]
+pub(crate) type ActiveBackend = TuiBackend;
+
+// The view-callback aliases name the active backend's erased view object. They
+// are cfg-duplicated (rather than written against a single `dyn` type alias)
+// so the GUI form stays byte-for-byte the original `dyn AnyView` signature,
+// preserving its elided trait-object lifetime; the TUI form uses `dyn AnyTuiView`.
+#[cfg(not(feature = "tui"))]
 type ActionCallback =
     dyn FnMut(&mut dyn AnyView, &dyn Any, &mut AppContext, WindowId, EntityId) -> bool;
+#[cfg(feature = "tui")]
+type ActionCallback =
+    dyn FnMut(&mut dyn tui_view::AnyTuiView, &dyn Any, &mut AppContext, WindowId, EntityId) -> bool;
 
+#[cfg(not(feature = "tui"))]
 type TypedActionCallback =
     dyn FnMut(&mut dyn AnyView, &dyn Any, &mut AppContext, WindowId, EntityId);
+#[cfg(feature = "tui")]
+type TypedActionCallback =
+    dyn FnMut(&mut dyn tui_view::AnyTuiView, &dyn Any, &mut AppContext, WindowId, EntityId);
 
 type GlobalActionCallback =
     dyn FnMut(&dyn Any, &'static std::panic::Location<'static>, &mut AppContext);
@@ -540,13 +570,25 @@ type ModelFromFutureCallback = dyn FnOnce(&mut dyn Any, Box<dyn Any>, &mut AppCo
 type ModelFromStreamItemCallback = dyn FnMut(&mut dyn Any, Box<dyn Any>, &mut AppContext, EntityId);
 type ModelFromStreamDoneCallback = dyn FnOnce(&mut dyn Any, &mut AppContext, EntityId);
 
+#[cfg(not(feature = "tui"))]
 type ViewFromFutureCallback =
     dyn FnOnce(&mut dyn AnyView, Box<dyn Any>, &mut AppContext, WindowId, EntityId);
+#[cfg(feature = "tui")]
+type ViewFromFutureCallback =
+    dyn FnOnce(&mut dyn tui_view::AnyTuiView, Box<dyn Any>, &mut AppContext, WindowId, EntityId);
 
+#[cfg(not(feature = "tui"))]
 type ViewFromStreamItemCallback =
     dyn FnMut(&mut dyn AnyView, Box<dyn Any>, &mut AppContext, WindowId, EntityId);
+#[cfg(feature = "tui")]
+type ViewFromStreamItemCallback =
+    dyn FnMut(&mut dyn tui_view::AnyTuiView, Box<dyn Any>, &mut AppContext, WindowId, EntityId);
 
+#[cfg(not(feature = "tui"))]
 type ViewFromStreamDoneCallback = dyn FnOnce(&mut dyn AnyView, &mut AppContext, WindowId, EntityId);
+#[cfg(feature = "tui")]
+type ViewFromStreamDoneCallback =
+    dyn FnOnce(&mut dyn tui_view::AnyTuiView, &mut AppContext, WindowId, EntityId);
 
 enum TaskCallback {
     ModelFromFuture {
@@ -669,6 +711,6 @@ impl<T> RequestState<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "mod_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/core/tui_backend.rs
+++ b/crates/warpui_core/src/core/tui_backend.rs
@@ -1,0 +1,47 @@
+//! The TUI [`Backend`] instantiation, gated behind the `tui` feature.
+//!
+//! `TuiBackend` mirrors [`GuiBackend`](super::GuiBackend) but keeps its render
+//! output abstract (`Box<dyn Any>`) so `warpui_core` never names a concrete TUI
+//! element type and therefore never depends on the downstream `warpui_tui`
+//! crate. The concrete element/buffer types are defined in `warpui_tui` (a later
+//! milestone) and recovered by downcasting this erased output.
+
+use std::any::Any;
+
+use super::backend::{Backend, BackendView, ErasedView, GuiPresenterState};
+use super::tui_view::{AnyTuiView, TuiView};
+use super::AppContextImpl;
+
+/// The TUI backend marker.
+pub struct TuiBackend;
+
+impl Backend for TuiBackend {
+    /// Abstract: the concrete TUI element/buffer type lives in `warpui_tui` and
+    /// is recovered by downcasting. Keeping this `Box<dyn Any>` is what prevents
+    /// a `warpui_core -> warpui_tui` dependency cycle.
+    type RenderOutput = Box<dyn Any>;
+
+    type AnyView = dyn AnyTuiView;
+
+    /// Reuses [`GuiPresenterState`] so the shared core retains the
+    /// window-invalidation bookkeeping that `notify`/dirty tracking depend on.
+    /// The real TUI presentation layer arrives in a later milestone; until then
+    /// the GUI presenter state simply goes unused on a TUI build.
+    type Presenter = GuiPresenterState;
+}
+
+impl ErasedView<TuiBackend> for dyn AnyTuiView {
+    fn render(&self, app: &AppContextImpl<TuiBackend>) -> Box<dyn Any> {
+        AnyTuiView::render_tui(self, app)
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        AnyTuiView::as_any_mut(self)
+    }
+}
+
+impl<T: TuiView> BackendView<TuiBackend> for T {
+    fn into_any_view(self: Box<Self>) -> Box<dyn AnyTuiView> {
+        self
+    }
+}

--- a/crates/warpui_core/src/core/tui_view/context.rs
+++ b/crates/warpui_core/src/core/tui_view/context.rs
@@ -1,0 +1,449 @@
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use futures::future::{AbortHandle, Abortable};
+use futures::{Future, FutureExt};
+
+use super::handle::{TuiReadView, TuiUpdateView, TuiViewAsRef, TuiViewHandle, WeakTuiViewHandle};
+use super::{TuiTypedActionView, TuiView};
+use crate::core::{Observation, Subscription, TaskCallback};
+use crate::r#async::executor::{Background, Foreground};
+use crate::r#async::{SpawnableOutput, SpawnedFutureHandle, SpawnedLocalStream};
+use crate::{
+    Action, AppContext, Effect, Entity, EntityId, GetSingletonModelHandle, ModelAsRef,
+    ModelContext, ModelHandle, ReadModel, UpdateModel, WindowId,
+};
+
+/// The TUI analogue of [`ViewContext`](crate::ViewContext): combines a view's
+/// identity with mutable access to the shared application context, exposing the
+/// same backend-agnostic operations (model access, async, subscriptions,
+/// observation, typed-action dispatch) as the GUI view context.
+pub struct TuiViewContext<'a, T: ?Sized> {
+    app: &'a mut AppContext,
+    window_id: WindowId,
+    view_id: EntityId,
+    view_type: PhantomData<T>,
+}
+
+impl<'a, T: TuiView> TuiViewContext<'a, T> {
+    pub(in crate::core) fn new(
+        app: &'a mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    ) -> Self {
+        Self {
+            app,
+            window_id,
+            view_id,
+            view_type: PhantomData,
+        }
+    }
+
+    pub fn handle(&self) -> WeakTuiViewHandle<T> {
+        WeakTuiViewHandle::new(self.view_id)
+    }
+
+    pub fn window_id(&self) -> WindowId {
+        self.window_id
+    }
+
+    pub fn view_id(&self) -> EntityId {
+        self.view_id
+    }
+
+    pub fn is_self_focused(&self) -> bool {
+        self.app.check_view_focused(self.window_id, &self.view_id)
+    }
+
+    pub fn focus<S: TuiView>(&mut self, handle: &TuiViewHandle<S>) {
+        self.app.pending_effects.push_back(Effect::Focus {
+            window_id: handle.window_id(self.app),
+            view_id: handle.id(),
+        });
+    }
+
+    pub fn focus_self(&mut self) {
+        self.app.pending_effects.push_back(Effect::Focus {
+            window_id: self.window_id,
+            view_id: self.view_id,
+        });
+    }
+
+    pub fn add_model<S, F>(&mut self, build_model: F) -> ModelHandle<S>
+    where
+        S: Entity,
+        F: FnOnce(&mut ModelContext<S>) -> S,
+    {
+        self.app.add_model(build_model)
+    }
+
+    pub fn add_view<S, F>(&mut self, build_view: F) -> TuiViewHandle<S>
+    where
+        S: TuiView,
+        F: FnOnce(&mut TuiViewContext<S>) -> S,
+    {
+        self.app.add_tui_view(self.window_id, build_view)
+    }
+
+    pub fn add_typed_action_view<V, F>(&mut self, build_view: F) -> TuiViewHandle<V>
+    where
+        V: TuiTypedActionView,
+        F: FnOnce(&mut TuiViewContext<V>) -> V,
+    {
+        self.app
+            .add_typed_action_tui_view_with_parent(self.window_id, build_view, self.view_id)
+    }
+
+    pub fn subscribe_to_model<E, F>(&mut self, handle: &ModelHandle<E>, mut callback: F)
+    where
+        E: Entity,
+        E::Event: 'static,
+        F: 'static + FnMut(&mut T, ModelHandle<E>, &E::Event, &mut TuiViewContext<T>),
+    {
+        let emitter_handle = handle.downgrade();
+        self.app
+            .subscriptions
+            .entry(handle.id())
+            .or_default()
+            .push(Subscription::FromView {
+                window_id: self.window_id,
+                view_id: self.view_id,
+                callback: Box::new(move |view, payload, app, window_id, view_id| {
+                    if let Some(emitter_handle) = emitter_handle.upgrade(app) {
+                        let view = view.downcast_mut().expect("downcast is type safe");
+                        let payload = payload.downcast_ref().expect("downcast is type safe");
+                        let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                        callback(view, emitter_handle, payload, &mut ctx);
+                    }
+                }),
+            });
+    }
+
+    pub fn subscribe_to_view<V, F>(&mut self, handle: &TuiViewHandle<V>, mut callback: F)
+    where
+        V: TuiView,
+        V::Event: 'static,
+        F: 'static + FnMut(&mut T, TuiViewHandle<V>, &V::Event, &mut TuiViewContext<T>),
+    {
+        let emitter_handle = handle.downgrade();
+        self.app
+            .subscriptions
+            .entry(handle.id())
+            .or_default()
+            .push(Subscription::FromView {
+                window_id: self.window_id,
+                view_id: self.view_id,
+                callback: Box::new(move |view, payload, app, window_id, view_id| {
+                    if let Some(emitter_handle) = emitter_handle.upgrade(app) {
+                        let view = view.downcast_mut().expect("downcast is type safe");
+                        let payload = payload.downcast_ref().expect("downcast is type safe");
+                        let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                        callback(view, emitter_handle, payload, &mut ctx);
+                    }
+                }),
+            });
+    }
+
+    pub fn observe<S, F>(&mut self, handle: &ModelHandle<S>, mut callback: F)
+    where
+        S: Entity,
+        F: 'static + FnMut(&mut T, ModelHandle<S>, &mut TuiViewContext<T>),
+    {
+        self.app
+            .observations
+            .entry(handle.id())
+            .or_default()
+            .push(Observation::FromView {
+                window_id: self.window_id,
+                view_id: self.view_id,
+                callback: Box::new(move |view, observed_id, app, window_id, view_id| {
+                    let view = view.downcast_mut().expect("downcast is type safe");
+                    let observed = ModelHandle::new(observed_id, &app.ref_counts);
+                    let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                    callback(view, observed, &mut ctx);
+                }),
+            });
+    }
+
+    /// Emits the provided event on this view, to be delivered to any subscribers.
+    pub fn emit(&mut self, payload: T::Event) {
+        self.app.pending_effects.push_back(Effect::Event {
+            entity_id: self.view_id,
+            payload: Box::new(payload),
+        });
+    }
+
+    /// Notifies the framework that this view is dirty and needs re-rendering.
+    pub fn notify(&mut self) {
+        self.app
+            .pending_effects
+            .push_back(Effect::ViewNotification {
+                window_id: self.window_id,
+                view_id: self.view_id,
+            });
+    }
+
+    /// Dispatches a typed action to this view through the shared dispatch path.
+    ///
+    /// The TUI backend has no layout-derived responder chain (that is a GUI
+    /// presenter concept), so the action is dispatched to this view directly.
+    pub fn dispatch_typed_action(&mut self, action: &dyn Action) {
+        self.app
+            .dispatch_typed_action(self.window_id, &[self.view_id], action, log::Level::Info);
+    }
+
+    /// Defers dispatching a typed action until effects are flushed.
+    pub fn dispatch_typed_action_deferred<A: Action + 'static>(&mut self, action: A) {
+        self.app.pending_effects.push_back(Effect::TypedAction {
+            window_id: self.window_id,
+            view_id: self.view_id,
+            action: Box::new(action),
+        });
+    }
+
+    /// Schedules a future on the main thread, invoking `callback` on the main
+    /// thread upon completion. See [`ViewContext::spawn`](crate::ViewContext).
+    fn spawn_local<S, F, U>(&mut self, future: S, callback: F) -> impl Future<Output = ()>
+    where
+        S: 'static + Future,
+        F: 'static + FnOnce(&mut T, S::Output, &mut TuiViewContext<T>) -> U,
+        U: 'static,
+    {
+        let (tx, rx) = futures::channel::oneshot::channel();
+
+        let task_id = self.app.spawn_local(future);
+
+        self.app.task_callbacks.insert(
+            task_id,
+            TaskCallback::ViewFromFuture {
+                window_id: self.window_id,
+                view_id: self.view_id,
+                callback: Box::new(move |view, output, app, window_id, view_id| {
+                    let view = view
+                        .as_any_mut()
+                        .downcast_mut()
+                        .expect("statically enforced by spawn_local generics");
+                    let output = *output
+                        .downcast()
+                        .expect("statically enforced by spawn_local generics");
+                    let result = callback(
+                        view,
+                        output,
+                        &mut TuiViewContext::new(app, window_id, view_id),
+                    );
+                    let _ = tx.send(result);
+                }),
+            },
+        );
+
+        async move {
+            if rx.await.is_err() {
+                log::error!("sender unexpectedly dropped before receiver");
+            }
+        }
+    }
+
+    /// Schedules a future on a background thread, invoking `callback` on the
+    /// main thread upon completion.
+    pub fn spawn<S, F, U>(&mut self, future: S, callback: F) -> SpawnedFutureHandle
+    where
+        S: crate::r#async::Spawnable,
+        <S as Future>::Output: crate::r#async::SpawnableOutput,
+        F: 'static + FnOnce(&mut T, <S as Future>::Output, &mut TuiViewContext<T>) -> U,
+        U: 'static,
+    {
+        self.spawn_abortable::<S, _, _>(
+            future,
+            |view, output, ctx| {
+                callback(view, output, ctx);
+            },
+            |_, _| {},
+        )
+    }
+
+    /// Schedules a future on a background thread, invoking `on_resolve` on the
+    /// main thread upon completion or `on_abort` if it was aborted.
+    pub fn spawn_abortable<S, F, A>(
+        &mut self,
+        future: S,
+        on_resolve: F,
+        on_abort: A,
+    ) -> SpawnedFutureHandle
+    where
+        S: crate::r#async::Spawnable,
+        <S as Future>::Output: crate::r#async::SpawnableOutput,
+        F: 'static + FnOnce(&mut T, <S as Future>::Output, &mut TuiViewContext<T>),
+        A: 'static + FnOnce(&mut T, &mut TuiViewContext<T>),
+    {
+        let (tx, rx) = futures::channel::oneshot::channel();
+
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        self.app
+            .background_executor()
+            .spawn_boxed(Box::pin(async move {
+                let abortable = Abortable::new(future, abort_registration);
+                if tx.send(abortable.await).is_err() {
+                    log::error!("Error sending background task result to main thread");
+                }
+            }))
+            .detach();
+
+        let future = self.spawn_local(rx, |view, rx_result, ctx| {
+            let output = match rx_result {
+                Ok(output) => output,
+                Err(_) => {
+                    log::error!("sender unexpectedly dropped before receiver");
+                    on_abort(view, ctx);
+                    return;
+                }
+            };
+
+            match output {
+                Ok(output) => on_resolve(view, output, ctx),
+                Err(_) => on_abort(view, ctx),
+            }
+        });
+
+        let future_id = self.app.register_spawned_future(future.boxed());
+        SpawnedFutureHandle::new(abort_handle, future_id)
+    }
+
+    /// Schedules a stream to be polled on the main thread, invoking callbacks on
+    /// each item and on completion.
+    pub fn spawn_stream_local<S, F, G>(
+        &mut self,
+        stream: S,
+        mut on_item: F,
+        mut on_done: G,
+    ) -> SpawnedLocalStream
+    where
+        S: 'static + crate::r#async::Stream,
+        S::Item: SpawnableOutput,
+        F: 'static + FnMut(&mut T, S::Item, &mut TuiViewContext<T>),
+        G: 'static + FnMut(&mut T, &mut TuiViewContext<T>),
+    {
+        let (tx, rx) = futures::channel::oneshot::channel();
+
+        let task_id = self.app.spawn_stream_local(stream, tx);
+        self.app.task_callbacks.insert(
+            task_id,
+            TaskCallback::ViewFromStream {
+                window_id: self.window_id,
+                view_id: self.view_id,
+                on_item: Box::new(move |view, output, app, window_id, view_id| {
+                    let view = view
+                        .as_any_mut()
+                        .downcast_mut()
+                        .expect("statically enforced by spawn_stream_local generics");
+                    let output = *output
+                        .downcast()
+                        .expect("statically enforced by spawn_stream_local generics");
+                    let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                    on_item(view, output, &mut ctx);
+                }),
+                on_done: Box::new(move |view, app, window_id, view_id| {
+                    let view = view
+                        .as_any_mut()
+                        .downcast_mut()
+                        .expect("statically enforced by spawn_stream_local generics");
+                    let mut ctx = TuiViewContext::new(app, window_id, view_id);
+                    on_done(view, &mut ctx);
+                }),
+            },
+        );
+
+        SpawnedLocalStream::new(
+            async move {
+                if rx.await.is_err() {
+                    log::error!("sender unexpectedly dropped before receiver");
+                }
+            }
+            .boxed_local(),
+        )
+    }
+
+    pub fn foreground_executor(&self) -> &Rc<Foreground> {
+        self.app.foreground_executor()
+    }
+
+    pub fn background_executor(&self) -> &Arc<Background> {
+        self.app.background_executor()
+    }
+}
+
+impl<T> std::ops::Deref for TuiViewContext<'_, T> {
+    type Target = AppContext;
+
+    fn deref(&self) -> &Self::Target {
+        self.app
+    }
+}
+
+impl<T> std::ops::DerefMut for TuiViewContext<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.app
+    }
+}
+
+impl<V> ModelAsRef for TuiViewContext<'_, V> {
+    fn model<T: Entity>(&self, handle: &ModelHandle<T>) -> &T {
+        self.app.model(handle)
+    }
+}
+
+impl<V> ReadModel for TuiViewContext<'_, V> {
+    fn read_model<T, F, S>(&self, handle: &ModelHandle<T>, read: F) -> S
+    where
+        T: Entity,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        self.app.read_model(handle, read)
+    }
+}
+
+impl<V: TuiView> UpdateModel for TuiViewContext<'_, V> {
+    fn update_model<T, F, S>(&mut self, handle: &ModelHandle<T>, update: F) -> S
+    where
+        T: Entity,
+        F: FnOnce(&mut T, &mut ModelContext<T>) -> S,
+    {
+        self.app.update_model(handle, update)
+    }
+}
+
+impl<V: TuiView> TuiViewAsRef for TuiViewContext<'_, V> {
+    fn tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> &T {
+        self.app.tui_view(handle)
+    }
+
+    fn try_tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> Option<&T> {
+        self.app.try_tui_view(handle)
+    }
+}
+
+impl<V: TuiView> TuiReadView for TuiViewContext<'_, V> {
+    fn read_tui_view<T, F, S>(&self, handle: &TuiViewHandle<T>, read: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        self.app.read_tui_view(handle, read)
+    }
+}
+
+impl<V: TuiView> TuiUpdateView for TuiViewContext<'_, V> {
+    fn update_tui_view<T, F, S>(&mut self, handle: &TuiViewHandle<T>, update: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S,
+    {
+        self.app.update_tui_view(handle, update)
+    }
+}
+
+impl<V: TuiView> GetSingletonModelHandle for TuiViewContext<'_, V> {
+    fn get_singleton_model_handle<T: crate::SingletonEntity>(&self) -> ModelHandle<T> {
+        self.app.get_singleton_model_handle()
+    }
+}

--- a/crates/warpui_core/src/core/tui_view/handle.rs
+++ b/crates/warpui_core/src/core/tui_view/handle.rs
@@ -1,0 +1,225 @@
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+use std::sync::{Arc, Weak};
+
+use parking_lot::Mutex;
+
+use super::context::TuiViewContext;
+use super::TuiView;
+use crate::core::view::AnyViewHandle;
+use crate::core::RefCounts;
+use crate::{AppContext, EntityId, WindowId};
+
+/// A strong reference to a particular [`TuiView`] instance, mirroring the GUI
+/// [`ViewHandle`](crate::ViewHandle).
+pub struct TuiViewHandle<T> {
+    window_id: WindowId,
+    view_id: EntityId,
+    view_type: PhantomData<T>,
+    ref_counts: Weak<Mutex<RefCounts>>,
+}
+
+impl<T: TuiView> TuiViewHandle<T> {
+    pub(in crate::core) fn new(
+        window_id: WindowId,
+        view_id: EntityId,
+        ref_counts: &Arc<Mutex<RefCounts>>,
+    ) -> Self {
+        ref_counts.lock().inc_entity(view_id);
+        Self {
+            window_id,
+            view_id,
+            view_type: PhantomData,
+            ref_counts: Arc::downgrade(ref_counts),
+        }
+    }
+
+    pub fn downgrade(&self) -> WeakTuiViewHandle<T> {
+        WeakTuiViewHandle::new(self.view_id)
+    }
+
+    /// Returns the current window this view belongs to.
+    pub fn window_id(&self, app: &AppContext) -> WindowId {
+        app.view_to_window
+            .get(&self.view_id)
+            .copied()
+            .unwrap_or(self.window_id)
+    }
+
+    pub fn id(&self) -> EntityId {
+        self.view_id
+    }
+
+    /// Convert a handle to a reference of the underlying [`TuiView`].
+    pub fn as_ref<'a, A: TuiViewAsRef>(&self, app: &'a A) -> &'a T {
+        app.tui_view(self)
+    }
+
+    /// Try to convert a handle to a reference of the underlying [`TuiView`].
+    /// Returns `None` if the view is currently borrowed (circular reference).
+    pub fn try_as_ref<'a, A: TuiViewAsRef>(&self, app: &'a A) -> Option<&'a T> {
+        app.try_tui_view(self)
+    }
+
+    /// Reads a value out of the underlying view.
+    pub fn read<A, F, S>(&self, app: &A, read: F) -> S
+    where
+        A: TuiReadView,
+        F: FnOnce(&T, &AppContext) -> S,
+    {
+        app.read_tui_view(self, read)
+    }
+
+    /// Updates a value within the underlying view.
+    pub fn update<A, F, S>(&self, app: &mut A, update: F) -> S
+    where
+        A: TuiUpdateView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S,
+    {
+        app.update_tui_view(self, update)
+    }
+
+    pub fn is_focused(&self, app: &AppContext) -> bool {
+        app.focused_view_id(self.window_id(app)) == Some(self.view_id)
+    }
+}
+
+impl<T> Clone for TuiViewHandle<T> {
+    fn clone(&self) -> Self {
+        if let Some(ref_counts) = self.ref_counts.upgrade() {
+            ref_counts.lock().inc_entity(self.view_id);
+        }
+
+        Self {
+            window_id: self.window_id,
+            view_id: self.view_id,
+            view_type: PhantomData,
+            ref_counts: self.ref_counts.clone(),
+        }
+    }
+}
+
+impl<T> PartialEq for TuiViewHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.window_id == other.window_id && self.view_id == other.view_id
+    }
+}
+
+impl<T> Eq for TuiViewHandle<T> {}
+
+impl<T> Debug for TuiViewHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(&format!("TuiViewHandle<{}>", core::any::type_name::<T>()))
+            .field("window_id", &self.window_id)
+            .field("view_id", &self.view_id)
+            .finish()
+    }
+}
+
+impl<T> Drop for TuiViewHandle<T> {
+    fn drop(&mut self) {
+        if let Some(ref_counts) = self.ref_counts.upgrade() {
+            ref_counts.lock().dec_view(self.window_id, self.view_id);
+        }
+    }
+}
+
+unsafe impl<T> Send for TuiViewHandle<T> {}
+unsafe impl<T> Sync for TuiViewHandle<T> {}
+
+impl<T: TuiView> From<&TuiViewHandle<T>> for AnyViewHandle {
+    fn from(handle: &TuiViewHandle<T>) -> Self {
+        AnyViewHandle::for_view::<T>(handle.window_id, handle.view_id, &handle.ref_counts)
+    }
+}
+
+impl<T: TuiView> From<TuiViewHandle<T>> for AnyViewHandle {
+    fn from(handle: TuiViewHandle<T>) -> Self {
+        (&handle).into()
+    }
+}
+
+/// A weak reference to a particular [`TuiView`] instance, mirroring the GUI
+/// [`WeakViewHandle`](crate::WeakViewHandle).
+pub struct WeakTuiViewHandle<T> {
+    view_id: EntityId,
+    view_type: PhantomData<T>,
+}
+
+impl<T: TuiView> WeakTuiViewHandle<T> {
+    pub(super) fn new(view_id: EntityId) -> Self {
+        Self {
+            view_id,
+            view_type: PhantomData,
+        }
+    }
+
+    pub fn upgrade(&self, app: &AppContext) -> Option<TuiViewHandle<T>> {
+        let window_id = app.view_to_window.get(&self.view_id).copied()?;
+
+        if app
+            .windows
+            .get(&window_id)
+            .and_then(|w| w.views.get(&self.view_id))
+            .is_some()
+            && !app.ref_counts.lock().is_view_dropped(self.view_id)
+        {
+            Some(TuiViewHandle::new(window_id, self.view_id, &app.ref_counts))
+        } else {
+            None
+        }
+    }
+
+    pub fn id(&self) -> EntityId {
+        self.view_id
+    }
+
+    pub fn window_id(&self, app: &AppContext) -> Option<WindowId> {
+        app.view_to_window.get(&self.view_id).copied()
+    }
+}
+
+impl<T> Clone for WeakTuiViewHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            view_id: self.view_id,
+            view_type: PhantomData,
+        }
+    }
+}
+
+impl<T> Debug for WeakTuiViewHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(&format!(
+            "WeakTuiViewHandle<{}>",
+            core::any::type_name::<T>()
+        ))
+        .field("view_id", &self.view_id)
+        .finish()
+    }
+}
+
+unsafe impl<T> Send for WeakTuiViewHandle<T> {}
+unsafe impl<T> Sync for WeakTuiViewHandle<T> {}
+
+pub trait TuiViewAsRef {
+    fn tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> &T;
+
+    /// Try to get a reference to the view. Returns `None` if the view is
+    /// currently borrowed (e.g., during a circular reference scenario).
+    fn try_tui_view<T: TuiView>(&self, handle: &TuiViewHandle<T>) -> Option<&T>;
+}
+
+pub trait TuiReadView: TuiViewAsRef {
+    fn read_tui_view<T, F, S>(&self, handle: &TuiViewHandle<T>, read: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&T, &AppContext) -> S;
+}
+
+pub trait TuiUpdateView: TuiReadView {
+    fn update_tui_view<T, F, S>(&mut self, handle: &TuiViewHandle<T>, update: F) -> S
+    where
+        T: TuiView,
+        F: FnOnce(&mut T, &mut TuiViewContext<T>) -> S;
+}

--- a/crates/warpui_core/src/core/tui_view/mod.rs
+++ b/crates/warpui_core/src/core/tui_view/mod.rs
@@ -1,0 +1,222 @@
+//! The TUI-side view abstraction, mirroring the GUI [`View`](crate::View) layer
+//! but rendering to an abstract, backend-owned output so that `warpui_core` never
+//! depends on the (downstream) `warpui_tui` crate.
+//!
+//! All items in this module are gated behind the `tui` feature. They reuse the
+//! shared application core ([`AppContextImpl`](crate::core::AppContextImpl) and
+//! the model/async/action/subscription machinery) exactly as the GUI view layer
+//! does.
+
+mod context;
+mod handle;
+
+use std::any::Any;
+
+pub use self::context::*;
+pub use self::handle::*;
+use super::EntityId;
+use crate::core::tui_backend::TuiBackend;
+use crate::core::{AppContextImpl, BlurContext, CursorInfo, FocusContext};
+use crate::{keymap, AppContext, Entity, WindowId};
+
+/// The TUI analogue of [`View`](crate::View).
+///
+/// A `TuiView` holds instance state and can render itself to its own
+/// [`RenderOutput`](TuiView::RenderOutput). Unlike the GUI [`View`](crate::View),
+/// the render output type is owned by the view (and ultimately the `warpui_tui`
+/// crate that defines concrete TUI elements), not by `warpui_core`; the shared
+/// core only ever sees it type-erased as [`TuiBackend::RenderOutput`].
+pub trait TuiView: Entity {
+    /// What this view renders to. The concrete element/buffer type lives in the
+    /// downstream `warpui_tui` crate; the shared core only stores it erased.
+    type RenderOutput: 'static;
+
+    /// Returns a unique name for this implementation of `TuiView`.
+    fn ui_name() -> &'static str;
+
+    /// Produces this view's render output.
+    fn render_tui(&self, ctx: &AppContextImpl<TuiBackend>) -> Self::RenderOutput;
+
+    /// Handles the view or its descendent receiving focus.
+    fn on_focus(&mut self, _focus_ctx: &FocusContext, _ctx: &mut TuiViewContext<Self>) {}
+
+    /// Handles the view or its descendent losing focus.
+    fn on_blur(&mut self, _blur_ctx: &BlurContext, _ctx: &mut TuiViewContext<Self>) {}
+
+    /// Reports the active cursor position for the view, if any.
+    fn active_cursor_position(&self, _ctx: &TuiViewContext<Self>) -> Option<CursorInfo> {
+        None
+    }
+
+    /// Handles the view's containing window closing.
+    fn on_window_closed(&mut self, _ctx: &mut TuiViewContext<Self>) {}
+
+    /// Called when the view is transferred from one window to another.
+    fn on_window_transferred(
+        &mut self,
+        _source_window_id: WindowId,
+        _target_window_id: WindowId,
+        _ctx: &mut TuiViewContext<Self>,
+    ) {
+    }
+
+    /// Returns a representation of the current UI context for use in computing
+    /// the set of valid actions/keyboard shortcuts.
+    fn keymap_context(&self, _: &AppContext) -> keymap::Context {
+        Self::default_keymap_context()
+    }
+
+    /// Returns the default context for a view.
+    fn default_keymap_context() -> keymap::Context {
+        let mut ctx = keymap::Context::default();
+        ctx.set.insert(Self::ui_name());
+        ctx
+    }
+
+    /// Allows a view to hook into any interactions with it or its children.
+    fn self_or_child_interacted_with(&self, _ctx: &mut TuiViewContext<Self>) {}
+}
+
+/// The TUI analogue of [`TypedActionView`](crate::TypedActionView): a `TuiView`
+/// that handles typed actions dispatched through the shared core.
+pub trait TuiTypedActionView: TuiView {
+    type Action: crate::Action;
+
+    /// Handles an action of type [`Self::Action`](TuiTypedActionView::Action)
+    /// dispatched from this view or a descendant.
+    fn handle_action(&mut self, _action: &Self::Action, _ctx: &mut TuiViewContext<Self>) {}
+}
+
+/// The object-safe surface stored per window for the TUI backend, mirroring
+/// [`AnyView`](crate::AnyView). Carries the render + focus/keymap hooks the
+/// shared core needs without naming the concrete view type.
+///
+/// This is the TUI value of [`TuiBackend::AnyView`].
+pub trait AnyTuiView {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn ui_name(&self) -> &'static str;
+    fn render_tui(&self, app: &AppContextImpl<TuiBackend>) -> Box<dyn Any>;
+    fn on_focus(
+        &mut self,
+        focus_ctx: &FocusContext,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    );
+    fn on_blur(
+        &mut self,
+        blur_ctx: &BlurContext,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    );
+    fn keymap_context(&self, app: &AppContext) -> keymap::Context;
+    fn active_cursor_position(
+        &self,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    ) -> Option<CursorInfo>;
+    fn on_window_closed(&mut self, app: &mut AppContext, window_id: WindowId, view_id: EntityId);
+    fn on_window_transferred(
+        &mut self,
+        source_window_id: WindowId,
+        target_window_id: WindowId,
+        app: &mut AppContext,
+        view_id: EntityId,
+    );
+    fn self_or_child_interacted_with(
+        &self,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    );
+}
+
+impl<T> AnyTuiView for T
+where
+    T: TuiView,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn ui_name(&self) -> &'static str {
+        T::ui_name()
+    }
+
+    fn render_tui(&self, app: &AppContextImpl<TuiBackend>) -> Box<dyn Any> {
+        Box::new(TuiView::render_tui(self, app))
+    }
+
+    fn on_focus(
+        &mut self,
+        focus_ctx: &FocusContext,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    ) {
+        let mut ctx = TuiViewContext::new(app, window_id, view_id);
+        TuiView::on_focus(self, focus_ctx, &mut ctx);
+    }
+
+    fn on_blur(
+        &mut self,
+        blur_ctx: &BlurContext,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    ) {
+        let mut ctx = TuiViewContext::new(app, window_id, view_id);
+        TuiView::on_blur(self, blur_ctx, &mut ctx);
+    }
+
+    fn keymap_context(&self, app: &AppContext) -> keymap::Context {
+        TuiView::keymap_context(self, app)
+    }
+
+    fn active_cursor_position(
+        &self,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    ) -> Option<CursorInfo> {
+        let ctx = TuiViewContext::new(app, window_id, view_id);
+        TuiView::active_cursor_position(self, &ctx)
+    }
+
+    fn on_window_closed(&mut self, app: &mut AppContext, window_id: WindowId, view_id: EntityId) {
+        let mut ctx = TuiViewContext::new(app, window_id, view_id);
+        TuiView::on_window_closed(self, &mut ctx);
+    }
+
+    fn on_window_transferred(
+        &mut self,
+        source_window_id: WindowId,
+        target_window_id: WindowId,
+        app: &mut AppContext,
+        view_id: EntityId,
+    ) {
+        let mut ctx = TuiViewContext::new(app, target_window_id, view_id);
+        TuiView::on_window_transferred(self, source_window_id, target_window_id, &mut ctx);
+    }
+
+    fn self_or_child_interacted_with(
+        &self,
+        app: &mut AppContext,
+        window_id: WindowId,
+        view_id: EntityId,
+    ) {
+        let mut ctx = TuiViewContext::new(app, window_id, view_id);
+        TuiView::self_or_child_interacted_with(self, &mut ctx);
+    }
+}
+
+#[cfg(test)]
+#[path = "tui_view_tests.rs"]
+mod tests;

--- a/crates/warpui_core/src/core/tui_view/tui_view_tests.rs
+++ b/crates/warpui_core/src/core/tui_view/tui_view_tests.rs
@@ -1,0 +1,240 @@
+//! Asserting tests proving that a [`TuiView`] reuses the shared application core
+//! exactly as a GUI `View` does: window registration + focus, handle
+//! update/read, `notify` invalidation, async `spawn`, model subscription, and
+//! typed-action dispatch — all under the `tui` backend (`--features tui`).
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use super::{TuiTypedActionView, TuiView, TuiViewContext};
+use crate::platform::WindowStyle;
+use crate::{AddWindowOptions, App, AppContext, Entity, ModelHandle, UpdateModel};
+
+fn window_options() -> AddWindowOptions {
+    AddWindowOptions {
+        window_style: WindowStyle::NotStealFocus,
+        ..Default::default()
+    }
+}
+
+/// A minimal `TuiView` carrying a counter, used by most tests. It is also a
+/// `TuiTypedActionView` (with a no-op action) so it can serve as a window root.
+#[derive(Default)]
+struct CounterView {
+    count: usize,
+}
+
+impl Entity for CounterView {
+    type Event = ();
+}
+
+impl TuiView for CounterView {
+    type RenderOutput = ();
+    fn ui_name() -> &'static str {
+        "CounterView"
+    }
+    fn render_tui(&self, _ctx: &AppContext) {}
+}
+
+impl TuiTypedActionView for CounterView {
+    type Action = ();
+}
+
+#[test]
+fn test_add_and_focus() {
+    App::test((), |mut app| async move {
+        let (window_id, root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| CounterView::default()));
+
+        // The root is focused on creation.
+        assert_eq!(app.focused_view_id(window_id), Some(root.id()));
+
+        // Add a child TuiView and focus it; the focus should move to the child.
+        let child = app.update(|ctx| ctx.add_tui_view(window_id, |_| CounterView::default()));
+        assert_ne!(child.id(), root.id());
+
+        child.update(&mut app, |_, ctx| ctx.focus_self());
+
+        assert_eq!(app.focused_view_id(window_id), Some(child.id()));
+        assert!(app.read(|ctx| child.is_focused(ctx)));
+        assert!(!app.read(|ctx| root.is_focused(ctx)));
+    });
+}
+
+#[test]
+fn test_update_and_read() {
+    App::test((), |mut app| async move {
+        let (_, handle) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| CounterView::default()));
+
+        handle.update(&mut app, |view, _| view.count = 41);
+        handle.update(&mut app, |view, _| view.count += 1);
+
+        let count = handle.read(&app, |view, _| view.count);
+        assert_eq!(count, 42);
+    });
+}
+
+#[test]
+fn test_notify_marks_window_invalidated() {
+    App::test((), |mut app| async move {
+        let (window_id, handle) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| CounterView::default()));
+
+        // Override the window's invalidation callback with our own recorder. This
+        // replaces the test harness's auto-build-scene callback (which would clear
+        // invalidations), so we can observe the same `window_invalidations` signal
+        // the GUI uses without it being immediately drained.
+        let invalidated = Rc::new(Cell::new(false));
+        let recorder = invalidated.clone();
+        app.update(move |ctx| {
+            ctx.on_window_invalidated(window_id, move |_, _| recorder.set(true));
+        });
+
+        invalidated.set(false);
+        handle.update(&mut app, |_, ctx| ctx.notify());
+
+        // The window-invalidated callback fired, and the invalidation signal is set.
+        assert!(invalidated.get(), "notify should invalidate the window");
+        assert!(app.read(|ctx| ctx.has_window_invalidations(window_id)));
+    });
+}
+
+#[test]
+fn test_async_spawn_runs_on_main_thread() {
+    App::test((), |mut app| async move {
+        let (_, handle) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| CounterView::default()));
+
+        let (tx, rx) = futures::channel::oneshot::channel();
+        handle.update(&mut app, move |_, ctx| {
+            ctx.spawn(async { 7usize }, move |view, output, _| {
+                view.count = output;
+                tx.send(()).unwrap();
+            })
+        });
+        rx.await.unwrap();
+
+        assert_eq!(handle.read(&app, |view, _| view.count), 7);
+    });
+}
+
+/// A backend-agnostic model (plain [`Entity`]/`ModelContext`, no backend
+/// parameter), reused by a `TuiView` exactly as a GUI `View` would.
+struct CounterModel {
+    value: usize,
+}
+
+impl Entity for CounterModel {
+    type Event = usize;
+}
+
+#[derive(Default)]
+struct SubscriberView {
+    last_seen: usize,
+    model: Option<ModelHandle<CounterModel>>,
+}
+
+impl Entity for SubscriberView {
+    type Event = ();
+}
+
+impl TuiView for SubscriberView {
+    type RenderOutput = ();
+    fn ui_name() -> &'static str {
+        "SubscriberView"
+    }
+    fn render_tui(&self, _ctx: &AppContext) {}
+}
+
+impl TuiTypedActionView for SubscriberView {
+    type Action = ();
+}
+
+#[test]
+fn test_model_reuse_subscribe_and_emit() {
+    App::test((), |mut app| async move {
+        let (_, handle) = app.update(|ctx| {
+            ctx.add_tui_window(window_options(), |vctx| {
+                let model = vctx.add_model(|_| CounterModel { value: 0 });
+                vctx.subscribe_to_model(&model, |view: &mut SubscriberView, _handle, event, _| {
+                    view.last_seen = *event;
+                });
+                SubscriberView {
+                    last_seen: 0,
+                    model: Some(model),
+                }
+            })
+        });
+
+        let model = handle.read(&app, |view, _| view.model.clone().unwrap());
+
+        // Mutate the model and emit an event; the view's subscription should react.
+        app.update(|ctx| {
+            ctx.update_model(&model, |model, mctx| {
+                model.value = 99;
+                mctx.emit(model.value);
+            });
+        });
+
+        assert_eq!(handle.read(&app, |view, _| view.last_seen), 99);
+    });
+}
+
+#[derive(Debug)]
+struct Increment(usize);
+
+#[derive(Default)]
+struct ActionView {
+    total: usize,
+}
+
+impl Entity for ActionView {
+    type Event = ();
+}
+
+impl TuiView for ActionView {
+    type RenderOutput = ();
+    fn ui_name() -> &'static str {
+        "ActionView"
+    }
+    fn render_tui(&self, _ctx: &AppContext) {}
+}
+
+impl TuiTypedActionView for ActionView {
+    type Action = Increment;
+    fn handle_action(&mut self, action: &Increment, _ctx: &mut TuiViewContext<Self>) {
+        self.total += action.0;
+    }
+}
+
+#[test]
+fn test_typed_action_dispatch() {
+    App::test((), |mut app| async move {
+        let (window_id, handle) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| ActionView::default()));
+
+        // Dispatch a typed action through the shared dispatch path. The view's
+        // `handle_action` should run and mutate it.
+        app.dispatch_typed_action(window_id, &[handle.id()], &Increment(5));
+        app.dispatch_typed_action(window_id, &[handle.id()], &Increment(3));
+
+        assert_eq!(handle.read(&app, |view, _| view.total), 8);
+    });
+}
+
+#[test]
+fn test_alias_resolves_to_tui_backend() {
+    // Under `--features tui`, the bare `AppContext` alias resolves to the
+    // `TuiBackend` instantiation: this whole module calls TUI-only methods
+    // (`add_tui_window`, `root_view_tui`, `add_tui_view`) on the bare alias, which
+    // only exist on `AppContextImpl<TuiBackend>`. The default-feature build
+    // resolves `AppContext` to `GuiBackend` and never compiles this module.
+    App::test((), |mut app| async move {
+        let (window_id, root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| CounterView::default()));
+
+        let resolved = app.read(|ctx| ctx.root_view_tui::<CounterView>(window_id).map(|h| h.id()));
+        assert_eq!(resolved, Some(root.id()));
+    });
+}

--- a/crates/warpui_core/src/core/view/context.rs
+++ b/crates/warpui_core/src/core/view/context.rs
@@ -9,7 +9,9 @@ use pathfinder_geometry::rect::RectF;
 use thiserror::Error;
 
 use super::handle::{AnyViewHandle, ReadView, UpdateView, ViewAsRef, ViewHandle, WeakViewHandle};
-use super::{TypedActionView, View};
+#[cfg(not(feature = "tui"))]
+use super::TypedActionView;
+use super::View;
 use crate::accessibility::AccessibilityContent;
 use crate::core::{Observation, Subscription, SubscriptionKey, TaskCallback};
 use crate::fonts::Cache as FontCache;
@@ -133,6 +135,7 @@ impl<'a, T: View> ViewContext<'a, T> {
         self.app.add_model(build_model)
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_view<S, F>(&mut self, build_view: F) -> ViewHandle<S>
     where
         S: View,
@@ -141,6 +144,7 @@ impl<'a, T: View> ViewContext<'a, T> {
         self.app.add_view(self.window_id, build_view)
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_typed_action_view<V, F>(&mut self, build_view: F) -> ViewHandle<V>
     where
         V: TypedActionView + View,
@@ -151,6 +155,7 @@ impl<'a, T: View> ViewContext<'a, T> {
             .add_typed_action_view_with_parent(self.window_id, build_view, self.view_id)
     }
 
+    #[cfg(not(feature = "tui"))]
     pub fn add_option_view<S, F>(&mut self, build_view: F) -> Option<ViewHandle<S>>
     where
         S: View,
@@ -908,6 +913,6 @@ impl<V: View> GetSingletonModelHandle for ViewContext<'_, V> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "context_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/core/view/handle.rs
+++ b/crates/warpui_core/src/core/view/handle.rs
@@ -185,6 +185,44 @@ impl AnyViewHandle {
         }
         None
     }
+
+    /// Builds an erased handle to a view of type `T` from raw parts (cloning a
+    /// strong reference). Used by the TUI strong-handle `From` impl, which lives
+    /// in a sibling module and so cannot touch these private fields directly;
+    /// `T: 'static` is all that is required since this stores only a `TypeId`.
+    #[cfg(feature = "tui")]
+    pub(in crate::core) fn for_view<T: 'static>(
+        window_id: WindowId,
+        view_id: EntityId,
+        ref_counts: &Weak<Mutex<RefCounts>>,
+    ) -> Self {
+        if let Some(ref_counts) = ref_counts.upgrade() {
+            ref_counts.lock().inc_entity(view_id);
+        }
+        AnyViewHandle {
+            window_id,
+            view_id,
+            view_type: TypeId::of::<T>(),
+            ref_counts: ref_counts.clone(),
+        }
+    }
+
+    /// The TUI analogue of [`downcast`](Self::downcast).
+    #[cfg(feature = "tui")]
+    pub(in crate::core) fn downcast_tui<T: super::super::TuiView>(
+        self,
+    ) -> Option<super::super::TuiViewHandle<T>> {
+        if self.is::<T>() {
+            if let Some(ref_counts) = self.ref_counts.upgrade() {
+                return Some(super::super::TuiViewHandle::new(
+                    self.window_id,
+                    self.view_id,
+                    &ref_counts,
+                ));
+            }
+        }
+        None
+    }
 }
 
 impl Clone for AnyViewHandle {

--- a/crates/warpui_core/src/elements/clipped.rs
+++ b/crates/warpui_core/src/elements/clipped.rs
@@ -96,6 +96,6 @@ impl Element for Clipped {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "clipped_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/clipped_scrollable.rs
+++ b/crates/warpui_core/src/elements/clipped_scrollable.rs
@@ -466,6 +466,6 @@ impl ScrollableElement for ClippedScrollable {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "clipped_scrollable_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/container.rs
+++ b/crates/warpui_core/src/elements/container.rs
@@ -418,6 +418,6 @@ impl SelectableElement for Container {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "container_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/event_handler.rs
+++ b/crates/warpui_core/src/elements/event_handler.rs
@@ -366,6 +366,6 @@ impl Element for EventHandler {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "event_handler_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/flex/mod.rs
+++ b/crates/warpui_core/src/elements/flex/mod.rs
@@ -995,6 +995,6 @@ impl SelectableElement for Expanded {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "mod_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/flex/wrap.rs
+++ b/crates/warpui_core/src/elements/flex/wrap.rs
@@ -604,6 +604,6 @@ impl RunBuilder {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "wrap_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/hoverable.rs
+++ b/crates/warpui_core/src/elements/hoverable.rs
@@ -827,6 +827,6 @@ impl SelectableElement for Hoverable {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "hoverable_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/new_scrollable/mod.rs
+++ b/crates/warpui_core/src/elements/new_scrollable/mod.rs
@@ -1585,6 +1585,6 @@ impl ClippedScrollStateHandle {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "scrollable_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/scrollable.rs
+++ b/crates/warpui_core/src/elements/scrollable.rs
@@ -682,6 +682,6 @@ impl Element for Scrollable {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "scrollable_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/size_constraint_switch.rs
+++ b/crates/warpui_core/src/elements/size_constraint_switch.rs
@@ -148,6 +148,6 @@ impl Element for SizeConstraintSwitch {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "size_constraint_switch_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/stack/mod.rs
+++ b/crates/warpui_core/src/elements/stack/mod.rs
@@ -440,6 +440,6 @@ impl Extend<Box<dyn Element>> for Stack {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "mod_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/uniform_list.rs
+++ b/crates/warpui_core/src/elements/uniform_list.rs
@@ -325,6 +325,6 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "uniform_list_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/viewported_list.rs
+++ b/crates/warpui_core/src/elements/viewported_list.rs
@@ -772,6 +772,6 @@ impl<T> ListStateInner<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tui")))]
 #[path = "viewported_list_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/lib.rs
+++ b/crates/warpui_core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod r#async;
 pub mod clipboard;
 pub mod clipboard_utils;
 mod core;
+#[cfg(not(feature = "tui"))]
 mod debug;
 pub mod elements;
 pub mod event;

--- a/crates/warpui_core/src/presenter.rs
+++ b/crates/warpui_core/src/presenter.rs
@@ -553,6 +553,7 @@ impl Presenter {
         self.frame_count
     }
 
+    #[cfg_attr(feature = "tui", allow(dead_code))]
     pub(crate) fn parents(&self) -> HashMap<EntityId, EntityId> {
         self.parents.clone()
     }
@@ -572,6 +573,7 @@ impl Presenter {
     /// Set the parent of a view.
     /// This will be overwritten on the next layout pass, but is useful before the initial layout
     /// of a view.
+    #[cfg_attr(feature = "tui", allow(dead_code))]
     pub(crate) fn set_parent(&mut self, view_id: EntityId, parent_id: EntityId) {
         self.parents.insert(view_id, parent_id);
     }


### PR DESCRIPTION
## Description
Milestone 2 of the warpui TUI-backend saga: adds the TUI-side view abstraction inside `warpui_core`, gated behind the `tui` feature, reusing the generic `Backend` core introduced in M1. No GUI behavior changes — the GUI build is a strict subset and stays green.

What's added (all `#[cfg(feature = "tui")]`):
- `TuiBackend: Backend` with an **abstract** `RenderOutput = Box<dyn Any>` so `warpui_core` never depends on the (future) `warpui_tui` crate; `AnyView = dyn AnyTuiView`; `Presenter` reuses `GuiPresenterState` so the shared window-invalidation machinery is available to TUI views.
- `TuiView` / `TuiTypedActionView` traits + the `AnyTuiView` erased per-window object.
- `TuiViewHandle` / `WeakTuiViewHandle` / `TuiViewContext`, exposing the same shared operations as the GUI `ViewContext`: `add_view`, `add_model`, `update`, `read`, `focus`, `notify`, `emit`, `subscribe_to_model`, `observe`, `spawn`, `spawn_abortable`, and typed-action dispatch.
- `#[cfg(feature = "tui")] pub type AppContext = AppContextImpl<TuiBackend>` alias + TUI view-lifecycle parallels (`add_tui_view`, `add_tui_window`, `add_typed_action_tui_view`, `root_view_tui`, `Tui{ViewAsRef,ReadView,UpdateView}` impls).

Approach: the GUI `View`/`AnyView`/`ViewContext`/presenter stay compiled under both backends. Only the storage/render entry points that coerce a concrete view into the window's erased box (`add_view`, `add_option_view`, `add_typed_action_view*`, `render_view(s)`, etc.) are cfg-split GUI/TUI; the shared dispatch/effects/async/subscription/observation machinery is reused unchanged. GUI-only test modules are gated to `not(tui)` (GUI xor TUI build). All changes are confined to `crates/warpui_core`.

## Testing
New `tui`-gated asserting tests in `core/tui_view/tui_view_tests.rs` prove a `TuiView` reuses the shared core: add+focus, update+read, `notify` invalidation, async `spawn` (driven on the main thread), model `subscribe_to_model`+`emit`, typed-action dispatch, and alias resolution to `TuiBackend`.

Validated on both configurations:
- `cargo build -p warpui_core` and `cargo build -p warpui_core --features tui` — clean.
- `cargo nextest run -p warpui_core` — 279 passed; `cargo nextest run -p warpui_core --features tui` — 151 passed.
- `cargo clippy -p warpui_core --all-targets -- -D warnings` and `... --features tui ...` — clean.
- `./script/format --check` — clean.

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-NONE -->

_Conversation: https://staging.warp.dev/conversation/47ca44ef-d082-464f-b3ca-ccb5805b01be_
_Run: https://oz.staging.warp.dev/runs/019eaa8e-bac5-7d2b-8e0b-3d7e31ba72c5_

_This PR was generated with [Oz](https://warp.dev/oz)._
