### PR TITLE
Fix OSC 52 clipboard writes with write_only default

### DIFF
--- a/app/src/terminal/settings.rs
+++ b/app/src/terminal/settings.rs
@@ -24,9 +24,9 @@ use crate::settings::{AISettings, InputSettings, TerminalSpacing};
     rename_all = "snake_case"
 )]
 pub enum Osc52ClipboardAccess {
-    #[default]
     #[schemars(description = "Deny all OSC 52 clipboard access.")]
     Deny,
+    #[default]
     #[schemars(description = "Allow terminal programs to write to the clipboard, but not read.")]
     WriteOnly,
     #[schemars(description = "Allow terminal programs to both read and write the clipboard.")]
@@ -185,7 +185,7 @@ define_settings_group!(TerminalSettings, settings: [
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: false,
         toml_path: "terminal.osc52_clipboard_access",
-        description: "Controls whether terminal programs can access the system clipboard via OSC 52 escape sequences. Options: deny (default), write_only, read_write.",
+        description: "Controls whether terminal programs can access the system clipboard via OSC 52 escape sequences. Options: deny, write_only (default), read_write.",
     },
     // Opt-in toggle for running terminal find on a background thread. Only consulted on
     // channels where `FeatureFlag::AsyncFind` is off; channels with the flag on force the

--- a/app/src/terminal/settings_tests.rs
+++ b/app/src/terminal/settings_tests.rs
@@ -3,8 +3,11 @@ use settings_value::SettingsValue;
 use super::*;
 
 #[test]
-fn osc52_default_is_deny() {
-    assert_eq!(Osc52ClipboardAccess::default(), Osc52ClipboardAccess::Deny);
+fn osc52_default_allows_writes_only() {
+    assert_eq!(
+        Osc52ClipboardAccess::default(),
+        Osc52ClipboardAccess::WriteOnly
+    );
 }
 
 #[test]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -18887,6 +18887,28 @@ impl TerminalView {
         self.clear_buffer(ctx);
     }
 
+    /// Simulates an OSC 52 clipboard write event for use in tests.
+    #[cfg(test)]
+    pub fn test_handle_osc52_store(&mut self, contents: String, ctx: &mut ViewContext<Self>) {
+        use crate::terminal::model_events::ModelEvent;
+        self.handle_terminal_event(
+            &ModelEvent::ClipboardStore(crate::terminal::ClipboardType::Clipboard, contents),
+            ctx,
+        );
+    }
+
+    #[cfg(test)]
+    pub fn test_handle_osc52_load(&mut self, ctx: &mut ViewContext<Self>) {
+        use crate::terminal::model_events::ModelEvent;
+        self.handle_terminal_event(
+            &ModelEvent::ClipboardLoad(
+                crate::terminal::ClipboardType::Clipboard,
+                std::sync::Arc::new(|text| format!("osc52:{text}")),
+            ),
+            ctx,
+        );
+    }
+
     /// Performs a variant of the "clear buffer" action that is special for the agent view.
     /// Returns true iff the clear was successful.
     fn try_clear_buffer_in_agent_view(&mut self, ctx: &mut ViewContext<Self>) -> bool {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -2429,6 +2429,174 @@ fn test_insert_into_input() {
 }
 
 #[test]
+fn test_osc52_clipboard_write_allowed_when_read_write() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            TerminalSettings::handle(ctx).update(ctx, |settings, ctx| {
+                let _ = settings
+                    .osc52_clipboard_access
+                    .set_value(crate::terminal::settings::Osc52ClipboardAccess::ReadWrite, ctx);
+            });
+            assert_eq!("", &read_from_clipboard(ctx));
+            view.test_handle_osc52_store("osc52-test".to_owned(), ctx);
+            assert_eq!("osc52-test", &read_from_clipboard(ctx));
+        });
+    })
+}
+
+#[test]
+fn test_osc52_clipboard_write_allowed_when_write_only() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            TerminalSettings::handle(ctx).update(ctx, |settings, ctx| {
+                let _ = settings
+                    .osc52_clipboard_access
+                    .set_value(crate::terminal::settings::Osc52ClipboardAccess::WriteOnly, ctx);
+            });
+            assert_eq!("", &read_from_clipboard(ctx));
+            view.test_handle_osc52_store("osc52-write-only".to_owned(), ctx);
+            assert_eq!("osc52-write-only", &read_from_clipboard(ctx));
+        });
+    })
+}
+
+#[test]
+fn test_osc52_clipboard_write_blocked_when_deny() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            TerminalSettings::handle(ctx).update(ctx, |settings, ctx| {
+                let _ = settings
+                    .osc52_clipboard_access
+                    .set_value(crate::terminal::settings::Osc52ClipboardAccess::Deny, ctx);
+            });
+            assert_eq!("", &read_from_clipboard(ctx));
+            view.test_handle_osc52_store("should-be-blocked".to_owned(), ctx);
+            // Clipboard must remain empty when OSC 52 access is denied.
+            assert_eq!("", &read_from_clipboard(ctx));
+        });
+    })
+}
+
+#[test]
+fn test_osc52_default_allows_write_without_read() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            // Default setting must allow writes so OSC 52 copy works out of the box,
+            // while keeping clipboard reads opt-in.
+            let access = *TerminalSettings::as_ref(ctx).osc52_clipboard_access;
+            assert_eq!(
+                access,
+                crate::terminal::settings::Osc52ClipboardAccess::WriteOnly
+            );
+            assert_eq!("", &read_from_clipboard(ctx));
+            view.test_handle_osc52_store("default-test".to_owned(), ctx);
+            assert_eq!("default-test", &read_from_clipboard(ctx));
+        });
+    })
+}
+
+#[test]
+fn test_osc52_clipboard_read_allowed_when_read_write() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            TerminalSettings::handle(ctx).update(ctx, |settings, ctx| {
+                let _ = settings
+                    .osc52_clipboard_access
+                    .set_value(crate::terminal::settings::Osc52ClipboardAccess::ReadWrite, ctx);
+            });
+            ctx.clipboard()
+                .write(ClipboardContent::plain_text("readable".to_owned()));
+            view.test_handle_osc52_load(ctx);
+        });
+
+        assert_eq!(*pty_writes.borrow(), vec![b"osc52:readable".to_vec()]);
+    })
+}
+
+#[test]
+fn test_osc52_clipboard_read_blocked_by_default() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            let access = *TerminalSettings::as_ref(ctx).osc52_clipboard_access;
+            assert_eq!(
+                access,
+                crate::terminal::settings::Osc52ClipboardAccess::WriteOnly
+            );
+            ctx.clipboard()
+                .write(ClipboardContent::plain_text("not-readable".to_owned()));
+            view.test_handle_osc52_load(ctx);
+        });
+
+        assert!(pty_writes.borrow().is_empty());
+    })
+}
+
+#[test]
+fn test_osc52_clipboard_read_blocked_when_deny() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            TerminalSettings::handle(ctx).update(ctx, |settings, ctx| {
+                let _ = settings
+                    .osc52_clipboard_access
+                    .set_value(crate::terminal::settings::Osc52ClipboardAccess::Deny, ctx);
+            });
+            ctx.clipboard()
+                .write(ClipboardContent::plain_text("not-readable".to_owned()));
+            view.test_handle_osc52_load(ctx);
+        });
+
+        assert!(pty_writes.borrow().is_empty());
+    })
+}
+
+#[test]
 fn test_copy_on_select() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);


### PR DESCRIPTION
## Summary

- Changes the default `terminal.osc52_clipboard_access` policy from `deny` to `write_only`.
- Restores OSC 52 clipboard writes out of the box for terminal-driven copy workflows.
- Keeps OSC 52 clipboard reads opt-in: reads are allowed only when users explicitly set `terminal.osc52_clipboard_access = "read_write"`.
- Updates the setting description and default-value coverage for `Osc52ClipboardAccess`.
- Adds view-level regression tests for OSC 52 write/read behavior across `read_write`, `write_only`, and `deny`.

## Root Cause

Starting with v0.2026.05.06, `settings_schema.json` shipped with `"osc52_clipboard_access": "deny"` as the default. That blocked OSC 52 clipboard writes, breaking workflows that rely on terminal-driven clipboard copy, including tmux, Neovim, remote editors, and other OSC 52 integrations.

The public code now already gates OSC 52 access behind `terminal.osc52_clipboard_access`, so this PR narrows the fix to the default policy. `write_only` restores clipboard-copy behavior while keeping clipboard reads disabled unless the user explicitly opts into `read_write`.

## Test plan

- [x] `git diff --check upstream/master...HEAD`
- [x] `PROTOC=$(brew --prefix protobuf)/bin/protoc BINDGEN_EXTRA_CLANG_ARGS="-isysroot $(xcrun --show-sdk-path)" cargo nextest run -p warp -- osc52`
  - Result: 13 tests passed; nextest reported 1 leaky test but exited successfully.
- [ ] Manual: `printf '\033]52;c;%s\a' "$(printf 'hello' | base64)"` in a Warp terminal should populate the clipboard with `hello`
- [ ] Manual: setting `terminal.osc52_clipboard_access = "deny"` in `~/.warp/settings.toml` should block the OSC 52 clipboard write above
- [ ] Manual: OSC 52 clipboard read should remain blocked by default and work only with `terminal.osc52_clipboard_access = "read_write"`

CHANGELOG-BUG-FIX: Restore OSC 52 clipboard writes by defaulting `osc52_clipboard_access` to `write_only`, while keeping OSC 52 reads opt-in (fixes #10516)
