### PR TITLE
Add parent-skill prerequisite preamble to -local specializers

### DIFF
--- a/.agents/skills/dedupe-issue-local/SKILL.md
+++ b/.agents/skills/dedupe-issue-local/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: dedupe-issue-local
 specializes: dedupe-issue
+specializes_source: warpdotdev/oz-for-oss:.agents/skills/dedupe-issue
 description: Repo-specific dedupe guidance for warp. Only the categories declared overridable by the core dedupe-issue skill may be specialized here.
 ---
 
 # Repo-specific dedupe guidance for `warp`
+
+## Prerequisite: install the parent skill
+
+This skill specializes the core `dedupe-issue` skill (named in the `specializes` frontmatter field) and is not functional on its own. Before applying its guidance, confirm the parent skill is installed and resolvable at `.agents/skills/dedupe-issue/SKILL.md`. If it is missing, install it first by copying the skill directory from the source declared in the `specializes_source` frontmatter field (`warpdotdev/oz-for-oss:.agents/skills/dedupe-issue`). Then continue with the guidance below.
 
 This file is a companion to the core `dedupe-issue` skill. It does not
 redefine the duplicate-detection algorithm, the similarity thresholds,

--- a/.agents/skills/reproduce-bug-report-local/SKILL.md
+++ b/.agents/skills/reproduce-bug-report-local/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: reproduce-bug-report-local
 specializes: reproduce-bug-report
+specializes_source: warpdotdev/common-skills:.agents/skills/reproduce-bug-report
 description: Repo-specific bug reproduction guidance for Warp. Specializes the core reproduce-bug-report skill for logged-out Warp UI repros, exact reporter-version installs, and login-free onboarding.
 ---
 
 # Repo-specific bug reproduction guidance for `warp`
+
+## Prerequisite: install the parent skill
+
+This skill specializes the core `reproduce-bug-report` skill (named in the `specializes` frontmatter field) and is not functional on its own. Before applying its guidance, confirm the parent skill is installed and resolvable at `.agents/skills/reproduce-bug-report/SKILL.md`. If it is missing, install it first by copying the skill directory from the source declared in the `specializes_source` frontmatter field (`warpdotdev/common-skills:.agents/skills/reproduce-bug-report`). Then continue with the guidance below.
 
 This file is a companion to the core `reproduce-bug-report` skill. It does not redefine the shared Oz computer-use orchestration, artifact handling, safety rules, or reporting format. It specializes scope and setup for Warp bug reports.
 

--- a/.agents/skills/review-pr-local/SKILL.md
+++ b/.agents/skills/review-pr-local/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: review-pr-local
 specializes: review-pr
+specializes_source: warpdotdev/common-skills:.agents/skills/review-pr
 description: Repo-specific review guidance for warp. Only the categories declared overridable by the core review-pr skill may be specialized here.
 ---
 
 # Repo-specific review guidance for `warp`
+
+## Prerequisite: install the parent skill
+
+This skill specializes the core `review-pr` skill (named in the `specializes` frontmatter field) and is not functional on its own. Before applying its guidance, confirm the parent skill is installed and resolvable at `.agents/skills/review-pr/SKILL.md`. If it is missing, install it first by copying the skill directory from the source declared in the `specializes_source` frontmatter field (`warpdotdev/common-skills:.agents/skills/review-pr`). Then continue with the guidance below.
 
 This file is a companion to the core `review-pr` skill. It does not
 redefine the review output schema, severity labels, safety rules, or

--- a/.agents/skills/triage-issue-local/SKILL.md
+++ b/.agents/skills/triage-issue-local/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: triage-issue-local
 specializes: triage-issue
+specializes_source: warpdotdev/oz-for-oss:.agents/skills/triage-issue
 description: Repo-specific triage guidance for warp. Only the categories declared overridable by the core triage-issue skill may be specialized here.
 ---
 
 # Repo-specific triage guidance for `warp`
+
+## Prerequisite: install the parent skill
+
+This skill specializes the core `triage-issue` skill (named in the `specializes` frontmatter field) and is not functional on its own. Before applying its guidance, confirm the parent skill is installed and resolvable at `.agents/skills/triage-issue/SKILL.md`. If it is missing, install it first by copying the skill directory from the source declared in the `specializes_source` frontmatter field (`warpdotdev/oz-for-oss:.agents/skills/triage-issue`). Then continue with the guidance below.
 
 This file is a companion to the core `triage-issue` skill. It does not
 redefine the triage output schema, safety rules, or follow-up-question


### PR DESCRIPTION
## Description
Each `-local` skill in `.agents/skills/` is a repo-specific specializer for a core "parent" skill that lives in a different repo. When the parent skill isn't installed in the checkout, agents that load the `-local` companion fail to resolve the parent (e.g. an agent looking for `review-pr` and not finding it).

This adds, to all four `-local` specializers:
- A standardized `## Prerequisite: install the parent skill` preamble (right after the H1) telling the agent to verify the parent resolves at `.agents/skills/<parent>/SKILL.md` and, if missing, install it from the named upstream before proceeding.
- A machine-readable `specializes_source` frontmatter field recording the upstream repo + path, so the preamble can stay generic and future tooling can automate the check/install.

Parent sources:
- `review-pr-local` → `warpdotdev/common-skills:.agents/skills/review-pr`
- `reproduce-bug-report-local` → `warpdotdev/common-skills:.agents/skills/reproduce-bug-report`
- `triage-issue-local` → `warpdotdev/oz-for-oss:.agents/skills/triage-issue`
- `dedupe-issue-local` → `warpdotdev/oz-for-oss:.agents/skills/dedupe-issue`

## Testing
Docs-only change to skill markdown files; no code paths affected. Verified each file received the frontmatter field and preamble and that frontmatter remains valid YAML.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/5aac570a-9baf-454f-85f9-42659f2e68c7_
_Run: https://oz.staging.warp.dev/runs/019eac78-85d6-76b9-beda-345cb7eac07a_

_This PR was generated with [Oz](https://warp.dev/oz)._
