### PR TITLE
Gracefully handle missing OS keyring in headless envs (REMOTE-1897)

### DIFF
--- a/crates/persistence/migrations/2026-06-09-000000_add_object_permissions_subject_type_index/down.sql
+++ b/crates/persistence/migrations/2026-06-09-000000_add_object_permissions_subject_type_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_object_permissions_subject_type;

--- a/crates/persistence/migrations/2026-06-09-000000_add_object_permissions_subject_type_index/up.sql
+++ b/crates/persistence/migrations/2026-06-09-000000_add_object_permissions_subject_type_index/up.sql
@@ -1,0 +1,9 @@
+-- Add an index on object_permissions(subject_type).
+--
+-- Without this index, SQLite builds a transient automatic index whenever a query
+-- filters or joins object_permissions on subject_type, which emits the noisy
+-- SQLITE_WARNING_AUTOINDEX diagnostic (error 284:
+-- "automatic index on object_permissions(subject_type)"). Materializing the
+-- index removes the warning and avoids the per-query autoindex work.
+CREATE INDEX IF NOT EXISTS idx_object_permissions_subject_type
+  ON object_permissions(subject_type);

--- a/crates/warpui_extras/src/secure_storage/linux.rs
+++ b/crates/warpui_extras/src/secure_storage/linux.rs
@@ -73,7 +73,18 @@ impl SecureStorage {
             .get_or_init(|| match Collection::open_default_collection() {
                 Ok(collection) => Some(collection),
                 Err(err) => {
-                    log::error!("Failed to acquire default Secret Service collection: {err:#}");
+                    // The OS keyring / Secret Service is frequently unavailable in
+                    // headless environments (CI, GitHub Actions, minimal Linux setups
+                    // without a running keyring daemon / D-Bus session). This is not
+                    // fatal: secret reads and writes transparently fall back to
+                    // encrypted on-disk storage (see `read_value` / `write_value`), so
+                    // we log at WARN rather than ERROR to avoid alarming users in those
+                    // environments.
+                    log::warn!(
+                        "OS Secret Service (keyring) unavailable; falling back to \
+                         encrypted on-disk secure storage. This is expected in headless \
+                         environments such as CI / GitHub Actions. Error: {err:#}"
+                    );
                     None
                 }
             })


### PR DESCRIPTION
## Description
Customer (Octopus Energy) running the Warp GitHub Actions / self-hosted `oz-agent-worker` integration reported the run surfacing:

```
[WARN] SQLite error 284 (Automatic indexing used ...): automatic index on object_permissions(subject_type)
[ERROR] Failed to acquire default Secret Service collection: unknown error
```

Both lines come from the `oz`/Warp binary that `oz-agent-worker` spawns (not the Go worker).

**Root cause:** in headless environments such as CI / GitHub Actions there is no running OS keyring / Secret Service (D-Bus session). On Linux, Warp's secure storage is registered **with an encrypted on-disk fallback** (`register_with_fallback`), so secret reads/writes transparently fall back and the run is **not** actually broken by this — but the keyring acquisition failure was logged at `error!`, which made the failure look fatal and alarmed the customer ("Unsure if it is a connectivity or token thing").

**Changes:**
1. `crates/warpui_extras/src/secure_storage/linux.rs`: downgrade the keyring-acquisition failure from `error!` to `warn!`, and clarify that Warp falls back to encrypted on-disk secure storage and that this is expected in headless environments (CI / GitHub Actions). The functional fallback was already in place; this only changes the (misleading) diagnostic.
2. `crates/persistence/migrations/2026-06-09-000000_add_object_permissions_subject_type_index/`: add an index on `object_permissions(subject_type)` so SQLite no longer builds a transient automatic index, eliminating the `SQLITE_WARNING_AUTOINDEX` (error 284) diagnostic emitted alongside the keyring error.

## Linked Issue
Linear: REMOTE-1897 (delegated from Feedback Bot). Not a GitHub issue, so the `ready-to-spec` / `ready-to-implement` checkboxes below are not applicable.

## Testing
- Scoped `cargo check -p persistence --features local_fs` (exercises `embed_migrations!` over the new migration dir) and `cargo check -p warpui_extras` — both compile.
- `cargo fmt -p warpui_extras -p persistence -- --check` — clean.
- `cargo clippy -p warpui_extras -- -D warnings` and `cargo clippy -p persistence --features local_fs -- -D warnings` — clean.
- The full workspace build/clippy was not run here due to environment resource limits; changes are limited to a log-level/message change and an embedded SQL migration.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Warp no longer logs a misleading OS keyring ("Secret Service") error in headless environments such as CI / GitHub Actions; it now logs a clear warning and falls back to encrypted on-disk secure storage as before.
-->

---
_Conversation: https://staging.warp.dev/conversation/c714dc54-c92f-41fa-93f0-12e410634b71_

_Run: https://oz.staging.warp.dev/runs/019eac7e-c72a-7ee0-adc4-5c3289016d20_

_This PR was generated with [Oz](https://warp.dev/oz)._
