### PR TITLE
Surface failed state when Cloud Mode setup terminates mid-setup

### DIFF
--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -871,6 +871,14 @@ impl TerminalManager {
                     if !is_owner {
                         Self::stop_orchestration_polling(&orchestration_viewer_model, ctx);
                     }
+                    // The spawn-status stream completes once the setup session
+                    // is joinable, so a setup-command failure surfaces only as
+                    // the session ending mid-setup. Leave the stuck "Running
+                    // setup commands…" / queued state for a terminal failed
+                    // state when that happens (no-op outside the setup phase).
+                    view.update(ctx, |terminal_view, ctx| {
+                        terminal_view.maybe_fail_cloud_mode_setup_on_session_end(ctx);
+                    });
                 } else {
                     Self::stop_orchestration_polling(&orchestration_viewer_model, ctx);
                     Self::shared_session_ended(&view, model.clone(), ctx);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7944,6 +7944,41 @@ impl TerminalView {
             )
     }
 
+    /// Surfaces a terminal failed state when a cloud-mode shared session ends
+    /// while the run is still in the environment-setup phase (before the agent's
+    /// first exchange). The spawn-status stream completes once the setup session
+    /// becomes joinable, so a setup-command failure that happens afterwards is
+    /// only observable to the client as the session ending mid-setup — the
+    /// otherwise-stuck "Running setup commands…" / queued state described in
+    /// APP-4693. Outside the setup phase this is a no-op, so normal run
+    /// completions and post-first-exchange failures are unaffected.
+    pub(crate) fn maybe_fail_cloud_mode_setup_on_session_end(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !FeatureFlag::CloudModeSetupV2.is_enabled() {
+            return;
+        }
+        let Some(ambient_agent_view_model) = self.ambient_agent_view_model.clone() else {
+            return;
+        };
+        let is_pre_first_exchange = {
+            let model = self.model.lock();
+            ambient_agent::is_cloud_agent_pre_first_exchange(
+                Some(&ambient_agent_view_model),
+                &self.agent_view_controller,
+                &model,
+                ctx,
+            )
+        };
+        if !is_pre_first_exchange {
+            return;
+        }
+        ambient_agent_view_model.update(ctx, |model, ctx| {
+            model.fail_due_to_setup_termination(ctx);
+        });
+    }
+
     /// Give the agent control of the active long running command
     /// (which was started outside of a conversation).
     fn tag_agent_in(&mut self, ctx: &mut ViewContext<Self>) {

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -64,6 +64,12 @@ const HANDOFF_CONTINUE_PROMPT: &str = "Continue";
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 const HANDOFF_APPLY_SNAPSHOT_PROMPT: &str = "Apply the workspace changes from my previous session.";
 
+/// Surfaced when a cloud run's shared session ends while environment setup is
+/// still running (before the agent produces its first exchange) — e.g. a setup
+/// command exited non-zero. The Oz webapp shows this as a terminal failure, so
+/// the client matches it instead of staying stuck on "Running setup commands…".
+const CLOUD_SETUP_FAILED_MESSAGE: &str = "Environment setup failed before the agent could start.";
+
 /// Tracks progress timestamps for each step during ambient agent spawning.
 #[derive(Debug, Clone)]
 pub struct AgentProgress {
@@ -1049,6 +1055,34 @@ impl AmbientAgentViewModel {
             ctx.emit(AmbientAgentViewModelEvent::RunLifecycleChanged);
         }
         self.last_ended_execution_session_id = Some(session_id);
+    }
+
+    /// Transitions an in-flight cloud run to [`Status::Failed`] when its shared
+    /// session ends during the environment-setup phase (before the agent's
+    /// first exchange). The spawn-status stream completes once the setup session
+    /// becomes joinable, so a setup-command failure that happens afterwards is
+    /// only observable to the client as the shared session ending mid-setup;
+    /// without this the UI stays stuck on "Running setup commands…".
+    ///
+    /// Finishes the active setup-command group so the summary stops reporting
+    /// "Running setup commands…", then reuses [`Self::handle_spawn_error`] so the
+    /// same terminal failed UI (tombstone, error conversation status) the Oz
+    /// webapp shows is surfaced in the client.
+    ///
+    /// The caller is responsible for confirming the run is still in the
+    /// pre-first-exchange phase (see `is_cloud_agent_pre_first_exchange`).
+    /// No-op once the run has already resolved to a failed, cancelled, or
+    /// auth-required state.
+    pub(crate) fn fail_due_to_setup_termination(&mut self, ctx: &mut ModelContext<Self>) {
+        if matches!(
+            self.status,
+            Status::Failed { .. } | Status::Cancelled { .. } | Status::NeedsGithubAuth { .. }
+        ) {
+            return;
+        }
+        let group_id = self.setup_commands_state.current_group_id();
+        self.finish_setup_command_group(group_id, ctx);
+        self.handle_spawn_error(CLOUD_SETUP_FAILED_MESSAGE.to_string(), ctx);
     }
 
     /// Attach a new execution session to an existing ambient agent pane (e.g. when the

--- a/app/src/terminal/view/ambient_agent/model_tests.rs
+++ b/app/src/terminal/view/ambient_agent/model_tests.rs
@@ -666,3 +666,57 @@ fn empty_prompt_submit_handoff_with_idle_source_and_no_snapshot_sends_none_on_th
         });
     });
 }
+
+#[test]
+fn fail_due_to_setup_termination_transitions_running_run_to_failed() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+
+        model.update(&mut app, |model, _| {
+            // Mirror the post-`SessionStarted` state: the run is "running" (the
+            // setup session is joinable) but the setup-command group is still
+            // marked running because no first exchange has arrived yet.
+            model.status = Status::AgentRunning;
+            let group_id = model.setup_command_state().current_group_id();
+            assert!(model.setup_command_state().is_running(group_id));
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.fail_due_to_setup_termination(ctx);
+        });
+
+        model.read(&app, |model, _| {
+            assert!(model.is_failed());
+            assert_eq!(model.error_message(), Some(CLOUD_SETUP_FAILED_MESSAGE));
+            let group_id = model.setup_command_state().current_group_id();
+            assert!(
+                !model.setup_command_state().is_running(group_id),
+                "the setup-command group should be finished so the summary stops \
+                 reporting \"Running setup commands…\"",
+            );
+        });
+    });
+}
+
+#[test]
+fn fail_due_to_setup_termination_is_noop_once_already_resolved() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let model = add_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.status = Status::Failed {
+                progress: AgentProgress::new(),
+                error_message: "original failure".to_string(),
+            };
+            model.fail_due_to_setup_termination(ctx);
+        });
+
+        model.read(&app, |model, _| {
+            // The pre-existing failure message must be preserved, not clobbered
+            // by the setup-termination message.
+            assert_eq!(model.error_message(), Some("original failure"));
+        });
+    });
+}


### PR DESCRIPTION
## Description
In Cloud Mode, when an environment **setup command fails after the run's shared session has become joinable**, the client UI gets stuck showing "Running setup commands…" with a "Queued" status, even though this is a terminal failure (correctly reflected in the Oz webapp).

Root cause: the spawn-status stream completes as soon as the session becomes joinable (`spawn_task` returns on `SessionStarted` in `app/src/ai/ambient_agents/spawn.rs`). Environment setup commands then run *inside* that shared session. A failure after this point is never observed by the ambient view model — the status stream has ended, so the model stays in `AgentRunning` and the setup-command group keeps reporting "Running setup commands…".

The client's remaining signal in this window is the shared session ending mid-setup. This PR handles `NetworkEvent::SessionEnded` for ambient sessions: if the run is still pre-first-exchange (`is_cloud_agent_pre_first_exchange`), it finishes the active setup-command group and transitions the run to `Failed`, reusing the existing failed-state UI (conversation-ended tombstone + error conversation status). Outside the setup phase this is a no-op, so normal run completions and post-first-exchange failures are unaffected.

Changes:
- `model.rs`: new `fail_due_to_setup_termination` that finishes the setup-command group and routes through the existing `handle_spawn_error` transition. No-op if the run already resolved.
- `view.rs`: new `maybe_fail_cloud_mode_setup_on_session_end` helper, gated on `CloudModeSetupV2` + pre-first-exchange.
- `terminal_manager.rs`: call the helper from the `SessionEnded` ambient branch.

## Linked Issue
APP-4693

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Added unit tests in `model_tests.rs`:
- `fail_due_to_setup_termination_transitions_running_run_to_failed` — an `AgentRunning` run with a still-running setup group transitions to `Failed`, surfaces the failure message, and finishes the setup group.
- `fail_due_to_setup_termination_is_noop_once_already_resolved` — preserves the original failure when already terminal.

Both pass (`cargo nextest run -p warp fail_due_to_setup_termination`). `cargo clippy -p warp --lib` and `./script/format` are clean. Note: this path is observable only against a live cloud run whose environment setup fails after the session is joinable, so it could not be exercised end-to-end in this sandbox.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Cloud Mode now shows a failed state when an environment setup command fails, instead of appearing stuck on "Running setup commands…".
-->

_Conversation: https://staging.warp.dev/conversation/b65b94d6-6a08-486a-9fa2-c3d2ca1e6b71_
_Run: https://oz.staging.warp.dev/runs/019eac7f-540b-7662-b3d6-6fd081c29586_

_This PR was generated with [Oz](https://warp.dev/oz)._
