### PR TITLE
Scroll vertical tabs panel to active tab when joining a shared session

### DIFF
--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -534,6 +534,13 @@ pub enum WorkspaceAction {
         page: SettingsSection,
         widget_id: &'static str,
     },
+    /// Scroll the vertical tabs panel so the active tab is visible.
+    ///
+    /// Dispatched (typically deferred) after programmatically adding and
+    /// activating a tab so the panel reliably scrolls the new active tab into
+    /// view once it has been laid out, even when the activation's immediate
+    /// scroll request was consumed before the new tab was rendered.
+    ScrollVerticalTabsToActiveTab,
     /// Navigate to an existing AI conversation, focusing on its terminal view.
     ///
     /// If the conversation is not in an open pane, restore it based on the layout setting or override.
@@ -982,6 +989,7 @@ impl WorkspaceAction {
             | ToggleVerticalTabsShowPrLink
             | ToggleVerticalTabsShowDiffStats
             | ToggleVerticalTabsShowDetailsOnHover
+            | ScrollVerticalTabsToActiveTab
             | ToggleWelcomeTips
             | CopyTextToClipboard(_)
             | CopyAccessTokenToClipboard

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -4176,6 +4176,14 @@ impl Workspace {
 
         self.tabs.push(TabData::new(new_pane_group));
         self.activate_tab_internal(self.tab_count() - 1, ctx);
+
+        // Joining a shared session frequently brings a background window to the
+        // foreground, and that window-show repaint can consume the activation's
+        // scroll-to-active-tab request before the new tab has been laid out into
+        // the vertical tabs panel, leaving the active tab scrolled out of view.
+        // Re-issue the scroll on a later turn, once the new tab is part of the
+        // rendered panel.
+        ctx.dispatch_typed_action_deferred(WorkspaceAction::ScrollVerticalTabsToActiveTab);
     }
 
     /// Opens a cloud conversation by server token.
@@ -5209,6 +5217,19 @@ impl Workspace {
         }
     }
 
+    /// Scrolls the vertical tabs panel so the active tab is visible, when the
+    /// panel is open and in use. Safe to call repeatedly: it's a no-op when the
+    /// active tab is already fully in view.
+    fn scroll_vertical_tabs_to_active_tab(&self, ctx: &AppContext) {
+        if self.vertical_tabs_panel_open
+            && FeatureFlag::VerticalTabs.is_enabled()
+            && *TabSettings::as_ref(ctx).use_vertical_tabs
+        {
+            self.vertical_tabs_panel
+                .scroll_to_tab(self.active_tab_index);
+        }
+    }
+
     /// Change the active tab index. This must be used instead of setting `self.active_tab_index`
     /// directly, as it updates related state.
     pub(crate) fn set_active_tab_index(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
@@ -5233,12 +5254,7 @@ impl Workspace {
             self.tab_mru_order.retain(|id| *id != pane_group_id);
             self.tab_mru_order.insert(0, pane_group_id);
         }
-        if self.vertical_tabs_panel_open
-            && FeatureFlag::VerticalTabs.is_enabled()
-            && *TabSettings::as_ref(ctx).use_vertical_tabs
-        {
-            self.vertical_tabs_panel.scroll_to_tab(index);
-        }
+        self.scroll_vertical_tabs_to_active_tab(ctx);
 
         if self.left_panel_visibility_across_tabs_enabled(ctx) {
             self.reconcile_left_panel_open_for_active_tab(ctx);
@@ -24229,6 +24245,9 @@ impl TypedActionView for Workspace {
                     settings.scroll_to_settings_widget(*page, widget_id, ctx);
                 });
                 ctx.notify();
+            }
+            ScrollVerticalTabsToActiveTab => {
+                self.scroll_vertical_tabs_to_active_tab(ctx);
             }
             OpenFileInNewTab {
                 full_path,


### PR DESCRIPTION
## Description
When opening a shared session viewer, Warp creates a new tab and makes it the active tab, but the vertical tabs side panel did not scroll to bring that tab into view, so a newly-joined session could land off-screen.

All tab-activation paths already request a scroll-to-active-tab in `set_active_tab_index`, and that request works for tabs added to the currently-focused window. The shared-session join flow is unique in that it brings a (frequently backgrounded) window to the foreground via `show_window_and_focus_app` right after adding and activating the tab. That window-show repaint can consume the activation's scroll-to-position request before the new tab has been laid out into the panel, so the request is dropped and the active tab stays out of view. Shared-session tabs are always appended at the end of the tab list, so this is exactly where an off-screen active tab is most visible.

Fix: after joining a shared session, re-issue the scroll on a deferred turn via a new `WorkspaceAction::ScrollVerticalTabsToActiveTab`. The deferred action runs once the new tab is part of the rendered panel, where the scroll-to-position machinery reliably brings the active tab into view. The scroll logic is extracted into a shared `scroll_vertical_tabs_to_active_tab` helper used by both `set_active_tab_index` and the new action.

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed the tabs side panel not scrolling to the new tab when joining a shared session.
-->

_Conversation: https://staging.warp.dev/conversation/c414805c-d6b5-49fe-abb6-711111a29394_

_Run: https://oz.staging.warp.dev/runs/019eacd0-b25c-77dd-948a-cbf007a26d4b_

_This PR was generated with [Oz](https://warp.dev/oz)._
