### PR TITLE
warpui_core: parameterize AppContext by a Backend trait (GUI unchanged)

### DIFF
--- a/crates/warpui_core/Cargo.toml
+++ b/crates/warpui_core/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT"
 
 [features]
 traces = []
+# Selects the TUI backend instead of the default GUI backend. A build is
+# GUI xor TUI: under this feature the public `AppContext` alias resolves to the
+# TUI backend instantiation (the TUI backend itself is added in a later milestone).
+tui = []
 # Feature enabled only when app is compiled for integration tests.
 integration_tests = ["dep:minimp4", "dep:openh264"]
 # If enabled, writes named telemetry events to the info log.  Should never be

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -21,9 +21,9 @@ use pathfinder_geometry::vector::Vector2F;
 use rustc_hash::FxHashMap;
 
 use super::{
-    autotracking, ActionCallback, BlurContext, FocusContext, GlobalActionCallback, GlobalShortcut,
-    InvalidationCallback, Observation, PendingUnsubscribes, RefCounts, Subscription, TaskCallback,
-    TypedActionCallback, ViewType,
+    autotracking, ActionCallback, Backend, BlurContext, FocusContext, GlobalActionCallback,
+    GlobalShortcut, GuiBackend, GuiPresenterState, Observation, PendingUnsubscribes, RefCounts,
+    Subscription, TaskCallback, TypedActionCallback, ViewType,
 };
 use crate::accessibility::{AccessibilityVerbosity, ActionAccessibilityContent};
 use crate::actions::StandardAction;
@@ -566,7 +566,10 @@ pub type FrameDrawnCallback = dyn Fn(&mut AppContext, WindowId);
 
 pub type BeforeOpenUrlCallback = dyn Fn(&str, &AppContext) -> String;
 
-pub struct AppContext {
+/// The generic application context. The public [`AppContext`] name is a
+/// feature-gated type alias to a fixed instantiation of this struct (GUI by
+/// default), so existing call sites that name `AppContext` never mention `B`.
+pub struct AppContextImpl<B: Backend> {
     /////////////////////////
     // Fields from AppContext
     /////////////////////////
@@ -578,8 +581,7 @@ pub struct AppContext {
     /// We use an FxHashMap here because `TypeId` hashes as a u64, and FxHasher
     /// is the fastest commonly-used hasher for this type.
     singleton_models: FxHashMap<TypeId, AnyModelHandle>,
-    last_frame_position_cache: HashMap<WindowId, crate::presenter::PositionCache>,
-    pub(super) windows: HashMap<WindowId, Window>,
+    pub(super) windows: HashMap<WindowId, Window<B>>,
     pub(super) ref_counts: Arc<Mutex<RefCounts>>,
     pub(super) platform_delegate: Box<dyn platform::Delegate>,
 
@@ -595,7 +597,10 @@ pub struct AppContext {
     /// Safety Note: The `TypedActionCallback` must only be called with parameters that match the
     /// type keys, as it requires the values to appropriately downcast.
     typed_actions: HashMap<ActionType, HashMap<ViewType, Box<TypedActionCallback>>>,
-    presenters: HashMap<WindowId, Rc<RefCell<Presenter>>>,
+    /// Backend-specific presentation state, hoisted into [`Backend::Presenter`] so
+    /// the generic core never names a GUI-only presenter/position-cache/
+    /// invalidation type. GUI: [`GuiPresenterState`].
+    presentation: B::Presenter,
     /// Configuration options related to rendering of the application.
     rendering_config: rendering::Config,
     global_actions: HashMap<String, Vec<Box<GlobalActionCallback>>>,
@@ -608,8 +613,6 @@ pub struct AppContext {
     /// When `emit_event` is processing callbacks, unsubscribes are deferred here to avoid
     /// O(N²) tombstone scanning. The unsubscribes are processed at the end of event emission.
     pub(super) pending_unsubscribes: Option<PendingUnsubscribes>,
-    window_invalidations: HashMap<WindowId, WindowInvalidation>,
-    invalidation_callbacks: HashMap<WindowId, Box<InvalidationCallback>>,
     disabled_key_bindings_windows: HashSet<WindowId>,
     window_bounds: HashMap<WindowId, Option<RectF>>,
     next_window_bounds_map: HashMap<WindowId, NextNewWindowsHasThisWindowsBoundsUponClose>,
@@ -708,6 +711,12 @@ pub struct AppContext {
     fallback_font_source_provider: Option<Box<dyn Fn(&str) -> AssetSource>>,
 }
 
+/// The public application-context name. Existing call sites use this alias and
+/// never mention `B`. A build is GUI **xor** TUI; the TUI instantiation is added
+/// in a later milestone.
+#[cfg(not(feature = "tui"))]
+pub type AppContext = AppContextImpl<GuiBackend>;
+
 impl AppContext {
     pub(crate) fn new(
         platform_delegate: Box<dyn platform::Delegate>,
@@ -751,13 +760,12 @@ impl AppContext {
             singleton_models: Default::default(),
             windows: Default::default(),
             ref_counts: Arc::new(Mutex::new(RefCounts::default())),
-            last_frame_position_cache: Default::default(),
             platform_delegate,
             // AppContext fields
             actions: Default::default(),
             typed_actions: Default::default(),
             global_actions: Default::default(),
-            presenters: Default::default(),
+            presentation: GuiPresenterState::default(),
             rendering_config: Default::default(),
             keystroke_matcher: Default::default(),
             disabled_key_bindings_windows: Default::default(),
@@ -768,8 +776,6 @@ impl AppContext {
             next_window_bounds_map: Default::default(),
             observations: Default::default(),
             pending_unsubscribes: None,
-            window_invalidations: Default::default(),
-            invalidation_callbacks: Default::default(),
             window_bounds: Default::default(),
             window_last_mouse_moved_event: Default::default(),
             foreground: foreground.clone(),
@@ -931,7 +937,8 @@ impl AppContext {
     }
 
     pub fn has_window_invalidations(&self, window_id: WindowId) -> bool {
-        self.window_invalidations
+        self.presentation
+            .window_invalidations
             .get(&window_id)
             .is_some_and(|invalidation| {
                 !invalidation.updated.is_empty() || !invalidation.removed.is_empty()
@@ -942,14 +949,15 @@ impl AppContext {
         // The presenter may not exist if there is a race condition where a window event comes in
         // after the window is closed (for example, if a fullscreen window is closed, a resize event
         // comes in after the window is closed.
-        self.presenters.get(&window_id).cloned()
+        self.presentation.presenters.get(&window_id).cloned()
     }
 
     fn invalidate_all_views_for_window(&mut self, window_id: WindowId) {
         let Some(window) = self.windows.get(&window_id) else {
             return;
         };
-        self.window_invalidations
+        self.presentation
+            .window_invalidations
             .entry(window_id)
             .or_default()
             .updated = window.views.keys().cloned().collect();
@@ -974,7 +982,8 @@ impl AppContext {
         window_id: WindowId,
         callback: F,
     ) {
-        self.invalidation_callbacks
+        self.presentation
+            .invalidation_callbacks
             .insert(window_id, Box::new(callback));
     }
 
@@ -2307,7 +2316,8 @@ impl AppContext {
         // from the last closed position after a new window has been created.
         self.next_window_bounds = None;
 
-        self.presenters
+        self.presentation
+            .presenters
             .insert(window_id, Rc::new(RefCell::new(Presenter::new(window_id))));
 
         let window_options = WindowOptions {
@@ -2550,9 +2560,9 @@ impl AppContext {
         WindowManager::handle(self).update(self, |windowing_state, ctx| {
             windowing_state.remove_window(window_id, ctx);
         });
-        self.presenters.remove(&window_id);
-        self.invalidation_callbacks.remove(&window_id);
-        self.window_invalidations.remove(&window_id);
+        self.presentation.presenters.remove(&window_id);
+        self.presentation.invalidation_callbacks.remove(&window_id);
+        self.presentation.window_invalidations.remove(&window_id);
         autotracking::close_window(window_id);
 
         let mut subscriptions = HashMap::new();
@@ -2748,7 +2758,8 @@ impl AppContext {
                 );
 
                 // Cache the last position cache after rendering.
-                self.last_frame_position_cache
+                self.presentation
+                    .last_frame_position_cache
                     .insert(window_id, presenter.position_cache().clone());
             }
 
@@ -2805,7 +2816,8 @@ impl AppContext {
                 panic!("Window does not exist");
             }
             self.view_to_window.insert(view_id, window_id);
-            self.window_invalidations
+            self.presentation
+                .window_invalidations
                 .entry(window_id)
                 .or_default()
                 .updated
@@ -2898,7 +2910,8 @@ impl AppContext {
         // Register the action handler for this view type (if it hasn't already been added)
         self.add_typed_action::<V>();
         // Mark the view as needing to be drawn
-        self.window_invalidations
+        self.presentation
+            .window_invalidations
             .entry(window_id)
             .or_default()
             .updated
@@ -2937,7 +2950,8 @@ impl AppContext {
 
         // Mark the view as removed from the source window's invalidation set.
         // This tells the renderer to stop tracking this view in the source window.
-        self.window_invalidations
+        self.presentation
+            .window_invalidations
             .entry(source_window_id)
             .or_default()
             .removed
@@ -2954,7 +2968,8 @@ impl AppContext {
         target_window.views.insert(view_id, view);
         self.view_to_window.insert(view_id, target_window_id);
 
-        self.window_invalidations
+        self.presentation
+            .window_invalidations
             .entry(target_window_id)
             .or_default()
             .updated
@@ -3099,7 +3114,8 @@ impl AppContext {
                 self.structural_parent_to_children.remove(&view_id);
 
                 if let Some(window) = self.windows.get_mut(&current_window_id) {
-                    self.window_invalidations
+                    self.presentation
+                        .window_invalidations
                         .entry(current_window_id)
                         .or_default()
                         .removed
@@ -3156,6 +3172,7 @@ impl AppContext {
 
     fn update_windows(&mut self) {
         let invalidated_window_ids = self
+            .presentation
             .window_invalidations
             .keys()
             .chain(autotracking::windows_with_invalidations().iter())
@@ -3163,9 +3180,12 @@ impl AppContext {
             .cloned()
             .collect_vec();
         for window_id in invalidated_window_ids {
-            if let Some(mut callback) = self.invalidation_callbacks.remove(&window_id) {
+            if let Some(mut callback) = self.presentation.invalidation_callbacks.remove(&window_id)
+            {
                 callback(window_id, self);
-                self.invalidation_callbacks.insert(window_id, callback);
+                self.presentation
+                    .invalidation_callbacks
+                    .insert(window_id, callback);
             }
         }
     }
@@ -3180,6 +3200,7 @@ impl AppContext {
         window_id: WindowId,
     ) -> WindowInvalidation {
         let mut invalidations = self
+            .presentation
             .window_invalidations
             .remove(&window_id)
             .unwrap_or_default();
@@ -3286,7 +3307,8 @@ impl AppContext {
 
                 // If the timer is no longer in repaint_tasks, it was cancelled.
                 if app.repaint_tasks.remove(&task_id).is_some() {
-                    app.window_invalidations
+                    app.presentation
+                        .window_invalidations
                         .entry(window_id)
                         .or_default()
                         .redraw_requested = true;
@@ -3341,7 +3363,7 @@ impl AppContext {
 
                 // If the timer is no longer in repaint_tasks, it was cancelled.
                 if app.repaint_tasks.remove(&task_id).is_some() {
-                    app.window_invalidations
+                    app.presentation.window_invalidations
                         .entry(window_id)
                         .or_default()
                         .redraw_requested = true;
@@ -3453,7 +3475,8 @@ impl AppContext {
         }
 
         // Trigger a redraw on the window.
-        self.window_invalidations
+        self.presentation
+            .window_invalidations
             .entry(window_id)
             .or_default()
             .redraw_requested = true;
@@ -3772,7 +3795,8 @@ impl AppContext {
     }
 
     fn notify_view_observers(&mut self, window_id: WindowId, view_id: EntityId) {
-        self.window_invalidations
+        self.presentation
+            .window_invalidations
             .entry(window_id)
             .or_default()
             .updated
@@ -4357,7 +4381,7 @@ impl AddSingletonModel for AppContext {
 
 pub struct ClosedWindowData {
     pub window_id: WindowId,
-    window: Window,
+    window: Window<GuiBackend>,
     subscriptions: HashMap<EntityId, Vec<Subscription>>,
     observations: HashMap<EntityId, Vec<Observation>>,
     view_to_window: HashMap<EntityId, WindowId>,
@@ -4494,7 +4518,8 @@ impl AppContext {
     where
         S: AsRef<str>,
     {
-        self.last_frame_position_cache
+        self.presentation
+            .last_frame_position_cache
             .get(&window_id)
             .and_then(|position_cache| position_cache.get_position(id))
     }

--- a/crates/warpui_core/src/core/backend.rs
+++ b/crates/warpui_core/src/core/backend.rs
@@ -1,0 +1,103 @@
+//! The `Backend` marker trait and the bridges that let the shared application
+//! core store and render backend-specific view objects without naming the
+//! concrete view trait.
+//!
+//! This is the parameterization seam. [`AppContextImpl<B>`](super::AppContextImpl)
+//! and [`Window<B>`](super::Window) are generic over `B: Backend`, and the
+//! associated types below carry the pieces that differ between the GUI backend
+//! (here, [`GuiBackend`]) and the TUI backend (added in a later milestone): the
+//! type-erased per-window view object, a view's render output, and the
+//! presentation layer.
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use super::{AnyView, AppContextImpl, InvalidationCallback};
+use crate::presenter::PositionCache;
+use crate::{Element, Presenter, View, WindowId, WindowInvalidation};
+
+/// Marker trait selecting a UI backend (GUI or TUI).
+///
+/// Rust cannot express an "associated trait", so the divergent view trait
+/// (`View` for GUI, `TuiView` for the TUI backend) is reached indirectly through
+/// the type-erased [`AnyView`](Self::AnyView) object stored per window and the
+/// [`RenderOutput`](Self::RenderOutput) it produces.
+pub trait Backend: Sized + 'static {
+    /// What a view of this backend renders to. GUI: `Box<dyn Element>`.
+    type RenderOutput;
+
+    /// The type-erased per-window view object, stored as `Box<Self::AnyView>` in
+    /// [`Window<B>::views`](super::Window). GUI: `dyn AnyView`.
+    ///
+    /// Bounded by [`ErasedView<Self>`] so the shared core can render any stored
+    /// view without naming the concrete view trait.
+    type AnyView: ?Sized + ErasedView<Self>;
+
+    /// The backend's presentation layer (lays out + paints a window's view tree)
+    /// plus the bookkeeping that drives it. GUI: [`GuiPresenterState`].
+    ///
+    /// Hoisted here so the generic core stores `B::Presenter` and never names a
+    /// backend-specific concrete presentation type; the GUI presenter API is
+    /// reached only through methods on the `AppContext` alias whose signatures
+    /// resolve through this associated type.
+    type Presenter;
+}
+
+/// The object-safe surface the shared core needs from any stored view: render it
+/// to the backend's output, and recover its concrete type during `update_view`.
+///
+/// For the GUI backend this is satisfied by the existing [`AnyView`] trait, which
+/// additionally carries the focus/blur/keymap/a11y hooks.
+pub trait ErasedView<B: Backend> {
+    fn render(&self, app: &AppContextImpl<B>) -> B::RenderOutput;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+/// Bridges a concrete view `T` into the backend's erased view object.
+///
+/// The single blanket impl per backend is where the `Box<T> -> Box<Self::AnyView>`
+/// unsizing coercion happens, so the generic core can box any concrete view
+/// without naming the view trait. A `T: View` bound on a GUI call site therefore
+/// satisfies `T: BackendView<GuiBackend>` automatically.
+pub trait BackendView<B: Backend>: 'static {
+    fn into_any_view(self: Box<Self>) -> Box<B::AnyView>;
+}
+
+/// The GUI backend marker.
+pub struct GuiBackend;
+
+impl Backend for GuiBackend {
+    type RenderOutput = Box<dyn Element>;
+    type AnyView = dyn AnyView;
+    type Presenter = GuiPresenterState;
+}
+
+impl ErasedView<GuiBackend> for dyn AnyView {
+    fn render(&self, app: &AppContextImpl<GuiBackend>) -> Box<dyn Element> {
+        AnyView::render(self, app)
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        AnyView::as_any_mut(self)
+    }
+}
+
+impl<T: View> BackendView<GuiBackend> for T {
+    fn into_any_view(self: Box<Self>) -> Box<dyn AnyView> {
+        self
+    }
+}
+
+/// Presentation state for the GUI backend, stored on `AppContextImpl<GuiBackend>`
+/// as `B::Presenter`. Wraps today's presenter collection plus the position cache
+/// and window-invalidation bookkeeping, so the generic core holds only an opaque
+/// `B::Presenter` while GUI method signatures that touch this state are unchanged.
+#[derive(Default)]
+pub struct GuiPresenterState {
+    pub(crate) presenters: HashMap<WindowId, Rc<RefCell<Presenter>>>,
+    pub(crate) last_frame_position_cache: HashMap<WindowId, PositionCache>,
+    pub(crate) window_invalidations: HashMap<WindowId, WindowInvalidation>,
+    pub(crate) invalidation_callbacks: HashMap<WindowId, Box<InvalidationCallback>>,
+}

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -1,6 +1,7 @@
 mod action;
 mod app;
 mod autotracking;
+mod backend;
 mod entity;
 mod model;
 mod view;
@@ -20,6 +21,7 @@ pub use action::*;
 use anyhow::Error;
 pub use app::*;
 pub use autotracking::Tracked;
+pub use backend::{Backend, BackendView, ErasedView, GuiBackend, GuiPresenterState};
 use derivative::Derivative;
 pub use entity::*;
 use futures_util::future::BoxFuture;

--- a/crates/warpui_core/src/core/window.rs
+++ b/crates/warpui_core/src/core/window.rs
@@ -4,8 +4,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde::{Deserialize, Serialize};
 
+use crate::core::backend::Backend;
 use crate::core::view::AnyViewHandle;
-use crate::{AnyView, EntityId};
+use crate::EntityId;
 
 /// A unique identifier for a window.
 ///
@@ -36,14 +37,28 @@ impl fmt::Display for WindowId {
 
 /// A structure holding all application state that is linked to a particular
 /// window.
-#[derive(Default)]
-pub(super) struct Window {
+///
+/// Generic over the active [`Backend`]: only `views` is backend-specific (it holds
+/// the backend's type-erased view object). `root_view`/`focused_view` couple to
+/// neither the view trait nor `B` and are shared across backends.
+pub(super) struct Window<B: Backend> {
     /// The set of views owned by this window, keyed by view ID.
-    pub views: HashMap<EntityId, Box<dyn AnyView>>,
+    pub views: HashMap<EntityId, Box<B::AnyView>>,
 
     /// A handle to the window's root view (top of the view hierarchy), if any.
     pub root_view: Option<AnyViewHandle>,
 
     /// The ID of the currently focused view, if any.
     pub focused_view: Option<EntityId>,
+}
+
+// Manual impl: `#[derive(Default)]` would wrongly require `B: Default`.
+impl<B: Backend> Default for Window<B> {
+    fn default() -> Self {
+        Self {
+            views: HashMap::new(),
+            root_view: None,
+            focused_view: None,
+        }
+    }
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
