### PR TITLE
warpui_tui: crate foundation - geometry, buffer, TuiElement, events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15450,6 +15450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "warpui_tui"
+version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "warpui_core",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/warpui_tui/Cargo.toml
+++ b/crates/warpui_tui/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "warpui_tui"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+publish.workspace = true
+license = "MIT"
+
+[dependencies]
+crossterm = "0.29.0"
+unicode-segmentation = "1.11.0"
+unicode-width.workspace = true
+# The TUI backend instantiation of the shared core lives behind the `tui`
+# feature. Enabling it here is what makes `AppContext`/`App`/`TuiView` resolve to
+# the TUI backend for everything built on top of this crate.
+warpui_core = { workspace = true, features = ["tui"] }

--- a/crates/warpui_tui/src/buffer.rs
+++ b/crates/warpui_tui/src/buffer.rs
@@ -1,0 +1,302 @@
+//! The in-memory cell grid that elements paint into and the renderer flushes to
+//! the terminal.
+//!
+//! [`TuiBuffer`] is the headless assertion surface for the whole crate: every
+//! element/presenter test paints into a buffer and compares
+//! [`to_lines`](TuiBuffer::to_lines) (and, where style matters, individual
+//! [`get`](TuiBuffer::get) cells) against expected values. All writes are
+//! clipped to the buffer bounds and are wide- and combining-grapheme aware, so
+//! callers never have to bounds-check or measure text themselves.
+
+use crossterm::style::Color;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+use crate::{TuiRect, TuiSize};
+
+/// The visual styling applied to a [`Cell`]. Cheap to copy; equality is exact,
+/// which is what makes style-sensitive buffer assertions possible.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TuiStyle {
+    pub foreground: Option<Color>,
+    pub background: Option<Color>,
+    pub bold: bool,
+    pub dim: bool,
+    pub italic: bool,
+    pub underline: bool,
+    pub reversed: bool,
+}
+
+impl TuiStyle {
+    pub fn with_foreground(mut self, color: Color) -> Self {
+        self.foreground = Some(color);
+        self
+    }
+
+    pub fn with_background(mut self, color: Color) -> Self {
+        self.background = Some(color);
+        self
+    }
+
+    pub fn with_bold(mut self, bold: bool) -> Self {
+        self.bold = bold;
+        self
+    }
+
+    pub fn with_dim(mut self, dim: bool) -> Self {
+        self.dim = dim;
+        self
+    }
+
+    pub fn with_italic(mut self, italic: bool) -> Self {
+        self.italic = italic;
+        self
+    }
+
+    pub fn with_underline(mut self, underline: bool) -> Self {
+        self.underline = underline;
+        self
+    }
+
+    pub fn with_reversed(mut self, reversed: bool) -> Self {
+        self.reversed = reversed;
+        self
+    }
+}
+
+/// A single terminal cell: one grapheme cluster plus its style.
+///
+/// A grapheme that occupies more than one column (e.g. a CJK character) is
+/// stored as a leading cell holding the symbol followed by one or more
+/// *continuation* cells; the renderer skips continuation cells so the wide
+/// glyph is emitted exactly once. Construct printable cells with [`Cell::new`];
+/// continuation cells are produced internally by the buffer.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Cell {
+    symbol: String,
+    continuation: bool,
+    style: TuiStyle,
+}
+
+impl Cell {
+    /// A printable cell holding `symbol` (a single grapheme cluster) styled
+    /// with `style`.
+    pub fn new(symbol: impl Into<String>, style: TuiStyle) -> Self {
+        Self {
+            symbol: symbol.into(),
+            continuation: false,
+            style,
+        }
+    }
+
+    /// A blank (space) cell with default styling. This is the fill value of a
+    /// freshly constructed buffer.
+    pub fn blank() -> Self {
+        Self {
+            symbol: " ".to_owned(),
+            continuation: false,
+            style: TuiStyle::default(),
+        }
+    }
+
+    pub fn symbol(&self) -> &str {
+        &self.symbol
+    }
+
+    pub fn style(&self) -> TuiStyle {
+        self.style
+    }
+
+    /// Whether this cell is the trailing column of a preceding wide grapheme.
+    /// The renderer emits nothing for continuation cells.
+    pub fn is_continuation(&self) -> bool {
+        self.continuation
+    }
+
+    fn continuation(style: TuiStyle) -> Self {
+        Self {
+            symbol: String::new(),
+            continuation: true,
+            style,
+        }
+    }
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self::blank()
+    }
+}
+
+/// A fixed-size grid of [`Cell`]s addressed by `(x, y)` in column/row order.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TuiBuffer {
+    size: TuiSize,
+    cells: Vec<Cell>,
+}
+
+impl TuiBuffer {
+    /// A blank buffer of the given size.
+    pub fn new(size: TuiSize) -> Self {
+        Self {
+            size,
+            cells: vec![Cell::default(); size.area()],
+        }
+    }
+
+    pub fn size(&self) -> TuiSize {
+        self.size
+    }
+
+    /// The cell at `(x, y)`, or `None` if out of bounds.
+    pub fn get(&self, x: u16, y: u16) -> Option<&Cell> {
+        self.index(x, y).map(|index| &self.cells[index])
+    }
+
+    /// Writes a single printable cell at `(x, y)`. Out-of-bounds positions are
+    /// silently ignored. Continuation/empty cells are ignored, since the buffer
+    /// manages continuations itself; use [`set_str`](TuiBuffer::set_str) for
+    /// wide graphemes.
+    pub fn set_cell(&mut self, x: u16, y: u16, cell: Cell) {
+        if cell.continuation || cell.symbol.is_empty() {
+            return;
+        }
+        self.write_grapheme(x, y, &cell.symbol, cell.style);
+    }
+
+    /// Writes `text` starting at `(x, y)`, clipped to the lesser of `max_width`
+    /// columns and the buffer's right edge. Grapheme clusters that would cross
+    /// the limit are dropped whole (a wide glyph is never split). Returns the
+    /// number of columns actually advanced.
+    pub fn set_str(&mut self, x: u16, y: u16, max_width: u16, text: &str, style: TuiStyle) -> u16 {
+        if y >= self.size.height || x >= self.size.width {
+            return 0;
+        }
+        let limit = x.saturating_add(max_width).min(self.size.width);
+        let mut column = x;
+        for grapheme in text.graphemes(true) {
+            let width = grapheme_width(grapheme);
+            if column.saturating_add(width) > limit {
+                break;
+            }
+            self.write_grapheme(column, y, grapheme, style);
+            column = column.saturating_add(width);
+        }
+        column - x
+    }
+
+    /// Fills every cell of `rect` (intersected with the buffer) with a clone of
+    /// `cell`. Typically used to paint a styled background.
+    pub fn fill(&mut self, rect: TuiRect, cell: Cell) {
+        for y in rect.y..rect.bottom().min(self.size.height) {
+            for x in rect.x..rect.right().min(self.size.width) {
+                self.set_cell(x, y, cell.clone());
+            }
+        }
+    }
+
+    /// Renders the buffer to one `String` per row, omitting continuation cells
+    /// so wide glyphs appear once. This is the primary headless assertion hook.
+    pub fn to_lines(&self) -> Vec<String> {
+        (0..self.size.height)
+            .map(|y| {
+                let mut line = String::new();
+                for x in 0..self.size.width {
+                    if let Some(cell) = self.get(x, y) {
+                        if !cell.is_continuation() {
+                            line.push_str(cell.symbol());
+                        }
+                    }
+                }
+                line
+            })
+            .collect()
+    }
+
+    fn write_grapheme(&mut self, x: u16, y: u16, grapheme: &str, style: TuiStyle) {
+        let width = grapheme_width(grapheme);
+        if x >= self.size.width
+            || y >= self.size.height
+            || x.saturating_add(width) > self.size.width
+        {
+            return;
+        }
+
+        // Clear any wide grapheme we are about to partially overwrite, both at
+        // the head and across the columns the new grapheme will occupy.
+        self.clear_grapheme_at(x, y);
+        for continuation_x in (x + 1)..(x + width) {
+            self.clear_grapheme_at(continuation_x, y);
+        }
+
+        if let Some(index) = self.index(x, y) {
+            self.cells[index] = Cell {
+                symbol: grapheme.to_owned(),
+                continuation: false,
+                style,
+            };
+        }
+        for continuation_x in (x + 1)..(x + width) {
+            if let Some(index) = self.index(continuation_x, y) {
+                self.cells[index] = Cell::continuation(style);
+            }
+        }
+    }
+
+    /// Blanks the full grapheme covering `(x, y)`, walking left to the leading
+    /// cell if `(x, y)` is a continuation, then clearing its trailing cells.
+    fn clear_grapheme_at(&mut self, x: u16, y: u16) {
+        let Some(index) = self.index(x, y) else {
+            return;
+        };
+
+        if self.cells[index].is_continuation() {
+            let mut start_x = x;
+            while start_x > 0 {
+                let previous_x = start_x - 1;
+                let Some(previous_index) = self.index(previous_x, y) else {
+                    break;
+                };
+                start_x = previous_x;
+                if !self.cells[previous_index].is_continuation() {
+                    break;
+                }
+            }
+            self.clear_grapheme_at(start_x, y);
+            return;
+        }
+
+        self.cells[index] = Cell::blank();
+        let mut continuation_x = x.saturating_add(1);
+        while continuation_x < self.size.width {
+            let Some(continuation_index) = self.index(continuation_x, y) else {
+                break;
+            };
+            if !self.cells[continuation_index].is_continuation() {
+                break;
+            }
+            self.cells[continuation_index] = Cell::blank();
+            continuation_x += 1;
+        }
+    }
+
+    fn index(&self, x: u16, y: u16) -> Option<usize> {
+        if x >= self.size.width || y >= self.size.height {
+            return None;
+        }
+        Some(usize::from(y) * usize::from(self.size.width) + usize::from(x))
+    }
+}
+
+/// The column width of a grapheme cluster, floored at 1 so zero-width clusters
+/// (e.g. a lone combining mark) still occupy a cell.
+fn grapheme_width(grapheme: &str) -> u16 {
+    UnicodeWidthStr::width(grapheme)
+        .max(1)
+        .try_into()
+        .unwrap_or(u16::MAX)
+}
+
+#[cfg(test)]
+#[path = "buffer_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/buffer_tests.rs
+++ b/crates/warpui_tui/src/buffer_tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+#[test]
+fn writes_ascii_text_and_pads_with_blanks() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(5, 1));
+
+    let advanced = buffer.set_str(0, 0, 5, "abc", TuiStyle::default());
+
+    assert_eq!(advanced, 3);
+    assert_eq!(buffer.to_lines(), vec!["abc  "]);
+}
+
+#[test]
+fn writes_text_at_an_offset() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(5, 2));
+
+    buffer.set_str(2, 1, 5, "hi", TuiStyle::default());
+
+    assert_eq!(
+        buffer.to_lines(),
+        vec!["     ".to_owned(), "  hi ".to_owned()]
+    );
+}
+
+#[test]
+fn out_of_bounds_writes_are_clipped_not_panicking() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(3, 2));
+
+    // Entirely out of bounds in x, y: no-ops.
+    assert_eq!(buffer.set_str(9, 0, 5, "xx", TuiStyle::default()), 0);
+    assert_eq!(buffer.set_str(0, 9, 5, "xx", TuiStyle::default()), 0);
+    buffer.set_cell(9, 9, Cell::new("z", TuiStyle::default()));
+    assert!(buffer.get(9, 9).is_none());
+
+    // Partially off the right edge: only what fits is written.
+    let advanced = buffer.set_str(1, 0, 5, "world", TuiStyle::default());
+    assert_eq!(advanced, 2);
+    assert_eq!(buffer.to_lines(), vec![" wo".to_owned(), "   ".to_owned()]);
+}
+
+#[test]
+fn max_width_clips_before_the_buffer_edge() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(10, 1));
+
+    let advanced = buffer.set_str(0, 0, 3, "abcdef", TuiStyle::default());
+
+    assert_eq!(advanced, 3);
+    assert_eq!(buffer.to_lines(), vec!["abc       "]);
+}
+
+#[test]
+fn set_cell_writes_one_glyph_and_get_reads_it_back() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(2, 1));
+    let style = TuiStyle::default().with_foreground(Color::Red);
+
+    buffer.set_cell(0, 0, Cell::new("x", style));
+
+    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "x");
+    assert_eq!(buffer.get(0, 0).unwrap().style(), style);
+    assert_eq!(buffer.get(1, 0).unwrap(), &Cell::blank());
+}
+
+#[test]
+fn fill_paints_a_styled_background_over_a_rect() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(4, 3));
+    let style = TuiStyle::default().with_background(Color::Blue);
+
+    buffer.fill(TuiRect::new(1, 1, 2, 1), Cell::new(" ", style));
+
+    assert_eq!(buffer.get(0, 1).unwrap().style(), TuiStyle::default());
+    assert_eq!(buffer.get(1, 1).unwrap().style(), style);
+    assert_eq!(buffer.get(2, 1).unwrap().style(), style);
+    assert_eq!(buffer.get(3, 1).unwrap().style(), TuiStyle::default());
+}
+
+#[test]
+fn buffers_compare_equal_iff_contents_and_styles_match() {
+    let mut a = TuiBuffer::new(TuiSize::new(3, 1));
+    let mut b = TuiBuffer::new(TuiSize::new(3, 1));
+    a.set_str(0, 0, 3, "ab", TuiStyle::default());
+    b.set_str(0, 0, 3, "ab", TuiStyle::default());
+    assert_eq!(a, b);
+
+    // Same glyphs, different style => not equal.
+    let mut c = TuiBuffer::new(TuiSize::new(3, 1));
+    c.set_str(0, 0, 3, "ab", TuiStyle::default().with_bold(true));
+    assert_ne!(a, c);
+
+    // Different size => not equal.
+    let d = TuiBuffer::new(TuiSize::new(3, 2));
+    assert_ne!(a, d);
+}
+
+#[test]
+fn combining_grapheme_occupies_a_single_cell() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
+
+    buffer.set_str(0, 0, 4, "e\u{301}x", TuiStyle::default());
+
+    assert_eq!(buffer.to_lines(), vec!["e\u{301}x  "]);
+    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "e\u{301}");
+    assert!(!buffer.get(0, 0).unwrap().is_continuation());
+    assert_eq!(buffer.get(1, 0).unwrap().symbol(), "x");
+}
+
+#[test]
+fn wide_grapheme_spans_two_columns_with_a_continuation_cell() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
+
+    buffer.set_str(0, 0, 4, "界a", TuiStyle::default());
+
+    assert_eq!(buffer.to_lines(), vec!["界a "]);
+    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "界");
+    assert!(buffer.get(1, 0).unwrap().is_continuation());
+    assert_eq!(buffer.get(2, 0).unwrap().symbol(), "a");
+}
+
+#[test]
+fn a_wide_grapheme_that_would_cross_the_edge_is_dropped_whole() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(3, 1));
+
+    buffer.set_str(0, 0, 3, "ab界", TuiStyle::default());
+
+    assert_eq!(buffer.to_lines(), vec!["ab "]);
+}
+
+#[test]
+fn overwriting_a_wide_grapheme_clears_its_continuation_cell() {
+    let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
+    buffer.set_str(0, 0, 4, "界a", TuiStyle::default());
+
+    buffer.set_str(0, 0, 1, "b", TuiStyle::default());
+
+    assert_eq!(buffer.to_lines(), vec!["b a "]);
+    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "b");
+    assert!(!buffer.get(1, 0).unwrap().is_continuation());
+    assert_eq!(buffer.get(1, 0).unwrap().symbol(), " ");
+}

--- a/crates/warpui_tui/src/elements/mod.rs
+++ b/crates/warpui_tui/src/elements/mod.rs
@@ -1,0 +1,145 @@
+//! The `TuiElement` trait — the unit of layout and paint — and the bridge that
+//! lets a [`TuiView`](warpui_core::TuiView) render to a boxed element while the
+//! shared core stores that output fully type-erased.
+//!
+//! The concrete elements (text, columns, styled containers, child-view,
+//! key-event handler) are added by task 3.2; this module owns the *trait* they
+//! implement and the *presentation context* they thread through during the
+//! child-view recursion that the presenter (task 3.3) drives.
+
+use std::collections::HashMap;
+
+use warpui_core::{AppContext, EntityId, Event};
+
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
+
+/// What a [`TuiView`](warpui_core::TuiView) renders to.
+///
+/// A view sets `type RenderOutput = TuiRenderOutput` and returns a boxed
+/// element from `render_tui`. The shared core never names this type: it boxes
+/// the value again into `Box<dyn Any>` (the abstract `TuiBackend::RenderOutput`),
+/// which the presenter recovers by downcasting back to `Box<dyn TuiElement>`.
+/// Because `TuiRenderOutput` is `'static`, it satisfies the core's
+/// `TuiView::RenderOutput: 'static` bound, and that erasure is exactly what
+/// keeps `warpui_core` free of any dependency on this crate.
+pub type TuiRenderOutput = Box<dyn TuiElement>;
+
+/// A node in the renderable tree: it measures itself against a constraint, then
+/// paints into a sub-rectangle of the buffer.
+///
+/// FROZEN METHOD SET. Sibling tasks (3.2 elements, 3.3 presenter, 3.4 runtime)
+/// build against exactly these methods:
+/// - [`layout`](TuiElement::layout): measure against a [`TuiConstraint`],
+///   returning a [`TuiSize`] within it (see [`TuiConstraint::clamp`]).
+/// - [`render`](TuiElement::render): paint into `area` of `buffer`. `area` is
+///   the rect the parent allocated (its size is the value `layout` returned,
+///   clamped to what was available).
+/// - [`desired_height`](TuiElement::desired_height): the height this element
+///   wants at a given width, used by stacking containers before they have a
+///   final height budget.
+/// - [`cursor_position`](TuiElement::cursor_position): where a text cursor
+///   should sit within `area`, if any (default: none).
+/// - [`present`](TuiElement::present): participate in the child-view recursion
+///   so the presenter can record parent/child view relationships (default:
+///   nothing — only container/child-view elements override this).
+/// - [`dispatch_event`](TuiElement::dispatch_event): offer an event to this
+///   element, returning whether it was handled (default: not handled).
+pub trait TuiElement {
+    /// Measures this element against `constraint`, returning the size it will
+    /// occupy (which must lie within `constraint`).
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize;
+
+    /// Paints this element into `area` of `buffer`. Implementations must confine
+    /// their writes to `area`; the buffer clips anything outside its own bounds
+    /// but does not clip to `area`.
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer);
+
+    /// The height this element wants when laid out at `width` columns.
+    fn desired_height(&self, width: u16) -> u16;
+
+    /// The `(x, y)` cell, within `area`, where the terminal cursor should be
+    /// placed for this element, if it owns the cursor.
+    fn cursor_position(&self, _area: TuiRect) -> Option<(u16, u16)> {
+        None
+    }
+
+    /// Walks this element during the presenter's child-view pass. Container and
+    /// child-view elements override this to enter/exit their children on `ctx`;
+    /// leaf elements do nothing.
+    fn present(&mut self, _ctx: &mut TuiPresentationContext<'_>) {}
+
+    /// Offers `event` to this element within `area`, returning `true` if it was
+    /// handled. `ctx` collects deferred app updates and typed actions; `app`
+    /// provides read access to the shared core during dispatch.
+    fn dispatch_event(
+        &mut self,
+        _event: &Event,
+        _area: TuiRect,
+        _ctx: &mut TuiEventContext,
+        _app: &AppContext,
+    ) -> bool {
+        false
+    }
+}
+
+impl TuiElement for () {
+    fn layout(&mut self, _constraint: TuiConstraint) -> TuiSize {
+        TuiSize::ZERO
+    }
+
+    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer) {}
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        0
+    }
+}
+
+/// Threads the current view ancestry through the element tree during the
+/// presenter's child-view recursion, recording each child view's parent so the
+/// shared core can attribute events and actions to the right view.
+///
+/// Constructed by the presenter (task 3.3); mutated by container/child-view
+/// elements (task 3.2) from their [`present`](TuiElement::present) impls. Its
+/// internals are inert until those consumers land.
+#[allow(dead_code)]
+pub struct TuiPresentationContext<'a> {
+    parent_by_child: &'a mut HashMap<EntityId, EntityId>,
+    view_stack: Vec<EntityId>,
+}
+
+impl<'a> TuiPresentationContext<'a> {
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        root_view_id: EntityId,
+        parent_by_child: &'a mut HashMap<EntityId, EntityId>,
+    ) -> Self {
+        Self {
+            parent_by_child,
+            view_stack: vec![root_view_id],
+        }
+    }
+
+    /// Records `child_view_id` as a child of the current view and descends into
+    /// it. Each call must be paired with [`exit_child`](Self::exit_child).
+    #[allow(dead_code)]
+    pub(crate) fn enter_child(&mut self, child_view_id: EntityId) {
+        let parent_view_id = *self
+            .view_stack
+            .last()
+            .expect("the TUI presentation stack always contains a root view");
+        self.parent_by_child.insert(child_view_id, parent_view_id);
+        self.view_stack.push(child_view_id);
+    }
+
+    /// Ascends back out of the most recently entered child view.
+    #[allow(dead_code)]
+    pub(crate) fn exit_child(&mut self) {
+        self.view_stack
+            .pop()
+            .expect("a child view is entered before it is exited");
+    }
+}
+
+#[cfg(test)]
+#[path = "mod_test.rs"]
+mod tests;

--- a/crates/warpui_tui/src/elements/mod_test.rs
+++ b/crates/warpui_tui/src/elements/mod_test.rs
@@ -1,0 +1,59 @@
+use warpui_core::{AppContext, Entity, TuiView};
+
+use super::{TuiElement, TuiRenderOutput};
+use crate::{TuiBuffer, TuiConstraint, TuiSize};
+
+#[test]
+fn unit_element_is_inert() {
+    let mut element = ();
+    assert_eq!(
+        element.layout(TuiConstraint::tight(TuiSize::new(4, 2))),
+        TuiSize::ZERO,
+    );
+    assert_eq!(element.desired_height(10), 0);
+    assert_eq!(
+        TuiElement::cursor_position(&(), crate::TuiRect::new(0, 0, 4, 2)),
+        None
+    );
+
+    // Painting a `()` leaves the buffer untouched.
+    let mut buffer = TuiBuffer::new(TuiSize::new(2, 1));
+    element.render(crate::TuiRect::new(0, 0, 2, 1), &mut buffer);
+    assert_eq!(buffer.to_lines(), vec!["  "]);
+}
+
+#[test]
+fn unit_element_is_boxable_as_render_output() {
+    let boxed: TuiRenderOutput = Box::new(());
+    assert_eq!(boxed.desired_height(3), 0);
+}
+
+// A minimal view that exists only to prove, at compile time, that the
+// `TuiRenderOutput` bridge is a valid `TuiView::RenderOutput` against
+// `warpui_core --features tui`. A real view returns its element tree from
+// `render_tui`; here we only need the types to line up.
+struct ProbeView;
+
+impl Entity for ProbeView {
+    type Event = ();
+}
+
+impl TuiView for ProbeView {
+    type RenderOutput = TuiRenderOutput;
+
+    fn ui_name() -> &'static str {
+        "ProbeView"
+    }
+
+    fn render_tui(&self, _ctx: &AppContext) -> Self::RenderOutput {
+        Box::new(())
+    }
+}
+
+#[test]
+fn render_output_bridge_satisfies_the_core_contract() {
+    // Compiles iff `TuiRenderOutput` binds as `ProbeView`'s erased render
+    // output, i.e. iff the bridge type is a valid `TuiView::RenderOutput`.
+    fn assert_bridge<T: TuiView<RenderOutput = TuiRenderOutput>>(_view: T) {}
+    assert_bridge(ProbeView);
+}

--- a/crates/warpui_tui/src/event.rs
+++ b/crates/warpui_tui/src/event.rs
@@ -1,0 +1,105 @@
+//! TUI event plumbing.
+//!
+//! The runtime converts raw crossterm events into the shared
+//! [`warpui_core::Event`] vocabulary (so element/view dispatch is identical to
+//! the GUI), then walks the rendered element tree handing each element the
+//! event plus a [`TuiEventContext`] it can use to queue app updates and typed
+//! actions back into the shared core.
+//!
+//! This module freezes the event *types* and the *signature* of
+//! [`crossterm_event_to_warp_event`]. The crossterm→warp mapping itself, along
+//! with any scroll/mouse normalization helpers, is implemented by the renderer/
+//! runtime layer (task 3.4).
+
+use crossterm::event::Event as CrosstermEvent;
+use warpui_core::{Action, App, EntityId, Event};
+
+/// Whether an element that handled an event wants its ancestors to keep seeing
+/// it. Returned by event-aware elements during dispatch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TuiDispatchEventResult {
+    /// Continue offering the event to ancestor elements.
+    PropagateToParent,
+    /// Consume the event; ancestors do not see it.
+    StopPropagation,
+}
+
+/// The outcome of dispatching an event through a rendered tree: whether any
+/// element handled it (e.g. to decide if a redraw is warranted).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TuiEventDispatchResult {
+    pub handled: bool,
+}
+
+type TuiAppUpdate = Box<dyn FnOnce(&mut App)>;
+
+/// Collects the side effects an element requests while handling an event:
+/// deferred mutations of the [`App`] and typed actions to dispatch through the
+/// shared core. The runtime drains these after dispatch and applies them on the
+/// main thread, mirroring how GUI event handlers defer work via the app context.
+#[derive(Default)]
+pub struct TuiEventContext {
+    updates: Vec<TuiAppUpdate>,
+    typed_actions: Vec<TuiDispatchedAction>,
+    origin_view_id: Option<EntityId>,
+}
+
+// Consumed by the runtime's dispatch loop (task 3.4); inert until then.
+#[allow(dead_code)]
+pub(crate) struct TuiDispatchedAction {
+    pub(crate) origin_view_id: EntityId,
+    pub(crate) action: Box<dyn Action>,
+}
+
+impl TuiEventContext {
+    /// Queues a closure to run against the [`App`] once dispatch completes.
+    pub fn dispatch_app_update<F>(&mut self, update: F)
+    where
+        F: 'static + FnOnce(&mut App),
+    {
+        self.updates.push(Box::new(update));
+    }
+
+    /// Queues a typed action to dispatch from the view currently being
+    /// processed. Panics if called outside of view event processing, where
+    /// there is no origin view to attribute the action to.
+    pub fn dispatch_typed_action(&mut self, action: impl Action) {
+        let origin_view_id = self
+            .origin_view_id
+            .expect("typed actions can only be dispatched while processing a rendered TUI view");
+        self.typed_actions.push(TuiDispatchedAction {
+            origin_view_id,
+            action: Box::new(action),
+        });
+    }
+
+    // The `take_*`/`set_origin_view` plumbing is drained by the runtime's
+    // dispatch loop (task 3.4); it is inert within the foundation crate alone.
+    #[allow(dead_code)]
+    pub(crate) fn take_updates(&mut self) -> Vec<TuiAppUpdate> {
+        std::mem::take(&mut self.updates)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn take_typed_actions(&mut self) -> Vec<TuiDispatchedAction> {
+        std::mem::take(&mut self.typed_actions)
+    }
+
+    /// Sets the view that subsequently dispatched actions are attributed to,
+    /// returning the previous origin so callers can restore it when leaving the
+    /// view's subtree.
+    #[allow(dead_code)]
+    pub(crate) fn set_origin_view(&mut self, view_id: Option<EntityId>) -> Option<EntityId> {
+        std::mem::replace(&mut self.origin_view_id, view_id)
+    }
+}
+
+/// Converts a raw crossterm event into the shared [`warpui_core::Event`]
+/// vocabulary, or `None` if the event has no warp equivalent.
+///
+/// FROZEN SIGNATURE. The mapping is implemented by the renderer/runtime layer
+/// (task 3.4); the signature is fixed here so sibling tasks can build against
+/// it.
+pub fn crossterm_event_to_warp_event(event: CrosstermEvent) -> Option<Event> {
+    todo!("crossterm_event_to_warp_event mapping is implemented in task 3.4: {event:?}")
+}

--- a/crates/warpui_tui/src/geometry.rs
+++ b/crates/warpui_tui/src/geometry.rs
@@ -1,0 +1,211 @@
+//! Integer cell-grid geometry shared across the TUI rendering layers.
+//!
+//! All dimensions are in terminal cells (`u16`). The geometry deliberately
+//! mirrors a small slice of the GUI geometry vocabulary but stays integral,
+//! since a terminal grid has no sub-cell positions.
+
+use warpui_core::geometry::vector::Vector2F;
+
+/// A width/height pair in terminal cells.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TuiSize {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl TuiSize {
+    pub const ZERO: Self = Self {
+        width: 0,
+        height: 0,
+    };
+
+    pub const fn new(width: u16, height: u16) -> Self {
+        Self { width, height }
+    }
+
+    /// The number of cells covered by a region of this size.
+    pub fn area(self) -> usize {
+        usize::from(self.width) * usize::from(self.height)
+    }
+}
+
+/// An axis-aligned rectangle of terminal cells. The covered columns are
+/// `x .. x + width` and rows `y .. y + height` (half-open).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TuiRect {
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+impl TuiRect {
+    pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    /// Builds a rect at the origin with the given size.
+    pub const fn from_size(size: TuiSize) -> Self {
+        Self::new(0, 0, size.width, size.height)
+    }
+
+    pub const fn size(self) -> TuiSize {
+        TuiSize::new(self.width, self.height)
+    }
+
+    /// The first column past the right edge (saturating).
+    pub fn right(self) -> u16 {
+        self.x.saturating_add(self.width)
+    }
+
+    /// The first row past the bottom edge (saturating).
+    pub fn bottom(self) -> u16 {
+        self.y.saturating_add(self.height)
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.width == 0 || self.height == 0
+    }
+
+    /// Shrinks the rect by `inset` cells on every side, saturating at zero. A
+    /// rect too small to inset collapses to zero width/height (never wraps).
+    ///
+    /// ```
+    /// # use warpui_tui::TuiRect;
+    /// assert_eq!(
+    ///     TuiRect::new(2, 2, 10, 6).inset(1),
+    ///     TuiRect::new(3, 3, 8, 4),
+    /// );
+    /// assert_eq!(TuiRect::new(0, 0, 1, 1).inset(2), TuiRect::new(2, 2, 0, 0));
+    /// ```
+    pub fn inset(self, inset: u16) -> Self {
+        let shrink = inset.saturating_mul(2);
+        Self {
+            x: self.x.saturating_add(inset),
+            y: self.y.saturating_add(inset),
+            width: self.width.saturating_sub(shrink),
+            height: self.height.saturating_sub(shrink),
+        }
+    }
+
+    /// Splits off the top `height` rows, returning `(top, remainder)`. `height`
+    /// is clamped to this rect's height, so the two halves always tile the
+    /// original rect exactly.
+    ///
+    /// ```
+    /// # use warpui_tui::TuiRect;
+    /// let (top, rest) = TuiRect::new(0, 0, 8, 5).split_top(2);
+    /// assert_eq!(top, TuiRect::new(0, 0, 8, 2));
+    /// assert_eq!(rest, TuiRect::new(0, 2, 8, 3));
+    /// ```
+    pub fn split_top(self, height: u16) -> (Self, Self) {
+        let top_height = height.min(self.height);
+        let top = Self::new(self.x, self.y, self.width, top_height);
+        let remainder = Self::new(
+            self.x,
+            self.y.saturating_add(top_height),
+            self.width,
+            self.height - top_height,
+        );
+        (top, remainder)
+    }
+
+    /// Splits off the left `width` columns, returning `(left, remainder)`.
+    /// `width` is clamped to this rect's width, so the two halves always tile
+    /// the original rect exactly.
+    ///
+    /// ```
+    /// # use warpui_tui::TuiRect;
+    /// let (left, rest) = TuiRect::new(0, 0, 8, 5).split_left(3);
+    /// assert_eq!(left, TuiRect::new(0, 0, 3, 5));
+    /// assert_eq!(rest, TuiRect::new(3, 0, 5, 5));
+    /// ```
+    pub fn split_left(self, width: u16) -> (Self, Self) {
+        let left_width = width.min(self.width);
+        let left = Self::new(self.x, self.y, left_width, self.height);
+        let remainder = Self::new(
+            self.x.saturating_add(left_width),
+            self.y,
+            self.width - left_width,
+            self.height,
+        );
+        (left, remainder)
+    }
+
+    /// Whether a (sub-cell) point falls inside this rect, used for mouse
+    /// hit-testing against crossterm's pixel-free cell coordinates.
+    pub fn contains_position(self, position: Vector2F) -> bool {
+        position.x() >= f32::from(self.x)
+            && position.x() < f32::from(self.right())
+            && position.y() >= f32::from(self.y)
+            && position.y() < f32::from(self.bottom())
+    }
+}
+
+/// A layout constraint: an element handed a `TuiConstraint` must return a
+/// [`TuiSize`] with `min.width <= width <= max.width` and
+/// `min.height <= height <= max.height`. Containers shrink their children by
+/// handing down tighter constraints; leaves clamp their natural size with
+/// [`clamp`](TuiConstraint::clamp).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TuiConstraint {
+    pub min: TuiSize,
+    pub max: TuiSize,
+}
+
+impl TuiConstraint {
+    pub const fn new(min: TuiSize, max: TuiSize) -> Self {
+        Self { min, max }
+    }
+
+    /// A constraint forcing exactly `size` (min == max).
+    pub const fn tight(size: TuiSize) -> Self {
+        Self {
+            min: size,
+            max: size,
+        }
+    }
+
+    /// A constraint allowing anything from zero up to `max`.
+    pub const fn loose(max: TuiSize) -> Self {
+        Self {
+            min: TuiSize::ZERO,
+            max,
+        }
+    }
+
+    /// Clamps a desired size into the `[min, max]` box on each axis.
+    ///
+    /// ```
+    /// # use warpui_tui::{TuiConstraint, TuiSize};
+    /// let constraint = TuiConstraint::new(TuiSize::new(2, 1), TuiSize::new(10, 4));
+    /// assert_eq!(constraint.clamp(TuiSize::new(7, 2)), TuiSize::new(7, 2));
+    /// assert_eq!(constraint.clamp(TuiSize::new(99, 0)), TuiSize::new(10, 1));
+    /// assert_eq!(constraint.clamp(TuiSize::new(0, 99)), TuiSize::new(2, 4));
+    /// ```
+    pub fn clamp(self, size: TuiSize) -> TuiSize {
+        TuiSize::new(
+            size.width.clamp(self.min.width, self.max.width),
+            size.height.clamp(self.min.height, self.max.height),
+        )
+    }
+
+    /// Clamps a width into `[min.width, max.width]`.
+    pub fn constrain_width(self, width: u16) -> u16 {
+        width.clamp(self.min.width, self.max.width)
+    }
+
+    /// Clamps a height into `[min.height, max.height]`.
+    pub fn constrain_height(self, height: u16) -> u16 {
+        height.clamp(self.min.height, self.max.height)
+    }
+}
+
+#[cfg(test)]
+#[path = "geometry_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/geometry_tests.rs
+++ b/crates/warpui_tui/src/geometry_tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+#[test]
+fn constraint_clamps_each_axis_independently() {
+    let constraint = TuiConstraint::new(TuiSize::new(2, 1), TuiSize::new(10, 4));
+
+    assert_eq!(constraint.clamp(TuiSize::new(7, 3)), TuiSize::new(7, 3));
+    assert_eq!(constraint.clamp(TuiSize::new(99, 99)), TuiSize::new(10, 4));
+    assert_eq!(constraint.clamp(TuiSize::new(0, 0)), TuiSize::new(2, 1));
+    assert_eq!(constraint.constrain_width(99), 10);
+    assert_eq!(constraint.constrain_height(0), 1);
+}
+
+#[test]
+fn tight_and_loose_constraints() {
+    let tight = TuiConstraint::tight(TuiSize::new(5, 5));
+    assert_eq!(tight.clamp(TuiSize::new(1, 9)), TuiSize::new(5, 5));
+
+    let loose = TuiConstraint::loose(TuiSize::new(8, 3));
+    assert_eq!(loose.clamp(TuiSize::new(4, 9)), TuiSize::new(4, 3));
+    assert_eq!(loose.clamp(TuiSize::ZERO), TuiSize::ZERO);
+}
+
+#[test]
+fn inset_shrinks_on_all_sides_and_saturates() {
+    assert_eq!(TuiRect::new(2, 2, 10, 6).inset(1), TuiRect::new(3, 3, 8, 4));
+    // Too small to inset: collapses to zero extent rather than wrapping.
+    assert_eq!(TuiRect::new(0, 0, 1, 1).inset(2), TuiRect::new(2, 2, 0, 0));
+}
+
+#[test]
+fn split_top_tiles_the_rect_exactly() {
+    let rect = TuiRect::new(0, 0, 8, 5);
+    let (top, rest) = rect.split_top(2);
+    assert_eq!(top, TuiRect::new(0, 0, 8, 2));
+    assert_eq!(rest, TuiRect::new(0, 2, 8, 3));
+
+    // Over-tall split is clamped; the remainder is empty but well-formed.
+    let (top, rest) = rect.split_top(99);
+    assert_eq!(top, rect);
+    assert_eq!(rest, TuiRect::new(0, 5, 8, 0));
+    assert!(rest.is_empty());
+}
+
+#[test]
+fn split_left_tiles_the_rect_exactly() {
+    let rect = TuiRect::new(1, 1, 8, 5);
+    let (left, rest) = rect.split_left(3);
+    assert_eq!(left, TuiRect::new(1, 1, 3, 5));
+    assert_eq!(rest, TuiRect::new(4, 1, 5, 5));
+}
+
+#[test]
+fn right_and_bottom_saturate() {
+    let rect = TuiRect::new(u16::MAX, u16::MAX, 4, 4);
+    assert_eq!(rect.right(), u16::MAX);
+    assert_eq!(rect.bottom(), u16::MAX);
+}

--- a/crates/warpui_tui/src/lib.rs
+++ b/crates/warpui_tui/src/lib.rs
@@ -1,0 +1,53 @@
+//! `warpui_tui` is the concrete TUI rendering stack for Warp's `warpui`
+//! framework: the terminal-side analogue of the GUI `warpui` crate. It turns a
+//! [`TuiView`]'s render output into terminal output via crossterm, driven by the
+//! same `App`/`AppContext`/handle/context/async/action machinery the GUI uses
+//! (re-exported from [`warpui_core`] under its `tui` feature).
+//!
+//! # Foundation (this module set) — FROZEN INTERFACES
+//!
+//! This crate is built in layers. The foundation defined here — [`geometry`],
+//! [`buffer`], the [`TuiElement`](elements::TuiElement) trait, and the
+//! [`event`] types — is **frozen**: the concrete elements, presenter, renderer,
+//! and runtime are built against these surfaces and must not need to change
+//! them. The frozen surfaces are:
+//!
+//! ## Geometry ([`TuiSize`], [`TuiRect`], [`TuiConstraint`])
+//! Integer (`u16`) cell-grid geometry. A [`TuiConstraint`] carries a `min` and
+//! `max` [`TuiSize`]; an element's [`layout`](elements::TuiElement::layout)
+//! returns a size within that box (use [`TuiConstraint::clamp`]). [`TuiRect`]
+//! provides [`inset`](TuiRect::inset) and the
+//! [`split_top`](TuiRect::split_top)/[`split_left`](TuiRect::split_left)
+//! helpers used for stacking layout.
+//!
+//! ## Cell buffer ([`TuiBuffer`], [`Cell`], [`TuiStyle`])
+//! An in-memory grid of styled [`Cell`]s. Construct with [`TuiBuffer::new`],
+//! write with [`set_cell`](TuiBuffer::set_cell)/[`set_str`](TuiBuffer::set_str)
+//! (wide- and combining-grapheme aware; out-of-bounds writes are clipped, never
+//! panic), read with [`get`](TuiBuffer::get), and assert against it headlessly
+//! with [`to_lines`](TuiBuffer::to_lines). Two buffers are equal iff their
+//! contents *and* styles match.
+//!
+//! ## Element trait ([`TuiElement`](elements::TuiElement)) and the render-output bridge
+//! [`TuiElement`](elements::TuiElement) is the unit of layout + paint. A
+//! [`TuiView`] renders to [`TuiRenderOutput`] (`Box<dyn TuiElement>`); see
+//! [`elements`] for how that satisfies the core's abstract, type-erased
+//! `RenderOutput`.
+//!
+//! ## Events ([`event`])
+//! TUI event plumbing ([`TuiEventContext`], [`TuiEventDispatchResult`],
+//! [`TuiDispatchEventResult`]) plus the frozen signature of
+//! [`crossterm_event_to_warp_event`] (implemented by the runtime layer).
+
+mod buffer;
+pub mod elements;
+mod event;
+mod geometry;
+
+pub use buffer::{Cell, TuiBuffer, TuiStyle};
+pub use elements::{TuiElement, TuiPresentationContext, TuiRenderOutput};
+pub use event::{
+    crossterm_event_to_warp_event, TuiDispatchEventResult, TuiEventContext, TuiEventDispatchResult,
+};
+pub use geometry::{TuiConstraint, TuiRect, TuiSize};
+pub use warpui_core::TuiView;


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
