### PR TITLE
warpui_tui: TUI elements (text, column, container, child-view, event-handler)

### DIFF
--- a/crates/warpui_tui/src/elements/child_view.rs
+++ b/crates/warpui_tui/src/elements/child_view.rs
@@ -1,0 +1,89 @@
+//! [`TuiChildView`]: embeds another [`TuiView`]'s rendered element tree as a
+//! node in this view's tree.
+//!
+//! # Construction
+//! Build with [`TuiChildView::new`], passing a [`TuiViewHandle`] and the current
+//! [`AppContext`]; the child view is rendered immediately and stored as the
+//! wrapped element.
+//!
+//! # Tree participation
+//! `TuiChildView` is otherwise transparent — layout, render, height, and cursor
+//! all delegate to the embedded element. It additionally hooks the two passes
+//! that are view-aware:
+//! - [`present`](TuiElement::present) enters the child's view id on the
+//!   presentation context (recording the parent/child relationship) before
+//!   descending, then exits it.
+//! - [`dispatch_event`](TuiElement::dispatch_event) marks the child's view id as
+//!   the action origin for the duration of the subtree's dispatch.
+
+use warpui_core::{AppContext, EntityId, Event, TuiView, TuiViewHandle};
+
+use crate::elements::{TuiElement, TuiPresentationContext};
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
+
+pub struct TuiChildView {
+    view_id: EntityId,
+    child: Box<dyn TuiElement>,
+}
+
+impl TuiChildView {
+    /// Renders `handle`'s view now and embeds the resulting element tree.
+    pub fn new<V>(handle: &TuiViewHandle<V>, app: &AppContext) -> Self
+    where
+        V: TuiView<RenderOutput = Box<dyn TuiElement>>,
+    {
+        Self {
+            view_id: handle.id(),
+            child: handle.read(app, |view, ctx| view.render_tui(ctx)),
+        }
+    }
+
+    /// Constructs a child view directly from an already-rendered element,
+    /// bypassing the live `App`. Used by headless tests to exercise the
+    /// embedding/recursion contract without standing up a real view.
+    #[cfg(test)]
+    pub(crate) fn from_rendered(view_id: EntityId, child: Box<dyn TuiElement>) -> Self {
+        Self { view_id, child }
+    }
+}
+
+impl TuiElement for TuiChildView {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.child.layout(constraint)
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        self.child.render(area, buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.child.desired_height(width)
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        self.child.cursor_position(area)
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        ctx.enter_child(self.view_id);
+        self.child.present(ctx);
+        ctx.exit_child();
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        area: TuiRect,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        let previous_origin = ctx.set_origin_view(Some(self.view_id));
+        let handled = self.child.dispatch_event(event, area, ctx, app);
+        ctx.set_origin_view(previous_origin);
+        handled
+    }
+}
+
+#[cfg(test)]
+#[path = "child_view_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/elements/child_view_tests.rs
+++ b/crates/warpui_tui/src/elements/child_view_tests.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+
+use warpui_core::EntityId;
+
+use super::TuiChildView;
+use crate::elements::{TuiElement, TuiPresentationContext, TuiText};
+use crate::{TuiBuffer, TuiRect, TuiSize};
+
+#[test]
+fn embeds_and_renders_the_stub_at_the_given_area() {
+    let view = TuiChildView::from_rendered(EntityId::from_usize(1), Box::new(TuiText::new("Z")));
+
+    let mut buffer = TuiBuffer::new(TuiSize::new(3, 1));
+    // Render offset one column in: the embedded glyph must land at x = 1.
+    view.render(TuiRect::new(1, 0, 2, 1), &mut buffer);
+    assert_eq!(buffer.to_lines(), vec![" Z "]);
+}
+
+#[test]
+fn delegates_desired_height_to_the_embedded_element() {
+    let view = TuiChildView::from_rendered(
+        EntityId::from_usize(1),
+        Box::new(TuiText::new("AB\nCD").truncate()),
+    );
+    assert_eq!(view.desired_height(2), 2);
+}
+
+#[test]
+fn present_records_the_child_as_a_child_of_the_current_view() {
+    let root = EntityId::from_usize(7);
+    let child = EntityId::from_usize(8);
+    let mut parent_by_child = HashMap::new();
+
+    {
+        let mut ctx = TuiPresentationContext::new(root, &mut parent_by_child);
+        let mut view = TuiChildView::from_rendered(child, Box::new(()));
+        view.present(&mut ctx);
+    }
+
+    assert_eq!(parent_by_child.get(&child), Some(&root));
+}
+
+#[test]
+fn present_nests_grandchildren_under_their_immediate_parent() {
+    let root = EntityId::from_usize(1);
+    let child = EntityId::from_usize(2);
+    let grandchild = EntityId::from_usize(3);
+    let mut parent_by_child = HashMap::new();
+
+    {
+        let mut ctx = TuiPresentationContext::new(root, &mut parent_by_child);
+        let nested = TuiChildView::from_rendered(grandchild, Box::new(()));
+        let mut view = TuiChildView::from_rendered(child, Box::new(nested));
+        view.present(&mut ctx);
+    }
+
+    assert_eq!(parent_by_child.get(&child), Some(&root));
+    assert_eq!(parent_by_child.get(&grandchild), Some(&child));
+}

--- a/crates/warpui_tui/src/elements/column.rs
+++ b/crates/warpui_tui/src/elements/column.rs
@@ -1,0 +1,77 @@
+//! [`TuiColumn`]: a vertical stack that lays its children out top-to-bottom.
+//!
+//! # Construction
+//! Start from [`TuiColumn::new`] (empty) and append children with
+//! [`child`](TuiColumn::child), or build from an iterator with
+//! [`with_children`](TuiColumn::with_children).
+//!
+//! # Layout policy
+//! The column fills the width it is offered and gives every child that same
+//! width. Each child is allocated exactly its
+//! [`desired_height`](TuiElement::desired_height) at that width; children are
+//! stacked without gaps from the top, and the column's own height is the sum of
+//! those heights clamped to the constraint. Children that fall past the
+//! available height are clipped.
+
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+
+#[derive(Default)]
+pub struct TuiColumn {
+    children: Vec<Box<dyn TuiElement>>,
+}
+
+impl TuiColumn {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn child(mut self, child: impl TuiElement + 'static) -> Self {
+        self.children.push(Box::new(child));
+        self
+    }
+
+    pub fn with_children(children: impl IntoIterator<Item = Box<dyn TuiElement>>) -> Self {
+        Self {
+            children: children.into_iter().collect(),
+        }
+    }
+}
+
+impl TuiElement for TuiColumn {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let width = constraint.constrain_width(constraint.max.width);
+        let mut total_height: u16 = 0;
+        for child in &mut self.children {
+            let child_height = child.desired_height(width);
+            let child_constraint =
+                TuiConstraint::new(TuiSize::new(width, 0), TuiSize::new(width, child_height));
+            let size = child.layout(child_constraint);
+            total_height = total_height.saturating_add(size.height);
+        }
+        TuiSize::new(width, constraint.constrain_height(total_height))
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        let mut remaining = area;
+        for child in &self.children {
+            if remaining.is_empty() {
+                break;
+            }
+            let child_height = child.desired_height(remaining.width);
+            let (slot, rest) = remaining.split_top(child_height);
+            child.render(slot, buffer);
+            remaining = rest;
+        }
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.children.iter().fold(0, |total, child| {
+            total.saturating_add(child.desired_height(width))
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "column_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/elements/column_tests.rs
+++ b/crates/warpui_tui/src/elements/column_tests.rs
@@ -1,0 +1,57 @@
+use super::TuiColumn;
+use crate::elements::{TuiElement, TuiText};
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+
+fn render_to_lines(element: &dyn TuiElement, size: TuiSize) -> Vec<String> {
+    let mut buffer = TuiBuffer::new(size);
+    element.render(TuiRect::from_size(size), &mut buffer);
+    buffer.to_lines()
+}
+
+#[test]
+fn stacks_two_children_top_to_bottom() {
+    let mut column = TuiColumn::new()
+        .child(TuiText::new("AA"))
+        .child(TuiText::new("BB"));
+
+    assert_eq!(column.desired_height(2), 2);
+    let size = column.layout(TuiConstraint::loose(TuiSize::new(2, 10)));
+    assert_eq!(size, TuiSize::new(2, 2));
+
+    assert_eq!(
+        render_to_lines(&column, TuiSize::new(2, 2)),
+        vec!["AA", "BB"]
+    );
+}
+
+#[test]
+fn sums_multi_row_children_at_the_correct_offsets() {
+    // The middle child spans two rows, so the trailing child must land on row 3.
+    let column = TuiColumn::new()
+        .child(TuiText::new("A"))
+        .child(TuiText::new("BB\nCC").truncate())
+        .child(TuiText::new("D"));
+
+    assert_eq!(column.desired_height(2), 4);
+    assert_eq!(
+        render_to_lines(&column, TuiSize::new(2, 4)),
+        vec!["A ", "BB", "CC", "D "],
+    );
+}
+
+#[test]
+fn clamps_total_height_to_the_constraint_and_clips_overflow() {
+    let mut column = TuiColumn::new()
+        .child(TuiText::new("A"))
+        .child(TuiText::new("BB\nCC").truncate())
+        .child(TuiText::new("D"));
+
+    let size = column.layout(TuiConstraint::new(TuiSize::ZERO, TuiSize::new(2, 3)));
+    assert_eq!(size, TuiSize::new(2, 3));
+
+    // Only the first three rows fit; the final child is clipped away.
+    assert_eq!(
+        render_to_lines(&column, TuiSize::new(2, 3)),
+        vec!["A ", "BB", "CC"],
+    );
+}

--- a/crates/warpui_tui/src/elements/container.rs
+++ b/crates/warpui_tui/src/elements/container.rs
@@ -1,0 +1,156 @@
+//! [`TuiContainer`]: a single-child decorator that adds a background fill, an
+//! optional box-drawing border, and uniform padding around its child.
+//!
+//! # Construction
+//! Wrap a child with [`TuiContainer::new`] and layer decorations:
+//! - [`with_padding`](TuiContainer::with_padding): cells of empty space on every
+//!   side, inside any border.
+//! - [`with_border`](TuiContainer::with_border) /
+//!   [`with_border_style`](TuiContainer::with_border_style): a one-cell box-drawn
+//!   frame.
+//! - [`with_background`](TuiContainer::with_background): a fill color painted
+//!   behind the border and padding.
+//!
+//! # Layout policy
+//! The child is inset on every side by `border (0 or 1) + padding`. The
+//! container reports its child's size grown by that inset on both axes (clamped
+//! to the constraint), so the child occupies exactly the area left inside the
+//! frame and padding.
+
+use crossterm::style::Color;
+
+use crate::elements::TuiElement;
+use crate::{Cell, TuiBuffer, TuiConstraint, TuiRect, TuiSize, TuiStyle};
+
+pub struct TuiContainer {
+    child: Box<dyn TuiElement>,
+    padding: u16,
+    border: bool,
+    border_style: TuiStyle,
+    background: Option<Color>,
+}
+
+impl TuiContainer {
+    pub fn new(child: impl TuiElement + 'static) -> Self {
+        Self {
+            child: Box::new(child),
+            padding: 0,
+            border: false,
+            border_style: TuiStyle::default(),
+            background: None,
+        }
+    }
+
+    pub fn with_padding(mut self, padding: u16) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    pub fn with_border(mut self) -> Self {
+        self.border = true;
+        self
+    }
+
+    pub fn with_border_style(mut self, style: TuiStyle) -> Self {
+        self.border = true;
+        self.border_style = style;
+        self
+    }
+
+    pub fn with_background(mut self, color: Color) -> Self {
+        self.background = Some(color);
+        self
+    }
+
+    /// The number of cells the child is inset on each side.
+    fn inset(&self) -> u16 {
+        u16::from(self.border) + self.padding
+    }
+
+    /// The style used to paint border glyphs, inheriting the background fill so
+    /// the frame sits seamlessly on the filled area.
+    fn painted_border_style(&self) -> TuiStyle {
+        let mut style = self.border_style;
+        if style.background.is_none() {
+            style.background = self.background;
+        }
+        style
+    }
+}
+
+impl TuiElement for TuiContainer {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let total = self.inset().saturating_mul(2);
+        let inner_max = TuiSize::new(
+            constraint.max.width.saturating_sub(total),
+            constraint.max.height.saturating_sub(total),
+        );
+        let inner = self.child.layout(TuiConstraint::loose(inner_max));
+        let size = TuiSize::new(
+            inner.width.saturating_add(total),
+            inner.height.saturating_add(total),
+        );
+        constraint.clamp(size)
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        if area.is_empty() {
+            return;
+        }
+
+        if let Some(background) = self.background {
+            buffer.fill(
+                area,
+                Cell::new(" ", TuiStyle::default().with_background(background)),
+            );
+        }
+
+        if self.border {
+            draw_border(area, buffer, self.painted_border_style());
+        }
+
+        self.child.render(area.inset(self.inset()), buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        let total = self.inset().saturating_mul(2);
+        let inner_width = width.saturating_sub(total);
+        self.child.desired_height(inner_width).saturating_add(total)
+    }
+}
+
+/// Paints a single-cell box-drawing frame around the perimeter of `area`.
+fn draw_border(area: TuiRect, buffer: &mut TuiBuffer, style: TuiStyle) {
+    let right = area.right().saturating_sub(1);
+    let bottom = area.bottom().saturating_sub(1);
+    let multi_column = area.width > 1;
+    let multi_row = area.height > 1;
+
+    for x in area.x..area.right() {
+        buffer.set_cell(x, area.y, Cell::new("─", style));
+        if multi_row {
+            buffer.set_cell(x, bottom, Cell::new("─", style));
+        }
+    }
+    for y in area.y..area.bottom() {
+        buffer.set_cell(area.x, y, Cell::new("│", style));
+        if multi_column {
+            buffer.set_cell(right, y, Cell::new("│", style));
+        }
+    }
+
+    buffer.set_cell(area.x, area.y, Cell::new("┌", style));
+    if multi_column {
+        buffer.set_cell(right, area.y, Cell::new("┐", style));
+    }
+    if multi_row {
+        buffer.set_cell(area.x, bottom, Cell::new("└", style));
+    }
+    if multi_column && multi_row {
+        buffer.set_cell(right, bottom, Cell::new("┘", style));
+    }
+}
+
+#[cfg(test)]
+#[path = "container_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/elements/container_tests.rs
+++ b/crates/warpui_tui/src/elements/container_tests.rs
@@ -1,0 +1,64 @@
+use crossterm::style::Color;
+
+use super::TuiContainer;
+use crate::elements::{TuiElement, TuiText};
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize};
+
+fn render_to_lines(element: &dyn TuiElement, size: TuiSize) -> Vec<String> {
+    let mut buffer = TuiBuffer::new(size);
+    element.render(TuiRect::from_size(size), &mut buffer);
+    buffer.to_lines()
+}
+
+#[test]
+fn padding_offsets_the_child() {
+    let container = TuiContainer::new(TuiText::new("X")).with_padding(1);
+    assert_eq!(container.desired_height(3), 3);
+    assert_eq!(
+        render_to_lines(&container, TuiSize::new(3, 3)),
+        vec!["   ", " X ", "   "],
+    );
+}
+
+#[test]
+fn border_frames_the_child() {
+    let container = TuiContainer::new(TuiText::new("X")).with_border();
+    assert_eq!(
+        render_to_lines(&container, TuiSize::new(3, 3)),
+        vec!["┌─┐", "│X│", "└─┘"],
+    );
+}
+
+#[test]
+fn border_and_padding_compose() {
+    let mut container = TuiContainer::new(TuiText::new("X"))
+        .with_border()
+        .with_padding(1);
+
+    // Child inset by 2 (border + padding) on each side: 1x1 child -> 5x5 total.
+    let size = container.layout(TuiConstraint::loose(TuiSize::new(20, 20)));
+    assert_eq!(size, TuiSize::new(5, 5));
+
+    assert_eq!(
+        render_to_lines(&container, TuiSize::new(5, 5)),
+        vec!["┌───┐", "│   │", "│ X │", "│   │", "└───┘"],
+    );
+}
+
+#[test]
+fn background_fills_the_padding_area() {
+    let container = TuiContainer::new(TuiText::new("X"))
+        .with_padding(1)
+        .with_background(Color::Blue);
+
+    let mut buffer = TuiBuffer::new(TuiSize::new(3, 3));
+    container.render(TuiRect::new(0, 0, 3, 3), &mut buffer);
+
+    // A padding cell carries the background fill...
+    assert_eq!(
+        buffer.get(0, 0).expect("cell in bounds").style().background,
+        Some(Color::Blue),
+    );
+    // ...and the child glyph lands in the center.
+    assert_eq!(buffer.get(1, 1).expect("cell in bounds").symbol(), "X");
+}

--- a/crates/warpui_tui/src/elements/event_handler.rs
+++ b/crates/warpui_tui/src/elements/event_handler.rs
@@ -1,0 +1,102 @@
+//! [`TuiEventHandler`]: wraps a child element and runs callbacks for keys the
+//! child itself did not handle.
+//!
+//! # Construction
+//! Wrap a child with [`TuiEventHandler::new`] and register handlers with
+//! [`on_key`](TuiEventHandler::on_key), matching against the
+//! [`Keystroke::key`](warpui_core::keymap::Keystroke) string (e.g. `"enter"`,
+//! `"a"`). Layout, render, height, and cursor are transparent — they delegate to
+//! the wrapped child.
+//!
+//! # Dispatch policy
+//! On [`dispatch_event`](TuiElement::dispatch_event) the event is offered to the
+//! child first. If the child consumes it, dispatch stops. Otherwise, for a
+//! `KeyDown` event, the first registered binding whose key matches is invoked
+//! (with the event, the [`TuiEventContext`], and the [`AppContext`]) and the
+//! event is reported handled. Events matching no binding are left unhandled so
+//! ancestors can react.
+
+use warpui_core::{AppContext, Event};
+
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
+
+type KeyCallback = Box<dyn FnMut(&Event, &mut TuiEventContext, &AppContext)>;
+
+struct KeyBinding {
+    key: String,
+    callback: KeyCallback,
+}
+
+pub struct TuiEventHandler {
+    child: Box<dyn TuiElement>,
+    bindings: Vec<KeyBinding>,
+}
+
+impl TuiEventHandler {
+    pub fn new(child: impl TuiElement + 'static) -> Self {
+        Self {
+            child: Box::new(child),
+            bindings: Vec::new(),
+        }
+    }
+
+    /// Registers `callback` to run when a `KeyDown` whose key equals `key`
+    /// reaches this element unhandled by the child.
+    pub fn on_key(
+        mut self,
+        key: impl Into<String>,
+        callback: impl FnMut(&Event, &mut TuiEventContext, &AppContext) + 'static,
+    ) -> Self {
+        self.bindings.push(KeyBinding {
+            key: key.into(),
+            callback: Box::new(callback),
+        });
+        self
+    }
+}
+
+impl TuiElement for TuiEventHandler {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.child.layout(constraint)
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        self.child.render(area, buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.child.desired_height(width)
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        self.child.cursor_position(area)
+    }
+
+    fn dispatch_event(
+        &mut self,
+        event: &Event,
+        area: TuiRect,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool {
+        if self.child.dispatch_event(event, area, ctx, app) {
+            return true;
+        }
+
+        if let Event::KeyDown { keystroke, .. } = event {
+            for binding in &mut self.bindings {
+                if binding.key == keystroke.key {
+                    (binding.callback)(event, ctx, app);
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+#[path = "event_handler_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/elements/event_handler_tests.rs
+++ b/crates/warpui_tui/src/elements/event_handler_tests.rs
@@ -1,0 +1,80 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use warpui_core::event::KeyEventDetails;
+use warpui_core::keymap::Keystroke;
+use warpui_core::{App, Event};
+
+use super::TuiEventHandler;
+use crate::elements::TuiElement;
+use crate::{TuiEventContext, TuiRect};
+
+fn key_event(key: &str) -> Event {
+    Event::KeyDown {
+        keystroke: Keystroke {
+            key: key.to_owned(),
+            ..Default::default()
+        },
+        chars: key.to_owned(),
+        details: KeyEventDetails::default(),
+        is_composing: false,
+    }
+}
+
+#[test]
+fn invokes_callback_on_matching_key_and_reports_handled() {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let hits = Rc::new(Cell::new(0u32));
+            let counter = hits.clone();
+            let mut handler =
+                TuiEventHandler::new(()).on_key("enter", move |_event, _ctx, _app| {
+                    counter.set(counter.get() + 1);
+                });
+
+            let area = TuiRect::new(0, 0, 4, 1);
+            let mut event_ctx = TuiEventContext::default();
+
+            let handled =
+                handler.dispatch_event(&key_event("enter"), area, &mut event_ctx, app_ctx);
+            assert!(handled);
+            assert_eq!(hits.get(), 1);
+
+            // A non-matching key is left unhandled for ancestors, runs no callback.
+            let handled = handler.dispatch_event(&key_event("esc"), area, &mut event_ctx, app_ctx);
+            assert!(!handled);
+            assert_eq!(hits.get(), 1);
+        });
+    });
+}
+
+#[test]
+fn child_consumes_the_event_before_the_wrapper() {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let inner_hits = Rc::new(Cell::new(0u32));
+            let outer_hits = Rc::new(Cell::new(0u32));
+            let inner_counter = inner_hits.clone();
+            let outer_counter = outer_hits.clone();
+
+            let inner = TuiEventHandler::new(()).on_key("enter", move |_, _, _| {
+                inner_counter.set(inner_counter.get() + 1)
+            });
+            let mut outer = TuiEventHandler::new(inner).on_key("enter", move |_, _, _| {
+                outer_counter.set(outer_counter.get() + 1)
+            });
+
+            let mut event_ctx = TuiEventContext::default();
+            let handled = outer.dispatch_event(
+                &key_event("enter"),
+                TuiRect::new(0, 0, 1, 1),
+                &mut event_ctx,
+                app_ctx,
+            );
+
+            assert!(handled);
+            assert_eq!(inner_hits.get(), 1);
+            assert_eq!(outer_hits.get(), 0);
+        });
+    });
+}

--- a/crates/warpui_tui/src/elements/mod.rs
+++ b/crates/warpui_tui/src/elements/mod.rs
@@ -13,6 +13,18 @@ use warpui_core::{AppContext, EntityId, Event};
 
 use crate::{TuiBuffer, TuiConstraint, TuiEventContext, TuiRect, TuiSize};
 
+mod child_view;
+mod column;
+mod container;
+mod event_handler;
+mod text;
+
+pub use child_view::TuiChildView;
+pub use column::TuiColumn;
+pub use container::TuiContainer;
+pub use event_handler::TuiEventHandler;
+pub use text::TuiText;
+
 /// What a [`TuiView`](warpui_core::TuiView) renders to.
 ///
 /// A view sets `type RenderOutput = TuiRenderOutput` and returns a boxed

--- a/crates/warpui_tui/src/elements/text.rs
+++ b/crates/warpui_tui/src/elements/text.rs
@@ -1,0 +1,199 @@
+//! [`TuiText`]: a styled run of text that wraps (or truncates) to the width it
+//! is laid out at.
+//!
+//! # Construction
+//! Build with [`TuiText::new`] and chain builders:
+//! - [`with_style`](TuiText::with_style) sets the [`TuiStyle`] applied to every
+//!   glyph.
+//! - [`truncate`](TuiText::truncate) switches from the default word-wrapping
+//!   policy to single-row-per-line truncation.
+//!
+//! # Layout policy
+//! The text is first split into *hard lines* on `'\n'`. Each hard line is then
+//! laid out against the available width in one of two modes:
+//!
+//! - **Wrap** (default): tokens (space-separated words) are packed greedily,
+//!   separated by a single space, starting a new row whenever the next token
+//!   would overflow. A token wider than the whole width is hard-broken at
+//!   grapheme boundaries. Runs of spaces collapse to a single separator.
+//! - **Truncate**: each hard line becomes exactly one row; glyphs past the
+//!   width are dropped by the buffer when painted.
+//!
+//! Column widths are measured with `unicode-width`, so a wide (CJK) glyph
+//! occupies two columns and is never split across rows.
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize, TuiStyle};
+
+pub struct TuiText {
+    text: String,
+    style: TuiStyle,
+    wrap: bool,
+}
+
+impl TuiText {
+    /// A wrapping text element holding `text` with default styling.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            style: TuiStyle::default(),
+            wrap: true,
+        }
+    }
+
+    pub fn with_style(mut self, style: TuiStyle) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Lays each hard line out as a single (clipped) row instead of wrapping.
+    pub fn truncate(mut self) -> Self {
+        self.wrap = false;
+        self
+    }
+
+    /// The rows this text occupies when laid out at `width` columns, under the
+    /// active wrap/truncate policy. This is the single source of truth shared by
+    /// [`layout`](TuiElement::layout), [`render`](TuiElement::render), and
+    /// [`desired_height`](TuiElement::desired_height).
+    fn rows(&self, width: u16) -> Vec<String> {
+        if self.text.is_empty() {
+            return Vec::new();
+        }
+        if self.wrap {
+            self.text
+                .split('\n')
+                .flat_map(|line| wrap_hard_line(line, width))
+                .collect()
+        } else {
+            self.text.split('\n').map(str::to_owned).collect()
+        }
+    }
+}
+
+impl TuiElement for TuiText {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let rows = self.rows(constraint.max.width);
+        let content_width = rows.iter().map(|row| text_width(row)).max().unwrap_or(0);
+        let height = u16::try_from(rows.len()).unwrap_or(u16::MAX);
+        TuiSize::new(
+            constraint.constrain_width(content_width),
+            constraint.constrain_height(height),
+        )
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        if area.is_empty() {
+            return;
+        }
+        for (offset, row) in self.rows(area.width).iter().enumerate() {
+            let Ok(offset) = u16::try_from(offset) else {
+                break;
+            };
+            if offset >= area.height {
+                break;
+            }
+            buffer.set_str(area.x, area.y + offset, area.width, row, self.style);
+        }
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        u16::try_from(self.rows(width).len()).unwrap_or(u16::MAX)
+    }
+}
+
+/// Greedily wraps a single newline-free line to `width` columns. Returns one
+/// `String` per visual row (empty when `width` is zero).
+fn wrap_hard_line(line: &str, width: u16) -> Vec<String> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let mut rows = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0;
+
+    for token in line.split(' ').filter(|token| !token.is_empty()) {
+        let token_width = text_width(token);
+
+        if !current.is_empty() && current_width + 1 + token_width <= width {
+            current.push(' ');
+            current.push_str(token);
+            current_width += 1 + token_width;
+            continue;
+        }
+
+        if !current.is_empty() {
+            rows.push(std::mem::take(&mut current));
+            current_width = 0;
+        }
+
+        if token_width <= width {
+            current = token.to_owned();
+            current_width = token_width;
+            continue;
+        }
+
+        // The token is wider than a full row: hard-break it at grapheme
+        // boundaries, carrying the final fragment into `current`.
+        let chunks = hard_break(token, width);
+        let last = chunks.len().saturating_sub(1);
+        for (index, chunk) in chunks.into_iter().enumerate() {
+            if index == last {
+                current_width = text_width(&chunk);
+                current = chunk;
+            } else {
+                rows.push(chunk);
+            }
+        }
+    }
+
+    if !current.is_empty() {
+        rows.push(current);
+    }
+    if rows.is_empty() {
+        rows.push(String::new());
+    }
+    rows
+}
+
+/// Splits `token` into fragments each at most `width` columns wide, breaking
+/// only on grapheme boundaries (a single glyph wider than `width` is kept whole
+/// and clipped later by the buffer).
+fn hard_break(token: &str, width: u16) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0;
+
+    for grapheme in token.graphemes(true) {
+        let glyph_width = grapheme_width(grapheme);
+        if !current.is_empty() && current_width + glyph_width > width {
+            chunks.push(std::mem::take(&mut current));
+            current_width = 0;
+        }
+        current.push_str(grapheme);
+        current_width += glyph_width;
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+fn text_width(text: &str) -> u16 {
+    u16::try_from(UnicodeWidthStr::width(text)).unwrap_or(u16::MAX)
+}
+
+/// The column width of a single grapheme, floored at 1 to mirror the buffer's
+/// own measurement of zero-width clusters.
+fn grapheme_width(grapheme: &str) -> u16 {
+    u16::try_from(UnicodeWidthStr::width(grapheme).max(1)).unwrap_or(u16::MAX)
+}
+
+#[cfg(test)]
+#[path = "text_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/elements/text_tests.rs
+++ b/crates/warpui_tui/src/elements/text_tests.rs
@@ -1,0 +1,95 @@
+use crossterm::style::Color;
+
+use super::TuiText;
+use crate::elements::TuiElement;
+use crate::{TuiBuffer, TuiConstraint, TuiRect, TuiSize, TuiStyle};
+
+fn render_to_lines(element: &dyn TuiElement, size: TuiSize) -> Vec<String> {
+    let mut buffer = TuiBuffer::new(size);
+    element.render(TuiRect::from_size(size), &mut buffer);
+    buffer.to_lines()
+}
+
+#[test]
+fn renders_a_single_short_line() {
+    let text = TuiText::new("hello");
+    assert_eq!(
+        render_to_lines(&text, TuiSize::new(10, 1)),
+        vec!["hello     "],
+    );
+}
+
+#[test]
+fn layout_reports_content_width_and_row_count() {
+    let mut text = TuiText::new("hello world foo");
+    let size = text.layout(TuiConstraint::loose(TuiSize::new(11, 10)));
+    // "hello world" packs onto row 1 (11 cols), "foo" wraps to row 2.
+    assert_eq!(size, TuiSize::new(11, 2));
+    assert_eq!(text.desired_height(11), 2);
+}
+
+#[test]
+fn word_wraps_at_the_width_boundary() {
+    let text = TuiText::new("hello world foo");
+    assert_eq!(
+        render_to_lines(&text, TuiSize::new(11, 2)),
+        vec!["hello world", "foo        "],
+    );
+}
+
+#[test]
+fn hard_breaks_a_token_wider_than_the_row() {
+    let text = TuiText::new("abcdefgh");
+    assert_eq!(text.desired_height(3), 3);
+    assert_eq!(
+        render_to_lines(&text, TuiSize::new(3, 3)),
+        vec!["abc", "def", "gh "],
+    );
+}
+
+#[test]
+fn wide_glyphs_occupy_two_columns_and_are_never_split() {
+    // A wide glyph painted with one trailing column to spare drops whole: only
+    // the leading "日" lands, proving it claimed two columns.
+    let truncated = TuiText::new("日本").truncate();
+    assert_eq!(render_to_lines(&truncated, TuiSize::new(3, 1)), vec!["日 "],);
+
+    // Given exactly four columns both wide glyphs fit.
+    assert_eq!(
+        render_to_lines(&TuiText::new("日本"), TuiSize::new(4, 1)),
+        vec!["日本"],
+    );
+
+    // Wrapping a wide pair into a three-column row splits between glyphs.
+    let wrapped = TuiText::new("日本");
+    assert_eq!(wrapped.desired_height(3), 2);
+    assert_eq!(
+        render_to_lines(&wrapped, TuiSize::new(3, 2)),
+        vec!["日 ", "本 "],
+    );
+}
+
+#[test]
+fn applies_its_style_to_every_painted_cell() {
+    let style = TuiStyle::default()
+        .with_foreground(Color::Red)
+        .with_bold(true);
+    let text = TuiText::new("a").with_style(style);
+
+    let mut buffer = TuiBuffer::new(TuiSize::new(1, 1));
+    text.render(TuiRect::new(0, 0, 1, 1), &mut buffer);
+
+    let cell = buffer.get(0, 0).expect("cell in bounds");
+    assert_eq!(cell.symbol(), "a");
+    assert_eq!(cell.style(), style);
+}
+
+#[test]
+fn truncation_keeps_one_row_per_hard_line() {
+    let text = TuiText::new("a\nb\nc").truncate();
+    assert_eq!(text.desired_height(10), 3);
+    assert_eq!(
+        render_to_lines(&text, TuiSize::new(3, 3)),
+        vec!["a  ", "b  ", "c  "],
+    );
+}

--- a/crates/warpui_tui/src/lib.rs
+++ b/crates/warpui_tui/src/lib.rs
@@ -45,7 +45,10 @@ mod event;
 mod geometry;
 
 pub use buffer::{Cell, TuiBuffer, TuiStyle};
-pub use elements::{TuiElement, TuiPresentationContext, TuiRenderOutput};
+pub use elements::{
+    TuiChildView, TuiColumn, TuiContainer, TuiElement, TuiEventHandler, TuiPresentationContext,
+    TuiRenderOutput, TuiText,
+};
 pub use event::{
     crossterm_event_to_warp_event, TuiDispatchEventResult, TuiEventContext, TuiEventDispatchResult,
 };


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
