### PR TITLE
warpui_tui: TuiPresenter + first-class TuiBackend::Presenter

### DIFF
--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -19,9 +19,13 @@ use parking_lot::Mutex;
 use pathfinder_geometry::rect::RectF;
 use rustc_hash::FxHashMap;
 
+#[cfg(not(feature = "tui"))]
+use super::GuiPresenterState;
+#[cfg(feature = "tui")]
+use super::TuiPresenterState;
 use super::{
     autotracking, ActionHandlersByName, ActiveBackend, Backend, BlurContext, FocusContext,
-    GlobalActionCallback, GlobalShortcut, GuiPresenterState, Observation, PendingUnsubscribes,
+    GlobalActionCallback, GlobalShortcut, InvalidationCallback, Observation, PendingUnsubscribes,
     RefCounts, Subscription, TaskCallback, TypedActionCallback, ViewType,
 };
 use crate::accessibility::AccessibilityVerbosity;
@@ -510,9 +514,15 @@ pub struct AppContextImpl<B: Backend> {
     /// type keys, as it requires the values to appropriately downcast.
     pub(super) typed_actions: HashMap<ActionType, HashMap<ViewType, Box<TypedActionCallback<B>>>>,
     /// Backend-specific presentation state, hoisted into [`Backend::Presenter`] so
-    /// the generic core never names a GUI-only presenter/position-cache/
-    /// invalidation type. GUI: [`GuiPresenterState`].
+    /// the generic core never names a GUI-only presenter/position-cache type.
+    /// GUI: [`GuiPresenterState`]; TUI: [`TuiPresenterState`](super::TuiPresenterState).
     presentation: B::Presenter,
+    /// Backend-agnostic per-window invalidation bookkeeping. Hoisted out of the
+    /// per-backend presenter state so neither `B::Presenter` carries it: dirty
+    /// tracking (`notify`) and the redraw callbacks are shared core concerns,
+    /// identical for the GUI and TUI backends.
+    window_invalidations: HashMap<WindowId, WindowInvalidation>,
+    invalidation_callbacks: HashMap<WindowId, Box<InvalidationCallback>>,
     /// Configuration options related to rendering of the application.
     rendering_config: rendering::Config,
     global_actions: HashMap<String, Vec<Box<GlobalActionCallback>>>,
@@ -679,7 +689,12 @@ impl AppContext {
             actions: Default::default(),
             typed_actions: Default::default(),
             global_actions: Default::default(),
+            #[cfg(not(feature = "tui"))]
             presentation: GuiPresenterState::default(),
+            #[cfg(feature = "tui")]
+            presentation: TuiPresenterState::default(),
+            window_invalidations: Default::default(),
+            invalidation_callbacks: Default::default(),
             rendering_config: Default::default(),
             keystroke_matcher: Default::default(),
             disabled_key_bindings_windows: Default::default(),
@@ -851,8 +866,7 @@ impl AppContext {
     }
 
     pub fn has_window_invalidations(&self, window_id: WindowId) -> bool {
-        self.presentation
-            .window_invalidations
+        self.window_invalidations
             .get(&window_id)
             .is_some_and(|invalidation| {
                 !invalidation.updated.is_empty() || !invalidation.removed.is_empty()
@@ -870,8 +884,7 @@ impl AppContext {
         let Some(window) = self.windows.get(&window_id) else {
             return;
         };
-        self.presentation
-            .window_invalidations
+        self.window_invalidations
             .entry(window_id)
             .or_default()
             .updated = window.views.keys().cloned().collect();
@@ -896,8 +909,7 @@ impl AppContext {
         window_id: WindowId,
         callback: F,
     ) {
-        self.presentation
-            .invalidation_callbacks
+        self.invalidation_callbacks
             .insert(window_id, Box::new(callback));
     }
 
@@ -2311,8 +2323,8 @@ impl AppContext {
             windowing_state.remove_window(window_id, ctx);
         });
         self.presentation.presenters.remove(&window_id);
-        self.presentation.invalidation_callbacks.remove(&window_id);
-        self.presentation.window_invalidations.remove(&window_id);
+        self.invalidation_callbacks.remove(&window_id);
+        self.window_invalidations.remove(&window_id);
         autotracking::close_window(window_id);
 
         let mut subscriptions = HashMap::new();
@@ -2563,8 +2575,7 @@ impl AppContext {
                 panic!("Window does not exist");
             }
             self.view_to_window.insert(view_id, window_id);
-            self.presentation
-                .window_invalidations
+            self.window_invalidations
                 .entry(window_id)
                 .or_default()
                 .updated
@@ -2614,8 +2625,7 @@ impl AppContext {
         }
 
         register_action_handler(self);
-        self.presentation
-            .window_invalidations
+        self.window_invalidations
             .entry(window_id)
             .or_default()
             .updated
@@ -2682,8 +2692,7 @@ impl AppContext {
 
         // Mark the view as removed from the source window's invalidation set.
         // This tells the renderer to stop tracking this view in the source window.
-        self.presentation
-            .window_invalidations
+        self.window_invalidations
             .entry(source_window_id)
             .or_default()
             .removed
@@ -2700,8 +2709,7 @@ impl AppContext {
         target_window.views.insert(view_id, view);
         self.view_to_window.insert(view_id, target_window_id);
 
-        self.presentation
-            .window_invalidations
+        self.window_invalidations
             .entry(target_window_id)
             .or_default()
             .updated
@@ -2846,8 +2854,7 @@ impl AppContext {
                 self.structural_parent_to_children.remove(&view_id);
 
                 if let Some(window) = self.windows.get_mut(&current_window_id) {
-                    self.presentation
-                        .window_invalidations
+                    self.window_invalidations
                         .entry(current_window_id)
                         .or_default()
                         .removed
@@ -2904,7 +2911,6 @@ impl AppContext {
 
     fn update_windows(&mut self) {
         let invalidated_window_ids = self
-            .presentation
             .window_invalidations
             .keys()
             .chain(autotracking::windows_with_invalidations().iter())
@@ -2912,12 +2918,9 @@ impl AppContext {
             .cloned()
             .collect_vec();
         for window_id in invalidated_window_ids {
-            if let Some(mut callback) = self.presentation.invalidation_callbacks.remove(&window_id)
-            {
+            if let Some(mut callback) = self.invalidation_callbacks.remove(&window_id) {
                 callback(window_id, self);
-                self.presentation
-                    .invalidation_callbacks
-                    .insert(window_id, callback);
+                self.invalidation_callbacks.insert(window_id, callback);
             }
         }
     }
@@ -2932,7 +2935,6 @@ impl AppContext {
         window_id: WindowId,
     ) -> WindowInvalidation {
         let mut invalidations = self
-            .presentation
             .window_invalidations
             .remove(&window_id)
             .unwrap_or_default();
@@ -3039,8 +3041,7 @@ impl AppContext {
 
                 // If the timer is no longer in repaint_tasks, it was cancelled.
                 if app.repaint_tasks.remove(&task_id).is_some() {
-                    app.presentation
-                        .window_invalidations
+                    app.window_invalidations
                         .entry(window_id)
                         .or_default()
                         .redraw_requested = true;
@@ -3095,7 +3096,7 @@ impl AppContext {
 
                 // If the timer is no longer in repaint_tasks, it was cancelled.
                 if app.repaint_tasks.remove(&task_id).is_some() {
-                    app.presentation.window_invalidations
+                    app.window_invalidations
                         .entry(window_id)
                         .or_default()
                         .redraw_requested = true;
@@ -3207,8 +3208,7 @@ impl AppContext {
         }
 
         // Trigger a redraw on the window.
-        self.presentation
-            .window_invalidations
+        self.window_invalidations
             .entry(window_id)
             .or_default()
             .redraw_requested = true;
@@ -3527,8 +3527,7 @@ impl AppContext {
     }
 
     fn notify_view_observers(&mut self, window_id: WindowId, view_id: EntityId) {
-        self.presentation
-            .window_invalidations
+        self.window_invalidations
             .entry(window_id)
             .or_default()
             .updated

--- a/crates/warpui_core/src/core/backend.rs
+++ b/crates/warpui_core/src/core/backend.rs
@@ -16,11 +16,11 @@ use std::rc::Rc;
 
 #[cfg(not(feature = "tui"))]
 use super::AnyView;
-use super::{AppContextImpl, InvalidationCallback};
+use super::AppContextImpl;
 use crate::presenter::PositionCache;
 #[cfg(not(feature = "tui"))]
 use crate::{Element, View};
-use crate::{Presenter, WindowId, WindowInvalidation};
+use crate::{Presenter, WindowId};
 
 /// Marker trait selecting a UI backend (GUI or TUI).
 ///
@@ -98,13 +98,17 @@ impl<T: View> BackendView<GuiBackend> for T {
 }
 
 /// Presentation state for the GUI backend, stored on `AppContextImpl<GuiBackend>`
-/// as `B::Presenter`. Wraps today's presenter collection plus the position cache
-/// and window-invalidation bookkeeping, so the generic core holds only an opaque
-/// `B::Presenter` while GUI method signatures that touch this state are unchanged.
+/// as `B::Presenter`. Wraps the presenter collection plus the position cache, so
+/// the generic core holds only an opaque `B::Presenter` while GUI method
+/// signatures that touch this state are unchanged. The backend-agnostic
+/// window-invalidation bookkeeping has been hoisted onto `AppContextImpl<B>`
+/// directly, so it no longer lives here (nor on the TUI presenter state).
+//
+// Defined in both builds but only instantiated by the GUI backend, so its
+// fields read as dead on a TUI build (where the GUI presenter is inert).
+#[cfg_attr(feature = "tui", allow(dead_code))]
 #[derive(Default)]
 pub struct GuiPresenterState {
     pub(crate) presenters: HashMap<WindowId, Rc<RefCell<Presenter>>>,
     pub(crate) last_frame_position_cache: HashMap<WindowId, PositionCache>,
-    pub(crate) window_invalidations: HashMap<WindowId, WindowInvalidation>,
-    pub(crate) invalidation_callbacks: HashMap<WindowId, Box<InvalidationCallback>>,
 }

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -38,7 +38,7 @@ pub use model::*;
 use pathfinder_geometry::rect::RectF;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "tui")]
-pub use tui_backend::TuiBackend;
+pub use tui_backend::{TuiBackend, TuiPresenterState};
 #[cfg(feature = "tui")]
 pub use tui_view::{
     AnyTuiView, TuiReadView, TuiTypedActionView, TuiUpdateView, TuiView, TuiViewAsRef,

--- a/crates/warpui_core/src/core/tui.rs
+++ b/crates/warpui_core/src/core/tui.rs
@@ -189,6 +189,18 @@ impl AppContext {
             .or_insert(handler);
     }
 
+    /// Renders the registered [`TuiView`] with the given id to its type-erased
+    /// output (a `Box<dyn Any>` wrapping the view's `RenderOutput`), or `None`
+    /// if no such view is registered. This is the TUI analogue of
+    /// [`render_view`](Self::render_view): the `warpui_tui` presenter calls it to
+    /// resolve a (root or child) view and downcasts the result back to the
+    /// concrete boxed element to lay out and paint it.
+    pub fn render_tui_view(&self, view_id: EntityId) -> Option<Box<dyn Any>> {
+        let window_id = *self.view_to_window.get(&view_id)?;
+        let view = self.windows.get(&window_id)?.views.get(&view_id)?;
+        Some(AnyTuiView::render_tui(view.as_ref(), self))
+    }
+
     /// Returns a handle to the window's root [`TuiView`], if it is of type `T`.
     pub fn root_view_tui<T: TuiView>(&self, window_id: WindowId) -> Option<TuiViewHandle<T>> {
         self.windows

--- a/crates/warpui_core/src/core/tui_backend.rs
+++ b/crates/warpui_core/src/core/tui_backend.rs
@@ -7,10 +7,15 @@
 //! milestone) and recovered by downcasting this erased output.
 
 use std::any::Any;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
 
-use super::backend::{Backend, BackendView, ErasedView, GuiPresenterState};
+use super::backend::{Backend, BackendView, ErasedView};
 use super::tui_view::{AnyTuiView, TuiView};
 use super::AppContextImpl;
+use crate::presenter::PositionCache;
+use crate::{Presenter, WindowId};
 
 /// The TUI backend marker.
 pub struct TuiBackend;
@@ -23,11 +28,29 @@ impl Backend for TuiBackend {
 
     type AnyView = dyn AnyTuiView;
 
-    /// Reuses [`GuiPresenterState`] so the shared core retains the
-    /// window-invalidation bookkeeping that `notify`/dirty tracking depend on.
-    /// The real TUI presentation layer arrives in a later milestone; until then
-    /// the GUI presenter state simply goes unused on a TUI build.
-    type Presenter = GuiPresenterState;
+    /// The TUI backend's own presentation state. The real TUI render/event loop
+    /// (layout + paint into a cell buffer) lives downstream in `warpui_tui`'s
+    /// `TuiPresenter`; this is the core-side handle for it.
+    type Presenter = TuiPresenterState;
+}
+
+/// Presentation state for the TUI backend, stored on `AppContextImpl<TuiBackend>`
+/// as `B::Presenter`. This is a first-class, TUI-owned type (replacing the M2
+/// placeholder that reused [`GuiPresenterState`](super::GuiPresenterState)); the
+/// backend-agnostic window-invalidation bookkeeping now lives on
+/// `AppContextImpl<B>` directly, so it is not duplicated here.
+///
+/// NOTE (deferred cleanup): the GUI presenter map + position cache below are a
+/// residual compile bridge. The shared scene/event/focus plumbing in `app.rs`
+/// (`presenter`, `build_scene`, `handle_window_event`, focus/blur, …) is not yet
+/// cfg-split between backends and still references these fields even on a TUI
+/// build, where they go unused (the GUI presenter is inert). Fully shedding them
+/// requires cfg-gating that GUI scene path and is intentionally left out of this
+/// task to keep the GUI + `--features tui` gates stable.
+#[derive(Default)]
+pub struct TuiPresenterState {
+    pub(crate) presenters: HashMap<WindowId, Rc<RefCell<Presenter>>>,
+    pub(crate) last_frame_position_cache: HashMap<WindowId, PositionCache>,
 }
 
 impl ErasedView<TuiBackend> for dyn AnyTuiView {

--- a/crates/warpui_tui/src/lib.rs
+++ b/crates/warpui_tui/src/lib.rs
@@ -43,6 +43,7 @@ mod buffer;
 pub mod elements;
 mod event;
 mod geometry;
+pub mod presenter;
 
 pub use buffer::{Cell, TuiBuffer, TuiStyle};
 pub use elements::{
@@ -53,4 +54,5 @@ pub use event::{
     crossterm_event_to_warp_event, TuiDispatchEventResult, TuiEventContext, TuiEventDispatchResult,
 };
 pub use geometry::{TuiConstraint, TuiRect, TuiSize};
+pub use presenter::{TuiFrame, TuiPresenter};
 pub use warpui_core::TuiView;

--- a/crates/warpui_tui/src/presenter.rs
+++ b/crates/warpui_tui/src/presenter.rs
@@ -1,0 +1,162 @@
+//! The TUI presenter: turns a root [`TuiView`]'s render output into a painted
+//! [`TuiFrame`] (a cell [`TuiBuffer`] plus the absolute cursor cell).
+//!
+//! # Layout pass ordering: measure → arrange → paint
+//!
+//! 1. **measure** — the root element is measured against a loose
+//!    [`TuiConstraint`] bounded by the target area, returning the size it wants
+//!    (within that box).
+//! 2. **arrange** — that size is anchored at the area's origin, producing the
+//!    absolute rectangle the root occupies. Container elements recurse this
+//!    measure/arrange internally for their children (the presenter only drives
+//!    the root; the element tree composes itself).
+//! 3. **paint** — the root paints into its arranged rectangle of a fresh buffer.
+//!    Each container paints its children into their sub-rectangles, so the whole
+//!    tree composites into one buffer.
+//!
+//! After arranging, the presenter walks the tree once more via
+//! [`TuiElement::present`] to record parent/child *view* relationships (for a
+//! [`TuiChildView`]-style element that embeds a sub-view); this ancestry is what
+//! lets the runtime attribute events and actions to the right view.
+//!
+//! # Child views
+//!
+//! A child view is a full [`TuiView`] registered in the app. It is embedded by
+//! resolving it through the app — [`AppContext::render_tui_view`] renders it to
+//! its boxed element tree — and wrapping that output in a child-view element
+//! during the *parent* view's render (which has app access). The presenter then
+//! lays out and paints the composed tree, so the child's output lands at exactly
+//! the area the layout allocated to it, and the [`present`](TuiElement::present)
+//! pass records the embedded view as a child of its parent.
+
+use std::collections::HashMap;
+
+use warpui_core::{AppContext, EntityId, TuiView, TuiViewHandle};
+
+use crate::elements::TuiPresentationContext;
+use crate::{TuiBuffer, TuiConstraint, TuiElement, TuiRect, TuiSize};
+
+/// A painted frame: the composited cell [`TuiBuffer`] plus the absolute cursor
+/// position (in buffer cell coordinates), if a focused element owns the cursor.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TuiFrame {
+    /// The composited cell grid, covering the columns/rows up to the painted
+    /// area's right/bottom edge.
+    pub buffer: TuiBuffer,
+    /// The absolute `(x, y)` cell the terminal cursor should occupy, if any.
+    pub cursor: Option<(u16, u16)>,
+}
+
+impl TuiFrame {
+    /// A blank frame sized to cover `area`, with no cursor.
+    fn blank(area: TuiRect) -> Self {
+        Self {
+            buffer: TuiBuffer::new(buffer_size_for(area)),
+            cursor: None,
+        }
+    }
+}
+
+/// Lays out and paints a [`TuiView`]'s element tree into a [`TuiFrame`].
+///
+/// The presenter retains the parent/child *view* ancestry recorded during the
+/// last [`present`](Self::present) so the runtime can resolve which view an
+/// event-handling element belongs to.
+#[derive(Default)]
+pub struct TuiPresenter {
+    /// Maps each embedded child view to its parent view, as recorded by the most
+    /// recent presentation pass.
+    parent_by_child: HashMap<EntityId, EntityId>,
+}
+
+impl TuiPresenter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Renders the root view through the app, then lays it out and paints it into
+    /// `area`, returning the composited [`TuiFrame`].
+    ///
+    /// The root is resolved via [`AppContext::render_tui_view`] and downcast back
+    /// to the concrete boxed [`TuiElement`]; a view that does not render to a
+    /// [`TuiRenderOutput`](crate::TuiRenderOutput) yields a blank frame.
+    pub fn present<V: TuiView>(
+        &mut self,
+        app: &AppContext,
+        root: &TuiViewHandle<V>,
+        area: TuiRect,
+    ) -> TuiFrame {
+        let root_view_id = root.id();
+        let Some(element) = app
+            .render_tui_view(root_view_id)
+            .and_then(|output| output.downcast::<Box<dyn TuiElement>>().ok())
+            .map(|boxed| *boxed)
+        else {
+            return TuiFrame::blank(area);
+        };
+        self.paint_tree(Some(root_view_id), element, area)
+    }
+
+    /// Lays out and paints an already-rendered element tree into `area`.
+    ///
+    /// This is the backend-agnostic core of [`present`](Self::present), exposed so
+    /// the runtime (and tests) can drive layout/paint for an element tree that was
+    /// produced outside the app's view registry. No view-ancestry is recorded.
+    pub fn present_element(&mut self, root: Box<dyn TuiElement>, area: TuiRect) -> TuiFrame {
+        self.paint_tree(None, root, area)
+    }
+
+    /// Returns the parent view of `child_view_id` as recorded by the last
+    /// presentation pass, if it was embedded as a child view.
+    pub fn parent_view(&self, child_view_id: EntityId) -> Option<EntityId> {
+        self.parent_by_child.get(&child_view_id).copied()
+    }
+
+    fn paint_tree(
+        &mut self,
+        root_view_id: Option<EntityId>,
+        mut root: Box<dyn TuiElement>,
+        area: TuiRect,
+    ) -> TuiFrame {
+        // measure: ask the root how big it wants to be within the area.
+        let measured = root.layout(TuiConstraint::loose(area.size()));
+
+        // arrange: anchor the measured size at the area's origin (the size is
+        // already within the area, but clamp defensively so writes stay in bounds).
+        let arranged = TuiRect::new(
+            area.x,
+            area.y,
+            measured.width.min(area.width),
+            measured.height.min(area.height),
+        );
+
+        // record parent/child view ancestry for the (root) view tree.
+        self.parent_by_child.clear();
+        if let Some(root_view_id) = root_view_id {
+            let mut ctx = TuiPresentationContext::new(root_view_id, &mut self.parent_by_child);
+            root.present(&mut ctx);
+        }
+
+        // paint: composite the whole tree into a fresh buffer.
+        let mut buffer = TuiBuffer::new(buffer_size_for(area));
+        root.render(arranged, &mut buffer);
+
+        // cursor: lift the root-relative cursor offset to absolute coordinates.
+        let cursor = root
+            .cursor_position(arranged)
+            .map(|(x, y)| (arranged.x.saturating_add(x), arranged.y.saturating_add(y)));
+
+        TuiFrame { buffer, cursor }
+    }
+}
+
+/// The buffer size needed to hold everything painted within `area`: it spans
+/// from the origin to the area's right/bottom edge, so absolute coordinates
+/// (including any area offset) index correctly.
+fn buffer_size_for(area: TuiRect) -> TuiSize {
+    TuiSize::new(area.right(), area.bottom())
+}
+
+#[cfg(test)]
+#[path = "presenter_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/presenter_tests.rs
+++ b/crates/warpui_tui/src/presenter_tests.rs
@@ -1,0 +1,389 @@
+//! Headless tests for [`TuiPresenter`]. They drive layout + paint against local
+//! [`TuiElement`] test-doubles (so they do not depend on task 3.2's concrete
+//! elements) and assert the composited [`TuiBuffer`] via `to_lines` plus the
+//! surfaced cursor. The child-view test registers a real [`TuiView`] in a test
+//! [`App`] and resolves it through the app, exactly as the live elements will.
+
+use warpui_core::platform::WindowStyle;
+use warpui_core::{
+    AddWindowOptions, App, AppContext, Entity, EntityId, TuiTypedActionView, TuiView,
+};
+
+use super::TuiPresenter;
+use crate::elements::TuiPresentationContext;
+use crate::{
+    Cell, TuiBuffer, TuiConstraint, TuiElement, TuiRect, TuiRenderOutput, TuiSize, TuiStyle,
+};
+
+// --- Test-double elements -------------------------------------------------
+
+/// A single line of text: as wide as its content, one row tall.
+struct TextDouble {
+    text: String,
+}
+
+impl TextDouble {
+    fn new(text: &str) -> Self {
+        Self {
+            text: text.to_owned(),
+        }
+    }
+
+    fn width(&self) -> u16 {
+        self.text.chars().count() as u16
+    }
+}
+
+impl TuiElement for TextDouble {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        constraint.clamp(TuiSize::new(self.width(), 1))
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        buffer.set_str(area.x, area.y, area.width, &self.text, TuiStyle::default());
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        1
+    }
+}
+
+/// A vertical stack: each child is laid out at the column's width and stacked
+/// top-to-bottom. Records per-child sizes at layout time so `render`/
+/// `cursor_position` (which take `&self`) can place children consistently.
+struct ColumnDouble {
+    children: Vec<Box<dyn TuiElement>>,
+    child_sizes: Vec<TuiSize>,
+}
+
+impl ColumnDouble {
+    fn new(children: Vec<Box<dyn TuiElement>>) -> Self {
+        Self {
+            children,
+            child_sizes: Vec::new(),
+        }
+    }
+}
+
+impl TuiElement for ColumnDouble {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.child_sizes.clear();
+        let mut total_height = 0u16;
+        let mut max_width = 0u16;
+        for child in &mut self.children {
+            let available = TuiSize::new(
+                constraint.max.width,
+                constraint.max.height.saturating_sub(total_height),
+            );
+            let size = child.layout(TuiConstraint::loose(available));
+            total_height = total_height.saturating_add(size.height);
+            max_width = max_width.max(size.width);
+            self.child_sizes.push(size);
+        }
+        constraint.clamp(TuiSize::new(max_width, total_height))
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        let mut remaining = area;
+        for (child, size) in self.children.iter().zip(&self.child_sizes) {
+            let (row, rest) = remaining.split_top(size.height);
+            let child_area = TuiRect::new(row.x, row.y, size.width.min(row.width), row.height);
+            child.render(child_area, buffer);
+            remaining = rest;
+        }
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.children
+            .iter()
+            .map(|child| child.desired_height(width))
+            .sum()
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        for child in &mut self.children {
+            child.present(ctx);
+        }
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        let mut remaining = area;
+        for (child, size) in self.children.iter().zip(&self.child_sizes) {
+            let (row, rest) = remaining.split_top(size.height);
+            let child_area = TuiRect::new(row.x, row.y, size.width.min(row.width), row.height);
+            if let Some((cx, cy)) = child.cursor_position(child_area) {
+                return Some((child_area.x - area.x + cx, child_area.y - area.y + cy));
+            }
+            remaining = rest;
+        }
+        None
+    }
+}
+
+/// A styled container that fills its area with `fill` then paints its child
+/// inset by `padding` on every side.
+struct ContainerDouble {
+    child: Box<dyn TuiElement>,
+    padding: u16,
+    fill: char,
+    child_size: TuiSize,
+}
+
+impl ContainerDouble {
+    fn new(child: Box<dyn TuiElement>, padding: u16, fill: char) -> Self {
+        Self {
+            child,
+            padding,
+            fill,
+            child_size: TuiSize::ZERO,
+        }
+    }
+}
+
+impl TuiElement for ContainerDouble {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let inset = self.padding.saturating_mul(2);
+        let inner_max = TuiSize::new(
+            constraint.max.width.saturating_sub(inset),
+            constraint.max.height.saturating_sub(inset),
+        );
+        let size = self.child.layout(TuiConstraint::loose(inner_max));
+        self.child_size = size;
+        constraint.clamp(TuiSize::new(
+            size.width.saturating_add(inset),
+            size.height.saturating_add(inset),
+        ))
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        buffer.fill(area, Cell::new(self.fill.to_string(), TuiStyle::default()));
+        let inner = area.inset(self.padding);
+        let child_area = TuiRect::new(
+            inner.x,
+            inner.y,
+            self.child_size.width.min(inner.width),
+            self.child_size.height.min(inner.height),
+        );
+        self.child.render(child_area, buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        let inset = self.padding.saturating_mul(2);
+        self.child
+            .desired_height(width.saturating_sub(inset))
+            .saturating_add(inset)
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        self.child.present(ctx);
+    }
+}
+
+/// A leaf that owns the cursor, reporting it at a fixed offset within its area.
+struct CursorDouble {
+    offset: (u16, u16),
+}
+
+impl CursorDouble {
+    fn new(offset: (u16, u16)) -> Self {
+        Self { offset }
+    }
+}
+
+impl TuiElement for CursorDouble {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        constraint.clamp(TuiSize::new(5, 1))
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        buffer.set_str(area.x, area.y, area.width, "INPUT", TuiStyle::default());
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        1
+    }
+
+    fn cursor_position(&self, _area: TuiRect) -> Option<(u16, u16)> {
+        Some(self.offset)
+    }
+}
+
+/// A [`TuiChildView`]-style element: it embeds an already-rendered child view's
+/// element tree and records the embedded view as a child during the present
+/// pass. Delegates layout/paint/cursor to the embedded tree.
+struct ChildViewElement {
+    child_view_id: EntityId,
+    inner: Box<dyn TuiElement>,
+}
+
+impl TuiElement for ChildViewElement {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        self.inner.layout(constraint)
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        self.inner.render(area, buffer);
+    }
+
+    fn desired_height(&self, width: u16) -> u16 {
+        self.inner.desired_height(width)
+    }
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        ctx.enter_child(self.child_view_id);
+        self.inner.present(ctx);
+        ctx.exit_child();
+    }
+
+    fn cursor_position(&self, area: TuiRect) -> Option<(u16, u16)> {
+        self.inner.cursor_position(area)
+    }
+}
+
+// --- Real views for the child-view recursion test -------------------------
+
+fn window_options() -> AddWindowOptions {
+    AddWindowOptions {
+        window_style: WindowStyle::NotStealFocus,
+        ..Default::default()
+    }
+}
+
+/// Minimal window root; never presented directly.
+#[derive(Default)]
+struct RootStub;
+
+impl Entity for RootStub {
+    type Event = ();
+}
+
+impl TuiView for RootStub {
+    type RenderOutput = ();
+    fn ui_name() -> &'static str {
+        "RootStub"
+    }
+    fn render_tui(&self, _ctx: &AppContext) {}
+}
+
+impl TuiTypedActionView for RootStub {
+    type Action = ();
+}
+
+/// A registered child view whose output is a single line of text.
+struct LeafView;
+
+impl Entity for LeafView {
+    type Event = ();
+}
+
+impl TuiView for LeafView {
+    type RenderOutput = TuiRenderOutput;
+    fn ui_name() -> &'static str {
+        "LeafView"
+    }
+    fn render_tui(&self, _ctx: &AppContext) -> TuiRenderOutput {
+        Box::new(TextDouble::new("CHILD"))
+    }
+}
+
+/// A parent view: a header above an embedded child view, which it resolves
+/// through the app at render time.
+struct ParentView {
+    child_view_id: EntityId,
+}
+
+impl Entity for ParentView {
+    type Event = ();
+}
+
+impl TuiView for ParentView {
+    type RenderOutput = TuiRenderOutput;
+    fn ui_name() -> &'static str {
+        "ParentView"
+    }
+    fn render_tui(&self, ctx: &AppContext) -> TuiRenderOutput {
+        let child_tree = ctx
+            .render_tui_view(self.child_view_id)
+            .and_then(|output| output.downcast::<Box<dyn TuiElement>>().ok())
+            .map(|boxed| *boxed)
+            .expect("child view should resolve to a boxed element");
+        let child = ChildViewElement {
+            child_view_id: self.child_view_id,
+            inner: child_tree,
+        };
+        Box::new(ColumnDouble::new(vec![
+            Box::new(TextDouble::new("HEADER")),
+            Box::new(child),
+        ]))
+    }
+}
+
+// --- Tests ----------------------------------------------------------------
+
+#[test]
+fn paints_single_root_element_into_area() {
+    let mut presenter = TuiPresenter::new();
+    let frame = presenter.present_element(
+        Box::new(TextDouble::new("HELLO")),
+        TuiRect::new(0, 0, 10, 1),
+    );
+    assert_eq!(frame.buffer.to_lines(), vec!["HELLO     "]);
+    assert_eq!(frame.cursor, None);
+}
+
+#[test]
+fn composites_nested_container_column_text_with_offsets() {
+    let column = ColumnDouble::new(vec![
+        Box::new(TextDouble::new("AB")),
+        Box::new(TextDouble::new("CDE")),
+    ]);
+    let container = ContainerDouble::new(Box::new(column), 1, '.');
+
+    let mut presenter = TuiPresenter::new();
+    let frame = presenter.present_element(Box::new(container), TuiRect::new(0, 0, 5, 4));
+
+    assert_eq!(
+        frame.buffer.to_lines(),
+        vec![".....", ".AB..", ".CDE.", "....."],
+    );
+}
+
+#[test]
+fn surfaces_cursor_at_absolute_coordinates() {
+    let column = ColumnDouble::new(vec![
+        Box::new(TextDouble::new("HEADER")),
+        Box::new(CursorDouble::new((2, 0))),
+    ]);
+
+    let mut presenter = TuiPresenter::new();
+    let frame = presenter.present_element(Box::new(column), TuiRect::new(0, 0, 8, 2));
+
+    // The cursor element sits on row 1 (below the header) at column 2.
+    assert_eq!(frame.cursor, Some((2, 1)));
+}
+
+#[test]
+fn recurses_into_registered_child_view() {
+    App::test((), |mut app| async move {
+        let (window_id, _root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| RootStub));
+
+        let child = app.update(|ctx| ctx.add_tui_view(window_id, |_| LeafView));
+        let child_view_id = child.id();
+        let parent =
+            app.update(|ctx| ctx.add_tui_view(window_id, move |_| ParentView { child_view_id }));
+
+        let mut presenter = TuiPresenter::new();
+        let frame = app.read(|ctx| presenter.present(ctx, &parent, TuiRect::new(0, 0, 8, 3)));
+
+        // The child view's output is painted directly below the header, at the
+        // area the layout allocated to the embedded child-view element.
+        assert_eq!(
+            frame.buffer.to_lines(),
+            vec!["HEADER  ", "CHILD   ", "        "],
+        );
+
+        // The presentation pass recorded the embedded view as a child of the root.
+        assert_eq!(presenter.parent_view(child_view_id), Some(parent.id()));
+    });
+}


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
