### PR TITLE
warpui_tui: crossterm renderer + runtime; wire runtime to TuiPresenter

### DIFF
--- a/crates/warpui_tui/src/event.rs
+++ b/crates/warpui_tui/src/event.rs
@@ -11,7 +11,13 @@
 //! with any scroll/mouse normalization helpers, is implemented by the renderer/
 //! runtime layer (task 3.4).
 
-use crossterm::event::Event as CrosstermEvent;
+use crossterm::event::{
+    Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
+    MouseEvent, MouseEventKind,
+};
+use warpui_core::event::{KeyEventDetails, ModifiersState};
+use warpui_core::geometry::vector::{vec2f, Vector2F};
+use warpui_core::keymap::Keystroke;
 use warpui_core::{Action, App, EntityId, Event};
 
 /// Whether an element that handled an event wants its ancestors to keep seeing
@@ -101,5 +107,160 @@ impl TuiEventContext {
 /// (task 3.4); the signature is fixed here so sibling tasks can build against
 /// it.
 pub fn crossterm_event_to_warp_event(event: CrosstermEvent) -> Option<Event> {
-    todo!("crossterm_event_to_warp_event mapping is implemented in task 3.4: {event:?}")
+    match event {
+        CrosstermEvent::Key(key_event) => key_event_to_warp_event(key_event),
+        CrosstermEvent::Mouse(mouse_event) => mouse_event_to_warp_event(mouse_event),
+        CrosstermEvent::FocusGained
+        | CrosstermEvent::FocusLost
+        | CrosstermEvent::Paste(_)
+        | CrosstermEvent::Resize(_, _) => None,
+    }
 }
+
+fn key_event_to_warp_event(event: KeyEvent) -> Option<Event> {
+    // Only key presses map to a warp `KeyDown`; repeats/releases are ignored so
+    // dispatch matches the GUI's press-driven keystroke model.
+    if event.kind != KeyEventKind::Press {
+        return None;
+    }
+
+    let key = key_name(event.code, event.modifiers)?;
+    let chars = match event.code {
+        KeyCode::Char(char) => char.to_string(),
+        _ => String::new(),
+    };
+
+    Some(Event::KeyDown {
+        keystroke: Keystroke {
+            ctrl: event.modifiers.contains(KeyModifiers::CONTROL),
+            alt: event.modifiers.contains(KeyModifiers::ALT),
+            shift: event.modifiers.contains(KeyModifiers::SHIFT),
+            cmd: event.modifiers.contains(KeyModifiers::SUPER),
+            meta: event.modifiers.contains(KeyModifiers::META),
+            key,
+        },
+        chars,
+        details: KeyEventDetails {
+            key_without_modifiers: key_without_modifiers(event.code),
+            ..Default::default()
+        },
+        is_composing: false,
+    })
+}
+
+/// The warp keystroke `key` name for a crossterm key code, or `None` for keys
+/// with no warp equivalent (pure modifiers, lock keys, media keys, etc.).
+fn key_name(code: KeyCode, modifiers: KeyModifiers) -> Option<String> {
+    match code {
+        KeyCode::Backspace => Some("backspace".to_owned()),
+        KeyCode::Enter => Some("enter".to_owned()),
+        KeyCode::Left => Some("left".to_owned()),
+        KeyCode::Right => Some("right".to_owned()),
+        KeyCode::Up => Some("up".to_owned()),
+        KeyCode::Down => Some("down".to_owned()),
+        KeyCode::Home => Some("home".to_owned()),
+        KeyCode::End => Some("end".to_owned()),
+        KeyCode::PageUp => Some("pageup".to_owned()),
+        KeyCode::PageDown => Some("pagedown".to_owned()),
+        KeyCode::Tab | KeyCode::BackTab => Some("\t".to_owned()),
+        KeyCode::Delete => Some("delete".to_owned()),
+        KeyCode::Insert => Some("insert".to_owned()),
+        KeyCode::Esc => Some("escape".to_owned()),
+        KeyCode::F(number) if number <= 20 => Some(format!("f{number}")),
+        KeyCode::Char(' ') => Some(" ".to_owned()),
+        KeyCode::Char(char) if modifiers.contains(KeyModifiers::SHIFT) => Some(char.to_string()),
+        KeyCode::Char(char) => Some(char.to_lowercase().to_string()),
+        KeyCode::Null
+        | KeyCode::CapsLock
+        | KeyCode::ScrollLock
+        | KeyCode::NumLock
+        | KeyCode::PrintScreen
+        | KeyCode::Pause
+        | KeyCode::Menu
+        | KeyCode::KeypadBegin
+        | KeyCode::Media(_)
+        | KeyCode::Modifier(_)
+        | KeyCode::F(_) => None,
+    }
+}
+
+fn key_without_modifiers(code: KeyCode) -> Option<String> {
+    match code {
+        KeyCode::Char(char) => Some(char.to_lowercase().to_string()),
+        _ => None,
+    }
+}
+
+fn mouse_event_to_warp_event(event: MouseEvent) -> Option<Event> {
+    let position = vec2f(f32::from(event.column), f32::from(event.row));
+    let modifiers = modifiers_state(event.modifiers);
+    match event.kind {
+        MouseEventKind::Down(MouseButton::Left) => Some(Event::LeftMouseDown {
+            position,
+            modifiers,
+            click_count: 1,
+            is_first_mouse: false,
+        }),
+        MouseEventKind::Up(MouseButton::Left) => Some(Event::LeftMouseUp {
+            position,
+            modifiers,
+        }),
+        MouseEventKind::Drag(MouseButton::Left) => Some(Event::LeftMouseDragged {
+            position,
+            modifiers,
+        }),
+        MouseEventKind::Down(MouseButton::Middle) => Some(Event::MiddleMouseDown {
+            position,
+            cmd: modifiers.cmd,
+            shift: modifiers.shift,
+            click_count: 1,
+        }),
+        MouseEventKind::Down(MouseButton::Right) => Some(Event::RightMouseDown {
+            position,
+            cmd: modifiers.cmd,
+            shift: modifiers.shift,
+            click_count: 1,
+        }),
+        MouseEventKind::Moved => Some(Event::MouseMoved {
+            position,
+            cmd: modifiers.cmd,
+            shift: modifiers.shift,
+            is_synthetic: false,
+        }),
+        MouseEventKind::ScrollUp => Some(scroll_wheel_event(position, modifiers, vec2f(0.0, 1.0))),
+        MouseEventKind::ScrollDown => {
+            Some(scroll_wheel_event(position, modifiers, vec2f(0.0, -1.0)))
+        }
+        MouseEventKind::ScrollLeft => {
+            Some(scroll_wheel_event(position, modifiers, vec2f(-1.0, 0.0)))
+        }
+        MouseEventKind::ScrollRight => {
+            Some(scroll_wheel_event(position, modifiers, vec2f(1.0, 0.0)))
+        }
+        MouseEventKind::Up(MouseButton::Middle | MouseButton::Right)
+        | MouseEventKind::Drag(MouseButton::Middle | MouseButton::Right) => None,
+    }
+}
+
+fn scroll_wheel_event(position: Vector2F, modifiers: ModifiersState, delta: Vector2F) -> Event {
+    Event::ScrollWheel {
+        position,
+        delta,
+        precise: false,
+        modifiers,
+    }
+}
+
+fn modifiers_state(modifiers: KeyModifiers) -> ModifiersState {
+    ModifiersState {
+        alt: modifiers.contains(KeyModifiers::ALT),
+        cmd: modifiers.contains(KeyModifiers::SUPER),
+        shift: modifiers.contains(KeyModifiers::SHIFT),
+        ctrl: modifiers.contains(KeyModifiers::CONTROL),
+        func: false,
+    }
+}
+
+#[cfg(test)]
+#[path = "event_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/event_tests.rs
+++ b/crates/warpui_tui/src/event_tests.rs
@@ -1,0 +1,128 @@
+use crossterm::event::{
+    Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
+    MouseEvent, MouseEventKind,
+};
+use warpui_core::geometry::vector::vec2f;
+use warpui_core::keymap::Keystroke;
+use warpui_core::Event;
+
+use super::crossterm_event_to_warp_event;
+
+fn key(code: KeyCode, modifiers: KeyModifiers) -> Option<Event> {
+    crossterm_event_to_warp_event(CrosstermEvent::Key(KeyEvent::new(code, modifiers)))
+}
+
+fn keystroke(code: KeyCode, modifiers: KeyModifiers) -> Keystroke {
+    match key(code, modifiers) {
+        Some(Event::KeyDown { keystroke, .. }) => keystroke,
+        other => panic!("expected a KeyDown, got {other:?}"),
+    }
+}
+
+#[test]
+fn printable_char_maps_to_lowercase_key_and_chars() {
+    let Some(Event::KeyDown {
+        keystroke, chars, ..
+    }) = key(KeyCode::Char('a'), KeyModifiers::empty())
+    else {
+        panic!("expected KeyDown");
+    };
+    assert_eq!(keystroke.key, "a");
+    assert_eq!(chars, "a");
+    assert!(!keystroke.ctrl && !keystroke.alt && !keystroke.shift);
+}
+
+#[test]
+fn enter_and_escape_map_to_named_keys() {
+    assert_eq!(
+        keystroke(KeyCode::Enter, KeyModifiers::empty()).key,
+        "enter"
+    );
+    assert_eq!(keystroke(KeyCode::Esc, KeyModifiers::empty()).key, "escape");
+}
+
+#[test]
+fn arrow_keys_map_to_direction_names() {
+    assert_eq!(keystroke(KeyCode::Left, KeyModifiers::empty()).key, "left");
+    assert_eq!(
+        keystroke(KeyCode::Right, KeyModifiers::empty()).key,
+        "right"
+    );
+    assert_eq!(keystroke(KeyCode::Up, KeyModifiers::empty()).key, "up");
+    assert_eq!(keystroke(KeyCode::Down, KeyModifiers::empty()).key, "down");
+}
+
+#[test]
+fn ctrl_modifier_is_carried_into_keystroke() {
+    let keystroke = keystroke(KeyCode::Char('c'), KeyModifiers::CONTROL);
+    assert!(keystroke.ctrl, "ctrl modifier should be set");
+    assert_eq!(keystroke.key, "c");
+}
+
+#[test]
+fn shifted_char_preserves_case() {
+    let keystroke = keystroke(KeyCode::Char('A'), KeyModifiers::SHIFT);
+    assert!(keystroke.shift);
+    assert_eq!(keystroke.key, "A");
+}
+
+#[test]
+fn non_press_key_events_are_ignored() {
+    let mut event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty());
+    event.kind = KeyEventKind::Release;
+    assert!(crossterm_event_to_warp_event(CrosstermEvent::Key(event)).is_none());
+}
+
+#[test]
+fn pure_modifier_keys_have_no_warp_equivalent() {
+    let event = KeyEvent::new(
+        KeyCode::Modifier(crossterm::event::ModifierKeyCode::LeftControl),
+        KeyModifiers::empty(),
+    );
+    assert!(crossterm_event_to_warp_event(CrosstermEvent::Key(event)).is_none());
+}
+
+#[test]
+fn left_mouse_down_maps_to_left_mouse_down_at_position() {
+    let event = CrosstermEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: 3,
+        row: 4,
+        modifiers: KeyModifiers::empty(),
+    });
+    let Some(Event::LeftMouseDown { position, .. }) = crossterm_event_to_warp_event(event) else {
+        panic!("expected LeftMouseDown");
+    };
+    assert_eq!(position, vec2f(3.0, 4.0));
+}
+
+#[test]
+fn scroll_up_and_down_map_to_vertical_scroll_wheel() {
+    let up = CrosstermEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollUp,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::empty(),
+    });
+    let Some(Event::ScrollWheel { delta, .. }) = crossterm_event_to_warp_event(up) else {
+        panic!("expected ScrollWheel");
+    };
+    assert_eq!(delta, vec2f(0.0, 1.0));
+
+    let down = CrosstermEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::empty(),
+    });
+    let Some(Event::ScrollWheel { delta, .. }) = crossterm_event_to_warp_event(down) else {
+        panic!("expected ScrollWheel");
+    };
+    assert_eq!(delta, vec2f(0.0, -1.0));
+}
+
+#[test]
+fn resize_and_focus_events_are_ignored() {
+    assert!(crossterm_event_to_warp_event(CrosstermEvent::Resize(80, 24)).is_none());
+    assert!(crossterm_event_to_warp_event(CrosstermEvent::FocusGained).is_none());
+}

--- a/crates/warpui_tui/src/lib.rs
+++ b/crates/warpui_tui/src/lib.rs
@@ -44,6 +44,8 @@ pub mod elements;
 mod event;
 mod geometry;
 pub mod presenter;
+pub mod renderer;
+pub mod runtime;
 
 pub use buffer::{Cell, TuiBuffer, TuiStyle};
 pub use elements::{
@@ -55,4 +57,6 @@ pub use event::{
 };
 pub use geometry::{TuiConstraint, TuiRect, TuiSize};
 pub use presenter::{TuiFrame, TuiPresenter};
+pub use renderer::TuiFrameRenderer;
+pub use runtime::{CrosstermTerminal, TuiRuntime, TuiTerminal};
 pub use warpui_core::TuiView;

--- a/crates/warpui_tui/src/renderer.rs
+++ b/crates/warpui_tui/src/renderer.rs
@@ -1,0 +1,230 @@
+//! Flushes a [`TuiBuffer`] to a terminal (or any [`io::Write`] target) as a
+//! minimal stream of crossterm commands.
+//!
+//! [`TuiFrameRenderer`] keeps the previously drawn buffer and, on each draw,
+//! emits only the cells that changed since the last frame — moving the cursor to
+//! each changed run and printing it with its style. The first frame (and any
+//! frame whose dimensions differ from the previous one) is painted in full.
+//! Because it writes to a generic writer, it is exercised headlessly against an
+//! in-memory buffer in tests rather than requiring a real tty.
+
+use std::io::{self, Write};
+
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::queue;
+use crossterm::style::{
+    Attribute, Color, Print, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor,
+};
+use crossterm::terminal::{Clear, ClearType};
+
+use crate::{TuiBuffer, TuiStyle};
+
+/// Renders successive [`TuiBuffer`]s to a writer, emitting only the per-frame
+/// diff. Construct one per output target and reuse it across frames so it can
+/// track the previously painted buffer.
+pub struct TuiFrameRenderer {
+    previous_buffer: Option<TuiBuffer>,
+}
+
+impl TuiFrameRenderer {
+    pub fn new() -> Self {
+        Self {
+            previous_buffer: None,
+        }
+    }
+
+    /// Forgets the previously drawn buffer so the next [`draw`](Self::draw)
+    /// repaints the whole frame (e.g. after the host terminal was cleared by
+    /// something outside the renderer).
+    pub fn reset(&mut self) {
+        self.previous_buffer = None;
+    }
+
+    /// Draws `buffer` to `writer`, emitting either a full repaint (first frame
+    /// or a size change) or just the cells that differ from the previous frame,
+    /// then positions or hides the cursor and flushes.
+    pub fn draw<W: Write>(
+        &mut self,
+        writer: &mut W,
+        buffer: &TuiBuffer,
+        cursor_position: Option<(u16, u16)>,
+    ) -> io::Result<()> {
+        let runs = if self.should_repaint(buffer) {
+            queue!(writer, Clear(ClearType::All))?;
+            full_frame_runs(buffer)
+        } else {
+            changed_runs(self.previous_buffer.as_ref().unwrap(), buffer)
+        };
+
+        for run in &runs {
+            draw_run(writer, run)?;
+        }
+        queue!(writer, ResetColor, SetAttribute(Attribute::Reset))?;
+        draw_cursor(writer, cursor_position)?;
+
+        writer.flush()?;
+        self.previous_buffer = Some(buffer.clone());
+        Ok(())
+    }
+
+    fn should_repaint(&self, buffer: &TuiBuffer) -> bool {
+        self.previous_buffer
+            .as_ref()
+            .is_none_or(|previous| previous.size() != buffer.size())
+    }
+}
+
+impl Default for TuiFrameRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A horizontal run of same-styled cells to emit with a single cursor move.
+#[derive(Debug, Eq, PartialEq)]
+struct StyledRun {
+    x: u16,
+    y: u16,
+    text: String,
+    style: TuiStyle,
+}
+
+/// Every row's full contents, split into style runs — used for a full repaint.
+fn full_frame_runs(buffer: &TuiBuffer) -> Vec<StyledRun> {
+    let size = buffer.size();
+    let mut runs = Vec::new();
+    for y in 0..size.height {
+        let mut x = 0;
+        while x < size.width {
+            let (run, next_x) = collect_run(buffer, x, y, size.width);
+            runs.push(run);
+            x = next_x;
+        }
+    }
+    runs
+}
+
+/// The runs that differ between `previous` and `next`, coalescing adjacent
+/// changed cells that share a style (and absorbing wide-grapheme continuation
+/// columns) into one run per cursor move.
+fn changed_runs(previous: &TuiBuffer, next: &TuiBuffer) -> Vec<StyledRun> {
+    if previous.size() != next.size() {
+        return full_frame_runs(next);
+    }
+
+    let size = next.size();
+    let mut runs = Vec::new();
+    for y in 0..size.height {
+        let mut x = 0;
+        while x < size.width {
+            if !cell_changed(previous, next, x, y) {
+                x += 1;
+                continue;
+            }
+
+            let start_x = x;
+            let style = cell_style(next, x, y);
+            x += 1;
+            while x < size.width
+                && cell_changed(previous, next, x, y)
+                && next
+                    .get(x, y)
+                    .is_some_and(|cell| cell.is_continuation() || cell.style() == style)
+            {
+                x += 1;
+            }
+            // Absorb any trailing continuation columns of the last grapheme so a
+            // changed wide glyph is emitted whole.
+            while x < size.width && next.get(x, y).is_some_and(|cell| cell.is_continuation()) {
+                x += 1;
+            }
+
+            runs.push(run_text(next, start_x, x, y, style));
+        }
+    }
+    runs
+}
+
+/// Collects the maximal same-styled run starting at `(start_x, y)`, returning
+/// the run and the first column past it.
+fn collect_run(buffer: &TuiBuffer, start_x: u16, y: u16, end_x: u16) -> (StyledRun, u16) {
+    let style = cell_style(buffer, start_x, y);
+    let mut x = start_x + 1;
+    while x < end_x
+        && buffer
+            .get(x, y)
+            .is_some_and(|cell| cell.is_continuation() || cell.style() == style)
+    {
+        x += 1;
+    }
+    (run_text(buffer, start_x, x, y, style), x)
+}
+
+fn run_text(buffer: &TuiBuffer, start_x: u16, end_x: u16, y: u16, style: TuiStyle) -> StyledRun {
+    let mut text = String::new();
+    for x in start_x..end_x {
+        if let Some(cell) = buffer.get(x, y) {
+            if !cell.is_continuation() {
+                text.push_str(cell.symbol());
+            }
+        }
+    }
+    // A run consisting solely of continuation columns has no symbols of its own;
+    // fall back to spaces so the changed columns are still cleared.
+    if text.is_empty() {
+        text = " ".repeat(usize::from(end_x.saturating_sub(start_x)));
+    }
+    StyledRun {
+        x: start_x,
+        y,
+        text,
+        style,
+    }
+}
+
+fn draw_run<W: Write>(writer: &mut W, run: &StyledRun) -> io::Result<()> {
+    queue!(writer, MoveTo(run.x, run.y), SetAttribute(Attribute::Reset))?;
+    queue!(
+        writer,
+        SetForegroundColor(run.style.foreground.unwrap_or(Color::Reset)),
+        SetBackgroundColor(run.style.background.unwrap_or(Color::Reset)),
+    )?;
+    if run.style.bold {
+        queue!(writer, SetAttribute(Attribute::Bold))?;
+    }
+    if run.style.dim {
+        queue!(writer, SetAttribute(Attribute::Dim))?;
+    }
+    if run.style.italic {
+        queue!(writer, SetAttribute(Attribute::Italic))?;
+    }
+    if run.style.underline {
+        queue!(writer, SetAttribute(Attribute::Underlined))?;
+    }
+    if run.style.reversed {
+        queue!(writer, SetAttribute(Attribute::Reverse))?;
+    }
+    queue!(writer, Print(&run.text))
+}
+
+fn draw_cursor<W: Write>(writer: &mut W, cursor_position: Option<(u16, u16)>) -> io::Result<()> {
+    match cursor_position {
+        Some((x, y)) => queue!(writer, MoveTo(x, y), Show),
+        None => queue!(writer, Hide),
+    }
+}
+
+fn cell_changed(previous: &TuiBuffer, next: &TuiBuffer, x: u16, y: u16) -> bool {
+    previous.get(x, y) != next.get(x, y)
+}
+
+fn cell_style(buffer: &TuiBuffer, x: u16, y: u16) -> TuiStyle {
+    buffer
+        .get(x, y)
+        .map(|cell| cell.style())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+#[path = "renderer_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/renderer_tests.rs
+++ b/crates/warpui_tui/src/renderer_tests.rs
@@ -1,0 +1,139 @@
+use crossterm::style::Color;
+
+use super::*;
+use crate::TuiSize;
+
+/// Builds a single-row buffer from `line`, sized to the line's column width.
+fn line_buffer(line: &str) -> TuiBuffer {
+    let width = u16::try_from(line.chars().count()).unwrap();
+    let mut buffer = TuiBuffer::new(TuiSize::new(width, 1));
+    buffer.set_str(0, 0, width, line, TuiStyle::default());
+    buffer
+}
+
+fn draw_to_string(renderer: &mut TuiFrameRenderer, buffer: &TuiBuffer) -> String {
+    let mut output = Vec::new();
+    renderer.draw(&mut output, buffer, None).unwrap();
+    String::from_utf8(output).unwrap()
+}
+
+/// The CSI sequence crossterm emits to move the cursor to `(x, y)` (1-based).
+fn move_to(x: u16, y: u16) -> String {
+    format!("\u{1b}[{};{}H", y + 1, x + 1)
+}
+
+#[test]
+fn first_paint_clears_and_writes_all_cells() {
+    let mut renderer = TuiFrameRenderer::new();
+    let output = draw_to_string(&mut renderer, &line_buffer("abc"));
+
+    // Full repaint clears the screen and prints every non-blank cell.
+    assert!(
+        output.contains("\u{1b}[2J"),
+        "first paint should clear screen"
+    );
+    assert!(output.contains("abc"), "first paint should write all cells");
+}
+
+#[test]
+fn unchanged_frame_emits_no_text() {
+    let mut renderer = TuiFrameRenderer::new();
+    let buffer = line_buffer("abc");
+    let _ = draw_to_string(&mut renderer, &buffer);
+
+    let output = draw_to_string(&mut renderer, &buffer);
+    assert!(
+        !output.contains("abc"),
+        "an unchanged frame should not re-emit any cell text"
+    );
+}
+
+#[test]
+fn diff_emits_only_changed_run() {
+    let mut renderer = TuiFrameRenderer::new();
+    let _ = draw_to_string(&mut renderer, &line_buffer("abcde"));
+
+    let output = draw_to_string(&mut renderer, &line_buffer("abXYe"));
+
+    assert!(output.contains("XY"), "diff should emit the changed run");
+    assert!(
+        output.contains(&move_to(2, 0)),
+        "diff should move the cursor to the first changed column"
+    );
+    assert!(
+        !output.contains("abcde") && !output.contains("abc"),
+        "diff should not re-emit unchanged cells"
+    );
+}
+
+#[test]
+fn size_change_triggers_full_repaint() {
+    let mut renderer = TuiFrameRenderer::new();
+    let _ = draw_to_string(&mut renderer, &line_buffer("abc"));
+
+    let output = draw_to_string(&mut renderer, &line_buffer("wxyz!"));
+    assert!(
+        output.contains("\u{1b}[2J"),
+        "a size change should force a full repaint"
+    );
+    assert!(output.contains("wxyz!"));
+}
+
+#[test]
+fn changed_wide_grapheme_is_emitted_whole() {
+    let mut renderer = TuiFrameRenderer::new();
+    let _ = draw_to_string(&mut renderer, &line_buffer("ab "));
+
+    // Replace the two leading columns with a single wide (CJK) grapheme.
+    let mut next = TuiBuffer::new(TuiSize::new(3, 1));
+    next.set_str(0, 0, 3, "界 ", TuiStyle::default());
+    let output = draw_to_string(&mut renderer, &next);
+
+    assert!(output.contains('界'), "the wide grapheme should be emitted");
+    assert!(output.contains(&move_to(0, 0)));
+}
+
+#[test]
+fn styled_run_changes_byte_stream() {
+    // A styled cell must add an SGR color escape that the same text painted with
+    // the default style does not, so the byte streams differ.
+    let styled = {
+        let mut buffer = TuiBuffer::new(TuiSize::new(3, 1));
+        buffer.set_str(0, 0, 2, "ab", TuiStyle::default());
+        buffer.set_str(
+            2,
+            0,
+            1,
+            "C",
+            TuiStyle::default().with_foreground(Color::Yellow),
+        );
+        draw_to_string(&mut TuiFrameRenderer::new(), &buffer)
+    };
+    let plain = draw_to_string(&mut TuiFrameRenderer::new(), &line_buffer("abC"));
+
+    assert!(
+        styled.contains('C'),
+        "styled run should still print its text"
+    );
+    assert_ne!(
+        styled, plain,
+        "a foreground color should change the byte stream"
+    );
+}
+
+#[test]
+fn cursor_is_shown_when_present_and_hidden_otherwise() {
+    let mut renderer = TuiFrameRenderer::new();
+    let buffer = line_buffer("abc");
+
+    let mut shown = Vec::new();
+    renderer.draw(&mut shown, &buffer, Some((1, 0))).unwrap();
+    let shown = String::from_utf8(shown).unwrap();
+    assert!(shown.contains("\u{1b}[?25h"), "cursor should be shown");
+    assert!(shown.contains(&move_to(1, 0)));
+
+    let mut hidden = Vec::new();
+    renderer.draw(&mut hidden, &buffer, None).unwrap();
+    let hidden = String::from_utf8(hidden).unwrap();
+    assert!(hidden.contains("\u{1b}[?25l"), "cursor should be hidden");
+}

--- a/crates/warpui_tui/src/runtime.rs
+++ b/crates/warpui_tui/src/runtime.rs
@@ -1,0 +1,286 @@
+//! The TUI runtime: the alternate-screen lifecycle and the draw + event loop
+//! that drives a [`TuiView`] through the shared `App`.
+//!
+//! [`TuiRuntime`] mirrors the GUI's invalidate→redraw flow. On
+//! [`enter`](TuiRuntime::enter) it puts the host terminal into raw mode + the
+//! alternate screen (restored on drop) and subscribes to the window's
+//! invalidation signal; [`run_until`](TuiRuntime::run_until) then repeatedly
+//! redraws when dirty and polls crossterm for input, converting each event with
+//! [`crossterm_event_to_warp_event`](crate::crossterm_event_to_warp_event) and
+//! dispatching it through the rendered element tree.
+//!
+//! The host terminal is abstracted behind [`TuiTerminal`] so the loop and the
+//! frame renderer can be exercised headlessly against an in-memory writer
+//! without a real tty. The concrete [`CrosstermTerminal`] is the production
+//! implementation.
+
+use std::cell::Cell;
+use std::io::{self, stdout, Stdout, Write};
+use std::rc::Rc;
+use std::time::Duration;
+
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent};
+use crossterm::execute;
+use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
+use warpui_core::{App, Event, TuiViewHandle, WindowId};
+
+use crate::{
+    crossterm_event_to_warp_event, TuiConstraint, TuiEventContext, TuiFrameRenderer, TuiPresenter,
+    TuiRect, TuiRenderOutput, TuiSize, TuiView,
+};
+
+/// The host terminal the runtime draws to and reads input from. Abstracted so
+/// the draw + event loop is testable against an in-memory target.
+pub trait TuiTerminal {
+    /// The current terminal size in cells (each axis at least 1).
+    fn size(&self) -> io::Result<TuiSize>;
+
+    /// Blocks up to `timeout` for the next input event, returning `None` on
+    /// timeout.
+    fn poll_event(&mut self, timeout: Duration) -> io::Result<Option<CrosstermEvent>>;
+
+    /// The writer the renderer flushes frames to.
+    fn writer(&mut self) -> &mut dyn Write;
+}
+
+/// Drives a single [`TuiView`] window: redraws it when invalidated and routes
+/// input events back through the shared core.
+pub struct TuiRuntime<T, R = CrosstermTerminal>
+where
+    R: TuiTerminal,
+{
+    window_id: WindowId,
+    root_view: TuiViewHandle<T>,
+    presenter: TuiPresenter,
+    renderer: TuiFrameRenderer,
+    terminal: R,
+    dirty: Rc<Cell<bool>>,
+    last_size: Option<TuiSize>,
+}
+
+impl<T> TuiRuntime<T, CrosstermTerminal>
+where
+    T: TuiView<RenderOutput = TuiRenderOutput>,
+{
+    /// Enters the alternate screen + raw mode and prepares to drive `root_view`.
+    /// The terminal is restored when the returned runtime is dropped.
+    pub fn enter(app: &App, window_id: WindowId, root_view: TuiViewHandle<T>) -> io::Result<Self> {
+        let terminal = CrosstermTerminal::enter()?;
+        Ok(Self::with_terminal(app, window_id, root_view, terminal))
+    }
+}
+
+impl<T, R> TuiRuntime<T, R>
+where
+    T: TuiView<RenderOutput = TuiRenderOutput>,
+    R: TuiTerminal,
+{
+    /// Builds a runtime over an arbitrary [`TuiTerminal`]. Subscribes to the
+    /// window's invalidation signal so a `notify` schedules a redraw, and marks
+    /// the runtime dirty so the first loop iteration paints.
+    pub fn with_terminal(
+        app: &App,
+        window_id: WindowId,
+        root_view: TuiViewHandle<T>,
+        terminal: R,
+    ) -> Self {
+        let dirty = Rc::new(Cell::new(true));
+        let dirty_for_callback = dirty.clone();
+        app.on_window_invalidated(window_id, move |_, _| dirty_for_callback.set(true));
+        Self {
+            window_id,
+            root_view,
+            presenter: TuiPresenter::new(),
+            renderer: TuiFrameRenderer::new(),
+            terminal,
+            dirty,
+            last_size: None,
+        }
+    }
+
+    /// Runs the draw + input loop until `should_quit` returns `true`, redrawing
+    /// when invalidated (or resized) and dispatching converted input events.
+    pub fn run_until(
+        &mut self,
+        app: &mut App,
+        mut should_quit: impl FnMut(&App) -> bool,
+    ) -> io::Result<()> {
+        while !should_quit(app) {
+            self.draw_if_dirty(app)?;
+            self.poll_and_dispatch(app, Duration::from_millis(250))?;
+        }
+        Ok(())
+    }
+
+    /// The terminal this runtime draws to. Primarily useful for inspecting an
+    /// in-memory terminal's captured output in tests.
+    pub fn terminal(&self) -> &R {
+        &self.terminal
+    }
+
+    fn draw_if_dirty(&mut self, app: &App) -> io::Result<()> {
+        let size = self.terminal.size()?;
+        if self.last_size != Some(size) {
+            self.dirty.set(true);
+        }
+        if !self.dirty.replace(false) {
+            return Ok(());
+        }
+
+        // Lay out and paint the view through the dedicated presenter, which
+        // resolves the root (and any embedded child views) through the app and
+        // returns a composited frame (buffer + cursor).
+        let area = TuiRect::from_size(size);
+        let presenter = &mut self.presenter;
+        let root_view = &self.root_view;
+        let frame = app.read(|ctx| presenter.present(ctx, root_view, area));
+
+        let mut writer = self.terminal.writer();
+        self.renderer
+            .draw(&mut writer, &frame.buffer, frame.cursor)?;
+        self.last_size = Some(size);
+        Ok(())
+    }
+
+    fn poll_and_dispatch(&mut self, app: &mut App, timeout: Duration) -> io::Result<()> {
+        let Some(event) = self.terminal.poll_event(timeout)? else {
+            return Ok(());
+        };
+
+        match event {
+            CrosstermEvent::Resize(_, _) => self.dirty.set(true),
+            event => {
+                if let Some(warp_event) = crossterm_event_to_warp_event(event) {
+                    if self.dispatch_event(app, &warp_event) {
+                        self.dirty.set(true);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn dispatch_event(&self, app: &mut App, event: &Event) -> bool {
+        let size = self
+            .last_size
+            .or_else(|| self.terminal.size().ok())
+            .unwrap_or_default();
+        let area = TuiRect::from_size(size);
+
+        let mut element = render_root(app, &self.root_view);
+        element.layout(TuiConstraint::tight(size));
+
+        let mut event_ctx = TuiEventContext::default();
+        event_ctx.set_origin_view(Some(self.root_view.id()));
+        let handled = app.read(|ctx| element.dispatch_event(event, area, &mut event_ctx, ctx));
+
+        for update in event_ctx.take_updates() {
+            update(app);
+        }
+        for action in event_ctx.take_typed_actions() {
+            app.dispatch_typed_action(
+                self.window_id,
+                &[action.origin_view_id],
+                action.action.as_ref(),
+            );
+        }
+        handled
+    }
+}
+
+fn render_root<T>(app: &App, root_view: &TuiViewHandle<T>) -> TuiRenderOutput
+where
+    T: TuiView<RenderOutput = TuiRenderOutput>,
+{
+    root_view.read(app, |view, ctx| view.render_tui(ctx))
+}
+
+/// The production [`TuiTerminal`]: reads from / writes to the real terminal and
+/// keeps it in the alternate screen + raw mode for the runtime's lifetime.
+pub struct CrosstermTerminal {
+    stdout: Stdout,
+    _mode_guard: RawModeGuard<CrosstermModeControl>,
+}
+
+impl CrosstermTerminal {
+    /// Enables raw mode and switches to the alternate screen, restoring the
+    /// terminal when the returned value is dropped.
+    pub fn enter() -> io::Result<Self> {
+        let mode_guard = RawModeGuard::enter(CrosstermModeControl)?;
+        Ok(Self {
+            stdout: stdout(),
+            _mode_guard: mode_guard,
+        })
+    }
+}
+
+impl TuiTerminal for CrosstermTerminal {
+    fn size(&self) -> io::Result<TuiSize> {
+        let (width, height) = terminal::size()?;
+        Ok(TuiSize::new(width.max(1), height.max(1)))
+    }
+
+    fn poll_event(&mut self, timeout: Duration) -> io::Result<Option<CrosstermEvent>> {
+        if event::poll(timeout)? {
+            Ok(Some(event::read()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn writer(&mut self) -> &mut dyn Write {
+        &mut self.stdout
+    }
+}
+
+/// The alternate-screen + raw-mode operations a [`RawModeGuard`] toggles.
+/// Behind a trait so the guard's enter/leave lifecycle can be exercised without
+/// a real terminal.
+trait TerminalModeControl {
+    fn enter(&mut self) -> io::Result<()>;
+    fn leave(&mut self);
+}
+
+struct CrosstermModeControl;
+
+impl TerminalModeControl for CrosstermModeControl {
+    fn enter(&mut self) -> io::Result<()> {
+        terminal::enable_raw_mode()?;
+        let mut out = stdout();
+        if let Err(error) = execute!(out, EnterAlternateScreen, EnableMouseCapture, Hide) {
+            let _ = terminal::disable_raw_mode();
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn leave(&mut self) {
+        let mut out = stdout();
+        let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+/// Restores the host terminal on drop, so a panic or early return never strands
+/// it in the alternate screen or raw mode.
+struct RawModeGuard<C: TerminalModeControl> {
+    control: C,
+}
+
+impl<C: TerminalModeControl> RawModeGuard<C> {
+    fn enter(mut control: C) -> io::Result<Self> {
+        control.enter()?;
+        Ok(Self { control })
+    }
+}
+
+impl<C: TerminalModeControl> Drop for RawModeGuard<C> {
+    fn drop(&mut self) {
+        self.control.leave();
+    }
+}
+
+#[cfg(test)]
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/crates/warpui_tui/src/runtime_tests.rs
+++ b/crates/warpui_tui/src/runtime_tests.rs
@@ -1,0 +1,181 @@
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::io::{self, Write};
+use std::rc::Rc;
+use std::time::Duration;
+
+use crossterm::event::Event as CrosstermEvent;
+use warpui_core::platform::WindowStyle;
+use warpui_core::{AddWindowOptions, App, AppContext, Entity, TuiTypedActionView};
+
+use super::*;
+use crate::{
+    TuiBuffer, TuiConstraint, TuiElement, TuiRect, TuiRenderOutput, TuiSize, TuiStyle, TuiView,
+};
+
+/// A trivial leaf element that paints a single line of text.
+struct TextElement {
+    text: String,
+}
+
+impl TuiElement for TextElement {
+    fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
+        let width = u16::try_from(self.text.chars().count()).unwrap_or(u16::MAX);
+        constraint.clamp(TuiSize::new(width, 1))
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer) {
+        buffer.set_str(area.x, area.y, area.width, &self.text, TuiStyle::default());
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        1
+    }
+}
+
+/// A minimal root view that renders the text "hello".
+struct TextView;
+
+impl Entity for TextView {
+    type Event = ();
+}
+
+impl TuiView for TextView {
+    type RenderOutput = TuiRenderOutput;
+
+    fn ui_name() -> &'static str {
+        "TextView"
+    }
+
+    fn render_tui(&self, _ctx: &AppContext) -> TuiRenderOutput {
+        Box::new(TextElement {
+            text: "hello".to_owned(),
+        })
+    }
+}
+
+impl TuiTypedActionView for TextView {
+    type Action = ();
+}
+
+/// An in-memory [`TuiTerminal`] that captures the renderer's bytes and replays a
+/// fixed queue of input events.
+struct TestTerminal {
+    size: TuiSize,
+    output: Vec<u8>,
+    events: VecDeque<CrosstermEvent>,
+}
+
+impl TestTerminal {
+    fn new(size: TuiSize) -> Self {
+        Self {
+            size,
+            output: Vec::new(),
+            events: VecDeque::new(),
+        }
+    }
+
+    fn output_string(&self) -> String {
+        String::from_utf8_lossy(&self.output).into_owned()
+    }
+}
+
+impl TuiTerminal for TestTerminal {
+    fn size(&self) -> io::Result<TuiSize> {
+        Ok(self.size)
+    }
+
+    fn poll_event(&mut self, _timeout: Duration) -> io::Result<Option<CrosstermEvent>> {
+        Ok(self.events.pop_front())
+    }
+
+    fn writer(&mut self) -> &mut dyn Write {
+        &mut self.output
+    }
+}
+
+fn window_options() -> AddWindowOptions {
+    AddWindowOptions {
+        window_style: WindowStyle::NotStealFocus,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn run_until_draws_view_text_and_exits_on_quit() {
+    App::test((), |mut app| async move {
+        let (window_id, root) =
+            app.update(|ctx| ctx.add_tui_window(window_options(), |_| TextView));
+        let terminal = TestTerminal::new(TuiSize::new(20, 3));
+        let mut runtime = TuiRuntime::with_terminal(&app, window_id, root, terminal);
+
+        // Quit after the first iteration so a single draw pass runs and the loop
+        // provably terminates rather than spinning forever.
+        let mut iterations = 0;
+        runtime
+            .run_until(&mut app, |_| {
+                iterations += 1;
+                iterations > 1
+            })
+            .unwrap();
+
+        assert!(iterations <= 2, "run_until should exit promptly");
+        assert!(
+            runtime.terminal().output_string().contains("hello"),
+            "the view's text should be drawn to the in-memory terminal"
+        );
+    });
+}
+
+/// Records the mode-control enter/leave calls so the guard's lifecycle can be
+/// asserted without touching a real terminal.
+struct RecordingControl {
+    log: Rc<RefCell<Vec<&'static str>>>,
+    fail_enter: bool,
+}
+
+impl TerminalModeControl for RecordingControl {
+    fn enter(&mut self) -> io::Result<()> {
+        if self.fail_enter {
+            return Err(io::Error::other("enter failed"));
+        }
+        self.log.borrow_mut().push("enter");
+        Ok(())
+    }
+
+    fn leave(&mut self) {
+        self.log.borrow_mut().push("leave");
+    }
+}
+
+#[test]
+fn raw_mode_guard_restores_on_drop() {
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let control = RecordingControl {
+        log: log.clone(),
+        fail_enter: false,
+    };
+    {
+        let _guard = RawModeGuard::enter(control).unwrap();
+        assert_eq!(*log.borrow(), vec!["enter"]);
+    }
+    assert_eq!(
+        *log.borrow(),
+        vec!["enter", "leave"],
+        "dropping the guard should restore the terminal"
+    );
+}
+
+#[test]
+fn raw_mode_guard_does_not_leave_when_enter_fails() {
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let control = RecordingControl {
+        log: log.clone(),
+        fail_enter: true,
+    };
+    assert!(RawModeGuard::enter(control).is_err());
+    assert!(
+        log.borrow().is_empty(),
+        "a failed enter must not run the leave/restore path"
+    );
+}


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
