### PR TITLE
Route bundled skills through active Agent Mode host

### DIFF
--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -327,7 +327,8 @@ impl BlocklistAIActionExecutor {
         let use_computer_executor = ctx.add_model(|_| UseComputerExecutor::new());
         let request_computer_use_executor =
             ctx.add_model(|_| RequestComputerUseExecutor::new(terminal_view_id));
-        let read_skill_executor = ctx.add_model(|_| ReadSkillExecutor::new());
+        let read_skill_executor =
+            ctx.add_model(|_| ReadSkillExecutor::new(active_session.clone()));
         let fetch_conversation_executor = ctx.add_model(|_| FetchConversationExecutor::new());
         let start_agent_executor = ctx.add_model(StartAgentExecutor::new);
         let run_agents_executor = ctx

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -327,8 +327,7 @@ impl BlocklistAIActionExecutor {
         let use_computer_executor = ctx.add_model(|_| UseComputerExecutor::new());
         let request_computer_use_executor =
             ctx.add_model(|_| RequestComputerUseExecutor::new(terminal_view_id));
-        let read_skill_executor =
-            ctx.add_model(|_| ReadSkillExecutor::new(active_session.clone()));
+        let read_skill_executor = ctx.add_model(|_| ReadSkillExecutor::new(active_session.clone()));
         let fetch_conversation_executor = ctx.add_model(|_| FetchConversationExecutor::new());
         let start_agent_executor = ctx.add_model(StartAgentExecutor::new);
         let run_agents_executor = ctx

--- a/app/src/ai/blocklist/action_model/execute/read_skill.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill.rs
@@ -1,17 +1,22 @@
 use ai::agent::action_result::{AnyFileContent, FileContext};
+use ai::skills::{SkillPathOrigin, SkillReference};
 use futures::future::{BoxFuture, FutureExt};
-use warpui::{Entity, ModelContext, SingletonEntity};
+use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity};
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
 use crate::ai::agent::{AIAgentActionType, ReadSkillRequest, ReadSkillResult};
+use crate::ai::blocklist::SessionContext;
 use crate::ai::skills::{SkillManager, SkillTelemetryEvent};
 use crate::send_telemetry_from_ctx;
+use crate::terminal::model::session::active_session::ActiveSession;
 
-pub struct ReadSkillExecutor;
+pub struct ReadSkillExecutor {
+    active_session: ModelHandle<ActiveSession>,
+}
 
 impl ReadSkillExecutor {
-    pub fn new() -> Self {
-        Self
+    pub fn new(active_session: ModelHandle<ActiveSession>) -> Self {
+        Self { active_session }
     }
 
     pub(super) fn should_autoexecute(
@@ -34,7 +39,16 @@ impl ReadSkillExecutor {
             return ActionExecution::<ReadSkillResult>::InvalidAction;
         };
 
-        match SkillManager::as_ref(ctx).active_skill_by_reference(skill_ref, ctx) {
+        // Resolve from the catalog selected by the active session's host, so
+        // remote sessions read the host-rendered bundled skill.
+        let path_origin =
+            SessionContext::from_session(self.active_session.as_ref(ctx), ctx).skill_path_origin();
+
+        match SkillManager::as_ref(ctx).active_skill_by_reference_with_origin(
+            skill_ref,
+            &path_origin,
+            ctx,
+        ) {
             Some(skill) => {
                 send_telemetry_from_ctx!(
                     SkillTelemetryEvent::Read {
@@ -65,9 +79,14 @@ impl ReadSkillExecutor {
                     },
                     ctx
                 );
-                ActionExecution::Sync(
-                    ReadSkillResult::Error(format!("Skill not found: {:?}", skill_ref)).into(),
-                )
+                let error = if matches!(&path_origin, SkillPathOrigin::Unavailable)
+                    && matches!(skill_ref, SkillReference::BundledSkillId(_))
+                {
+                    "Bundled skills are not available on this remote session".to_string()
+                } else {
+                    format!("Skill not found: {skill_ref:?}")
+                };
+                ActionExecution::Sync(ReadSkillResult::Error(error).into())
             }
         }
     }

--- a/app/src/ai/blocklist/action_model/execute/read_skill.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill.rs
@@ -1,5 +1,4 @@
 use ai::agent::action_result::{AnyFileContent, FileContext};
-use ai::skills::{SkillPathOrigin, SkillReference};
 use futures::future::{BoxFuture, FutureExt};
 use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity};
 
@@ -49,7 +48,7 @@ impl ReadSkillExecutor {
             &path_origin,
             ctx,
         ) {
-            Some(skill) => {
+            Ok(skill) => {
                 send_telemetry_from_ctx!(
                     SkillTelemetryEvent::Read {
                         reference: skill_ref.clone(),
@@ -68,7 +67,7 @@ impl ReadSkillExecutor {
                 );
                 ActionExecution::Sync(ReadSkillResult::Success { content }.into())
             }
-            None => {
+            Err(error) => {
                 send_telemetry_from_ctx!(
                     SkillTelemetryEvent::Read {
                         reference: skill_ref.clone(),
@@ -79,14 +78,7 @@ impl ReadSkillExecutor {
                     },
                     ctx
                 );
-                let error = if matches!(&path_origin, SkillPathOrigin::Unavailable)
-                    && matches!(skill_ref, SkillReference::BundledSkillId(_))
-                {
-                    "Bundled skills are not available on this remote session".to_string()
-                } else {
-                    format!("Skill not found: {skill_ref:?}")
-                };
-                ActionExecution::Sync(ReadSkillResult::Error(error).into())
+                ActionExecution::Sync(ReadSkillResult::Error(error.to_string()).into())
             }
         }
     }

--- a/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
@@ -3,13 +3,17 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use ai::skills::{parse_skill, ParsedSkill, SkillProvider, SkillReference, SkillScope};
+use async_channel::unbounded;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
 use repo_metadata::RepoMetadataModel;
 use tempfile::TempDir;
 use warp_core::features::FeatureFlag;
+use warp_core::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warpui::App;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
+use warpui::{App, ModelHandle};
 use watcher::HomeDirectoryWatcher;
 
 use super::*;
@@ -21,6 +25,9 @@ use crate::ai::agent::{
 use crate::ai::blocklist::action_model::AIConversationId;
 use crate::ai::skills::{BundledSkillActivation, SkillManager};
 use crate::settings::AISettings;
+use crate::terminal::model::session::active_session::ActiveSession;
+use crate::terminal::model::session::{BootstrapSessionType, SessionId, SessionInfo, Sessions};
+use crate::terminal::model_events::ModelEventDispatcher;
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
 
 fn initialize_app(app: &mut App) {
@@ -31,6 +38,15 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
     app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
     app.add_singleton_model(SkillManager::new);
+}
+fn add_test_read_skill_executor(app: &mut App) -> ModelHandle<ReadSkillExecutor> {
+    let sessions = app.add_model(|_| Sessions::new_for_test());
+    let (_model_events_tx, model_events_rx) = unbounded();
+    let model_event_dispatcher =
+        app.add_model(|ctx| ModelEventDispatcher::new(model_events_rx, sessions.clone(), ctx));
+    let active_session = app
+        .add_model(|ctx| ActiveSession::new(sessions.clone(), model_event_dispatcher.clone(), ctx));
+    app.add_model(|_| ReadSkillExecutor::new(active_session))
 }
 
 fn bundled_skill(name: &str) -> ParsedSkill {
@@ -87,7 +103,7 @@ fn test_read_skill_executor_success() {
             manager.add_skill_for_testing(parsed_skill);
         });
 
-        let executor_handle = app.add_model(|_| ReadSkillExecutor::new());
+        let executor_handle = add_test_read_skill_executor(&mut app);
 
         let action = AIAgentAction {
             id: AIAgentActionId::from("test-action-id".to_string()),
@@ -119,6 +135,158 @@ fn test_read_skill_executor_success() {
 }
 
 #[test]
+fn disconnected_remote_session_does_not_fall_back_to_client_global_bundled_skill() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let _bundled_skills = FeatureFlag::BundledSkills.override_enabled(true);
+        SkillManager::handle(&app).update(&mut app, |manager, _ctx| {
+            manager.add_bundled_skill_for_testing(
+                "remote-only",
+                bundled_skill("remote-only"),
+                BundledSkillActivation::Always,
+            );
+        });
+
+        let session_id = SessionId::from(42);
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        sessions.update(&mut app, |sessions, _ctx| {
+            sessions.register_session_for_test(
+                SessionInfo::new_for_test()
+                    .with_id(session_id)
+                    .with_session_type(BootstrapSessionType::WarpifiedRemote),
+            );
+        });
+        let (_model_events_tx, model_events_rx) = unbounded();
+        let model_event_dispatcher =
+            app.add_model(|ctx| ModelEventDispatcher::new(model_events_rx, sessions.clone(), ctx));
+        model_event_dispatcher.update(&mut app, |dispatcher, _ctx| {
+            dispatcher.set_active_session_id(session_id);
+        });
+        let active_session = app.add_model(|ctx| {
+            ActiveSession::new(sessions.clone(), model_event_dispatcher.clone(), ctx)
+        });
+        let executor_handle = app.add_model(|_| ReadSkillExecutor::new(active_session));
+
+        let action = AIAgentAction {
+            id: AIAgentActionId::from("test-action-id".to_string()),
+            action: AIAgentActionType::ReadSkill(ReadSkillRequest {
+                skill: SkillReference::BundledSkillId("remote-only".to_string()),
+            }),
+            task_id: TaskId::new("test-task-id".to_string()),
+            requires_result: false,
+        };
+        let input = ExecuteActionInput {
+            action: &action,
+            conversation_id: AIConversationId::new(),
+        };
+
+        executor_handle.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor.execute(input, ctx).into();
+            assert!(matches!(
+                result,
+                AnyActionExecution::Sync(AIAgentActionResultType::ReadSkill(
+                    ReadSkillResult::Error(error)
+                )) if error == "Bundled skills are not available on this remote session"
+            ));
+        });
+    });
+}
+
+#[test]
+fn remote_session_reads_remote_bundled_skill_catalog() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let _bundled_skills = FeatureFlag::BundledSkills.override_enabled(true);
+        let host_id = HostId::new("remote-host".to_string());
+        let remote_skill = ParsedSkill {
+            name: "host-specific".to_string(),
+            description: "remote bundled skill".to_string(),
+            path: LocalOrRemotePath::Remote(RemotePath::new(
+                host_id.clone(),
+                StandardizedPath::try_new(
+                    "/opt/warp/resources/bundled/skills/host-specific/SKILL.md",
+                )
+                .unwrap(),
+            )),
+            content: "remote rendered content".to_string(),
+            line_range: None,
+            provider: SkillProvider::Warp,
+            scope: SkillScope::Bundled,
+        };
+        SkillManager::handle(&app).update(&mut app, |manager, _ctx| {
+            manager.add_bundled_skill_for_testing(
+                "host-specific",
+                bundled_skill("host-specific"),
+                BundledSkillActivation::Always,
+            );
+            manager.add_remote_bundled_skill_for_testing(
+                host_id.clone(),
+                "host-specific",
+                remote_skill,
+                BundledSkillActivation::Always,
+            );
+        });
+
+        let session_id = SessionId::from(42);
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        sessions.update(&mut app, |sessions, _ctx| {
+            sessions.register_session_for_test(
+                SessionInfo::new_for_test()
+                    .with_id(session_id)
+                    .with_session_type(BootstrapSessionType::WarpifiedRemote),
+            );
+        });
+        let session = sessions
+            .read(&app, |sessions, _ctx| sessions.get(session_id))
+            .unwrap();
+        session.set_remote_host_id(Some(host_id));
+
+        let (_model_events_tx, model_events_rx) = unbounded();
+        let model_event_dispatcher =
+            app.add_model(|ctx| ModelEventDispatcher::new(model_events_rx, sessions.clone(), ctx));
+        model_event_dispatcher.update(&mut app, |dispatcher, _ctx| {
+            dispatcher.set_active_session_id(session_id);
+        });
+        let active_session = app.add_model(|ctx| {
+            ActiveSession::new(sessions.clone(), model_event_dispatcher.clone(), ctx)
+        });
+        let executor_handle = app.add_model(|_| ReadSkillExecutor::new(active_session));
+
+        let action = AIAgentAction {
+            id: AIAgentActionId::from("test-action-id".to_string()),
+            action: AIAgentActionType::ReadSkill(ReadSkillRequest {
+                skill: SkillReference::BundledSkillId("host-specific".to_string()),
+            }),
+            task_id: TaskId::new("test-task-id".to_string()),
+            requires_result: false,
+        };
+        let input = ExecuteActionInput {
+            action: &action,
+            conversation_id: AIConversationId::new(),
+        };
+
+        executor_handle.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor.execute(input, ctx).into();
+            match result {
+                AnyActionExecution::Sync(AIAgentActionResultType::ReadSkill(
+                    ReadSkillResult::Success { content },
+                )) => {
+                    assert_eq!(
+                        content.file_name,
+                        "/opt/warp/resources/bundled/skills/host-specific/SKILL.md"
+                    );
+                    assert_eq!(
+                        content.content,
+                        AnyFileContent::StringContent("remote rendered content".to_string())
+                    );
+                }
+                _ => panic!("Remote session should read its host-specific bundled skill"),
+            }
+        });
+    });
+}
+
+#[test]
 fn test_read_skill_executor_reads_enabled_bundled_skill() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);
@@ -130,7 +298,7 @@ fn test_read_skill_executor_reads_enabled_bundled_skill() {
                 BundledSkillActivation::Always,
             );
         });
-        let executor_handle = app.add_model(|_| ReadSkillExecutor::new());
+        let executor_handle = add_test_read_skill_executor(&mut app);
 
         let action = AIAgentAction {
             id: AIAgentActionId::from("test-action-id".to_string()),
@@ -175,7 +343,7 @@ fn test_read_skill_executor_rejects_warp_control_bundled_skills_when_disabled() 
                 BundledSkillActivation::RequiresFeature(FeatureFlag::WarpControlCli),
             );
         });
-        let executor_handle = app.add_model(|_| ReadSkillExecutor::new());
+        let executor_handle = add_test_read_skill_executor(&mut app);
         let action = AIAgentAction {
             id: AIAgentActionId::from(format!("test-action-id-{skill_id}")),
             action: AIAgentActionType::ReadSkill(ReadSkillRequest {
@@ -209,7 +377,7 @@ fn test_read_skill_executor_file_not_found() {
 
     App::test((), |mut app| async move {
         initialize_app(&mut app);
-        let executor_handle = app.add_model(|_| ReadSkillExecutor::new());
+        let executor_handle = add_test_read_skill_executor(&mut app);
 
         let action = AIAgentAction {
             id: AIAgentActionId::from("test-action-id".to_string()),

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -421,6 +421,11 @@ impl InputQuery {
 }
 
 impl BlocklistAIController {
+    /// Returns the bundled-skill catalog origin for this controller's active session.
+    pub fn skill_path_origin(&self, ctx: &AppContext) -> SkillPathOrigin {
+        SessionContext::from_session(self.active_session.as_ref(ctx), ctx).skill_path_origin()
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input_model: ModelHandle<BlocklistAIInputModel>,

--- a/app/src/ai/blocklist/controller/input_context.rs
+++ b/app/src/ai/blocklist/controller/input_context.rs
@@ -79,8 +79,10 @@ pub(super) fn input_context_for_request(
     }
 
     if FeatureFlag::ListSkills.is_enabled() {
+        let path_origin = SessionContext::from_session(active_session, app).skill_path_origin();
         let skills = list_skills_if_changed(
             current_working_directory_location.as_ref(),
+            &path_origin,
             conversation_id,
             app,
         );

--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -127,6 +127,8 @@ impl BundledSkills {
             .get(&path.host_id)?
             .active_skill_by_path(&LocalOrRemotePath::Remote(path.clone()), ctx)
     }
+
+    /// Returns the bundled catalog selected by the execution path origin.
     fn for_path_origin(&self, path_origin: &SkillPathOrigin) -> Option<&BundledSkill> {
         match path_origin {
             SkillPathOrigin::Local | SkillPathOrigin::RestoredDisplayOnly => Some(&self.local),

--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use ai::skills::{parse_bundled_skill, ParsedSkill, SkillReference};
+use ai::skills::{parse_bundled_skill, ParsedSkill, SkillPathOrigin, SkillReference};
 use futures::TryStreamExt;
 use warp_core::channel::ChannelState;
 use warp_core::features::FeatureFlag;
@@ -55,8 +55,38 @@ impl BundledSkills {
         self.local = bundled_skill;
     }
 
-    pub fn local(&self) -> &BundledSkill {
-        &self.local
+    pub fn active_descriptors(
+        &self,
+        path_origin: &SkillPathOrigin,
+        ctx: &AppContext,
+    ) -> Vec<SkillDescriptor> {
+        match path_origin {
+            SkillPathOrigin::Local | SkillPathOrigin::RestoredDisplayOnly => {
+                self.local.active_descriptors(ctx)
+            }
+            SkillPathOrigin::Remote { host_id } => self
+                .remote(host_id)
+                .map(|bundled_skill| bundled_skill.active_path_referenced_descriptors(ctx))
+                .unwrap_or_default(),
+            SkillPathOrigin::Unavailable => Vec::new(),
+        }
+    }
+
+    pub fn reference_for_path(&self, path: &LocalOrRemotePath) -> Option<SkillReference> {
+        self.local.reference_for_path(path)
+    }
+
+    pub fn local_skill(&self, id: &str) -> Option<&ParsedSkill> {
+        self.local.skill(id)
+    }
+
+    pub fn active_skill(
+        &self,
+        id: &str,
+        path_origin: &SkillPathOrigin,
+        ctx: &AppContext,
+    ) -> Option<&ParsedSkill> {
+        self.for_path_origin(path_origin)?.active_skill(id, ctx)
     }
 
     /// Installs the catalog for a connected remote host, replacing any
@@ -97,6 +127,13 @@ impl BundledSkills {
             .get(&path.host_id)?
             .active_skill_by_path(&LocalOrRemotePath::Remote(path.clone()), ctx)
     }
+    fn for_path_origin(&self, path_origin: &SkillPathOrigin) -> Option<&BundledSkill> {
+        match path_origin {
+            SkillPathOrigin::Local | SkillPathOrigin::RestoredDisplayOnly => Some(&self.local),
+            SkillPathOrigin::Remote { host_id } => self.remote(host_id),
+            SkillPathOrigin::Unavailable => None,
+        }
+    }
 
     #[cfg(test)]
     pub fn insert_local_for_testing(
@@ -106,6 +143,20 @@ impl BundledSkills {
         activation: BundledSkillActivation,
     ) {
         self.local.insert_for_testing(id, skill, activation);
+    }
+
+    #[cfg(test)]
+    pub fn insert_remote_for_testing(
+        &mut self,
+        host_id: HostId,
+        id: impl Into<String>,
+        skill: ParsedSkill,
+        activation: BundledSkillActivation,
+    ) {
+        self.remote_by_host
+            .entry(host_id)
+            .or_default()
+            .insert_for_testing(id, skill, activation);
     }
 }
 

--- a/app/src/ai/skills/bundled_tests.rs
+++ b/app/src/ai/skills/bundled_tests.rs
@@ -40,8 +40,7 @@ fn local_and_remote_catalogs_are_isolated() {
 
     assert_eq!(
         bundled_skills
-            .local()
-            .skill("test-skill")
+            .local_skill("test-skill")
             .map(|skill| skill.content.as_str()),
         Some("local")
     );
@@ -65,8 +64,7 @@ fn local_and_remote_catalogs_are_isolated() {
     bundled_skills.remove_remote(&first_host_id);
     assert_eq!(
         bundled_skills
-            .local()
-            .skill("test-skill")
+            .local_skill("test-skill")
             .map(|skill| skill.content.as_str()),
         Some("local")
     );

--- a/app/src/ai/skills/dummy_skill_manager.rs
+++ b/app/src/ai/skills/dummy_skill_manager.rs
@@ -2,7 +2,7 @@ use ai::skills::{ParsedSkill, SkillPathOrigin, SkillProvider, SkillReference};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
-use crate::ai::skills::{SkillDescriptor, SkillPathQuery};
+use crate::ai::skills::{ActiveSkillLookupError, SkillDescriptor, SkillPathQuery};
 
 pub struct SkillManager {}
 
@@ -54,14 +54,17 @@ impl SkillManager {
     }
     pub fn active_skill_by_reference_with_origin(
         &self,
-        _reference: &SkillReference,
-        _path_origin: &SkillPathOrigin,
+        reference: &SkillReference,
+        path_origin: &SkillPathOrigin,
         _ctx: &AppContext,
-    ) -> Option<&ParsedSkill> {
-        None
+    ) -> Result<&ParsedSkill, ActiveSkillLookupError> {
+        Err(ActiveSkillLookupError::for_reference(
+            reference,
+            path_origin,
+        ))
     }
 
-    pub fn active_bundled_skill(&self, _id: &str, _ctx: &AppContext) -> Option<&ParsedSkill> {
+    pub fn active_local_bundled_skill(&self, _id: &str, _ctx: &AppContext) -> Option<&ParsedSkill> {
         None
     }
 

--- a/app/src/ai/skills/dummy_skill_manager.rs
+++ b/app/src/ai/skills/dummy_skill_manager.rs
@@ -1,4 +1,4 @@
-use ai::skills::{ParsedSkill, SkillProvider, SkillReference};
+use ai::skills::{ParsedSkill, SkillPathOrigin, SkillProvider, SkillReference};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
@@ -14,6 +14,15 @@ impl SkillManager {
     pub fn get_skills_for_working_directory(
         &self,
         _working_directory: Option<&LocalOrRemotePath>,
+        _ctx: &AppContext,
+    ) -> Vec<SkillDescriptor> {
+        vec![]
+    }
+
+    pub fn get_skills_for_working_directory_with_origin(
+        &self,
+        _working_directory: Option<&LocalOrRemotePath>,
+        _path_origin: &SkillPathOrigin,
         _ctx: &AppContext,
     ) -> Vec<SkillDescriptor> {
         vec![]
@@ -39,6 +48,14 @@ impl SkillManager {
     pub fn active_skill_by_reference(
         &self,
         _reference: &SkillReference,
+        _ctx: &AppContext,
+    ) -> Option<&ParsedSkill> {
+        None
+    }
+    pub fn active_skill_by_reference_with_origin(
+        &self,
+        _reference: &SkillReference,
+        _path_origin: &SkillPathOrigin,
         _ctx: &AppContext,
     ) -> Option<&ParsedSkill> {
         None

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use ai::skills::SkillPathOrigin;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 
 mod telemetry;
@@ -23,6 +24,28 @@ cfg_if::cfg_if! {
 }
 
 pub use ai::skills::SkillReference;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ActiveSkillLookupError {
+    #[error("Bundled skills are not available on this remote session")]
+    BundledSkillsUnavailable,
+    #[error("Skill not found: {reference}")]
+    NotFound { reference: SkillReference },
+}
+
+impl ActiveSkillLookupError {
+    pub(crate) fn for_reference(reference: &SkillReference, path_origin: &SkillPathOrigin) -> Self {
+        if matches!(path_origin, SkillPathOrigin::Unavailable)
+            && matches!(reference, SkillReference::BundledSkillId(_))
+        {
+            Self::BundledSkillsUnavailable
+        } else {
+            Self::NotFound {
+                reference: reference.clone(),
+            }
+        }
+    }
+}
 
 #[cfg(not(target_family = "wasm"))]
 mod global_skills;

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -18,7 +18,7 @@ use super::bundled::{
     BundledSkillActivation,
 };
 use super::bundled::{BundledSkill, BundledSkills};
-use super::{SkillDescriptor, SkillPathQuery};
+use super::{ActiveSkillLookupError, SkillDescriptor, SkillPathQuery};
 use crate::ai::skills::skill_utils::unique_skills;
 
 pub struct SkillManager {
@@ -360,6 +360,7 @@ impl SkillManager {
         ctx: &AppContext,
     ) -> Option<&ParsedSkill> {
         self.active_skill_by_reference_with_origin(reference, &SkillPathOrigin::Local, ctx)
+            .ok()
     }
 
     /// Get the definition of a skill for the selected execution host only if it is active.
@@ -368,8 +369,8 @@ impl SkillManager {
         reference: &SkillReference,
         path_origin: &SkillPathOrigin,
         ctx: &AppContext,
-    ) -> Option<&ParsedSkill> {
-        match reference {
+    ) -> Result<&ParsedSkill, ActiveSkillLookupError> {
+        let skill = match reference {
             SkillReference::Path(path) => self.skills_by_path.get(path).or_else(|| {
                 let remote = path.as_remote()?;
                 let SkillPathOrigin::Remote { host_id } = path_origin else {
@@ -383,11 +384,12 @@ impl SkillManager {
             SkillReference::BundledSkillId(id) => {
                 self.bundled_skills.active_skill(id, path_origin, ctx)
             }
-        }
+        };
+        skill.ok_or_else(|| ActiveSkillLookupError::for_reference(reference, path_origin))
     }
 
-    /// Returns a bundled skill by ID only if its activation condition is met.
-    pub fn active_bundled_skill(&self, id: &str, ctx: &AppContext) -> Option<&ParsedSkill> {
+    /// Returns a local bundled skill by ID only if its activation condition is met.
+    pub fn active_local_bundled_skill(&self, id: &str, ctx: &AppContext) -> Option<&ParsedSkill> {
         self.bundled_skills
             .active_skill(id, &SkillPathOrigin::Local, ctx)
     }

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -3,7 +3,7 @@ mod file_watchers;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use ai::skills::{provider_rank, ParsedSkill, SkillProvider, SkillReference};
+use ai::skills::{provider_rank, ParsedSkill, SkillPathOrigin, SkillProvider, SkillReference};
 pub use file_watchers::{
     extract_skill_parent_directory, read_skills_from_directories, SkillWatcher, SkillWatcherEvent,
 };
@@ -92,6 +92,22 @@ impl SkillManager {
         working_directory: Option<&LocalOrRemotePath>,
         ctx: &AppContext,
     ) -> Vec<SkillDescriptor> {
+        let path_origin = match working_directory {
+            Some(LocalOrRemotePath::Remote(path)) => SkillPathOrigin::Remote {
+                host_id: path.host_id.clone(),
+            },
+            Some(LocalOrRemotePath::Local(_)) | None => SkillPathOrigin::Local,
+        };
+        self.get_skills_for_working_directory_with_origin(working_directory, &path_origin, ctx)
+    }
+
+    /// Returns skills available for the given working directory and execution host.
+    pub fn get_skills_for_working_directory_with_origin(
+        &self,
+        working_directory: Option<&LocalOrRemotePath>,
+        path_origin: &SkillPathOrigin,
+        ctx: &AppContext,
+    ) -> Vec<SkillDescriptor> {
         // Collect skill paths as (dir_path, skill_path) tuples for later deduplication.
         // Home skills use the home directory as their dir_path; project skills use their
         // owning directory.
@@ -168,19 +184,10 @@ impl SkillManager {
         // catalog of the host that owns the working directory: SSH sessions
         // see the remote daemon's catalog (empty until its snapshot arrives),
         // never the local client's. Remote catalog descriptors are referenced
-        // by their remote paths so invocation resolves back to the same
-        // host's catalog; `BundledSkillId` references are local-only.
+        // by their remote paths so invocation resolves back to the same host's
+        // catalog, while direct `BundledSkillId` lookups use `path_origin`.
         if FeatureFlag::BundledSkills.is_enabled() {
-            match working_directory {
-                Some(LocalOrRemotePath::Remote(remote)) => {
-                    if let Some(bundled) = self.bundled_skills.remote(&remote.host_id) {
-                        skills.extend(bundled.active_path_referenced_descriptors(ctx));
-                    }
-                }
-                Some(LocalOrRemotePath::Local(_)) | None => {
-                    skills.extend(self.bundled_skills.local().active_descriptors(ctx));
-                }
-            }
+            skills.extend(self.bundled_skills.active_descriptors(path_origin, ctx));
         }
 
         skills
@@ -323,7 +330,7 @@ impl SkillManager {
     ) -> SkillReference {
         let skill_path = skill_path.to_skill_location();
         // Check if this path belongs to a bundled skill.
-        if let Some(reference) = self.bundled_skills.local().reference_for_path(&skill_path) {
+        if let Some(reference) = self.bundled_skills.reference_for_path(&skill_path) {
             return reference;
         }
         // Default to path-based reference.
@@ -337,7 +344,7 @@ impl SkillManager {
                 path.as_remote()
                     .and_then(|remote| self.bundled_skills.remote_skill_by_path(remote))
             }),
-            SkillReference::BundledSkillId(id) => self.bundled_skills.local().skill(id),
+            SkillReference::BundledSkillId(id) => self.bundled_skills.local_skill(id),
         }
     }
 
@@ -352,18 +359,37 @@ impl SkillManager {
         reference: &SkillReference,
         ctx: &AppContext,
     ) -> Option<&ParsedSkill> {
+        self.active_skill_by_reference_with_origin(reference, &SkillPathOrigin::Local, ctx)
+    }
+
+    /// Get the definition of a skill for the selected execution host only if it is active.
+    pub fn active_skill_by_reference_with_origin(
+        &self,
+        reference: &SkillReference,
+        path_origin: &SkillPathOrigin,
+        ctx: &AppContext,
+    ) -> Option<&ParsedSkill> {
         match reference {
             SkillReference::Path(path) => self.skills_by_path.get(path).or_else(|| {
-                path.as_remote()
-                    .and_then(|remote| self.bundled_skills.remote_active_skill_by_path(remote, ctx))
+                let remote = path.as_remote()?;
+                let SkillPathOrigin::Remote { host_id } = path_origin else {
+                    return None;
+                };
+                if remote.host_id != *host_id {
+                    return None;
+                }
+                self.bundled_skills.remote_active_skill_by_path(remote, ctx)
             }),
-            SkillReference::BundledSkillId(id) => self.active_bundled_skill(id, ctx),
+            SkillReference::BundledSkillId(id) => {
+                self.bundled_skills.active_skill(id, path_origin, ctx)
+            }
         }
     }
 
     /// Returns a bundled skill by ID only if its activation condition is met.
     pub fn active_bundled_skill(&self, id: &str, ctx: &AppContext) -> Option<&ParsedSkill> {
-        self.bundled_skills.local().active_skill(id, ctx)
+        self.bundled_skills
+            .active_skill(id, &SkillPathOrigin::Local, ctx)
     }
 
     pub(super) fn set_remote_bundled_skill(
@@ -472,6 +498,18 @@ impl SkillManager {
     ) {
         self.bundled_skills
             .insert_local_for_testing(id, skill, activation);
+    }
+
+    #[cfg(test)]
+    pub fn add_remote_bundled_skill_for_testing(
+        &mut self,
+        host_id: HostId,
+        id: impl Into<String>,
+        skill: ParsedSkill,
+        activation: BundledSkillActivation,
+    ) {
+        self.bundled_skills
+            .insert_remote_for_testing(host_id, id, skill, activation);
     }
 }
 

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -738,7 +738,7 @@ fn get_skills_for_working_directory_respects_location() {
                 )
                 .map(|skill| skill.content.clone())
         });
-        assert_eq!(resolved_content, Some("# remote-bundled".to_string()));
+        assert_eq!(resolved_content, Ok("# remote-bundled".to_string()));
         let wrong_origin_content = handle.read(&app, |manager, ctx| {
             manager
                 .active_skill_by_reference_with_origin(
@@ -748,10 +748,10 @@ fn get_skills_for_working_directory_respects_location() {
                 )
                 .map(|skill| skill.content.clone())
         });
-        assert_eq!(
-            wrong_origin_content, None,
-            "Remote bundled paths must only resolve for their active host"
-        );
+        assert!(matches!(
+            wrong_origin_content,
+            Err(ActiveSkillLookupError::NotFound { .. })
+        ));
 
         let disconnected_remote_skills = handle.read(&app, |manager, ctx| {
             manager.get_skills_for_working_directory(None, ctx)
@@ -985,6 +985,45 @@ fn active_skill_by_reference_distinguishes_remote_hosts_with_the_same_display_pa
             )
         });
         assert_eq!(resolved, (Some(first_path), Some(second_path)));
+    });
+}
+
+// Origin-aware lookup reports why an active bundled skill could not be resolved.
+#[test]
+fn active_skill_by_reference_with_origin_returns_typed_lookup_errors() {
+    App::test((), |app| async move {
+        app.add_singleton_model(DirectoryWatcher::new);
+        app.add_singleton_model(AISettings::new_with_defaults);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
+        app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+        let handle = app.add_singleton_model(SkillManager::new);
+        let reference = SkillReference::BundledSkillId("missing".to_string());
+
+        let unavailable_error = handle.read(&app, |manager, ctx| {
+            manager
+                .active_skill_by_reference_with_origin(
+                    &reference,
+                    &SkillPathOrigin::Unavailable,
+                    ctx,
+                )
+                .unwrap_err()
+        });
+        assert_eq!(
+            unavailable_error,
+            ActiveSkillLookupError::BundledSkillsUnavailable
+        );
+
+        let not_found_error = handle.read(&app, |manager, ctx| {
+            manager
+                .active_skill_by_reference_with_origin(&reference, &SkillPathOrigin::Local, ctx)
+                .unwrap_err()
+        });
+        assert_eq!(
+            not_found_error,
+            ActiveSkillLookupError::NotFound { reference }
+        );
     });
 }
 

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -649,7 +649,7 @@ fn get_skills_for_working_directory_respects_location() {
         (home_dir, local_home_skill),
         (local_project_dir.clone(), local_project_skill),
         (same_host_dir.clone(), same_host_skill),
-        (other_host_dir, other_host_skill),
+        (other_host_dir.clone(), other_host_skill),
     ] {
         directory_skills
             .entry(dir)
@@ -701,6 +701,15 @@ fn get_skills_for_working_directory_respects_location() {
         assert!(!remote_names.contains("local-home"));
         assert!(!remote_names.contains("local-project"));
         assert!(!remote_names.contains("other-host-project"));
+        let other_remote_skills = handle.read(&app, |manager, ctx| {
+            manager.get_skills_for_working_directory(Some(&other_host_dir), ctx)
+        });
+        let other_remote_names: HashSet<_> = other_remote_skills
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect();
+        assert!(other_remote_names.contains("other-host-project"));
+        assert!(!other_remote_names.contains("bundled"));
 
         // Remote catalog descriptors are path-referenced, and that reference
         // resolves back to the remote host's catalog entry. A
@@ -720,10 +729,29 @@ fn get_skills_for_working_directory_respects_location() {
         assert_eq!(remote_bundled_descriptor.scope, SkillScope::Bundled);
         let resolved_content = handle.read(&app, |manager, ctx| {
             manager
-                .active_skill_by_reference(&remote_bundled_descriptor.reference, ctx)
+                .active_skill_by_reference_with_origin(
+                    &remote_bundled_descriptor.reference,
+                    &SkillPathOrigin::Remote {
+                        host_id: same_host_id.clone(),
+                    },
+                    ctx,
+                )
                 .map(|skill| skill.content.clone())
         });
         assert_eq!(resolved_content, Some("# remote-bundled".to_string()));
+        let wrong_origin_content = handle.read(&app, |manager, ctx| {
+            manager
+                .active_skill_by_reference_with_origin(
+                    &remote_bundled_descriptor.reference,
+                    &SkillPathOrigin::Local,
+                    ctx,
+                )
+                .map(|skill| skill.content.clone())
+        });
+        assert_eq!(
+            wrong_origin_content, None,
+            "Remote bundled paths must only resolve for their active host"
+        );
 
         let disconnected_remote_skills = handle.read(&app, |manager, ctx| {
             manager.get_skills_for_working_directory(None, ctx)
@@ -733,6 +761,17 @@ fn get_skills_for_working_directory_respects_location() {
             .map(|skill| skill.name.as_str())
             .collect();
         assert_eq!(disconnected_remote_names, HashSet::from(["bundled"]));
+        let unavailable_remote_skills = handle.read(&app, |manager, ctx| {
+            manager.get_skills_for_working_directory_with_origin(
+                None,
+                &SkillPathOrigin::Unavailable,
+                ctx,
+            )
+        });
+        assert!(
+            unavailable_remote_skills.is_empty(),
+            "Unavailable remote sessions must not fall back to client-global bundles"
+        );
 
         let local_skills = handle.read(&app, |manager, ctx| {
             manager.get_skills_for_working_directory(Some(&local_project_dir), ctx)

--- a/app/src/ai/skills/skill_utils.rs
+++ b/app/src/ai/skills/skill_utils.rs
@@ -5,7 +5,8 @@ use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 use ai::skills::{
-    provider_parent_directory_for_skills_root, provider_rank, ParsedSkill, SkillProvider,
+    provider_parent_directory_for_skills_root, provider_rank, ParsedSkill, SkillPathOrigin,
+    SkillProvider,
 };
 use lazy_static::lazy_static;
 use siphasher::sip::SipHasher;
@@ -88,11 +89,15 @@ pub(crate) fn unique_skills(
 /// Skills are always included except when the current list matches the last list sent.
 pub fn list_skills_if_changed(
     working_directory: Option<&LocalOrRemotePath>,
+    path_origin: &SkillPathOrigin,
     conversation_id: Option<AIConversationId>,
     app: &AppContext,
 ) -> Option<Vec<SkillDescriptor>> {
-    let current_skills =
-        SkillManager::as_ref(app).get_skills_for_working_directory(working_directory, app);
+    let current_skills = SkillManager::as_ref(app).get_skills_for_working_directory_with_origin(
+        working_directory,
+        path_origin,
+        app,
+    );
 
     let previous_skills: Option<Vec<SkillDescriptor>> =
         conversation_id.and_then(|conversation_id| {

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -37,7 +37,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use ai::skills::SkillReference;
+use ai::skills::{SkillPathOrigin, SkillReference};
 use async_channel::Sender;
 use base64::Engine as _;
 #[cfg(feature = "local_fs")]
@@ -5491,18 +5491,27 @@ impl Input {
         ctx: &mut ViewContext<Self>,
     ) -> bool {
         let is_queued_prompt = queued_query_id.is_some();
-        // Resolve the skill from SkillManager
+        // Resolve the skill from the catalog selected by the active session's host,
+        // so remote sessions invoke the host-rendered bundled skill.
+        let path_origin = self.ai_controller.as_ref(ctx).skill_path_origin(ctx);
         let skill = match SkillManager::handle(ctx)
             .as_ref(ctx)
-            .active_skill_by_reference(&reference, ctx)
+            .active_skill_by_reference_with_origin(&reference, &path_origin, ctx)
         {
             Some(skill) => skill.clone(),
             None => {
                 // Show error toast if skill not found
+                let message = if matches!(&path_origin, SkillPathOrigin::Unavailable)
+                    && matches!(&reference, SkillReference::BundledSkillId(_))
+                {
+                    "Bundled skills are not available on this remote session".to_string()
+                } else {
+                    format!("Skill not found: {reference}")
+                };
                 let window_id = ctx.window_id();
                 ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                     toast_stack.add_ephemeral_toast(
-                        DismissibleToast::error(format!("Skill not found: {}", reference)),
+                        DismissibleToast::error(message),
                         window_id,
                         ctx,
                     );

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -37,7 +37,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use ai::skills::{SkillPathOrigin, SkillReference};
+use ai::skills::SkillReference;
 use async_channel::Sender;
 use base64::Engine as _;
 #[cfg(feature = "local_fs")]
@@ -5498,20 +5498,13 @@ impl Input {
             .as_ref(ctx)
             .active_skill_by_reference_with_origin(&reference, &path_origin, ctx)
         {
-            Some(skill) => skill.clone(),
-            None => {
+            Ok(skill) => skill.clone(),
+            Err(error) => {
                 // Show error toast if skill not found
-                let message = if matches!(&path_origin, SkillPathOrigin::Unavailable)
-                    && matches!(&reference, SkillReference::BundledSkillId(_))
-                {
-                    "Bundled skills are not available on this remote session".to_string()
-                } else {
-                    format!("Skill not found: {reference}")
-                };
                 let window_id = ctx.window_id();
                 ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                     toast_stack.add_ephemeral_toast(
-                        DismissibleToast::error(message),
+                        DismissibleToast::error(error.to_string()),
                         window_id,
                         ctx,
                     );

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -23316,7 +23316,7 @@ impl TypedActionView for Workspace {
             FixSettingsWithOz { error_description } => {
                 use crate::ai::skills::SkillManager;
                 let modify_settings_skill = SkillManager::as_ref(ctx)
-                    .active_bundled_skill("modify-settings", ctx)
+                    .active_local_bundled_skill("modify-settings", ctx)
                     .cloned();
                 let query = format!(
                     "My settings.toml file has an error: {error_description}. Please fix it."


### PR DESCRIPTION
## Description

Routes Agent Mode bundled-skill listing, `read_skill` resolution, and slash-command skill invocation through the active session's bundled-skill catalog. Local sessions continue using the local catalog, while connected remote sessions use the ready catalog for their exact `HostId`.

The Agent input context passes the active session's `SkillPathOrigin` into skill listing, and `ReadSkillExecutor` receives `ActiveSession` so bundled IDs resolve from the same selected host catalog. Slash-command invocations (`/skill-name`) resolve through a new `BlocklistAIController::skill_path_origin` accessor backed by the same active session, so remote sessions embed host-rendered content instead of client-local paths. Remote sessions whose host identity/catalog is unavailable return no bundled skills and do not fall back to client-local bundled content — both `read_skill` and the slash-command toast surface "Bundled skills are not available on this remote session". Existing path-based skill behavior remains unchanged.

This is the third PR in the stack:

- #12377 introduces the single-host `BundledSkill` abstraction.
- #12378 installs complete remote bundles and manages per-host rendered catalogs.
- This PR connects those catalogs to Agent Mode listing, `read_skill`, and slash-command invocation.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

![Screenshot 2026-06-09 at 9.37.59 PM.png](https://app.graphite.com/user-attachments/assets/4cc0a987-0f30-4d08-887b-ffe207c54c37.png)



- Added coverage for host-specific bundled-skill listing, same-ID host isolation, unavailable remote-session no-fallback behavior, remote bundled-skill reads, and preservation of local reads.
- `cargo check -p warp --all-targets` passes cleanly (including removal of the now-unused `BundledSkills::local` accessor); tests, formatters, and Clippy were not run per request.
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Agent conversation: https://staging.warp.dev/conversation/5f4415d3-76ab-4edf-aa62-ada66bac74f4
- Plan: https://staging.warp.dev/drive/notebook/F5HotaELiARZxrQCvUmKqD

CHANGELOG-NONE

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)