### PR TITLE
Fix tab restoration bug: caused group split

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11762,7 +11762,7 @@ impl Workspace {
     pub fn restore_closed_tab(
         &mut self,
         tab_index: usize,
-        tab_data: TabData,
+        mut tab_data: TabData,
         ctx: &mut ViewContext<Self>,
     ) {
         // When restoring a closed tab, we have to reattach its panes so that they know they're
@@ -11771,10 +11771,36 @@ impl Workspace {
             pane_group.reattach_panes(ctx);
         });
 
-        self.tabs.insert(tab_index, tab_data);
+        // If the tab belonged to a group, try to re-join it by appending after
+        // the group's current last member. If the group no longer exists (it was
+        // pruned when the tab was closed), drop the membership and fall back to
+        // the original index instead.
+        let insert_index = if let Some(group_id) = tab_data.group_id {
+            if self.tab_groups.contains_key(&group_id) {
+                // Group still exists — append after its current last member.
+                group_member_indices(&self.tabs, group_id)
+                    .last()
+                    .map(|i| i + 1)
+                    .unwrap_or_else(|| tab_index.min(self.tabs.len()))
+            } else {
+                // Group was pruned — drop membership.
+                tab_data.group_id = None;
+                tab_index.min(self.tabs.len())
+            }
+        } else {
+            tab_index
+        };
+
+        self.tabs.insert(insert_index, tab_data);
         self.tab_mru_order
-            .push(self.tabs[tab_index].pane_group.id());
-        self.activate_tab(tab_index, ctx);
+            .push(self.tabs[insert_index].pane_group.id());
+
+        // Expand the group so the restored tab is immediately visible.
+        if let Some(group_id) = self.tabs[insert_index].group_id {
+            self.expand_tab_group(group_id, ctx);
+        }
+
+        self.activate_tab(insert_index, ctx);
 
         ctx.notify();
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11781,11 +11781,11 @@ impl Workspace {
                 group_member_indices(&self.tabs, group_id)
                     .last()
                     .map(|i| i + 1)
-                    .unwrap_or_else(|| tab_index.min(self.tabs.len()))
+                    .unwrap_or(self.tabs.len())
             } else {
                 // Group was pruned — drop membership.
                 tab_data.group_id = None;
-                tab_index.min(self.tabs.len())
+                tab_index
             }
         } else {
             tab_index


### PR DESCRIPTION
## Description

Fix a bug where restoring a closed tab that previously belonged to a tab group would cause the group to split if the group had moved since the tab was closed.

Root cause: `restore_closed_tab` blindly inserted the TabData at the `tab_index` with its original `group_id` still set. If the group's contiguous block had shifted in the meantime, the restored tab would land at the wrong position — violating the group contiguity invariant and visually splitting the group.

Fix: On restore, branch on the group's current state:
•  Group still exists (`tab_groups.contains_key`): append the restored tab after the group's current last member and expand the group so it's immediately visible. This is consistent with how `move_tab_to_group` places tabs.
•  Group was pruned (all other members were also closed): clear `group_id` and fall back to the original `tab_index`. The group metadata is gone at this point (pruned when the last member closed), so there's nothing to rejoin.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4699/tab-restoration-leaves-grouped-tabs-in-broken-state

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of issue](https://www.loom.com/share/112bd75f169744a688d62ba0ca4f30f9)


[Demo of fix](https://www.loom.com/share/25a139170bdd4a4d99fc501f3340ba58)