### PR TITLE
Fix shared hover/click state across "Open skill" buttons

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -477,13 +477,10 @@ pub(super) struct AIBlockStateHandles {
     /// Mouse state handle for AI document created block
     ai_document_handle: MouseStateHandle,
 
-    /// Mouse state handle for 'open skill' button
-    /// from an OpenSkill action banner
-    open_skill_button_handle: MouseStateHandle,
-
-    /// Mouse state handle for 'open skill' button
-    /// from a ReadFiles action banner
-    read_from_skill_button_handle: MouseStateHandle,
+    /// Per-action mouse state handles for the 'open skill' button shown on
+    /// ReadSkill and ReadFiles action banners. Keyed by action id so that
+    /// multiple skill banners in the same block don't share hover/click state.
+    skill_button_handles: HashMap<AIAgentActionId, MouseStateHandle>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -2007,6 +2004,16 @@ impl AIBlock {
             if matches!(&action.action, AIAgentActionType::StartAgent { .. }) {
                 self.state_handles
                     .orchestration_navigation_card_handles
+                    .entry(action.id.clone())
+                    .or_default();
+            }
+
+            if matches!(
+                &action.action,
+                AIAgentActionType::ReadSkill(_) | AIAgentActionType::ReadFiles(_)
+            ) {
+                self.state_handles
+                    .skill_button_handles
                     .entry(action.id.clone())
                     .or_default();
             }
@@ -6591,10 +6598,7 @@ impl TypedActionView for AIBlock {
             } => {
                 // Resets the interaction states of ReadSkill and ReadFiles tool call banners before opening a new code pane
                 // Avoids an immediate re-hover (and stuck tooltip) while the new code pane is being created
-                for handle in [
-                    &self.state_handles.open_skill_button_handle,
-                    &self.state_handles.read_from_skill_button_handle,
-                ] {
+                for handle in self.state_handles.skill_button_handles.values() {
                     if let Ok(mut state) = handle.lock() {
                         state.reset_interaction_state();
                     }

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1749,32 +1749,29 @@ fn render_read_skill(
     // Renders the 'open skill' button for known, non-bundled skills.
     if let Some(skill) = skill {
         if !skill.is_bundled() {
-            let source = CodeSource::Skill {
-                reference: skill_reference.clone(),
-                location: skill.path.clone(),
-                origin: SkillOpenOrigin::ReadSkill,
-            };
+            if let Some(button_handle) = props.state_handles.skill_button_handles.get(id).cloned() {
+                let source = CodeSource::Skill {
+                    reference: skill_reference.clone(),
+                    location: skill.path.clone(),
+                    origin: SkillOpenOrigin::ReadSkill,
+                };
 
-            let skill_icon_override = icon_override_for_skill_name(&skill.name);
-            let open_button = render_skill_button(
-                "Open skill",
-                props
-                    .state_handles
-                    .skill_button_handles
-                    .get(id)
-                    .cloned()
-                    .unwrap_or_default(),
-                appearance,
-                skill.provider,
-                skill_icon_override,
-                move |ctx| {
-                    ctx.dispatch_typed_action(AIBlockAction::OpenCodeInWarp {
-                        source: source.clone(),
-                    });
-                },
-            );
+                let skill_icon_override = icon_override_for_skill_name(&skill.name);
+                let open_button = render_skill_button(
+                    "Open skill",
+                    button_handle,
+                    appearance,
+                    skill.provider,
+                    skill_icon_override,
+                    move |ctx| {
+                        ctx.dispatch_typed_action(AIBlockAction::OpenCodeInWarp {
+                            source: source.clone(),
+                        });
+                    },
+                );
 
-            renderable_action = renderable_action.with_action_button(open_button);
+                renderable_action = renderable_action.with_action_button(open_button);
+            }
         }
     }
 
@@ -1856,33 +1853,30 @@ fn render_read_files(
 
     // Renders the 'open skill' button if all files belong to the same skill directory.
     if let Some(skill) = parsed_skill {
-        let reference = SkillManager::handle(app)
-            .as_ref(app)
-            .reference_for_skill_path(&skill.path);
-        let source = CodeSource::Skill {
-            reference,
-            location: skill.path.clone(),
-            origin: SkillOpenOrigin::ReadFiles,
-        };
-        let skill_icon_override = icon_override_for_skill_name(&skill.name);
-        let open_button = render_skill_button(
-            &format!("/{}", skill.name),
-            props
-                .state_handles
-                .skill_button_handles
-                .get(id)
-                .cloned()
-                .unwrap_or_default(),
-            appearance,
-            skill.provider,
-            skill_icon_override,
-            move |ctx| {
-                ctx.dispatch_typed_action(AIBlockAction::OpenCodeInWarp {
-                    source: source.clone(),
-                });
-            },
-        );
-        renderable_action = renderable_action.with_action_button(open_button);
+        if let Some(button_handle) = props.state_handles.skill_button_handles.get(id).cloned() {
+            let reference = SkillManager::handle(app)
+                .as_ref(app)
+                .reference_for_skill_path(&skill.path);
+            let source = CodeSource::Skill {
+                reference,
+                location: skill.path.clone(),
+                origin: SkillOpenOrigin::ReadFiles,
+            };
+            let skill_icon_override = icon_override_for_skill_name(&skill.name);
+            let open_button = render_skill_button(
+                &format!("/{}", skill.name),
+                button_handle,
+                appearance,
+                skill.provider,
+                skill_icon_override,
+                move |ctx| {
+                    ctx.dispatch_typed_action(AIBlockAction::OpenCodeInWarp {
+                        source: source.clone(),
+                    });
+                },
+            );
+            renderable_action = renderable_action.with_action_button(open_button);
+        }
     }
 
     renderable_action.render(app).finish()

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1758,7 +1758,12 @@ fn render_read_skill(
             let skill_icon_override = icon_override_for_skill_name(&skill.name);
             let open_button = render_skill_button(
                 "Open skill",
-                props.state_handles.open_skill_button_handle.clone(),
+                props
+                    .state_handles
+                    .skill_button_handles
+                    .get(id)
+                    .cloned()
+                    .unwrap_or_default(),
                 appearance,
                 skill.provider,
                 skill_icon_override,
@@ -1862,7 +1867,12 @@ fn render_read_files(
         let skill_icon_override = icon_override_for_skill_name(&skill.name);
         let open_button = render_skill_button(
             &format!("/{}", skill.name),
-            props.state_handles.read_from_skill_button_handle.clone(),
+            props
+                .state_handles
+                .skill_button_handles
+                .get(id)
+                .cloned()
+                .unwrap_or_default(),
             appearance,
             skill.provider,
             skill_icon_override,


### PR DESCRIPTION
## Description
Fixes the "Open skill" button bug reported in warp#12427: when the agent reads two or more skills in a single block (the repro here is when an agent makes parallel tool calls), hovering one "Open skill" button highlights both, and clicking is flaky/slow.

Root cause: it is **not** that we mint a new `MouseStateHandle` per button — it's the opposite. All skill banners shared a single per-block handle. `MouseStateHandle = Arc<Mutex<MouseState>>`, so the two skill banners (`ReadSkill` and `ReadFiles`) each cloned the same `open_skill_button_handle` / `read_from_skill_button_handle` stored on `AIBlockStateHandles`. Sharing the underlying `MouseState` means hover/click state is shared across every skill button in the block.

Fix: replace the two single handles with a per-action `HashMap<AIAgentActionId, MouseStateHandle>` (`skill_button_handles`), registered in `handle_updated_output` alongside the existing per-action handles (`orchestration_navigation_card_handles`, etc.). Each banner now looks up its own handle by action id, so each button has independent hover/click state. The `OpenCodeInWarp` reset now iterates the per-action handles (same "reset before navigation" intent as before).

## Linked Issue
warp#12427
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Demo [here](https://www.loom.com/share/e7dee62b8c9d46e7ad6abfabc68a8055).
- `cargo check -p warp --lib --features local_fs` passes
- `cargo clippy -p warp --lib --features local_fs` passes
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed "Open skill" buttons sharing hover and click state when multiple skills are read in one agent block.
-->

_Conversation: https://staging.warp.dev/conversation/3c4fc723-000e-4978-ae5f-5991647d4467_
_Run: https://oz.staging.warp.dev/runs/019eae3a-7601-7299-909c-f719e8af7fca_

_This PR was generated with [Oz](https://warp.dev/oz)._
