### PR TITLE
Fix horizontal tab dragging bugs for tab groups

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -26777,6 +26777,8 @@ impl Workspace {
         // it out of its group. The dragged tab is the one whose
         // `DraggableState` reports an active drag, so trust that identity
         // over the captured index.
+        //
+        // TODO(johnturcoo): determine the right shape for a long-term solution.
         let current_index = if self
             .tabs
             .get(current_index)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19027,14 +19027,19 @@ impl Workspace {
             }
         }
 
-        let container = Container::new(row.finish())
-            .with_border(
-                Border::all(1.)
-                    // Left border only on the first slot to avoid double borders.
-                    .with_sides(false, is_first_in_bar, false, true)
-                    .with_border_fill(internal_colors::fg_overlay_1(theme)),
-            )
-            .finish();
+        // Additional padding on expanded groups,
+        // allowing tabs to be dropped into the last position of the group.
+        const EXPANDED_GROUP_TRAILING_PADDING: f32 = 8.;
+        let mut container = Container::new(row.finish()).with_border(
+            Border::all(1.)
+                // Left border only on the first slot to avoid double borders.
+                .with_sides(false, is_first_in_bar, false, true)
+                .with_border_fill(internal_colors::fg_overlay_1(theme)),
+        );
+        if !is_collapsed {
+            container = container.with_padding_right(EXPANDED_GROUP_TRAILING_PADDING);
+        }
+        let container = container.finish();
 
         let group_id = group.id;
         let group_draggable_state = group.draggable_state.clone();
@@ -26762,6 +26767,31 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         const DETACH_SENSITIVITY: f32 = 10.0;
+        // `current_index` was captured by the tab's `Draggable` closure at
+        // render time. Mid-drag mutations (swaps, hops over collapsed
+        // blocks, membership changes) reorder `self.tabs`, and mouse events
+        // that arrive before the next repaint still carry the pre-mutation
+        // index — which can point at an innocent bystander. E.g. after the
+        // dragged tab hops over a collapsed block, the stale index lands on
+        // a member of that block and the membership logic below would rip
+        // it out of its group. The dragged tab is the one whose
+        // `DraggableState` reports an active drag, so trust that identity
+        // over the captured index.
+        let current_index = if self
+            .tabs
+            .get(current_index)
+            .is_some_and(|tab| tab.draggable_state.is_dragging())
+        {
+            current_index
+        } else {
+            self.tabs
+                .iter()
+                .position(|tab| tab.draggable_state.is_dragging())
+                .unwrap_or(current_index)
+        };
+        if current_index >= self.tabs.len() {
+            return;
+        }
         // Only detach when the drag leaves every tab-bar presentation on its
         // perpendicular axis. Windows with vertical tabs still render the
         // horizontal bar, so checking only the horizontal rect would make


### PR DESCRIPTION
## Description

Fixes two bugs in horizontal tab-bar dragging around tab groups:

**1. Dragging a tab slowly into a group from the right could split the group**

Cause: dragged tab was trying to swap positions with the last tab before registering as inside the group. 

Fix: add 8px of trailing padding inside the expanded group container, giving the right edge the same buffer the header gives the left. The entrance zone now extends past the last member's edge, so entrance always registers first. Collapsed groups are unchanged, and the inward `EDGE_MARGIN` still leaves a dead strip between adjacent groups so a tab can be dropped between them without joining either.

**2. Dragging across a collapsed group could eject one of its members**

Repro: `[collapsed][expanded (tab1)(tab2)] (tab3)` — dragging tab3 leftward across both groups would pop a member out of the collapsed group (it landed ungrouped between the two groups).

Root cause: `DragTab { tab_index }` carries an index captured at render time by the tab's `Draggable` closure. Mid-drag mutations (swaps, the hop over a collapsed block) reorder `self.tabs`, and mouse events arrive faster than frames repaint — so in-flight events can carry a stale index that now points at a different tab. After the hop shifts the collapsed members by one slot, a stale event runs the group-membership logic on a collapsed member and rips it out of its group.

Fix: `on_tab_drag` now resolves the dragged tab by identity — the tab whose `DraggableState` reports an active drag — and only trusts the event index when it matches. A bounds guard also drops late events whose index no longer points at a real tab (previously a latent panic via direct indexing in the groups block). This mirrors how group drags were already immune: `DragGroup` dispatches a stable `TabGroupId` instead of an index.

No behavior change in the steady state: when the event index is accurate the identity check is a no-op, for both horizontal and vertical layouts.

**NOTE**  The second fix is a bit of a bandaid, and I can follow up to clean up this pattern. Logically it is correct and I have tested that dragging was not regressed.


## Linked Issue

https://linear.app/warpdotdev/issue/APP-4679/dragging-a-tab-in-horizontal-tabs-causes-group-to-split

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of bug 1](https://www.loom.com/share/2741c5cd82234a45a1bb43c88810b9ba)

[Demo of bug 2](https://www.loom.com/share/d588be6822e44f67b2e6fe40e569eeab)

[Demo of fix](https://www.loom.com/share/6f6d6223882c4ed2b0ef957714f96aea)