### PR TITLE
Fix cmd-enter block attachment not starting a new conversation

### DIFF
--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -340,6 +340,21 @@ impl BlocklistAIContextModel {
         !self.pending_attachments.is_empty()
     }
 
+    /// Returns `true` if the user has explicitly attached context for the next query:
+    /// selected blocks, selected text, image/file attachments, or a document.
+    ///
+    /// Auto-attached agent-view blocks are intentionally excluded because they are not the
+    /// result of a deliberate user selection. This is used to bypass the keybinding
+    /// second-press confirmation for starting a new conversation: when the user has
+    /// deliberately attached context, a `cmd-enter` clearly signals intent to start a new
+    /// conversation with that context.
+    pub fn has_pending_user_context(&self) -> bool {
+        !self.pending_context_block_ids.is_empty()
+            || self.pending_context_selected_text.is_some()
+            || !self.pending_attachments.is_empty()
+            || self.pending_document_id.is_some()
+    }
+
     /// Returns the set `BlockId`s corresponding to blocks to be included as context with the next
     /// query.
     pub fn pending_context_block_ids(&self) -> &HashSet<BlockId> {

--- a/app/src/ai/blocklist/context_model_tests.rs
+++ b/app/src/ai/blocklist/context_model_tests.rs
@@ -178,6 +178,56 @@ fn has_locking_attachment_is_false_with_only_pending_block_id() {
 }
 
 #[test]
+fn has_pending_user_context_is_false_for_default_state() {
+    App::test((), |mut app| async move {
+        let model = build_test_context_model(&mut app);
+
+        model.read(&app, |m, _| assert!(!m.has_pending_user_context()));
+    });
+}
+
+#[test]
+fn has_pending_user_context_is_true_with_pending_block_id() {
+    // A deliberately selected block signals intent to start a new conversation with that
+    // context, so `cmd-enter` should bypass the second-press confirmation.
+    App::test((), |mut app| async move {
+        let model = build_test_context_model(&mut app);
+
+        model.update(&mut app, |m, _| {
+            m.insert_pending_block_id_for_test(BlockId::new());
+        });
+
+        model.read(&app, |m, _| assert!(m.has_pending_user_context()));
+    });
+}
+
+#[test]
+fn has_pending_user_context_is_true_with_pending_selected_text() {
+    App::test((), |mut app| async move {
+        let model = build_test_context_model(&mut app);
+
+        model.update(&mut app, |m, _| {
+            m.set_pending_selected_text_for_test(Some("hello".to_owned()));
+        });
+
+        model.read(&app, |m, _| assert!(m.has_pending_user_context()));
+    });
+}
+
+#[test]
+fn has_pending_user_context_is_true_with_pending_attachment() {
+    App::test((), |mut app| async move {
+        let model = build_test_context_model(&mut app);
+
+        model.update(&mut app, |m, _| {
+            m.append_pending_attachments_for_test(vec![make_image_attachment("a.png")]);
+        });
+
+        model.read(&app, |m, _| assert!(m.has_pending_user_context()));
+    });
+}
+
+#[test]
 fn repository_context_from_repository_info_converts_to_agent_context() {
     let repository_info = RepositoryInfo {
         name: "warp-internal".to_owned(),

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -426,7 +426,16 @@ impl Input {
                 // Keybindings can be triggered reflexively while users are already in an active
                 // conversation, so we gate only this path behind a second-press confirmation.
                 // Typed `/agent`/`/new` and slash-menu execution stay single-step by design.
-                if trigger.is_keybinding() && self.agent_view_controller.as_ref(ctx).is_active() {
+                //
+                // When the user has deliberately attached context (e.g. selected a block via
+                // `cmd-enter`), the intent to start a new conversation with that context is
+                // unambiguous, so we skip the confirmation and proceed in a single step.
+                let has_pending_user_context =
+                    self.ai_context_model.as_ref(ctx).has_pending_user_context();
+                if trigger.is_keybinding()
+                    && self.agent_view_controller.as_ref(ctx).is_active()
+                    && !has_pending_user_context
+                {
                     let should_start_new_conversation =
                         self.agent_view_controller.update(ctx, |controller, ctx| {
                             controller


### PR DESCRIPTION
## Description
Pressing `cmd-enter` while a block (or text) is selected stopped starting a new conversation with that block attached as context. The block-attach flow now works again in a single press.

### Root cause
A recent change (`should_start_new_conversation_for_keybinding`) gates keybinding-triggered `/agent` / `/new` behind a second-press confirmation when the user is already in an active, non-empty conversation. This guards against accidental conversation resets from reflexive keypresses, but it also intercepted the deliberate "select a block → `cmd-enter`" flow: the first press only armed the confirmation rather than starting the conversation, so the block was never attached.

### Fix
In `Input::execute_slash_command`, when the user has deliberately attached context (selected blocks, selected text, image/file attachments, or a document) we now skip the confirmation and start the new conversation in a single step. A new `BlocklistAIContextModel::has_pending_user_context()` helper centralizes that check. Auto-attached agent-view blocks are intentionally excluded since they are not a deliberate user selection. The muscle-memory protection is preserved for the empty-handed case.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
Added unit tests for `has_pending_user_context` covering the default (empty) state and the pending-block, pending-selected-text, and pending-attachment cases. `cargo check -p warp --tests` and `cargo clippy -p warp --lib -- -D warnings` both pass.

> Note: the full test binary could not be linked in the sandbox environment due to a memory limit (the linker was OOM-killed), so the new tests were validated for compilation via `cargo check --tests` but not executed here.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed cmd-enter on a selected block not starting a new conversation with the block attached.
-->

_Conversation: https://staging.warp.dev/conversation/c4254450-1bca-436d-a75d-48d7b2f5094d_
_Run: https://oz.staging.warp.dev/runs/019eae75-a9f0-784c-923e-475937db7038_

_This PR was generated with [Oz](https://warp.dev/oz)._
