### PR TITLE
Properly fix zsh command grid rendering glitches.

### DIFF
--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -762,7 +762,15 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       # holds the pristine value, whose width annotations are still needed if
       # we later switch to honoring the PS1.
       if [[ "$PROMPT" != "${WARP_STRIPPED_ORIGINAL_PROMPT:-}" ]]; then
-        ORIGINAL_PROMPT=$PROMPT
+        if [[ -n "${WARP_STRIPPED_ORIGINAL_PROMPT:-}" && "$PROMPT" == *"$WARP_STRIPPED_ORIGINAL_PROMPT"* ]]; then
+          # Another hook added content around the stripped prompt that we
+          # installed (e.g. a virtualenv prefix). Rehydrate the stripped
+          # portion back to its pristine value before saving, so that the
+          # width annotations survive alongside the added content.
+          ORIGINAL_PROMPT=${PROMPT//$WARP_STRIPPED_ORIGINAL_PROMPT/$ORIGINAL_PROMPT}
+        else
+          ORIGINAL_PROMPT=$PROMPT
+        fi
       fi
       PROMPT="$prompt_prefix$PROMPT$suffix"
     fi

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -661,6 +661,21 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       fi
   }
 
+  # Strips prompt constructs that zsh counts as visible "glitch" columns even
+  # when they appear inside a %{...%} zero-width region, returning the result
+  # in $REPLY. The explicit-width form %n{ is rewritten to %{ (preserving the
+  # brace pairing), and the %G, %nG, and %-nG forms are removed entirely.
+  # Neither change affects the rendered prompt bytes, only zsh's internal
+  # width accounting. Literal %% escapes are matched first so that they cannot
+  # form false positives (e.g. %%1{ renders as literal text and must be left
+  # alone).
+  function warp_strip_glitch_width_constructs() {
+    setopt localoptions extendedglob
+    local match mbegin mend
+    REPLY=${1:-}
+    REPLY=${REPLY//(#b)(%%|%<->\{|%(-|)(<->|)G)/${${match[1]:#%(-|)(<->|)G}/(#s)%<->\{(#e)/%\{}}
+  }
+
   # Check whether the prompt-related variables have OSC prompt marker sequences,
   # and if not, wrap them with the appropriate markers so that we can direct the
   # prompt bytes to the appropriate grids.
@@ -742,7 +757,13 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
         PROMPT=$preceding_suffix$following_suffix
       fi
 
-      ORIGINAL_PROMPT=$PROMPT
+      # If the prompt we extracted is exactly the glitch-stripped value that we
+      # installed on a previous refresh, keep the existing ORIGINAL_PROMPT: it
+      # holds the pristine value, whose width annotations are still needed if
+      # we later switch to honoring the PS1.
+      if [[ "$PROMPT" != "${WARP_STRIPPED_ORIGINAL_PROMPT:-}" ]]; then
+        ORIGINAL_PROMPT=$PROMPT
+      fi
       PROMPT="$prompt_prefix$PROMPT$suffix"
     fi
 
@@ -762,14 +783,26 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
     # If we are using the Warp prompt, we pass a "hidden left prompt" to the prompt
     # preview grid (the hidden prompt grid) with cursor markers surrounding the entire prompt.
     if [[ "$WARP_HONOR_PS1" != "1" ]]; then
-      if [[ "$PROMPT" != "%{$prompt_prefix$ORIGINAL_PROMPT$suffix%}" ]]; then
+      # Even though the entire prompt is surrounded by cursor markers below,
+      # zsh still counts explicit-width constructs (%n{...%} and %G) within it
+      # as visible "glitch" columns. Since the prompt is routed to the hidden
+      # prompt grid and occupies zero columns of the combined prompt/command
+      # grid, any nonzero counted width desyncs zle's internal cursor position
+      # from the physical one, which corrupts partial redraws of the command
+      # (e.g. when zsh-syntax-highlighting recolors individual tokens). Strip
+      # those constructs before wrapping; this only changes zsh's width
+      # accounting, never the rendered prompt bytes.
+      local REPLY
+      warp_strip_glitch_width_constructs "$ORIGINAL_PROMPT"
+      WARP_STRIPPED_ORIGINAL_PROMPT=$REPLY
+      if [[ "$PROMPT" != "%{$prompt_prefix$WARP_STRIPPED_ORIGINAL_PROMPT$suffix%}" ]]; then
         # We purposefully surround this entire prompt with cursor markers to prevent
         # the shell from moving its internal state of the cursor position, for purposes
         # of printing the command with the Warp prompt.
         # Note that the Warp prompt is always ABOVE the combined grid in finished blocks
         # (same line prompt only affects the input editor with Warp prompt, not
         # finished blocks).
-        PROMPT="%{$prompt_prefix$ORIGINAL_PROMPT$suffix%}"
+        PROMPT="%{$prompt_prefix$WARP_STRIPPED_ORIGINAL_PROMPT$suffix%}"
       fi
     # Otherwise, if we are using the PS1, we use the normal prompt markers.
     else


### PR DESCRIPTION
## Description
Fixes corrupted command rendering in the command grid (e.g. `../script/terraform-e staging ...` instead of `./script/terraform -e staging ...`) when using the Warp prompt with zsh themes containing explicit-width prompt constructs (e.g. oh-my-zsh robbyrussell's `%1{➜%}`) together with plugins that partially repaint the command line, like zsh-syntax-highlighting.

In Warp-prompt mode we wrap the user's entire `$PROMPT` in `%{...%}` so zsh counts it as zero-width, matching physical reality: the prompt bytes are routed to the hidden prompt-preview grid and occupy no columns of the combined prompt/command grid. However, the explicit-width constructs `%n{...%}`, `%G`, `%nG`, and `%-nG` are documented exceptions to `%{...%}`: they exist precisely to declare, from inside a zero-width region, that the enclosed output occupies real "glitch" columns, and zsh honors them regardless of `%{` nesting (see zsh `Src/prompt.c`: `putpromptchar` emits `Nularg` placeholders for these, and `countprompt` counts `Nularg` unconditionally). zle therefore trusts the theme's width annotations and models the prompt as wider than zero — but Warp has routed those bytes away from the grid, so the declared columns never physically appear, and zle's internal cursor model ends up offset from the physical cursor by that amount. When zsh-syntax-highlighting triggers a partial repaint of a recolored token, zle rewrites it at the shifted columns — leaving stale characters behind and overwriting others (the extra leading dot and swallowed space above). This is not a zsh bug: zsh provides no construct meaning "unconditionally zero width, overriding inner width declarations", so we synthesize one by stripping the annotations, which is sound here because we know the physical width is zero.

The fix strips those constructs from the prompt before wrapping it, in Warp-prompt mode only. They affect only zsh's width accounting, never the rendered bytes, so the prompt preview is unchanged. In honor-PS1 mode the prompt is physically visible and the width annotations are load-bearing, so they are left intact; the pristine prompt is also preserved for intra-session prompt-mode switches.

Known limitation: content injected at display time via `$(...)` under `PROMPT_SUBST` (e.g. robbyrussell's dirty-repo `%1{✗%}` from `$(git_prompt_info)`) cannot be statically stripped and can still shift a repaint in that case.

## Linked Issue
None.

## Testing
- Unit-tested the stripping expression (escaped `%%`, `%G`/`%nG`/`%-nG` variants, multi-digit widths, idempotency, unicode, no-op inputs).
- Simulated the full `warp_update_prompt_vars` precmd flow with a robbyrussell-style prompt across Warp-prompt ↔ PS1 mode switches, asserting the stripped wrap in Warp-prompt mode, idempotency across precmds, and that width annotations are restored when honoring PS1.
- `zsh -n` syntax check on the modified script.

- [x] I have manually tested my changes locally with `./script/run` (zsh + oh-my-zsh robbyrussell + zsh-syntax-highlighting, comparing behavior with and without the change)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/cef91665-4fbf-4176-a32d-3de2484b2fcf)

<!--
## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed commands rendering with duplicated or missing characters in blocks when using the Warp prompt with zsh themes like oh-my-zsh's robbyrussell alongside plugins such as zsh-syntax-highlighting.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
