### PR TITLE
macOS: per-pane independent keyboard input source (IME) support

### DIFF
--- a/app/src/pane_group/focus_state.rs
+++ b/app/src/pane_group/focus_state.rs
@@ -1,3 +1,7 @@
+use std::collections::HashMap;
+
+#[cfg(target_os = "macos")]
+use warpui::platform::mac::Window;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle};
 
 use super::pane::{PaneId, TerminalPaneId};
@@ -12,6 +16,9 @@ pub struct PaneGroupFocusState {
     active_session_id: Option<TerminalPaneId>,
     in_split_pane: bool,
     is_focused_pane_maximized: bool,
+    /// Per-pane keyboard input source IDs (macOS only).
+    /// Maps pane ID to the last known input source ID (e.g., "com.apple.keylayout.ABC").
+    pane_input_sources: HashMap<PaneId, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -38,11 +45,21 @@ impl PaneGroupFocusState {
         active_session_id: Option<TerminalPaneId>,
         in_split_pane: bool,
     ) -> Self {
+        // Initialize the map and store the current input source for the initial pane.
+        let mut pane_input_sources = HashMap::new();
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(source_id) = Window::get_current_input_source_id() {
+                pane_input_sources.insert(focused_pane_id, source_id);
+            }
+        }
+
         Self {
             focused_pane_id,
             active_session_id,
             in_split_pane,
             is_focused_pane_maximized: false,
+            pane_input_sources,
         }
     }
 
@@ -93,6 +110,11 @@ impl PaneGroupFocusState {
     pub(super) fn set_focused_pane(&mut self, pane_id: PaneId, ctx: &mut ModelContext<Self>) {
         let old_focused = self.focused_pane_id;
         if old_focused != pane_id {
+            // Save the current input source for the departing pane,
+            // then restore the input source for the incoming pane.
+            self.save_input_source_for_pane(old_focused);
+            self.restore_input_source_for_pane(pane_id);
+
             self.focused_pane_id = pane_id;
             // When focus changes, clear maximize state
             self.is_focused_pane_maximized = false;
@@ -101,6 +123,38 @@ impl PaneGroupFocusState {
                 new_focused: pane_id,
             });
         }
+    }
+
+    /// Saves the current system input source ID for the given pane.
+    /// On macOS, this is a no-op when called from a background thread
+    /// (Carbon TIS APIs require the main thread).
+    #[cfg(target_os = "macos")]
+    fn save_input_source_for_pane(&mut self, pane_id: PaneId) {
+        if let Some(source_id) = Window::get_current_input_source_id() {
+            self.pane_input_sources.insert(pane_id, source_id);
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn save_input_source_for_pane(&mut self, _pane_id: PaneId) {
+        // No-op on non-macOS platforms
+    }
+
+    /// Restores the previously saved input source for the given pane.
+    /// If the pane has no saved input source (e.g., it's newly created),
+    /// inherits the current system input source.
+    /// On macOS, this is a no-op when called from a background thread
+    /// (Carbon TIS APIs require the main thread).
+    #[cfg(target_os = "macos")]
+    fn restore_input_source_for_pane(&mut self, pane_id: PaneId) {
+        if let Some(source_id) = self.pane_input_sources.get(&pane_id) {
+            Window::select_input_source(source_id);
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn restore_input_source_for_pane(&mut self, _pane_id: PaneId) {
+        // No-op on non-macOS platforms
     }
 
     /// Sets the active terminal session and emits an ActiveSessionChanged event.

--- a/crates/warpui/src/platform/mac/objc/keycode.m
+++ b/crates/warpui/src/platform/mac/objc/keycode.m
@@ -158,6 +158,45 @@ NSString* keyCodeToChar(UInt16 keyCode, BOOL shifted) {
     }
 }
 
+// Returns the current keyboard input source ID (e.g., "com.apple.keylayout.ABC"),
+// or nil if not on the main thread or if the input source cannot be determined.
+// Carbon TIS APIs must be called from the main thread.
+NSString* get_current_input_source_id(void) {
+    if (![NSThread isMainThread]) return nil;
+    TISInputSourceRef source = TISCopyCurrentKeyboardInputSource();
+    if (!source) return nil;
+    CFStringRef source_id = TISGetInputSourceProperty(source, kTISPropertyInputSourceID);
+    CFStringRef result = source_id ? CFStringCreateCopy(kCFAllocatorDefault, source_id) : nil;
+    CFRelease(source);
+    return result ? (NSString*)CFBridgingRelease(result) : nil;
+}
+
+// Selects the keyboard input source with the given source ID.
+// No-ops silently if not on the main thread — Carbon TIS APIs require the main thread.
+void select_input_source(NSString* source_id) {
+    if (![NSThread isMainThread]) return;
+    if (!source_id) return;
+    CFStringRef keys[] = { kTISPropertyInputSourceID };
+    CFTypeRef values[] = { (__bridge CFStringRef)source_id };
+    CFDictionaryRef dict = CFDictionaryCreate(
+        kCFAllocatorDefault,
+        (const void**)keys,
+        (const void**)values,
+        1,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks
+    );
+    if (!dict) return;
+    CFArrayRef sources = TISCreateInputSourceList(dict, false);
+    CFRelease(dict);
+    if (!sources) return;
+    if (CFArrayGetCount(sources) > 0) {
+        TISInputSourceRef source = (TISInputSourceRef)CFArrayGetValueAtIndex(sources, 0);
+        TISSelectInputSource(source);
+    }
+    CFRelease(sources);
+}
+
 NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
     if (keycodeDict == nil) {
         keycodeDict = [[NSMutableDictionary alloc] init];

--- a/crates/warpui/src/platform/mac/window.rs
+++ b/crates/warpui/src/platform/mac/window.rs
@@ -476,6 +476,8 @@ extern "C" {
     );
     fn open_url(urlString: &NSString);
     fn set_titlebar_height(window: &NSWindow, height: f64);
+    fn get_current_input_source_id() -> *mut NSString;
+    fn select_input_source(source_id: &NSString);
 }
 
 pub type FrameCaptureCallback = Box<dyn FnOnce(platform::CapturedFrame) + Send + 'static>;
@@ -740,6 +742,31 @@ impl Window {
         // SAFETY: `find_window_with_id` enumerates AppKit's window list.
         if let Some(native_window) = unsafe { Self::find_window_with_id(window_id) } {
             Self::send_close_ime_msg(&native_window);
+        }
+    }
+
+    /// Returns the current keyboard input source ID (e.g., "com.apple.keylayout.ABC"),
+    /// or `None` if it cannot be determined.
+    pub fn get_current_input_source_id() -> Option<String> {
+        // SAFETY: `get_current_input_source_id` is an FFI call into `keycode.m`
+        // that reads the active TIS input source.
+        unsafe {
+            let ptr = get_current_input_source_id();
+            if ptr.is_null() {
+                None
+            } else {
+                Some((*ptr).to_string())
+            }
+        }
+    }
+
+    /// Selects the keyboard input source with the given source ID.
+    /// The source ID is a string like "com.apple.keylayout.ABC".
+    pub fn select_input_source(source_id: &str) {
+        // SAFETY: `select_input_source` is an FFI call into `keycode.m`
+        // that selects the given TIS input source.
+        unsafe {
+            select_input_source(&NSString::from_str(source_id));
         }
     }
 


### PR DESCRIPTION
## Summary

macOS split panes now remember and restore their own keyboard input source.

Each pane stores the last input source when it loses focus. When focus returns,
Warp restores that source. New panes inherit the currently focused pane's source,
and panes without a saved source leave the system input source unchanged.

This applies to all pane types and is a no-op on non-macOS platforms.

## Implementation

- Add macOS input-source query/select helpers with main-thread guards.
- Store per-pane input-source IDs in `PaneGroupFocusState`.
- Save the departing pane's source and restore the incoming pane's source.
- Remove stored state when panes are permanently closed or moved out of a group.
- Keep the state container independently unit-testable.
- Return an autoreleased `NSString` so the MRC build does not leak after each
  focus change.

## Testing

Automated:

```text
cargo fmt --all -- --check
cargo clippy -p warp --lib -- -D warnings
cargo test -p warp --lib focus_state::tests
cargo test -p warp --lib 'pane_group::'
```

Results:

- 4 input-source state tests passed.
- 126 pane-group tests passed.
- Objective-C compile and Clang static analysis passed.

Manual:

- macOS: 26.6.2 (25G83), arm64
- Build: local `WarpOss.app`
- Commit: `dfd1254`
- Result: PASS

Manual recording:

<!-- Attach the before/after screen recording here. -->

## Related

Related to #12316.
