### PR TITLE
Fix file search returning no results when directories fill the result cap

### DIFF
--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -253,11 +253,13 @@ impl FileSearchModel {
 
     /// Builds the [`GetContentsArgs`] used to traverse repo metadata.
     ///
-    /// For an empty `query` this returns the default args (unfiltered). For a
-    /// non-empty `query` it installs a traversal filter that keeps only entries
+    /// For an empty `query` this returns the default args (unfiltered, folders included). For a
+    /// non-empty `query` it installs a traversal filter that keeps only file entries
     /// whose repo-relative path (produced by `relative_path`) fuzzy-matches the
-    /// query. Pushing the query into traversal ensures the result cap applies
-    /// to *matching* files rather than the first files encountered.
+    /// query. Folders are excluded when a query is present because they are
+    /// filtered out in the search results anyway; excluding them ensures the
+    /// result cap applies only to *matching files* rather than being shared with
+    /// matching directories.
     #[cfg(feature = "local_fs")]
     fn contents_args<F>(query: &str, relative_path: F) -> GetContentsArgs
     where
@@ -267,10 +269,12 @@ impl FileSearchModel {
             return GetContentsArgs::default();
         }
         let query = query.to_string();
-        GetContentsArgs::default().with_filter(move |content| {
-            relative_path(content)
-                .is_some_and(|path| FileSearchModel::fuzzy_match_path(&path, &query).is_some())
-        })
+        GetContentsArgs::default()
+            .exclude_folders()
+            .with_filter(move |content| {
+                relative_path(content)
+                    .is_some_and(|path| FileSearchModel::fuzzy_match_path(&path, &query).is_some())
+            })
     }
 
     /// Gets repository contents for a local or remote repo root, converting


### PR DESCRIPTION
## Description

<img width="1800" height="1131" alt="image" src="https://github.com/user-attachments/assets/c198f89c-b1c8-473d-887b-6886ad310a0b" />


When searching for files by name in the Command Palette, directories that matched the query were consuming slots in the 100-entry result cap (`MAX_REPO_CONTENTS_RESULTS`) but then being discarded in the UI. In repositories with many directories whose names match the query (e.g. searching `"src"` in a large monorepo), all 100 slots could be taken by folders, leaving no room for actual files and returning zero results.

The fix is to call `.exclude_folders()` on `GetContentsArgs` in `contents_args()` when a query is present. This ensures the 100-entry cap applies only to matching files. The directory tree is still fully traversed to find files inside subdirectories — only the directories themselves are excluded from the result set.

The zero-state (empty query, `Cmd+O` with no text) is unaffected and continues to include directories.

## Linked Issue

Closes #12391

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Tested by searching for file names in the Warp repository itself (a large repo with many nested directories). Before the fix, queries like `"model"` or `"view"` returned no results due to the cap being filled with matching directories. After the fix, matching files appear correctly.

### Root cause

In `app/src/search/files/model.rs`, `contents_args()` built `GetContentsArgs` with `include_folders: true` (the default). Matching directories filled the 100-entry cap during repo traversal. In `app/src/search/command_palette/files/data_source.rs`, directories are explicitly skipped:

```rust
// Never show directories -- there's no way to open them currently.
if item.is_directory { continue; }
```

So the directories wasted cap slots without contributing any visible results.

### Fix

```rust
GetContentsArgs::default()
    .exclude_folders()   // ← added
    .with_filter(move |content| { ... })
```

<!-- CHANGELOG-BUG-FIX: Fixed file search in Command Palette returning no results in repositories with many directories. -->