### PR TITLE
Normalize CRLF command paste for POSIX shells

### DIFF
--- a/app/src/terminal/writeable_pty/pty_controller.rs
+++ b/app/src/terminal/writeable_pty/pty_controller.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use async_channel::{Receiver, Sender};
 use parking_lot::FairMutex;
 use thiserror::Error;
+use warp_util::path::ShellFamily;
 use warpui::r#async::block_on;
 use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity};
 
@@ -493,8 +494,6 @@ impl<T: EventLoopSender> PtyController<T> {
         shell_type: ShellType,
         ctx: &mut ModelContext<Self>,
     ) {
-        use warp_util::path::ShellFamily;
-
         // TODO(CORE-2099): Figure out a more robust solution here. Fish users
         // can redefine these functions via fish functions. Ideally this won't
         // break if the user redefines the `source` or `.` built-in.
@@ -800,11 +799,10 @@ fn bytes_to_execute_command(
     is_bracketed_paste_enabled: bool,
 ) -> Vec<u8> {
     let mut command_bytes = shell_type.kill_buffer_bytes().to_vec();
-    let command = match shell_type {
-        ShellType::Bash | ShellType::Zsh | ShellType::Fish => {
-            LINEFEED_REGEX.replace_all(command, "\n")
-        }
-        ShellType::PowerShell => Cow::Borrowed(command),
+    let command = match ShellFamily::from(shell_type) {
+        ShellFamily::Posix if cfg!(windows) => LINEFEED_REGEX.replace_all(command, "\n"),
+        ShellFamily::PowerShell => LINEFEED_REGEX.replace_all(command, "\r"),
+        _ => Cow::Borrowed(command),
     };
 
     // Only execute the command via bracketed paste if the command is not empty. Some ZSH
@@ -842,11 +840,7 @@ fn bytes_to_execute_command(
         }
     } else {
         let command_without_escapes = command.replace(escape_sequences::C0::ESC as char, "");
-        // This is a fix for PLAT-770 to allow multi-line commands in Powershell.
-        // In general, shells without bracketed paste don't handle `\n` that well,
-        // and in the case of PowerShell, it is explicitly ignored.
-        let command_without_newlines = LINEFEED_REGEX.replace_all(&command_without_escapes, "\r");
-        command_bytes.extend(command_without_newlines.as_bytes());
+        command_bytes.extend(command_without_escapes.as_bytes());
     }
     command_bytes.extend(shell_type.execute_command_bytes().to_vec());
     command_bytes

--- a/app/src/terminal/writeable_pty/pty_controller.rs
+++ b/app/src/terminal/writeable_pty/pty_controller.rs
@@ -800,6 +800,12 @@ fn bytes_to_execute_command(
     is_bracketed_paste_enabled: bool,
 ) -> Vec<u8> {
     let mut command_bytes = shell_type.kill_buffer_bytes().to_vec();
+    let command = match shell_type {
+        ShellType::Bash | ShellType::Zsh | ShellType::Fish => {
+            LINEFEED_REGEX.replace_all(command, "\n")
+        }
+        ShellType::PowerShell => Cow::Borrowed(command),
+    };
 
     // Only execute the command via bracketed paste if the command is not empty. Some ZSH
     // bracketed paste magic functions return errors if bracketed paste is used without text
@@ -855,6 +861,10 @@ fn wrap_bytes_in_bracketed_paste(bytes: impl IntoIterator<Item = u8>) -> impl It
         .chain(bytes)
         .chain(escape_sequences::BRACKETED_PASTE_END.iter().copied())
 }
+
+#[cfg(test)]
+#[path = "pty_controller_command_bytes_tests.rs"]
+mod command_bytes_tests;
 
 #[derive(Error, Debug)]
 pub enum EventLoopSendError {

--- a/app/src/terminal/writeable_pty/pty_controller_command_bytes_tests.rs
+++ b/app/src/terminal/writeable_pty/pty_controller_command_bytes_tests.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+#[test]
+fn bracketed_paste_command_execution_normalizes_crlf_to_lf_for_posix_shells() {
+    let command = "curl 'https://google.com' \\\r\n  -H 'accept: application/json'";
+
+    let bytes = bytes_to_execute_command(command, ShellType::Bash, true);
+
+    let mut expected = ShellType::Bash.kill_buffer_bytes().to_vec();
+    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_START);
+    expected.extend_from_slice(b"curl 'https://google.com' \\\n  -H 'accept: application/json'");
+    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_END);
+    expected.extend_from_slice(ShellType::Bash.execute_command_bytes());
+
+    assert_eq!(bytes, expected);
+    assert!(!bytes.contains(&b'\r'));
+}
+
+#[test]
+fn powershell_bracketed_paste_command_execution_preserves_crlf() {
+    let command = "Write-Output 'hello'\r\nWrite-Output 'world'";
+
+    let bytes = bytes_to_execute_command(command, ShellType::PowerShell, true);
+
+    let mut expected = ShellType::PowerShell.kill_buffer_bytes().to_vec();
+    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_START);
+    expected.extend_from_slice(b"Write-Output 'hello'\r\nWrite-Output 'world'");
+    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_END);
+    expected.extend_from_slice(ShellType::PowerShell.execute_command_bytes());
+
+    assert_eq!(bytes, expected);
+}

--- a/app/src/terminal/writeable_pty/pty_controller_command_bytes_tests.rs
+++ b/app/src/terminal/writeable_pty/pty_controller_command_bytes_tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 #[test]
-fn bracketed_paste_command_execution_normalizes_crlf_to_lf_for_posix_shells() {
+#[cfg(windows)]
+fn bracketed_paste_command_execution_normalizes_crlf_to_lf_for_posix_shells_on_windows() {
     let command = "curl 'https://google.com' \\\r\n  -H 'accept: application/json'";
 
     let bytes = bytes_to_execute_command(command, ShellType::Bash, true);
@@ -17,16 +18,46 @@ fn bracketed_paste_command_execution_normalizes_crlf_to_lf_for_posix_shells() {
 }
 
 #[test]
-fn powershell_bracketed_paste_command_execution_preserves_crlf() {
-    let command = "Write-Output 'hello'\r\nWrite-Output 'world'";
+#[cfg(not(windows))]
+fn bracketed_paste_command_execution_preserves_crlf_for_posix_shells_off_windows() {
+    let command = "curl 'https://google.com' \\\r\n  -H 'accept: application/json'";
 
-    let bytes = bytes_to_execute_command(command, ShellType::PowerShell, true);
+    let bytes = bytes_to_execute_command(command, ShellType::Bash, true);
+
+    let mut expected = ShellType::Bash.kill_buffer_bytes().to_vec();
+    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_START);
+    expected.extend_from_slice(b"curl 'https://google.com' \\\r\n  -H 'accept: application/json'");
+    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_END);
+    expected.extend_from_slice(ShellType::Bash.execute_command_bytes());
+
+    assert_eq!(bytes, expected);
+    assert!(bytes.contains(&b'\r'));
+}
+
+#[test]
+fn unbracketed_paste_command_execution_preserves_lf_for_posix_shells() {
+    let command = "printf 'hello'\nprintf 'world'";
+
+    let bytes = bytes_to_execute_command(command, ShellType::Bash, false);
+
+    let mut expected = ShellType::Bash.kill_buffer_bytes().to_vec();
+    expected.extend_from_slice(b"printf 'hello'\nprintf 'world'");
+    expected.extend_from_slice(ShellType::Bash.execute_command_bytes());
+
+    assert_eq!(bytes, expected);
+    assert!(!bytes.contains(&b'\r'));
+}
+
+#[test]
+fn powershell_command_execution_normalizes_linefeeds_to_carriage_returns() {
+    let command = "Write-Output 'hello'\r\nWrite-Output 'world'\nWrite-Output 'again'";
+
+    let bytes = bytes_to_execute_command(command, ShellType::PowerShell, false);
 
     let mut expected = ShellType::PowerShell.kill_buffer_bytes().to_vec();
-    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_START);
-    expected.extend_from_slice(b"Write-Output 'hello'\r\nWrite-Output 'world'");
-    expected.extend_from_slice(escape_sequences::BRACKETED_PASTE_END);
+    expected.extend_from_slice(b"Write-Output 'hello'\rWrite-Output 'world'\rWrite-Output 'again'");
     expected.extend_from_slice(ShellType::PowerShell.execute_command_bytes());
 
     assert_eq!(bytes, expected);
+    assert!(!bytes.contains(&b'\n'));
 }


### PR DESCRIPTION
## Description

Normalize CRLF line endings before writing bracketed command paste bytes for POSIX shells.

On Windows, pasted multi-line commands can include `\r\n`. When those bytes are sent to bash through bracketed paste, a trailing `\` no longer escapes the newline, so the next line is executed as a separate command. For bash, zsh, and fish, this now treats CRLF the same as LF before writing command bytes.

PowerShell command paste line endings continue to be normalized to carriage returns.

## Linked Issue

Fixes #7479

- [x] The linked issue is labeled `ready-to-implement`.

## Testing

- `cargo fmt --check`
- `git diff --check`
- `./script/check_no_inline_test_modules`
- `PROTOC_INCLUDE=/usr/include cargo test -p warp command_bytes_tests --lib`
- `./script/run` built and launched Warp OSS locally.
- WSL2 bash shell-level check: verified that CRLF after a trailing `\` makes the next line execute separately, while the LF-normalized form keeps the continued line in the same command.
- Manual GUI verification on Windows/WSL:
  - Current stable `v0.2026.06.03.09.49.stable_02`: CRLF paste causes the continued `-H` lines to execute separately.
  - This PR branch: the same CRLF paste stays on one continued command.

Verification videos:

Current stable repro:

![Current stable CRLF paste repro](https://gist.github.com/bbbiggest/121256cd7e3b35bb7fc4e6dd6ba89cef/raw/warp_release_crlf_repro_sanitized.gif)

MP4: https://gist.github.com/bbbiggest/121256cd7e3b35bb7fc4e6dd6ba89cef/raw/warp_release_crlf_repro_sanitized.mp4

PR branch fixed behavior:

![PR branch CRLF paste fixed behavior](https://gist.github.com/bbbiggest/121256cd7e3b35bb7fc4e6dd6ba89cef/raw/warp_pr_crlf_fixed_sanitized.gif)

MP4: https://gist.github.com/bbbiggest/121256cd7e3b35bb7fc4e6dd6ba89cef/raw/warp_pr_crlf_fixed_sanitized.mp4

- [x] I have manually tested my changes locally with `./script/run`

CHANGELOG-BUG-FIX: [Windows] Fixed pasted CRLF line endings breaking multi-line commands in POSIX shells.

