### PR TITLE
Fix code review file header opaque corner fill

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -5073,6 +5073,7 @@ impl CodeReviewView {
 
         Container::new(inner_header)
             .with_background(outer_bg)
+            .with_corner_radius(inner_corner_radius)
             .finish()
     }
 


### PR DESCRIPTION
## Description
Fixes the code review file section header showing square opaque corners behind its rounded card. In `render_file_header`, the rounded inner header was wrapped in an outer container painted with an opaque `theme.background()` fill but **no** corner radius, so the background square poked out at the four corners (visible as dark corners). The fix applies the inner header's `inner_corner_radius` to the outer backing container so the opaque fill matches the rounded card (all corners when collapsed, top-only when expanded).

## Linked Issue
Closes #12436
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Verified `cargo check -p warp --features local_fs` succeeds. The change is a one-line styling fix using the existing in-scope `inner_corner_radius` and the `with_corner_radius` builder already used throughout this file.

### Screenshots / Videos

**File header cards after fix — corners cleanly rounded, no square bleed-through:**

![Code review file header fix (close-up)](https://i.imgur.com/JNZE0gP.png)

<details>
<summary>Full Code Review pane screenshot</summary>

![Code review pane (full)](https://i.imgur.com/to6ZB8r.png)

</details>

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed the code review file section header rendering opaque square corners behind its rounded background.
-->

_Conversation: https://staging.warp.dev/conversation/ef39588f-f62b-412b-8db6-471335becc65_

_Run: https://oz.staging.warp.dev/runs/019eb197-c57d-7795-a750-6ebedada5d5c_

_This PR was generated with [Oz](https://warp.dev/oz)._