### PR TITLE
Fix/block reflow on resize

### DIFF
--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2127,6 +2127,22 @@ impl BlockList {
                 }
             },
         );
+
+        // Rich content blocks are sized by the UI layout engine, not by the terminal
+        // grid, so they don't get reflowed by the Block::resize() calls above.
+        // Mark them all dirty so they are re-measured against the new pane width.
+        if size_update.pane_size_changed() {
+            self.mark_all_rich_content_dirty();
+        }
+    }
+
+    /// Marks every rich content item dirty so heights are re-measured on the next layout pass.
+    fn mark_all_rich_content_dirty(&mut self) {
+        for item in self.removable_blocklist_item_positions.keys() {
+            if let RemovableBlocklistItem::RichContent(view_id) = item {
+                self.dirty_rich_content_items.insert(*view_id);
+            }
+        }
     }
 
     /// Helper function to update each block--ensuring the BlockHeights sumtree is appropriately

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -2168,3 +2168,41 @@ fn test_device_status_uses_active_block_if_no_typeahead() {
 
     assert_eq!(writer, "\x1b[1;21R".as_bytes());
 }
+
+/// Regression test: rich content blocks must be marked dirty when the pane width
+/// changes so the layout engine re-measures them on the next frame. Without this,
+/// blocks kept their old wrap width after the window was maximized, leaving a blank
+/// area on the right side.
+#[test]
+fn test_resize_marks_rich_content_dirty() {
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+
+    let view_id_a = EntityId::new();
+    let view_id_b = EntityId::new();
+    block_list.append_rich_content(RichContentItem::new_for_test(None, view_id_a, None), false);
+    block_list.append_rich_content(RichContentItem::new_for_test(None, view_id_b, None), false);
+
+    // Clear any dirty state left over from appending.
+    let _ = block_list.take_dirty_rich_content_items();
+
+    let old_size = SizeInfo::new_without_font_metrics(24, 80);
+    let new_size = SizeInfo::new_without_font_metrics(24, 200);
+
+    let size_update = SizeUpdate {
+        update_reason: SizeUpdateReason::Refresh,
+        last_size: old_size,
+        new_size,
+        new_gap_height: None,
+        natural_rows: 24,
+        natural_cols: 200,
+    };
+
+    assert!(size_update.pane_size_changed());
+
+    block_list.resize(&size_update, true);
+
+    let dirty = block_list.take_dirty_rich_content_items();
+    assert!(dirty.contains(&view_id_a));
+    assert!(dirty.contains(&view_id_b));
+}


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
