### PR TITLE
Fix issue when installing oz-harness-support on the update path

### DIFF
--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -52,26 +52,6 @@ impl ClaudeCodePluginManager {
             .map(|path| HashMap::from([("PATH".to_owned(), path.to_owned())]));
         run_cli_command_logged("claude", args, &self.executor, env_vars, log).await
     }
-
-    async fn attempt_to_install_oz_harness_support_plugin(
-        &self,
-        log: &mut String,
-    ) -> Result<(), PluginInstallError> {
-        if self
-            .run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], log)
-            .await
-            .is_err()
-        {
-            self.run_logged(
-                &["plugin", "marketplace", "add", PLATFORM_MARKETPLACE_REPO],
-                log,
-            )
-            .await?;
-            self.run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], log)
-                .await?;
-        }
-        Ok(())
-    }
 }
 
 #[async_trait]
@@ -97,6 +77,7 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
         };
         check_platform_plugin_installed(&claude_dir)
     }
+
     fn platform_plugin_needs_update(&self) -> bool {
         let Ok(claude_dir) = claude_home_dir() else {
             return false;
@@ -194,31 +175,26 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
 
     async fn install_platform_plugin(&self) -> Result<(), PluginInstallError> {
         let mut log = String::new();
-        self.attempt_to_install_oz_harness_support_plugin(&mut log)
-            .await?;
-        let still_outdated = claude_home_dir()
-            .ok()
-            .and_then(|dir| installed_platform_plugin_version(&dir))
-            .map(|v| compare_versions(&v, MINIMUM_PLATFORM_PLUGIN_VERSION).is_lt())
-            .unwrap_or(true);
-        if still_outdated {
-            log.push_str("Post-install version check: platform plugin is still outdated\n");
-            return Err(PluginInstallError {
-                message: "Platform plugin installation did not take effect".to_owned(),
-                log,
-            });
-        }
-        Ok(())
-    }
-    async fn update_platform_plugin(&self) -> Result<(), PluginInstallError> {
-        let mut log = String::new();
         self.run_logged(
-            &["plugin", "marketplace", "update", MARKETPLACE_NAME],
+            &["plugin", "marketplace", "add", PLATFORM_MARKETPLACE_REPO],
             &mut log,
         )
         .await?;
-        self.attempt_to_install_oz_harness_support_plugin(&mut log)
+        self.run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], &mut log)
             .await?;
+        Ok(())
+    }
+
+    async fn update_platform_plugin(&self) -> Result<(), PluginInstallError> {
+        let mut log = String::new();
+        self.run_logged(
+            &["plugin", "marketplace", "add", PLATFORM_MARKETPLACE_REPO],
+            &mut log,
+        )
+        .await?;
+        self.run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], &mut log)
+            .await?;
+        
         let still_outdated = claude_home_dir()
             .ok()
             .and_then(|dir| installed_platform_plugin_version(&dir))

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -53,7 +53,10 @@ impl ClaudeCodePluginManager {
         run_cli_command_logged("claude", args, &self.executor, env_vars, log).await
     }
 
-    async fn attempt_to_install_oz_harness_support_plugin(&self, log: &mut String) -> Result<(), PluginInstallError> {
+    async fn attempt_to_install_oz_harness_support_plugin(
+        &self,
+        log: &mut String,
+    ) -> Result<(), PluginInstallError> {
         if self
             .run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], log)
             .await
@@ -191,7 +194,8 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
 
     async fn install_platform_plugin(&self) -> Result<(), PluginInstallError> {
         let mut log = String::new();
-        self.attempt_to_install_oz_harness_support_plugin(&mut log).await?;
+        self.attempt_to_install_oz_harness_support_plugin(&mut log)
+            .await?;
         let still_outdated = claude_home_dir()
             .ok()
             .and_then(|dir| installed_platform_plugin_version(&dir))
@@ -213,7 +217,8 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
             &mut log,
         )
         .await?;
-        self.attempt_to_install_oz_harness_support_plugin(&mut log).await?;
+        self.attempt_to_install_oz_harness_support_plugin(&mut log)
+            .await?;
         let still_outdated = claude_home_dir()
             .ok()
             .and_then(|dir| installed_platform_plugin_version(&dir))

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -194,7 +194,7 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
         .await?;
         self.run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], &mut log)
             .await?;
-        
+
         let still_outdated = claude_home_dir()
             .ok()
             .and_then(|dir| installed_platform_plugin_version(&dir))

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -52,6 +52,23 @@ impl ClaudeCodePluginManager {
             .map(|path| HashMap::from([("PATH".to_owned(), path.to_owned())]));
         run_cli_command_logged("claude", args, &self.executor, env_vars, log).await
     }
+
+    async fn attempt_to_install_oz_harness_support_plugin(&self, log: &mut String) -> Result<(), PluginInstallError> {
+        if self
+            .run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], log)
+            .await
+            .is_err()
+        {
+            self.run_logged(
+                &["plugin", "marketplace", "add", PLATFORM_MARKETPLACE_REPO],
+                log,
+            )
+            .await?;
+            self.run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], log)
+                .await?;
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -174,19 +191,7 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
 
     async fn install_platform_plugin(&self) -> Result<(), PluginInstallError> {
         let mut log = String::new();
-        if self
-            .run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], &mut log)
-            .await
-            .is_err()
-        {
-            self.run_logged(
-                &["plugin", "marketplace", "add", PLATFORM_MARKETPLACE_REPO],
-                &mut log,
-            )
-            .await?;
-            self.run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], &mut log)
-                .await?;
-        }
+        self.attempt_to_install_oz_harness_support_plugin(&mut log).await?;
         let still_outdated = claude_home_dir()
             .ok()
             .and_then(|dir| installed_platform_plugin_version(&dir))
@@ -208,8 +213,7 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
             &mut log,
         )
         .await?;
-        self.run_logged(&["plugin", "install", PLATFORM_PLUGIN_KEY], &mut log)
-            .await?;
+        self.attempt_to_install_oz_harness_support_plugin(&mut log).await?;
         let still_outdated = claude_home_dir()
             .ok()
             .and_then(|dir| installed_platform_plugin_version(&dir))

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs
@@ -224,6 +224,7 @@ pub(crate) trait CliAgentPluginManager: Send + Sync {
     async fn install_platform_plugin(&self) -> Result<(), PluginInstallError> {
         Ok(())
     }
+
     /// Update the Oz platform plugin for this CLI agent, if one exists.
     /// Default reuses the install path because most agents do not have a
     /// platform plugin or need distinct update behavior.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Fixes REMOTE-1906. The update path got regressed in https://github.com/warpdotdev/warp/pull/11571 and we would no longer clone the internal version of the repo that contains the `oz-harness-support` plugin.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [X] I have manually tested my changes locally with `./script/run`

Tested locally with the self-hosted direct backend path (i.e. `oz-local`). It did not work before but now does.

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [X] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Helped with logs!
