### PR TITLE
Suppress agent completion notifications when a prompt is queued

### DIFF
--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -11,7 +11,7 @@ use crate::ai::agent_management::notifications::{
     NotificationSourceAgent,
 };
 use crate::ai::artifacts::Artifact;
-use crate::ai::blocklist::{BlocklistAIHistoryEvent, ConversationStatusUpdate};
+use crate::ai::blocklist::{BlocklistAIHistoryEvent, ConversationStatusUpdate, QueuedQueryModel};
 use crate::server::telemetry::TelemetryEvent;
 use crate::settings::AISettings;
 use crate::terminal::cli_agent_sessions::{
@@ -283,6 +283,14 @@ impl AgentNotificationsModel {
             return;
         }
 
+        // Mirror the mailbox path: a finished response shouldn't notify when a queued follow-up
+        // prompt will auto-send as soon as the conversation finishes.
+        if matches!(status, ConversationStatus::Success)
+            && QueuedQueryModel::as_ref(ctx).has_autofireable_prompt(*conversation_id)
+        {
+            return;
+        }
+
         if is_terminal_view_visible(*terminal_view_id, ctx) {
             return;
         }
@@ -331,6 +339,14 @@ impl AgentNotificationsModel {
                 self.remove_notification_by_source(origin, ctx);
             }
             ConversationStatus::Success => {
+                // Suppress the completion notification when a queued follow-up prompt will
+                // auto-send as soon as this conversation finishes. The conversation isn't
+                // really in a stopped state, so the notification would be noisy. Pending
+                // artifacts are left intact so they roll into the notification fired when the
+                // conversation eventually finishes with an empty queue.
+                if QueuedQueryModel::as_ref(ctx).has_autofireable_prompt(conversation_id) {
+                    return;
+                }
                 let artifacts = self.flush_pending_artifacts(conversation_id);
                 self.add_notification(
                     title,

--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -283,14 +283,6 @@ impl AgentNotificationsModel {
             return;
         }
 
-        // Mirror the mailbox path: a finished response shouldn't notify when a queued follow-up
-        // prompt will auto-send as soon as the conversation finishes.
-        if matches!(status, ConversationStatus::Success)
-            && QueuedQueryModel::as_ref(ctx).has_autofireable_prompt(*conversation_id)
-        {
-            return;
-        }
-
         if is_terminal_view_visible(*terminal_view_id, ctx) {
             return;
         }

--- a/app/src/ai/agent_management/agent_management_model_tests.rs
+++ b/app/src/ai/agent_management/agent_management_model_tests.rs
@@ -23,6 +23,9 @@ fn setup_app(
 ) {
     initialize_settings_for_tests(app);
     let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+    // Registered after the history model since it subscribes to history events; the
+    // notifications model reads it to suppress completion notifications when a prompt is queued.
+    app.add_singleton_model(crate::ai::blocklist::QueuedQueryModel::new);
     app.add_singleton_model(|_| CLIAgentSessionsModel::new());
     app.add_singleton_model(|_| ActiveAgentViewsModel::new());
     let notifications = app.add_singleton_model(AgentNotificationsModel::new);

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -303,6 +303,16 @@ impl QueuedQueryModel {
             .is_some_and(|state| !state.queue.is_empty())
     }
 
+    /// Returns true when a queued row would auto-fire for `conversation_id` the next time the
+    /// conversation finishes successfully. Mirrors [`Self::peek_autofire`]'s gating: false for an
+    /// empty queue or a locked head row (which never auto-fires).
+    pub fn has_autofireable_prompt(&self, conversation_id: AIConversationId) -> bool {
+        self.queues
+            .get(&conversation_id)
+            .and_then(|state| state.queue.first())
+            .is_some_and(|first| !first.is_locked())
+    }
+
     /// Marks that a dispatched queued command is running for `conversation_id`. While set, the
     /// queue keeps accepting new rows (the agent is idle) and the next drain waits for the
     /// command to finish.

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -832,3 +832,45 @@ fn clear_conversations_in_terminal_view_drops_every_listed_conversation() {
         });
     });
 }
+
+#[test]
+fn has_autofireable_prompt_is_false_for_an_empty_queue() {
+    with_model(|app, model, _events| {
+        let conv = AIConversationId::new();
+        model.read(&app, |m, _| assert!(!m.has_autofireable_prompt(conv)));
+    });
+}
+
+#[test]
+fn has_autofireable_prompt_is_true_for_a_queued_prompt() {
+    with_model(|mut app, model, _events| {
+        let conv = AIConversationId::new();
+        append_user(&model, &mut app, conv, "follow up");
+        model.read(&app, |m, _| assert!(m.has_autofireable_prompt(conv)));
+    });
+}
+
+#[test]
+fn has_autofireable_prompt_is_false_when_only_a_locked_head_is_queued() {
+    // A locked initial Cloud Mode head never auto-fires on finish, so it must not count.
+    with_model(|mut app, model, _events| {
+        let conv = AIConversationId::new();
+        model.update(&mut app, |m, ctx| {
+            m.append(conv, initial_cloud_mode_query("initial"), ctx)
+        });
+        model.read(&app, |m, _| assert!(!m.has_autofireable_prompt(conv)));
+    });
+}
+
+#[test]
+fn has_autofireable_prompt_is_false_when_a_locked_head_precedes_a_prompt() {
+    // The head row gates auto-fire; a locked head blocks the trailing prompt from firing.
+    with_model(|mut app, model, _events| {
+        let conv = AIConversationId::new();
+        model.update(&mut app, |m, ctx| {
+            m.append(conv, initial_cloud_mode_query("initial"), ctx)
+        });
+        append_user(&model, &mut app, conv, "follow up");
+        model.read(&app, |m, _| assert!(!m.has_autofireable_prompt(conv)));
+    });
+}


### PR DESCRIPTION
## Description

It's kind of noisy to have notifications when the agent is responding if there are prompts queued up for that agent. Further, the notifications aren't really valuable because, where they are usually a sign that the agent is done and you should go interact w/ it, in this case the agent isn't done because it will immediately start responding to a new prompt.

To fix this, we should suppress agent notifications for response finish events when there are more prompts queued.

## Testing
- [x] I have manually tested my changes locally with `./script/run`
https://www.loom.com/share/8e4a40068964499b8c636b2c18b758ba

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Agent completion notifications are no longer shown when a follow-up prompt is queued to auto-send.
-->
_Conversation: https://staging.warp.dev/conversation/6a984387-fcac-4577-a792-7abf434b28ab_

_Run: https://oz.staging.warp.dev/runs/019eb281-de1f-7278-a362-056ec2a3b2e2_

_This PR was generated with [Oz](https://warp.dev/oz)._
