### PR TITLE
Fix IME (input method) on Linux/Wayland (GNOME, Sway, Hyprland)

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -962,8 +962,9 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::Autoupdate,
     FeatureFlag::Changelog,
     FeatureFlag::CrashReporting,
-    // Marked text is currently only supported on MacOS.
     #[cfg(target_os = "macos")]
+    FeatureFlag::ImeMarkedText,
+    #[cfg(target_os = "linux")]
     FeatureFlag::ImeMarkedText,
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]

--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -1423,7 +1423,11 @@ fn create_window(
             window_target.display_handle().map(|dh| dh.as_raw()),
             Ok(RawDisplayHandle::Xlib(_)) | Ok(RawDisplayHandle::Xcb(_))
         );
-        if is_x11 {
+        let is_kde_wayland = !is_x11
+            && std::env::var("XDG_CURRENT_DESKTOP")
+                .map(|v| v.to_uppercase().contains("KDE"))
+                .unwrap_or(false);
+        if !is_kde_wayland {
             window.set_ime_allowed(true);
         }
     }


### PR DESCRIPTION
## Description

Fixes #5279.

IME (input methods such as fcitx5, ibus) is completely non-functional on Linux/Wayland (GNOME, Sway, Hyprland, etc.) due to two independent bugs that both need to be fixed for CJK input to work.

Related: #11593, #12252, #12297, #12444 (all closed as duplicates of #5279).

### Root Cause Analysis

**Bug 1 — `set_ime_allowed(true)` never called on Wayland** (`crates/warpui/src/windowing/winit/window.rs`)

`set_ime_allowed(true)` was restricted to X11 only by PR #12277, which intentionally excluded Wayland to avoid a known infinite loop on KDE (PR #11032). However, on GNOME/Sway/Hyprland Wayland, `set_ime_allowed` being `false` causes winit's `text_input` Enter handler to skip `zwp_text_input_v3.enable()` entirely. Without `enable()`, the compositor does not know the application wants IME, so all keystrokes (including IME toggle keys like Super+Space) are delivered as raw key events.

Wayland protocol trace on GNOME (before fix):
```
zwp_text_input_v3.enter(surface)    // Mutter sends enter
// enable() is NEVER called         // winit skips it because ime_allowed == false
zwp_text_input_v3.leave(surface)    // IME immediately deactivated
```

**Bug 2 — `ImeMarkedText` feature flag not enabled for Linux** (`crates/warp_features/src/lib.rs`)

Even if Bug 1 were fixed and the compositor activates IME, Warp's terminal and editor views gate all IME event handling (`Ime::Preedit`, `Ime::Commit`) behind `FeatureFlag::ImeMarkedText.is_enabled()`. This flag was only added to `RELEASE_FLAGS` for macOS, not Linux. Without it, all IME events from winit are silently discarded at the application level.

Both bugs must be fixed: Bug 1 activates the IME pipeline, Bug 2 lets Warp process the resulting events.

### Fix

**1. Enable `set_ime_allowed(true)` on Linux, excluding KDE** (`window.rs`)

Instead of the previous X11-only approach, we now enable IME for all Linux display backends but skip KDE Plasma to avoid the known infinite loop from PR #11032:

```rust
#[cfg(target_os = "linux")]
if let Ok(window) = created_window.as_ref() {
    let is_kde = std::env::var("XDG_CURRENT_DESKTOP")
        .map(|v| v.to_uppercase().contains("KDE"))
        .unwrap_or(false);
    if !is_kde {
        window.set_ime_allowed(true);
    }
}
```

`XDG_CURRENT_DESKTOP` is a freedesktop.org standard set by all mainstream desktop environments. KDE Plasma sets it to `KDE`. This allows GNOME, Sway, Hyprland, and other non-KDE Wayland compositors to use IME while avoiding the KDE regression.

**2. Add `ImeMarkedText` to `RELEASE_FLAGS` for Linux** (`lib.rs`)

```rust
#[cfg(target_os = "macos")]
FeatureFlag::ImeMarkedText,
#[cfg(target_os = "linux")]
FeatureFlag::ImeMarkedText,
```

This mirrors the existing macOS pattern and enables the marked text (preedit) code paths in the terminal and editor views for Linux release builds.

## Linked Issue

- [x] Fixes #5279 — fcitx5-rime cannot input into Warp
- [x] The linked issue is labeled `ready-to-implement`.

## Testing

- Built with `cargo build --release --bin warp-oss` on Fedora 44, GNOME Shell 50.2, Wayland.
- Verified Chinese input (fcitx5 5.1.19 + fcitx5-rime) works end-to-end in the patched binary.
- Verified the KDE guard works by setting `XDG_CURRENT_DESKTOP=KDE` and confirming `set_ime_allowed` is skipped.
- Compilation verified with `cargo check --bin warp-oss` (0 errors, only pre-existing warnings).

### Screenshots / Videos

*(Available on request — Chinese input working in Warp terminal via fcitx5-rime on GNOME Wayland.)*

## Known Issue

KDE Plasma Wayland users are excluded from this fix via the `XDG_CURRENT_DESKTOP` check. The infinite loop reported in PR #11032 needs investigation at the winit level. When that is resolved, the KDE guard can be removed.

## Server API

No server changes.

## Agent Mode

- [ ] Warp Agent Mode - This PR was **not** created via Warp's AI Agent Mode
