### PR TITLE
Add setting to enable reusing user's existing control master

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1008,6 +1008,40 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             # and use printf to convert back to plaintext
             local zsh_env_script=$(printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; WARP_SESSION_ID='$remote_session_id'; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; WARP_HONOR_PS1='$WARP_HONOR_PS1'; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d '"'"' \n'"'"'); printf '"'"'\e]9278;d;%s\x07'"'"' $_msg; unset _hostname _user _msg' | command -p od -An -v -tx1 | command -p tr -d ' \n')
 
+            # Optionally attach to an existing ControlMaster the user already
+            # runs for this destination instead of creating our own. Resolve
+            # the user's configured ControlPath with `ssh -G` (which expands
+            # tokens like %h/%p/%r/%C into a literal path), then verify the
+            # master is alive with `ssh -O check`. Both probes are local-only
+            # commands. On any failure we fall back to creating a Warp-owned
+            # master, preserving the existing behavior.
+            local control_path="$SSH_SOCKET_DIR/$WARP_SESSION_ID"
+            local control_master_mode="yes"
+            local external_master="false"
+            if [[ "$WARP_SSH_REUSE_CONTROL_MASTER" == "1" ]]; then
+                local user_control_path=$(command ssh -G "${@:1}" 2>/dev/null | command -p awk '$1 == "controlpath" { sub(/^controlpath[ \t]+/, ""); print; exit }')
+                case "$user_control_path" in
+                    "" | none)
+                        # No ControlPath configured for this destination.
+                        ;;
+                    *[![:alnum:]._/~@:+,-]*)
+                        # The resolved path contains characters we cannot safely
+                        # embed in the SSH hook JSON below (e.g. an unexpanded %
+                        # token, quotes, or whitespace); fall back to a
+                        # Warp-owned master.
+                        ;;
+                    *)
+                        if command ssh -O check -o ControlPath="$user_control_path" "${@:1}" >/dev/null 2>&1; then
+                            # A live master exists: multiplex through it and let
+                            # the client know Warp does not own it.
+                            control_path="$user_control_path"
+                            control_master_mode="no"
+                            external_master="true"
+                        fi
+                        ;;
+                esac
+            fi
+
             # Keep remote commands up-to-date with shell.rs & bash.sh.
             # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
             # escaped with "''" to avoid the local shell from expanding them before they're passed to the remote shell.
@@ -1015,7 +1049,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
             # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
             # support.
-            command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$WARP_SESSION_ID \
+            command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
             -t "${@:1}" \
 "
 export TERM_PROGRAM='WarpTerminal'
@@ -1027,7 +1061,7 @@ test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSI
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
 
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$WARP_SESSION_ID'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_master\": '"$external_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then

--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1017,9 +1017,9 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             # master, preserving the existing behavior.
             local control_path="$SSH_SOCKET_DIR/$WARP_SESSION_ID"
             local control_master_mode="yes"
-            local external_master="false"
+            local external_control_master="false"
             if [[ "$WARP_SSH_REUSE_CONTROL_MASTER" == "1" ]]; then
-                local user_control_path=$(command ssh -G "${@:1}" 2>/dev/null | command -p awk '$1 == "controlpath" { sub(/^controlpath[ \t]+/, ""); print; exit }')
+                local user_control_path=$(command ssh -G "${@:1}" 2>/dev/null | command -p sed -n 's/^controlpath //p')
                 case "$user_control_path" in
                     "" | none)
                         # No ControlPath configured for this destination.
@@ -1036,7 +1036,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
                             # the client know Warp does not own it.
                             control_path="$user_control_path"
                             control_master_mode="no"
-                            external_master="true"
+                            external_control_master="true"
                         fi
                         ;;
                 esac
@@ -1061,7 +1061,7 @@ test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSI
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
 
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_master\": '"$external_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_control_master\": '"$external_control_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -644,9 +644,9 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
         # master, preserving the existing behavior.
         set -l control_path "$SSH_SOCKET_DIR/$WARP_SESSION_ID"
         set -l control_master_mode "yes"
-        set -l external_master "false"
+        set -l external_control_master "false"
         if test "$WARP_SSH_REUSE_CONTROL_MASTER" = "1"
-            set -l user_control_path (command ssh -G $argv 2>/dev/null | command awk '$1 == "controlpath" { sub(/^controlpath[ \t]+/, ""); print; exit }')
+            set -l user_control_path (command ssh -G $argv 2>/dev/null | command sed -n 's/^controlpath //p')
             # Skip when no ControlPath is configured, and reject resolved
             # paths containing characters we cannot safely embed in the SSH
             # hook JSON below (e.g. an unexpanded % token, quotes, or
@@ -659,7 +659,7 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
                     # client know Warp does not own it.
                     set control_path "$user_control_path"
                     set control_master_mode "no"
-                    set external_master "true"
+                    set external_control_master "true"
                 end
             end
         end
@@ -677,7 +677,7 @@ export TERM_PROGRAM='WarpTerminal'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_master\": '"$external_master"'}}" "${SHELL##*/}" | command od -An -v -tx1 | command tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_control_master\": '"$external_control_master"'}}" "${SHELL##*/}" | command od -An -v -tx1 | command tr -d " \n")'"
 printf '$DCS_START$DCS_JSON_MARKER%s$DCS_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -635,20 +635,49 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
         # and use printf to convert back to plaintext
         set -l zsh_env_script (printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; WARP_SESSION_ID='$remote_session_id'; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; WARP_HONOR_PS1='$WARP_HONOR_PS1'; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d " \n"); printf '"'"'\x1b\x50\x24\x64%s\x1b\x5c'"'"' $_msg; unset _hostname _user _msg' | command od -An -v -tx1 | command tr -d ' \n')
 
+        # Optionally attach to an existing ControlMaster the user already
+        # runs for this destination instead of creating our own. Resolve
+        # the user's configured ControlPath with `ssh -G` (which expands
+        # tokens like %h/%p/%r/%C into a literal path), then verify the
+        # master is alive with `ssh -O check`. Both probes are local-only
+        # commands. On any failure we fall back to creating a Warp-owned
+        # master, preserving the existing behavior.
+        set -l control_path "$SSH_SOCKET_DIR/$WARP_SESSION_ID"
+        set -l control_master_mode "yes"
+        set -l external_master "false"
+        if test "$WARP_SSH_REUSE_CONTROL_MASTER" = "1"
+            set -l user_control_path (command ssh -G $argv 2>/dev/null | command awk '$1 == "controlpath" { sub(/^controlpath[ \t]+/, ""); print; exit }')
+            # Skip when no ControlPath is configured, and reject resolved
+            # paths containing characters we cannot safely embed in the SSH
+            # hook JSON below (e.g. an unexpanded % token, quotes, or
+            # whitespace); in those cases fall back to a Warp-owned master.
+            if test -n "$user_control_path"
+                and test "$user_control_path" != "none"
+                and string match --quiet --regex '^[A-Za-z0-9._/~@:+,-]+$' -- "$user_control_path"
+                if command ssh -O check -o ControlPath="$user_control_path" $argv >/dev/null 2>&1
+                    # A live master exists: multiplex through it and let the
+                    # client know Warp does not own it.
+                    set control_path "$user_control_path"
+                    set control_master_mode "no"
+                    set external_master "true"
+                end
+            end
+        end
+
         # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
         # escaped with "''" to avoid the local shell from expanding them before they're passed to the remote shell.
         # We check the SHELL env var and use shell string manipulation to get the contents after the last slash to
         # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
         # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
         # support.
-        command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$WARP_SESSION_ID \
+        command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
         -t $argv \
 "
 export TERM_PROGRAM='WarpTerminal'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$WARP_SESSION_ID'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"'}}" "${SHELL##*/}" | command od -An -v -tx1 | command tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_master\": '"$external_master"'}}" "${SHELL##*/}" | command od -An -v -tx1 | command tr -d " \n")'"
 printf '$DCS_START$DCS_JSON_MARKER%s$DCS_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -905,9 +905,9 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
           # master, preserving the existing behavior.
           local control_path="$SSH_SOCKET_DIR/$WARP_SESSION_ID"
           local control_master_mode="yes"
-          local external_master="false"
+          local external_control_master="false"
           if [[ "$WARP_SSH_REUSE_CONTROL_MASTER" == "1" ]]; then
-              local user_control_path=$(command ssh -G "${@:1}" 2>/dev/null | command -p awk '$1 == "controlpath" { sub(/^controlpath[ \t]+/, ""); print; exit }')
+              local user_control_path=$(command ssh -G "${@:1}" 2>/dev/null | command -p sed -n 's/^controlpath //p')
               case "$user_control_path" in
                   "" | none)
                       # No ControlPath configured for this destination.
@@ -924,7 +924,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
                           # the client know Warp does not own it.
                           control_path="$user_control_path"
                           control_master_mode="no"
-                          external_master="true"
+                          external_control_master="true"
                       fi
                       ;;
               esac
@@ -948,7 +948,7 @@ export WARP_IS_SSH='1'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_master\": '"$external_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_control_master\": '"$external_control_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -896,6 +896,40 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
           # and use printf to convert back to plaintext
           local zsh_env_script=$(printf '%s' 'unsetopt ZLE; unset RCS; unset GLOBAL_RCS; WARP_SESSION_ID='$remote_session_id'; WARP_USING_WINDOWS_CON_PTY=@@USING_CON_PTY_BOOLEAN@@; _hostname=$(command -pv hostname >/dev/null 2>&1 && command -p hostname 2>/dev/null || command -p uname -n); _user=$(command -pv whoami >/dev/null 2>&1 && command -p whoami 2>/dev/null || echo $USER); _msg=$(printf "{\"hook\": \"InitShell\", \"value\": {\"session_id\": $WARP_SESSION_ID, \"shell\": \"zsh\", \"user\": \"%s\", \"hostname\": \"%s\"}}" "$_user" "$_hostname" | command -p od -An -v -tx1 | command -p tr -d '"'"' \n'"'"'); printf '"'"'\e]9278;d;%s\x07'"'"' $_msg; unset _hostname _user _msg' | command -p od -An -v -tx1 | command -p tr -d ' \n')
 
+          # Optionally attach to an existing ControlMaster the user already
+          # runs for this destination instead of creating our own. Resolve
+          # the user's configured ControlPath with `ssh -G` (which expands
+          # tokens like %h/%p/%r/%C into a literal path), then verify the
+          # master is alive with `ssh -O check`. Both probes are local-only
+          # commands. On any failure we fall back to creating a Warp-owned
+          # master, preserving the existing behavior.
+          local control_path="$SSH_SOCKET_DIR/$WARP_SESSION_ID"
+          local control_master_mode="yes"
+          local external_master="false"
+          if [[ "$WARP_SSH_REUSE_CONTROL_MASTER" == "1" ]]; then
+              local user_control_path=$(command ssh -G "${@:1}" 2>/dev/null | command -p awk '$1 == "controlpath" { sub(/^controlpath[ \t]+/, ""); print; exit }')
+              case "$user_control_path" in
+                  "" | none)
+                      # No ControlPath configured for this destination.
+                      ;;
+                  *[![:alnum:]._/~@:+,-]*)
+                      # The resolved path contains characters we cannot safely
+                      # embed in the SSH hook JSON below (e.g. an unexpanded %
+                      # token, quotes, or whitespace); fall back to a
+                      # Warp-owned master.
+                      ;;
+                  *)
+                      if command ssh -O check -o ControlPath="$user_control_path" "${@:1}" >/dev/null 2>&1; then
+                          # A live master exists: multiplex through it and let
+                          # the client know Warp does not own it.
+                          control_path="$user_control_path"
+                          control_master_mode="no"
+                          external_master="true"
+                      fi
+                      ;;
+              esac
+          fi
+
           # Keep remote commands up-to-date with shell.rs & bash.sh.
           # Note that in this command, we're passing a string to the remote shell. Any variable expansions need to be
           # escaped with "''" to avoid the local shell from expanding them before they're passed to the remote shell.
@@ -903,7 +937,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
           # determine what shell is the login shell on the remote machine.  We perform a preliminary check to see if
           # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
           # support.
-          command ssh -o ControlMaster=yes -o ControlPath=$SSH_SOCKET_DIR/$WARP_SESSION_ID \
+          command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
           -t "${@:1}" \
 "
 export TERM_PROGRAM='WarpTerminal'
@@ -914,7 +948,7 @@ export WARP_IS_SSH='1'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'
 # Only forward the protocol version if it was set locally (i.e. the HOANotifications feature flag is on).
 test -n '$WARP_CLI_AGENT_PROTOCOL_VERSION' && export WARP_CLI_AGENT_PROTOCOL_VERSION='$WARP_CLI_AGENT_PROTOCOL_VERSION'
-hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$SSH_SOCKET_DIR/$WARP_SESSION_ID'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
+hook="'$(printf "{\"hook\": \"SSH\", \"value\": {\"socket_path\": \"'$control_path'\", \"remote_shell\": \"%s\", \"session_id\": '"$WARP_SESSION_ID"', \"remote_session_id\": '"$remote_session_id"', \"external_master\": '"$external_master"'}}" "${SHELL##*/}" | command -p od -An -v -tx1 | command -p tr -d " \n")'"
 printf '$OSC_START$DCS_JSON_MARKER$OSC_PARAM_SEPARATOR%s$OSC_END' "'$hook'"
 
 if test "'"${SHELL##*/}" != "bash" -a "${SHELL##*/}" != "zsh"'"; then

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -37,14 +37,14 @@ pub struct SshTransport {
     /// when the SSH wrapper attached to a master the user already had
     /// running, in which case Warp must not run `ssh -O exit` against it
     /// on teardown.
-    owns_master: bool,
+    warp_owns_control_master: bool,
 }
 
 impl fmt::Debug for SshTransport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SshTransport")
             .field("socket_path", &self.socket_path)
-            .field("owns_master", &self.owns_master)
+            .field("warp_owns_control_master", &self.warp_owns_control_master)
             .finish_non_exhaustive()
     }
 }
@@ -53,12 +53,12 @@ impl SshTransport {
     pub fn new(
         socket_path: PathBuf,
         auth_context: Arc<RemoteServerAuthContext>,
-        owns_master: bool,
+        warp_owns_control_master: bool,
     ) -> Self {
         Self {
             socket_path,
             auth_context,
-            owns_master,
+            warp_owns_control_master,
         }
     }
 
@@ -66,8 +66,8 @@ impl SshTransport {
         &self.socket_path
     }
 
-    pub fn owns_master(&self) -> bool {
-        self.owns_master
+    pub fn warp_owns_control_master(&self) -> bool {
+        self.warp_owns_control_master
     }
 
     pub fn remote_daemon_socket_path(&self) -> String {
@@ -227,7 +227,7 @@ impl RemoteTransport for SshTransport {
         executor: Arc<executor::Background>,
     ) -> Pin<Box<dyn Future<Output = Result<Connection>> + Send>> {
         let socket_path = self.socket_path.clone();
-        let owns_master = self.owns_master;
+        let warp_owns_control_master = self.warp_owns_control_master;
         let remote_proxy_command = self.remote_proxy_command();
         Box::pin(async move {
             let mut args = ssh_args(&socket_path);
@@ -271,7 +271,7 @@ impl RemoteTransport for SshTransport {
                 // `ssh -O exit` against Warp-managed masters; a user-owned
                 // (external) master must be left running when the Warp
                 // session exits.
-                control_path: if owns_master {
+                control_path: if warp_owns_control_master {
                     ControlPath::WarpManaged(socket_path)
                 } else {
                     ControlPath::UserOwned(socket_path)

--- a/app/src/remote_server/ssh_transport.rs
+++ b/app/src/remote_server/ssh_transport.rs
@@ -17,7 +17,7 @@ use remote_server::setup::{
     parse_uname_output, remote_server_daemon_dir, PreinstallCheckResult, RemotePlatform,
 };
 use remote_server::ssh::ssh_args;
-use remote_server::transport::{Connection, Error, InstallOutcome, RemoteTransport};
+use remote_server::transport::{Connection, ControlPath, Error, InstallOutcome, RemoteTransport};
 use warpui::r#async::executor;
 
 #[path = "ssh_transport/installation.rs"]
@@ -33,26 +33,41 @@ pub(crate) mod installation;
 pub struct SshTransport {
     socket_path: PathBuf,
     auth_context: Arc<RemoteServerAuthContext>,
+    /// Whether Warp owns the ControlMaster behind `socket_path`. `false`
+    /// when the SSH wrapper attached to a master the user already had
+    /// running, in which case Warp must not run `ssh -O exit` against it
+    /// on teardown.
+    owns_master: bool,
 }
 
 impl fmt::Debug for SshTransport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SshTransport")
             .field("socket_path", &self.socket_path)
+            .field("owns_master", &self.owns_master)
             .finish_non_exhaustive()
     }
 }
 
 impl SshTransport {
-    pub fn new(socket_path: PathBuf, auth_context: Arc<RemoteServerAuthContext>) -> Self {
+    pub fn new(
+        socket_path: PathBuf,
+        auth_context: Arc<RemoteServerAuthContext>,
+        owns_master: bool,
+    ) -> Self {
         Self {
             socket_path,
             auth_context,
+            owns_master,
         }
     }
 
     pub fn socket_path(&self) -> &PathBuf {
         &self.socket_path
+    }
+
+    pub fn owns_master(&self) -> bool {
+        self.owns_master
     }
 
     pub fn remote_daemon_socket_path(&self) -> String {
@@ -212,6 +227,7 @@ impl RemoteTransport for SshTransport {
         executor: Arc<executor::Background>,
     ) -> Pin<Box<dyn Future<Output = Result<Connection>> + Send>> {
         let socket_path = self.socket_path.clone();
+        let owns_master = self.owns_master;
         let remote_proxy_command = self.remote_proxy_command();
         Box::pin(async move {
             let mut args = ssh_args(&socket_path);
@@ -251,7 +267,15 @@ impl RemoteTransport for SshTransport {
                 failure_rx,
                 host_response_rx,
                 child,
-                control_path: Some(socket_path),
+                // Tag the socket with master ownership. Teardown only runs
+                // `ssh -O exit` against Warp-managed masters; a user-owned
+                // (external) master must be left running when the Warp
+                // session exits.
+                control_path: if owns_master {
+                    ControlPath::WarpManaged(socket_path)
+                } else {
+                    ControlPath::UserOwned(socket_path)
+                },
                 stderr_tail,
             })
         })

--- a/app/src/remote_server/ssh_transport_tests.rs
+++ b/app/src/remote_server/ssh_transport_tests.rs
@@ -17,6 +17,7 @@ fn remote_proxy_command_quotes_identity_key() {
     let transport = SshTransport::new(
         PathBuf::from("/tmp/control-master.sock"),
         static_auth_context(),
+        true,
     );
 
     let command = transport.remote_proxy_command();

--- a/app/src/settings/ssh.rs
+++ b/app/src/settings/ssh.rs
@@ -13,5 +13,15 @@ define_settings_group!(SshSettings,
             toml_path: "warpify.ssh.enable_legacy_ssh_wrapper",
             description: "Whether the legacy SSH wrapper is enabled for SSH sessions.",
         },
+        reuse_existing_control_master: ReuseExistingSshControlMaster {
+            type: bool,
+            default: false,
+            supported_platforms: SupportedPlatforms::ALL,
+            sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+            private: false,
+            storage_key: "ReuseExistingSshControlMaster",
+            toml_path: "warpify.ssh.reuse_existing_control_master",
+            description: "Whether the legacy SSH wrapper attaches to an existing SSH ControlMaster for the destination host instead of always creating its own.",
+        },
     ]
 );

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -312,8 +312,20 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
             context,
             #[allow(deprecated)]
             flags::LEGACY_SSH_WRAPPER_CONTEXT_FLAG,
-        ))
+        ));
     }
+
+    // Registered regardless of the SSHTmuxWrapper feature flag: even when the
+    // flag is on, the legacy ControlMaster wrapper is still what runs unless
+    // the user opts into the tmux wrapper, so this setting stays meaningful.
+    toggle_binding_pairs.push(ToggleSettingActionPair::new(
+        "reuse existing SSH ControlMaster in the Warp SSH wrapper",
+        builder(SettingsAction::FeaturesPageToggle(
+            FeaturesPageAction::ToggleSshReuseControlMaster,
+        )),
+        context,
+        flags::SSH_REUSE_CONTROL_MASTER_CONTEXT_FLAG,
+    ));
 
     toggle_binding_pairs.push(ToggleSettingActionPair::new(
         "show tooltip on click on links",
@@ -738,6 +750,7 @@ pub enum FeaturesPageAction {
     ToggleOpenLinksInDesktopApp,
     #[deprecated]
     ToggleSshWrapper,
+    ToggleSshReuseControlMaster,
     ToggleSnackbar,
     ToggleLinkTooltip,
     ToggleCompletionsOpenWhileTyping,
@@ -931,6 +944,10 @@ impl FeaturesPageAction {
             Self::ToggleSshWrapper => TelemetryEvent::FeaturesPageAction {
                 action: "ToggleSshWrapper".to_string(),
                 value: to_string(*ssh_settings.enable_legacy_ssh_wrapper.value()),
+            },
+            Self::ToggleSshReuseControlMaster => TelemetryEvent::FeaturesPageAction {
+                action: "ToggleSshReuseControlMaster".to_string(),
+                value: to_string(*ssh_settings.reuse_existing_control_master.value()),
             },
             Self::SetGlobalHotkeyMode(mode) => TelemetryEvent::FeaturesPageAction {
                 action: "SetGlobalHotkeyMode".to_string(),
@@ -1526,6 +1543,13 @@ impl TypedActionView for FeaturesPageView {
                 SshSettings::handle(ctx).update(ctx, |ssh_settings, ctx| {
                     report_if_error!(ssh_settings
                         .enable_legacy_ssh_wrapper
+                        .toggle_and_save_value(ctx));
+                });
+            }
+            ToggleSshReuseControlMaster => {
+                SshSettings::handle(ctx).update(ctx, |ssh_settings, ctx| {
+                    report_if_error!(ssh_settings
+                        .reuse_existing_control_master
                         .toggle_and_save_value(ctx));
                 });
             }

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -443,6 +443,7 @@ pub mod flags {
     pub const FOCUS_REPORTING_CONTEXT_FLAG: &str = "Focus_Reporting";
     #[deprecated = "Use `SSH_TMUX_WRAPPER_CONTEXT_FLAG` for new ssh warpification logic"]
     pub const LEGACY_SSH_WRAPPER_CONTEXT_FLAG: &str = "SSH_Wrapper";
+    pub const SSH_REUSE_CONTROL_MASTER_CONTEXT_FLAG: &str = "SSH_Reuse_Control_Master";
     pub const SSH_WARPIFICATION_CONTEXT_FLAG: &str = "SSH_Warpification";
     pub const SSH_TMUX_WRAPPER_CONTEXT_FLAG: &str = "SSH_Tmux_Wrapper";
     pub const NOTIFICATIONS_CONTEXT_FLAG: &str = "Notifications_Enabled";

--- a/app/src/settings_view/warpify_page.rs
+++ b/app/src/settings_view/warpify_page.rs
@@ -28,6 +28,7 @@ use super::settings_page::{
 use super::{flags, SettingsAction, SettingsSection, ToggleSettingActionPair};
 use crate::appearance::Appearance;
 use crate::server::telemetry::TelemetryEvent;
+use crate::settings::{ReuseExistingSshControlMaster, SshSettings};
 use crate::terminal::warpify::settings::{
     EnableSshWarpification, SshExtensionInstallMode, SshExtensionInstallModeSetting,
     UseSshTmuxWrapper, WarpifySettings, WarpifySettingsChangedEvent,
@@ -84,6 +85,8 @@ const BUILT_IN_TEXT_INPUT_MARGIN: f32 = 10.;
 const SPACE_AFTER_TEXT_INPUT: f32 = ITEM_VERTICAL_SPACING - BUILT_IN_TEXT_INPUT_MARGIN;
 
 const SSH_TMUX_WARPIFICATION_DESCRIPTION: &str = "The tmux ssh wrapper works in many situations where the default one does not, but may require you to hit a button to warpify. Takes effect in new tabs.";
+
+const SSH_REUSE_CONTROL_MASTER_DESCRIPTION: &str = "Attach to a live SSH ControlMaster you already have configured for the destination host instead of creating a Warp-owned one. Takes effect in new tabs.";
 
 const SSH_EXTENSION_INSTALL_MODE_DESCRIPTION: &str =
     "Controls the installation behavior for Warp's SSH extension when a remote host doesn't have it installed.";
@@ -432,6 +435,9 @@ pub enum WarpifyPageAction {
     /// If disabled, auto-Warpification and the SSH Warpification prompt will be disabled.
     ToggleTmuxWarpification,
     ToggleSshWarpification,
+    /// Toggles whether the legacy SSH wrapper attaches to an existing
+    /// ControlMaster for the destination host instead of creating its own.
+    ToggleReuseSshControlMaster,
     /// Set the SSH extension installation mode (always ask / always install / always skip).
     SetSshExtensionInstallMode(SshExtensionInstallMode),
     OpenUrl(String),
@@ -475,6 +481,23 @@ impl TypedActionView for WarpifyPageView {
                     send_telemetry_from_ctx!(
                         TelemetryEvent::ToggleSshTmuxWrapper {
                             enabled: *ssh_settings.use_ssh_tmux_wrapper.value(),
+                        },
+                        ctx
+                    );
+                });
+            }
+            ToggleReuseSshControlMaster => {
+                SshSettings::handle(ctx).update(ctx, |ssh_settings, ctx| {
+                    report_if_error!(ssh_settings
+                        .reuse_existing_control_master
+                        .toggle_and_save_value(ctx));
+                    send_telemetry_from_ctx!(
+                        TelemetryEvent::FeaturesPageAction {
+                            action: "ToggleSshReuseControlMaster".to_string(),
+                            value: ssh_settings
+                                .reuse_existing_control_master
+                                .value()
+                                .to_string(),
                         },
                         ctx
                     );
@@ -655,6 +678,7 @@ impl SettingsWidget for SubshellsWidget {
 struct SSHWidget {
     tmux_warpification_switch_state: SwitchStateHandle,
     enable_ssh_warpification_switch_state: SwitchStateHandle,
+    reuse_control_master_switch_state: SwitchStateHandle,
     additional_info_mouse_state: MouseStateHandle,
     local_only_icon_tooltip_states: RefCell<HashMap<String, MouseStateHandle>>,
 }
@@ -739,6 +763,64 @@ impl SettingsWidget for SSHWidget {
                     ))
                     .with_padding_bottom(HEADER_PADDING)
                     .finish()
+                },
+            );
+        }
+
+        // Reuse-ControlMaster only applies to the legacy (ControlMaster)
+        // SSH wrapper, which is bypassed while the tmux wrapper is in use.
+        if !should_prompt_ssh_tmux_wrapper {
+            let reuse_existing_control_master = *SshSettings::as_ref(app)
+                .reuse_existing_control_master
+                .value();
+            add_setting(
+                &mut column,
+                &SshSettings::as_ref(app).reuse_existing_control_master,
+                move || {
+                    let mut column = Flex::column();
+                    column.add_child(render_body_item::<WarpifyPageAction>(
+                        "Reuse existing SSH ControlMaster".into(),
+                        None,
+                        LocalOnlyIconState::for_setting(
+                            ReuseExistingSshControlMaster::storage_key(),
+                            ReuseExistingSshControlMaster::sync_to_cloud(),
+                            &mut self.local_only_icon_tooltip_states.borrow_mut(),
+                            app,
+                        ),
+                        enable_ssh_warpification.into(),
+                        appearance,
+                        ui_builder
+                            .switch(self.reuse_control_master_switch_state.clone())
+                            .check(reuse_existing_control_master)
+                            .with_disabled(!enable_ssh_warpification)
+                            .build()
+                            .on_click(move |ctx, _, _| {
+                                if !enable_ssh_warpification {
+                                    return;
+                                }
+                                ctx.dispatch_typed_action(
+                                    WarpifyPageAction::ToggleReuseSshControlMaster,
+                                );
+                            })
+                            .finish(),
+                        None,
+                    ));
+                    column.add_child(
+                        ui_builder
+                            .paragraph(SSH_REUSE_CONTROL_MASTER_DESCRIPTION.to_owned())
+                            .with_style(UiComponentStyles {
+                                font_color: Some(description_text_color.into_solid()),
+                                margin: Some(
+                                    Coords::default()
+                                        .top(styles::DESCRIPTION_NEGATIVE_MARGIN_OFFSET)
+                                        .bottom(styles::DESCRIPTION_LINE_MARGIN_BOTTOM),
+                                ),
+                                ..Default::default()
+                            })
+                            .build()
+                            .finish(),
+                    );
+                    column.finish()
                 },
             );
         }

--- a/app/src/terminal/local_tty/mod.rs
+++ b/app/src/terminal/local_tty/mod.rs
@@ -96,6 +96,11 @@ pub struct PtyOptions {
     // Refers to the original SSH wrapper that uses ControlMaster and
     // requires overwriting the user's SSH command at the shell layer.
     pub enable_ssh_wrapper: bool,
+    /// Whether the legacy SSH wrapper should attach to an existing
+    /// ControlMaster for the destination host (discovered via `ssh -G` and
+    /// verified with `ssh -O check`) instead of always creating its own.
+    #[serde(default)]
+    pub reuse_ssh_control_master: bool,
     pub shell_debug_mode: bool,
     pub honor_ps1: bool,
     /// Whether the Node.js Version context chip is enabled for this session. When

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -1137,6 +1137,12 @@ impl TerminalManager {
             *SshSettings::as_ref(ctx).enable_legacy_ssh_wrapper.value()
         };
 
+        // Only meaningful when the legacy ControlMaster wrapper is active.
+        let reuse_ssh_control_master = enable_ssh_wrapper
+            && *SshSettings::as_ref(ctx)
+                .reuse_existing_control_master
+                .value();
+
         let size: crate::terminal::SizeInfo = model.lock().block_list().size().to_owned();
         let options = PtyOptions {
             size,
@@ -1145,6 +1151,7 @@ impl TerminalManager {
             start_dir: startup_directory,
             env_vars,
             enable_ssh_wrapper,
+            reuse_ssh_control_master,
             shell_debug_mode: is_shell_debug_mode_enabled,
             honor_ps1: is_honor_ps1_enabled,
             node_version_chip_enabled,

--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -185,6 +185,7 @@ pub(super) fn spawn(options: PtyOptions) -> Result<PtySpawnInfo> {
         start_dir,
         env_vars,
         enable_ssh_wrapper,
+        reuse_ssh_control_master,
         shell_debug_mode,
         honor_ps1,
         node_version_chip_enabled,
@@ -205,6 +206,7 @@ pub(super) fn spawn(options: PtyOptions) -> Result<PtySpawnInfo> {
         env_vars,
         start_dir,
         enable_ssh_wrapper,
+        reuse_ssh_control_master,
         shell_debug_mode,
         honor_ps1,
         node_version_chip_enabled,
@@ -225,6 +227,7 @@ fn build_host_shell_command(
     env_vars: HashMap<OsString, OsString>,
     start_dir: Option<PathBuf>,
     enable_ssh_wrapper: bool,
+    reuse_ssh_control_master: bool,
     shell_debug_mode: bool,
     honor_ps1: bool,
     node_version_chip_enabled: bool,
@@ -299,6 +302,13 @@ fn build_host_shell_command(
     } else {
         builder.env("WARP_USE_SSH_WRAPPER", "0");
     }
+
+    // Whether the SSH wrapper should attach to an existing ControlMaster
+    // for the destination host instead of always creating its own.
+    builder.env(
+        "WARP_SSH_REUSE_CONTROL_MASTER",
+        if reuse_ssh_control_master { "1" } else { "0" },
+    );
 
     // For integration tests, put SSH control master sockets under the actual
     // home directory, as the length of the path to sockets placed in the
@@ -716,6 +726,7 @@ fn spawn_docker_sandbox(
         start_dir: _,
         env_vars,
         enable_ssh_wrapper,
+        reuse_ssh_control_master,
         shell_debug_mode,
         honor_ps1,
         node_version_chip_enabled,
@@ -727,6 +738,7 @@ fn spawn_docker_sandbox(
         window_id,
         env_vars,
         enable_ssh_wrapper,
+        reuse_ssh_control_master,
         shell_debug_mode,
         honor_ps1,
         node_version_chip_enabled,
@@ -747,6 +759,7 @@ fn build_docker_sandbox_command(
     window_id: Option<usize>,
     env_vars: HashMap<OsString, OsString>,
     enable_ssh_wrapper: bool,
+    reuse_ssh_control_master: bool,
     shell_debug_mode: bool,
     honor_ps1: bool,
     node_version_chip_enabled: bool,
@@ -798,6 +811,10 @@ fn build_docker_sandbox_command(
     builder.env(
         "WARP_USE_SSH_WRAPPER",
         if enable_ssh_wrapper { "1" } else { "0" },
+    );
+    builder.env(
+        "WARP_SSH_REUSE_CONTROL_MASTER",
+        if reuse_ssh_control_master { "1" } else { "0" },
     );
     builder.env("SSH_SOCKET_DIR", ssh_socket_dir());
     builder.env("WARP_IS_LOCAL_SHELL_SESSION", "1");

--- a/app/src/terminal/local_tty/unix_tests.rs
+++ b/app/src/terminal/local_tty/unix_tests.rs
@@ -21,6 +21,7 @@ fn host_bash_command_sets_history_size_sentinels() {
         false,
         false,
         false,
+        false,
         true,
     );
 
@@ -52,6 +53,7 @@ fn host_non_bash_command_does_not_set_history_size_sentinels() {
         false,
         false,
         false,
+        false,
         true,
     );
 
@@ -69,6 +71,7 @@ fn docker_sandbox_command_sets_history_size_sentinels() {
         &docker_starter,
         None,
         HashMap::new(),
+        false,
         false,
         false,
         false,

--- a/app/src/terminal/local_tty/windows/environment.rs
+++ b/app/src/terminal/local_tty/windows/environment.rs
@@ -21,6 +21,7 @@ const HONOR_PS1_NAME: &str = "WARP_HONOR_PS1";
 const PROMPT_NODE_VERSION_ENABLED_NAME: &str = "WARP_PROMPT_NODE_VERSION_ENABLED";
 const INITIAL_WORKING_DIR_NAME: &str = "WARP_INITIAL_WORKING_DIR";
 const USE_SSH_WRAPPER_NAME: &str = "WARP_USE_SSH_WRAPPER";
+const SSH_REUSE_CONTROL_MASTER_NAME: &str = "WARP_SSH_REUSE_CONTROL_MASTER";
 const SHELL_DEBUG_MODE_NAME: &str = "WARP_SHELL_DEBUG_MODE";
 const TERM_PROGRAM_NAME: &str = "TERM_PROGRAM";
 const IS_LOCAL_SESSION_NAME: &str = "WARP_IS_LOCAL_SHELL_SESSION";
@@ -90,6 +91,15 @@ pub(super) fn get_shell_environment_variables(options: &PtyOptions) -> Vec<u16> 
         EnvEntry {
             preferred_key: USE_SSH_WRAPPER_NAME.into(),
             value: (options.enable_ssh_wrapper as usize).to_string().into(),
+        },
+    );
+    env.insert(
+        map_key(SSH_REUSE_CONTROL_MASTER_NAME.into()),
+        EnvEntry {
+            preferred_key: SSH_REUSE_CONTROL_MASTER_NAME.into(),
+            value: (options.reuse_ssh_control_master as usize)
+                .to_string()
+                .into(),
         },
     );
     env.insert(
@@ -208,6 +218,7 @@ fn wsl_env_allowlist(include_initial_working_dir: bool) -> OsString {
     let mut entries = vec![
         format!("{HONOR_PS1_NAME}/u"),
         format!("{USE_SSH_WRAPPER_NAME}/u"),
+        format!("{SSH_REUSE_CONTROL_MASTER_NAME}/u"),
         format!("{SHELL_DEBUG_MODE_NAME}/u"),
         format!("{TERM_PROGRAM_NAME}/u"),
         format!("{IS_LOCAL_SESSION_NAME}/u"),

--- a/app/src/terminal/local_tty/windows/environment_tests.rs
+++ b/app/src/terminal/local_tty/windows/environment_tests.rs
@@ -11,6 +11,7 @@ fn wsl_env_allowlist_includes_client_version_without_notifications_flag() {
         vec![
             format!("{HONOR_PS1_NAME}/u"),
             format!("{USE_SSH_WRAPPER_NAME}/u"),
+            format!("{SSH_REUSE_CONTROL_MASTER_NAME}/u"),
             format!("{SHELL_DEBUG_MODE_NAME}/u"),
             format!("{TERM_PROGRAM_NAME}/u"),
             format!("{IS_LOCAL_SESSION_NAME}/u"),
@@ -34,6 +35,7 @@ fn wsl_env_allowlist_includes_cli_agent_protocol_when_notifications_flag_is_enab
         vec![
             format!("{HONOR_PS1_NAME}/u"),
             format!("{USE_SSH_WRAPPER_NAME}/u"),
+            format!("{SSH_REUSE_CONTROL_MASTER_NAME}/u"),
             format!("{SHELL_DEBUG_MODE_NAME}/u"),
             format!("{TERM_PROGRAM_NAME}/u"),
             format!("{IS_LOCAL_SESSION_NAME}/u"),

--- a/app/src/terminal/model/ansi/dcs_hooks.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks.rs
@@ -389,7 +389,9 @@ impl DProtoHook {
                 "remote_shell" => value.remote_shell = v,
                 "session_id" => value.session_id = v.parse::<u64>().ok(),
                 "remote_session_id" => value.remote_session_id = v.parse::<u64>().ok(),
-                "external_master" => value.external_master = v.parse::<bool>().unwrap_or(false),
+                "external_control_master" => {
+                    value.external_control_master = v.parse::<bool>().unwrap_or(false)
+                }
                 _ => {
                     log::warn!("Tried to add unknown field {key} to SSH hook");
                 }
@@ -731,7 +733,7 @@ pub struct SSHValue {
     /// Warp must not tear down such a master on session exit. Defaults to
     /// `false` for hooks emitted by older bootstrap scripts.
     #[serde(default)]
-    pub external_master: bool,
+    pub external_control_master: bool,
 }
 
 /// Received from the pty after the shell session has been initialized, marking

--- a/app/src/terminal/model/ansi/dcs_hooks.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks.rs
@@ -389,6 +389,7 @@ impl DProtoHook {
                 "remote_shell" => value.remote_shell = v,
                 "session_id" => value.session_id = v.parse::<u64>().ok(),
                 "remote_session_id" => value.remote_session_id = v.parse::<u64>().ok(),
+                "external_master" => value.external_master = v.parse::<bool>().unwrap_or(false),
                 _ => {
                     log::warn!("Tried to add unknown field {key} to SSH hook");
                 }
@@ -725,6 +726,12 @@ pub struct SSHValue {
     pub session_id: HookSessionId,
     #[serde(default)]
     pub remote_session_id: HookSessionId,
+    /// `true` when `socket_path` points at a ControlMaster the user already
+    /// had running (the wrapper attached to it instead of creating its own).
+    /// Warp must not tear down such a master on session exit. Defaults to
+    /// `false` for hooks emitted by older bootstrap scripts.
+    #[serde(default)]
+    pub external_master: bool,
 }
 
 /// Received from the pty after the shell session has been initialized, marking

--- a/app/src/terminal/model/ansi/mod_tests.rs
+++ b/app/src/terminal/model/ansi/mod_tests.rs
@@ -534,6 +534,39 @@ fn parse_dcs_ssh() {
                 remote_shell: "zsh".to_string(),
                 session_id: Some(167303092612201),
                 remote_session_id: Some(167303092612202),
+                external_master: false,
+            }
+        ),
+        _ => panic!("incorrect dcs value"),
+    };
+}
+
+#[test]
+fn parse_dcs_ssh_with_external_master() {
+    let bytes = hex_encoded_dcs_string(
+        r#"{
+                "hook": "SSH",
+                "value": {
+                    "socket_path": "/home/user/.ssh/cm-user@host:22",
+                    "remote_shell": "zsh",
+                    "session_id": 167303092612201,
+                    "remote_session_id": 167303092612202,
+                    "external_master": true
+                }
+            }"#,
+    );
+    let (_, handler) = parse_bytes(&bytes);
+
+    assert_eq!(handler.d_proto_hooks.len(), 1);
+    match handler.d_proto_hooks.first().unwrap() {
+        DProtoHook::SSH { value } => assert_eq!(
+            *value,
+            SSHValue {
+                socket_path: PathBuf::from("/home/user/.ssh/cm-user@host:22"),
+                remote_shell: "zsh".to_string(),
+                session_id: Some(167303092612201),
+                remote_session_id: Some(167303092612202),
+                external_master: true,
             }
         ),
         _ => panic!("incorrect dcs value"),

--- a/app/src/terminal/model/ansi/mod_tests.rs
+++ b/app/src/terminal/model/ansi/mod_tests.rs
@@ -534,7 +534,7 @@ fn parse_dcs_ssh() {
                 remote_shell: "zsh".to_string(),
                 session_id: Some(167303092612201),
                 remote_session_id: Some(167303092612202),
-                external_master: false,
+                external_control_master: false,
             }
         ),
         _ => panic!("incorrect dcs value"),
@@ -542,7 +542,7 @@ fn parse_dcs_ssh() {
 }
 
 #[test]
-fn parse_dcs_ssh_with_external_master() {
+fn parse_dcs_ssh_with_external_control_master() {
     let bytes = hex_encoded_dcs_string(
         r#"{
                 "hook": "SSH",
@@ -551,7 +551,7 @@ fn parse_dcs_ssh_with_external_master() {
                     "remote_shell": "zsh",
                     "session_id": 167303092612201,
                     "remote_session_id": 167303092612202,
-                    "external_master": true
+                    "external_control_master": true
                 }
             }"#,
     );
@@ -566,7 +566,7 @@ fn parse_dcs_ssh_with_external_master() {
                 remote_shell: "zsh".to_string(),
                 session_id: Some(167303092612201),
                 remote_session_id: Some(167303092612202),
-                external_master: true,
+                external_control_master: true,
             }
         ),
         _ => panic!("incorrect dcs value"),

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -532,7 +532,14 @@ impl From<&SessionType> for command_corrections::SessionType {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IsLegacySSHSession {
-    Yes { socket_path: PathBuf },
+    Yes {
+        socket_path: PathBuf,
+        /// `true` when `socket_path` points at a ControlMaster the user
+        /// already had running (the SSH wrapper attached to it instead of
+        /// creating a Warp-owned one). Warp must not tear down such a
+        /// master on session exit.
+        external_master: bool,
+    },
     No,
 }
 
@@ -616,6 +623,7 @@ impl SessionInfo {
         let is_legacy_ssh_session = match legacy_ssh_session {
             Some(ssh_value) => IsLegacySSHSession::Yes {
                 socket_path: ssh_value.socket_path,
+                external_master: ssh_value.external_master,
             },
             None => IsLegacySSHSession::No,
         };
@@ -1687,7 +1695,10 @@ pub mod testing {
             if let BootstrapSessionType::Local = self.session_type {
                 self.session_type = BootstrapSessionType::WarpifiedRemote;
             }
-            self.is_legacy_ssh_session = IsLegacySSHSession::Yes { socket_path };
+            self.is_legacy_ssh_session = IsLegacySSHSession::Yes {
+                socket_path,
+                external_master: false,
+            };
             self
         }
 

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -538,7 +538,7 @@ pub enum IsLegacySSHSession {
         /// already had running (the SSH wrapper attached to it instead of
         /// creating a Warp-owned one). Warp must not tear down such a
         /// master on session exit.
-        external_master: bool,
+        external_control_master: bool,
     },
     No,
 }
@@ -623,7 +623,7 @@ impl SessionInfo {
         let is_legacy_ssh_session = match legacy_ssh_session {
             Some(ssh_value) => IsLegacySSHSession::Yes {
                 socket_path: ssh_value.socket_path,
-                external_master: ssh_value.external_master,
+                external_control_master: ssh_value.external_control_master,
             },
             None => IsLegacySSHSession::No,
         };
@@ -1697,7 +1697,7 @@ pub mod testing {
             }
             self.is_legacy_ssh_session = IsLegacySSHSession::Yes {
                 socket_path,
-                external_master: false,
+                external_control_master: false,
             };
             self
         }

--- a/app/src/terminal/model/session/command_executor.rs
+++ b/app/src/terminal/model/session/command_executor.rs
@@ -313,7 +313,8 @@ fn new_command_executor_for_local_tty_session(
                 && !FeatureFlag::InBandGeneratorsForSSH.is_enabled()
                 && !force_use_in_band_generators =>
         {
-            if let IsLegacySSHSession::Yes { socket_path } = &session_info.is_legacy_ssh_session {
+            if let IsLegacySSHSession::Yes { socket_path, .. } = &session_info.is_legacy_ssh_session
+            {
                 let wsl_distro = parent_session_info
                     .and_then(|session| session.wsl_name())
                     .map(ToOwned::to_owned);

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -2972,6 +2972,13 @@ impl ansi::Handler for TerminalModel {
                 return;
             }
             self.register_session_id(remote_session_id);
+            if value.external_master {
+                log::info!(
+                    "SSH wrapper attached to an external ControlMaster at {}; \
+                     Warp will not tear it down on session exit",
+                    value.socket_path.display()
+                );
+            }
             self.pending_legacy_ssh_session = Some(value);
             self.event_proxy
                 .send_terminal_event(Event::SSH(remote_shell));

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -2972,7 +2972,7 @@ impl ansi::Handler for TerminalModel {
                 return;
             }
             self.register_session_id(remote_session_id);
-            if value.external_master {
+            if value.external_control_master {
                 log::info!(
                     "SSH wrapper attached to an external ControlMaster at {}; \
                      Warp will not tear it down on session exit",

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -188,14 +188,14 @@ impl<T: EventLoopSender> RemoteServerController<T> {
     fn on_ssh_init_shell_requested(&mut self, info: SessionInfo, ctx: &mut ModelContext<Self>) {
         let IsLegacySSHSession::Yes {
             socket_path,
-            external_master,
+            external_control_master,
         } = &info.is_legacy_ssh_session
         else {
             return;
         };
         let session_id = info.session_id;
         let socket_path = socket_path.clone();
-        let owns_master = !external_master;
+        let warp_owns_control_master = !external_control_master;
         debug_assert!(matches!(self.state, SshInitState::Idle));
         match std::mem::replace(&mut self.state, SshInitState::Idle) {
             SshInitState::Idle => {}
@@ -218,7 +218,11 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.flush_stashed_bootstrap(old_info, ctx);
             }
         }
-        let transport = SshTransport::new(socket_path, self.build_auth_context(ctx), owns_master);
+        let transport = SshTransport::new(
+            socket_path,
+            self.build_auth_context(ctx),
+            warp_owns_control_master,
+        );
         self.did_install = false;
         self.remote_platform = None;
         self.preinstall_check = None;
@@ -272,7 +276,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         match result {
             Ok(true) => {
                 let socket_path = transport.socket_path().clone();
-                let owns_master = transport.owns_master();
+                let warp_owns_control_master = transport.warp_owns_control_master();
                 let connection_label = connection_label_for_session_info(&session_info);
                 self.state = SshInitState::AwaitingConnect {
                     session_id,
@@ -282,7 +286,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.connect_session_for_current_identity(
                     session_id,
                     socket_path,
-                    owns_master,
+                    warp_owns_control_master,
                     connection_label,
                     ctx,
                 );
@@ -507,7 +511,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         match result {
             Ok(()) => {
                 let socket_path = transport.socket_path().clone();
-                let owns_master = transport.owns_master();
+                let warp_owns_control_master = transport.warp_owns_control_master();
                 let connection_label = connection_label_for_session_info(&session_info);
                 self.state = SshInitState::AwaitingConnect {
                     session_id,
@@ -517,7 +521,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.connect_session_for_current_identity(
                     session_id,
                     socket_path,
-                    owns_master,
+                    warp_owns_control_master,
                     connection_label,
                     ctx,
                 );
@@ -552,12 +556,13 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         &mut self,
         session_id: SessionId,
         socket_path: PathBuf,
-        owns_master: bool,
+        warp_owns_control_master: bool,
         connection_label: String,
         ctx: &mut ModelContext<Self>,
     ) {
         let auth_context = self.build_auth_context(ctx);
-        let transport = SshTransport::new(socket_path, auth_context.clone(), owns_master);
+        let transport =
+            SshTransport::new(socket_path, auth_context.clone(), warp_owns_control_master);
         RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
             mgr.connect_session(
                 session_id,

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -186,11 +186,16 @@ impl<T: EventLoopSender> RemoteServerController<T> {
 
     /// Idle -> AwaitingCheck
     fn on_ssh_init_shell_requested(&mut self, info: SessionInfo, ctx: &mut ModelContext<Self>) {
-        let IsLegacySSHSession::Yes { socket_path } = &info.is_legacy_ssh_session else {
+        let IsLegacySSHSession::Yes {
+            socket_path,
+            external_master,
+        } = &info.is_legacy_ssh_session
+        else {
             return;
         };
         let session_id = info.session_id;
         let socket_path = socket_path.clone();
+        let owns_master = !external_master;
         debug_assert!(matches!(self.state, SshInitState::Idle));
         match std::mem::replace(&mut self.state, SshInitState::Idle) {
             SshInitState::Idle => {}
@@ -213,7 +218,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.flush_stashed_bootstrap(old_info, ctx);
             }
         }
-        let transport = SshTransport::new(socket_path, self.build_auth_context(ctx));
+        let transport = SshTransport::new(socket_path, self.build_auth_context(ctx), owns_master);
         self.did_install = false;
         self.remote_platform = None;
         self.preinstall_check = None;
@@ -267,6 +272,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         match result {
             Ok(true) => {
                 let socket_path = transport.socket_path().clone();
+                let owns_master = transport.owns_master();
                 let connection_label = connection_label_for_session_info(&session_info);
                 self.state = SshInitState::AwaitingConnect {
                     session_id,
@@ -276,6 +282,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.connect_session_for_current_identity(
                     session_id,
                     socket_path,
+                    owns_master,
                     connection_label,
                     ctx,
                 );
@@ -500,6 +507,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         match result {
             Ok(()) => {
                 let socket_path = transport.socket_path().clone();
+                let owns_master = transport.owns_master();
                 let connection_label = connection_label_for_session_info(&session_info);
                 self.state = SshInitState::AwaitingConnect {
                     session_id,
@@ -509,6 +517,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
                 self.connect_session_for_current_identity(
                     session_id,
                     socket_path,
+                    owns_master,
                     connection_label,
                     ctx,
                 );
@@ -543,11 +552,12 @@ impl<T: EventLoopSender> RemoteServerController<T> {
         &mut self,
         session_id: SessionId,
         socket_path: PathBuf,
+        owns_master: bool,
         connection_label: String,
         ctx: &mut ModelContext<Self>,
     ) {
         let auth_context = self.build_auth_context(ctx);
-        let transport = SshTransport::new(socket_path, auth_context.clone());
+        let transport = SshTransport::new(socket_path, auth_context.clone(), owns_master);
         RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
             mgr.connect_session(
                 session_id,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -21971,6 +21971,11 @@ impl Workspace {
             #[allow(deprecated)]
             context.set.insert(flags::LEGACY_SSH_WRAPPER_CONTEXT_FLAG);
         }
+        if *ssh_settings.reuse_existing_control_master.value() {
+            context
+                .set
+                .insert(flags::SSH_REUSE_CONTROL_MASTER_CONTEXT_FLAG);
+        }
         if *warpify_settings.enable_ssh_warpification.value() {
             context.set.insert(flags::SSH_WARPIFICATION_CONTEXT_FLAG);
         }

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -1,7 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-#[cfg(not(target_family = "wasm"))]
-use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
@@ -39,7 +37,7 @@ use crate::setup::RemoteOs;
 use crate::setup::UnsupportedReason;
 use crate::setup::{PreinstallCheckResult, RemotePlatform, RemoteServerSetupState};
 #[cfg(not(target_family = "wasm"))]
-use crate::transport::Connection;
+use crate::transport::{Connection, ControlPath};
 use crate::transport::{Error, InstallSource, RemoteTransport};
 use crate::HostId;
 
@@ -70,7 +68,7 @@ struct ReconnectParams {
     transport: Arc<dyn RemoteTransport>,
     auth_context: Arc<RemoteServerAuthContext>,
     codebase_index_limits: Option<CodebaseIndexLimits>,
-    control_path: Option<PathBuf>,
+    control_path: ControlPath,
     identity_key: String,
 }
 #[cfg(not(target_family = "wasm"))]
@@ -315,12 +313,14 @@ pub struct RemoteCodebaseIndexStatusWithPath {
 /// unaffected by lingering `Arc<RemoteServerClient>` clones held
 /// elsewhere (e.g. the per-session command executor).
 ///
-/// They also optionally carry a `control_path` pointing at the SSH
-/// `ControlMaster` socket for this session. On explicit teardown
-/// (after the user's shell exits), `deregister_session` uses this to
-/// run `ssh -O exit`, forcing the master to terminate without waiting
-/// for half-closed multiplexed channels to finish cleanup on the
-/// remote side.
+/// They also carry a [`ControlPath`] identifying the SSH
+/// `ControlMaster` socket for this session and who owns the master. On
+/// explicit teardown (after the user's shell exits),
+/// `deregister_session` runs `ssh -O exit` against `WarpManaged`
+/// masters, forcing them to terminate without waiting for half-closed
+/// multiplexed channels to finish cleanup on the remote side.
+/// `UserOwned` masters (the SSH wrapper attached to a master the user
+/// already had running) are left untouched.
 #[derive(Debug)]
 pub enum RemoteSessionState {
     /// `connect_session` has been called; background task is starting the
@@ -336,7 +336,7 @@ pub enum RemoteSessionState {
         _child: async_process::Child,
         /// See type-level doc.
         #[cfg(not(target_family = "wasm"))]
-        control_path: Option<PathBuf>,
+        control_path: ControlPath,
         /// Tail buffer of the last N stderr lines from the proxy subprocess.
         #[cfg(not(target_family = "wasm"))]
         stderr_tail: crate::client::RemoteServerLog,
@@ -356,7 +356,7 @@ pub enum RemoteSessionState {
         _child: async_process::Child,
         /// See type-level doc.
         #[cfg(not(target_family = "wasm"))]
-        control_path: Option<PathBuf>,
+        control_path: ControlPath,
         /// Transport stored for reconnection after spontaneous disconnect.
         #[cfg(not(target_family = "wasm"))]
         transport: Arc<dyn RemoteTransport>,
@@ -366,14 +366,14 @@ pub enum RemoteSessionState {
     Reconnecting {
         attempt: u32,
         host_id: HostId,
-        control_path: Option<PathBuf>,
+        control_path: ControlPath,
     },
     /// The connection failed and the background task is briefly awaiting
     /// the child process's exit status before emitting the failure event.
     /// Preserves the `control_path` so `deregister_session` can still
     /// call `stop_control_master` if the user exits during this window.
     #[cfg(not(target_family = "wasm"))]
-    AwaitingExitStatus { control_path: Option<PathBuf> },
+    AwaitingExitStatus { control_path: ControlPath },
     /// Connection dropped (EOF/error from the reader task).
     Disconnected,
 }
@@ -2236,13 +2236,16 @@ impl RemoteServerManager {
     /// user's interactive ssh process and, without the explicit
     /// `-O exit`, it hangs waiting for remote-side cleanup of
     /// multiplexed channels (see [`crate::ssh::stop_control_master`]).
+    /// Sessions multiplexed through an external master carry
+    /// [`ControlPath::UserOwned`], so this step is skipped and the
+    /// user's master is left running.
     ///
     /// Mechanically:
     /// 1. Remove the session entry. Dropping the `RemoteSessionState`
     ///    drops the transport's owned `Child`, which SIGKILLs the
     ///    `ssh … remote-server-proxy` subprocess via `kill_on_drop`.
-    /// 2. If the session had a ControlMaster `control_path`, spawn a
-    ///    background task that runs `ssh -O exit` against it.
+    /// 2. If the session's `control_path` is [`ControlPath::WarpManaged`],
+    ///    spawn a background task that runs `ssh -O exit` against it.
     ///
     /// The `Child` is owned by the manager's state, *not* by
     /// `Arc<RemoteServerClient>`. Lingering `Arc` clones held elsewhere
@@ -2275,8 +2278,8 @@ impl RemoteServerManager {
         // `kill_on_drop`.
         let prev = self.sessions.remove(&session_id);
 
-        // Extract the ControlMaster socket path (if any) so we can
-        // force the master to exit below. Safe to do under the
+        // Extract the ControlMaster socket (if any) so we can force
+        // Warp-managed masters to exit below. Safe to do under the
         // "caller already observed ExitShell" assumption documented
         // above.
         #[cfg(not(target_family = "wasm"))]
@@ -2287,7 +2290,7 @@ impl RemoteServerManager {
                 control_path.clone()
             }
             Some(RemoteSessionState::Reconnecting { control_path, .. }) => control_path.clone(),
-            _ => None,
+            _ => ControlPath::None,
         };
 
         // Extract `host_id` from states that track a host connection.
@@ -2309,16 +2312,26 @@ impl RemoteServerManager {
         }
         ctx.emit(RemoteServerManagerEvent::SessionDeregistered { session_id });
 
-        // Force the local SSH ControlMaster to exit after teardown.
-        // Spawned detached because the ssh subcommand may take a moment
-        // to complete and we don't want to block the main thread on it.
+        // Force the local SSH ControlMaster to exit after teardown when
+        // Warp owns it. Spawned detached because the ssh subcommand may
+        // take a moment to complete and we don't want to block the main
+        // thread on it. User-owned masters are deliberately left running.
         #[cfg(not(target_family = "wasm"))]
-        if let Some(control_path) = control_path {
-            ctx.background_executor()
-                .spawn(async move {
-                    crate::ssh::stop_control_master(&control_path).await;
-                })
-                .detach();
+        match control_path {
+            ControlPath::WarpManaged(control_path) => {
+                ctx.background_executor()
+                    .spawn(async move {
+                        crate::ssh::stop_control_master(&control_path).await;
+                    })
+                    .detach();
+            }
+            ControlPath::UserOwned(control_path) => {
+                log::info!(
+                    "deregister_session: leaving user-owned ControlMaster at {} running",
+                    control_path.display()
+                );
+            }
+            ControlPath::None => {}
         }
     }
 

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -2312,27 +2312,17 @@ impl RemoteServerManager {
         }
         ctx.emit(RemoteServerManagerEvent::SessionDeregistered { session_id });
 
-        // Force the local SSH ControlMaster to exit after teardown when
-        // Warp owns it. Spawned detached because the ssh subcommand may
-        // take a moment to complete and we don't want to block the main
-        // thread on it. User-owned masters are deliberately left running.
+        // Force the local SSH ControlMaster to exit after teardown.
+        // `stop_control_master` only acts on Warp-managed masters and
+        // leaves user-owned masters running. Spawned detached because
+        // the ssh subcommand may take a moment to complete and we don't
+        // want to block the main thread on it.
         #[cfg(not(target_family = "wasm"))]
-        match control_path {
-            ControlPath::WarpManaged(control_path) => {
-                ctx.background_executor()
-                    .spawn(async move {
-                        crate::ssh::stop_control_master(&control_path).await;
-                    })
-                    .detach();
-            }
-            ControlPath::UserOwned(control_path) => {
-                log::info!(
-                    "deregister_session: leaving user-owned ControlMaster at {} running",
-                    control_path.display()
-                );
-            }
-            ControlPath::None => {}
-        }
+        ctx.background_executor()
+            .spawn(async move {
+                crate::ssh::stop_control_master(&control_path).await;
+            })
+            .detach();
     }
 
     /// Returns the client for this session, if connected.

--- a/crates/remote_server/src/ssh.rs
+++ b/crates/remote_server/src/ssh.rs
@@ -6,6 +6,8 @@ use anyhow::anyhow;
 use command::r#async::Command;
 use warpui_core::r#async::FutureExt as _;
 
+use crate::transport::ControlPath;
+
 /// Transport-level error from [`run_ssh_command`] or [`run_ssh_script`].
 ///
 /// Distinguishes timeouts from other I/O failures so callers can promote
@@ -48,7 +50,7 @@ pub fn ssh_args(socket_path: &Path) -> Vec<String> {
 }
 
 /// Runs `ssh -O exit -o ControlPath=<socket_path>` to force the local
-/// SSH `ControlMaster` managing `socket_path` to exit immediately,
+/// SSH `ControlMaster` behind `control_path` to exit immediately,
 /// without waiting for multiplexed channels to finish draining.
 ///
 /// The user's interactive ssh is spawned with `-o ControlMaster=yes` by
@@ -58,18 +60,30 @@ pub fn ssh_args(socket_path: &Path) -> Vec<String> {
 /// `ssh ... remote-server-proxy`) to finish cleanup on the remote
 /// side. Sending `-O exit` bypasses that wait.
 ///
-/// **Only safe to call on Warp-owned masters, once the user's shell has
-/// already exited** -- this tears down the master outright. When the
-/// wrapper attached to an external master the user already had running
-/// (see `IsLegacySSHSession::Yes { external_master, .. }`), this must
-/// not be called; the session state carries
-/// [`ControlPath::UserOwned`](crate::transport::ControlPath::UserOwned)
-/// in that case so the teardown path skips it. In practice it is invoked
-/// from the `ExitShell` teardown path on the client.
+/// Only [`ControlPath::WarpManaged`] masters are acted on: a
+/// [`ControlPath::UserOwned`] master (the SSH wrapper attached to a
+/// master the user already had running) is left untouched, and
+/// [`ControlPath::None`] is a no-op.
+///
+/// **Only safe to call once the user's shell has already exited** --
+/// for Warp-managed masters this tears down the interactive ssh
+/// outright. In practice it is invoked from the `ExitShell` teardown
+/// path on the client.
 ///
 /// Fire-and-forget. Errors are logged but not propagated: at teardown
 /// time there is nothing useful to do with them.
-pub async fn stop_control_master(socket_path: &Path) {
+pub async fn stop_control_master(control_path: &ControlPath) {
+    let socket_path = match control_path {
+        ControlPath::WarpManaged(socket_path) => socket_path,
+        ControlPath::UserOwned(socket_path) => {
+            log::info!(
+                "stop_control_master: leaving user-owned ControlMaster at {} running",
+                socket_path.display()
+            );
+            return;
+        }
+        ControlPath::None => return,
+    };
     let args = ssh_args(socket_path);
     let result = async {
         Command::new("ssh")

--- a/crates/remote_server/src/ssh.rs
+++ b/crates/remote_server/src/ssh.rs
@@ -58,9 +58,14 @@ pub fn ssh_args(socket_path: &Path) -> Vec<String> {
 /// `ssh ... remote-server-proxy`) to finish cleanup on the remote
 /// side. Sending `-O exit` bypasses that wait.
 ///
-/// **Only safe to call once the user's shell has already exited** --
-/// this tears down the interactive ssh outright. In practice it is
-/// invoked from the `ExitShell` teardown path on the client.
+/// **Only safe to call on Warp-owned masters, once the user's shell has
+/// already exited** -- this tears down the master outright. When the
+/// wrapper attached to an external master the user already had running
+/// (see `IsLegacySSHSession::Yes { external_master, .. }`), this must
+/// not be called; the session state carries
+/// [`ControlPath::UserOwned`](crate::transport::ControlPath::UserOwned)
+/// in that case so the teardown path skips it. In practice it is invoked
+/// from the `ExitShell` teardown path on the client.
 ///
 /// Fire-and-forget. Errors are logged but not propagated: at teardown
 /// time there is nothing useful to do with them.

--- a/crates/remote_server/src/transport.rs
+++ b/crates/remote_server/src/transport.rs
@@ -139,6 +139,24 @@ impl Error {
     }
 }
 
+/// The SSH `ControlMaster` socket (if any) behind a connection, tagged
+/// with who owns the master process. Ownership decides teardown
+/// behavior: only `WarpManaged` masters are stopped with `ssh -O exit`
+/// on explicit teardown (see [`crate::ssh::stop_control_master`]);
+/// `UserOwned` masters must be left running.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug, Clone)]
+pub enum ControlPath {
+    /// Warp created the ControlMaster at this socket path and is
+    /// responsible for tearing it down on session exit.
+    WarpManaged(PathBuf),
+    /// The SSH wrapper attached to a ControlMaster the user already had
+    /// running at this socket path. Warp must never tear it down.
+    UserOwned(PathBuf),
+    /// No ControlMaster socket (e.g. in-process test transports).
+    None,
+}
+
 /// A successful return from [`RemoteTransport::connect`].
 ///
 /// Bundles the live [`RemoteServerClient`] and its [`ClientEvent`]
@@ -172,15 +190,12 @@ pub struct Connection {
     #[cfg(not(target_family = "wasm"))]
     pub child: async_process::Child,
     /// For transports that multiplex through a local SSH
-    /// `ControlMaster` socket: the path to that socket, used on
-    /// explicit teardown (after the user's shell exits) to run
-    /// `ssh -O exit` and force the master to terminate without
-    /// waiting for half-closed channels. `None` for transports with
-    /// no separate master process (in-process tests, etc.).
-    ///
-    /// See [`crate::ssh::stop_control_master`] for the exact command.
+    /// `ControlMaster` socket: the socket path tagged with master
+    /// ownership, which decides whether explicit teardown (after the
+    /// user's shell exits) runs `ssh -O exit` against it. See
+    /// [`ControlPath`].
     #[cfg(not(target_family = "wasm"))]
-    pub control_path: Option<PathBuf>,
+    pub control_path: ControlPath,
     /// Tail buffer of the last N stderr lines from the SSH subprocess.
     /// Drained on connection failure and attached to telemetry.
     #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
## Description

### Problem
Some users manage their own SSH `ControlMaster` for a host: their ssh config sets `ControlMaster auto` + `ControlPath`, and that master owns shared state — in the reported case, a reverse-forwarded (`RemoteForward`) socket used by all of their SSH clients. Warp's SSH wrapper always forces `-o ControlMaster=yes -o ControlPath=~/.ssh/<session_id>` on warpified sessions, so connecting from Warp creates a **second, competing master** for the same host. Only one connection can bind the reverse forward, so the two masters race over it and the user's tooling becomes unreliable (`Warning: remote port forwarding failed ...`).

### Fix
Behind a new opt-in setting (`warpify.ssh.reuse_existing_control_master`, default **off**; toggleable from the Warpify settings page and the Command Palette), the SSH wrapper now looks for a live master the user already runs for the destination before creating its own:

1. `ssh -G "$@"` resolves the user's effective `ControlPath`, with tokens (`%h`/`%p`/`%r`/`%C`) expanded into a literal path.
2. `ssh -O check` verifies a master is actually alive on that socket. Both probes are local-only commands.
3. If alive, the foreground ssh runs with `ControlMaster=no` against the user's socket — Warp becomes just another client of the user's master, so there is no second master and no forward conflict. All multiplexed traffic (remote-server proxy, scp, generators) flows through the same socket unchanged.
4. On any miss (no `ControlPath` configured, dead master, path characters we can't safely embed, older ssh), the wrapper falls back to today's behavior exactly.

Master ownership is threaded end-to-end so teardown is safe: the SSH DCS hook reports a new `external_master` field, plumbed through `IsLegacySSHSession` → `SshTransport` → a new `ControlPath` enum (`WarpManaged` / `UserOwned` / `None`) on the remote-server session state. Session teardown only runs `ssh -O exit` against `WarpManaged` masters — Warp never tears down a master the user owns.

### Alternatives considered
- **Stop binding forwards from Warp's master** (e.g. force `ClearAllForwardings=yes` in the wrapper): prevents this specific conflict but still leaves two masters per host, doesn't address non-forward conflicts, and silently drops forwards users *do* want in Warp sessions.
- **Manual "attach to this socket" setting** (user supplies a ControlPath per host): avoids discovery entirely, but requires per-host configuration and can't express tokenized ControlPaths (`%C`, `%r@%h:%p`), which are the recommended and most common setup.
- **Destination-aware transport refactor**: thread the user's real ssh destination through the client so secondary commands name the host instead of `placeholder@placeholder`. Most general, but a much larger change — and unnecessary, since `ssh -G` already yields a literal expanded socket path that the existing socket-only transport consumes as-is.
- **No product change** (user-side workaround): users can move `RemoteForward` to a dedicated master started outside Warp. Works, but pushes config surgery onto every affected user and leaves the surprising two-master behavior in place.

### Rollout
Default **off** for safety: reusing a master couples Warp's session lifetime to the user's master and shares its `MaxSessions` channel budget, which existing multiplexing users may not expect. Once validated more broadly we can flip the default and keep the setting as an escape hatch.

## Linked Issue
No linked issue — this addresses a customer support request about the SSH wrapper's forced ControlMaster conflicting with user-managed masters.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] I have manually tested my changes locally with `./script/run`

**Automated**
- Unit tests for SSH DCS hook parsing of the new `external_master` field, including the default (`false`) for hooks emitted by older bootstrap scripts.
- Updated transport/session tests for the new `SshTransport` ownership parameter; `cargo nextest` passes for the affected crates; `./script/format` + clippy clean.
- Syntax-checked all three modified bootstrap scripts (`bash -n`, `zsh -n`, `fish --no-execute`).

**Manual E2E** (`./script/run` against a remote devbox configured like the customer: `ControlMaster auto`, tokenized `ControlPath`, `RemoteForward`):
- With a user-started master running: Warp attached to it — no new Warp socket in `~/.ssh`, no port-forward failure, session fully warpified, remote-server features work over the reused socket.
- After exiting the Warp session: `ssh -O check` confirms the user's master is **still running** (Warp did not tear it down) and the reverse forward stays bound.
- Fallback: with no live master, the wrapper creates a Warp-owned master exactly as before and cleans it up on exit.
- Regression: a host with no `ControlPath` configured behaves identically to today.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/665a4e24-372b-4e95-8c19-601228ec77eb) | [Options plan](https://staging.warp.dev/drive/notebook/CCVs76IlBdsQNB5PBsaePx)

CHANGELOG-IMPROVEMENT: Added an opt-in setting (`warpify.ssh.reuse_existing_control_master`) that makes Warp's SSH wrapper attach to an existing SSH ControlMaster for the destination host instead of always creating its own, preserving user-managed masters and their port forwards.

Co-Authored-By: Oz <oz-agent@warp.dev>
