### PR TITLE
APP-4709: One-click "Grant full control" for agent permissions

### DIFF
--- a/app/src/ai/execution_profiles/editor/grant_full_control_confirmation_dialog.rs
+++ b/app/src/ai/execution_profiles/editor/grant_full_control_confirmation_dialog.rs
@@ -1,0 +1,121 @@
+use warpui::elements::{ChildView, Container, Dismiss, Empty};
+use warpui::ui_components::components::UiComponent;
+use warpui::{
+    AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
+};
+
+use crate::appearance::Appearance;
+use crate::ui_components::dialog::{dialog_styles, Dialog};
+use crate::view_components::action_button::{ActionButton, DangerPrimaryTheme, NakedTheme};
+
+const DIALOG_WIDTH: f32 = 460.;
+
+const DIALOG_BODY: &str =
+    "This grants the Agent full control: it will apply code diffs, read files, \
+execute commands, interact with running commands, run orchestrated agents, and call MCP servers \
+without ever asking for approval. Your command and MCP denylists for this profile will also be \
+cleared. You can change individual permissions again afterward.";
+
+pub enum GrantFullControlConfirmationDialogEvent {
+    Cancel,
+    Confirm,
+}
+
+#[derive(Debug)]
+pub enum GrantFullControlConfirmationDialogAction {
+    Cancel,
+    Confirm,
+}
+
+pub struct GrantFullControlConfirmationDialog {
+    visible: bool,
+    cancel_button: ViewHandle<ActionButton>,
+    confirm_button: ViewHandle<ActionButton>,
+}
+
+impl GrantFullControlConfirmationDialog {
+    pub fn new(ctx: &mut ViewContext<Self>) -> Self {
+        let cancel_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Cancel", NakedTheme).on_click(|ctx| {
+                ctx.dispatch_typed_action(GrantFullControlConfirmationDialogAction::Cancel);
+            })
+        });
+
+        let confirm_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Grant full control", DangerPrimaryTheme).on_click(|ctx| {
+                ctx.dispatch_typed_action(GrantFullControlConfirmationDialogAction::Confirm);
+            })
+        });
+
+        Self {
+            visible: false,
+            cancel_button,
+            confirm_button,
+        }
+    }
+
+    pub fn show(&mut self, ctx: &mut ViewContext<Self>) {
+        self.visible = true;
+        ctx.notify();
+    }
+
+    pub fn hide(&mut self, ctx: &mut ViewContext<Self>) {
+        self.visible = false;
+        ctx.notify();
+    }
+}
+
+impl Entity for GrantFullControlConfirmationDialog {
+    type Event = GrantFullControlConfirmationDialogEvent;
+}
+
+impl View for GrantFullControlConfirmationDialog {
+    fn ui_name() -> &'static str {
+        "GrantFullControlConfirmationDialog"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        if !self.visible {
+            return Empty::new().finish();
+        }
+
+        let appearance = Appearance::as_ref(app);
+
+        let dialog = Dialog::new(
+            "Grant full control?".to_string(),
+            Some(DIALOG_BODY.to_string()),
+            dialog_styles(appearance),
+        )
+        .with_bottom_row_child(ChildView::new(&self.cancel_button).finish())
+        .with_bottom_row_child(
+            Container::new(ChildView::new(&self.confirm_button).finish())
+                .with_margin_left(12.)
+                .finish(),
+        )
+        .with_width(DIALOG_WIDTH)
+        .build()
+        .finish();
+
+        Dismiss::new(dialog)
+            .prevent_interaction_with_other_elements()
+            .on_dismiss(|ctx, _app| {
+                ctx.dispatch_typed_action(GrantFullControlConfirmationDialogAction::Cancel)
+            })
+            .finish()
+    }
+}
+
+impl TypedActionView for GrantFullControlConfirmationDialog {
+    type Action = GrantFullControlConfirmationDialogAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            GrantFullControlConfirmationDialogAction::Cancel => {
+                ctx.emit(GrantFullControlConfirmationDialogEvent::Cancel)
+            }
+            GrantFullControlConfirmationDialogAction::Confirm => {
+                ctx.emit(GrantFullControlConfirmationDialogEvent::Confirm)
+            }
+        }
+    }
+}

--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -2,13 +2,16 @@ use std::path::{Path, PathBuf};
 
 use ai::api_keys::{ApiKeyManager, ApiKeyManagerEvent};
 use itertools::Itertools;
+use pathfinder_geometry::vector::vec2f;
 use regex::Regex;
 use thousands::Separable;
+use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::color::internal_colors;
 use warpui::elements::{
-    Align, Border, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox,
-    Container, CrossAxisAlignment, Expanded, Flex, Highlight, MouseStateHandle, ParentElement,
-    PartialClickableElement, ScrollbarWidth, Text,
+    Align, Border, ChildAnchor, ChildView, ClippedScrollStateHandle, ClippedScrollable,
+    ConstrainedBox, Container, CrossAxisAlignment, Expanded, Flex, Highlight, MouseStateHandle,
+    OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, PartialClickableElement,
+    ScrollbarWidth, Stack, Text,
 };
 use warpui::fonts::Properties;
 use warpui::platform::Cursor;
@@ -20,6 +23,9 @@ use warpui::{
 };
 
 use crate::ai::blocklist::BlocklistAIPermissions;
+use crate::ai::execution_profiles::editor::grant_full_control_confirmation_dialog::{
+    GrantFullControlConfirmationDialog, GrantFullControlConfirmationDialogEvent,
+};
 use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
 use crate::ai::execution_profiles::profiles::{
     AIExecutionProfilesModel, AIExecutionProfilesModelEvent, ClientProfileId,
@@ -138,6 +144,8 @@ struct TooltipMouseStateHandles {
 pub mod manager;
 pub use manager::*;
 
+mod grant_full_control_confirmation_dialog;
+
 pub const HEADER_TEXT: &str = "Profile Editor";
 
 #[derive(Debug, Clone)]
@@ -227,6 +235,8 @@ pub enum ExecutionProfileEditorViewAction {
         id: uuid::Uuid,
     },
     DeleteProfile,
+    /// Opens the confirmation dialog for granting the agent full control.
+    GrantFullControl,
     SetPlanAutoSync {
         enabled: bool,
     },
@@ -270,6 +280,8 @@ pub struct ExecutionProfileEditorView {
     mcp_denylist_mouse_state_handles: Vec<MouseStateHandle>,
     profile_name_editor: ViewHandle<EditorView>,
     delete_button: ViewHandle<ActionButton>,
+    full_control_button: ViewHandle<ActionButton>,
+    full_control_confirmation_dialog: ViewHandle<GrantFullControlConfirmationDialog>,
     tooltip_mouse_state_handles: TooltipMouseStateHandles,
     plan_auto_sync_switch: SwitchStateHandle,
     web_search_switch: SwitchStateHandle,
@@ -642,6 +654,17 @@ impl ExecutionProfileEditorView {
                 })
         });
 
+        let full_control_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Grant full control", DangerSecondaryTheme)
+                .with_icon(Icon::AlertTriangle)
+                .on_click(|ctx| {
+                    ctx.dispatch_typed_action(ExecutionProfileEditorViewAction::GrantFullControl);
+                })
+        });
+
+        let full_control_confirmation_dialog =
+            ctx.add_typed_action_view(GrantFullControlConfirmationDialog::new);
+
         let mut view = Self {
             profile_id,
             pane_configuration,
@@ -680,6 +703,8 @@ impl ExecutionProfileEditorView {
             mcp_denylist_mouse_state_handles,
             profile_name_editor,
             delete_button,
+            full_control_button,
+            full_control_confirmation_dialog,
             tooltip_mouse_state_handles: Default::default(),
             plan_auto_sync_switch: Default::default(),
             web_search_switch: Default::default(),
@@ -691,6 +716,13 @@ impl ExecutionProfileEditorView {
                 view.save_profile_name_if_valid(ctx);
             }
         });
+
+        ctx.subscribe_to_view(
+            &view.full_control_confirmation_dialog,
+            |view, _, event, ctx| {
+                view.handle_full_control_confirmation_event(event, ctx);
+            },
+        );
 
         ctx.subscribe_to_view(&view.context_window_editor, |view, _, event, ctx| {
             view.handle_context_window_editor_event(event, ctx);
@@ -931,6 +963,12 @@ impl ExecutionProfileEditorView {
         let run_agents_disabled = !ai_settings.is_run_agents_permissions_editable(ctx);
         let mcp_disabled = !ai_settings.is_mcp_permission_editable(ctx);
 
+        // The "Grant full control" button is disabled when AI is off or the
+        // profile already grants full control (nothing left to apply).
+        let include_computer_use = FeatureFlag::LocalComputerUse.is_enabled();
+        let full_control_disabled = !ai_settings.is_any_ai_enabled(ctx)
+            || current_permissions.has_full_control(include_computer_use);
+
         Self::refresh_filterable_model_dropdown(
             &self.base_model_dropdown,
             current_permissions.base_model.clone(),
@@ -1028,7 +1066,34 @@ impl ExecutionProfileEditorView {
         );
 
         Self::update_profile_name_editor(&self.profile_name_editor, &current_permissions, ctx);
+        self.full_control_button.update(ctx, |button, ctx| {
+            button.set_disabled(full_control_disabled, ctx);
+        });
         self.sync_context_window_editor(ctx, false);
+    }
+
+    fn handle_full_control_confirmation_event(
+        &mut self,
+        event: &GrantFullControlConfirmationDialogEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            GrantFullControlConfirmationDialogEvent::Cancel => {
+                self.full_control_confirmation_dialog
+                    .update(ctx, |dialog, ctx| dialog.hide(ctx));
+                ctx.notify();
+            }
+            GrantFullControlConfirmationDialogEvent::Confirm => {
+                let include_computer_use = FeatureFlag::LocalComputerUse.is_enabled();
+                let profile_id = self.profile_id;
+                AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles_model, ctx| {
+                    profiles_model.grant_full_control(profile_id, include_computer_use, ctx);
+                });
+                self.full_control_confirmation_dialog
+                    .update(ctx, |dialog, ctx| dialog.hide(ctx));
+                ctx.notify();
+            }
+        }
     }
 
     fn refresh_execution_profile_dropdown_menu(
@@ -1533,7 +1598,7 @@ impl View for ExecutionProfileEditorView {
             .with_uniform_padding(16.)
             .finish();
 
-        ClippedScrollable::vertical(
+        let scrollable = ClippedScrollable::vertical(
             self.clipped_scroll_state.clone(),
             Align::new(content).top_center().finish(),
             ScrollbarWidth::Auto,
@@ -1541,7 +1606,22 @@ impl View for ExecutionProfileEditorView {
             appearance.theme().active_ui_detail().into(),
             warpui::elements::Fill::None,
         )
-        .finish()
+        .finish();
+
+        // Overlay the "Grant full control" confirmation dialog centered over
+        // the editor. The dialog renders nothing when it isn't visible.
+        let mut stack = Stack::new();
+        stack.add_child(scrollable);
+        stack.add_positioned_overlay_child(
+            ChildView::new(&self.full_control_confirmation_dialog).finish(),
+            OffsetPositioning::offset_from_parent(
+                vec2f(0., 0.),
+                ParentOffsetBounds::WindowByPosition,
+                ParentAnchor::Center,
+                ChildAnchor::Center,
+            ),
+        );
+        stack.finish()
     }
 }
 
@@ -1737,6 +1817,11 @@ impl TypedActionView for ExecutionProfileEditorView {
                     profiles_model.delete_profile(self.profile_id, ctx);
                 });
                 ctx.emit(ExecutionProfileEditorViewEvent::Pane(PaneEvent::Close));
+            }
+            ExecutionProfileEditorViewAction::GrantFullControl => {
+                self.full_control_confirmation_dialog
+                    .update(ctx, |dialog, ctx| dialog.show(ctx));
+                ctx.notify();
             }
             ExecutionProfileEditorViewAction::SetPlanAutoSync { enabled } => {
                 AIExecutionProfilesModel::handle(ctx).update(ctx, |profiles_model, ctx| {

--- a/app/src/ai/execution_profiles/editor/ui_helpers.rs
+++ b/app/src/ai/execution_profiles/editor/ui_helpers.rs
@@ -447,9 +447,15 @@ pub fn render_permissions_section(
     app: &warpui::AppContext,
 ) -> Box<dyn Element> {
     let ai_settings = AISettings::as_ref(app);
-    let mut column = Flex::column().with_children([
-        render_separator(appearance),
-        render_section_label("PERMISSIONS", appearance),
+    let mut column = Flex::column()
+        .with_child(render_separator(appearance))
+        .with_child(render_section_label("PERMISSIONS", appearance));
+
+    if FeatureFlag::FullControlPermissionPreset.is_enabled() {
+        column.add_child(render_full_control_section(appearance, view));
+    }
+
+    column.add_children([
         render_permission_row(
             appearance,
             Icon::Code2,
@@ -625,6 +631,41 @@ pub fn render_permissions_section(
     Container::new(column.finish())
         .with_margin_bottom(24.)
         .finish()
+}
+
+/// Renders the one-click "Grant full control" button and its description at
+/// the top of the permissions section. The button opens a confirmation dialog
+/// before bulk-applying the most permissive settings to every per-action
+/// permission.
+fn render_full_control_section(
+    appearance: &Appearance,
+    view: &ExecutionProfileEditorView,
+) -> Box<dyn Element> {
+    let description = Text::new(
+        "Grant the Agent full control to act without asking for approval — it will apply code diffs, read files, run commands, and call MCP servers, and this profile's command and MCP denylists will be cleared. You can still adjust individual permissions below.".to_string(),
+        appearance.ui_font_family(),
+        11.,
+    )
+    .with_color(
+        appearance
+            .theme()
+            .sub_text_color(appearance.theme().surface_1())
+            .into(),
+    )
+    .finish();
+
+    Container::new(
+        Flex::column()
+            .with_child(
+                Container::new(ChildView::new(&view.full_control_button).finish())
+                    .with_margin_bottom(6.)
+                    .finish(),
+            )
+            .with_child(description)
+            .finish(),
+    )
+    .with_margin_bottom(16.)
+    .finish()
 }
 
 fn create_section_header(

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -921,6 +921,39 @@ impl AIExecutionProfilesModel {
         );
     }
 
+    /// Bulk-applies the most permissive "full control" settings to every
+    /// per-action permission on the profile (analogous to Claude Code's
+    /// `--dangerously-skip-permissions`). See
+    /// [`AIExecutionProfile::apply_full_control`].
+    pub fn grant_full_control(
+        &mut self,
+        profile_id: ClientProfileId,
+        include_computer_use: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let changed = self.edit_profile_internal(
+            profile_id,
+            |profile| {
+                if profile.has_full_control(include_computer_use) {
+                    return false;
+                }
+                profile.apply_full_control(include_computer_use);
+                true
+            },
+            ctx,
+        );
+
+        if changed {
+            send_telemetry_from_ctx!(
+                TelemetryEvent::AIExecutionProfileSettingUpdated {
+                    setting_type: "grant_full_control".to_string(),
+                    setting_value: format!("include_computer_use={include_computer_use}"),
+                },
+                ctx
+            );
+        }
+    }
+
     pub fn set_autosync_plans_to_warp_drive(
         &mut self,
         profile_id: ClientProfileId,

--- a/app/src/ai/execution_profiles/profiles_tests.rs
+++ b/app/src/ai/execution_profiles/profiles_tests.rs
@@ -5,7 +5,8 @@ use warpui::{App, SingletonEntity};
 
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::execution_profiles::{
-    AIExecutionProfile, ActionPermission, CloudAIExecutionProfileModel, WriteToPtyPermission,
+    AIExecutionProfile, ActionPermission, AskUserQuestionPermission, CloudAIExecutionProfileModel,
+    RunAgentsPermission, WriteToPtyPermission,
 };
 use crate::ai::mcp::TemplatableMCPServerManager;
 use crate::auth::user::TEST_USER_UID;
@@ -369,6 +370,44 @@ fn filters_non_owned_non_default_profile_from_list() {
                 "Default",
                 "surviving profile should be the user's default, not the attacker's"
             );
+        });
+    })
+}
+
+/// `grant_full_control` should flip every per-action permission on the default
+/// profile to its most permissive value and clear the denylists in a single
+/// edit.
+#[test]
+fn grant_full_control_makes_default_profile_permissive() {
+    App::test((), |mut app| async move {
+        install_singletons(&mut app, AuthStateProvider::new_logged_out_for_test());
+        let profile_model = app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+
+        let default_profile_id = profile_model.read(&app, |model, _ctx| model.default_profile_id());
+
+        // Precondition: a fresh default profile is restrictive.
+        profile_model.read(&app, |model, ctx| {
+            assert!(!model.default_profile(ctx).data().has_full_control(false));
+        });
+
+        profile_model.update(&mut app, |model, ctx| {
+            model.grant_full_control(default_profile_id, false, ctx);
+        });
+
+        profile_model.read(&app, |model, ctx| {
+            let data = model.default_profile(ctx).data().clone();
+            assert_eq!(data.apply_code_diffs, ActionPermission::AlwaysAllow);
+            assert_eq!(data.read_files, ActionPermission::AlwaysAllow);
+            assert_eq!(data.execute_commands, ActionPermission::AlwaysAllow);
+            assert_eq!(data.write_to_pty, WriteToPtyPermission::AlwaysAllow);
+            assert_eq!(data.mcp_permissions, ActionPermission::AlwaysAllow);
+            assert_eq!(data.ask_user_question, AskUserQuestionPermission::Never);
+            assert_eq!(data.run_agents, RunAgentsPermission::AlwaysAllow);
+            assert!(data.command_denylist.is_empty());
+            assert!(data.mcp_denylist.is_empty());
+            assert!(data.has_full_control(false));
         });
     })
 }

--- a/crates/cloud_object_models/src/ai_execution_profile.rs
+++ b/crates/cloud_object_models/src/ai_execution_profile.rs
@@ -449,6 +449,52 @@ impl AIExecutionProfile {
         }
     }
 
+    /// Bulk-applies the most permissive "full control" settings to every
+    /// per-action permission, clearing the command and MCP denylists so the
+    /// agent never pauses for approval. This is analogous to Claude Code's
+    /// `--dangerously-skip-permissions`.
+    ///
+    /// `include_computer_use` controls whether computer use is also granted.
+    /// Callers should pass the current computer-use availability (e.g. the
+    /// computer-use feature flag) so we don't silently enable a capability the
+    /// user can't see or configure in the UI.
+    pub fn apply_full_control(&mut self, include_computer_use: bool) {
+        self.apply_code_diffs = ActionPermission::AlwaysAllow;
+        self.read_files = ActionPermission::AlwaysAllow;
+        self.execute_commands = ActionPermission::AlwaysAllow;
+        self.write_to_pty = WriteToPtyPermission::AlwaysAllow;
+        self.mcp_permissions = ActionPermission::AlwaysAllow;
+        self.ask_user_question = AskUserQuestionPermission::Never;
+        self.run_agents = RunAgentsPermission::AlwaysAllow;
+        if include_computer_use {
+            self.computer_use = ComputerUsePermission::AlwaysAllow;
+        }
+        self.web_search_enabled = true;
+        // Clearing the denylists ensures the agent truly never asks for
+        // approval. Org-enforced denylist entries are merged in separately at
+        // permission-resolution time, so org policy is unaffected.
+        self.command_denylist.clear();
+        self.mcp_denylist.clear();
+    }
+
+    /// Returns `true` if this profile already grants the agent full control
+    /// (every per-action permission is at its most permissive value and the
+    /// denylists are empty). `include_computer_use` mirrors the same parameter
+    /// on [`Self::apply_full_control`].
+    pub fn has_full_control(&self, include_computer_use: bool) -> bool {
+        self.apply_code_diffs.is_always_allow()
+            && self.read_files.is_always_allow()
+            && self.execute_commands.is_always_allow()
+            && self.write_to_pty.is_always_allow()
+            && self.mcp_permissions.is_always_allow()
+            && matches!(self.ask_user_question, AskUserQuestionPermission::Never)
+            && self.run_agents.is_always_allow()
+            && (!include_computer_use || self.computer_use.is_always_allow())
+            && self.web_search_enabled
+            && self.command_denylist.is_empty()
+            && self.mcp_denylist.is_empty()
+    }
+
     /// This creates a CLI-specific profile that will never ask the user for permission,
     /// since we cannot do so in a non-interactive setting.
     pub fn create_default_cli_profile(
@@ -517,3 +563,82 @@ pub type CloudAIExecutionProfile =
 pub type CloudAIExecutionProfileModel = GenericStringModel<AIExecutionProfile, JsonSerializer>;
 pub type ServerAIExecutionProfile =
     GenericServerObject<GenericStringObjectId, CloudAIExecutionProfileModel>;
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn restrictive_profile() -> AIExecutionProfile {
+        AIExecutionProfile {
+            apply_code_diffs: ActionPermission::AgentDecides,
+            read_files: ActionPermission::AlwaysAsk,
+            execute_commands: ActionPermission::AlwaysAsk,
+            write_to_pty: WriteToPtyPermission::AlwaysAsk,
+            mcp_permissions: ActionPermission::AlwaysAsk,
+            ask_user_question: AskUserQuestionPermission::AlwaysAsk,
+            run_agents: RunAgentsPermission::AlwaysAsk,
+            computer_use: ComputerUsePermission::Never,
+            web_search_enabled: false,
+            command_denylist: vec![AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap()],
+            mcp_denylist: vec![uuid::Uuid::new_v4()],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_full_control_makes_all_permissions_permissive() {
+        let mut profile = restrictive_profile();
+        profile.apply_full_control(true);
+
+        assert_eq!(profile.apply_code_diffs, ActionPermission::AlwaysAllow);
+        assert_eq!(profile.read_files, ActionPermission::AlwaysAllow);
+        assert_eq!(profile.execute_commands, ActionPermission::AlwaysAllow);
+        assert_eq!(profile.write_to_pty, WriteToPtyPermission::AlwaysAllow);
+        assert_eq!(profile.mcp_permissions, ActionPermission::AlwaysAllow);
+        assert_eq!(profile.ask_user_question, AskUserQuestionPermission::Never);
+        assert_eq!(profile.run_agents, RunAgentsPermission::AlwaysAllow);
+        assert_eq!(profile.computer_use, ComputerUsePermission::AlwaysAllow);
+        assert!(profile.web_search_enabled);
+        assert!(profile.command_denylist.is_empty());
+        assert!(profile.mcp_denylist.is_empty());
+        assert!(profile.has_full_control(true));
+    }
+
+    #[test]
+    fn apply_full_control_leaves_computer_use_when_not_included() {
+        let mut profile = restrictive_profile();
+        profile.apply_full_control(false);
+
+        // Computer use is untouched when not included, but everything else is
+        // permissive, so full control still holds for the not-included variant.
+        assert_eq!(profile.computer_use, ComputerUsePermission::Never);
+        assert!(profile.has_full_control(false));
+        assert!(!profile.has_full_control(true));
+    }
+
+    #[test]
+    fn has_full_control_is_false_for_default_profile() {
+        let profile = AIExecutionProfile::default();
+        assert!(!profile.has_full_control(false));
+        assert!(!profile.has_full_control(true));
+    }
+
+    #[test]
+    fn has_full_control_requires_empty_denylists() {
+        let mut profile = restrictive_profile();
+        profile.apply_full_control(true);
+        assert!(profile.has_full_control(true));
+
+        // Re-adding a denylist entry should flip the predicate back to false.
+        profile.command_denylist =
+            vec![AgentModeCommandExecutionPredicate::new_regex("rm .*").unwrap()];
+        assert!(!profile.has_full_control(true));
+
+        // Directory allowlist entries are unrelated to full control.
+        profile.command_denylist.clear();
+        profile.directory_allowlist = vec![PathBuf::from("/tmp")];
+        assert!(profile.has_full_control(true));
+    }
+}

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -882,6 +882,12 @@ pub enum FeatureFlag {
     /// and whole tab groups so they stay at the front of the tab list and
     /// are protected from reordering.
     PinnedTabs,
+
+    /// Gates the one-click "Grant full control" action in the agent Profile
+    /// Editor permissions section, which bulk-applies the most permissive
+    /// value to every per-action permission (analogous to Claude Code's
+    /// `--dangerously-skip-permissions`).
+    FullControlPermissionPreset,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -950,6 +956,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::AsyncFind,
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
+    FeatureFlag::FullControlPermissionPreset,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Adds a single, overarching **"Grant full control"** action to the agent Profile Editor permissions section — analogous to Claude Code's `--dangerously-skip-permissions` — so users can grant the agent full permissions at once instead of configuring each per-action control separately.

Clicking the button opens a confirmation dialog with a clear warning. On confirm, it bulk-applies the most permissive value to every per-action permission (Apply code diffs, Read files, Execute commands, Interact with running commands, Run orchestrated agents, Call MCP servers → Always allow), sets **Ask questions → Never**, enables web search, and clears the profile's command and MCP denylists so the agent never pauses for approval.

Design decisions:
- **Sits alongside** the existing granular settings rather than replacing them. The per-action dropdowns remain visible/editable and immediately reflect the new "Always allow" values, so the resulting state is transparent and individually adjustable afterward.
- **No new persisted profile field.** It bulk-updates the existing `AIExecutionProfile` fields through the normal setter path, so cloud sync, permission resolution, and org/workspace overrides are unchanged. Org-enforced denylist entries are merged separately at resolution time and are unaffected by clearing the profile's own denylists.
- **Gated** behind a clear confirmation dialog (`DangerPrimaryTheme` confirm button) and the new `FeatureFlag::FullControlPermissionPreset` (dogfood-enabled).
- Computer use is only granted when the local computer-use feature is available, so we don't silently enable a capability the user can't see in the UI.

Key changes:
- `crates/cloud_object_models/src/ai_execution_profile.rs`: `AIExecutionProfile::apply_full_control` / `has_full_control` (+ unit tests).
- `app/src/ai/execution_profiles/profiles.rs`: `AIExecutionProfilesModel::grant_full_control` (+ telemetry).
- `app/src/ai/execution_profiles/editor/grant_full_control_confirmation_dialog.rs`: new confirmation dialog view.
- `app/src/ai/execution_profiles/editor/{mod,ui_helpers}.rs`: button, dialog wiring, render overlay, disabled-state handling.
- `crates/warp_features/src/lib.rs`: new feature flag.

## Linked Issue
Linear APP-4709 (routed via the GitHub-first feedback flow; public GitHub issue creation was skipped upstream due to missing credentials).
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo check -p warp --tests`, `cargo check -p cloud_object_models -p warp_features --tests`: pass.
- `cargo clippy -p warp -p cloud_object_models -p warp_features --all-targets --tests -- -D warnings`: pass.
- New unit tests in `cloud_object_models` for `apply_full_control` / `has_full_control`: pass.
- New model test `grant_full_control_makes_default_profile_permissive` in `profiles_tests.rs` type-checks and clippy-compiles; the full `warp` test binary could not be linked in this environment due to a memory limit, so it was not executed here. It mirrors the existing `edits_persist_on_unsynced_default_profile_when_logged_out` test and wraps the already-tested `edit_profile_internal` path.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not captured in this environment (headless). UI is gated behind `FeatureFlag::FullControlPermissionPreset`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Added a one-click "Grant full control" option in agent permission profiles to grant the agent full permissions at once.
-->

_Conversation: https://staging.warp.dev/conversation/7d3d80f0-3ca7-4e86-8084-c173f73ab14a_
_Run: https://oz.staging.warp.dev/runs/019eb2f2-2bc9-7f00-afe8-c8cd5d313945_
_Plans_:
- _[APP-4709: One-click "Grant full control" for agent permissions](https://staging.warp.dev/drive/notebook/sMagOwSynCvnMECQ0XzhyJ)_

_This PR was generated with [Oz](https://warp.dev/oz)._
