### PR TITLE
Make MCP server startup non-fatal for Oz agent runs

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::future::Future;
@@ -16,7 +15,7 @@ use futures::channel::oneshot;
 use futures::future::{self, join_all, Either};
 use futures::FutureExt as _;
 use itertools::Itertools as _;
-use oneshot::{Canceled, Receiver, Sender};
+use oneshot::{Canceled, Receiver};
 use repo_metadata::local_model::IndexedRepoState;
 use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
 use session_sharing_protocol::sharer::SessionRetentionReason;
@@ -75,7 +74,7 @@ use crate::auth::AuthStateProvider;
 use crate::cloud_object::{CloudObject, CloudObjectLookup as _};
 use crate::send_telemetry_from_app_ctx;
 use crate::server::ids::{ServerId, SyncId};
-use crate::server::server_api::ai::AIClient;
+use crate::server::server_api::ai::{AIClient, TaskStatusUpdate};
 use crate::server::server_api::harness_support::{
     HarnessSupportClient, ResolvePromptAttachedSkill, ResolvePromptRequest,
 };
@@ -262,6 +261,11 @@ pub struct AgentDriverOptions {
     /// `--skip-initial-turn` CLI flag, which the worker emits when the
     /// execution input has neither a prompt nor a snapshot token.
     pub skip_initial_turn: bool,
+    /// Fail the run when MCP servers fail to start, instead of continuing
+    /// without the unavailable servers.
+    pub strict_mcp_startup: bool,
+    /// MCP server startup timeout override.
+    pub mcp_startup_timeout: Option<Duration>,
 }
 
 /// `AgentDriver` is a model for driving an ambient Warp agent to completion.
@@ -338,6 +342,12 @@ pub struct AgentDriver {
     /// sourced from the `--skip-initial-turn` CLI flag. Read by `execute_run`
     /// to gate the empty-prompt short-circuit path.
     skip_initial_turn: bool,
+
+    /// Whether MCP server startup failures are fatal for the run.
+    strict_mcp_startup: bool,
+    /// How long to wait for MCP servers to start before degrading (or failing,
+    /// in strict mode).
+    mcp_startup_timeout: Duration,
 }
 
 pub(crate) enum SDKConversationOutputStatus {
@@ -408,8 +418,8 @@ pub enum AgentDriverError {
     InvalidRuntimeState,
     #[error("Requested MCP server not found: {0}")]
     MCPServerNotFound(uuid::Uuid),
-    #[error("Failed to start MCP servers")]
-    MCPStartupFailed,
+    #[error("Failed to start MCP servers: {details}")]
+    MCPStartupFailed { details: String },
     #[error("Failed to parse MCP server JSON: {0}")]
     MCPJsonParseError(String),
     #[error("MCP server configuration is missing required variables")]
@@ -552,6 +562,8 @@ impl AgentDriver {
             snapshot_upload_timeout,
             snapshot_script_timeout,
             skip_initial_turn,
+            strict_mcp_startup,
+            mcp_startup_timeout,
         } = options;
 
         // Split the unified resume option into the two internal slots that the rest of
@@ -679,6 +691,8 @@ impl AgentDriver {
             third_party_harness_model_config,
             snapshot_file_writer,
             skip_initial_turn,
+            strict_mcp_startup,
+            mcp_startup_timeout: mcp_startup_timeout.unwrap_or(MCP_SERVER_STARTUP_TIMEOUT),
         })
     }
 
@@ -719,6 +733,8 @@ impl AgentDriver {
             third_party_harness_model_config: None,
             snapshot_file_writer: None,
             skip_initial_turn: false,
+            strict_mcp_startup: false,
+            mcp_startup_timeout: MCP_SERVER_STARTUP_TIMEOUT,
         }
     }
 
@@ -1019,53 +1035,211 @@ impl AgentDriver {
         Ok(servers_to_start)
     }
 
-    fn subscribe_to_mcp_managers(
+    /// Subscribe to MCP server state changes and wait for every server in
+    /// `servers` (keyed by installation UUID, valued by display name) to reach
+    /// a terminal state (`Running` or `FailedToStart`), up to the configured
+    /// startup timeout.
+    ///
+    /// Returns [`AgentDriverError::MCPStartupFailed`] naming the servers that
+    /// failed to start or were still starting at the deadline. Callers decide
+    /// whether that is fatal (see strict MCP startup handling in
+    /// `run_internal`).
+    ///
+    /// Must be called before the servers are spawned so no state changes are
+    /// missed, and never concurrently with another MCP wait: the driver keeps
+    /// at most one subscription to [`TemplatableMCPServerManager`].
+    fn wait_for_mcp_servers_started(
         &self,
-        tx: Sender<Result<(), AgentDriverError>>,
-        servers_to_start: HashSet<Uuid>,
+        servers: HashMap<Uuid, String>,
         ctx: &mut ModelContext<Self>,
-    ) {
-        use std::rc::Rc;
+    ) -> impl Future<Output = Result<(), AgentDriverError>> {
+        if servers.is_empty() {
+            return Either::Right(future::ready(Ok(())));
+        }
+
+        let timeout = self.mcp_startup_timeout;
+        let (tx, rx) = oneshot::channel::<()>();
+        let mut tx = Some(tx);
+
+        let pending = Arc::new(Mutex::new(servers));
+        let failed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let pending_for_subscription = Arc::clone(&pending);
+        let failed_for_subscription = Arc::clone(&failed);
 
         let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
-        let mcp_to_start = Rc::new(RefCell::new(servers_to_start));
         let manager_clone = templatable_mcp_manager.clone();
-        let mut tx = Some(tx);
-        ctx.subscribe_to_model(
-            &templatable_mcp_manager,
-            move |_me, event, ctx| match event {
-                TemplatableMCPServerManagerEvent::StateChanged { uuid, state } => {
-                    let mut pending_ids = mcp_to_start.borrow_mut();
-                    if !pending_ids.contains(uuid) {
-                        return;
-                    }
-                    match state {
-                        MCPServerState::Running => {
-                            pending_ids.remove(uuid);
-                            if pending_ids.is_empty() {
-                                log::info!("All MCP servers started");
-                                if let Some(sender) = tx.take() {
-                                    let _ = sender.send(Ok(()));
-                                }
-                                ctx.unsubscribe_from_model(&manager_clone);
-                            }
-                        }
-                        MCPServerState::FailedToStart => {
-                            log::warn!("Failed to start MCP server {uuid}");
-                            if let Some(sender) = tx.take() {
-                                let _ = sender.send(Err(AgentDriverError::MCPStartupFailed));
-                            }
-                            ctx.unsubscribe_from_model(&manager_clone);
-                        }
-                        _ => {}
+
+        // Clear any stale subscription left behind by a previous wait that
+        // timed out, so it can't tear down this wait's subscription.
+        ctx.unsubscribe_from_model(&templatable_mcp_manager);
+        ctx.subscribe_to_model(&templatable_mcp_manager, move |_me, event, ctx| {
+            let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event else {
+                return;
+            };
+            let Ok(mut pending_servers) = pending_for_subscription.lock() else {
+                return;
+            };
+            let Some(name) = pending_servers.get(uuid).cloned() else {
+                return;
+            };
+            match state {
+                MCPServerState::Running => {
+                    pending_servers.remove(uuid);
+                }
+                MCPServerState::FailedToStart => {
+                    pending_servers.remove(uuid);
+                    let error = TemplatableMCPServerManager::as_ref(ctx)
+                        .get_server_error_message(*uuid)
+                        .map(|message| format!(": {message}"))
+                        .unwrap_or_default();
+                    log::warn!("MCP server '{name}' failed to start{error}");
+                    if let Ok(mut failed_servers) = failed_for_subscription.lock() {
+                        failed_servers.push(name);
                     }
                 }
-                TemplatableMCPServerManagerEvent::ServerInstallationAdded(_)
-                | TemplatableMCPServerManagerEvent::ServerInstallationDeleted(_)
-                | TemplatableMCPServerManagerEvent::TemplatableMCPServersUpdated
-                | TemplatableMCPServerManagerEvent::LegacyServerConverted => {}
-            },
+                MCPServerState::NotRunning
+                | MCPServerState::Starting
+                | MCPServerState::Authenticating
+                | MCPServerState::ShuttingDown => return,
+            }
+            if pending_servers.is_empty() {
+                log::info!("All requested MCP servers reached a terminal state");
+                if let Some(sender) = tx.take() {
+                    let _ = sender.send(());
+                }
+                ctx.unsubscribe_from_model(&manager_clone);
+            }
+        });
+
+        let spawner = ctx.spawner();
+        Either::Left(async move {
+            let wait_result = rx.with_timeout(timeout).await;
+
+            let mut still_starting: Vec<String> = Vec::new();
+            match wait_result {
+                Ok(Ok(())) => {}
+                Ok(Err(Canceled)) => {
+                    log::error!("Subscription dropped before MCP servers started");
+                    return Err(AgentDriverError::InvalidRuntimeState);
+                }
+                Err(TimeoutError) => {
+                    still_starting = pending
+                        .lock()
+                        .map(|pending_servers| pending_servers.values().cloned().collect())
+                        .unwrap_or_default();
+                    still_starting.sort();
+                    // The subscription is now stale; remove it so it can't
+                    // tear down a later wait's subscription. This completes
+                    // before this future resolves, so it cannot race with a
+                    // subsequent wait.
+                    let _ = spawner
+                        .spawn(|_, ctx| {
+                            let manager = TemplatableMCPServerManager::handle(ctx);
+                            ctx.unsubscribe_from_model(&manager);
+                        })
+                        .await;
+                }
+            }
+
+            let mut failed_names = failed
+                .lock()
+                .map(|failed_servers| failed_servers.clone())
+                .unwrap_or_default();
+            failed_names.sort();
+
+            let mut details = Vec::new();
+            if !failed_names.is_empty() {
+                details.push(format!("failed to start: {}", failed_names.join(", ")));
+            }
+            if !still_starting.is_empty() {
+                details.push(format!(
+                    "still starting after {}s: {}",
+                    timeout.as_secs(),
+                    still_starting.join(", ")
+                ));
+            }
+
+            if details.is_empty() {
+                Ok(())
+            } else {
+                Err(AgentDriverError::MCPStartupFailed {
+                    details: details.join("; "),
+                })
+            }
+        })
+    }
+
+    /// Fold an MCP startup result into `degraded`, propagating any error that
+    /// is fatal regardless of the strict MCP startup setting.
+    fn collect_mcp_degradation(
+        result: Result<(), AgentDriverError>,
+        degraded: &mut Vec<String>,
+    ) -> Result<(), AgentDriverError> {
+        match result {
+            Ok(()) => Ok(()),
+            Err(AgentDriverError::MCPStartupFailed { details }) => {
+                degraded.push(details);
+                Ok(())
+            }
+            Err(other) => Err(other),
+        }
+    }
+
+    /// Apply strict MCP startup handling to a recorded startup result.
+    ///
+    /// Degraded startup (`MCPStartupFailed`) is fatal only in strict mode.
+    /// Otherwise the run continues without the unavailable servers: the
+    /// degradation is logged and reported as a run status message.
+    async fn handle_mcp_startup_result(
+        result: Result<(), AgentDriverError>,
+        foreground: &ModelSpawner<Self>,
+    ) -> Result<(), AgentDriverError> {
+        let Err(error) = result else {
+            return Ok(());
+        };
+        let AgentDriverError::MCPStartupFailed { details } = &error else {
+            return Err(error);
+        };
+        let details = details.clone();
+
+        let strict = foreground.spawn(|me, _| me.strict_mcp_startup).await?;
+        if strict {
+            return Err(error);
+        }
+
+        log::warn!(
+            "MCP startup degraded ({details}); continuing without the unavailable MCP servers"
         );
+
+        // Surface the degradation on the run itself. The server currently only
+        // persists status messages on terminal state transitions, so this is
+        // best-effort until message-only updates are supported.
+        let (task_id, ai_client) = foreground
+            .spawn(|me, ctx| {
+                (
+                    me.task_id,
+                    ServerApiProvider::as_ref(ctx).get_ai_client().clone(),
+                )
+            })
+            .await?;
+        if let Some(task_id) = task_id {
+            let message = format!(
+                "Warning: some MCP servers were unavailable during startup ({details}); continuing without their tools."
+            );
+            if let Err(err) = ai_client
+                .update_agent_task(
+                    task_id,
+                    None,
+                    None,
+                    None,
+                    Some(TaskStatusUpdate::message(message)),
+                )
+                .await
+            {
+                log::warn!("Failed to report MCP startup warning for task {task_id}: {err:#}");
+            }
+        }
+        Ok(())
     }
 
     fn spawn_inactive_servers(
@@ -1086,7 +1260,6 @@ impl AgentDriver {
         uuids: &[uuid::Uuid],
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = Result<(), AgentDriverError>> {
-        let (tx, rx) = oneshot::channel();
         let servers_to_start = match self.get_mcp_servers_to_start(uuids, ctx) {
             Ok(val) => val,
             Err(e) => {
@@ -1101,23 +1274,24 @@ impl AgentDriver {
 
         log::info!("Starting {} MCP servers...", servers_to_start.len());
 
-        self.subscribe_to_mcp_managers(tx, servers_to_start.clone(), ctx);
+        let named_servers: HashMap<Uuid, String> = {
+            let manager = TemplatableMCPServerManager::as_ref(ctx);
+            servers_to_start
+                .iter()
+                .map(|uuid| {
+                    let name = manager
+                        .get_installed_server(uuid)
+                        .map(|installation| installation.templatable_mcp_server().name.clone())
+                        .unwrap_or_else(|| uuid.to_string());
+                    (*uuid, name)
+                })
+                .collect()
+        };
+        let wait = self.wait_for_mcp_servers_started(named_servers, ctx);
 
         self.spawn_inactive_servers(servers_to_start, ctx);
 
-        Either::Left(async move {
-            match rx.with_timeout(MCP_SERVER_STARTUP_TIMEOUT).await {
-                Ok(Ok(result)) => result,
-                Ok(Err(Canceled)) => {
-                    log::error!("Subscription dropped before MCP servers started");
-                    Err(AgentDriverError::InvalidRuntimeState)
-                }
-                Err(TimeoutError) => {
-                    log::error!("Timed out waiting for MCP servers to start");
-                    Err(AgentDriverError::MCPStartupFailed)
-                }
-            }
-        })
+        Either::Left(wait)
     }
 
     /// Start ephemeral MCP servers from inline JSON specifications.
@@ -1136,64 +1310,28 @@ impl AgentDriver {
             installation.apply_secrets(&self.secrets);
         }
 
-        let (tx, rx) = oneshot::channel();
-        let mut tx = Some(tx);
-        let mut uuids_to_start: HashSet<Uuid> = installations.iter().map(|i| i.uuid()).collect();
-
         log::info!("Starting {} ephemeral MCP servers...", installations.len());
 
-        // Subscribe to state changes for these ephemeral servers.
-        let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
-        let manager_clone = templatable_mcp_manager.clone();
-
-        ctx.subscribe_to_model(&templatable_mcp_manager, move |_me, event, ctx| {
-            if let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event {
-                if !uuids_to_start.contains(uuid) {
-                    return;
-                }
-                match state {
-                    MCPServerState::Running => {
-                        uuids_to_start.remove(uuid);
-                        if uuids_to_start.is_empty() {
-                            log::info!("All ephemeral MCP servers started");
-                            if let Some(sender) = tx.take() {
-                                let _ = sender.send(Ok(()));
-                            }
-                            ctx.unsubscribe_from_model(&manager_clone);
-                        }
-                    }
-                    MCPServerState::FailedToStart => {
-                        log::warn!("Failed to start ephemeral MCP server {uuid}");
-                        if let Some(sender) = tx.take() {
-                            let _ = sender.send(Err(AgentDriverError::MCPStartupFailed));
-                        }
-                        ctx.unsubscribe_from_model(&manager_clone);
-                    }
-                    _ => {}
-                }
-            }
-        });
+        let named_servers: HashMap<Uuid, String> = installations
+            .iter()
+            .map(|installation| {
+                (
+                    installation.uuid(),
+                    installation.templatable_mcp_server().name.clone(),
+                )
+            })
+            .collect();
+        let wait = self.wait_for_mcp_servers_started(named_servers, ctx);
 
         // Spawn the ephemeral servers.
+        let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
         templatable_mcp_manager.update(ctx, move |manager, ctx| {
             for installation in installations {
                 manager.spawn_cli_ephemeral_server(installation, ctx);
             }
         });
 
-        Either::Left(async move {
-            match rx.with_timeout(MCP_SERVER_STARTUP_TIMEOUT).await {
-                Ok(Ok(result)) => result,
-                Ok(Err(Canceled)) => {
-                    log::error!("Subscription dropped before ephemeral MCP servers started");
-                    Err(AgentDriverError::InvalidRuntimeState)
-                }
-                Err(TimeoutError) => {
-                    log::error!("Timed out waiting for ephemeral MCP servers to start");
-                    Err(AgentDriverError::MCPStartupFailed)
-                }
-            }
-        })
+        Either::Left(wait)
     }
 
     /// Subscribe to [`FileBasedMCPManagerEvent::CloudEnvMcpScanComplete`]
@@ -1715,27 +1853,39 @@ impl AgentDriver {
                 ephemeral_installations.len()
             );
 
-            setup_events
+            let mcp_startup_result = setup_events
                 .record_result(SetupStep::McpServerStartup, async {
-                    // TODO(BenS): combine these
+                    // Run both startup phases even when one degrades, collecting
+                    // degradation details so non-strict runs can continue with
+                    // whichever servers did start.
+                    let mut degraded = Vec::new();
                     if !existing_uuids.is_empty() {
-                        foreground
+                        let result = foreground
                             .spawn(move |me, ctx| me.start_mcp_servers(&existing_uuids, ctx))
                             .await?
-                            .await?;
+                            .await;
+                        Self::collect_mcp_degradation(result, &mut degraded)?;
                     }
                     // Start ephemeral MCP servers from inline JSON specs.
                     if !ephemeral_installations.is_empty() {
-                        foreground
+                        let result = foreground
                             .spawn(move |me, ctx| {
                                 me.start_ephemeral_mcp_servers(ephemeral_installations, ctx)
                             })
                             .await?
-                            .await?;
+                            .await;
+                        Self::collect_mcp_degradation(result, &mut degraded)?;
                     }
-                    Ok::<(), AgentDriverError>(())
+                    if degraded.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(AgentDriverError::MCPStartupFailed {
+                            details: degraded.join("; "),
+                        })
+                    }
                 })
-                .await?;
+                .await;
+            Self::handle_mcp_startup_result(mcp_startup_result, &foreground).await?;
             let profile = task.profile.clone();
             setup_events
                 .record_result(SetupStep::AgentProfileConfiguration, async {
@@ -1752,14 +1902,15 @@ impl AgentDriver {
                     .await??;
             }
 
-            setup_events
+            let profile_mcp_startup_result = setup_events
                 .record_result(SetupStep::ProfileMcpServerStartup, async {
                     foreground
                         .spawn(|me, ctx| me.start_profile_mcp_servers(ctx))
                         .await?
                         .await
                 })
-                .await?;
+                .await;
+            Self::handle_mcp_startup_result(profile_mcp_startup_result, &foreground).await?;
         }
 
         // For all harnesses: wait for the shared session and prepare the environment.

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -418,8 +418,12 @@ pub enum AgentDriverError {
     InvalidRuntimeState,
     #[error("Requested MCP server not found: {0}")]
     MCPServerNotFound(uuid::Uuid),
-    #[error("Failed to start MCP servers: {details}")]
-    MCPStartupFailed { details: String },
+    #[error("Failed to start MCP servers: {}", .details.join("; "))]
+    MCPStartupFailed {
+        /// One line per unavailable server (e.g. "'datadog' failed to start:
+        /// connection refused").
+        details: Vec<String>,
+    },
     #[error("Failed to parse MCP server JSON: {0}")]
     MCPJsonParseError(String),
     #[error("MCP server configuration is missing required variables")]
@@ -1053,10 +1057,12 @@ impl AgentDriver {
         servers: HashMap<Uuid, String>,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = Result<(), AgentDriverError>> {
+        // If no servers to wait for, complete immediately.
         if servers.is_empty() {
             return Either::Right(future::ready(Ok(())));
         }
 
+        // Stall for user-configured timeout, else 20 seconds (configured in [`AgentDriverOptions`]).
         let timeout = self.mcp_startup_timeout;
         let (tx, rx) = oneshot::channel::<()>();
         let mut tx = Some(tx);
@@ -1080,6 +1086,7 @@ impl AgentDriver {
                 return;
             };
             let Some(name) = pending_servers.get(uuid).cloned() else {
+                // If we receive a state change for a server that we're not waiting for, ignore it.
                 return;
             };
             match state {
@@ -1092,9 +1099,10 @@ impl AgentDriver {
                         .get_server_error_message(*uuid)
                         .map(|message| format!(": {message}"))
                         .unwrap_or_default();
-                    log::warn!("MCP server '{name}' failed to start{error}");
+                    let detail = format!("'{name}' failed to start{error}");
+                    log::warn!("MCP server {detail}");
                     if let Ok(mut failed_servers) = failed_for_subscription.lock() {
-                        failed_servers.push(name);
+                        failed_servers.push(detail);
                     }
                 }
                 MCPServerState::NotRunning
@@ -1141,30 +1149,21 @@ impl AgentDriver {
                 }
             }
 
-            let mut failed_names = failed
+            let mut details = failed
                 .lock()
                 .map(|failed_servers| failed_servers.clone())
                 .unwrap_or_default();
-            failed_names.sort();
-
-            let mut details = Vec::new();
-            if !failed_names.is_empty() {
-                details.push(format!("failed to start: {}", failed_names.join(", ")));
-            }
-            if !still_starting.is_empty() {
-                details.push(format!(
-                    "still starting after {}s: {}",
-                    timeout.as_secs(),
-                    still_starting.join(", ")
-                ));
-            }
+            details.sort();
+            details.extend(
+                still_starting
+                    .iter()
+                    .map(|name| format!("'{name}' did not start within {}s", timeout.as_secs())),
+            );
 
             if details.is_empty() {
                 Ok(())
             } else {
-                Err(AgentDriverError::MCPStartupFailed {
-                    details: details.join("; "),
-                })
+                Err(AgentDriverError::MCPStartupFailed { details })
             }
         })
     }
@@ -1178,7 +1177,7 @@ impl AgentDriver {
         match result {
             Ok(()) => Ok(()),
             Err(AgentDriverError::MCPStartupFailed { details }) => {
-                degraded.push(details);
+                degraded.extend(details);
                 Ok(())
             }
             Err(other) => Err(other),
@@ -1200,7 +1199,7 @@ impl AgentDriver {
         let AgentDriverError::MCPStartupFailed { details } = &error else {
             return Err(error);
         };
-        let details = details.clone();
+        let details = details.join("; ");
 
         let strict = foreground.spawn(|me, _| me.strict_mcp_startup).await?;
         if strict {
@@ -1879,9 +1878,7 @@ impl AgentDriver {
                     if degraded.is_empty() {
                         Ok(())
                     } else {
-                        Err(AgentDriverError::MCPStartupFailed {
-                            details: degraded.join("; "),
-                        })
+                        Err(AgentDriverError::MCPStartupFailed { details: degraded })
                     }
                 })
                 .await;

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -100,15 +100,22 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
-        AgentDriverError::MCPStartupFailed { details } => (
-            AgentTaskState::Failed,
-            TaskStatusUpdate::with_error_code(
-                format!(
-                    "One or more MCP servers failed to start ({details}). Check that your MCP server configuration is valid and the server process is runnable."
+        AgentDriverError::MCPStartupFailed { details } => {
+            let server_lines = details
+                .iter()
+                .map(|detail| format!("- {detail}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            (
+                AgentTaskState::Failed,
+                TaskStatusUpdate::with_error_code(
+                    format!(
+                        "One or more MCP servers failed to start:\n\n{server_lines}\n\nCheck that each server's configuration is valid and that it is reachable from the agent's environment."
+                    ),
+                    PlatformErrorCode::EnvironmentSetupFailed,
                 ),
-                PlatformErrorCode::EnvironmentSetupFailed,
-            ),
-        ),
+            )
+        }
         AgentDriverError::MCPJsonParseError(msg) => (
             AgentTaskState::Failed,
             TaskStatusUpdate::with_error_code(

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -100,10 +100,12 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
-        AgentDriverError::MCPStartupFailed => (
+        AgentDriverError::MCPStartupFailed { details } => (
             AgentTaskState::Failed,
             TaskStatusUpdate::with_error_code(
-                "One or more MCP servers failed to start. Check that your MCP server configuration is valid and the server process is runnable.",
+                format!(
+                    "One or more MCP servers failed to start ({details}). Check that your MCP server configuration is valid and the server process is runnable."
+                ),
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -73,16 +73,25 @@ fn mcp_server_not_found_is_failed_with_env_setup() {
 }
 
 #[test]
-fn mcp_startup_failed_is_failed_with_env_setup_and_details() {
+fn mcp_startup_failed_is_failed_with_env_setup_and_per_server_details() {
     let (state, update) = classify_driver_error(&AgentDriverError::MCPStartupFailed {
-        details: "failed to start: devin".into(),
+        details: vec![
+            "'devin' failed to start: connection refused".to_string(),
+            "'datadog' did not start within 20s".to_string(),
+        ],
     });
     assert_eq!(state, AgentTaskState::Failed);
     assert_eq!(
         update.error_code,
         Some(PlatformErrorCode::EnvironmentSetupFailed)
     );
-    assert!(update.message.contains("failed to start: devin"));
+    // Each unavailable server is rendered as its own bullet line.
+    assert!(update
+        .message
+        .contains("- 'devin' failed to start: connection refused"));
+    assert!(update
+        .message
+        .contains("- 'datadog' did not start within 20s"));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -73,6 +73,19 @@ fn mcp_server_not_found_is_failed_with_env_setup() {
 }
 
 #[test]
+fn mcp_startup_failed_is_failed_with_env_setup_and_details() {
+    let (state, update) = classify_driver_error(&AgentDriverError::MCPStartupFailed {
+        details: "failed to start: devin".into(),
+    });
+    assert_eq!(state, AgentTaskState::Failed);
+    assert_eq!(
+        update.error_code,
+        Some(PlatformErrorCode::EnvironmentSetupFailed)
+    );
+    assert!(update.message.contains("failed to start: devin"));
+}
+
+#[test]
 fn environment_setup_failed_is_failed() {
     assert_state_and_code(
         AgentDriverError::EnvironmentSetupFailed("bad repo".into()),

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1004,6 +1004,8 @@ impl AgentDriverRunner {
                         .snapshot_script_timeout
                         .map(|duration| duration.into()),
                     skip_initial_turn: args.skip_initial_turn,
+                    strict_mcp_startup: args.strict_mcp_startup,
+                    mcp_startup_timeout: args.mcp_startup_timeout.map(|duration| duration.into()),
                 };
 
                 Ok((merged_config, task, driver_options))

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -312,6 +312,15 @@ pub struct RunAgentArgs {
     /// LEGACY: MCP servers to start before executing the agent, identified by UUID.
     #[arg(long = "mcp-server", value_name = "UUID", hide = true)]
     pub mcp_servers: Vec<uuid::Uuid>,
+    /// Fail the run when any requested MCP server fails to start.
+    ///
+    /// By default, MCP servers that don't start within the startup timeout are
+    /// skipped and the agent runs without their tools.
+    #[arg(long = "strict-mcp-startup")]
+    pub strict_mcp_startup: bool,
+    /// Maximum time to wait for requested MCP servers to start (e.g. `30s`, `1m`).
+    #[arg(long = "mcp-startup-timeout", value_name = "DURATION")]
+    pub mcp_startup_timeout: Option<humantime::Duration>,
     /// Cloud environment to use, identified by ID.
     #[arg(long = "environment", short = 'e', value_name = "ID")]
     pub environment: Option<String>,


### PR DESCRIPTION
## Description

Makes MCP server startup non-fatal by default for Oz agent runs.

Previously, cloud agent runs failed outright with "One or more MCP servers failed to start..." when any requested MCP server failed to reach `Running` within the 20s startup timeout. Several Oz users hit issues where some subset of their servers wouldn't spawn within the (non-configurable) timeout and thus the entire run was borked.

The shape of this solution:

- The MCP startup waiters in `AgentDriver` now wait for _every_ requested server to reach a terminal state (`Running` or `FailedToStart`) instead of failing fast on the first failure, and track per-server names so degradation is reportable (e.g. `failed to start: server_x; still starting after 20s: server_y`).
- `AgentDriverError::MCPStartupFailed` carries those details, which surface in both the strict-mode failure message and the non-strict warning.
- In `run_internal`, both the spec'd (`--mcp`) and profile MCP startup results are handled outside `record_result` (preserving `setup_mcp_server_startup` telemetry): non-strict runs log a WARN naming the unavailable servers and post a best-effort message-only `update_agent_task` status update, then continue. `MCPServerNotFound` (bad UUID config) stays fatal.
- Two new CLI flags on `oz agent run`: `--strict-mcp-startup` (restores the old fail-fast behavior) and `--mcp-startup-timeout <DURATION>` (default 20s), plumbed through `AgentDriverOptions`.

Servers that connect after the timeout still become usable mid-run: in-flight spawns are never aborted, and the per-request `mcp_context` is rebuilt from active servers each turn.

## Follow-ups

This PR sets up client-side scaffolding that lets us configure how strict we are about spawning MCP servers prior to cloud agent runs, and the duration we wait for those servers to spawn before propagating the first user query. The intended follow-up here is to surface these as configurable options via the Oz web app, which should be a fairly trivial change.

## Testing

Manually tested via local Oz CLI; here's an example of a publicly reachable MCP server (`deepwiki`) and an _unreachable_ server configured via a URL that explicitly accepts no connections. Notice that the conversation proceeds despite the failure.

![Screenshot 2026-06-10 at 5.47.07 PM.png](https://app.graphite.com/user-attachments/assets/785b6dca-0108-4ffe-b67a-fa37ae34e1df.png)

`cargo nextest run -p warp -E 'test(error_classification) or test(driver_tests)'` — 32/32 pass, including a new test asserting `MCPStartupFailed` details surface in the classified message.

- `cargo nextest run -p warp_cli` — 175/175 pass (clap arg definitions).
- `./script/format` and presubmit's `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` pass.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: By default, cloud agent runs now continue without configured MCP servers that fail to start within the 20s default startup window, instead of failing the run.

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)

Plan: https://staging.warp.dev/drive/notebook/ASfpNkdsDIpw6hkTsmooCo  
Conversation: https://staging.warp.dev/conversation/44d42331-9340-4dbe-9e87-276117c147cb