### PR TITLE
Add remote ripgrep search request support

### DIFF
--- a/app/src/remote_server/mod.rs
+++ b/app/src/remote_server/mod.rs
@@ -26,6 +26,8 @@ pub mod git_status_proto;
 #[cfg(not(target_family = "wasm"))]
 pub(crate) mod handoff_snapshot;
 #[cfg(not(target_family = "wasm"))]
+mod ripgrep_search;
+#[cfg(not(target_family = "wasm"))]
 pub mod server_buffer_tracker;
 #[cfg(not(target_family = "wasm"))]
 pub mod server_model;

--- a/app/src/remote_server/ripgrep_search.rs
+++ b/app/src/remote_server/ripgrep_search.rs
@@ -1,0 +1,131 @@
+use std::path::{Path, PathBuf};
+
+use futures::StreamExt as _;
+
+use super::proto::{
+    ripgrep_search_response, RipgrepSearchError, RipgrepSearchMatch, RipgrepSearchRequest,
+    RipgrepSearchResponse, RipgrepSearchSubmatch, RipgrepSearchSuccess,
+};
+
+/// Server-side cap on the number of matched lines returned by `RipgrepSearch`.
+const MAX_RIPGREP_SEARCH_MATCH_CAP: usize = 5_000;
+/// Approximate payload budget for one remote search response.
+///
+/// Eight MB keeps transfer latency and memory well below the protocol's
+/// 64 MB frame limit. Individual matches are never truncated because doing so
+/// could remove a late submatch and corrupt its preview and click location.
+const MAX_RIPGREP_SEARCH_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) struct RipgrepSearchParams {
+    pattern: String,
+    roots: Vec<PathBuf>,
+    ignore_case: bool,
+    multiline: bool,
+    match_cap: usize,
+}
+
+pub(super) fn validate_request(msg: RipgrepSearchRequest) -> Result<RipgrepSearchParams, String> {
+    if msg.pattern.is_empty() || msg.roots.is_empty() {
+        return Err("RipgrepSearch requires a pattern and at least one root".to_string());
+    }
+    if let Some(root) = msg.roots.iter().find(|root| !Path::new(root).is_absolute()) {
+        return Err(format!("RipgrepSearch root must be absolute: {root}"));
+    }
+
+    let roots = msg.roots.iter().map(PathBuf::from).collect();
+    let match_cap = match msg.max_matches as usize {
+        0 => MAX_RIPGREP_SEARCH_MATCH_CAP,
+        requested => requested.min(MAX_RIPGREP_SEARCH_MATCH_CAP),
+    };
+
+    Ok(RipgrepSearchParams {
+        pattern: msg.pattern,
+        roots,
+        ignore_case: msg.ignore_case,
+        multiline: msg.multiline,
+        match_cap,
+    })
+}
+
+pub(super) async fn run_search(
+    params: RipgrepSearchParams,
+) -> anyhow::Result<RipgrepSearchSuccess> {
+    let stream = warp_ripgrep::search::search_streaming(
+        std::slice::from_ref(&params.pattern),
+        &params.roots,
+        params.ignore_case,
+        params.multiline,
+    )?;
+    futures::pin_mut!(stream);
+
+    let mut matches = Vec::new();
+    let mut response_bytes: usize = 0;
+    let mut capped = false;
+    while let Some(m) = stream.next().await {
+        if matches.len() >= params.match_cap {
+            capped = true;
+            break;
+        }
+        let m = ripgrep_match_to_proto(m);
+        let match_bytes = m
+            .file_path
+            .len()
+            .saturating_add(m.line_text.len())
+            .saturating_add(
+                m.submatches
+                    .len()
+                    .saturating_mul(2 * std::mem::size_of::<u64>()),
+            );
+        if response_bytes.saturating_add(match_bytes) > MAX_RIPGREP_SEARCH_RESPONSE_BYTES {
+            capped = true;
+            break;
+        }
+
+        response_bytes += match_bytes;
+        matches.push(m);
+    }
+
+    Ok(RipgrepSearchSuccess { matches, capped })
+}
+
+pub(super) fn error_response(message: String) -> RipgrepSearchResponse {
+    RipgrepSearchResponse {
+        result: Some(ripgrep_search_response::Result::Error(RipgrepSearchError {
+            message,
+        })),
+    }
+}
+
+pub(super) fn search_result_to_response(
+    result: anyhow::Result<RipgrepSearchSuccess>,
+) -> RipgrepSearchResponse {
+    match result {
+        Ok(success) => RipgrepSearchResponse {
+            result: Some(ripgrep_search_response::Result::Success(success)),
+        },
+        Err(err) => error_response(format!("{err:#}")),
+    }
+}
+
+/// Converts a ripgrep match to its proto form without altering line text or
+/// submatch offsets. Response-wide caps bound payload size without corrupting
+/// individual matches.
+fn ripgrep_match_to_proto(m: warp_ripgrep::search::Match) -> RipgrepSearchMatch {
+    RipgrepSearchMatch {
+        file_path: m.file_path.to_string_lossy().to_string(),
+        line_number: m.line_number,
+        line_text: m.line_text,
+        submatches: m
+            .submatches
+            .into_iter()
+            .map(|submatch| RipgrepSearchSubmatch {
+                byte_start: submatch.byte_start.as_usize() as u64,
+                byte_end: submatch.byte_end.as_usize() as u64,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+#[path = "ripgrep_search_tests.rs"]
+mod tests;

--- a/app/src/remote_server/ripgrep_search_tests.rs
+++ b/app/src/remote_server/ripgrep_search_tests.rs
@@ -1,0 +1,49 @@
+use std::path::PathBuf;
+
+use string_offset::ByteOffset;
+use warp_ripgrep::search::{Match as RipgrepMatch, Submatch};
+
+use super::ripgrep_match_to_proto;
+
+fn submatch(start: usize, end: usize) -> Submatch {
+    Submatch {
+        byte_start: ByteOffset::from(start),
+        byte_end: ByteOffset::from(end),
+    }
+}
+
+#[test]
+fn ripgrep_match_to_proto_maps_fields() {
+    let m = RipgrepMatch {
+        file_path: PathBuf::from("/repo/src/main.rs"),
+        line_number: 42,
+        line_text: "fn main() {}".to_string(),
+        submatches: vec![submatch(3, 7)],
+    };
+
+    let proto = ripgrep_match_to_proto(m);
+
+    assert_eq!(proto.file_path, "/repo/src/main.rs");
+    assert_eq!(proto.line_number, 42);
+    assert_eq!(proto.line_text, "fn main() {}");
+    assert_eq!(proto.submatches.len(), 1);
+    assert_eq!(proto.submatches[0].byte_start, 3);
+    assert_eq!(proto.submatches[0].byte_end, 7);
+}
+
+#[test]
+fn ripgrep_match_to_proto_preserves_late_submatch_and_full_line() {
+    let line = format!("{}needle", "x".repeat(8_000));
+    let m = RipgrepMatch {
+        file_path: PathBuf::from("/repo/long.rs"),
+        line_number: 1,
+        line_text: line.clone(),
+        submatches: vec![submatch(8_000, 8_006)],
+    };
+
+    let proto = ripgrep_match_to_proto(m);
+
+    assert_eq!(proto.line_text, line);
+    assert_eq!(proto.submatches[0].byte_start, 8_000);
+    assert_eq!(proto.submatches[0].byte_end, 8_006);
+}

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -10,6 +10,7 @@ use ::ai::index::full_source_code_embedding::manager::{
 use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
+use futures::StreamExt as _;
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
@@ -38,9 +39,10 @@ use super::proto::{
     get_fragment_metadata_from_hash_response, git_commit_chain_response, git_create_pr_response,
     git_generate_commit_message_response, git_get_committed_branch_files_response,
     git_push_response, host_scoped_request, notification, resolve_conflict_response,
-    run_command_response, save_buffer_response, server_message, session_scoped_request,
-    write_file_response, Abort, Authenticate, BranchInfo, BufferEdit, BufferUpdatedPush,
-    BundledSkillProto, BundledSkillsSnapshot, ClientMessage, CloseBuffer, CodebaseIndexLimits,
+    ripgrep_search_response, run_command_response, save_buffer_response, server_message,
+    session_scoped_request, write_file_response, Abort, Authenticate, BranchInfo, BufferEdit,
+    BufferUpdatedPush, BundledSkillProto, BundledSkillsSnapshot, ClientMessage, CloseBuffer,
+    CodebaseIndexLimits,
     CodebaseIndexStatus, CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot,
     CodebaseResyncMode, DeleteFile, DeleteFileResponse, DeleteFileSuccess, DiscardFilesError,
     DiscardFilesResponse, DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse,
@@ -58,10 +60,12 @@ use super::proto::{
     InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
     NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
     ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, ResyncCodebase,
-    RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess,
-    SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped,
-    TextEdit, UpdateGitHubPrInfo, UpdateGitHubRepoInfo, UpdateGitStatus, UploadHandoffSnapshot,
-    WriteFile, WriteFileResponse, WriteFileSuccess,
+    RipgrepSearchError, RipgrepSearchMatch, RipgrepSearchRequest, RipgrepSearchResponse,
+    RipgrepSearchSubmatch, RipgrepSearchSuccess, RunCommandError, RunCommandErrorCode,
+    RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
+    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, UpdateGitHubPrInfo,
+    UpdateGitHubRepoInfo, UpdateGitStatus, UploadHandoffSnapshot, WriteFile, WriteFileResponse,
+    WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
@@ -79,6 +83,15 @@ pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 
 /// Prevents a client from forcing the daemon to enumerate an arbitrarily
 /// large ref list.
 const MAX_BRANCH_COUNT_CAP: usize = 500;
+
+/// Server-side cap on the number of matched lines returned by `RipgrepSearch`.
+const MAX_RIPGREP_SEARCH_MATCH_CAP: usize = 5_000;
+/// Approximate payload budget for one remote search response.
+///
+/// Eight MB keeps transfer latency and memory well below the protocol's
+/// 64 MB frame limit. Individual matches are never truncated because doing so
+/// could remove a late submatch and corrupt its preview and click location.
+const MAX_RIPGREP_SEARCH_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
 
 /// Unique identifier for a connected proxy session in daemon mode.
 pub type ConnectionId = uuid::Uuid;
@@ -858,6 +871,9 @@ impl ServerModel {
                     }
                     Some(host_scoped_request::Message::GitGetCommittedBranchFiles(m)) => {
                         self.handle_get_committed_branch_files(m, &request_id, conn_id, ctx)
+                    }
+                    Some(host_scoped_request::Message::RipgrepSearch(m)) => {
+                        self.handle_ripgrep_search(m, &request_id, conn_id, ctx)
                     }
                     None => {
                         log::warn!(
@@ -2878,6 +2894,110 @@ impl ServerModel {
         HandlerOutcome::Async(Some(handle))
     }
 
+    /// Handles `RipgrepSearch` — request/response backing global search in
+    /// remote sessions.
+    ///
+    /// Runs the same ripgrep subprocess used by local global search (the
+    /// daemon binary includes the `ripgrep-search` worker subcommand) over
+    /// the requested roots and responds with all matches once the search
+    /// completes, capped to bound response size. Cancellable via `Abort`
+    /// like other async handlers.
+    fn handle_ripgrep_search(
+        &mut self,
+        msg: RipgrepSearchRequest,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        log::info!(
+            "Handling RipgrepSearch ({} roots, request_id={request_id})",
+            msg.roots.len()
+        );
+
+        if msg.pattern.is_empty() || msg.roots.is_empty() {
+            return ripgrep_search_error_response(
+                "RipgrepSearch requires a pattern and at least one root".to_string(),
+            );
+        }
+        if let Some(root) = msg.roots.iter().find(|root| !Path::new(root).is_absolute()) {
+            return ripgrep_search_error_response(format!(
+                "RipgrepSearch root must be absolute: {root}"
+            ));
+        }
+
+        let roots: Vec<PathBuf> = msg.roots.iter().map(PathBuf::from).collect();
+        let match_cap = match msg.max_matches as usize {
+            0 => MAX_RIPGREP_SEARCH_MATCH_CAP,
+            requested => requested.min(MAX_RIPGREP_SEARCH_MATCH_CAP),
+        };
+        let pattern = msg.pattern;
+        let ignore_case = msg.ignore_case;
+        let multiline = msg.multiline;
+
+        let request_id_for_response = request_id.clone();
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move {
+                let stream = warp_ripgrep::search::search_streaming(
+                    std::slice::from_ref(&pattern),
+                    &roots,
+                    ignore_case,
+                    multiline,
+                )?;
+                futures::pin_mut!(stream);
+
+                let mut matches = Vec::new();
+                let mut response_bytes: usize = 0;
+                let mut capped = false;
+                while let Some(m) = stream.next().await {
+                    if matches.len() >= match_cap {
+                        capped = true;
+                        break;
+                    }
+                    let m = ripgrep_match_to_proto(m);
+                    let match_bytes = m
+                        .file_path
+                        .len()
+                        .saturating_add(m.line_text.len())
+                        .saturating_add(
+                            m.submatches
+                                .len()
+                                .saturating_mul(2 * std::mem::size_of::<u64>()),
+                        );
+                    if response_bytes.saturating_add(match_bytes)
+                        > MAX_RIPGREP_SEARCH_RESPONSE_BYTES
+                    {
+                        capped = true;
+                        break;
+                    }
+
+                    response_bytes += match_bytes;
+                    matches.push(m);
+                }
+                anyhow::Ok(RipgrepSearchSuccess { matches, capped })
+            },
+            move |me, result: anyhow::Result<RipgrepSearchSuccess>, _ctx| {
+                let response = match result {
+                    Ok(success) => RipgrepSearchResponse {
+                        result: Some(ripgrep_search_response::Result::Success(success)),
+                    },
+                    Err(err) => RipgrepSearchResponse {
+                        result: Some(ripgrep_search_response::Result::Error(RipgrepSearchError {
+                            message: format!("{err:#}"),
+                        })),
+                    },
+                };
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::RipgrepSearchResponse(response),
+                );
+            },
+            ctx,
+        );
+        HandlerOutcome::Async(Some(handle))
+    }
+
     /// Handles `DiscardFilesRequest` — request/response.
     ///
     /// Runs git restore/stash on the remote filesystem for the specified files.
@@ -3586,6 +3706,35 @@ fn invalid_request_response(message: String) -> HandlerOutcome {
         code: ErrorCode::InvalidRequest.into(),
         message,
     }))
+}
+
+fn ripgrep_search_error_response(message: String) -> HandlerOutcome {
+    HandlerOutcome::Sync(server_message::Message::RipgrepSearchResponse(
+        RipgrepSearchResponse {
+            result: Some(ripgrep_search_response::Result::Error(RipgrepSearchError {
+                message,
+            })),
+        },
+    ))
+}
+
+/// Converts a ripgrep match to its proto form without altering line text or
+/// submatch offsets. Response-wide caps bound payload size without corrupting
+/// individual matches.
+fn ripgrep_match_to_proto(m: warp_ripgrep::search::Match) -> RipgrepSearchMatch {
+    RipgrepSearchMatch {
+        file_path: m.file_path.to_string_lossy().to_string(),
+        line_number: m.line_number,
+        line_text: m.line_text,
+        submatches: m
+            .submatches
+            .into_iter()
+            .map(|submatch| RipgrepSearchSubmatch {
+                byte_start: submatch.byte_start.as_usize() as u64,
+                byte_end: submatch.byte_end.as_usize() as u64,
+            })
+            .collect(),
+    }
 }
 
 fn codebase_index_status_response(status: CodebaseIndexStatus) -> HandlerOutcome {

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -10,7 +10,6 @@ use ::ai::index::full_source_code_embedding::manager::{
 use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
-use futures::StreamExt as _;
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
@@ -30,7 +29,6 @@ use super::codebase_index_status::{
     not_enabled_codebase_index_status, queued_codebase_index_status,
     unavailable_codebase_index_status,
 };
-use super::diff_state_proto;
 use super::diff_state_tracker::{
     DiffModelKey, DiffStateUpdate, RemoteDiffStateManager, SubscribeOutcome,
 };
@@ -39,10 +37,9 @@ use super::proto::{
     get_fragment_metadata_from_hash_response, git_commit_chain_response, git_create_pr_response,
     git_generate_commit_message_response, git_get_committed_branch_files_response,
     git_push_response, host_scoped_request, notification, resolve_conflict_response,
-    ripgrep_search_response, run_command_response, save_buffer_response, server_message,
-    session_scoped_request, write_file_response, Abort, Authenticate, BranchInfo, BufferEdit,
-    BufferUpdatedPush, BundledSkillProto, BundledSkillsSnapshot, ClientMessage, CloseBuffer,
-    CodebaseIndexLimits,
+    run_command_response, save_buffer_response, server_message, session_scoped_request,
+    write_file_response, Abort, Authenticate, BranchInfo, BufferEdit, BufferUpdatedPush,
+    BundledSkillProto, BundledSkillsSnapshot, ClientMessage, CloseBuffer, CodebaseIndexLimits,
     CodebaseIndexStatus, CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot,
     CodebaseResyncMode, DeleteFile, DeleteFileResponse, DeleteFileSuccess, DiscardFilesError,
     DiscardFilesResponse, DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse,
@@ -60,14 +57,13 @@ use super::proto::{
     InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
     NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
     ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, ResyncCodebase,
-    RipgrepSearchError, RipgrepSearchMatch, RipgrepSearchRequest, RipgrepSearchResponse,
-    RipgrepSearchSubmatch, RipgrepSearchSuccess, RunCommandError, RunCommandErrorCode,
-    RunCommandRequest, RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse,
-    SaveBufferSuccess, ServerMessage, SessionBootstrapped, TextEdit, UpdateGitHubPrInfo,
-    UpdateGitHubRepoInfo, UpdateGitStatus, UploadHandoffSnapshot, WriteFile, WriteFileResponse,
-    WriteFileSuccess,
+    RipgrepSearchRequest, RunCommandError, RunCommandErrorCode, RunCommandRequest,
+    RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess,
+    ServerMessage, SessionBootstrapped, TextEdit, UpdateGitHubPrInfo, UpdateGitHubRepoInfo,
+    UpdateGitStatus, UploadHandoffSnapshot, WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
+use super::{diff_state_proto, ripgrep_search};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
 use crate::code_review::diff_state::{CommitChainMode, DiffMode, FileStatusInfo};
 use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusModel};
@@ -83,15 +79,6 @@ pub const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10 
 /// Prevents a client from forcing the daemon to enumerate an arbitrarily
 /// large ref list.
 const MAX_BRANCH_COUNT_CAP: usize = 500;
-
-/// Server-side cap on the number of matched lines returned by `RipgrepSearch`.
-const MAX_RIPGREP_SEARCH_MATCH_CAP: usize = 5_000;
-/// Approximate payload budget for one remote search response.
-///
-/// Eight MB keeps transfer latency and memory well below the protocol's
-/// 64 MB frame limit. Individual matches are never truncated because doing so
-/// could remove a late submatch and corrupt its preview and click location.
-const MAX_RIPGREP_SEARCH_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
 
 /// Unique identifier for a connected proxy session in daemon mode.
 pub type ConnectionId = uuid::Uuid;
@@ -2914,79 +2901,21 @@ impl ServerModel {
             msg.roots.len()
         );
 
-        if msg.pattern.is_empty() || msg.roots.is_empty() {
-            return ripgrep_search_error_response(
-                "RipgrepSearch requires a pattern and at least one root".to_string(),
-            );
-        }
-        if let Some(root) = msg.roots.iter().find(|root| !Path::new(root).is_absolute()) {
-            return ripgrep_search_error_response(format!(
-                "RipgrepSearch root must be absolute: {root}"
-            ));
-        }
-
-        let roots: Vec<PathBuf> = msg.roots.iter().map(PathBuf::from).collect();
-        let match_cap = match msg.max_matches as usize {
-            0 => MAX_RIPGREP_SEARCH_MATCH_CAP,
-            requested => requested.min(MAX_RIPGREP_SEARCH_MATCH_CAP),
+        let params = match ripgrep_search::validate_request(msg) {
+            Ok(params) => params,
+            Err(message) => {
+                return HandlerOutcome::Sync(server_message::Message::RipgrepSearchResponse(
+                    ripgrep_search::error_response(message),
+                ));
+            }
         };
-        let pattern = msg.pattern;
-        let ignore_case = msg.ignore_case;
-        let multiline = msg.multiline;
 
         let request_id_for_response = request_id.clone();
         let handle = self.spawn_request_handler(
             request_id.clone(),
-            async move {
-                let stream = warp_ripgrep::search::search_streaming(
-                    std::slice::from_ref(&pattern),
-                    &roots,
-                    ignore_case,
-                    multiline,
-                )?;
-                futures::pin_mut!(stream);
-
-                let mut matches = Vec::new();
-                let mut response_bytes: usize = 0;
-                let mut capped = false;
-                while let Some(m) = stream.next().await {
-                    if matches.len() >= match_cap {
-                        capped = true;
-                        break;
-                    }
-                    let m = ripgrep_match_to_proto(m);
-                    let match_bytes = m
-                        .file_path
-                        .len()
-                        .saturating_add(m.line_text.len())
-                        .saturating_add(
-                            m.submatches
-                                .len()
-                                .saturating_mul(2 * std::mem::size_of::<u64>()),
-                        );
-                    if response_bytes.saturating_add(match_bytes)
-                        > MAX_RIPGREP_SEARCH_RESPONSE_BYTES
-                    {
-                        capped = true;
-                        break;
-                    }
-
-                    response_bytes += match_bytes;
-                    matches.push(m);
-                }
-                anyhow::Ok(RipgrepSearchSuccess { matches, capped })
-            },
-            move |me, result: anyhow::Result<RipgrepSearchSuccess>, _ctx| {
-                let response = match result {
-                    Ok(success) => RipgrepSearchResponse {
-                        result: Some(ripgrep_search_response::Result::Success(success)),
-                    },
-                    Err(err) => RipgrepSearchResponse {
-                        result: Some(ripgrep_search_response::Result::Error(RipgrepSearchError {
-                            message: format!("{err:#}"),
-                        })),
-                    },
-                };
+            async move { ripgrep_search::run_search(params).await },
+            move |me, result, _ctx| {
+                let response = ripgrep_search::search_result_to_response(result);
                 me.send_server_message(
                     Some(conn_id),
                     Some(&request_id_for_response),
@@ -3706,35 +3635,6 @@ fn invalid_request_response(message: String) -> HandlerOutcome {
         code: ErrorCode::InvalidRequest.into(),
         message,
     }))
-}
-
-fn ripgrep_search_error_response(message: String) -> HandlerOutcome {
-    HandlerOutcome::Sync(server_message::Message::RipgrepSearchResponse(
-        RipgrepSearchResponse {
-            result: Some(ripgrep_search_response::Result::Error(RipgrepSearchError {
-                message,
-            })),
-        },
-    ))
-}
-
-/// Converts a ripgrep match to its proto form without altering line text or
-/// submatch offsets. Response-wide caps bound payload size without corrupting
-/// individual matches.
-fn ripgrep_match_to_proto(m: warp_ripgrep::search::Match) -> RipgrepSearchMatch {
-    RipgrepSearchMatch {
-        file_path: m.file_path.to_string_lossy().to_string(),
-        line_number: m.line_number,
-        line_text: m.line_text,
-        submatches: m
-            .submatches
-            .into_iter()
-            .map(|submatch| RipgrepSearchSubmatch {
-                byte_start: submatch.byte_start.as_usize() as u64,
-                byte_end: submatch.byte_end.as_usize() as u64,
-            })
-            .collect(),
-    }
 }
 
 fn codebase_index_status_response(status: CodebaseIndexStatus) -> HandlerOutcome {

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
-use string_offset::ByteOffset;
-use warp_ripgrep::search::{Match as RipgrepMatch, Submatch};
 use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
@@ -14,7 +11,7 @@ use super::super::proto::{
 };
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{ripgrep_match_to_proto, ConnectionId, PendingFileOps, ServerModel};
+use super::{ConnectionId, PendingFileOps, ServerModel};
 use crate::auth::auth_state::AuthState;
 use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
@@ -439,51 +436,6 @@ fn host_scoped_response_fails_over_when_target_missing() {
         assert_eq!(received.request_id, request_id.to_string());
         assert!(!model.host_scoped_requests.contains_key(&request_id));
     });
-}
-
-// ── Ripgrep search match conversion ──────────────────────────────────
-
-fn submatch(start: usize, end: usize) -> Submatch {
-    Submatch {
-        byte_start: ByteOffset::from(start),
-        byte_end: ByteOffset::from(end),
-    }
-}
-
-#[test]
-fn ripgrep_match_to_proto_maps_fields() {
-    let m = RipgrepMatch {
-        file_path: PathBuf::from("/repo/src/main.rs"),
-        line_number: 42,
-        line_text: "fn main() {}".to_string(),
-        submatches: vec![submatch(3, 7)],
-    };
-
-    let proto = ripgrep_match_to_proto(m);
-
-    assert_eq!(proto.file_path, "/repo/src/main.rs");
-    assert_eq!(proto.line_number, 42);
-    assert_eq!(proto.line_text, "fn main() {}");
-    assert_eq!(proto.submatches.len(), 1);
-    assert_eq!(proto.submatches[0].byte_start, 3);
-    assert_eq!(proto.submatches[0].byte_end, 7);
-}
-
-#[test]
-fn ripgrep_match_to_proto_preserves_late_submatch_and_full_line() {
-    let line = format!("{}needle", "x".repeat(8_000));
-    let m = RipgrepMatch {
-        file_path: PathBuf::from("/repo/long.rs"),
-        line_number: 1,
-        line_text: line.clone(),
-        submatches: vec![submatch(8_000, 8_006)],
-    };
-
-    let proto = ripgrep_match_to_proto(m);
-
-    assert_eq!(proto.line_text, line);
-    assert_eq!(proto.submatches[0].byte_start, 8_000);
-    assert_eq!(proto.submatches[0].byte_end, 8_006);
 }
 
 #[test]

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use string_offset::ByteOffset;
+use warp_ripgrep::search::{Match as RipgrepMatch, Submatch};
 use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 
@@ -11,7 +14,7 @@ use super::super::proto::{
 };
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
-use super::{ConnectionId, PendingFileOps, ServerModel};
+use super::{ripgrep_match_to_proto, ConnectionId, PendingFileOps, ServerModel};
 use crate::auth::auth_state::AuthState;
 use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
@@ -436,6 +439,51 @@ fn host_scoped_response_fails_over_when_target_missing() {
         assert_eq!(received.request_id, request_id.to_string());
         assert!(!model.host_scoped_requests.contains_key(&request_id));
     });
+}
+
+// ── Ripgrep search match conversion ──────────────────────────────────
+
+fn submatch(start: usize, end: usize) -> Submatch {
+    Submatch {
+        byte_start: ByteOffset::from(start),
+        byte_end: ByteOffset::from(end),
+    }
+}
+
+#[test]
+fn ripgrep_match_to_proto_maps_fields() {
+    let m = RipgrepMatch {
+        file_path: PathBuf::from("/repo/src/main.rs"),
+        line_number: 42,
+        line_text: "fn main() {}".to_string(),
+        submatches: vec![submatch(3, 7)],
+    };
+
+    let proto = ripgrep_match_to_proto(m);
+
+    assert_eq!(proto.file_path, "/repo/src/main.rs");
+    assert_eq!(proto.line_number, 42);
+    assert_eq!(proto.line_text, "fn main() {}");
+    assert_eq!(proto.submatches.len(), 1);
+    assert_eq!(proto.submatches[0].byte_start, 3);
+    assert_eq!(proto.submatches[0].byte_end, 7);
+}
+
+#[test]
+fn ripgrep_match_to_proto_preserves_late_submatch_and_full_line() {
+    let line = format!("{}needle", "x".repeat(8_000));
+    let m = RipgrepMatch {
+        file_path: PathBuf::from("/repo/long.rs"),
+        line_number: 1,
+        line_text: line.clone(),
+        submatches: vec![submatch(8_000, 8_006)],
+    };
+
+    let proto = ripgrep_match_to_proto(m);
+
+    assert_eq!(proto.line_text, line);
+    assert_eq!(proto.submatches[0].byte_start, 8_000);
+    assert_eq!(proto.submatches[0].byte_end, 8_006);
 }
 
 #[test]

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -48,6 +48,7 @@ message HostScopedRequest {
     GitCreatePrRequest git_create_pr = 17;
     GitGenerateCommitMessageRequest git_generate_commit_message = 18;
     GitGetCommittedBranchFilesRequest git_get_committed_branch_files = 19;
+    RipgrepSearchRequest ripgrep_search = 21;
   }
 }
 
@@ -123,6 +124,7 @@ message ServerMessage {
     GitStatusPush git_status_push = 34;
     GitHubPrInfoPush github_pr_info_push = 35;
     GitHubRepositoryInfoPush github_repository_info_push = 36;
+    RipgrepSearchResponse ripgrep_search_response = 37;
   }
 }
 
@@ -433,6 +435,56 @@ message FileContextProto {
   optional uint32 line_range_end = 5;
   optional uint64 last_modified_epoch_millis = 6;
   uint32 line_count = 7;
+}
+
+// ── Ripgrep search (global search) ────────────────────────────────
+
+// Client → server: run a ripgrep search over the given root directories
+// on the host. Used by global search for remote sessions.
+message RipgrepSearchRequest {
+  // Regex pattern. Already escaped client-side for literal (non-regex)
+  // searches, matching local global search behavior.
+  string pattern = 1;
+  // Absolute directories on the host to search.
+  repeated string roots = 2;
+  bool ignore_case = 3;
+  bool multiline = 4;
+  // Maximum number of matched lines to return. The server also applies its
+  // own match and approximate payload caps.
+  uint32 max_matches = 5;
+}
+
+// Server → client: result of a RipgrepSearchRequest.
+message RipgrepSearchResponse {
+  oneof result {
+    RipgrepSearchSuccess success = 1;
+    RipgrepSearchError error = 2;
+  }
+}
+
+message RipgrepSearchSuccess {
+  repeated RipgrepSearchMatch matches = 1;
+  // True when the search stopped early because the match cap was reached.
+  bool capped = 2;
+}
+
+message RipgrepSearchError {
+  string message = 1;
+}
+
+// A single matched line in a file. A line may contain multiple submatches;
+// the client expands them into per-submatch result rows.
+message RipgrepSearchMatch {
+  string file_path = 1;
+  uint32 line_number = 2;
+  string line_text = 3;
+  repeated RipgrepSearchSubmatch submatches = 4;
+}
+
+// Byte offsets into `line_text` for one submatch (end exclusive).
+message RipgrepSearchSubmatch {
+  uint64 byte_start = 1;
+  uint64 byte_end = 2;
 }
 
 // ── Remote codebase indexing status ───────────────────────────────

--- a/crates/remote_server/src/host_response_tests.rs
+++ b/crates/remote_server/src/host_response_tests.rs
@@ -166,6 +166,7 @@ fn every_host_scoped_request_has_a_response_disposition() {
             M::GitCreatePr(_) => "manager::create_pr",
             M::GitGenerateCommitMessage(_) => "manager::generate_commit_message",
             M::GitGetCommittedBranchFiles(_) => "manager::get_committed_branch_files",
+            M::RipgrepSearch(_) => "manager::start_ripgrep_search",
         }
     }
 

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -754,6 +754,10 @@ pub enum HostRequestError {
     /// server-provided message verbatim so callers can surface it directly.
     #[error("{0}")]
     OperationFailed(String),
+    /// The request was cancelled client-side via
+    /// [`RemoteServerManager::abort_host_request`].
+    #[error("host request aborted")]
+    Aborted,
 }
 
 impl From<crate::client::ClientError> for HostRequestError {
@@ -805,6 +809,55 @@ impl PendingHostRequest {
     fn cancel_timeout(&self) {
         if let Some(abort) = &self.timeout_abort {
             abort.abort();
+        }
+    }
+}
+
+/// A host-scoped remote ripgrep search registered synchronously with
+/// [`RemoteServerManager`], whose typed result can be awaited off-thread.
+///
+/// Synchronous registration is important for query cancellation: by the time
+/// this value is returned, [`RemoteServerManager::abort_host_request`] can
+/// always find the request instead of racing an asynchronously queued
+/// registration task.
+#[must_use = "pending remote searches must be awaited or aborted by request id"]
+pub struct PendingRipgrepSearch {
+    request_id: crate::protocol::RequestId,
+    response: oneshot::Receiver<Result<crate::proto::ServerMessage, HostRequestError>>,
+}
+
+impl PendingRipgrepSearch {
+    pub fn request_id(&self) -> &crate::protocol::RequestId {
+        &self.request_id
+    }
+
+    pub async fn result(self) -> Result<crate::proto::RipgrepSearchSuccess, HostRequestError> {
+        let msg = self
+            .response
+            .await
+            .map_err(|_| HostRequestError::AllSessionsDisconnected)??;
+        ripgrep_search_result(msg)
+    }
+}
+
+fn ripgrep_search_result(
+    msg: crate::proto::ServerMessage,
+) -> Result<crate::proto::RipgrepSearchSuccess, HostRequestError> {
+    match msg.message {
+        Some(crate::proto::server_message::Message::RipgrepSearchResponse(resp)) => {
+            match resp.result {
+                Some(crate::proto::ripgrep_search_response::Result::Success(success)) => {
+                    Ok(success)
+                }
+                Some(crate::proto::ripgrep_search_response::Result::Error(error)) => {
+                    Err(HostRequestError::OperationFailed(error.message))
+                }
+                None => Err(HostRequestError::UnexpectedResponse),
+            }
+        }
+        other => {
+            log::error!("Unexpected response variant for RipgrepSearch: {other:?}");
+            Err(HostRequestError::UnexpectedResponse)
         }
     }
 }
@@ -1539,6 +1592,48 @@ impl RemoteServerManager {
             client.abort_request(&request_id);
         }
         let _ = pending.result_tx.send(Err(HostRequestError::Timeout));
+    }
+
+    /// Registers a remote ripgrep request synchronously and returns its typed
+    /// pending result. Global search uses this instead of `HostRequestHandle`
+    /// so query cancellation cannot race request registration.
+    pub fn start_ripgrep_search(
+        &mut self,
+        host_id: &HostId,
+        request: crate::proto::RipgrepSearchRequest,
+    ) -> PendingRipgrepSearch {
+        let request_id = crate::protocol::RequestId::new();
+        let msg = crate::proto::ClientMessage::host_scoped(
+            request_id.to_string(),
+            crate::proto::host_scoped_request::Message::RipgrepSearch(request),
+        );
+        let response = self.send_host_request(host_id, msg);
+        PendingRipgrepSearch {
+            request_id,
+            response,
+        }
+    }
+
+    /// Aborts a pending host-scoped request: resolves the caller with
+    /// [`HostRequestError::Aborted`], cancels its timeout timer, and sends a
+    /// best-effort `Abort` notification so the daemon stops work. No-op if
+    /// the request already resolved (response arrived, timed out, or all
+    /// sessions disconnected).
+    pub fn abort_host_request(&mut self, request_id: &crate::protocol::RequestId) {
+        let Some(pending) = self.pending_host_requests.remove(request_id) else {
+            return;
+        };
+        pending.cancel_timeout();
+        log::info!(
+            "Aborting host-scoped request: host={} request_id={request_id}",
+            pending.host_id
+        );
+        // Best-effort daemon-side cancellation. The connection may already
+        // be gone, in which case this is a no-op.
+        if let Some(client) = self.client_for_host(&pending.host_id) {
+            client.abort_request(request_id);
+        }
+        let _ = pending.result_tx.send(Err(HostRequestError::Aborted));
     }
 
     /// Convenience wrapper: constructs a `ClientMessage::host_scoped` from
@@ -2603,7 +2698,8 @@ impl RemoteServerManager {
                             HostRequestError::Timeout => RemoteServerErrorKind::Timeout,
                             HostRequestError::ServerError { .. }
                             | HostRequestError::OperationFailed(_) => RemoteServerErrorKind::ServerError,
-                            HostRequestError::UnexpectedResponse => RemoteServerErrorKind::Other,
+                            HostRequestError::UnexpectedResponse
+                            | HostRequestError::Aborted => RemoteServerErrorKind::Other,
                         };
                         let _ = spawner
                             .spawn(move |_me, ctx| {
@@ -3964,3 +4060,7 @@ impl RemoteServerManager {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "manager_tests.rs"]
+mod tests;

--- a/crates/remote_server/src/manager_tests.rs
+++ b/crates/remote_server/src/manager_tests.rs
@@ -1,0 +1,70 @@
+use futures::channel::oneshot;
+use warp_core::SessionId;
+use warpui_core::App;
+
+use super::{HostRequestError, PendingHostRequest, RemoteServerManager};
+use crate::proto::{host_scoped_request, ClientMessage, RipgrepSearchRequest, WriteFile};
+use crate::protocol::RequestId;
+use crate::HostId;
+
+#[test]
+fn abort_host_request_removes_pending_request_and_resolves_caller() {
+    App::test((), |mut app| async move {
+        let manager = app.add_model(RemoteServerManager::new);
+        let host_id = HostId::new("test-host".to_string());
+        let request_id = RequestId::new();
+        let (result_tx, result_rx) = oneshot::channel();
+        let msg = ClientMessage::host_scoped(
+            request_id.to_string(),
+            host_scoped_request::Message::WriteFile(WriteFile {
+                path: "/tmp/test".to_string(),
+                content: String::new(),
+            }),
+        );
+
+        manager.update(&mut app, |manager, _ctx| {
+            manager.pending_host_requests.insert(
+                request_id.clone(),
+                PendingHostRequest {
+                    host_id,
+                    dispatched_session_id: SessionId::from(1),
+                    msg,
+                    result_tx,
+                    timeout_abort: None,
+                },
+            );
+            manager.abort_host_request(&request_id);
+            assert!(!manager.pending_host_requests.contains_key(&request_id));
+        });
+
+        assert!(matches!(
+            result_rx.await.expect("manager should resolve caller"),
+            Err(HostRequestError::Aborted)
+        ));
+    });
+}
+
+#[test]
+fn start_ripgrep_search_without_connected_host_resolves_immediately() {
+    App::test((), |mut app| async move {
+        let manager = app.add_model(RemoteServerManager::new);
+        let host_id = HostId::new("missing-host".to_string());
+        let pending = manager.update(&mut app, |manager, _ctx| {
+            manager.start_ripgrep_search(
+                &host_id,
+                RipgrepSearchRequest {
+                    pattern: "needle".to_string(),
+                    roots: vec!["/repo".to_string()],
+                    ignore_case: false,
+                    multiline: false,
+                    max_matches: 100,
+                },
+            )
+        });
+
+        assert!(matches!(
+            pending.result().await,
+            Err(HostRequestError::AllSessionsDisconnected)
+        ));
+    });
+}


### PR DESCRIPTION
## Description

Base PR (1/2) for remote global search.

`app/src/remote_server/server_model.rs` is the main logic change, I tried to add comments to break it down and explain what it's doing.

Adds a bounded, cancellable host-scoped remote-server API for running `warp_ripgrep` on a remote host. The daemon preserves complete matches, caps responses at 5,000 raw matched lines and an approximate 8 MB payload budget, and registers requests synchronously so callers can deterministically cancel stale searches.

The user-facing global search integration is in the stacked follow-up PR.

- Stacked PR: https://github.com/warpdotdev/warp/pull/12477
- Plan: https://staging.warp.dev/drive/notebook/Dt2dvso69qyHPyIc0TRdxS
- Agent conversation: https://staging.warp.dev/conversation/71ba0eaa-6bf6-4c0e-9c27-427ec2f3eaa5

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format`
- `cargo nextest run -p remote_server` — 89 passed
- `cargo nextest run -p warp -E 'test(global_search) or test(ripgrep_match_to_proto) or test(host_scoped_response)'` — 10 passed
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)