### PR TITLE
Enable global search in remote sessions

### DIFF
--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -531,7 +531,7 @@ impl CodeView {
                 );
             }
             LocalCodeEditorEvent::FileSaved => {
-                me.sync_active_tab_path(ctx);
+                me.sync_active_tab_location(ctx);
                 me.set_title_after_content_update(ctx);
                 CodeView::display_save_success(ctx.window_id(), ctx);
                 ctx.notify();
@@ -990,16 +990,11 @@ impl CodeView {
         self.set_title(self.contains_unsaved_changes(ctx), ctx);
     }
 
-    /// Update the TabData path for the active tab to match the LocalCodeEditor metadata.
-    /// This is needed after save_as operations to keep the paths in sync.
-    fn sync_active_tab_path(&mut self, ctx: &mut ViewContext<Self>) {
+    /// Update the TabData location for the active tab to match the LocalCodeEditor metadata.
+    /// This is needed after save operations to keep local and remote locations in sync.
+    fn sync_active_tab_location(&mut self, ctx: &mut ViewContext<Self>) {
         if let Some(tab) = self.tab_group.get_mut(self.active_tab_index) {
-            let new_path = tab
-                .editor_view
-                .as_ref(ctx)
-                .file_path()
-                .map(|p| LocalOrRemotePath::Local(p.to_path_buf()));
-            tab.location = new_path;
+            tab.location = tab.editor_view.as_ref(ctx).file_location().cloned();
         }
     }
 

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1587,6 +1587,19 @@ pub enum TelemetryEvent {
     },
     GlobalSearchOpened,
     GlobalSearchQueryStarted,
+    GlobalSearchQueryCompleted {
+        duration_ms: u64,
+        /// Number of distinct remote hosts searched via the remote server
+        /// daemon (0 for purely local searches).
+        remote_host_count: usize,
+        total_match_count: usize,
+        /// Whether the result set was capped (locally or by a remote
+        /// server-side cap).
+        capped: bool,
+        /// Number of search sources (local, or one per remote host) that
+        /// failed while the others completed.
+        source_failures: usize,
+    },
     AICommandSearchOpened {
         entrypoint: AICommandSearchEntrypoint,
     },
@@ -4230,6 +4243,19 @@ impl TelemetryEvent {
             | TelemetryEvent::GlobalSearchOpened
             | TelemetryEvent::GlobalSearchQueryStarted
             | TelemetryEvent::GetStartedSkipToTerminal => None,
+            TelemetryEvent::GlobalSearchQueryCompleted {
+                duration_ms,
+                remote_host_count,
+                total_match_count,
+                capped,
+                source_failures,
+            } => Some(json!({
+                "duration_ms": duration_ms,
+                "remote_host_count": remote_host_count,
+                "total_match_count": total_match_count,
+                "capped": capped,
+                "source_failures": source_failures,
+            })),
             TelemetryEvent::SSHControlMasterError { has_remote_server } => Some(json!({
                 "has_remote_server": has_remote_server,
             })),
@@ -4953,6 +4979,7 @@ impl TelemetryEvent {
             | TelemetryEvent::KeybindingsPageOpened
             | TelemetryEvent::GlobalSearchOpened
             | TelemetryEvent::GlobalSearchQueryStarted
+            | TelemetryEvent::GlobalSearchQueryCompleted { .. }
             | TelemetryEvent::CommandSearchOpened { .. }
             | TelemetryEvent::CommandSearchExited { .. }
             | TelemetryEvent::CommandSearchResultAccepted { .. }
@@ -5511,6 +5538,7 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::KeybindingsPageOpened => EnablementState::Always,
             Self::GlobalSearchOpened => EnablementState::Always,
             Self::GlobalSearchQueryStarted => EnablementState::Always,
+            Self::GlobalSearchQueryCompleted => EnablementState::Always,
             Self::CommandSearchOpened => EnablementState::Always,
             Self::CommandSearchExited => EnablementState::Always,
             Self::CommandSearchResultAccepted => EnablementState::Always,
@@ -6009,6 +6037,7 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::KeybindingsPageOpened => "Resource Center Keybindings Page Opened",
             Self::GlobalSearchOpened => "Global Search Opened",
             Self::GlobalSearchQueryStarted => "Global Search Query Started",
+            Self::GlobalSearchQueryCompleted => "Global Search Query Completed",
             Self::CommandSearchOpened => "Command Search Opened",
             Self::CommandSearchExited => "Command Search Exited",
             Self::CommandSearchResultAccepted => "Command Search Result Accepted",
@@ -6944,6 +6973,9 @@ impl TelemetryEventDesc for TelemetryEventDiscriminants {
             Self::FileTreeToggled => "Opened the file tree/project explorer",
             Self::GlobalSearchOpened => "Opened the global search view",
             Self::GlobalSearchQueryStarted => "Started a global search (warp_ripgrep) search",
+            Self::GlobalSearchQueryCompleted => {
+                "Completed a global search across local and remote sources"
+            }
             Self::FileTreeItemAttachedAsContext => {
                 "Attached a file or directory as context from the file tree"
             }

--- a/app/src/server/telemetry/events.rs
+++ b/app/src/server/telemetry/events.rs
@@ -1596,9 +1596,12 @@ pub enum TelemetryEvent {
         /// Whether the result set was capped (locally or by a remote
         /// server-side cap).
         capped: bool,
-        /// Number of search sources (local, or one per remote host) that
-        /// failed while the others completed.
-        source_failures: usize,
+        /// Whether the local search source failed while another source
+        /// completed.
+        local_source_failed: bool,
+        /// Number of remote host search sources that failed while another
+        /// source completed.
+        remote_source_failures: usize,
     },
     AICommandSearchOpened {
         entrypoint: AICommandSearchEntrypoint,
@@ -4248,13 +4251,15 @@ impl TelemetryEvent {
                 remote_host_count,
                 total_match_count,
                 capped,
-                source_failures,
+                local_source_failed,
+                remote_source_failures,
             } => Some(json!({
                 "duration_ms": duration_ms,
                 "remote_host_count": remote_host_count,
                 "total_match_count": total_match_count,
                 "capped": capped,
-                "source_failures": source_failures,
+                "local_source_failed": local_source_failed,
+                "remote_source_failures": remote_source_failures,
             })),
             TelemetryEvent::SSHControlMasterError { has_remote_server } => Some(json!({
                 "has_remote_server": has_remote_server,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6191,7 +6191,7 @@ impl Workspace {
                         self.open_code(
                             code_source,
                             crate::util::openable_file_type::EditorLayout::SplitPane,
-                            None,
+                            *line_col,
                             false,
                             &[],
                             ctx,

--- a/app/src/workspace/view/global_search/mod.rs
+++ b/app/src/workspace/view/global_search/mod.rs
@@ -1,6 +1,23 @@
+use warp_ripgrep::search::Submatch;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+
 pub struct SearchConfig {
     pub use_regex: bool,
     pub use_case_sensitivity: bool,
+}
+
+/// A single global search match: one line in one file, which may live on
+/// the local filesystem or on a remote host.
+#[derive(Clone, Debug)]
+pub struct GlobalSearchMatch {
+    pub location: LocalOrRemotePath,
+    pub line_number: u32,
+    /// Original 1-based character column in the file. This is captured
+    /// before display-only whitespace trimming so opening a result navigates
+    /// to the correct location.
+    pub column_num: Option<usize>,
+    pub line_text: String,
+    pub submatches: Vec<Submatch>,
 }
 
 #[cfg_attr(not(target_family = "wasm"), path = "model.rs")]

--- a/app/src/workspace/view/global_search/model.rs
+++ b/app/src/workspace/view/global_search/model.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::future::Future;
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -5,20 +7,57 @@ use futures::StreamExt as _;
 use instant::Instant;
 use num_traits::SaturatingSub;
 use regex::escape;
+use remote_server::manager::{HostRequestError, RemoteServerManager};
+use remote_server::proto::{RipgrepSearchRequest, RipgrepSearchSuccess};
+use remote_server::protocol::RequestId;
+use remote_server::HostId;
 use string_offset::ByteOffset;
 use warp_ripgrep::search::{Match as RipgrepMatch, Submatch};
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::r#async::SpawnedFutureHandle;
-use warpui::{Entity, ModelContext, ModelSpawner};
+use warpui::{Entity, ModelContext, ModelSpawner, SingletonEntity};
 
 use crate::workspace::view::global_search::view::GlobalSearchEvent;
-use crate::workspace::view::global_search::SearchConfig;
+use crate::workspace::view::global_search::{GlobalSearchMatch, SearchConfig};
 
 const START_BATCH_AFTER_COUNT: usize = 50;
 const MAX_BATCH_SIZE: usize = 512;
 const MAX_BATCH_AGE_MS: u64 = 4000;
 
+/// Client-requested cap on remote matches per host. The daemon clamps this
+/// to its own server-side cap; both bound the single-frame response size.
+const REMOTE_MAX_MATCH_COUNT: u32 = 5_000;
+
+/// Aggregate state for one logical search across all of its sources
+/// (one local ripgrep run plus one remote request per searched host).
+struct ActiveSearch {
+    search_id: u32,
+    remaining_sources: usize,
+    completed_sources: usize,
+    failed_sources: usize,
+    total_match_count: usize,
+    /// True when any remote source hit the server-side match cap.
+    capped: bool,
+}
+
+/// Result of one search source (the local ripgrep run, or one remote
+/// host's request) that ran to completion.
+struct SourceResult {
+    match_count: usize,
+    capped: bool,
+}
+
 pub struct GlobalSearch {
-    search_handle: Option<SpawnedFutureHandle>,
+    /// Spawned local/remote search tasks for the current search.
+    search_handles: Vec<SpawnedFutureHandle>,
+    /// Request ids of remote searches started for the current search, so
+    /// they can be aborted daemon-side when the query changes. May contain
+    /// ids of already-resolved requests; aborting those is a no-op.
+    in_flight_remote_requests: Vec<RequestId>,
+    /// Aggregate completion state for the current search.
+    active_search: Option<ActiveSearch>,
     // track the search ID so that we only show results for the current search
     next_search_id: u32,
 }
@@ -30,7 +69,7 @@ impl Entity for GlobalSearch {
 async fn flush_batch(
     spawner: &ModelSpawner<GlobalSearch>,
     search_id: u32,
-    batch: &mut Vec<RipgrepMatch>,
+    batch: &mut Vec<GlobalSearchMatch>,
 ) {
     if batch.is_empty() {
         return;
@@ -48,35 +87,47 @@ async fn flush_batch(
 impl GlobalSearch {
     pub fn new() -> Self {
         GlobalSearch {
-            search_handle: None,
+            search_handles: Vec::new(),
+            in_flight_remote_requests: Vec::new(),
+            active_search: None,
             next_search_id: 1,
         }
     }
 
-    pub fn abort_search(&mut self) {
-        if let Some(handle) = self.search_handle.take() {
+    pub fn abort_search(&mut self, ctx: &mut ModelContext<Self>) {
+        for handle in self.search_handles.drain(..) {
             handle.abort();
+        }
+        self.active_search = None;
+
+        // Cancel in-flight remote searches daemon-side as well: queries
+        // change on every debounced edit, so without this the daemon piles
+        // up wasted ripgrep runs.
+        let request_ids = std::mem::take(&mut self.in_flight_remote_requests);
+        if !request_ids.is_empty() {
+            RemoteServerManager::handle(ctx).update(ctx, |manager, _| {
+                for request_id in &request_ids {
+                    manager.abort_host_request(request_id);
+                }
+            });
         }
     }
 
     pub fn run_search(
         &mut self,
         pattern: String,
-        roots: Vec<PathBuf>,
+        roots: Vec<LocalOrRemotePath>,
         search_config: SearchConfig,
         ctx: &mut ModelContext<Self>,
     ) {
-        if let Some(handle) = self.search_handle.take() {
+        if !self.search_handles.is_empty() {
             log::info!("GlobalSearch: aborting previous search");
-            handle.abort();
         }
+        self.abort_search(ctx);
 
         let search_id = self.next_search_id;
         self.next_search_id += 1;
 
-        ctx.emit(GlobalSearchEvent::Started { search_id });
-
-        let spawner = ctx.spawner();
         let effective_pattern = if search_config.use_regex {
             pattern
         } else {
@@ -85,36 +136,265 @@ impl GlobalSearch {
         let ignore_case = !search_config.use_case_sensitivity;
         let multiline = effective_pattern.contains('\n');
 
-        let handle = ctx.spawn(
+        // Split roots into the local filesystem source and one remote
+        // source per host.
+        let mut local_roots: Vec<PathBuf> = Vec::new();
+        let mut remote_roots: HashMap<HostId, Vec<StandardizedPath>> = HashMap::new();
+        for root in roots {
+            match root {
+                LocalOrRemotePath::Local(path) => local_roots.push(path),
+                LocalOrRemotePath::Remote(remote) => {
+                    remote_roots
+                        .entry(remote.host_id)
+                        .or_default()
+                        .push(remote.path);
+                }
+            }
+        }
+
+        let remote_host_count = remote_roots.len();
+        ctx.emit(GlobalSearchEvent::Started {
+            search_id,
+            remote_host_count,
+        });
+        let source_count = usize::from(!local_roots.is_empty()) + remote_roots.len();
+        if source_count == 0 {
+            ctx.emit(GlobalSearchEvent::Completed {
+                search_id,
+                total_match_count: 0,
+                capped: false,
+                source_failures: 0,
+            });
+            return;
+        }
+
+        self.active_search = Some(ActiveSearch {
+            search_id,
+            remaining_sources: source_count,
+            completed_sources: 0,
+            failed_sources: 0,
+            total_match_count: 0,
+            capped: false,
+        });
+
+        if !local_roots.is_empty() {
+            self.spawn_local_search(
+                search_id,
+                effective_pattern.clone(),
+                local_roots,
+                ignore_case,
+                multiline,
+                ctx,
+            );
+        }
+
+        for (host_id, paths) in remote_roots {
+            self.spawn_remote_search(
+                search_id,
+                effective_pattern.clone(),
+                host_id,
+                paths,
+                ignore_case,
+                multiline,
+                ctx,
+            );
+        }
+    }
+
+    fn spawn_local_search(
+        &mut self,
+        search_id: u32,
+        pattern: String,
+        roots: Vec<PathBuf>,
+        ignore_case: bool,
+        multiline: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let spawner = ctx.spawner();
+        self.spawn_source(
+            search_id,
             async move {
-                Self::run_warp_ripgrep_cli(
+                let result = Self::run_warp_ripgrep_cli(
                     search_id,
-                    effective_pattern,
+                    pattern,
                     roots,
                     ignore_case,
                     multiline,
                     spawner,
                 )
-                .await
-            },
-            move |_, result, ctx| match result {
-                Ok(total_match_count) => {
-                    ctx.emit(GlobalSearchEvent::Completed {
-                        search_id,
-                        total_match_count,
-                    });
-                }
-                Err(err) => {
-                    log::error!("GlobalSearch: warp_ripgrep CLI search failed or aborted: {err}");
-                    ctx.emit(GlobalSearchEvent::Failed {
-                        search_id,
-                        error: "Global search failed.".to_string(),
-                    });
+                .await;
+                match result {
+                    Ok(match_count) => Some(SourceResult {
+                        match_count,
+                        capped: false,
+                    }),
+                    Err(err) => {
+                        log::error!(
+                            "GlobalSearch: warp_ripgrep CLI search failed or aborted: {err}"
+                        );
+                        None
+                    }
                 }
             },
+            ctx,
         );
+    }
 
-        self.search_handle = Some(handle);
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_remote_search(
+        &mut self,
+        search_id: u32,
+        pattern: String,
+        host_id: HostId,
+        paths: Vec<StandardizedPath>,
+        ignore_case: bool,
+        multiline: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let request = RipgrepSearchRequest {
+            pattern,
+            roots: paths.iter().map(|p| p.to_string()).collect(),
+            ignore_case,
+            multiline,
+            max_matches: REMOTE_MAX_MATCH_COUNT,
+        };
+        let pending = RemoteServerManager::handle(ctx).update(ctx, |manager, _| {
+            manager.start_ripgrep_search(&host_id, request)
+        });
+        self.in_flight_remote_requests
+            .push(pending.request_id().clone());
+        let spawner = ctx.spawner();
+        self.spawn_source(
+            search_id,
+            async move {
+                match pending.result().await {
+                    Ok(success) => {
+                        let capped = success.capped;
+                        let mut items = Self::remote_matches_to_global(&host_id, success);
+                        let match_count = items.len();
+                        flush_batch(&spawner, search_id, &mut items).await;
+                        Some(SourceResult {
+                            match_count,
+                            capped,
+                        })
+                    }
+                    // An abort is initiated by a newer search (or a reset),
+                    // which already replaced the aggregate state; the stale
+                    // search-id guard drops this outcome regardless.
+                    Err(HostRequestError::Aborted) => None,
+                    Err(err) => {
+                        log::warn!("GlobalSearch: remote search failed for host {host_id}: {err}");
+                        None
+                    }
+                }
+            },
+            ctx,
+        );
+    }
+
+    /// Spawns one search source (the local ripgrep run, or one remote
+    /// host's request) and routes its outcome into the shared completion
+    /// accounting. Sources emit their matches via `Progress`/`ProgressBatch`
+    /// while running and log their own failures.
+    fn spawn_source(
+        &mut self,
+        search_id: u32,
+        source: impl Future<Output = Option<SourceResult>> + Send + 'static,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let task = ctx.spawn(source, move |me, outcome, ctx| {
+            me.handle_source_completed(search_id, outcome, ctx);
+        });
+        self.search_handles.push(task);
+    }
+
+    /// Converts a remote search response into per-submatch result rows,
+    /// attaching the originating host to each match location.
+    fn remote_matches_to_global(
+        host_id: &HostId,
+        success: RipgrepSearchSuccess,
+    ) -> Vec<GlobalSearchMatch> {
+        success
+            .matches
+            .into_iter()
+            .filter_map(|m| {
+                let path = match StandardizedPath::try_new(&m.file_path) {
+                    Ok(path) => path,
+                    Err(err) => {
+                        log::warn!("GlobalSearch: dropping remote match with invalid path: {err}");
+                        return None;
+                    }
+                };
+                let submatches = m
+                    .submatches
+                    .into_iter()
+                    .map(|s| Submatch {
+                        byte_start: ByteOffset::from(s.byte_start as usize),
+                        byte_end: ByteOffset::from(s.byte_end as usize),
+                    })
+                    .collect();
+                Some(GlobalSearchMatch {
+                    location: LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), path)),
+                    line_number: m.line_number,
+                    column_num: None,
+                    line_text: m.line_text,
+                    submatches,
+                })
+            })
+            .flat_map(Self::expand_submatches)
+            .collect()
+    }
+
+    /// Records the completion of one search source (`None` when the source
+    /// failed; the source already logged the failure). When all sources have
+    /// finished, emits `Completed` (or `Failed` when every source failed).
+    fn handle_source_completed(
+        &mut self,
+        search_id: u32,
+        outcome: Option<SourceResult>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(active) = self.active_search.as_mut() else {
+            return;
+        };
+        if active.search_id != search_id {
+            return;
+        }
+
+        match outcome {
+            Some(SourceResult {
+                match_count,
+                capped,
+            }) => {
+                active.completed_sources += 1;
+                active.total_match_count += match_count;
+                active.capped |= capped;
+            }
+            None => active.failed_sources += 1,
+        }
+
+        active.remaining_sources = active.remaining_sources.saturating_sub(1);
+        if active.remaining_sources > 0 {
+            return;
+        }
+
+        let active = self
+            .active_search
+            .take()
+            .expect("active search was checked above");
+        if active.completed_sources == 0 {
+            ctx.emit(GlobalSearchEvent::Failed {
+                search_id,
+                error: "Global search failed.".to_string(),
+            });
+        } else {
+            ctx.emit(GlobalSearchEvent::Completed {
+                search_id,
+                total_match_count: active.total_match_count,
+                capped: active.capped,
+                source_failures: active.failed_sources,
+            });
+        }
     }
 
     async fn run_warp_ripgrep_cli(
@@ -137,14 +417,14 @@ impl GlobalSearch {
 
         let mut total_match_count: usize = 0;
         let mut num_unbatched_emitted: usize = 0;
-        let mut batch: Vec<RipgrepMatch> = Vec::new();
+        let mut batch: Vec<GlobalSearchMatch> = Vec::new();
         let mut last_batch_flush_at = Instant::now();
 
         while let Some(raw_match) = stream.next().await {
             // Expand each submatch into its own result row (matching
             // the old per-submatch behavior). Each row gets the line
             // text trimmed up to that particular submatch.
-            for per_submatch in Self::expand_submatches(raw_match) {
+            for per_submatch in Self::expand_submatches(Self::local_match_to_global(raw_match)) {
                 total_match_count += 1;
 
                 if num_unbatched_emitted < START_BATCH_AFTER_COUNT {
@@ -180,40 +460,65 @@ impl GlobalSearch {
         Ok(total_match_count)
     }
 
-    /// Expand a single ripgrep match (which may contain multiple submatches
+    fn local_match_to_global(m: RipgrepMatch) -> GlobalSearchMatch {
+        GlobalSearchMatch {
+            location: LocalOrRemotePath::Local(m.file_path),
+            line_number: m.line_number,
+            column_num: None,
+            line_text: m.line_text,
+            submatches: m.submatches,
+        }
+    }
+
+    /// Expand a single match (which may contain multiple submatches
     /// on the same line) into one result per submatch. Each result gets the
     /// line text trimmed of leading whitespace up to that submatch.
-    fn expand_submatches(m: RipgrepMatch) -> Vec<RipgrepMatch> {
+    fn expand_submatches(m: GlobalSearchMatch) -> Vec<GlobalSearchMatch> {
         if m.submatches.len() <= 1 {
+            let submatch = m.submatches.into_iter().next();
+            let column_num = Self::column_from_submatch(&m.line_text, submatch.as_ref());
             return vec![Self::trim_leading_whitespace_for_submatch(
                 &m.line_text,
-                m.file_path,
+                m.location,
                 m.line_number,
-                m.submatches.into_iter().next(),
+                column_num,
+                submatch,
             )];
         }
 
         m.submatches
             .into_iter()
             .map(|sub| {
+                let column_num = Self::column_from_submatch(&m.line_text, Some(&sub));
                 Self::trim_leading_whitespace_for_submatch(
                     &m.line_text,
-                    m.file_path.clone(),
+                    m.location.clone(),
                     m.line_number,
+                    column_num,
                     Some(sub),
                 )
             })
             .collect()
     }
 
+    /// Returns the original 1-based character column for a submatch.
+    fn column_from_submatch(line_text: &str, submatch: Option<&Submatch>) -> Option<usize> {
+        let byte_start = submatch?.byte_start.as_usize();
+        if byte_start > line_text.len() || !line_text.is_char_boundary(byte_start) {
+            return None;
+        }
+        Some(line_text[..byte_start].chars().count() + 1)
+    }
+
     /// Trim leading whitespace from a line up to the given submatch,
     /// adjusting the submatch offset accordingly.
     fn trim_leading_whitespace_for_submatch(
         original_line: &str,
-        file_path: PathBuf,
+        location: LocalOrRemotePath,
         line_number: u32,
+        column_num: Option<usize>,
         submatch: Option<Submatch>,
-    ) -> RipgrepMatch {
+    ) -> GlobalSearchMatch {
         let submatch_start = submatch
             .as_ref()
             .map(|s| s.byte_start)
@@ -241,9 +546,10 @@ impl GlobalSearch {
             Vec::new()
         };
 
-        RipgrepMatch {
-            file_path,
+        GlobalSearchMatch {
+            location,
             line_number,
+            column_num,
             line_text: trimmed_line,
             submatches,
         }
@@ -255,3 +561,7 @@ impl Default for GlobalSearch {
         Self::new()
     }
 }
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod tests;

--- a/app/src/workspace/view/global_search/model.rs
+++ b/app/src/workspace/view/global_search/model.rs
@@ -189,15 +189,14 @@ impl GlobalSearch {
         }
 
         for (host_id, paths) in remote_roots {
-            self.spawn_remote_search(
-                search_id,
-                effective_pattern.clone(),
-                host_id,
-                paths,
+            let request = RipgrepSearchRequest {
+                pattern: effective_pattern.clone(),
+                roots: paths.iter().map(|p| p.to_string()).collect(),
                 ignore_case,
                 multiline,
-                ctx,
-            );
+                max_matches: REMOTE_MAX_MATCH_COUNT,
+            };
+            self.spawn_remote_search(search_id, host_id, request, ctx);
         }
     }
 
@@ -240,24 +239,13 @@ impl GlobalSearch {
         );
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn spawn_remote_search(
         &mut self,
         search_id: u32,
-        pattern: String,
         host_id: HostId,
-        paths: Vec<StandardizedPath>,
-        ignore_case: bool,
-        multiline: bool,
+        request: RipgrepSearchRequest,
         ctx: &mut ModelContext<Self>,
     ) {
-        let request = RipgrepSearchRequest {
-            pattern,
-            roots: paths.iter().map(|p| p.to_string()).collect(),
-            ignore_case,
-            multiline,
-            max_matches: REMOTE_MAX_MATCH_COUNT,
-        };
         let pending = RemoteServerManager::handle(ctx).update(ctx, |manager, _| {
             manager.start_ripgrep_search(&host_id, request)
         });

--- a/app/src/workspace/view/global_search/model.rs
+++ b/app/src/workspace/view/global_search/model.rs
@@ -7,8 +7,8 @@ use futures::StreamExt as _;
 use instant::Instant;
 use num_traits::SaturatingSub;
 use regex::escape;
-use remote_server::manager::{HostRequestError, RemoteServerManager};
-use remote_server::proto::{RipgrepSearchRequest, RipgrepSearchSuccess};
+use remote_server::manager::{HostRequestError, RemoteServerManager, RipgrepSearchParams};
+use remote_server::proto::RipgrepSearchSuccess;
 use remote_server::protocol::RequestId;
 use remote_server::HostId;
 use string_offset::ByteOffset;
@@ -36,10 +36,17 @@ struct ActiveSearch {
     search_id: u32,
     remaining_sources: usize,
     completed_sources: usize,
-    failed_sources: usize,
+    local_source_failed: bool,
+    remote_source_failures: usize,
     total_match_count: usize,
     /// True when any remote source hit the server-side match cap.
     capped: bool,
+}
+
+#[derive(Clone, Copy)]
+enum SearchSource {
+    Local,
+    Remote,
 }
 
 /// Result of one search source (the local ripgrep run, or one remote
@@ -163,7 +170,8 @@ impl GlobalSearch {
                 search_id,
                 total_match_count: 0,
                 capped: false,
-                source_failures: 0,
+                local_source_failed: false,
+                remote_source_failures: 0,
             });
             return;
         }
@@ -172,7 +180,8 @@ impl GlobalSearch {
             search_id,
             remaining_sources: source_count,
             completed_sources: 0,
-            failed_sources: 0,
+            local_source_failed: false,
+            remote_source_failures: 0,
             total_match_count: 0,
             capped: false,
         });
@@ -189,14 +198,14 @@ impl GlobalSearch {
         }
 
         for (host_id, paths) in remote_roots {
-            let request = RipgrepSearchRequest {
+            let params = RipgrepSearchParams {
                 pattern: effective_pattern.clone(),
-                roots: paths.iter().map(|p| p.to_string()).collect(),
+                roots: paths,
                 ignore_case,
                 multiline,
                 max_matches: REMOTE_MAX_MATCH_COUNT,
             };
-            self.spawn_remote_search(search_id, host_id, request, ctx);
+            self.spawn_remote_search(search_id, host_id, params, ctx);
         }
     }
 
@@ -212,6 +221,7 @@ impl GlobalSearch {
         let spawner = ctx.spawner();
         self.spawn_source(
             search_id,
+            SearchSource::Local,
             async move {
                 let result = Self::run_warp_ripgrep_cli(
                     search_id,
@@ -243,17 +253,18 @@ impl GlobalSearch {
         &mut self,
         search_id: u32,
         host_id: HostId,
-        request: RipgrepSearchRequest,
+        params: RipgrepSearchParams,
         ctx: &mut ModelContext<Self>,
     ) {
         let pending = RemoteServerManager::handle(ctx).update(ctx, |manager, _| {
-            manager.start_ripgrep_search(&host_id, request)
+            manager.start_ripgrep_search(&host_id, params)
         });
         self.in_flight_remote_requests
             .push(pending.request_id().clone());
         let spawner = ctx.spawner();
         self.spawn_source(
             search_id,
+            SearchSource::Remote,
             async move {
                 match pending.result().await {
                     Ok(success) => {
@@ -287,11 +298,12 @@ impl GlobalSearch {
     fn spawn_source(
         &mut self,
         search_id: u32,
+        source_kind: SearchSource,
         source: impl Future<Output = Option<SourceResult>> + Send + 'static,
         ctx: &mut ModelContext<Self>,
     ) {
         let task = ctx.spawn(source, move |me, outcome, ctx| {
-            me.handle_source_completed(search_id, outcome, ctx);
+            me.handle_source_completed(search_id, source_kind, outcome, ctx);
         });
         self.search_handles.push(task);
     }
@@ -339,6 +351,7 @@ impl GlobalSearch {
     fn handle_source_completed(
         &mut self,
         search_id: u32,
+        source_kind: SearchSource,
         outcome: Option<SourceResult>,
         ctx: &mut ModelContext<Self>,
     ) {
@@ -358,7 +371,10 @@ impl GlobalSearch {
                 active.total_match_count += match_count;
                 active.capped |= capped;
             }
-            None => active.failed_sources += 1,
+            None => match source_kind {
+                SearchSource::Local => active.local_source_failed = true,
+                SearchSource::Remote => active.remote_source_failures += 1,
+            },
         }
 
         active.remaining_sources = active.remaining_sources.saturating_sub(1);
@@ -380,7 +396,8 @@ impl GlobalSearch {
                 search_id,
                 total_match_count: active.total_match_count,
                 capped: active.capped,
-                source_failures: active.failed_sources,
+                local_source_failed: active.local_source_failed,
+                remote_source_failures: active.remote_source_failures,
             });
         }
     }

--- a/app/src/workspace/view/global_search/model_tests.rs
+++ b/app/src/workspace/view/global_search/model_tests.rs
@@ -1,0 +1,121 @@
+use remote_server::proto::{RipgrepSearchMatch, RipgrepSearchSubmatch, RipgrepSearchSuccess};
+use remote_server::HostId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+
+use super::GlobalSearch;
+
+fn host() -> HostId {
+    HostId::new("test-host".to_string())
+}
+
+fn proto_match(
+    path: &str,
+    line_number: u32,
+    line_text: &str,
+    submatches: Vec<(u64, u64)>,
+) -> RipgrepSearchMatch {
+    RipgrepSearchMatch {
+        file_path: path.to_string(),
+        line_number,
+        line_text: line_text.to_string(),
+        submatches: submatches
+            .into_iter()
+            .map(|(byte_start, byte_end)| RipgrepSearchSubmatch {
+                byte_start,
+                byte_end,
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn remote_matches_become_remote_locations_on_the_host() {
+    let success = RipgrepSearchSuccess {
+        matches: vec![proto_match(
+            "/repo/src/main.rs",
+            7,
+            "fn main() {}",
+            vec![(3, 7)],
+        )],
+        capped: false,
+    };
+
+    let results = GlobalSearch::remote_matches_to_global(&host(), success);
+
+    assert_eq!(results.len(), 1);
+    match &results[0].location {
+        LocalOrRemotePath::Remote(remote) => {
+            assert_eq!(remote.host_id, host());
+            assert_eq!(remote.path.as_str(), "/repo/src/main.rs");
+        }
+        LocalOrRemotePath::Local(_) => panic!("expected a remote location"),
+    }
+    assert_eq!(results[0].line_number, 7);
+    assert_eq!(results[0].column_num, Some(4));
+    assert_eq!(results[0].line_text, "fn main() {}");
+}
+
+#[test]
+fn remote_matches_expand_one_row_per_submatch() {
+    let success = RipgrepSearchSuccess {
+        matches: vec![proto_match(
+            "/repo/a.rs",
+            1,
+            "foo foo",
+            vec![(0, 3), (4, 7)],
+        )],
+        capped: false,
+    };
+
+    let results = GlobalSearch::remote_matches_to_global(&host(), success);
+
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(|m| m.submatches.len() == 1));
+}
+
+#[test]
+fn remote_matches_with_invalid_paths_are_dropped() {
+    let success = RipgrepSearchSuccess {
+        matches: vec![
+            proto_match("relative/path.rs", 1, "x", vec![(0, 1)]),
+            proto_match("/repo/ok.rs", 2, "x", vec![(0, 1)]),
+        ],
+        capped: false,
+    };
+
+    let results = GlobalSearch::remote_matches_to_global(&host(), success);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].location.display_path(), "/repo/ok.rs");
+}
+
+#[test]
+fn remote_match_leading_whitespace_is_trimmed_per_submatch() {
+    // Leading whitespace before the submatch is trimmed and offsets adjusted,
+    // matching local search behavior.
+    let success = RipgrepSearchSuccess {
+        matches: vec![proto_match("/repo/a.rs", 1, "    foo", vec![(4, 7)])],
+        capped: false,
+    };
+
+    let results = GlobalSearch::remote_matches_to_global(&host(), success);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].line_text, "foo");
+    assert_eq!(results[0].column_num, Some(5));
+    assert_eq!(results[0].submatches[0].byte_start.as_usize(), 0);
+    assert_eq!(results[0].submatches[0].byte_end.as_usize(), 3);
+}
+
+#[test]
+fn remote_match_column_counts_characters_not_bytes() {
+    let success = RipgrepSearchSuccess {
+        matches: vec![proto_match("/repo/a.rs", 1, "€foo", vec![(3, 6)])],
+        capped: false,
+    };
+
+    let results = GlobalSearch::remote_matches_to_global(&host(), success);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].column_num, Some(2));
+}

--- a/app/src/workspace/view/global_search/model_wasm.rs
+++ b/app/src/workspace/view/global_search/model_wasm.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{Entity, ModelContext};
 
 use crate::workspace::view::global_search::view::GlobalSearchEvent;
@@ -16,12 +15,12 @@ impl GlobalSearch {
         GlobalSearch {}
     }
 
-    pub fn abort_search(&mut self) {}
+    pub fn abort_search(&mut self, _ctx: &mut ModelContext<Self>) {}
 
     pub fn run_search(
         &mut self,
         _pattern: String,
-        _root: Vec<PathBuf>,
+        _roots: Vec<LocalOrRemotePath>,
         _search_config: SearchConfig,
         _ctx: &mut ModelContext<Self>,
     ) {

--- a/app/src/workspace/view/global_search/view.rs
+++ b/app/src/workspace/view/global_search/view.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -9,6 +9,7 @@ use async_channel::Sender;
 use instant::Instant;
 use pathfinder_geometry::vector::vec2f;
 use remote_server::manager::RemoteServerManager;
+use remote_server::HostId;
 use string_offset::{ByteOffset, CharCounter};
 use warp_core::r#async::debounce;
 use warp_core::send_telemetry_from_ctx;
@@ -19,6 +20,8 @@ use warp_core::ui::Icon;
 use warp_editor::editor::NavigationKey;
 use warp_ripgrep::search::Submatch;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::elements::{
     Border, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container, CornerRadius,
     CrossAxisAlignment, DispatchEventResult, Empty, EventHandler, Fill, Flex, FormattedTextElement,
@@ -1014,32 +1017,40 @@ impl GlobalSearchView {
     ) {
         // Ancestor-dedup search roots so we don't search the same file twice
         // when terminal directories are nested (e.g. `~/code` + `~/code/a`).
-        // Local roots share `group_roots_by_common_ancestor` with
-        // `FileTreeView` for consistency; remote roots are deduped per host
-        // via `LocalOrRemotePath::starts_with`.
+        // Local and remote roots share `group_roots_by_common_ancestor` with
+        // `FileTreeView` for consistency; remote roots are grouped per host
+        // and deduped within each host independently.
         let local_roots: Vec<PathBuf> = roots
             .iter()
             .filter_map(|root| root.to_local_path().map(Path::to_path_buf))
             .collect();
         let deduped_local = warp_util::path::group_roots_by_common_ancestor(&local_roots).roots;
 
-        let mut seen_remote = HashSet::new();
-        let unique_remote: Vec<LocalOrRemotePath> = roots
-            .iter()
-            .filter(|root| root.is_remote())
-            .filter(|root| seen_remote.insert((*root).clone()))
-            .cloned()
-            .collect();
-        let deduped_remote = unique_remote
-            .iter()
-            .enumerate()
-            .filter(|(index, root)| {
-                !unique_remote
-                    .iter()
-                    .enumerate()
-                    .any(|(other_index, other)| other_index != *index && root.starts_with(other))
-            })
-            .map(|(_, root)| root.clone());
+        let mut remote_roots_by_host: Vec<(HostId, Vec<StandardizedPath>)> = Vec::new();
+        for root in &roots {
+            let LocalOrRemotePath::Remote(remote) = root else {
+                continue;
+            };
+            match remote_roots_by_host
+                .iter_mut()
+                .find(|(host_id, _)| host_id == &remote.host_id)
+            {
+                Some((_, paths)) => paths.push(remote.path.clone()),
+                None => {
+                    remote_roots_by_host.push((remote.host_id.clone(), vec![remote.path.clone()]))
+                }
+            }
+        }
+        let deduped_remote = remote_roots_by_host
+            .into_iter()
+            .flat_map(|(host_id, paths)| {
+                warp_util::path::group_roots_by_common_ancestor(&paths)
+                    .roots
+                    .into_iter()
+                    .map(move |path| {
+                        LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), path))
+                    })
+            });
 
         self.search_roots = deduped_local
             .into_iter()

--- a/app/src/workspace/view/global_search/view.rs
+++ b/app/src/workspace/view/global_search/view.rs
@@ -1,12 +1,14 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_channel::Sender;
+use instant::Instant;
 use pathfinder_geometry::vector::vec2f;
+use remote_server::manager::RemoteServerManager;
 use string_offset::{ByteOffset, CharCounter};
 use warp_core::r#async::debounce;
 use warp_core::send_telemetry_from_ctx;
@@ -15,7 +17,8 @@ use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::{AnsiColorIdentifier, Fill as ThemeFill};
 use warp_core::ui::Icon;
 use warp_editor::editor::NavigationKey;
-use warp_ripgrep::search::{Match as RipgrepMatch, Submatch};
+use warp_ripgrep::search::Submatch;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::elements::{
     Border, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container, CornerRadius,
     CrossAxisAlignment, DispatchEventResult, Empty, EventHandler, Fill, Flex, FormattedTextElement,
@@ -48,7 +51,7 @@ use crate::ui_components::item_highlight::{ImageOrIcon, ItemHighlightState};
 use crate::ui_components::render_file_search_row::{render_file_search_row, FileSearchRowOptions};
 use crate::view_components::action_button::{ActionButton, ButtonSize, NakedTheme};
 use crate::workspace::view::global_search::model::GlobalSearch;
-use crate::workspace::view::global_search::SearchConfig;
+use crate::workspace::view::global_search::{GlobalSearchMatch, SearchConfig};
 use crate::TelemetryEvent;
 
 const BORDER_RADIUS: f32 = 6.;
@@ -76,19 +79,19 @@ enum FocusMode {
 #[derive(Debug, Clone)]
 pub enum GlobalSearchAction {
     SelectRow {
-        directory_path: PathBuf,
-        file_path: PathBuf,
+        directory_path: LocalOrRemotePath,
+        file_path: LocalOrRemotePath,
         match_index: Option<usize>,
     },
     ToggleFileCollapsed {
-        directory_path: PathBuf,
-        file_path: PathBuf,
+        directory_path: LocalOrRemotePath,
+        file_path: LocalOrRemotePath,
     },
     ToggleDirectoryCollapsed {
-        directory_path: PathBuf,
+        directory_path: LocalOrRemotePath,
     },
     OpenMatch {
-        path: PathBuf,
+        location: LocalOrRemotePath,
         line_number: u32,
         column_num: Option<usize>,
     },
@@ -107,18 +110,25 @@ pub enum GlobalSearchAction {
 pub enum GlobalSearchEvent {
     Started {
         search_id: u32,
+        remote_host_count: usize,
     },
     Progress {
         search_id: u32,
-        result: RipgrepMatch,
+        result: GlobalSearchMatch,
     },
     ProgressBatch {
         search_id: u32,
-        items: Vec<RipgrepMatch>,
+        items: Vec<GlobalSearchMatch>,
     },
     Completed {
         search_id: u32,
         total_match_count: usize,
+        /// True when a remote source hit the server-side match cap.
+        capped: bool,
+        /// Number of search sources (local, or one remote host) that failed
+        /// while the others completed. Results from the surviving sources
+        /// remain valid.
+        source_failures: usize,
     },
     Failed {
         search_id: u32,
@@ -129,7 +139,7 @@ pub enum GlobalSearchEvent {
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 pub enum Event {
     OpenMatch {
-        path: PathBuf,
+        location: LocalOrRemotePath,
         line_number: u32,
         column_num: Option<usize>,
     },
@@ -166,14 +176,14 @@ enum RowIndexType {
 
 /// A root directory containing matched files.
 struct DirectoryEntry {
-    path: PathBuf,
+    path: LocalOrRemotePath,
     is_collapsed: bool,
     mouse_state: MouseStateHandle,
     matched_paths: MatchedPaths,
 }
 
 impl DirectoryEntry {
-    fn new(path: PathBuf) -> Self {
+    fn new(path: LocalOrRemotePath) -> Self {
         Self {
             path,
             is_collapsed: false,
@@ -206,7 +216,7 @@ impl DirectoryEntry {
 /// Collection of matched files within a directory.
 struct MatchedPaths {
     paths: Vec<MatchedPath>,
-    index_by_path: HashMap<PathBuf, usize>,
+    index_by_path: HashMap<LocalOrRemotePath, usize>,
 }
 
 impl MatchedPaths {
@@ -222,21 +232,21 @@ impl MatchedPaths {
         self.paths.iter().map(|p| p.visible_count()).sum()
     }
 
-    /// Gets or creates a MatchedPath entry for the given file path.
+    /// Gets or creates a MatchedPath entry for the given file location.
     /// Returns a mutable reference to the entry and its index.
-    fn get_or_create(&mut self, path: &Path) -> (&mut MatchedPath, usize) {
+    fn get_or_create(&mut self, path: &LocalOrRemotePath) -> (&mut MatchedPath, usize) {
         if let Some(&index) = self.index_by_path.get(path) {
             (&mut self.paths[index], index)
         } else {
             let index = self.paths.len();
-            self.paths.push(MatchedPath::new(path.to_path_buf()));
-            self.index_by_path.insert(path.to_path_buf(), index);
+            self.paths.push(MatchedPath::new(path.clone()));
+            self.index_by_path.insert(path.clone(), index);
             (&mut self.paths[index], index)
         }
     }
 
-    /// Gets a mutable MatchedPath entry by file path.
-    fn get_mut(&mut self, path: &Path) -> Option<&mut MatchedPath> {
+    /// Gets a mutable MatchedPath entry by file location.
+    fn get_mut(&mut self, path: &LocalOrRemotePath) -> Option<&mut MatchedPath> {
         self.index_by_path
             .get(path)
             .copied()
@@ -246,14 +256,14 @@ impl MatchedPaths {
 
 /// A file containing matches.
 struct MatchedPath {
-    path: PathBuf,
+    path: LocalOrRemotePath,
     is_collapsed: bool,
     mouse_state: MouseStateHandle,
     matches: Vec<Match>,
 }
 
 impl MatchedPath {
-    fn new(path: PathBuf) -> Self {
+    fn new(path: LocalOrRemotePath) -> Self {
         Self {
             path,
             is_collapsed: false,
@@ -278,15 +288,22 @@ impl MatchedPath {
 struct Match {
     line_text: String,
     line_number: u32,
+    column_num: Option<usize>,
     submatches: Vec<Submatch>,
     mouse_state: MouseStateHandle,
 }
 
 impl Match {
-    fn new(line_text: String, line_number: u32, submatches: Vec<Submatch>) -> Self {
+    fn new(
+        line_text: String,
+        line_number: u32,
+        column_num: Option<usize>,
+        submatches: Vec<Submatch>,
+    ) -> Self {
         Self {
             line_text,
             line_number,
+            column_num,
             submatches,
             mouse_state: MouseStateHandle::default(),
         }
@@ -298,17 +315,20 @@ pub struct GlobalSearchView {
     query_editor: ViewHandle<EditorView>,
     query_change_tx: Sender<()>,
     /// All terminal working directories for display grouping (preserved as-is)
-    root_directories: Vec<PathBuf>,
-    /// Deduplicated roots for ripgrep search (excludes nested subdirectories)
-    search_roots: Vec<PathBuf>,
+    root_directories: Vec<LocalOrRemotePath>,
+    /// Deduplicated roots for search (excludes nested subdirectories)
+    search_roots: Vec<LocalOrRemotePath>,
     last_searched_pattern: Option<String>,
     directory_entries: Vec<DirectoryEntry>,
-    directory_path_to_directory_index_entry: HashMap<PathBuf, usize>,
+    directory_path_to_directory_index_entry: HashMap<LocalOrRemotePath, usize>,
     selected_row: Option<RowIndex>,
     total_match_count: usize,
     is_search_in_progress: bool,
     capped_matches: bool,
     last_error: Option<String>,
+    /// When the current search started, for completion telemetry.
+    search_started_at: Option<Instant>,
+    active_search_remote_host_count: usize,
     scroll_state: ScrollStateHandle,
     uniform_list_state: UniformListState,
     handle: WeakViewHandle<GlobalSearchView>,
@@ -352,12 +372,12 @@ impl TypedActionView for GlobalSearchView {
                 self.toggle_directory_collapsed(directory_path, ctx);
             }
             GlobalSearchAction::OpenMatch {
-                path,
+                location,
                 line_number,
                 column_num,
             } => {
                 ctx.emit(Event::OpenMatch {
-                    path: path.clone(),
+                    location: location.clone(),
                     line_number: *line_number,
                     column_num: *column_num,
                 });
@@ -485,24 +505,6 @@ impl TypedActionView for GlobalSearchView {
 }
 
 impl GlobalSearchView {
-    /// Calculate the 1-indexed column number from the first submatch.
-    /// Returns None if there are no submatches or the line is empty.
-    fn column_from_submatches(line_text: &str, submatches: &[Submatch]) -> Option<usize> {
-        if line_text.is_empty() || submatches.is_empty() {
-            return None;
-        }
-
-        let first_submatch = &submatches[0];
-        let max_byte = ByteOffset::from(line_text.len());
-        let start_b = first_submatch.byte_start.min(max_byte);
-
-        let mut char_counter = CharCounter::new(line_text);
-        let start_char = char_counter.char_offset(start_b)?;
-
-        // Return 1-indexed column number
-        Some(start_char.as_usize() + 1)
-    }
-
     /// Convert submatch byte ranges into character indices for highlighting.
     fn highlight_indices_from_submatches(line_text: &str, submatches: &[Submatch]) -> Vec<usize> {
         if line_text.is_empty() || submatches.is_empty() {
@@ -704,6 +706,8 @@ impl GlobalSearchView {
             is_search_in_progress: false,
             capped_matches: false,
             last_error: None,
+            search_started_at: None,
+            active_search_remote_host_count: 0,
             scroll_state: ScrollStateHandle::default(),
             uniform_list_state: UniformListState::new(),
             handle,
@@ -745,32 +749,30 @@ impl GlobalSearchView {
         ctx.notify();
     }
 
-    /// Returns an iterator over all directory paths where the given file path should appear.
-    /// A file matches a directory if the file path starts with that directory.
+    /// Returns an iterator over all directory locations where the given file should appear.
+    /// A file matches a directory if the file location starts with that directory
+    /// (remote files only match directories on the same host).
     fn find_matching_directories<'a>(
         &'a self,
-        file_path: &'a Path,
-    ) -> impl Iterator<Item = &'a PathBuf> {
+        location: &'a LocalOrRemotePath,
+    ) -> impl Iterator<Item = &'a LocalOrRemotePath> {
         self.root_directories
             .iter()
-            .filter(move |root| file_path.starts_with(root))
+            .filter(move |root| location.starts_with(root))
     }
 
-    fn apply_progress_item(&mut self, result: RipgrepMatch, ctx: &mut ViewContext<Self>) {
+    fn apply_progress_item(&mut self, result: GlobalSearchMatch, ctx: &mut ViewContext<Self>) {
         if self.total_match_count >= MAX_MATCH_COUNT {
             return;
         }
 
-        let file_path = result.file_path.clone();
+        let location = result.location.clone();
 
         // Find all directories that this file belongs to
-        let mut matching_directories = self.find_matching_directories(&file_path).peekable();
+        let mut matching_directories = self.find_matching_directories(&location).peekable();
         if matching_directories.peek().is_none() {
             // File doesn't match any root directory, skip it
-            let file_path_name = file_path
-                .file_name()
-                .map(|name| name.to_string_lossy())
-                .unwrap_or_else(|| std::borrow::Cow::Borrowed("<unknown>"));
+            let file_path_name = location.file_name().unwrap_or("<unknown>");
             log::warn!("[Global search] file {file_path_name} was not found in directories");
             return;
         }
@@ -794,12 +796,13 @@ impl GlobalSearchView {
 
             // Get or create the matched path entry within this directory
             let dir_entry = &mut directory_entries[dir_index];
-            let (matched_path, _path_index) = dir_entry.matched_paths.get_or_create(&file_path);
+            let (matched_path, _path_index) = dir_entry.matched_paths.get_or_create(&location);
 
             // Add the match
             matched_path.matches.push(Match::new(
                 result.line_text.clone(),
                 result.line_number,
+                result.column_num,
                 result.submatches.clone(),
             ));
         }
@@ -812,11 +815,16 @@ impl GlobalSearchView {
     }
     fn abort_search(&mut self, ctx: &mut ViewContext<Self>) {
         self.capped_matches = true;
+        self.cancel_search(ctx);
+    }
+
+    fn cancel_search(&mut self, ctx: &mut ViewContext<Self>) {
         self.is_search_in_progress = false;
         self.current_search_id = None;
+        self.search_started_at = None;
 
-        self.find_model.update(ctx, |model, _| {
-            model.abort_search();
+        self.find_model.update(ctx, |model, model_ctx| {
+            model.abort_search(model_ctx);
         });
     }
     fn handle_debounced_query_change(&mut self, _event: (), ctx: &mut ViewContext<Self>) {
@@ -839,8 +847,7 @@ impl GlobalSearchView {
             | EditorEvent::BufferReinitialized => {
                 let query_text = self.query_editor.as_ref(ctx).buffer_text(ctx);
                 if query_text.is_empty() {
-                    self.current_search_id = None;
-                    self.is_search_in_progress = false;
+                    self.cancel_search(ctx);
                     self.reset_search_state(true);
                     ctx.notify();
                     return;
@@ -880,8 +887,7 @@ impl GlobalSearchView {
 
         let pattern = self.query_editor.as_ref(ctx).buffer_text(ctx);
         if pattern.is_empty() {
-            self.current_search_id = None;
-            self.is_search_in_progress = false;
+            self.cancel_search(ctx);
             self.reset_search_state(true);
             ctx.notify();
             return;
@@ -923,10 +929,15 @@ impl GlobalSearchView {
 
     fn handle_find_model_event(&mut self, event: &GlobalSearchEvent, ctx: &mut ViewContext<Self>) {
         match event {
-            GlobalSearchEvent::Started { search_id } => {
+            GlobalSearchEvent::Started {
+                search_id,
+                remote_host_count,
+            } => {
                 send_telemetry_from_ctx!(TelemetryEvent::GlobalSearchQueryStarted, ctx);
 
                 self.current_search_id = Some(*search_id);
+                self.search_started_at = Some(Instant::now());
+                self.active_search_remote_host_count = *remote_host_count;
 
                 self.is_search_in_progress = true;
                 self.reset_search_state(false);
@@ -957,6 +968,8 @@ impl GlobalSearchView {
             GlobalSearchEvent::Completed {
                 search_id,
                 total_match_count,
+                capped,
+                source_failures,
             } => {
                 if Some(*search_id) != self.current_search_id {
                     return;
@@ -964,6 +977,20 @@ impl GlobalSearchView {
 
                 self.is_search_in_progress = false;
                 self.total_match_count = *total_match_count;
+                self.capped_matches |= capped;
+
+                if let Some(started_at) = self.search_started_at.take() {
+                    send_telemetry_from_ctx!(
+                        TelemetryEvent::GlobalSearchQueryCompleted {
+                            duration_ms: started_at.elapsed().as_millis() as u64,
+                            remote_host_count: self.active_search_remote_host_count,
+                            total_match_count: *total_match_count,
+                            capped: self.capped_matches,
+                            source_failures: *source_failures,
+                        },
+                        ctx
+                    );
+                }
                 ctx.notify();
             }
             GlobalSearchEvent::Failed { search_id, error } => {
@@ -972,6 +999,7 @@ impl GlobalSearchView {
                 }
 
                 self.is_search_in_progress = false;
+                self.search_started_at = None;
                 self.reset_search_state(false);
                 self.last_error = Some(error.clone());
                 ctx.notify();
@@ -979,11 +1007,45 @@ impl GlobalSearchView {
         }
     }
 
-    pub fn set_root_directories(&mut self, roots: Vec<PathBuf>, _ctx: &mut ViewContext<Self>) {
+    pub fn set_root_directories(
+        &mut self,
+        roots: Vec<LocalOrRemotePath>,
+        _ctx: &mut ViewContext<Self>,
+    ) {
         // Ancestor-dedup search roots so we don't search the same file twice
         // when terminal directories are nested (e.g. `~/code` + `~/code/a`).
-        // Shared with `FileTreeView` for consistency.
-        self.search_roots = warp_util::path::group_roots_by_common_ancestor(&roots).roots;
+        // Local roots share `group_roots_by_common_ancestor` with
+        // `FileTreeView` for consistency; remote roots are deduped per host
+        // via `LocalOrRemotePath::starts_with`.
+        let local_roots: Vec<PathBuf> = roots
+            .iter()
+            .filter_map(|root| root.to_local_path().map(Path::to_path_buf))
+            .collect();
+        let deduped_local = warp_util::path::group_roots_by_common_ancestor(&local_roots).roots;
+
+        let mut seen_remote = HashSet::new();
+        let unique_remote: Vec<LocalOrRemotePath> = roots
+            .iter()
+            .filter(|root| root.is_remote())
+            .filter(|root| seen_remote.insert((*root).clone()))
+            .cloned()
+            .collect();
+        let deduped_remote = unique_remote
+            .iter()
+            .enumerate()
+            .filter(|(index, root)| {
+                !unique_remote
+                    .iter()
+                    .enumerate()
+                    .any(|(other_index, other)| other_index != *index && root.starts_with(other))
+            })
+            .map(|(_, root)| root.clone());
+
+        self.search_roots = deduped_local
+            .into_iter()
+            .map(LocalOrRemotePath::Local)
+            .chain(deduped_remote)
+            .collect();
         self.root_directories = roots;
     }
 
@@ -1029,7 +1091,7 @@ impl GlobalSearchView {
 
         match &row_index.index_type {
             RowIndexType::DirectoryHeader => {
-                self.render_directory_header_from_entry(index, dir_entry, appearance, theme)
+                self.render_directory_header_from_entry(index, dir_entry, appearance, theme, app)
             }
             RowIndexType::FileHeader { path_index } => {
                 let Some(matched_path) = dir_entry.matched_paths.paths.get(*path_index) else {
@@ -1070,7 +1132,7 @@ impl GlobalSearchView {
     fn render_file_header(
         &self,
         index: usize,
-        directory_path: &Path,
+        directory_path: &LocalOrRemotePath,
         matched_path: &MatchedPath,
         appearance: &Appearance,
         theme: &warp_core::ui::theme::WarpTheme,
@@ -1082,14 +1144,14 @@ impl GlobalSearchView {
         let file_path = matched_path.path.clone();
         let match_count = matched_path.matches.len();
 
-        let directory_path_for_select = directory_path.to_path_buf();
+        let directory_path_for_select = directory_path.clone();
         let file_path_clone = file_path.clone();
-        let directory_path_for_toggle = directory_path.to_path_buf();
+        let directory_path_for_toggle = directory_path.clone();
 
-        let display_path = file_path
-            .strip_prefix(directory_path)
-            .unwrap_or(file_path.as_path());
-        let display_path = display_path.to_path_buf();
+        let display_path = directory_path
+            .strip_repo_prefix(&file_path)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(file_path.display_path()));
 
         Hoverable::new(file_mouse_state, move |mouse_state| {
             let item_highlight_state = ItemHighlightState::new(is_selected, mouse_state);
@@ -1112,7 +1174,7 @@ impl GlobalSearchView {
                 .finish();
             let chevron_container = Container::new(chevron_icon).with_margin_right(8.).finish();
 
-            let tooltip_text = file_path.to_string_lossy().to_string();
+            let tooltip_text = file_path.display_path();
 
             let header_text_fill = match list_highlight_state {
                 ItemHighlightState::None => {
@@ -1149,7 +1211,7 @@ impl GlobalSearchView {
                 .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
                 .finish();
 
-            let icon_from_file_path = icon_from_file_path(&file_path.to_string_lossy(), appearance)
+            let icon_from_file_path = icon_from_file_path(&file_path.display_path(), appearance)
                 .map(ImageOrIcon::Image)
                 .unwrap_or(ImageOrIcon::Icon(Icon::File));
 
@@ -1243,7 +1305,7 @@ impl GlobalSearchView {
     fn render_match_row(
         &self,
         index: usize,
-        directory_path: &Path,
+        directory_path: &LocalOrRemotePath,
         matched_path: &MatchedPath,
         matched: &Match,
         match_index: usize,
@@ -1252,17 +1314,14 @@ impl GlobalSearchView {
     ) -> Box<dyn Element> {
         let is_selected = self.is_row_at_index_selected(index);
         let line_number = matched.line_number;
+        let column_num = matched.column_num;
         let line_text = matched.line_text.clone();
         let submatches = matched.submatches.clone();
         let mouse_state = matched.mouse_state.clone();
 
-        let directory_path_for_select = directory_path.to_path_buf();
+        let directory_path_for_select = directory_path.clone();
         let file_path_for_select = matched_path.path.clone();
-        let path_for_click = matched_path.path.clone();
-
-        // Clone for the on_click closure since line_text and submatches are moved into Hoverable
-        let line_text_for_click = line_text.clone();
-        let submatches_for_click = submatches.clone();
+        let location_for_click = matched_path.path.clone();
 
         Hoverable::new(mouse_state, move |mouse_state| {
             let list_highlight_state = ItemHighlightState::new(is_selected, mouse_state);
@@ -1318,12 +1377,8 @@ impl GlobalSearchView {
                 file_path: file_path_for_select.clone(),
                 match_index: Some(match_index),
             });
-            let column_num = GlobalSearchView::column_from_submatches(
-                &line_text_for_click,
-                &submatches_for_click,
-            );
             ctx.dispatch_typed_action(GlobalSearchAction::OpenMatch {
-                path: path_for_click.clone(),
+                location: location_for_click.clone(),
                 line_number,
                 column_num,
             });
@@ -1482,18 +1537,21 @@ impl GlobalSearchView {
             .sum()
     }
 
-    /// Gets or creates a DirectoryEntry for the given path.
+    /// Gets or creates a DirectoryEntry for the given location.
     /// Returns a mutable reference to the entry and its index.
     #[allow(dead_code)] // Will be used in later PRs
-    fn get_or_create_directory_entry(&mut self, path: &Path) -> (&mut DirectoryEntry, usize) {
+    fn get_or_create_directory_entry(
+        &mut self,
+        path: &LocalOrRemotePath,
+    ) -> (&mut DirectoryEntry, usize) {
         if let Some(&index) = self.directory_path_to_directory_index_entry.get(path) {
             (&mut self.directory_entries[index], index)
         } else {
             let index = self.directory_entries.len();
             self.directory_entries
-                .push(DirectoryEntry::new(path.to_path_buf()));
+                .push(DirectoryEntry::new(path.clone()));
             self.directory_path_to_directory_index_entry
-                .insert(path.to_path_buf(), index);
+                .insert(path.clone(), index);
             (&mut self.directory_entries[index], index)
         }
     }
@@ -1502,8 +1560,8 @@ impl GlobalSearchView {
     /// Returns None if the paths are not found
     fn path_to_row_index(
         &self,
-        directory_path: &Path,
-        file_path: &Path,
+        directory_path: &LocalOrRemotePath,
+        file_path: &LocalOrRemotePath,
         match_index: Option<usize>,
     ) -> Option<RowIndex> {
         let &directory_index = self
@@ -1526,15 +1584,15 @@ impl GlobalSearchView {
         })
     }
 
-    /// Gets the directory path for a given RowIndex.
-    fn directory_path_for_row_index(&self, row: &RowIndex) -> Option<&PathBuf> {
+    /// Gets the directory location for a given RowIndex.
+    fn directory_path_for_row_index(&self, row: &RowIndex) -> Option<&LocalOrRemotePath> {
         self.directory_entries
             .get(row.directory_index)
             .map(|e| &e.path)
     }
 
-    /// Gets the file path for a given RowIndex (if it refers to a file or match).
-    fn file_path_for_row_index(&self, row: &RowIndex) -> Option<&PathBuf> {
+    /// Gets the file location for a given RowIndex (if it refers to a file or match).
+    fn file_path_for_row_index(&self, row: &RowIndex) -> Option<&LocalOrRemotePath> {
         let dir_entry = self.directory_entries.get(row.directory_index)?;
         match &row.index_type {
             RowIndexType::DirectoryHeader => None,
@@ -1723,12 +1781,10 @@ impl GlobalSearchView {
                 let Some(matched) = matched_path.matches.get(*match_index) else {
                     return;
                 };
-                let column_num =
-                    Self::column_from_submatches(&matched.line_text, &matched.submatches);
                 ctx.emit(Event::OpenMatch {
-                    path: matched_path.path.clone(),
+                    location: matched_path.path.clone(),
                     line_number: matched.line_number,
-                    column_num,
+                    column_num: matched.column_num,
                 });
             }
             RowIndexType::DirectoryHeader => {
@@ -1739,7 +1795,11 @@ impl GlobalSearchView {
         }
     }
 
-    fn toggle_directory_collapsed(&mut self, directory_path: &Path, ctx: &mut ViewContext<Self>) {
+    fn toggle_directory_collapsed(
+        &mut self,
+        directory_path: &LocalOrRemotePath,
+        ctx: &mut ViewContext<Self>,
+    ) {
         let Some(&dir_idx) = self
             .directory_path_to_directory_index_entry
             .get(directory_path)
@@ -1773,8 +1833,8 @@ impl GlobalSearchView {
 
     fn toggle_file_collapsed(
         &mut self,
-        directory_path: &Path,
-        file_path: &PathBuf,
+        directory_path: &LocalOrRemotePath,
+        file_path: &LocalOrRemotePath,
         ctx: &mut ViewContext<Self>,
     ) {
         // Get directory index
@@ -1853,6 +1913,7 @@ impl GlobalSearchView {
         dir_entry: &DirectoryEntry,
         appearance: &Appearance,
         theme: &warp_core::ui::theme::WarpTheme,
+        app: &AppContext,
     ) -> Box<dyn Element> {
         let is_selected = self.is_row_at_index_selected(index);
         let mouse_state = dir_entry.mouse_state.clone();
@@ -1861,14 +1922,36 @@ impl GlobalSearchView {
         let directory_path = &dir_entry.path;
 
         // Get the display name (last component of the path)
-        let display_name = directory_path
-            .file_name()
-            .map(|s| s.to_string_lossy().to_string())
-            .unwrap_or_else(|| directory_path.to_string_lossy().to_string());
-        let directory_path = directory_path.clone();
+        let mut display_name = match directory_path.file_name() {
+            Some(name) if !name.is_empty() => name.to_string(),
+            _ => directory_path.display_path(),
+        };
+        let remote_host_label = match directory_path {
+            LocalOrRemotePath::Remote(remote) => Some(
+                RemoteServerManager::as_ref(app)
+                    .host_label(&remote.host_id)
+                    .unwrap_or(remote.host_id.as_str())
+                    .to_string(),
+            ),
+            LocalOrRemotePath::Local(_) => None,
+        };
+        if let Some(host_label) = &remote_host_label {
+            display_name = format!("{display_name} — {host_label}");
+        }
         let directory_path_for_click = directory_path.clone();
 
-        let tooltip_text = directory_path.to_string_lossy().to_string();
+        // Include the host on remote directories so identically-named
+        // directories on different hosts are distinguishable.
+        let tooltip_text = match directory_path {
+            LocalOrRemotePath::Local(path) => path.to_string_lossy().to_string(),
+            LocalOrRemotePath::Remote(remote) => format!(
+                "{} on {}",
+                remote.path,
+                remote_host_label
+                    .as_deref()
+                    .unwrap_or(remote.host_id.as_str())
+            ),
+        };
 
         Hoverable::new(mouse_state, move |mouse_state| {
             let list_highlight_state = ItemHighlightState::new(is_selected, mouse_state);
@@ -1994,9 +2077,15 @@ impl View for GlobalSearchView {
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         match self.enablement {
-            CodingPanelEnablementState::PendingRemoteSession
-            | CodingPanelEnablementState::RemoteSession { .. } => {
+            CodingPanelEnablementState::PendingRemoteSession => {
                 return self.render_remote_state(app);
+            }
+            CodingPanelEnablementState::RemoteSession { has_remote_server } => {
+                // Remote-server sessions can search via the daemon; sessions
+                // without one (tmux / subshell SSH) stay unavailable.
+                if !has_remote_server {
+                    return self.render_remote_state(app);
+                }
             }
             CodingPanelEnablementState::UnsupportedSession => {
                 return self.render_unsupported_session_state(app);
@@ -2066,8 +2155,10 @@ impl View for GlobalSearchView {
         let files = self.unique_match_count();
         let file_word = if files == 1 { "file" } else { "files" };
 
-        let message = if self.is_search_in_progress && self.total_match_count == 0 {
-            "".to_string()
+        let message = if let Some(error) = &self.last_error {
+            error.clone()
+        } else if self.is_search_in_progress && self.total_match_count == 0 {
+            "Searching…".to_string()
         } else if !self.is_search_in_progress && self.total_match_count == 0 {
             "No results found. Review your gitignore files.".to_string()
         } else {
@@ -2265,7 +2356,7 @@ impl GlobalSearchView {
         self.render_zero_state(
             Icon::AlertTriangle,
             "Global search unavailable",
-            "Global search requires access to your local workspace, which isn't supported in remote sessions",
+            "Global search isn't available for this remote session.",
             app,
         )
     }

--- a/app/src/workspace/view/global_search/view.rs
+++ b/app/src/workspace/view/global_search/view.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use async_channel::Sender;
 use instant::Instant;
 use pathfinder_geometry::vector::vec2f;
-use remote_server::manager::RemoteServerManager;
 use remote_server::HostId;
 use string_offset::{ByteOffset, CharCounter};
 use warp_core::r#async::debounce;
@@ -52,6 +51,7 @@ use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon as UiIcon;
 use crate::ui_components::item_highlight::{ImageOrIcon, ItemHighlightState};
 use crate::ui_components::render_file_search_row::{render_file_search_row, FileSearchRowOptions};
+use crate::util::path::{display_name_with_host, display_path_with_host};
 use crate::view_components::action_button::{ActionButton, ButtonSize, NakedTheme};
 use crate::workspace::view::global_search::model::GlobalSearch;
 use crate::workspace::view::global_search::{GlobalSearchMatch, SearchConfig};
@@ -128,10 +128,12 @@ pub enum GlobalSearchEvent {
         total_match_count: usize,
         /// True when a remote source hit the server-side match cap.
         capped: bool,
-        /// Number of search sources (local, or one remote host) that failed
-        /// while the others completed. Results from the surviving sources
-        /// remain valid.
-        source_failures: usize,
+        /// Whether the local search source failed while another source
+        /// completed. Results from the surviving sources remain valid.
+        local_source_failed: bool,
+        /// Number of remote host search sources that failed while another
+        /// source completed. Results from the surviving sources remain valid.
+        remote_source_failures: usize,
     },
     Failed {
         search_id: u32,
@@ -972,7 +974,8 @@ impl GlobalSearchView {
                 search_id,
                 total_match_count,
                 capped,
-                source_failures,
+                local_source_failed,
+                remote_source_failures,
             } => {
                 if Some(*search_id) != self.current_search_id {
                     return;
@@ -989,7 +992,8 @@ impl GlobalSearchView {
                             remote_host_count: self.active_search_remote_host_count,
                             total_match_count: *total_match_count,
                             capped: self.capped_matches,
-                            source_failures: *source_failures,
+                            local_source_failed: *local_source_failed,
+                            remote_source_failures: *remote_source_failures,
                         },
                         ctx
                     );
@@ -1932,37 +1936,13 @@ impl GlobalSearchView {
         let is_collapsed = dir_entry.is_collapsed;
         let directory_path = &dir_entry.path;
 
-        // Get the display name (last component of the path)
-        let mut display_name = match directory_path.file_name() {
-            Some(name) if !name.is_empty() => name.to_string(),
-            _ => directory_path.display_path(),
+        let display_name = if directory_path.display_name().is_empty() {
+            display_path_with_host(directory_path, false, app)
+        } else {
+            display_name_with_host(directory_path, app)
         };
-        let remote_host_label = match directory_path {
-            LocalOrRemotePath::Remote(remote) => Some(
-                RemoteServerManager::as_ref(app)
-                    .host_label(&remote.host_id)
-                    .unwrap_or(remote.host_id.as_str())
-                    .to_string(),
-            ),
-            LocalOrRemotePath::Local(_) => None,
-        };
-        if let Some(host_label) = &remote_host_label {
-            display_name = format!("{display_name} — {host_label}");
-        }
         let directory_path_for_click = directory_path.clone();
-
-        // Include the host on remote directories so identically-named
-        // directories on different hosts are distinguishable.
-        let tooltip_text = match directory_path {
-            LocalOrRemotePath::Local(path) => path.to_string_lossy().to_string(),
-            LocalOrRemotePath::Remote(remote) => format!(
-                "{} on {}",
-                remote.path,
-                remote_host_label
-                    .as_deref()
-                    .unwrap_or(remote.host_id.as_str())
-            ),
-        };
+        let tooltip_text = display_path_with_host(directory_path, false, app);
 
         Hoverable::new(mouse_state, move |mouse_state| {
             let list_highlight_state = ItemHighlightState::new(is_selected, mouse_state);
@@ -2089,7 +2069,7 @@ impl View for GlobalSearchView {
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         match self.enablement {
             CodingPanelEnablementState::PendingRemoteSession => {
-                return self.render_remote_state(app);
+                return self.render_remote_loading_state(app);
             }
             CodingPanelEnablementState::RemoteSession { has_remote_server } => {
                 // Remote-server sessions can search via the daemon; sessions
@@ -2368,6 +2348,14 @@ impl GlobalSearchView {
             Icon::AlertTriangle,
             "Global search unavailable",
             "Global search isn't available for this remote session.",
+            app,
+        )
+    }
+    fn render_remote_loading_state(&self, app: &AppContext) -> Box<dyn Element> {
+        self.render_zero_state(
+            Icon::Loading,
+            "Connecting to remote session",
+            "Global search will be available once the connection is ready.",
             app,
         )
     }

--- a/app/src/workspace/view/left_panel.rs
+++ b/app/src/workspace/view/left_panel.rs
@@ -44,9 +44,11 @@ use crate::ui_components::icons;
 use crate::util::bindings::keybinding_name_to_display_string;
 #[cfg(feature = "local_fs")]
 use crate::util::file::external_editor::EditorSettings;
-#[cfg(feature = "local_fs")]
-use crate::util::openable_file_type::resolve_file_target_with_editor_choice;
 use crate::util::openable_file_type::FileTarget;
+#[cfg(feature = "local_fs")]
+use crate::util::openable_file_type::{
+    is_markdown_file, resolve_file_target_with_editor_choice, EditorLayout,
+};
 use crate::workspace::view::conversation_list::view::{
     ConversationListView, Event as ConversationListViewEvent,
 };
@@ -292,11 +294,13 @@ impl LeftPanelView {
                     })
                     .collect();
 
-                // Update GlobalSearchView root directories (local only).
+                // Update GlobalSearchView root directories (local + remote).
+                let all_directories: Vec<LocalOrRemotePath> =
+                    directories.iter().map(|d| d.path.clone()).collect();
                 let global_search_view =
                     me.get_or_create_global_search_view_for_pane_group(active_pane_group.id(), ctx);
                 global_search_view.update(ctx, |view, view_ctx| {
-                    view.set_root_directories(local_paths.clone(), view_ctx);
+                    view.set_root_directories(all_directories, view_ctx);
                 });
 
                 // Directories are already in display order (most recent first) from the model
@@ -629,11 +633,13 @@ impl LeftPanelView {
             })
             .collect();
 
-        // Update GlobalSearchView root directories (local only).
+        // Update GlobalSearchView root directories (local + remote).
+        let all_directories: Vec<LocalOrRemotePath> =
+            active_directories.iter().map(|d| d.path.clone()).collect();
         let global_search_view =
             self.get_or_create_global_search_view_for_pane_group(pane_group_id, ctx);
         global_search_view.update(ctx, |view, view_ctx| {
-            view.set_root_directories(local_paths.clone(), view_ctx);
+            view.set_root_directories(all_directories, view_ctx);
         });
 
         let local_directories = deduplicate_by_directory_name(local_paths);
@@ -736,7 +742,7 @@ impl LeftPanelView {
     ) {
         match event {
             GlobalSearchViewEvent::OpenMatch {
-                path,
+                location,
                 line_number,
                 column_num,
             } => {
@@ -746,13 +752,27 @@ impl LeftPanelView {
                 };
 
                 let settings = EditorSettings::as_ref(ctx);
-                let target = resolve_file_target_with_editor_choice(
-                    path,
-                    *settings.open_code_panels_file_editor,
-                    *settings.prefer_markdown_viewer,
-                    *settings.open_file_layout,
-                    None,
-                );
+                let target = match location {
+                    LocalOrRemotePath::Local(path) => resolve_file_target_with_editor_choice(
+                        path,
+                        *settings.open_code_panels_file_editor,
+                        *settings.prefer_markdown_viewer,
+                        *settings.open_file_layout,
+                        None,
+                    ),
+                    // Local-fs-based target resolution can't inspect remote
+                    // files; mirror the file tree's remote handling (code
+                    // editor, or markdown viewer by extension + preference).
+                    LocalOrRemotePath::Remote(remote) => {
+                        let is_markdown =
+                            is_markdown_file(std::path::Path::new(remote.path.as_str()));
+                        if is_markdown && *settings.prefer_markdown_viewer {
+                            FileTarget::MarkdownViewer(EditorLayout::SplitPane)
+                        } else {
+                            FileTarget::CodeEditor(EditorLayout::SplitPane)
+                        }
+                    }
+                };
 
                 send_telemetry_from_ctx!(
                     TelemetryEvent::CodePanelsFileOpened {
@@ -763,7 +783,7 @@ impl LeftPanelView {
                 );
 
                 ctx.emit(LeftPanelEvent::OpenFileWithTarget {
-                    location: LocalOrRemotePath::Local(path.clone()),
+                    location: location.clone(),
                     target,
                     line_col: Some(line_col),
                 });

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -813,6 +813,20 @@ impl PendingHostRequest {
     }
 }
 
+/// Parameters for a host-scoped remote ripgrep search.
+pub struct RipgrepSearchParams {
+    /// Effective ripgrep pattern after applying the caller's regex settings.
+    pub pattern: String,
+    /// Absolute roots to search on the remote host.
+    pub roots: Vec<StandardizedPath>,
+    /// Whether matching should ignore case.
+    pub ignore_case: bool,
+    /// Whether matching should span multiple lines.
+    pub multiline: bool,
+    /// Maximum number of matches requested from the remote host.
+    pub max_matches: u32,
+}
+
 /// A host-scoped remote ripgrep search registered synchronously with
 /// [`RemoteServerManager`], whose typed result can be awaited off-thread.
 ///
@@ -1600,12 +1614,24 @@ impl RemoteServerManager {
     pub fn start_ripgrep_search(
         &mut self,
         host_id: &HostId,
-        request: crate::proto::RipgrepSearchRequest,
+        params: RipgrepSearchParams,
     ) -> PendingRipgrepSearch {
         let request_id = crate::protocol::RequestId::new();
         let msg = crate::proto::ClientMessage::host_scoped(
             request_id.to_string(),
-            crate::proto::host_scoped_request::Message::RipgrepSearch(request),
+            crate::proto::host_scoped_request::Message::RipgrepSearch(
+                crate::proto::RipgrepSearchRequest {
+                    pattern: params.pattern,
+                    roots: params
+                        .roots
+                        .into_iter()
+                        .map(|path| path.to_string())
+                        .collect(),
+                    ignore_case: params.ignore_case,
+                    multiline: params.multiline,
+                    max_matches: params.max_matches,
+                },
+            ),
         );
         let response = self.send_host_request(host_id, msg);
         PendingRipgrepSearch {

--- a/crates/remote_server/src/manager_tests.rs
+++ b/crates/remote_server/src/manager_tests.rs
@@ -1,9 +1,10 @@
 use futures::channel::oneshot;
 use warp_core::SessionId;
+use warp_util::standardized_path::StandardizedPath;
 use warpui_core::App;
 
-use super::{HostRequestError, PendingHostRequest, RemoteServerManager};
-use crate::proto::{host_scoped_request, ClientMessage, RipgrepSearchRequest, WriteFile};
+use super::{HostRequestError, PendingHostRequest, RemoteServerManager, RipgrepSearchParams};
+use crate::proto::{host_scoped_request, ClientMessage, WriteFile};
 use crate::protocol::RequestId;
 use crate::HostId;
 
@@ -52,9 +53,9 @@ fn start_ripgrep_search_without_connected_host_resolves_immediately() {
         let pending = manager.update(&mut app, |manager, _ctx| {
             manager.start_ripgrep_search(
                 &host_id,
-                RipgrepSearchRequest {
+                RipgrepSearchParams {
                     pattern: "needle".to_string(),
-                    roots: vec!["/repo".to_string()],
+                    roots: vec![StandardizedPath::try_new("/repo").unwrap()],
                     ignore_case: false,
                     multiline: false,
                     max_matches: 100,


### PR DESCRIPTION
## Description

Stacked PR (2/2) on top of #12475.

Enables global search for remote-server sessions. The global-search model now dispatches local roots locally and remote roots per host, merges results by `LocalOrRemotePath`, preserves original editor line/column navigation, and opens remote results in the remote code editor. It also adds bounded-search latency/completion telemetry and user-facing partial failure/searching states.

The base PR provides the remote-server ripgrep request API and cancellation lifecycle.

- Base PR: https://github.com/warpdotdev/warp/pull/12475
- Plan: https://staging.warp.dev/drive/notebook/Dt2dvso69qyHPyIc0TRdxS
- Agent conversation: https://staging.warp.dev/conversation/71ba0eaa-6bf6-4c0e-9c27-427ec2f3eaa5

## Linked Issue
N/A
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format`
- `cargo check -p warp --target wasm32-unknown-unknown`
- `cargo nextest run -p warp --no-fail-fast` — 5157 passed, 1 pre-existing leaky test, 6 skipped
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- Focused global-search, navigation-column, payload-cap, and request-cancellation unit tests
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

![Screenshot 2026-06-10 at 4.47.12 PM.png](https://app.graphite.com/user-attachments/assets/ca8c8c36-cd04-42fe-8626-c0ae8c4d17cb.png)

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)