### PR TITLE
skip registering secure_storage for remote daemon

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1088,16 +1088,23 @@ pub(crate) fn initialize_app(
     // any other stuff here, as failures will be silent. Push them to pre_sentry_errors instead.
     let data_domain = ChannelState::data_domain();
 
-    // Register an implementation of the secure storage service.
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "integration_tests")] {
-            warpui_extras::secure_storage::register_noop(&data_domain, ctx);
-        } else if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
-            warpui_extras::secure_storage::register_with_fallback(&data_domain, warp_core::paths::state_dir(), ctx)
-        } else if #[cfg(target_os = "windows")] {
-            warpui_extras::secure_storage::register_with_dir(&data_domain, warp_core::paths::state_dir(), ctx)
-        } else {
-            warpui_extras::secure_storage::register(&data_domain, ctx);
+    // Daemon auth arrives through the client handshake, so avoid platform keychains that may
+    // require an interactive unlock prompt. Other headless modes still use secure storage for
+    // persisted login and BYO provider credentials.
+    if matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. }) {
+        warpui_extras::secure_storage::register_unavailable(ctx);
+    } else {
+        // Register an implementation of the secure storage service.
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "integration_tests")] {
+                warpui_extras::secure_storage::register_noop(&data_domain, ctx);
+            } else if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
+                warpui_extras::secure_storage::register_with_fallback(&data_domain, warp_core::paths::state_dir(), ctx)
+            } else if #[cfg(target_os = "windows")] {
+                warpui_extras::secure_storage::register_with_dir(&data_domain, warp_core::paths::state_dir(), ctx)
+            } else {
+                warpui_extras::secure_storage::register(&data_domain, ctx);
+            }
         }
     }
 

--- a/crates/warpui_extras/src/secure_storage/mod.rs
+++ b/crates/warpui_extras/src/secure_storage/mod.rs
@@ -10,6 +10,7 @@
 #[cfg_attr(target_os = "windows", path = "windows.rs")]
 mod imp;
 mod noop;
+mod unavailable;
 
 // Treat this as a noop on web, as there is no backing storage which is "secure".
 #[cfg(target_family = "wasm")]
@@ -58,6 +59,13 @@ pub fn register(service_name: &str, ctx: &mut warpui_core::AppContext) {
 /// Registers a no-op Secure Storage provider with the application.
 pub fn register_noop(service_name: &str, ctx: &mut warpui_core::AppContext) {
     ctx.add_singleton_model(|_| -> Model { Box::new(noop::SecureStorage::new(service_name)) });
+}
+
+/// Registers an unavailable Secure Storage provider that deliberately does not persist values.
+///
+/// Reads report missing values, while writes and removals succeed without accessing storage.
+pub fn register_unavailable(ctx: &mut warpui_core::AppContext) {
+    ctx.add_singleton_model(|_| -> Model { Box::new(unavailable::SecureStorage) });
 }
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]

--- a/crates/warpui_extras/src/secure_storage/unavailable.rs
+++ b/crates/warpui_extras/src/secure_storage/unavailable.rs
@@ -1,0 +1,23 @@
+//! [`SecureStorage`] provider for processes that must not access persistent secrets.
+
+use super::Error;
+
+pub struct SecureStorage;
+
+impl super::SecureStorage for SecureStorage {
+    fn write_value(&self, _key: &str, _value: &str) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_value(&self, _key: &str) -> Result<String, Error> {
+        Err(Error::NotFound)
+    }
+
+    fn remove_value(&self, _key: &str) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "unavailable_tests.rs"]
+mod tests;

--- a/crates/warpui_extras/src/secure_storage/unavailable_tests.rs
+++ b/crates/warpui_extras/src/secure_storage/unavailable_tests.rs
@@ -1,0 +1,25 @@
+use super::SecureStorage;
+use crate::secure_storage::{Error, SecureStorage as _};
+
+#[test]
+fn read_value_returns_not_found() {
+    let storage = SecureStorage;
+
+    assert!(matches!(storage.read_value("key"), Err(Error::NotFound)));
+}
+
+#[test]
+fn write_value_is_discarded() {
+    let storage = SecureStorage;
+
+    storage.write_value("key", "value").expect("write succeeds");
+
+    assert!(matches!(storage.read_value("key"), Err(Error::NotFound)));
+}
+
+#[test]
+fn remove_value_succeeds() {
+    let storage = SecureStorage;
+
+    storage.remove_value("key").expect("remove succeeds");
+}


### PR DESCRIPTION
## Description

Here's the original issue report: https://github.com/warpdotdev/Warp/issues/12449

The issue is because of our dependency on secure storage, which has platform specific implementations so on Linux it uses `SecretService` which results in the reported lock issue. We technically don't need it for the remote daemon case because we handle auth in thehandshake, we are just incidentally using it right now during daemon setup so I'm skipping it for the remote daemon case.

<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue

https://github.com/warpdotdev/Warp/issues/12449

<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

![Screenshot 2026-06-10 at 3.54.16 PM.png](https://app.graphite.com/user-attachments/assets/0c964dae-aa2f-4ea1-9ffc-a366c75e4628.png)

<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->