### PR TITLE
Don't block system-initiated termination (logout, shutdown, scheduled OS update)

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -226,7 +226,7 @@ use warp_logging::LogDestination;
 use warp_managed_secrets::ManagedSecretManager;
 use warpui::integration::TestDriver;
 use warpui::modals::{AlertDialogWithCallbacks, AppModalCallback};
-use warpui::platform::app::ApproveTerminateResult;
+use warpui::platform::app::{ApproveTerminateResult, TerminationRequestSource};
 use warpui::platform::TerminationMode;
 use warpui::windowing::state::ApplicationStage;
 use warpui::{App, AppContext, Event, SingletonEntity, WindowId};
@@ -2268,7 +2268,20 @@ pub(crate) fn app_callbacks(is_integration_test: bool) -> warpui::platform::AppC
                 ApproveTerminateResult::Terminate
             }
         })),
-        on_should_terminate_app: Some(Box::new(move |ctx| {
+        on_should_terminate_app: Some(Box::new(move |source, ctx| {
+            // Never interrupt a system-initiated termination (logout / restart /
+            // scheduled OS update): both cancel paths below return
+            // `ApproveTerminateResult::Cancel`, which macOS interprets as Warp
+            // refusing to quit. That can abort a scheduled OS update while the
+            // quit-warning modal has no visible window to attach to, leaving
+            // Warp waiting on a prompt nobody can see (#12441). Skipping
+            // `apply_pending_update` here doesn't lose the update: the next
+            // update check re-detects it (autoupdate state isn't persisted
+            // across restarts, so the artifact may be re-downloaded).
+            if source == TerminationRequestSource::System {
+                return ApproveTerminateResult::Terminate;
+            }
+
             send_telemetry_from_app_ctx!(
                 TelemetryEvent::UserInitiatedClose {
                     initiated_on: CloseTarget::App,

--- a/crates/warpui/src/platform/headless/event_loop.rs
+++ b/crates/warpui/src/platform/headless/event_loop.rs
@@ -1,7 +1,9 @@
 use std::mem::ManuallyDrop;
 use std::sync::mpsc::{Receiver, Sender};
 
-use crate::platform::app::{AppCallbackDispatcher, ApproveTerminateResult, TerminationResult};
+use crate::platform::app::{
+    AppCallbackDispatcher, ApproveTerminateResult, TerminationRequestSource, TerminationResult,
+};
 use crate::platform::{self, TerminationMode};
 use crate::{AppContext, WindowId};
 
@@ -46,7 +48,7 @@ pub(super) fn run(
                 let should_terminate = match termination_mode {
                     TerminationMode::Cancellable => {
                         matches!(
-                            callbacks.should_terminate_app(),
+                            callbacks.should_terminate_app(TerminationRequestSource::User),
                             ApproveTerminateResult::Terminate
                         )
                     }

--- a/crates/warpui/src/platform/mac/app.rs
+++ b/crates/warpui/src/platform/mac/app.rs
@@ -14,7 +14,9 @@ use warpui_core::assets::AssetProvider;
 use warpui_core::integration::TestDriver;
 use warpui_core::keymap::{Keystroke, Trigger};
 use warpui_core::modals::{AlertDialog, ModalId};
-use warpui_core::platform::app::{AppCallbackDispatcher, ApproveTerminateResult};
+use warpui_core::platform::app::{
+    AppCallbackDispatcher, ApproveTerminateResult, TerminationRequestSource,
+};
 use warpui_core::platform::menu::{Menu, MenuBar};
 use warpui_core::platform::{self, FilePickerCallback, SaveFilePickerCallback};
 use warpui_core::{AppContext, Event};
@@ -299,10 +301,18 @@ pub(crate) extern "C-unwind" fn warp_app_internet_reachability_changed(
 
 /// Returns whether or not we can proceed with termination.
 #[no_mangle]
-pub(crate) extern "C-unwind" fn warp_app_should_terminate_app(this: &mut Object) -> BOOL {
+pub(crate) extern "C-unwind" fn warp_app_should_terminate_app(
+    this: &mut Object,
+    system_initiated: BOOL,
+) -> BOOL {
     let app = unsafe { get_app(this) };
 
-    match app.callbacks.should_terminate_app() {
+    let source = if system_initiated != NO {
+        TerminationRequestSource::System
+    } else {
+        TerminationRequestSource::User
+    };
+    match app.callbacks.should_terminate_app(source) {
         ApproveTerminateResult::Terminate => YES,
         ApproveTerminateResult::Cancel => NO,
     }

--- a/crates/warpui/src/platform/mac/objc/app.h
+++ b/crates/warpui/src/platform/mac/objc/app.h
@@ -32,7 +32,7 @@ void warp_app_active_window_changed(id app);
 void warp_app_notification_clicked(id app, double date, id data);
 void warp_app_open_urls(id app, id urls);
 void warp_app_os_appearance_changed(id app);
-BOOL warp_app_should_terminate_app(id app);
+BOOL warp_app_should_terminate_app(id app, BOOL systemInitiated);
 BOOL warp_app_should_close_window(id app, id window);
 BOOL warp_app_are_key_bindings_disabled_for_window(id app, id window);
 BOOL warp_app_has_binding_for_keystroke(id app, id event);

--- a/crates/warpui/src/platform/mac/objc/app.m
+++ b/crates/warpui/src/platform/mac/objc/app.m
@@ -254,8 +254,29 @@ NSUInteger activeScreenId() {
     }
 }
 
+// Returns YES when the in-flight quit Apple event carries a kAEQuitReason
+// indicating the system (logout / restart / shutdown / scheduled OS update)
+// initiated the termination, as opposed to the user quitting the app directly.
+// Per AERegistry.h, the documented kAEQuitReason values are kAEQuitAll,
+// kAEShutDown, kAERestart, and kAEReallyLogOut; a missing event or reason
+// (both accessors return 0 on nil) means the user or another process quit us.
+static BOOL isSystemInitiatedTermination(void) {
+    NSAppleEventDescriptor *event = [[NSAppleEventManager sharedAppleEventManager] currentAppleEvent];
+    NSAppleEventDescriptor *reason = [event attributeDescriptorForKeyword:kAEQuitReason];
+    switch ([reason typeCodeValue]) {
+        case kAEQuitAll:
+        case kAEShutDown:
+        case kAERestart:
+        case kAEReallyLogOut:
+            return YES;
+        default:
+            return NO;
+    }
+}
+
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)application {
     BOOL okToTerminate = YES;
+    BOOL systemInitiated = isSystemInitiatedTermination();
 
     // If this is the second termination attempt after we've already hidden the app, we can go ahead
     // and terminate.
@@ -266,10 +287,18 @@ NSUInteger activeScreenId() {
     if (!forceTermination) {
         // Make sure the rust app doesn't have any reasons to interrupt quit, e.g. needs to relaunch
         // for autoupdate, but launching the new process failed.
-        okToTerminate = warp_app_should_terminate_app(application);
+        okToTerminate = warp_app_should_terminate_app(application, systemInitiated);
     }
 
     if (okToTerminate) {
+        if (systemInitiated) {
+            // Comply immediately when the system asked us to quit. Anything but
+            // `NSTerminateNow` here (including the hide-then-reterminate dance
+            // below, which returns `NSTerminateCancel`) makes macOS treat Warp
+            // as blocking the logout/shutdown, which can abort a scheduled OS
+            // update and leave the app in a stuck-looking state (#12441).
+            return NSTerminateNow;
+        }
         // We want to hide the application before we start the teardown
         // process, to ensure the user isn't affected by any slow teardown
         // steps.  The tricky part here is that a call to `[NSApp hide]` isn't

--- a/crates/warpui/src/platform/mac/objc/app.m
+++ b/crates/warpui/src/platform/mac/objc/app.m
@@ -261,7 +261,8 @@ NSUInteger activeScreenId() {
 // kAEShutDown, kAERestart, and kAEReallyLogOut; a missing event or reason
 // (both accessors return 0 on nil) means the user or another process quit us.
 static BOOL isSystemInitiatedTermination(void) {
-    NSAppleEventDescriptor *event = [[NSAppleEventManager sharedAppleEventManager] currentAppleEvent];
+    NSAppleEventDescriptor *event =
+        [[NSAppleEventManager sharedAppleEventManager] currentAppleEvent];
     NSAppleEventDescriptor *reason = [event attributeDescriptorForKeyword:kAEQuitReason];
     switch ([reason typeCodeValue]) {
         case kAEQuitAll:

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -31,7 +31,9 @@ use crate::actions::StandardAction;
 use crate::event::ModifiersState;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::notification::RequestPermissionsOutcome;
-use crate::platform::app::{AppCallbackDispatcher, ApproveTerminateResult};
+use crate::platform::app::{
+    AppCallbackDispatcher, ApproveTerminateResult, TerminationRequestSource,
+};
 use crate::platform::{self, NotificationInfo, OperatingSystem, TerminationMode, WindowContext};
 use crate::r#async::Timer;
 use crate::rendering::wgpu::renderer;
@@ -1504,7 +1506,11 @@ impl EventLoop {
             return ApproveTerminateResult::Terminate;
         }
 
-        let approve_terminate_result = self.callbacks.should_terminate_app();
+        // Winit doesn't tell us why termination was requested, so assume the
+        // user asked (system-initiated shutdown detection is macOS-only for now).
+        let approve_terminate_result = self
+            .callbacks
+            .should_terminate_app(TerminationRequestSource::User);
         if let ApproveTerminateResult::Terminate = approve_terminate_result {}
         approve_terminate_result
     }

--- a/crates/warpui_core/src/platform/app.rs
+++ b/crates/warpui_core/src/platform/app.rs
@@ -25,7 +25,8 @@ pub struct AppCallbacks {
     pub on_resigned_active: Option<Box<dyn FnMut(&mut AppContext)>>,
     pub on_will_terminate: Option<Box<dyn FnMut(&mut AppContext)>>,
     /// Callback on whether the app will proceed with termination.
-    pub on_should_terminate_app: Option<Box<dyn FnMut(&mut AppContext) -> ApproveTerminateResult>>,
+    pub on_should_terminate_app:
+        Option<Box<dyn FnMut(TerminationRequestSource, &mut AppContext) -> ApproveTerminateResult>>,
     /// Callback on whether the window will proceed with closing.
     pub on_should_close_window:
         Option<Box<dyn FnMut(WindowId, &mut AppContext) -> ApproveTerminateResult>>,
@@ -64,6 +65,22 @@ pub enum ApproveTerminateResult {
     Terminate,
     /// Do not close the window or app.
     Cancel,
+}
+
+/// Who asked the app to terminate.
+///
+/// Platform code passes this through to `on_should_terminate_app` so the
+/// application can decide whether it is appropriate to interrupt the
+/// termination, e.g. with a confirmation dialog. Blocking a system-initiated
+/// termination (logout / restart / scheduled OS update) makes the OS treat the
+/// app as refusing to quit, which can abort the whole system operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminationRequestSource {
+    /// The user asked the app to quit (menu, keyboard shortcut, Dock, …).
+    User,
+    /// The system asked the app to quit (logout, restart, shutdown, or a
+    /// scheduled OS update).
+    System,
 }
 
 impl AppCallbackDispatcher {
@@ -141,9 +158,12 @@ impl AppCallbackDispatcher {
         }
     }
 
-    pub fn should_terminate_app(&mut self) -> ApproveTerminateResult {
+    pub fn should_terminate_app(
+        &mut self,
+        source: TerminationRequestSource,
+    ) -> ApproveTerminateResult {
         if let Some(callback) = &mut self.callbacks.on_should_terminate_app {
-            self.ui_app.update(|ctx| callback(ctx))
+            self.ui_app.update(|ctx| callback(source, ctx))
         } else {
             ApproveTerminateResult::Terminate
         }


### PR DESCRIPTION
## Description

When macOS asks Warp to quit because of a logout, restart, shutdown, or a scheduled OS update, `applicationShouldTerminate` can answer `NSTerminateCancel` up to three times: while a deferred autoupdate is applied (`app/src/lib.rs`), when the running-process quit warning is shown (`app/src/quit_warning/mod.rs`), and in the hide-then-reterminate dance that even the success path runs (`crates/warpui/src/platform/mac/objc/app.m`). macOS interprets any of those as Warp refusing to quit: the scheduled OS update is aborted and reverted, while Warp keeps waiting on a quit-warning modal that has no visible window to attach to — it looks frozen and can only be force-killed.

This PR reads `kAEQuitReason` off the in-flight quit Apple event (documented values per `AERegistry.h`: `kAEQuitAll`, `kAEShutDown`, `kAERestart`, `kAEReallyLogOut`) and plumbs a `TerminationRequestSource` through `warp_app_should_terminate_app` into the app-level callback. For system-initiated termination Warp now:

- skips the deferred-autoupdate cancel — the downloaded update stays staged and is re-detected by the next update check;
- skips the running-process quit-warning dialog;
- returns `NSTerminateNow` immediately instead of the hide-then-reterminate dance.

User-initiated quits behave exactly as before. Winit and headless platforms pass `TerminationRequestSource::User`, keeping their previous behavior (system-shutdown detection on those platforms is a separate concern).

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

Fixes #12441

## Testing

- [x] `cargo fmt -- --check`
- [x] `cargo check` (workspace default members, includes the `warp` app crate)
- [x] `PATH="/tmp/warp-corepack-shims:$PATH" cargo clippy --workspace --all-targets -- -D warnings` → No issues found (`--all-features` fails on this OSS checkout for the `stable`/`preview` channel bins due to missing internal channel configs — reproducible on unmodified `master`, unrelated to this diff)
- [x] `cargo nextest run -p warpui_core -p warpui` → 317 passed, 8 skipped
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Controlled experiment on a local OSS build: a `sleep 9999` process is running, then a quit Apple event carrying `kAEQuitReason=kAEShutDown` (what loginwindow sends during logout / shutdown / a scheduled OS update) is delivered to the app.

**Before (unmodified `master`)** — the system shutdown is blocked by the running-process quit dialog; the app stays alive instead of quitting, which is what hangs a scheduled OS update:

<img width="372" height="414" alt="before_modal" src="https://github.com/user-attachments/assets/34fe99bc-d86d-4157-8fc2-4b6225120e79" />

**Before / after screen recording** (red = master blocks on the dialog, green = this branch exits immediately with no dialog):

https://github.com/user-attachments/assets/290d75f0-9c84-427a-988a-b3cb2e9023cc


## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Warp no longer blocks logout, shutdown, or scheduled macOS updates when terminal processes are running or an autoupdate is pending.
-->

