### PR TITLE
Fix "Accept w/o orchestration" showing misleading re-enable message (REMOTE-1913)

### DIFF
--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -72,6 +72,16 @@ use crate::view_components::{FilterableDropdownEvent, FilterableDropdownOrientat
 
 const RUN_AGENTS_CARD_TITLE: &str = "Can I start additional agents for this task?";
 
+/// Reason attached to the `Denied` result when the user explicitly picks
+/// "Accept w/o orchestration". It distinguishes the deliberate user opt-out
+/// from system denials (disapproved config, duplicate agents, never-allow
+/// policy, missing auth secret) so the terminal-state card can render a
+/// neutral message instead of telling the user to re-enable orchestration.
+/// The text is also surfaced to the agent as the denial reason, signalling
+/// that it should complete the task itself without starting child agents.
+pub(crate) const RUN_WITHOUT_ORCHESTRATION_DENY_REASON: &str =
+    "The user chose to run without orchestration; complete the task yourself without starting child agents.";
+
 pub fn init(app: &mut AppContext) {
     use warpui::keymap::macros::*;
 
@@ -1050,7 +1060,11 @@ impl TypedActionView for RunAgentsCardView {
                 self.emit_decision(RunAgentsCardDecision::AcceptWithoutOrchestration, ctx);
                 let action_id = self.action_id.clone();
                 self.action_model.update(ctx, |action_model, action_ctx| {
-                    action_model.deny_run_agents(&action_id, String::new(), action_ctx);
+                    action_model.deny_run_agents(
+                        &action_id,
+                        RUN_WITHOUT_ORCHESTRATION_DENY_REASON.to_string(),
+                        action_ctx,
+                    );
                 });
             }
             RunAgentsCardViewAction::ToggleAcceptMenu => {
@@ -1381,6 +1395,15 @@ pub(crate) fn format_terminal_state(result: &RunAgentsResult) -> (String, Status
             (label, kind)
         }
         RunAgentsResult::Denied { reason } => {
+            // The user deliberately chose "Accept w/o orchestration": this is
+            // not a failure and must not tell the user to re-enable
+            // orchestration. The agent proceeds without child agents.
+            if reason == RUN_WITHOUT_ORCHESTRATION_DENY_REASON {
+                return (
+                    "Continuing without orchestration".to_string(),
+                    StatusKind::Cancelled,
+                );
+            }
             let body = if reason.is_empty() {
                 "Orchestration is currently disabled. Re-enable on the plan card to launch."
                     .to_string()

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -345,6 +345,18 @@ mod format_terminal_state_tests {
     }
 
     #[test]
+    fn user_opt_out_denial_renders_neutral_message() {
+        // "Accept w/o orchestration" is a deliberate user choice, not a
+        // failure. It must not instruct the user to re-enable orchestration.
+        let (label, kind) = format_terminal_state(&RunAgentsResult::Denied {
+            reason: super::super::RUN_WITHOUT_ORCHESTRATION_DENY_REASON.to_string(),
+        });
+        assert_eq!(label, "Continuing without orchestration");
+        assert!(!label.contains("Re-enable"));
+        assert!(matches!(kind, StatusKind::Cancelled));
+    }
+
+    #[test]
     fn cancelled_uses_cancelled_status() {
         let (label, kind) = format_terminal_state(&RunAgentsResult::Cancelled);
         assert_eq!(label, "Spawn agents cancelled");


### PR DESCRIPTION
## Description
Fixes the orchestration kickoff confirmation card so **"Accept w/o orchestration"** (reported by the user as *"Run w/o orchestration"*) no longer looks like a failure.

When a user disables orchestration on a plan and asks their local agent to kick off an Oz agent, the run_agents confirmation card appears. Selecting the **"Accept w/o orchestration"** menu item correctly sends a `Denied` result so the agent proceeds without child agents — and this already works regardless of the plan's orchestration toggle. However, the terminal-state card rendered **every** `Denied` result with:

> Orchestration is currently disabled. Re-enable on the plan card to launch.

That message conflated the deliberate user opt-out with genuine system denials (disapproved config, duplicate agents, never-allow policy, missing auth secret). The result: a user who intentionally chose to run *without* orchestration was told to *re-enable* it, making the action appear to fail — exactly the bug reported in REMOTE-1913 ("run without orchestration still requires orchestration to be enabled").

### Changes
- Added `RUN_WITHOUT_ORCHESTRATION_DENY_REASON`, an explicit reason attached to the `Denied` result when the user picks "Accept w/o orchestration". This distinguishes the user opt-out from system denials and is also surfaced to the agent so it clearly knows to complete the task itself.
- `format_terminal_state` now renders the user opt-out as a neutral **"Continuing without orchestration"** message instead of the "re-enable orchestration" failure message. System denials are unchanged.

## Linked Issue
REMOTE-1913

## Testing
- Added `user_opt_out_denial_renders_neutral_message` covering the new terminal-state rendering.
- `cargo nextest run -p warp run_agents_card_view` — 29 passed.
- `cargo check -p warp` and `cargo clippy -p warp --tests -- -D warnings` — clean.
- `./script/format` — clean.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed the orchestration confirmation card showing "Orchestration is currently disabled. Re-enable on the plan card to launch." when choosing "Accept w/o orchestration"; it now reads "Continuing without orchestration".
-->

_Conversation: https://staging.warp.dev/conversation/32229ce8-4ea8-4e53-95df-db27498516a3_
_Run: https://oz.staging.warp.dev/runs/019eb3c8-e032-7da4-9846-fa155619af35_

_This PR was generated with [Oz](https://warp.dev/oz)._
