### PR TITLE
Fix LRC cancellation: prevent spurious follow-up on ManuallyCancelled

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1292,14 +1292,21 @@ impl BlocklistAIActionModel {
         {
             if !cancellation_reason.is_some_and(|r| r.should_preserve_in_progress_status()) {
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-                    let status = if self
+                    let all_results_cancelled = self
                         .finished_action_results
                         .get(&conversation_id)
                         .is_some_and(|finished_results| {
                             finished_results
                                 .iter()
                                 .all(|result| result.result.is_cancelled())
-                        }) {
+                        });
+                    // Also mark as Cancelled when the user explicitly stopped the agent, even if
+                    // some earlier actions in the same batch completed successfully.  Without this,
+                    // the InProgress status set here could persist and override a prior explicit
+                    // Cancelled update, leaving the "Warping..." indicator stuck.
+                    let is_manually_cancelled =
+                        cancellation_reason.is_some_and(|r| r.is_manually_cancelled());
+                    let status = if all_results_cancelled || is_manually_cancelled {
                         ConversationStatus::Cancelled
                     } else {
                         ConversationStatus::InProgress

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -480,8 +480,16 @@ impl BlocklistAIController {
                 cancellation_reason.is_some_and(|reason| reason.is_lrc_command_completed());
             let should_preserve_in_progress_status = cancellation_reason
                 .is_some_and(|reason| reason.should_preserve_in_progress_status());
+            // When the user explicitly cancels (e.g. pressing the stop button), do not send a
+            // follow-up even if earlier results in the same batch would normally trigger one.
+            // Without this check, a successfully-completed action earlier in the same batch
+            // (e.g. ReadFiles) could cause a spurious follow-up that re-enters InProgress
+            // despite the cancellation, leaving the "Warping..." indicator stuck indefinitely.
+            let is_manually_cancelled =
+                cancellation_reason.is_some_and(|reason| reason.is_manually_cancelled());
             let should_trigger_follow_up_request = (!is_passive_code_diff
                 && !is_lrc_command_completed
+                && !is_manually_cancelled
                 && finished_action_results
                     .iter()
                     .any(|result| result.result.should_trigger_request_upon_completion()))


### PR DESCRIPTION
## Description

Fixes a regression where cancelling a running long-running command (LRC) leaves the agent UI stuck in an infinite "Warping..." state.

### Root Cause

When the agent is executing a mixed batch of actions — e.g., a `ReadFiles` action that completed successfully *and* a `ReadShellCommandOutput` that's monitoring an LRC — cancelling the in-flight `ReadShellCommandOutput` would leave the prior successful `ReadFilesResult::Success` result in `finished_action_results`. The controller's `FinishedAction` subscription would then see those prior results and incorrectly trigger a follow-up request (since they satisfy `should_trigger_request_upon_completion()`), which put the conversation back into `InProgress` and caused the "Warping..." indicator to persist indefinitely.

### Fix

Two coordinated fixes:

1. **`controller.rs`**: Added `is_manually_cancelled` guard to `should_trigger_follow_up_request` so that prior successful results in the same batch cannot cause a spurious follow-up when the user explicitly cancels via the stop button.

2. **`action_model.rs`**: In `handle_action_result`, when the cancellation reason is `ManuallyCancelled`, set the conversation status to `Cancelled` (not `InProgress`) even if not all accumulated results in the batch are cancelled. This ensures the intermediate `InProgress` update cannot transiently override the explicit `Cancelled` state set by `stop_local_agent_conversation`.

## Linked Issue

APP-4712

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

The fix can be tested by:
1. Starting an agent session with a long-running command (e.g., `cargo nextest run`)
2. Waiting for the agent to start monitoring the LRC (see the "Warping..." indicator)
3. Clicking the stop/cancel button
4. Verifying the "Warping..." indicator disappears and the conversation is marked as Cancelled

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed regression where cancelling a running long-running command left the agent UI stuck in an infinite "Warping..." state.
-->

_Conversation: https://staging.warp.dev/conversation/534515bf-5074-4417-9d2a-a399456cc482_
_Run: https://oz.staging.warp.dev/runs/019eb437-2321-756f-842e-e2ea7d98fad3_
_This PR was generated with [Oz](https://warp.dev/oz)._
