### PR TITLE
remove redundant path canonicalizations causing UI to freeze with WSL tabs

### DIFF
--- a/app/src/code/language_server_shutdown_manager.rs
+++ b/app/src/code/language_server_shutdown_manager.rs
@@ -107,15 +107,11 @@ fn has_terminal_for_workspace(root: &Path, app: &AppContext) -> bool {
     for window_id in app.window_ids() {
         if let Some(terminals) = app.views_of_type::<TerminalView>(window_id) {
             for terminal in terminals {
-                let Some(pwd) = terminal.as_ref(app).pwd_if_local(app) else {
+                let Some(pwd) = terminal.as_ref(app).canonical_session_pwd_if_local(app) else {
                     continue;
                 };
 
-                let Ok(cwd) = PathBuf::from(pwd).canonicalize() else {
-                    continue;
-                };
-
-                if cwd.starts_with(root) {
+                if pwd.as_path().starts_with(root) {
                     return true;
                 }
             }

--- a/app/src/search/ai_context_menu/view.rs
+++ b/app/src/search/ai_context_menu/view.rs
@@ -389,7 +389,7 @@ impl AIContextMenu {
                     .and_then(|window_id| ActiveSession::as_ref(app).working_directory(window_id))
                     .is_some_and(|dir| {
                         DetectedRepositories::as_ref(app)
-                            .get_root_for_path(dir)
+                            .get_root_for_canonicalized_path(dir)
                             .is_some()
                     })
             }

--- a/app/src/search/ai_context_menu/view.rs
+++ b/app/src/search/ai_context_menu/view.rs
@@ -389,7 +389,7 @@ impl AIContextMenu {
                     .and_then(|window_id| ActiveSession::as_ref(app).working_directory(window_id))
                     .is_some_and(|dir| {
                         DetectedRepositories::as_ref(app)
-                            .get_root_for_canonicalized_path(dir)
+                            .get_root_for_canonical_path(dir)
                             .is_some()
                     })
             }

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -90,10 +90,10 @@ use crate::window_settings::{
 };
 use crate::workspace::header_toolbar_editor::HeaderToolbarInlineEditor;
 use crate::workspace::tab_settings::{
-    DirectoryTabColor, HideTitleBarSearchBarInVerticalTabs, PreserveActiveTabColor,
-    ShowCodeReviewButton, ShowIndicatorsButton, ShowVerticalTabPanelInRestoredWindows,
-    TabCloseButtonPosition, TabSettings, TabSettingsChangedEvent,
-    UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
+    canonical_directory_key, DirectoryTabColor, HideTitleBarSearchBarInVerticalTabs,
+    PreserveActiveTabColor, ShowCodeReviewButton, ShowIndicatorsButton,
+    ShowVerticalTabPanelInRestoredWindows, TabCloseButtonPosition, TabSettings,
+    TabSettingsChangedEvent, UseLatestUserPromptAsConversationTitleInTabNames, UseVerticalTabs,
     WorkspaceDecorationVisibility,
 };
 use crate::workspace::WorkspaceAction;
@@ -4905,8 +4905,7 @@ fn build_directory_delete_buttons(
 fn add_directory_tab_color_path(path: PathBuf, ctx: &mut ViewContext<AppearanceSettingsPageView>) {
     TabSettings::handle(ctx).update(ctx, |settings, ctx| {
         let current = settings.directory_tab_colors.value();
-        let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
-        let key = canonical.to_string_lossy().to_string();
+        let key = canonical_directory_key(&path);
         let dominated_by_existing = current
             .0
             .get(&key)

--- a/app/src/settings_view/directory_color_add_picker.rs
+++ b/app/src/settings_view/directory_color_add_picker.rs
@@ -21,7 +21,8 @@ use crate::ui_components::icons;
 use crate::view_components::action_button::{ActionButton, SecondaryTheme};
 use crate::view_components::{DropdownItem, FilterableDropdown};
 use crate::workspace::tab_settings::{
-    DirectoryTabColor, DirectoryTabColors, TabSettings, TabSettingsChangedEvent,
+    canonical_directory_key, DirectoryTabColor, DirectoryTabColors, TabSettings,
+    TabSettingsChangedEvent,
 };
 
 const ADD_DIRECTORY_LABEL: &str = "+ Add directory…";
@@ -283,15 +284,6 @@ impl TypedActionView for DirectoryColorAddPicker {
     }
 }
 
-/// Canonicalizes `path` using the same fallback logic that [`DirectoryTabColors::with_color`]
-/// uses, so candidate keys line up with the keys stored in the setting.
-fn canonical_key(path: &Path) -> String {
-    path.canonicalize()
-        .unwrap_or_else(|_| path.to_path_buf())
-        .to_string_lossy()
-        .to_string()
-}
-
 /// Computes the set of directory paths that should be offered in the add-directory dropdown.
 ///
 /// Candidates are the union of indexed codebase paths and persisted workspace
@@ -319,7 +311,7 @@ fn compute_candidate_paths(
             continue;
         }
 
-        let key = canonical_key(&path);
+        let key = canonical_directory_key(&path);
 
         if let Some(existing_color) = existing.0.get(&key) {
             if !matches!(existing_color, DirectoryTabColor::Suppressed) {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2453,6 +2453,13 @@ impl DropTargetData for TerminalDropTargetData {
     }
 }
 
+/// Cached result of [`TerminalView::canonical_session_pwd_if_local`].
+struct CanonicalSessionPwdCache {
+    /// Non-canonical path
+    path: PathBuf,
+    canonical: PathBuf,
+}
+
 pub struct TerminalView {
     pub model: Arc<FairMutex<TerminalModel>>,
     view_handle: WeakViewHandle<Self>,
@@ -2601,6 +2608,8 @@ pub struct TerminalView {
 
     sessions: ModelHandle<Sessions>,
     active_block_metadata: Option<BlockMetadata>,
+    /// Memoized result of `canonical_session_pwd_if_local`.
+    canonical_session_pwd_cache: RefCell<Option<CanonicalSessionPwdCache>>,
 
     block_text_selection_start_position: Option<Vector2F>,
 
@@ -4290,6 +4299,7 @@ impl TerminalView {
             sessions,
             remote_server_shimmer_handle: ShimmeringTextStateHandle::new(),
             active_block_metadata: None,
+            canonical_session_pwd_cache: RefCell::new(None),
             block_text_selection_start_position: None,
             background_executor: ctx.background_executor().clone(),
             inline_banners_state: Default::default(),
@@ -7643,6 +7653,33 @@ impl TerminalView {
         } else {
             None
         }
+    }
+
+    /// Returns the active local session's CWD, canonicalized via `dunce::canonicalize` to resolve
+    /// symlinks and normalize the path.
+    ///
+    /// The canonicalization is memoized in `canonical_session_pwd_cache`, keyed on the
+    /// non-canonical path, and only recomputed when that path changes.
+    pub fn canonical_session_pwd_if_local<C: ModelAsRef>(&self, ctx: &C) -> Option<PathBuf> {
+        let path = self.active_session_path_if_local(ctx)?;
+
+        // Return the cached value when the non-canonical path has not changed.
+        if let Some(cached) = self.canonical_session_pwd_cache.borrow().as_ref() {
+            if cached.path == path {
+                return Some(cached.canonical.clone());
+            }
+        }
+
+        let canonical = dunce::canonicalize(&path).ok()?;
+
+        if let Ok(mut cache) = self.canonical_session_pwd_cache.try_borrow_mut() {
+            *cache = Some(CanonicalSessionPwdCache {
+                path,
+                canonical: canonical.clone(),
+            });
+        }
+
+        Some(canonical)
     }
 
     pub fn input(&self) -> &ViewHandle<Input> {
@@ -11730,6 +11767,9 @@ impl TerminalView {
 
         self.active_block_metadata = Some(block_metadata.clone());
 
+        // Not needed for correctness, but this method memoizes its result. This "warms" the cache.
+        let _ = self.canonical_session_pwd_if_local(ctx);
+
         if let Some(session) = block_metadata
             .session_id()
             .and_then(|id| self.sessions.as_ref(ctx).get(id))
@@ -13642,10 +13682,9 @@ impl TerminalView {
         self.any_session_contains_remote_blocks |= self.active_block_is_considered_remote(ctx);
         self.update_focused_terminal_info(ctx);
 
-        if let Some(working_directory) = self.pwd_if_local(ctx) {
+        if let Some(working_directory) = self.active_session_path_if_local(ctx) {
             CodebaseIndexManager::handle(ctx).update(ctx, |manager, _ctx| {
-                let path_buf = PathBuf::from(&working_directory);
-                manager.handle_session_bootstrapped(&path_buf);
+                manager.handle_session_bootstrapped(&working_directory);
             });
         }
 
@@ -14086,11 +14125,10 @@ impl TerminalView {
         self.init_project(true, ctx);
     }
 
-    // Show or hide codebase index speedbump depending when a settings change happens.
+    /// Show or hide codebase index speedbump depending when a settings change happens.
     fn check_codebase_index_speedbump_on_settings_changed(&mut self, ctx: &mut ViewContext<Self>) {
-        if let Some(working_directory) = self.pwd_if_local(ctx) {
-            let path_buf = PathBuf::from(&working_directory);
-            self.update_repo_banner_state(path_buf, ctx);
+        if let Some(working_directory) = self.active_session_path_if_local(ctx) {
+            self.update_repo_banner_state(working_directory, ctx);
         }
     }
 
@@ -25914,11 +25952,7 @@ impl TerminalView {
     fn start_lsp_server_in_active_pwd(&self, ctx: &mut ViewContext<Self>) {
         use crate::ai::persisted_workspace::LspTask;
 
-        let Some(cwd) = self
-            .pwd_if_local(ctx)
-            .map(PathBuf::from)
-            .and_then(|p| p.canonicalize().ok())
-        else {
+        let Some(cwd) = self.canonical_session_pwd_if_local(ctx) else {
             return;
         };
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -11767,9 +11767,6 @@ impl TerminalView {
 
         self.active_block_metadata = Some(block_metadata.clone());
 
-        // Not needed for correctness, but this method memoizes its result. This "warms" the cache.
-        let _ = self.canonical_session_pwd_if_local(ctx);
-
         if let Some(session) = block_metadata
             .session_id()
             .and_then(|id| self.sessions.as_ref(ctx).get(id))

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2457,7 +2457,7 @@ impl DropTargetData for TerminalDropTargetData {
 }
 
 /// Cached result of [`TerminalView::canonical_session_pwd_if_local`].
-struct CanonicalSessionPwdCache {
+struct LocalSessionCanonicalPwdCache {
     /// Non-canonical path
     path: PathBuf,
     canonical: CanonicalizedPath,
@@ -2612,7 +2612,7 @@ pub struct TerminalView {
     sessions: ModelHandle<Sessions>,
     active_block_metadata: Option<BlockMetadata>,
     /// Memoized result of `canonical_session_pwd_if_local`.
-    canonical_session_pwd_cache: RefCell<Option<CanonicalSessionPwdCache>>,
+    canonical_session_pwd_cache: RefCell<Option<LocalSessionCanonicalPwdCache>>,
 
     block_text_selection_start_position: Option<Vector2F>,
 
@@ -7679,7 +7679,7 @@ impl TerminalView {
         let canonical = CanonicalizedPath::try_from(&path).ok()?;
 
         if let Ok(mut cache) = self.canonical_session_pwd_cache.try_borrow_mut() {
-            *cache = Some(CanonicalSessionPwdCache {
+            *cache = Some(LocalSessionCanonicalPwdCache {
                 path,
                 canonical: canonical.clone(),
             });

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -24,6 +24,7 @@ pub use init_project::{
 };
 use onboarding::callout::{FinalState, OnboardingCalloutViewEvent, OnboardingQuery};
 use onboarding::{OnboardingCalloutView, OnboardingKeybindings};
+use repo_metadata::CanonicalizedPath;
 
 use crate::ai::block_context::BlockContext;
 use crate::global_resource_handles::GlobalResourceHandlesProvider;
@@ -2457,7 +2458,7 @@ impl DropTargetData for TerminalDropTargetData {
 struct CanonicalSessionPwdCache {
     /// Non-canonical path
     path: PathBuf,
-    canonical: PathBuf,
+    canonical: CanonicalizedPath,
 }
 
 pub struct TerminalView {
@@ -7660,7 +7661,10 @@ impl TerminalView {
     ///
     /// The canonicalization is memoized in `canonical_session_pwd_cache`, keyed on the
     /// non-canonical path, and only recomputed when that path changes.
-    pub fn canonical_session_pwd_if_local<C: ModelAsRef>(&self, ctx: &C) -> Option<PathBuf> {
+    pub fn canonical_session_pwd_if_local<C: ModelAsRef>(
+        &self,
+        ctx: &C,
+    ) -> Option<CanonicalizedPath> {
         let path = self.active_session_path_if_local(ctx)?;
 
         // Return the cached value when the non-canonical path has not changed.
@@ -7670,7 +7674,7 @@ impl TerminalView {
             }
         }
 
-        let canonical = dunce::canonicalize(&path).ok()?;
+        let canonical = CanonicalizedPath::try_from(&path).ok()?;
 
         if let Ok(mut cache) = self.canonical_session_pwd_cache.try_borrow_mut() {
             *cache = Some(CanonicalSessionPwdCache {
@@ -11697,7 +11701,7 @@ impl TerminalView {
                                         };
 
                                         let Ok(active_directory) =
-                                            repo_metadata::CanonicalizedPath::try_from(
+                                            CanonicalizedPath::try_from(
                                                 active_directory,
                                             )
                                         else {
@@ -25954,7 +25958,12 @@ impl TerminalView {
         };
 
         PersistedWorkspace::handle(ctx).update(ctx, |workspace, ctx| {
-            workspace.execute_lsp_task(LspTask::Spawn { file_path: cwd }, ctx);
+            workspace.execute_lsp_task(
+                LspTask::Spawn {
+                    file_path: cwd.into(),
+                },
+                ctx,
+            );
         });
     }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -25,6 +25,8 @@ pub use init_project::{
 use onboarding::callout::{FinalState, OnboardingCalloutViewEvent, OnboardingQuery};
 use onboarding::{OnboardingCalloutView, OnboardingKeybindings};
 use repo_metadata::CanonicalizedPath;
+use warp_util::remote_path::RemotePath;
+use warp_util::standardized_path::StandardizedPath;
 
 use crate::ai::block_context::BlockContext;
 use crate::global_resource_handles::GlobalResourceHandlesProvider;
@@ -23207,10 +23209,10 @@ impl TerminalView {
                 SessionType::WarpifiedRemote { host_id } => host_id,
                 SessionType::Local => return None,
             }?;
-            let std_path = warp_util::standardized_path::StandardizedPath::try_new(cwd_str).ok()?;
-            Some(LocalOrRemotePath::Remote(
-                warp_util::remote_path::RemotePath::new(host_id, std_path),
-            ))
+            let std_path = StandardizedPath::try_new(cwd_str).ok()?;
+            Some(LocalOrRemotePath::Remote(RemotePath::new(
+                host_id, std_path,
+            )))
         }
     }
 

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -220,11 +220,17 @@ impl DirectoryTabColors {
     /// Returns a new value with the given directory's color updated.
     pub fn with_color(&self, path: &Path, color: DirectoryTabColor) -> Self {
         let mut map = self.0.clone();
-
-        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-        map.insert(canonical.to_string_lossy().to_string(), color);
+        map.insert(canonical_directory_key(path), color);
         Self(map)
     }
+}
+
+/// Canonicalizes `path` into the string key used in [`DirectoryTabColors`].
+pub fn canonical_directory_key(path: &Path) -> String {
+    dunce::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
 }
 
 #[derive(

--- a/app/src/workspace/tab_settings.rs
+++ b/app/src/workspace/tab_settings.rs
@@ -201,8 +201,7 @@ settings::macros::implement_setting_for_enum!(
 impl DirectoryTabColors {
     /// Returns the configured tab color for a directory using longest-prefix matching.
     /// Returns `None` if no configured directory is a prefix of `dir`.
-    pub fn color_for_directory(&self, dir: &Path) -> Option<DirectoryTabColor> {
-        let canonical_dir = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
+    pub fn color_for_directory(&self, canonical_dir: &Path) -> Option<DirectoryTabColor> {
         self.0
             .iter()
             .filter_map(|(configured_path, color)| {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5434,22 +5434,18 @@ impl Workspace {
     /// If the CWD is within a directory that has a configured color, applies it.
     /// If the CWD moves outside all configured directories, the directory color is cleared.
     fn sync_codebase_tab_color(tab: &mut TabData, ctx: &mut ViewContext<Self>) {
-        let cwd = tab
+        let color = tab
             .pane_group
             .as_ref(ctx)
             .active_session_view(ctx)
-            .and_then(|tv| tv.as_ref(ctx).pwd_if_local(ctx));
-
-        let Some(cwd) = cwd else {
-            return;
-        };
-
-        let cwd_path = Path::new(&cwd);
-        let color = TabSettings::as_ref(ctx)
-            .directory_tab_colors
-            .value()
-            .color_for_directory(cwd_path)
-            .and_then(|c| c.ansi_color());
+            .and_then(|tv| tv.as_ref(ctx).canonical_session_pwd_if_local(ctx))
+            .and_then(|cwd| {
+                TabSettings::as_ref(ctx)
+                    .directory_tab_colors
+                    .value()
+                    .color_for_directory(cwd.as_path())
+                    .and_then(|c| c.ansi_color())
+            });
 
         tab.default_directory_color = color;
         ctx.notify();

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5434,18 +5434,20 @@ impl Workspace {
     /// If the CWD is within a directory that has a configured color, applies it.
     /// If the CWD moves outside all configured directories, the directory color is cleared.
     fn sync_codebase_tab_color(tab: &mut TabData, ctx: &mut ViewContext<Self>) {
-        let color = tab
+        let Some(cwd) = tab
             .pane_group
             .as_ref(ctx)
             .active_session_view(ctx)
             .and_then(|tv| tv.as_ref(ctx).canonical_session_pwd_if_local(ctx))
-            .and_then(|cwd| {
-                TabSettings::as_ref(ctx)
-                    .directory_tab_colors
-                    .value()
-                    .color_for_directory(cwd.as_path())
-                    .and_then(|c| c.ansi_color())
-            });
+        else {
+            return;
+        };
+
+        let color = TabSettings::as_ref(ctx)
+            .directory_tab_colors
+            .value()
+            .color_for_directory(cwd.as_path())
+            .and_then(|c| c.ansi_color());
 
         tab.default_directory_color = color;
         ctx.notify();

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -5177,7 +5177,7 @@ fn compute_tab_group_color_mode(
     app: &AppContext,
 ) -> TabGroupColorMode {
     // Manual override applies to the whole group.
-    if !matches!(tab.selected_color, SelectedTabColor::Unset) {
+    if tab.selected_color != SelectedTabColor::Unset {
         return match tab.color() {
             Some(color) => TabGroupColorMode::Uniform(
                 color.to_ansi_color(&theme.terminal_colors().normal).into(),
@@ -5195,11 +5195,13 @@ fn compute_tab_group_color_mode(
         .map(|&pane_id| {
             let color = if let Some(tv) = pane_group.terminal_view_from_pane_id(pane_id, app) {
                 // Terminal pane: determine color from CWD.
-                tv.as_ref(app).pwd_if_local(app).and_then(|cwd| {
-                    dir_colors
-                        .color_for_directory(Path::new(&cwd))
-                        .and_then(|c| c.ansi_color())
-                })
+                tv.as_ref(app)
+                    .canonical_session_pwd_if_local(app)
+                    .and_then(|cwd| {
+                        dir_colors
+                            .color_for_directory(cwd.as_path())
+                            .and_then(|c| c.ansi_color())
+                    })
             } else if let Some(code_view) = pane_group.code_view_from_pane_id(pane_id, app) {
                 // Code pane: determine color from the open file path using longest-prefix
                 // matching against configured directories, so e.g. warp-internal/code.rs

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -5210,9 +5210,11 @@ fn compute_tab_group_color_mode(
                     .as_ref(app)
                     .local_path(app)
                     .as_deref()
+                    // TODO(andy): avoid canonicalizing on a render code path
+                    .and_then(|file_path| dunce::canonicalize(file_path).ok())
                     .and_then(|file_path| {
                         dir_colors
-                            .color_for_directory(file_path)
+                            .color_for_directory(&file_path)
                             .and_then(|c| c.ansi_color())
                     })
             } else {

--- a/crates/ai/src/index/full_source_code_embedding/manager.rs
+++ b/crates/ai/src/index/full_source_code_embedding/manager.rs
@@ -1138,6 +1138,7 @@ impl CodebaseIndexManager {
             .map(|(_, path)| path)
             .ok()
     }
+
     pub fn with_indexed_codebase<T>(
         &mut self,
         path: &Path,

--- a/crates/repo_metadata/src/repositories.rs
+++ b/crates/repo_metadata/src/repositories.rs
@@ -218,12 +218,38 @@ impl DetectedRepositories {
     }
 
     /// Given a local or remote path, return its corresponding repo root.
-    /// This does not run the check against the actual file system.
-    /// Instead it checks against our cached path to root mapping.
+    ///
+    /// No git detection is performed; roots are looked up in our cached
+    /// path-to-root mapping. Note that for local paths this still hits the
+    /// file system: the path is canonicalized first (resolving symlinks and
+    /// requiring it to exist) so it can match the canonicalized cached roots.
+    /// If the input is already canonicalized, prefer
+    /// [`Self::get_root_for_canonicalized_path`], which performs no I/O.
     pub fn get_root_for_path(&self, path: &LocalOrRemotePath) -> Option<LocalOrRemotePath> {
         match path {
             LocalOrRemotePath::Local(local_path) => {
                 let std_path = StandardizedPath::from_local_canonicalized(local_path).ok()?;
+                self.find_local_repository_root(&std_path)
+            }
+            LocalOrRemotePath::Remote(remote_path) => self.find_remote_repository_root(remote_path),
+        }
+    }
+
+    /// Given a local or remote path, return its corresponding repo root.
+    /// This does not run the check against the actual file system.
+    /// Instead it checks against our cached path to root mapping.
+    ///
+    /// Local paths must already be canonicalized (symlinks resolved); they
+    /// are only normalized here, without any filesystem I/O. A
+    /// non-canonical path may fail to match the canonicalized cached roots
+    /// — use [`Self::get_root_for_path`] for such paths instead.
+    pub fn get_root_for_canonicalized_path(
+        &self,
+        path: &LocalOrRemotePath,
+    ) -> Option<LocalOrRemotePath> {
+        match path {
+            LocalOrRemotePath::Local(local_path) => {
+                let std_path = StandardizedPath::try_from_local(local_path).ok()?;
                 self.find_local_repository_root(&std_path)
             }
             LocalOrRemotePath::Remote(remote_path) => self.find_remote_repository_root(remote_path),

--- a/crates/repo_metadata/src/repositories.rs
+++ b/crates/repo_metadata/src/repositories.rs
@@ -224,7 +224,7 @@ impl DetectedRepositories {
     /// file system: the path is canonicalized first (resolving symlinks and
     /// requiring it to exist) so it can match the canonicalized cached roots.
     /// If the input is already canonicalized, prefer
-    /// [`Self::get_root_for_canonicalized_path`], which performs no I/O.
+    /// [`Self::get_root_for_canonical_path`], which performs no I/O.
     pub fn get_root_for_path(&self, path: &LocalOrRemotePath) -> Option<LocalOrRemotePath> {
         match path {
             LocalOrRemotePath::Local(local_path) => {

--- a/crates/repo_metadata/src/repositories.rs
+++ b/crates/repo_metadata/src/repositories.rs
@@ -243,7 +243,7 @@ impl DetectedRepositories {
     /// are only normalized here, without any filesystem I/O. A
     /// non-canonical path may fail to match the canonicalized cached roots
     /// — use [`Self::get_root_for_path`] for such paths instead.
-    pub fn get_root_for_canonicalized_path(
+    pub fn get_root_for_canonical_path(
         &self,
         path: &LocalOrRemotePath,
     ) -> Option<LocalOrRemotePath> {

--- a/crates/warp_util/src/path.rs
+++ b/crates/warp_util/src/path.rs
@@ -455,21 +455,26 @@ pub fn convert_wsl_to_windows_host_path(
     }
     let components = unix_path.components();
     let prefix = components.take(3).collect::<Vec<_>>();
-    let windows_path = match prefix.as_slice() {
+    let mut windows_path = TypedPathBuf::new(PathType::Windows);
+    match prefix.as_slice() {
         // Check if the prefix is "/mnt/c/" or similar, which is how WSL refers to Windows drive
         // "C:\". Valid drive names are a..=z, which are bytes 97..=122.
         [TypedComponent::Unix(UnixComponent::RootDir), TypedComponent::Unix(UnixComponent::Normal(b"mnt")), TypedComponent::Unix(UnixComponent::Normal(bytes))]
             if bytes.len() == 1 && (97..=122).contains(&bytes[0]) =>
         {
-            let mut windows_path = TypedPathBuf::new(PathType::Windows);
             windows_path.push([*bytes, b":\\"].concat());
             for component in unix_path.with_windows_encoding().components().skip(3) {
                 windows_path.push(component.as_bytes());
             }
-            windows_path
+            let pathbuf = PathBuf::try_from(windows_path)
+                .map_err(WSLPathConversionError::CouldNotConvertToPath)?;
+            // Many directories are symlinks into the underlying file-system location in Windows.
+            match std::fs::read_link(&pathbuf) {
+                Ok(linked_file) => Ok(linked_file),
+                Err(_) => Ok(pathbuf),
+            }
         }
         _ => {
-            let mut windows_path = TypedPathBuf::new(PathType::Windows);
             windows_path.push(format!(r"\\WSL$\{distro_name}"));
             for component in unix_path
                 .with_windows_encoding()
@@ -478,15 +483,8 @@ pub fn convert_wsl_to_windows_host_path(
             {
                 windows_path.push(component.as_bytes());
             }
-            windows_path
+            PathBuf::try_from(windows_path).map_err(WSLPathConversionError::CouldNotConvertToPath)
         }
-    };
-    let pathbuf =
-        PathBuf::try_from(windows_path).map_err(WSLPathConversionError::CouldNotConvertToPath)?;
-    // Many directories are symlinks into the underlying file-system location in Windows.
-    match std::fs::read_link(&pathbuf) {
-        Ok(linked_file) => Ok(linked_file),
-        Err(_) => Ok(pathbuf),
     }
 }
 


### PR DESCRIPTION
## Description

This PR mainly fixes an issue where switching to a WSL tab freezes the app for a second or two. The root cause is `std::fs::canonicalize` (or anything derived from that) being called repeatedly on WSL paths. Canonicalizing a path through WSL, e.g. `\\WSL$\Ubuntu\home\username\somefile` is slow because it crosses the VM boundary. It's not **so** slow that we have to avoid it entirely. However, it's slow enough that calling it 10+ times on the main thread in succession causes noticeable lag. This is actually happening. The lag grows linearly with the number of tabs in the workspace.

To make things worse, some callees are defensively re-canonicalizing even though their callers had already canonical a path, for example:

1. When [this value](https://github.com/warpdotdev/warp/blob/3d8235443c6eadab65159e2cd5e0f27f2204be99/app/src/workspace/view.rs#L16711) is produced it [is already canonical](https://github.com/warpdotdev/warp/blob/ba25a8474cdca53414cbe52eada1cbcdd5fde8a7/app/src/terminal/view.rs#L23201-L23201).
2. That gets [saved on the `ActiveSession` singleton](https://github.com/warpdotdev/warp/blob/3d8235443c6eadab65159e2cd5e0f27f2204be99/app/src/workspace/view.rs#L16729-L16729).
3. That gets [retrieved here](https://github.com/warpdotdev/warp/blob/3d8235443c6eadab65159e2cd5e0f27f2204be99/app/src/search/ai_context_menu/view.rs#L389-L392) and then passed to `DetectedRepositories::get_root_for_path` which in turn [canonicalized again](https://github.com/warpdotdev/warp/blob/3d8235443c6eadab65159e2cd5e0f27f2204be99/crates/repo_metadata/src/repositories.rs#L226).

I propose fixing this with the following:

1. Cache a canonical version of the PWD on the `TerminalView`. Basically I added a analogous method `canonical_session_pwd_if_local`. It wraps the existing `active_session_path_if_local` method but canonicalizes it afterwards and then memoizes that result. I have consumers call this new method instead. The main culprit for this is [`DirectoryTabColors::color_for_directory`](https://github.com/warpdotdev/warp/blob/3d8235443c6eadab65159e2cd5e0f27f2204be99/app/src/workspace/tab_settings.rs#L204-L204)
2. Add a non-canonicalizing version of [`DetectedRepositories::get_root_for_path`](https://github.com/warpdotdev/warp/blob/1e43a0a0bc610b63edce624a01d1cbae8835f374/crates/repo_metadata/src/repositories.rs#L228-L228) which I call [`get_root_for_canonical_path`](https://github.com/warpdotdev/warp/blob/bb432670251e4a0ab00e8cbd8190299a239217fd/crates/repo_metadata/src/repositories.rs#L246-L246). Callers which have already canonicalized the path can call this instead to bypass the canonicalization performance penalty. I only needed to have AIContextMenu call this to fix the issue.

## Alternatives Considered

Having both [`get_root_for_path`](https://github.com/warpdotdev/warp/blob/1e43a0a0bc610b63edce624a01d1cbae8835f374/crates/repo_metadata/src/repositories.rs#L228-L228) and [`get_root_for_canonical_path`](https://github.com/warpdotdev/warp/blob/bb432670251e4a0ab00e8cbd8190299a239217fd/crates/repo_metadata/src/repositories.rs#L246-L246) is definitely not ideal. It's too easy to use the wrong method. Ideally the type system would help enforce correctness. We already have `CanonicalizedPath` but that isn't used by this `LocalOrRemotePath` wrapper. Maybe we can make it generic `LocalOrRemotePath<LocalPathT>` so that it can represent different types of local paths either `PathBuf` or `CanonicalizedPath`. I'm assuming there are _also_ situations where `StandardizedPath` would be preferred.

## Linked Issue

Closes #9920

## Testing

The issue can be repro'd by opening a bunch of WSL tabs, it may take 10-20 tabs on a fast machine to start noticing the lag. Just activate any of the WSL tabs and it will freeze the UI for a bit.

On this branch, there is no longer perceptible lag. It feels instant!


<!--
## Changelog Entries for Stable


CHANGELOG-IMPROVEMENT: [Windows] Reduce lag when switching tabs to a WSL tab.
-->