### PR TITLE
Launch SuperGrok

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -681,6 +681,7 @@ default = [
     "remote_codebase_indexing",
     "solo_user_byok",
     "custom_inference_endpoints",
+    "supergrok",
     "billing_and_usage_page_v2",
     "remote_code_review",
     "git_operations_in_code_review",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -954,7 +954,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::AsyncFind,
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
-    FeatureFlag::SuperGrok,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Promote the SuperGrok feature to stable launch.

- Add `"supergrok"` to the `default` feature list in `app/Cargo.toml` so the feature is compiled into all builds.
- Remove `FeatureFlag::SuperGrok` from `DOGFOOD_FLAGS` in `crates/warp_features/src/lib.rs`.

The runtime bridge (cfg gate in `app/src/features.rs` + subscription refresh wiring in `app/src/lib.rs`) was already present. The feature previously lived only in `DOGFOOD_FLAGS` (no `PREVIEW_FLAGS` entry).

Users can now connect a Grok/xAI subscription to use Grok models in the Warp Agent through their xAI account on stable channels (previously dogfood only).

## Linked Issue
N/A (feature flag promotion rollout)

## Testing
- `./script/format --check` passed.
- Presubmit clippy commands per `./script/presubmit`:
  - `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
  - `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- No functional code changes; this is a staged rollout promotion per the documented promote-feature process.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: SuperGrok: connect an xAI Grok subscription to use Grok models in the agent (now available on stable; previously dogfood only).

_Conversation: https://staging.warp.dev/conversation/2335de63-51e2-4381-83b5-ddc429890e02_
_Run: https://oz.staging.warp.dev/runs/019eb50b-c251-7aa3-98a6-534c459bcb08_
_This PR was generated with [Oz](https://warp.dev/oz)._
