### PR TITLE
Pin Metal AIR bytecode target to MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/crates/warpui/build.rs
+++ b/crates/warpui/build.rs
@@ -81,8 +81,27 @@ fn compile_metal_shaders() {
 
     println!("cargo:rerun-if-changed={header_path}");
     println!("cargo:rerun-if-changed={metal_path}");
+    println!("cargo:rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET");
 
-    let mut compile_args = vec!["-sdk", "macosx", "metal", "-c", metal_path, "-o", air_path];
+    // Pin the AIR bytecode target to `MACOSX_DEPLOYMENT_TARGET`. Without an
+    // explicit `-mmacosx-version-min`, `xcrun metal` on recent Xcode toolchains
+    // emits AIR for the current SDK (e.g. `air64_v27-apple-macosx15.0.0`)
+    // regardless of the env var, and older Metal driver stacks reject the
+    // resulting `.metallib` during pipeline state creation. See #11700.
+    let min_macos_version = env::var("MACOSX_DEPLOYMENT_TARGET")
+        .expect("MACOSX_DEPLOYMENT_TARGET must be set for macOS builds");
+    let min_version_arg = format!("-mmacosx-version-min={min_macos_version}");
+
+    let mut compile_args = vec![
+        "-sdk",
+        "macosx",
+        "metal",
+        "-c",
+        metal_path,
+        "-o",
+        air_path,
+        &min_version_arg,
+    ];
     if cfg!(feature = "enable-metal-frame-capture") {
         compile_args.push("-frecord-sources");
         compile_args.push("-gline-tables-only");


### PR DESCRIPTION
## Description

`xcrun metal` on recent Xcode toolchains emits AIR targeted at the current SDK (e.g. `air64_v27-apple-macosx15.0.0`) regardless of the `MACOSX_DEPLOYMENT_TARGET` env var. On older Metal driver stacks (legacy Bronze drivers on older Intel Macs, OCLP machines running macOS 15 with injected legacy drivers) the resulting `.metallib` is rejected during pipeline state creation, which `Renderer::new` unwraps and aborts the app on launch.

The crash is shader-cache-mediated: a fresh launch can JIT-compile the shaders, the legacy driver then writes a corrupted cache entry to `/var/folders/.../com.apple.metal/`, and every subsequent launch aborts when the driver tries to deserialize that cache. The reporter in #11700 narrowed this down to a deployment-target mismatch (`air64_v27-apple-macosx15.0.0` vs. the driver's `air64-apple-macosx14.2.0` ceiling) and provided the exact error string.

Pass `-mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET` to `xcrun metal -c` so the AIR bytecode matches the rest of the build's minimum deployment target (`10.14`, set in `.cargo/config.toml`). This mirrors the same pattern already in use for the dock tile plugin build in `app/build.rs`.

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

Fixes #11700

## Testing

- [x] `./script/format --check` (Rust 1.92.0 per `rust-toolchain.toml`)
- [ ] I have manually tested my changes locally with `./script/run`

I do not have a full Xcode install on this machine, only Command Line Tools — `xcrun metal` is unavailable, so `cargo check -p warpui` cannot complete the build script and `./script/run` cannot be run. The change is a one-line addition to an existing argument vector, mirroring the `MACOSX_DEPLOYMENT_TARGET` plumbing in `app/build.rs` for the dock tile plugin build.

Requesting:
- CI to confirm `xcrun metal` accepts `-mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET` and the metallib still builds.
- @trfeng91 (issue reporter — has a MacBookPro11,5 / OCLP setup with the affected Bronze driver stack and explicitly offered to test pre-release builds in the issue) to verify that launch and subsequent relaunches no longer crash.

### Screenshots / Videos

N/A — build-system change with no UI surface.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Pin Metal AIR bytecode target to the build's minimum macOS deployment target, fixing launch crashes (`Renderer::new` unwrap) on legacy Metal driver stacks where the shipped metallib targeted a higher macOS version than the driver supports.
-->